### PR TITLE
feat(explore): Don't discard controls with custom sql when changing datasource

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/query/types/Column.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Column.ts
@@ -29,6 +29,7 @@ export interface AdhocColumn {
   expressionType: 'SQL';
   columnType?: 'BASE_AXIS' | 'SERIES';
   timeGrain?: string;
+  datasourceWarning?: boolean;
 }
 
 /**

--- a/superset-frontend/packages/superset-ui-core/src/utils/isDefined.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/isDefined.ts
@@ -17,6 +17,6 @@
  * under the License.
  */
 
-export default function isDefined(x: unknown) {
+export default function isDefined<T>(x: T): x is NonNullable<T> {
   return x !== null && x !== undefined;
 }

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -36,6 +36,7 @@ import {
   css,
   SupersetTheme,
   useTheme,
+  isDefined,
 } from '@superset-ui/core';
 import {
   ControlPanelSectionConfig,
@@ -45,6 +46,9 @@ import {
   ExpandedControlItem,
   sections,
 } from '@superset-ui/chart-controls';
+import { useSelector } from 'react-redux';
+import { rgba } from 'emotion-rgba';
+import { kebabCase } from 'lodash';
 
 import Collapse from 'src/components/Collapse';
 import Tabs from 'src/components/Tabs';
@@ -57,9 +61,6 @@ import { ExploreActions } from 'src/explore/actions/exploreActions';
 import { ChartState, ExplorePageState } from 'src/explore/types';
 import { Tooltip } from 'src/components/Tooltip';
 import Icons from 'src/components/Icons';
-
-import { rgba } from 'emotion-rgba';
-import { kebabCase } from 'lodash';
 import ControlRow from './ControlRow';
 import Control from './Control';
 import { ExploreAlert } from './ExploreAlert';
@@ -269,6 +270,30 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
 
   const containerRef = useRef<HTMLDivElement>(null);
 
+  const controlsTransferred = useSelector<
+    ExplorePageState,
+    string[] | undefined
+  >(state => state.explore.controlsTransferred);
+
+  useEffect(() => {
+    if (props.chart.chartStatus === 'success') {
+      controlsTransferred?.forEach(controlName => {
+        const alteredControls = ensureIsArray(
+          props.controls[controlName].value,
+        ).map(value => {
+          if (
+            typeof value === 'object' &&
+            isDefined(value) &&
+            'datasourceWarning' in value
+          ) {
+            return { ...value, datasourceWarning: false };
+          }
+          return value;
+        });
+        props.actions.setControlValue(controlName, alteredControls);
+      });
+    }
+  }, [props.chart.chartStatus]);
   useEffect(() => {
     if (
       prevDatasource &&
@@ -455,7 +480,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
           >
             <Icons.InfoCircleOutlined
               css={css`
-                ${iconStyles}
+                ${iconStyles};
                 color: ${errorColor};
               `}
             />
@@ -591,7 +616,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
             >
               <Icons.ExclamationCircleOutlined
                 css={css`
-                  ${iconStyles}
+                  ${iconStyles};
                   color: ${errorColor};
                 `}
               />

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -293,7 +293,13 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
         props.actions.setControlValue(controlName, alteredControls);
       });
     }
-  }, [props.chart.chartStatus]);
+  }, [
+    controlsTransferred,
+    props.actions,
+    props.chart.chartStatus,
+    props.controls,
+  ]);
+
   useEffect(() => {
     if (
       prevDatasource &&

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -458,6 +458,7 @@ function ExploreViewContainer(props) {
           !areObjectsEqual(
             props.controls[key].value,
             lastQueriedControls[key].value,
+            { ignoreFields: ['datasourceWarning'] },
           ),
       );
 

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndAdhocFilterOption.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndAdhocFilterOption.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import React from 'react';
+import { t } from '@superset-ui/core';
 import { DndItemType } from 'src/explore/components/DndItemType';
 import AdhocFilterPopoverTrigger from 'src/explore/components/controls/FilterControl/AdhocFilterPopoverTrigger';
 import AdhocFilter from 'src/explore/components/controls/FilterControl/AdhocFilter';
@@ -63,6 +64,11 @@ export default function DndAdhocFilterOption({
         type={DndItemType.FilterOption}
         withCaret
         isExtra={adhocFilter.isExtra}
+        datasourceWarningMessage={
+          adhocFilter.datasourceWarning
+            ? t('This filter might be incompatible with current dataset')
+            : undefined
+        }
       />
     </AdhocFilterPopoverTrigger>
   );

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.test.tsx
@@ -133,6 +133,7 @@ test('remove selected custom metric when metric gets removed from dataset', () =
   );
   expect(screen.getByText('metric_a')).toBeVisible();
   expect(screen.queryByText('Metric B')).not.toBeInTheDocument();
+  expect(screen.queryByText('metric_b')).not.toBeInTheDocument();
   expect(screen.getByText('SUM(column_a)')).toBeVisible();
   expect(screen.getByText('SUM(Column B)')).toBeVisible();
 });
@@ -171,15 +172,6 @@ test('remove selected custom metric when metric gets removed from dataset for si
     ],
   };
 
-  // rerender twice - first to update columns, second to update value
-  rerender(
-    <DndMetricSelect
-      {...newPropsWithRemovedMetric}
-      value={metricValue}
-      onChange={onChange}
-      multi={false}
-    />,
-  );
   rerender(
     <DndMetricSelect
       {...newPropsWithRemovedMetric}
@@ -220,15 +212,6 @@ test('remove selected adhoc metric when column gets removed from dataset', async
     ],
   };
 
-  // rerender twice - first to update columns, second to update value
-  rerender(
-    <DndMetricSelect
-      {...newPropsWithRemovedColumn}
-      value={metricValues}
-      onChange={onChange}
-      multi
-    />,
-  );
   rerender(
     <DndMetricSelect
       {...newPropsWithRemovedColumn}

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
@@ -78,10 +78,18 @@ const coerceMetrics = (
   );
 
   return metricsCompatibleWithDataset.map(metric => {
-    if (isDictionaryForAdhocMetric(metric)) {
-      return new AdhocMetric(metric);
+    if (!isDictionaryForAdhocMetric(metric)) {
+      return metric;
     }
-    return metric;
+    if (isAdhocMetricSimple(metric)) {
+      const column = columns.find(
+        col => col.column_name === metric.column.column_name,
+      );
+      if (column) {
+        return new AdhocMetric({ ...metric, column });
+      }
+    }
+    return new AdhocMetric(metric);
   });
 };
 

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/Option.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/Option.tsx
@@ -38,6 +38,7 @@ export default function Option({
   clickClose,
   withCaret,
   isExtra,
+  datasourceWarningMessage,
   canDelete = true,
 }: OptionProps) {
   const theme = useTheme();
@@ -60,15 +61,18 @@ export default function Option({
         </CloseContainer>
       )}
       <Label data-test="control-label">{children}</Label>
-      {isExtra && (
+      {(!!datasourceWarningMessage || isExtra) && (
         <StyledInfoTooltipWithTrigger
           icon="exclamation-triangle"
           placement="top"
           bsStyle="warning"
-          tooltip={t(`
+          tooltip={
+            datasourceWarningMessage ||
+            t(`
                 This filter was inherited from the dashboard's context.
                 It won't be saved when saving the chart.
-              `)}
+              `)
+          }
         />
       )}
       {withCaret && (

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/OptionWrapper.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/OptionWrapper.tsx
@@ -57,6 +57,7 @@ export default function OptionWrapper(
     clickClose,
     withCaret,
     isExtra,
+    datasourceWarningMessage,
     canDelete = true,
     ...rest
   } = props;
@@ -176,6 +177,7 @@ export default function OptionWrapper(
         clickClose={clickClose}
         withCaret={withCaret}
         isExtra={isExtra}
+        datasourceWarningMessage={datasourceWarningMessage}
         canDelete={canDelete}
       >
         <Label />

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/types.ts
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/types.ts
@@ -30,6 +30,7 @@ export interface OptionProps {
   clickClose: (index: number) => void;
   withCaret?: boolean;
   isExtra?: boolean;
+  datasourceWarningMessage?: string;
   canDelete?: boolean;
 }
 

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/AdhocFilter.test.js
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/AdhocFilter.test.js
@@ -36,6 +36,7 @@ describe('AdhocFilter', () => {
       expressionType: EXPRESSION_TYPES.SIMPLE,
       subject: 'value',
       operator: '>',
+      datasourceWarning: false,
       comparator: '10',
       clause: CLAUSES.WHERE,
       filterOptionName: adhocFilter.filterOptionName,

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/index.js
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/index.js
@@ -118,6 +118,7 @@ export default class AdhocFilter {
     }
     this.isExtra = !!adhocFilter.isExtra;
     this.isNew = !!adhocFilter.isNew;
+    this.datasourceWarning = !!adhocFilter.datasourceWarning;
 
     this.filterOptionName =
       adhocFilter.filterOptionName ||

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetric.js
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetric.js
@@ -76,6 +76,7 @@ export default class AdhocMetric {
       this.aggregate = null;
     }
     this.isNew = !!adhocMetric.isNew;
+    this.datasourceWarning = !!adhocMetric.datasourceWarning;
     this.hasCustomLabel = !!(adhocMetric.hasCustomLabel && adhocMetric.label);
     this.label = this.hasCustomLabel
       ? adhocMetric.label

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetric.test.js
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetric.test.js
@@ -34,6 +34,7 @@ describe('AdhocMetric', () => {
       expressionType: EXPRESSION_TYPES.SIMPLE,
       column: valueColumn,
       aggregate: AGGREGATES.SUM,
+      datasourceWarning: false,
       label: 'SUM(value)',
       hasCustomLabel: false,
       optionName: adhocMetric.optionName,

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricOption.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricOption.jsx
@@ -38,6 +38,7 @@ const propTypes = {
   index: PropTypes.number,
   type: PropTypes.string,
   multi: PropTypes.bool,
+  datasourceWarningMessage: PropTypes.string,
 };
 
 class AdhocMetricOption extends React.PureComponent {
@@ -64,6 +65,7 @@ class AdhocMetricOption extends React.PureComponent {
       index,
       type,
       multi,
+      datasourceWarningMessage,
     } = this.props;
 
     return (
@@ -87,6 +89,7 @@ class AdhocMetricOption extends React.PureComponent {
           withCaret
           isFunction
           multi={multi}
+          datasourceWarningMessage={datasourceWarningMessage}
         />
       </AdhocMetricPopoverTrigger>
     );

--- a/superset-frontend/src/explore/components/controls/MetricControl/MetricDefinitionValue.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/MetricDefinitionValue.jsx
@@ -35,6 +35,7 @@ const propTypes = {
   savedMetricsOptions: PropTypes.arrayOf(savedMetricType),
   multi: PropTypes.bool,
   datasource: PropTypes.object,
+  datasourceWarningMessage: PropTypes.string,
 };
 
 export default function MetricDefinitionValue({
@@ -50,6 +51,7 @@ export default function MetricDefinitionValue({
   index,
   type,
   multi,
+  datasourceWarningMessage,
 }) {
   const getSavedMetricByName = metricName =>
     savedMetrics.find(metric => metric.metric_name === metricName);
@@ -78,6 +80,7 @@ export default function MetricDefinitionValue({
       savedMetric: savedMetric ?? {},
       type,
       multi,
+      datasourceWarningMessage,
     };
 
     return <AdhocMetricOption {...metricOptionProps} />;

--- a/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
+++ b/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
@@ -179,6 +179,7 @@ export const OptionControlLabel = ({
   type,
   index,
   isExtra,
+  datasourceWarningMessage,
   tooltipTitle,
   multi = true,
   ...props
@@ -195,7 +196,8 @@ export const OptionControlLabel = ({
   type: string;
   index: number;
   isExtra?: boolean;
-  tooltipTitle: string;
+  datasourceWarningMessage?: string;
+  tooltipTitle?: string;
   multi?: boolean;
 }) => {
   const theme = useTheme();
@@ -314,15 +316,18 @@ export const OptionControlLabel = ({
         {isFunction && <Icons.FieldDerived />}
         {getLabelContent()}
       </Label>
-      {isExtra && (
+      {(!!datasourceWarningMessage || isExtra) && (
         <StyledInfoTooltipWithTrigger
           icon="exclamation-triangle"
           placement="top"
           bsStyle="warning"
-          tooltip={t(`
+          tooltip={
+            datasourceWarningMessage ||
+            t(`
                 This filter was inherited from the dashboard's context.
                 It won't be saved when saving the chart.
-              `)}
+              `)
+          }
         />
       )}
       {withCaret && (

--- a/superset-frontend/src/explore/controlUtils/getControlValuesCompatibleWithDatasource.test.ts
+++ b/superset-frontend/src/explore/controlUtils/getControlValuesCompatibleWithDatasource.test.ts
@@ -210,6 +210,7 @@ test('SQL ad-hoc metric values', () => {
       },
     }),
   ).toEqual({
+    datasourceWarning: true,
     expressionType: 'SQL',
     sqlExpression: 'select * from sample_column_1;',
   });
@@ -279,6 +280,7 @@ test('SQL ad-hoc filter values', () => {
       },
     }),
   ).toEqual({
+    datasourceWarning: true,
     expressionType: 'SQL',
     sqlExpression: 'select * from sample_column_1;',
   });

--- a/superset-frontend/src/explore/controlUtils/getControlValuesCompatibleWithDatasource.ts
+++ b/superset-frontend/src/explore/controlUtils/getControlValuesCompatibleWithDatasource.ts
@@ -21,9 +21,9 @@ import { ControlState, Dataset, Metric } from '@superset-ui/chart-controls';
 import {
   Column,
   isAdhocMetricSimple,
+  isAdhocMetricSQL,
   isSavedMetric,
   isSimpleAdhocFilter,
-  isFreeFormAdhocFilter,
   JsonValue,
   SimpleAdhocFilter,
 } from '@superset-ui/core';
@@ -72,7 +72,10 @@ const isControlValueCompatibleWithDatasource = (
         column.column_name === (value as SimpleAdhocFilter).subject,
     );
   }
-  if (isFreeFormAdhocFilter(value)) return true;
+  if (isAdhocMetricSQL(value)) {
+    Object.assign(value, { datasourceWarning: true });
+    return true;
+  }
   return false;
 };
 

--- a/superset-frontend/src/explore/reducers/exploreReducer.js
+++ b/superset-frontend/src/explore/reducers/exploreReducer.js
@@ -54,42 +54,39 @@ export default function exploreReducer(state = {}, action) {
       const { prevDatasource, newDatasource } = action;
       const controls = { ...state.controls };
       const controlsTransferred = [];
+
       if (
         prevDatasource.id !== newDatasource.id ||
         prevDatasource.type !== newDatasource.type
       ) {
         // reset time range filter to default
         newFormData.time_range = DEFAULT_TIME_RANGE;
-
         newFormData.datasource = newDatasource.uid;
-
-        // reset control values for column/metric related controls
-        Object.entries(controls).forEach(([controlName, controlState]) => {
-          if (
-            // for direct column select controls
-            controlState.valueKey === 'column_name' ||
-            // for all other controls
-            'savedMetrics' in controlState ||
-            'columns' in controlState ||
-            ('options' in controlState && !Array.isArray(controlState.options))
-          ) {
-            controls[controlName] = {
-              ...controlState,
-            };
-            newFormData[controlName] = getControlValuesCompatibleWithDatasource(
-              newDatasource,
-              controlState,
-              controlState.value,
-            );
-            if (
-              ensureIsArray(newFormData[controlName]).length > 0 &&
-              newFormData[controlName] !== controls[controlName].default
-            ) {
-              controlsTransferred.push(controlName);
-            }
-          }
-        });
       }
+
+      // reset control values for column/metric related controls
+      Object.entries(controls).forEach(([controlName, controlState]) => {
+        if (
+          // for direct column select controls
+          controlState.valueKey === 'column_name' ||
+          // for all other controls
+          'savedMetrics' in controlState ||
+          'columns' in controlState ||
+          ('options' in controlState && !Array.isArray(controlState.options))
+        ) {
+          newFormData[controlName] = getControlValuesCompatibleWithDatasource(
+            newDatasource,
+            controlState,
+            controlState.value,
+          );
+          if (
+            ensureIsArray(newFormData[controlName]).length > 0 &&
+            newFormData[controlName] !== controls[controlName].default
+          ) {
+            controlsTransferred.push(controlName);
+          }
+        }
+      });
 
       const newState = {
         ...state,

--- a/superset-frontend/src/reduxUtils.ts
+++ b/superset-frontend/src/reduxUtils.ts
@@ -19,7 +19,15 @@
 import shortid from 'shortid';
 import { compose } from 'redux';
 import persistState, { StorageAdapter } from 'redux-localstorage';
-import { isEqual, omitBy, isUndefined, isNull } from 'lodash';
+import {
+  isEqual,
+  omitBy,
+  omit,
+  isUndefined,
+  isNull,
+  isEqualWith,
+} from 'lodash';
+import { ensureIsArray } from '@superset-ui/core';
 
 export function addToObject(
   state: Record<string, any>,
@@ -181,7 +189,8 @@ export function areObjectsEqual(
   opts: {
     ignoreUndefined?: boolean;
     ignoreNull?: boolean;
-  } = { ignoreUndefined: false, ignoreNull: false },
+    ignoreFields: string[];
+  } = { ignoreUndefined: false, ignoreNull: false, ignoreFields: [] },
 ) {
   let comp1 = obj1;
   let comp2 = obj2;
@@ -192,6 +201,14 @@ export function areObjectsEqual(
   if (opts.ignoreNull) {
     comp1 = omitBy(comp1, isNull);
     comp2 = omitBy(comp2, isNull);
+  }
+  if (opts.ignoreFields?.length) {
+    return isEqualWith(comp1, comp2, (val1, val2) =>
+      isEqual(
+        ensureIsArray(val1).map(value => omit(value, opts.ignoreFields)),
+        ensureIsArray(val2).map(value => omit(value, opts.ignoreFields)),
+      ),
+    );
   }
   return isEqual(comp1, comp2);
 }

--- a/superset-frontend/src/reduxUtils.ts
+++ b/superset-frontend/src/reduxUtils.ts
@@ -202,7 +202,7 @@ export function areObjectsEqual(
     comp1 = omitBy(comp1, isNull);
     comp2 = omitBy(comp2, isNull);
   }
-  if (opts.ignoreFields) {
+  if (opts.ignoreFields?.length) {
     const ignoreFields = ensureIsArray(opts.ignoreFields);
     return isEqualWith(comp1, comp2, (val1, val2) =>
       isEqual(

--- a/superset-frontend/src/reduxUtils.ts
+++ b/superset-frontend/src/reduxUtils.ts
@@ -189,7 +189,7 @@ export function areObjectsEqual(
   opts: {
     ignoreUndefined?: boolean;
     ignoreNull?: boolean;
-    ignoreFields: string[];
+    ignoreFields?: string[];
   } = { ignoreUndefined: false, ignoreNull: false, ignoreFields: [] },
 ) {
   let comp1 = obj1;
@@ -202,11 +202,12 @@ export function areObjectsEqual(
     comp1 = omitBy(comp1, isNull);
     comp2 = omitBy(comp2, isNull);
   }
-  if (opts.ignoreFields?.length) {
+  if (opts.ignoreFields) {
+    const ignoreFields = ensureIsArray(opts.ignoreFields);
     return isEqualWith(comp1, comp2, (val1, val2) =>
       isEqual(
-        ensureIsArray(val1).map(value => omit(value, opts.ignoreFields)),
-        ensureIsArray(val2).map(value => omit(value, opts.ignoreFields)),
+        ensureIsArray(val1).map(value => omit(value, ignoreFields)),
+        ensureIsArray(val2).map(value => omit(value, ignoreFields)),
       ),
     );
   }


### PR DESCRIPTION

### SUMMARY
Currently, when user changes datasource in Explore, we try to keep controls that use columns available in the new datasource, but we always discard adhoc columns/metrics/filters that use custom SQL. This PR changes that behaviour by always keeping the controls with custom sql, but with added warning icon. We can't reliably verify if controls with custom SQL are compatible with the new datasource, so we let the user decide (since it's quicker to remove a control than to create it from scratch). If user runs a successful query, the warning icons disappear.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/15073128/182167215-e3606801-5ec9-4b3e-b7f7-fec893fea6b0.mov


### TESTING INSTRUCTIONS
1. Add some controls with custom sql
2. Switch to a different datasource
3. Verify that the controls with custom sql now have a warning icon with a tooltip
4. If the next query is successful, the warning icons should disappear. Otherwise, they should still be displayed

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
