### PR TITLE
chore(db): ensure query_context is MediumText before viz migration

### DIFF
--- a/superset/migrations/versions/2022-07-07_13-00_c747c78868b6_migrating_legacy_treemap.py
+++ b/superset/migrations/versions/2022-07-07_13-00_c747c78868b6_migrating_legacy_treemap.py
@@ -21,6 +21,9 @@ Revises: cdcf3d64daf4
 Create Date: 2022-06-30 22:04:17.686635
 
 """
+from alembic import op
+from sqlalchemy.dialects.mysql.base import MySQLDialect
+
 from superset.migrations.shared.migrate_viz import MigrateTreeMap
 
 # revision identifiers, used by Alembic.
@@ -29,6 +32,14 @@ down_revision = "cdcf3d64daf4"
 
 
 def upgrade():
+    # Ensure `slice.params` and `slice.query_context`` in MySQL is MEDIUMTEXT
+    # before migration, as the migration will save a duplicate form_data backup
+    # which may significantly increase the size of these fields.
+    if isinstance(op.get_bind().dialect, MySQLDialect):
+        # If the columns are already MEDIUMTEXT, this is a no-op
+        op.execute("ALTER TABLE slices MODIFY params MEDIUMTEXT")
+        op.execute("ALTER TABLE slices MODIFY query_context MEDIUMTEXT")
+
     MigrateTreeMap.upgrade()
 
 

--- a/superset/migrations/versions/2022-07-19_15-16_a39867932713_query_context_to_mediumtext.py
+++ b/superset/migrations/versions/2022-07-19_15-16_a39867932713_query_context_to_mediumtext.py
@@ -21,13 +21,12 @@ Revises: 06e1e70058c7
 Create Date: 2022-07-19 15:16:06.091961
 
 """
+from alembic import op
+from sqlalchemy.dialects.mysql.base import MySQLDialect
 
 # revision identifiers, used by Alembic.
 revision = "a39867932713"
 down_revision = "06e1e70058c7"
-
-from alembic import op
-from sqlalchemy.dialects.mysql.base import MySQLDialect
 
 
 def upgrade():


### PR DESCRIPTION
### SUMMARY

Since #20779 will just be an no-op if the columns are already MediumText, let's just do it again before the viz migration. This way, administrators don't have to remember to manually migrate the columns before running `superset db migration`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

CI and tested locally via `superset db upgrade`.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
