### PR TITLE
fix(sqllab): tracking url and error alert padding

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -78,9 +78,12 @@ interface ResultSetState {
   alertIsOpen: boolean;
 }
 
-const Styles = styled.div`
+const ResultlessStyles = styled.div`
   position: relative;
   minheight: 100px;
+  [role='alert'] {
+    margin-top: ${({ theme }) => theme.gridUnit * 2}px;
+  }
   .sql-result-track-job {
     margin-top: ${({ theme }) => theme.gridUnit * 2}px;
   }
@@ -111,10 +114,6 @@ const ResultSetButtons = styled.div`
   display: grid;
   grid-auto-flow: column;
   padding-right: ${({ theme }) => 2 * theme.gridUnit}px;
-`;
-
-const ResultSetErrorMessage = styled.div`
-  padding-top: ${({ theme }) => 4 * theme.gridUnit}px;
 `;
 
 export default class ResultSet extends React.PureComponent<
@@ -448,7 +447,7 @@ export default class ResultSet extends React.PureComponent<
     }
     if (query.state === 'failed') {
       return (
-        <ResultSetErrorMessage>
+        <ResultlessStyles>
           <ErrorMessageWithStackTrace
             title={t('Database error')}
             error={query?.errors?.[0]}
@@ -458,7 +457,7 @@ export default class ResultSet extends React.PureComponent<
             source="sqllab"
           />
           {trackingUrl}
-        </ResultSetErrorMessage>
+        </ResultlessStyles>
       );
     }
     if (query.state === 'success' && query.ctas) {
@@ -589,7 +588,7 @@ export default class ResultSet extends React.PureComponent<
         : null;
 
     return (
-      <Styles>
+      <ResultlessStyles>
         <div>{!progressBar && <Loading position="normal" />}</div>
         {/* show loading bar whenever progress bar is completed but needs time to render */}
         <div>{query.progress === 100 && <Loading position="normal" />}</div>
@@ -599,7 +598,7 @@ export default class ResultSet extends React.PureComponent<
         </div>
         <div>{query.progress !== 100 && progressBar}</div>
         {trackingUrl && <div>{trackingUrl}</div>}
-      </Styles>
+      </ResultlessStyles>
     );
   }
 }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Add back the missing space between tracking url button and alert messages when SQL Lab query results failed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before

<img width="940" alt="Xnip2022-08-01_10-07-06" src="https://user-images.githubusercontent.com/335541/182204790-3882f961-c984-43bf-aefa-596913f6c2f1.png">

#### After

<img width="928" alt="Xnip2022-08-01_10-08-38" src="https://user-images.githubusercontent.com/335541/182204802-038449bc-948b-4631-bab6-b268c7d00f66.png">


### TESTING INSTRUCTIONS

Run a failed query in Presto 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
