### PR TITLE
fix: skip row if created_at_fk is null

### DIFF
--- a/superset/migrations/versions/2022-07-05_15-48_409c7b420ab0_add_created_by_fk_as_owner.py
+++ b/superset/migrations/versions/2022-07-05_15-48_409c7b420ab0_add_created_by_fk_as_owner.py
@@ -22,15 +22,16 @@ Create Date: 2022-07-05 15:48:06.029190
 
 """
 
-# revision identifiers, used by Alembic.
-revision = "409c7b420ab0"
-down_revision = "a39867932713"
-
 from alembic import op
 from sqlalchemy import and_, Column, insert, Integer
 from sqlalchemy.ext.declarative import declarative_base
 
+# revision identifiers, used by Alembic.
 from superset import db
+
+revision = "409c7b420ab0"
+down_revision = "a39867932713"
+
 
 Base = declarative_base()
 
@@ -95,7 +96,7 @@ def upgrade():
                     DatasetUser.user_id == Dataset.created_by_fk,
                 ),
             )
-            .filter(DatasetUser.dataset_id == None),
+            .filter(DatasetUser.dataset_id == None, Dataset.created_by_fk != None),
         )
     )
 


### PR DESCRIPTION
Some migrations are failing for `ffa79af61a56` when a created_by_fk is blank for a dataset. This PR skips that row if null


### TESTING INSTRUCTIONS
TBD

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
