### PR TITLE
fix(viz): Show zero percent changes in Big Number Viz

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.ts
@@ -125,8 +125,10 @@ export default function transformProps(
       if (compareIndex < sortedData.length) {
         const compareValue = sortedData[compareIndex][1];
         // compare values must both be non-nulls
-        if (bigNumber !== null && compareValue !== null && compareValue !== 0) {
-          percentChange = (bigNumber - compareValue) / Math.abs(compareValue);
+        if (bigNumber !== null && compareValue !== null) {
+          percentChange = compareValue
+            ? (bigNumber - compareValue) / Math.abs(compareValue)
+            : 0;
           formattedSubheader = `${formatPercentChange(
             percentChange,
           )} ${compareSuffix}`;


### PR DESCRIPTION
### SUMMARY
When preventing the division by zero we totally skipped zero percent changes to show. So, now if zero is present we avoid diving but still display zero.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="776" alt="error" src="https://user-images.githubusercontent.com/38889534/182470935-ab1e8747-f999-4b08-ad5c-f5d544047bc7.png">


After:
<img width="776" alt="test" src="https://user-images.githubusercontent.com/38889534/182470660-d24bf43c-e852-41bb-95ca-2bbde12aefb0.png">


### TESTING INSTRUCTIONS
1. Create a KPI with trendline
2. Write "0" in Metrics / Custom SQL
3. Chose time comparison period = 1

Expected results:
+0.0% and suffix displays.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: https://github.com/apache/superset/issues/17012
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
