### PR TITLE
fix: remove extra line for link

### DIFF
--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
@@ -394,7 +394,7 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
                     >
                       {t('Create a dataset')}
                     </span>
-                    {t('to add metrics')}
+                    {t(' to add metrics')}
                   </>
                 }
               />

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
@@ -392,7 +392,7 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
                         this.props.onClose();
                       }}
                     >
-                      {t('Create a dataset')}{' '}
+                      {t('Create a dataset')}
                     </span>
                     {t('to add metrics')}
                   </>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Remove extended hyperlink caused by extra space in blank state metric popover

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before
<img width="289" alt="Screen Shot 2022-08-03 at 10 37 23 AM" src="https://user-images.githubusercontent.com/17326228/182673260-e6e3de27-7276-44e6-b95d-f7d2b83663f9.png">

after
<img width="301" alt="Screen Shot 2022-08-03 at 10 28 10 AM" src="https://user-images.githubusercontent.com/17326228/182673173-146d2e5a-3b79-44f0-be53-e1a7291a6133.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
