### PR TITLE
fix: Explore scrolled down when navigating from dashboard

### DIFF
--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -35,6 +35,7 @@ import setupPlugins from 'src/setup/setupPlugins';
 import { routes, isFrontendRoute } from 'src/views/routes';
 import { Logger } from 'src/logger/LogUtils';
 import { RootContextProviders } from './RootContextProviders';
+import { ScrollToTop } from './ScrollToTop';
 
 setupApp();
 setupPlugins();
@@ -60,6 +61,7 @@ const LocationPathnameLogger = () => {
 
 const App = () => (
   <Router>
+    <ScrollToTop />
     <LocationPathnameLogger />
     <RootContextProviders>
       <GlobalStyles />

--- a/superset-frontend/src/views/ScrollToTop.tsx
+++ b/superset-frontend/src/views/ScrollToTop.tsx
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};


### PR DESCRIPTION
### SUMMARY
Sometimes when user entered Explore from Dashboard, Explore was scrolled down and user was stuck in that position. That's because Explore is sometimes mounted with initial scroll set to some value above 0. We are stuck in this position, because of `overflow: hidden` on body. It’s related to how react-router mounts components on navigation, but I haven’t been able to find an answer why this bug is so non-deterministic.
We fix it by programmatically scrolling to top when SPA route pathname changes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
The bug shown in the video shows up only from time to time. After this fix, Explore should always open normally.

https://user-images.githubusercontent.com/15073128/182681101-02d03f7e-6fd3-4f7f-b7f6-270d16410580.mov


### TESTING INSTRUCTIONS
1. Open a dashboard
2. Scroll down and open some chart in Explore.
3. Go back to dashboard and repeat step 2.
4. Repeat step 3 multiple times. Bug occurs very randomly.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @andrey-zayats