### PR TITLE
fix: No back button in save dataset modal

### DIFF
--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
@@ -18,7 +18,13 @@
  */
 import React from 'react';
 import * as reactRedux from 'react-redux';
-import { render, screen, waitFor, within } from 'spec/helpers/testing-library';
+import {
+  render,
+  screen,
+  waitFor,
+  within,
+  cleanup,
+} from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import { SaveDatasetModal } from 'src/SqlLab/components/SaveDatasetModal';
@@ -39,7 +45,10 @@ fetchMock.get('glob:*/api/v1/dataset?*', {
 
 // Mock the user
 const useSelectorMock = jest.spyOn(reactRedux, 'useSelector');
-beforeEach(() => useSelectorMock.mockClear());
+beforeEach(() => {
+  useSelectorMock.mockClear();
+  cleanup();
+});
 
 describe('SaveDatasetModal', () => {
   it('renders a "Save as new" field', async () => {
@@ -88,7 +97,7 @@ describe('SaveDatasetModal', () => {
     expect(screen.getByRole('button', { name: /save/i })).toBeVisible();
   });
 
-  it('renders a back and overwrite button when "Overwrite existing" is selected', async () => {
+  it('renders an overwrite button when "Overwrite existing" is selected', async () => {
     render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
 
     // Click the overwrite radio button to reveal the overwrite confirmation and back buttons
@@ -97,11 +106,10 @@ describe('SaveDatasetModal', () => {
     });
     userEvent.click(overwriteRadioBtn);
 
-    expect(screen.getByRole('button', { name: /back/i })).toBeVisible();
     expect(screen.getByRole('button', { name: /overwrite/i })).toBeVisible();
   });
 
-  it('renders the overwrite button as disabled until an existing dataset is selected', async () => {
+  it('renders the overwrite button as disabled until an existing dataset is selected, confirms overwrite', async () => {
     useSelectorMock.mockReturnValue({ ...user });
     render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
 
@@ -131,5 +139,10 @@ describe('SaveDatasetModal', () => {
 
     // Overwrite button should now be enabled
     expect(overwriteConfirmationBtn).toBeEnabled();
+
+    // Check Overwrite confirmation functionality
+    userEvent.click(overwriteConfirmationBtn);
+    expect(screen.getByRole('button', { name: /back/i })).toBeVisible();
+    expect(screen.getByRole('button', { name: /overwrite/i })).toBeVisible();
   });
 });

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
@@ -357,7 +357,9 @@ export const SaveDatasetModal: FunctionComponent<SaveDatasetModalProps> = ({
           )}
           {newOrOverwrite === DatasetRadioState.OVERWRITE_DATASET && (
             <>
-              <Button onClick={handleOverwriteCancel}>Back</Button>
+              {shouldOverwriteDataset && (
+                <Button onClick={handleOverwriteCancel}>Back</Button>
+              )}
               <Button
                 className="md"
                 buttonStyle="primary"


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

We only want the back button to appear when a user has already selected the dataset that they are going to over write and are in the confirmation portion of the model. 

This adds a line of logic to get to that effect. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

https://user-images.githubusercontent.com/48933336/182697933-0a247d5b-08a4-45f5-b95b-51243f2854ad.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
