### PR TITLE
fix: save dataset and repopulate state

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/api/types/core.ts
+++ b/superset-frontend/packages/superset-ui-core/src/api/types/core.ts
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// /superset/sqllab_viz
+interface SqlLabPostRequest {
+  data: {
+    schema: string;
+    sql: string;
+    dbId: number;
+    templateParams?: string | undefined;
+    datasourceName: string;
+    metrics?: string[];
+    columns?: string[];
+  };
+}

--- a/superset-frontend/src/explore/actions/datasourcesActions.ts
+++ b/superset-frontend/src/explore/actions/datasourcesActions.ts
@@ -17,8 +17,12 @@
  * under the License.
  */
 
-import { Dispatch } from 'redux';
+import { Dispatch, AnyAction } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
 import { Dataset } from '@superset-ui/chart-controls';
+import { SupersetClient } from '@superset-ui/core';
+import { addDangerToast } from 'src/components/MessageToasts/actions';
+import { getClientErrorObject } from 'src/utils/getClientErrorObject';
 import { updateFormDataByDatasource } from './exploreActions';
 import { ExplorePageState } from '../types';
 
@@ -29,6 +33,45 @@ export interface SetDatasource {
 }
 export function setDatasource(datasource: Dataset) {
   return { type: SET_DATASOURCE, datasource };
+}
+
+export function saveDataset({
+  schema,
+  sql,
+  database,
+  templateParams,
+  datasourceName,
+  columns,
+}: Omit<SqlLabPostRequest['data'], 'dbId'> & { database: { id: number } }) {
+  return async function (dispatch: ThunkDispatch<any, undefined, AnyAction>) {
+    // Create a dataset object
+    try {
+      const {
+        json: { data },
+      } = await SupersetClient.post({
+        endpoint: '/superset/sqllab_viz/',
+        postPayload: {
+          data: {
+            schema,
+            sql,
+            dbId: database?.id,
+            templateParams,
+            datasourceName,
+            metrics: [],
+            columns,
+          },
+        },
+      });
+      // Update form_data to point to new dataset
+      dispatch(changeDatasource(data));
+      return data;
+    } catch (error) {
+      getClientErrorObject(error).then(e => {
+        addDangerToast(e.error);
+      });
+      throw error;
+    }
+  };
 }
 
 export function changeDatasource(newDatasource: Dataset) {
@@ -44,6 +87,7 @@ export function changeDatasource(newDatasource: Dataset) {
 export const datasourcesActions = {
   setDatasource,
   changeDatasource,
+  saveDataset,
 };
 
 export type AnyDatasourcesAction = SetDatasource;

--- a/superset-frontend/src/explore/actions/datasourcesActions.ts
+++ b/superset-frontend/src/explore/actions/datasourcesActions.ts
@@ -67,7 +67,7 @@ export function saveDataset({
       return data;
     } catch (error) {
       getClientErrorObject(error).then(e => {
-        addDangerToast(e.error);
+        dispatch(addDangerToast(e.error));
       });
       throw error;
     }

--- a/superset-frontend/src/explore/actions/exploreActions.ts
+++ b/superset-frontend/src/explore/actions/exploreActions.ts
@@ -104,6 +104,11 @@ export function setExploreControls(formData: QueryFormData) {
   return { type: SET_EXPLORE_CONTROLS, formData };
 }
 
+export const SET_FORM_DATA = 'UPDATE_FORM_DATA';
+export function setFormData(formData: QueryFormData) {
+  return { type: SET_FORM_DATA, formData };
+}
+
 export const UPDATE_CHART_TITLE = 'UPDATE_CHART_TITLE';
 export function updateChartTitle(sliceName: string) {
   return { type: UPDATE_CHART_TITLE, sliceName };

--- a/superset-frontend/src/explore/actions/hydrateExplore.test.ts
+++ b/superset-frontend/src/explore/actions/hydrateExplore.test.ts
@@ -82,7 +82,77 @@ test('creates hydrate action from initial data', () => {
           controls: expect.any(Object),
           form_data: exploreInitialData.form_data,
           slice: exploreInitialData.slice,
-          controlsTransferred: [],
+          standalone: null,
+          force: null,
+        },
+      },
+    }),
+  );
+});
+
+test('creates hydrate action with existing state', () => {
+  const dispatch = jest.fn();
+  const getState = jest.fn(() => ({
+    user: {},
+    charts: {},
+    datasources: {},
+    common: {},
+    explore: { controlsTransferred: ['all_columns'] },
+  }));
+  // ignore type check - we dont need exact explore state for this test
+  // @ts-ignore
+  hydrateExplore(exploreInitialData)(dispatch, getState);
+  expect(dispatch).toHaveBeenCalledWith(
+    expect.objectContaining({
+      type: HYDRATE_EXPLORE,
+      data: {
+        charts: {
+          371: {
+            id: 371,
+            chartAlert: null,
+            chartStatus: null,
+            chartStackTrace: null,
+            chartUpdateEndTime: null,
+            chartUpdateStartTime: 0,
+            latestQueryFormData: {
+              cache_timeout: undefined,
+              datasource: '8__table',
+              slice_id: 371,
+              url_params: undefined,
+              viz_type: 'table',
+            },
+            sliceFormData: {
+              cache_timeout: undefined,
+              datasource: '8__table',
+              slice_id: 371,
+              url_params: undefined,
+              viz_type: 'table',
+            },
+            queryController: null,
+            queriesResponse: null,
+            triggerQuery: false,
+            lastRendered: 0,
+          },
+        },
+        datasources: {
+          '8__table': exploreInitialData.dataset,
+        },
+        saveModal: {
+          dashboards: [],
+          saveModalAlert: null,
+        },
+        explore: {
+          can_add: false,
+          can_download: false,
+          can_overwrite: false,
+          isDatasourceMetaLoading: false,
+          isStarred: false,
+          triggerRender: false,
+          datasource: exploreInitialData.dataset,
+          controls: expect.any(Object),
+          controlsTransferred: ['all_columns'],
+          form_data: exploreInitialData.form_data,
+          slice: exploreInitialData.slice,
           standalone: null,
           force: null,
         },

--- a/superset-frontend/src/explore/actions/hydrateExplore.ts
+++ b/superset-frontend/src/explore/actions/hydrateExplore.ts
@@ -49,7 +49,8 @@ export const HYDRATE_EXPLORE = 'HYDRATE_EXPLORE';
 export const hydrateExplore =
   ({ form_data, slice, dataset }: ExplorePageInitialData) =>
   (dispatch: Dispatch, getState: () => ExplorePageState) => {
-    const { user, datasources, charts, sliceEntities, common } = getState();
+    const { user, datasources, charts, sliceEntities, common, explore } =
+      getState();
 
     const sliceId = getUrlParam(URL_PARAMS.sliceId);
     const dashboardId = getUrlParam(URL_PARAMS.dashboardId);
@@ -119,7 +120,7 @@ export const hydrateExplore =
       controls: initialControls,
       form_data: initialFormData,
       slice: initialSlice,
-      controlsTransferred: [],
+      controlsTransferred: explore.controlsTransferred,
       standalone: getUrlParam(URL_PARAMS.standalone),
       force: getUrlParam(URL_PARAMS.force),
       sliceDashboards: initialFormData.dashboards,

--- a/superset-frontend/src/explore/actions/saveModalActions.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.js
@@ -135,8 +135,13 @@ const addToasts = (isNewSlice, sliceName, addedToDashboard) => {
 
 //  Update existing slice
 export const updateSlice =
-  ({ slice_id: sliceId, owners }, sliceName, formData, addedToDashboard) =>
-  async dispatch => {
+  ({ slice_id: sliceId, owners }, sliceName, addedToDashboard) =>
+  async (dispatch, getState) => {
+    const {
+      explore: {
+        form_data: { url_params: _, ...formData },
+      },
+    } = getState();
     try {
       const response = await SupersetClient.put({
         endpoint: `/api/v1/chart/${sliceId}`,
@@ -154,7 +159,12 @@ export const updateSlice =
 
 //  Create new slice
 export const createSlice =
-  (sliceName, formData, addedToDashboard) => async dispatch => {
+  (sliceName, addedToDashboard) => async (dispatch, getState) => {
+    const {
+      explore: {
+        form_data: { url_params: _, ...formData },
+      },
+    } = getState();
     try {
       const response = await SupersetClient.post({
         endpoint: `/api/v1/chart/`,

--- a/superset-frontend/src/explore/actions/saveModalActions.test.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.test.js
@@ -75,6 +75,7 @@ const formData = {
   datasource: `${datasourceId}__${datasourceType}`,
   dashboards,
 };
+const mockExploreState = { explore: { form_data: formData } };
 
 const sliceResponsePayload = {
   id: 10,
@@ -95,11 +96,11 @@ test('updateSlice handles success', async () => {
   fetchMock.reset();
   fetchMock.put(updateSliceEndpoint, sliceResponsePayload);
   const dispatch = sinon.spy();
-  const slice = await updateSlice(
-    { slice_id: sliceId },
-    sliceName,
-    formData,
-  )(dispatch);
+  const getState = sinon.spy(() => mockExploreState);
+  const slice = await updateSlice({ slice_id: sliceId }, sliceName)(
+    dispatch,
+    getState,
+  );
 
   expect(fetchMock.calls(updateSliceEndpoint)).toHaveLength(1);
   expect(dispatch.callCount).toBe(2);
@@ -117,9 +118,10 @@ test('updateSlice handles failure', async () => {
   fetchMock.reset();
   fetchMock.put(updateSliceEndpoint, { throws: sampleError });
   const dispatch = sinon.spy();
+  const getState = sinon.spy(() => mockExploreState);
   let caughtError;
   try {
-    await updateSlice({ slice_id: sliceId }, sliceName, formData)(dispatch);
+    await updateSlice({ slice_id: sliceId }, sliceName)(dispatch, getState);
   } catch (error) {
     caughtError = error;
   }
@@ -139,7 +141,8 @@ test('createSlice handles success', async () => {
   fetchMock.reset();
   fetchMock.post(createSliceEndpoint, sliceResponsePayload);
   const dispatch = sinon.spy();
-  const slice = await createSlice(sliceName, formData)(dispatch);
+  const getState = sinon.spy(() => mockExploreState);
+  const slice = await createSlice(sliceName)(dispatch, getState);
   expect(fetchMock.calls(createSliceEndpoint)).toHaveLength(1);
   expect(dispatch.callCount).toBe(2);
   expect(dispatch.getCall(0).args[0].type).toBe(SAVE_SLICE_SUCCESS);
@@ -156,9 +159,10 @@ test('createSlice handles failure', async () => {
   fetchMock.reset();
   fetchMock.post(createSliceEndpoint, { throws: sampleError });
   const dispatch = sinon.spy();
+  const getState = sinon.spy(() => mockExploreState);
   let caughtError;
   try {
-    await createSlice(sliceName, formData)(dispatch);
+    await createSlice(sliceName)(dispatch, getState);
   } catch (error) {
     caughtError = error;
   }
@@ -243,10 +247,11 @@ test('updateSlice with add to new dashboard handles success', async () => {
   fetchMock.reset();
   fetchMock.put(updateSliceEndpoint, sliceResponsePayload);
   const dispatch = sinon.spy();
-  const slice = await updateSlice({ slice_id: sliceId }, sliceName, formData, {
+  const getState = sinon.spy(() => mockExploreState);
+  const slice = await updateSlice({ slice_id: sliceId }, sliceName, {
     new: true,
     title: dashboardName,
-  })(dispatch);
+  })(dispatch, getState);
 
   expect(fetchMock.calls(updateSliceEndpoint)).toHaveLength(1);
   expect(dispatch.callCount).toBe(3);
@@ -269,10 +274,11 @@ test('updateSlice with add to existing dashboard handles success', async () => {
   fetchMock.reset();
   fetchMock.put(updateSliceEndpoint, sliceResponsePayload);
   const dispatch = sinon.spy();
-  const slice = await updateSlice({ slice_id: sliceId }, sliceName, formData, {
+  const getState = sinon.spy(() => mockExploreState);
+  const slice = await updateSlice({ slice_id: sliceId }, sliceName, {
     new: false,
     title: dashboardName,
-  })(dispatch);
+  })(dispatch, getState);
 
   expect(fetchMock.calls(updateSliceEndpoint)).toHaveLength(1);
   expect(dispatch.callCount).toBe(3);

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -368,7 +368,9 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
         buttonSize="small"
         disabled={
           !this.state.newSliceName ||
-          (!this.state.saveToDashboardId && !this.state.newDashboardName)
+          (!this.state.saveToDashboardId && !this.state.newDashboardName) ||
+          (this.props.datasource?.type !== DatasourceType.Table &&
+            !this.state.datasetName)
         }
         onClick={() => this.saveOrOverwrite(true)}
       >

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -178,6 +178,7 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
         });
       } catch {
         // Don't continue since server was unable to create dataset
+        this.setState({ isLoading: false });
         return;
       }
     }

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -21,7 +21,7 @@ import React from 'react';
 import { Input } from 'src/components/Input';
 import { Form, FormItem } from 'src/components/Form';
 import Alert from 'src/components/Alert';
-import { t, styled, SupersetClient, DatasourceType } from '@superset-ui/core';
+import { t, styled, DatasourceType } from '@superset-ui/core';
 import ReactMarkdown from 'react-markdown';
 import Modal from 'src/components/Modal';
 import { Radio } from 'src/components/Radio';
@@ -31,7 +31,6 @@ import { SelectValue } from 'antd/lib/select';
 import { connect } from 'react-redux';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
-import { getClientErrorObject } from 'src/utils/getClientErrorObject';
 import Loading from 'src/components/Loading';
 
 // Session storage key for recent dashboard
@@ -87,7 +86,6 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
       alert: null,
       action: this.canOverwriteSlice() ? 'overwrite' : 'saveas',
       isLoading: false,
-      saveStatus: null,
     };
     this.onDashboardSelectChange = this.onDashboardSelectChange.bind(this);
     this.onSliceNameChange = this.onSliceNameChange.bind(this);
@@ -154,7 +152,6 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
     this.setState({ alert: null, isLoading: true });
     this.props.actions.removeSaveModalAlert();
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { url_params, ...formData } = this.props.form_data || {};
 
     let promise = Promise.resolve();
 
@@ -170,37 +167,20 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
       const { templateParams } = this.props.datasource;
       const columns = this.props.datasource?.columns || [];
 
-      // Create a dataset object
-      await SupersetClient.post({
-        endpoint: '/superset/sqllab_viz/',
-        postPayload: {
-          data: {
-            schema,
-            sql,
-            dbId: database?.id,
-            templateParams,
-            datasourceName: this.state.datasetName,
-            metrics: [],
-            columns,
-          },
-        },
-      })
-        .then(({ json }) => json)
-        .then(async (data: { table_id: number }) => {
-          // Update form_data to point to new dataset
-          formData.datasource = `${data.table_id}__table`;
-          this.setState({ saveStatus: 'succeed' });
-        })
-        .catch(response =>
-          getClientErrorObject(response).then(e => {
-            this.setState({ isLoading: false, saveStatus: 'failed' });
-            this.props.addDangerToast(e.error);
-          }),
-        );
+      try {
+        await this.props.actions.saveDataset({
+          schema,
+          sql,
+          database,
+          templateParams,
+          datasourceName: this.state.datasetName,
+          columns,
+        });
+      } catch {
+        // Don't continue since server was unable to create dataset
+        return;
+      }
     }
-
-    // Don't continue since server was unable to create dataset
-    if (this.state.saveStatus === 'failed') return;
 
     let dashboard: DashboardGetResponse | null = null;
     if (this.state.newDashboardName || this.state.saveToDashboardId) {
@@ -221,7 +201,11 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
           dashboard = response.result;
           const dashboards = new Set<number>(this.props.sliceDashboards);
           dashboards.add(dashboard.id);
-          formData.dashboards = Array.from(dashboards);
+          const { url_params, ...formData } = this.props.form_data || {};
+          this.props.actions.setFormData({
+            ...formData,
+            dashboards: Array.from(dashboards),
+          });
         });
     }
 
@@ -231,7 +215,6 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
         this.props.actions.updateSlice(
           this.props.slice,
           this.state.newSliceName,
-          formData,
           dashboard
             ? {
                 title: dashboard.dashboard_title,
@@ -244,7 +227,6 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
       promise = promise.then(() =>
         this.props.actions.createSlice(
           this.state.newSliceName,
-          formData,
           dashboard
             ? {
                 title: dashboard.dashboard_title,
@@ -399,7 +381,12 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
         buttonSize="small"
         buttonStyle="primary"
         onClick={() => this.saveOrOverwrite(false)}
-        disabled={this.state.isLoading || !this.state.newSliceName}
+        disabled={
+          this.state.isLoading ||
+          !this.state.newSliceName ||
+          (this.props.datasource?.type !== DatasourceType.Table &&
+            !this.state.datasetName)
+        }
         data-test="btn-modal-save"
       >
         {!this.canOverwriteSlice() && this.props.slice

--- a/superset-frontend/src/explore/reducers/exploreReducer.js
+++ b/superset-frontend/src/explore/reducers/exploreReducer.js
@@ -62,6 +62,8 @@ export default function exploreReducer(state = {}, action) {
         // reset time range filter to default
         newFormData.time_range = DEFAULT_TIME_RANGE;
 
+        newFormData.datasource = newDatasource.uid;
+
         // reset control values for column/metric related controls
         Object.entries(controls).forEach(([controlName, controlState]) => {
           if (
@@ -213,6 +215,12 @@ export default function exploreReducer(state = {}, action) {
       return {
         ...state,
         controls: getControlsState(state, action.formData),
+      };
+    },
+    [actions.SET_FORM_DATA]() {
+      return {
+        ...state,
+        form_data: action.formData,
       };
     },
     [actions.UPDATE_CHART_TITLE]() {

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2135,7 +2135,12 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         table.columns = cols
         table.metrics = [SqlMetric(metric_name="count", expression="count(*)")]
         db.session.commit()
-        return json_success(json.dumps({"table_id": table.id}))
+
+        return json_success(
+            json.dumps(
+                {"table_id": table.id, "data": sanitize_datasource_data(table.data)}
+            )
+        )
 
     @has_access
     @expose("/extra_table_metadata/<int:database_id>/<table_name>/<schema>/")


### PR DESCRIPTION
### SUMMARY
This PR fixes a bug in the sqllab to explore chart with a query flow where upon saving, there was an error saying that the form fields had not been transferred when they had. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: 
![Clipboard 2022-29-07 at 11 00 05 AM](https://user-images.githubusercontent.com/5186919/182731098-8639b0ea-7696-44e3-9725-318b6f346275.png)

After:
![_DEV__Superset](https://user-images.githubusercontent.com/5186919/182731486-e75a9ab4-3835-43e1-86f0-614894e123ca.png)



### TESTING INSTRUCTIONS
Repro steps
1, query in sql and click create chart
2, create chart in explore and save chart
3, in save chart modal when chart power=query, remove dataset name and leave it blank
4, click save button

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
