### PR TITLE
fix: BigQuery get_parameters_from_uri

### DIFF
--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -386,7 +386,9 @@ class BigQueryEngineSpec(BaseEngineSpec):
 
         # Building parameters from encrypted_extra and uri
         if encrypted_extra:
-            return {**encrypted_extra, "query": value.query}
+            # ``value.query`` needs to be explicitly converted into a dict (from an
+            # ``immutabledict``) so that it can be JSON serialized
+            return {**encrypted_extra, "query": dict(value.query)}
 
         raise ValidationError("Invalid service credentials")
 

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -16,6 +16,8 @@
 # under the License.
 # pylint: disable=unused-argument, import-outside-toplevel, protected-access
 
+import json
+
 from flask.ctx import AppContext
 from pybigquery.sqlalchemy_bigquery import BigQueryDialect
 from pytest_mock import MockFixture
@@ -145,3 +147,17 @@ def test_select_star(mocker: MockFixture, app_context: AppContext) -> None:
 FROM `my_table`
 LIMIT :param_1"""
     )
+
+
+def test_get_parameters_from_uri(app_context: None) -> None:
+    """
+    Test that the result from ``get_parameters_from_uri`` is JSON serializable.
+    """
+    from superset.db_engine_specs.bigquery import BigQueryEngineSpec
+
+    parameters = BigQueryEngineSpec.get_parameters_from_uri(
+        "bigquery://dbt-tutorial-347100/",
+        {"access_token": "TOP_SECRET"},
+    )
+    assert parameters == {"access_token": "TOP_SECRET", "query": {}}
+    assert json.loads(json.dumps(parameters)) == parameters


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fix a bug in BigQuery probably introduced with the upgrade to SQLAlchemy 1.4. When building a URL with `make_url`, the `query` attribute is now an `immutabledict`, which fails to be serialized to JSON. I fixed the `get_parameters_from_uri` method in the BigQuery DB engine spec by explicitly converting it into a dictionary.

I also checked for other places where this could happen, but couldn't find any other place where we return the `query` attribute to be serialized to JSON.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

None.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Added unit tests and confirmed that I was able to (1) add a BigQuery database (this was failing) and edit it later (also failing).

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
