### PR TITLE
fix(explore): Replace url search params only if current page is Explore

### DIFF
--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -153,7 +153,7 @@ const ExploreChartPanel = ({
   const [showDatasetModal, setShowDatasetModal] = useState(false);
 
   const metaDataRegistry = getChartMetadataRegistry();
-  const { useLegacyApi } = metaDataRegistry.get(vizType);
+  const { useLegacyApi } = metaDataRegistry.get(vizType) ?? {};
   const vizTypeNeedsDataset =
     useLegacyApi && datasource.type !== DatasourceType.Table;
   // added boolean column to below show boolean so that the errors aren't overlapping

--- a/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
@@ -84,9 +84,21 @@ fetchMock.put('glob:*/api/v1/explore/form_data*', { key });
 fetchMock.get('glob:*/api/v1/explore/form_data*', {});
 fetchMock.get('glob:*/favstar/slice*', { count: 0 });
 
-const renderWithRouter = (withKey?: boolean) => {
-  const path = '/explore/';
+const defaultPath = '/explore/';
+const renderWithRouter = ({
+  withKey,
+  overridePathname,
+}: {
+  withKey?: boolean;
+  overridePathname?: string;
+} = {}) => {
+  const path = overridePathname ?? defaultPath;
   const search = withKey ? `?form_data_key=${key}&dataset_id=1` : '';
+  Object.defineProperty(window, 'location', {
+    get() {
+      return { pathname: path, search };
+    },
+  });
   return render(
     <MemoryRouter initialEntries={[`${path}${search}`]}>
       <Route path={path}>
@@ -123,7 +135,7 @@ test('generates a new form_data param when none is available', async () => {
 
 test('generates a different form_data param when one is provided and is mounting', async () => {
   const replaceState = jest.spyOn(window.history, 'replaceState');
-  await waitFor(() => renderWithRouter(true));
+  await waitFor(() => renderWithRouter({ withKey: true }));
   expect(replaceState).not.toHaveBeenLastCalledWith(
     0,
     expect.anything(),
@@ -144,7 +156,7 @@ test('reuses the same form_data param when updating', async () => {
   });
   const replaceState = jest.spyOn(window.history, 'replaceState');
   const pushState = jest.spyOn(window.history, 'pushState');
-  await waitFor(() => renderWithRouter());
+  await waitFor(() => renderWithRouter({ withKey: true }));
   expect(replaceState.mock.calls.length).toBe(1);
   userEvent.click(screen.getByText('Update chart'));
   await waitFor(() => expect(pushState.mock.calls.length).toBe(1));
@@ -152,4 +164,19 @@ test('reuses the same form_data param when updating', async () => {
   replaceState.mockRestore();
   pushState.mockRestore();
   getChartControlPanelRegistry().remove('table');
+});
+
+test('doesnt call replaceState when pathname is not /explore', async () => {
+  getChartMetadataRegistry().registerValue(
+    'table',
+    new ChartMetadata({
+      name: 'fake table',
+      thumbnail: '.png',
+      useLegacyApi: false,
+    }),
+  );
+  const replaceState = jest.spyOn(window.history, 'replaceState');
+  await waitFor(() => renderWithRouter({ overridePathname: '/dashboard' }));
+  expect(replaceState).not.toHaveBeenCalled();
+  replaceState.mockRestore();
 });

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -206,15 +206,18 @@ const updateHistory = debounce(
         );
         stateModifier = 'pushState';
       }
-      const url = mountExploreUrl(
-        standalone ? URL_PARAMS.standalone.name : null,
-        {
-          [URL_PARAMS.formDataKey.name]: key,
-          ...additionalParam,
-        },
-        force,
-      );
-      window.history[stateModifier](payload, title, url);
+      // avoid race condition in case user changes route before explore updates the url
+      if (window.location.pathname.startsWith('/explore')) {
+        const url = mountExploreUrl(
+          standalone ? URL_PARAMS.standalone.name : null,
+          {
+            [URL_PARAMS.formDataKey.name]: key,
+            ...additionalParam,
+          },
+          force,
+        );
+        window.history[stateModifier](payload, title, url);
+      }
     } catch (e) {
       logging.warn('Failed at altering browser history', e);
     }


### PR DESCRIPTION
### SUMMARY
When user opens Explore and then immediately navigates back, some unexpected URL replacements happen because of logic in Explore which asynchronously replaces URL search params when form_data_key request is completed. This PR fixes that behaviour by ensuring that current page is Explore before replacing the URL

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before (I navigated back with my touchpad right after opening Explore, remained in Explore anyways and then navigating back didn't take me back to the dashboard):

https://user-images.githubusercontent.com/15073128/182869927-30a25e7d-b94c-494a-acde-5a09ab512e07.mov

After:

https://user-images.githubusercontent.com/15073128/182869865-a0b65f47-d9a2-472d-b921-90056481789e.mov


### TESTING INSTRUCTIONS
1. Open dashboard and then click "Edit chart"
2. Navigate back immediately after Explore opens
3. Verify that navigation worked as expected

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
