### PR TITLE
feat(helm): add custom images for different pods

### DIFF
--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
   - name: craig-rueda
     email: craig@craigrueda.com
     url: https://github.com/craig-rueda
-version: 0.7.0
+version: 0.7.1
 dependencies:
 - name: postgresql
   version: 11.1.22

--- a/helm/superset/templates/_helpers.tpl
+++ b/helm/superset/templates/_helpers.tpl
@@ -89,6 +89,9 @@ WTF_CSRF_ENABLED = True
 WTF_CSRF_EXEMPT_LIST = []
 # A CSRF token that expires in 1 year
 WTF_CSRF_TIME_LIMIT = 60 * 60 * 24 * 365
+
+{{- if .Values.supersetCeleryBeat.enabled }}
+from celery.schedules import crontab
 class CeleryConfig(object):
   CELERY_IMPORTS = ('superset.sql_lab', )
   CELERY_ANNOTATIONS = {'tasks.add': {'rate_limit': '10/s'}}
@@ -101,6 +104,8 @@ class CeleryConfig(object):
 {{- end }}
 
 CELERY_CONFIG = CeleryConfig
+{{- end }}
+
 RESULTS_BACKEND = RedisCache(
       host=env('REDIS_HOST'),
 {{- if .Values.supersetNode.connections.redis_password }}

--- a/helm/superset/templates/deployment-beat.yaml
+++ b/helm/superset/templates/deployment-beat.yaml
@@ -76,8 +76,13 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.supersetCeleryBeat.image }}
+          image: "{{ .Values.supersetCeleryBeat.image.repository }}:{{ .Values.supersetCeleryBeat.image.tag }}"
+          imagePullPolicy: {{ .Values.supersetCeleryBeat.image.pullPolicy }}
+          {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- end }}
           {{- if .Values.supersetCeleryBeat.containerSecurityContext }}
           securityContext: {{ toYaml .Values.supersetCeleryBeat.containerSecurityContext | nindent 12 }}
           {{- end }}

--- a/helm/superset/templates/deployment-worker.yaml
+++ b/helm/superset/templates/deployment-worker.yaml
@@ -74,8 +74,13 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.supersetWorker.image }}
+          image: "{{ .Values.supersetWorker.image.repository }}:{{ .Values.supersetWorker.image.tag }}"
+          imagePullPolicy: {{ .Values.supersetWorker.image.pullPolicy }}
+          {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- end }}
           {{- if .Values.supersetWorker.containerSecurityContext }}
           securityContext: {{ toYaml .Values.supersetWorker.containerSecurityContext | nindent 12 }}
           {{- end }}

--- a/helm/superset/templates/deployment.yaml
+++ b/helm/superset/templates/deployment.yaml
@@ -77,8 +77,13 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.supersetNode.image }}
+          image: "{{ .Values.supersetNode.image.repository }}:{{ .Values.supersetNode.image.tag }}"
+          imagePullPolicy: {{ .Values.supersetNode.image.pullPolicy }}
+          {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- end }}
           {{- if .Values.supersetNode.containerSecurityContext }}
           securityContext: {{ toYaml .Values.supersetNode.containerSecurityContext | nindent 12 }}
           {{- end }}

--- a/helm/superset/templates/init-job.yaml
+++ b/helm/superset/templates/init-job.yaml
@@ -45,7 +45,16 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "superset.name" . }}-init-db
+        {{- if .Values.init.image }}
+        image: "{{ .Values.init.image.repository }}:{{ .Values.init.image.tag }}"
+        imagePullPolicy: {{ .Values.init.image.pullPolicy }}
+        {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- end }}
+        {{- if .Values.init.containerSecurityContext }}
+        securityContext: {{ toYaml .Values.init.containerSecurityContext | nindent 12 }}
+        {{- end }}
         {{- if or .Values.extraEnv .Values.extraEnvRaw }}
         env:
           {{- range $key, $value := .Values.extraEnv }}
@@ -63,10 +72,6 @@ spec:
           - secretRef:
               name: {{ tpl . $ }}
           {{- end }}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{- if .Values.init.containerSecurityContext }}
-        securityContext: {{ toYaml .Values.init.containerSecurityContext | nindent 12 }}
-        {{- end }}
         volumeMounts:
           - name: superset-config
             mountPath: {{ .Values.configMountPath | quote }}

--- a/helm/superset/values.schema.json
+++ b/helm/superset/values.schema.json
@@ -264,6 +264,26 @@
                 "forceReload": {
                     "type": "boolean"
                 },
+                "image": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        },
+                        "pullPolicy": {
+                            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.23.0/_definitions.json##/definitions/io.k8s.api.core.v1.Container/properties/imagePullPolicy"
+                        }
+                    },
+                    "required": [
+                        "repository",
+                        "tag",
+                        "pullPolicy"
+                    ]
+                },
                 "initContainers": {
                     "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.23.0/_definitions.json##/definitions/io.k8s.api.core.v1.PodSpec/properties/initContainers"
                 },
@@ -307,6 +327,26 @@
                 "forceReload": {
                     "type": "boolean"
                 },
+                "image": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        },
+                        "pullPolicy": {
+                            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.23.0/_definitions.json##/definitions/io.k8s.api.core.v1.Container/properties/imagePullPolicy"
+                        }
+                    },
+                    "required": [
+                        "repository",
+                        "tag",
+                        "pullPolicy"
+                    ]
+                },
                 "initContainers": {
                     "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.23.0/_definitions.json##/definitions/io.k8s.api.core.v1.PodSpec/properties/initContainers"
                 },
@@ -347,6 +387,26 @@
                 },
                 "forceReload": {
                     "type": "boolean"
+                },
+                "image": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        },
+                        "pullPolicy": {
+                            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.23.0/_definitions.json##/definitions/io.k8s.api.core.v1.Container/properties/imagePullPolicy"
+                        }
+                    },
+                    "required": [
+                        "repository",
+                        "tag",
+                        "pullPolicy"
+                    ]
                 },
                 "initContainers": {
                     "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.23.0/_definitions.json##/definitions/io.k8s.api.core.v1.PodSpec/properties/initContainers"
@@ -421,6 +481,26 @@
                         "lastname",
                         "email",
                         "password"
+                    ]
+                },
+                "image": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        },
+                        "pullPolicy": {
+                            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.23.0/_definitions.json##/definitions/io.k8s.api.core.v1.Container/properties/imagePullPolicy"
+                        }
+                    },
+                    "required": [
+                        "repository",
+                        "tag",
+                        "pullPolicy"
                     ]
                 },
                 "initContainers": {

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -222,6 +222,11 @@ hostAliases: []
 ##
 ## Superset node configuration
 supersetNode:
+  # You can set custom docker image for every Superset element
+  # image:
+  #   repository: apache/superset
+  #   tag: latest
+  #   pullPolicy: IfNotPresent
   replicaCount: 1
   command:
     - "/bin/sh"
@@ -267,6 +272,11 @@ supersetNode:
 ##
 ## Superset worker configuration
 supersetWorker:
+  # You can set custom docker image for every Superset element
+  # image:
+  #   repository: apache/superset
+  #   tag: latest
+  #   pullPolicy: IfNotPresent
   replicaCount: 1
   command:
     - "/bin/sh"
@@ -302,6 +312,11 @@ supersetWorker:
 supersetCeleryBeat:
   # This is only required if you intend to use alerts and reports
   enabled: false
+  # You can set custom docker image for every Superset element
+  # image:
+  #   repository: apache/superset
+  #   tag: latest
+  #   pullPolicy: IfNotPresent
   command:
     - "/bin/sh"
     - "-c"
@@ -346,6 +361,11 @@ init:
     # requests:
     #   cpu:
     #   memory:
+  # You can set custom docker image for every Superset element
+  # image:
+  #   repository: apache/superset
+  #   tag: latest
+  #   pullPolicy: IfNotPresent
   command:
     - "/bin/sh"
     - "-c"


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I've added support for different docker images for different pods. It's extremely useful when using custom build images (such as worker with webdriver and the rest without).
Image still can be defined globally (as earlier) or specific for every pod in `values` file.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: No, since feature request are moved to Discussions section.
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
