### PR TITLE
perf: Implement model specific lookups by id to improve performance

### DIFF
--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -491,6 +491,8 @@ class QueryContextProcessor:
         chart = ChartDAO.find_by_id(annotation_layer["value"])
         if not chart:
             raise QueryObjectValidationError(_("The chart does not exist"))
+        if not chart.datasource:
+            raise QueryObjectValidationError(_("The chart datasource does not exist"))
         form_data = chart.form_data.copy()
         try:
             viz_obj = get_viz(

--- a/superset/dao/base.py
+++ b/superset/dao/base.py
@@ -50,14 +50,17 @@ class BaseDAO:
 
     @classmethod
     def find_by_id(
-        cls, model_id: Union[str, int], session: Session = None
+        cls,
+        model_id: Union[str, int],
+        session: Session = None,
+        no_filter: bool = False,
     ) -> Optional[Model]:
         """
         Find a model by id, if defined applies `base_filter`
         """
         session = session or db.session
         query = session.query(cls.model_cls)
-        if cls.base_filter:
+        if cls.base_filter and not no_filter:
             data_model = SQLAInterface(cls.model_cls, session)
             query = cls.base_filter(  # pylint: disable=not-callable
                 cls.id_column_name, data_model

--- a/superset/dao/base.py
+++ b/superset/dao/base.py
@@ -53,14 +53,14 @@ class BaseDAO:
         cls,
         model_id: Union[str, int],
         session: Session = None,
-        skip_filter: bool = False,
+        skip_base_filter: bool = False,
     ) -> Optional[Model]:
         """
         Find a model by id, if defined applies `base_filter`
         """
         session = session or db.session
         query = session.query(cls.model_cls)
-        if cls.base_filter and not skip_filter:
+        if cls.base_filter and not skip_base_filter:
             data_model = SQLAInterface(cls.model_cls, session)
             query = cls.base_filter(  # pylint: disable=not-callable
                 cls.id_column_name, data_model

--- a/superset/dao/base.py
+++ b/superset/dao/base.py
@@ -53,14 +53,14 @@ class BaseDAO:
         cls,
         model_id: Union[str, int],
         session: Session = None,
-        no_filter: bool = False,
+        skip_filter: bool = False,
     ) -> Optional[Model]:
         """
         Find a model by id, if defined applies `base_filter`
         """
         session = session or db.session
         query = session.query(cls.model_cls)
-        if cls.base_filter and not no_filter:
+        if cls.base_filter and not skip_filter:
             data_model = SQLAInterface(cls.model_cls, session)
             query = cls.base_filter(  # pylint: disable=not-callable
                 cls.id_column_name, data_model

--- a/superset/explore/utils.py
+++ b/superset/explore/utils.py
@@ -39,7 +39,7 @@ from superset.utils.core import DatasourceType
 def check_dataset_access(dataset_id: int) -> Optional[bool]:
     if dataset_id:
         # Access checks below, no need to validate them twice as they can be expensive.
-        dataset = DatasetDAO.find_by_id(dataset_id, skip_filter=True)
+        dataset = DatasetDAO.find_by_id(dataset_id, skip_base_filter=True)
         if dataset:
             can_access_datasource = security_manager.can_access_datasource(dataset)
             if can_access_datasource:
@@ -51,7 +51,7 @@ def check_dataset_access(dataset_id: int) -> Optional[bool]:
 def check_query_access(query_id: int) -> Optional[bool]:
     if query_id:
         # Access checks below, no need to validate them twice as they can be expensive.
-        query = QueryDAO.find_by_id(query_id, skip_filter=True)
+        query = QueryDAO.find_by_id(query_id, skip_base_filter=True)
         if query:
             security_manager.raise_for_access(query=query)
             return True
@@ -84,7 +84,7 @@ def check_access(
     if not chart_id:
         return True
     # Access checks below, no need to validate them twice as they can be expensive.
-    chart = ChartDAO.find_by_id(chart_id, skip_filter=True)
+    chart = ChartDAO.find_by_id(chart_id, skip_base_filter=True)
     if chart:
         can_access_chart = security_manager.is_owner(
             chart

--- a/superset/explore/utils.py
+++ b/superset/explore/utils.py
@@ -39,7 +39,7 @@ from superset.utils.core import DatasourceType
 def check_dataset_access(dataset_id: int) -> Optional[bool]:
     if dataset_id:
         # Access checks below, no need to validate them twice as they can be expensive.
-        dataset = DatasetDAO.find_by_id(dataset_id, no_filter=True)
+        dataset = DatasetDAO.find_by_id(dataset_id, skip_filter=True)
         if dataset:
             can_access_datasource = security_manager.can_access_datasource(dataset)
             if can_access_datasource:
@@ -51,7 +51,7 @@ def check_dataset_access(dataset_id: int) -> Optional[bool]:
 def check_query_access(query_id: int) -> Optional[bool]:
     if query_id:
         # Access checks below, no need to validate them twice as they can be expensive.
-        query = QueryDAO.find_by_id(query_id, no_filter=True)
+        query = QueryDAO.find_by_id(query_id, skip_filter=True)
         if query:
             security_manager.raise_for_access(query=query)
             return True
@@ -84,7 +84,7 @@ def check_access(
     if not chart_id:
         return True
     # Access checks below, no need to validate them twice as they can be expensive.
-    chart = ChartDAO.find_by_id(chart_id, no_filter=True)
+    chart = ChartDAO.find_by_id(chart_id, skip_filter=True)
     if chart:
         can_access_chart = security_manager.is_owner(
             chart

--- a/superset/explore/utils.py
+++ b/superset/explore/utils.py
@@ -38,7 +38,8 @@ from superset.utils.core import DatasourceType
 
 def check_dataset_access(dataset_id: int) -> Optional[bool]:
     if dataset_id:
-        dataset = DatasetDAO.find_by_id(dataset_id)
+        # Access checks below, no need to validate them twice as they can be expensive.
+        dataset = DatasetDAO.find_by_id(dataset_id, no_filter=True)
         if dataset:
             can_access_datasource = security_manager.can_access_datasource(dataset)
             if can_access_datasource:
@@ -49,7 +50,8 @@ def check_dataset_access(dataset_id: int) -> Optional[bool]:
 
 def check_query_access(query_id: int) -> Optional[bool]:
     if query_id:
-        query = QueryDAO.find_by_id(query_id)
+        # Access checks below, no need to validate them twice as they can be expensive.
+        query = QueryDAO.find_by_id(query_id, no_filter=True)
         if query:
             security_manager.raise_for_access(query=query)
             return True
@@ -81,7 +83,8 @@ def check_access(
     check_datasource_access(datasource_id, datasource_type)
     if not chart_id:
         return True
-    chart = ChartDAO.find_by_id(chart_id)
+    # Access checks below, no need to validate them twice as they can be expensive.
+    chart = ChartDAO.find_by_id(chart_id, no_filter=True)
     if chart:
         can_access_chart = security_manager.is_owner(
             chart

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -1817,6 +1817,7 @@ class TestDatasetApi(SupersetTestCase):
         rv = self.client.get(uri)
         assert rv.status_code == 404
         self.logout()
+
         self.login(username="gamma")
         table = self.get_birth_names_dataset()
         uri = f"api/v1/dataset/{table.id}/related_objects"

--- a/tests/integration_tests/explore/form_data/api_tests.py
+++ b/tests/integration_tests/explore/form_data/api_tests.py
@@ -126,7 +126,7 @@ def test_post_access_denied(
         "form_data": INITIAL_FORM_DATA,
     }
     resp = test_client.post("api/v1/explore/form_data", json=payload)
-    assert resp.status_code == 404
+    assert resp.status_code == 403
 
 
 def test_post_same_key_for_same_context(
@@ -337,7 +337,7 @@ def test_put_access_denied(test_client, login_as, chart_id: int, datasource: Sql
         "form_data": UPDATED_FORM_DATA,
     }
     resp = test_client.put(f"api/v1/explore/form_data/{KEY}", json=payload)
-    assert resp.status_code == 404
+    assert resp.status_code == 403
 
 
 def test_put_not_owner(test_client, login_as, chart_id: int, datasource: SqlaTable):
@@ -349,7 +349,7 @@ def test_put_not_owner(test_client, login_as, chart_id: int, datasource: SqlaTab
         "form_data": UPDATED_FORM_DATA,
     }
     resp = test_client.put(f"api/v1/explore/form_data/{KEY}", json=payload)
-    assert resp.status_code == 404
+    assert resp.status_code == 403
 
 
 def test_get_key_not_found(test_client, login_as_admin):
@@ -367,7 +367,7 @@ def test_get(test_client, login_as_admin):
 def test_get_access_denied(test_client, login_as):
     login_as("gamma")
     resp = test_client.get(f"api/v1/explore/form_data/{KEY}")
-    assert resp.status_code == 404
+    assert resp.status_code == 403
 
 
 @patch("superset.security.SupersetSecurityManager.can_access_datasource")
@@ -387,7 +387,7 @@ def test_delete(test_client, login_as_admin):
 def test_delete_access_denied(test_client, login_as):
     login_as("gamma")
     resp = test_client.delete(f"api/v1/explore/form_data/{KEY}")
-    assert resp.status_code == 404
+    assert resp.status_code == 403
 
 
 def test_delete_not_owner(

--- a/tests/integration_tests/explore/permalink/api_tests.py
+++ b/tests/integration_tests/explore/permalink/api_tests.py
@@ -84,7 +84,7 @@ def test_post(
 def test_post_access_denied(test_client, login_as, form_data):
     login_as("gamma")
     resp = test_client.post(f"api/v1/explore/permalink", json={"formData": form_data})
-    assert resp.status_code == 404
+    assert resp.status_code == 403
 
 
 def test_get_missing_chart(

--- a/tests/unit_tests/charts/dao/__init__.py
+++ b/tests/unit_tests/charts/dao/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/unit_tests/charts/dao/dao_tests.py
+++ b/tests/unit_tests/charts/dao/dao_tests.py
@@ -42,6 +42,7 @@ def session_with_data(session: Session) -> Iterator[Session]:
     session.flush()
     yield session
     session.delete(slice_obj)
+    session.commit()
 
 
 def test_slice_find_by_id_skip_filter(session_with_data: Session) -> None:

--- a/tests/unit_tests/charts/dao/dao_tests.py
+++ b/tests/unit_tests/charts/dao/dao_tests.py
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Iterator
+
+import pytest
+from sqlalchemy.orm.session import Session
+
+from superset.utils.core import DatasourceType
+
+
+@pytest.fixture
+def session_with_data(session: Session) -> Iterator[Session]:
+    from superset.models.slice import Slice
+
+    engine = session.get_bind()
+    Slice.metadata.create_all(engine)  # pylint: disable=no-member
+
+    slice_obj = Slice(
+        id=1,
+        datasource_id=1,
+        datasource_type=DatasourceType.TABLE,
+        datasource_name="tmp_perm_table",
+        slice_name="slice_name",
+    )
+
+    session.add(slice_obj)
+    session.flush()
+    yield session
+
+
+def test_slice_find_by_id_no_filter(session_with_data: Session) -> None:
+    from superset.charts.dao import ChartDAO
+    from superset.models.slice import Slice
+
+    result = ChartDAO.find_by_id(1, session=session_with_data, no_filter=True)
+
+    assert result
+    assert 1 == result.id
+    assert "slice_name" == result.slice_name
+    assert isinstance(result, Slice)
+
+
+def test_datasource_find_by_id_no_filter_not_found(session_with_data: Session) -> None:
+    from superset.charts.dao import ChartDAO
+
+    result = ChartDAO.find_by_id(125326326, session=session_with_data, no_filter=True)
+    assert result is None

--- a/tests/unit_tests/charts/dao/dao_tests.py
+++ b/tests/unit_tests/charts/dao/dao_tests.py
@@ -41,13 +41,14 @@ def session_with_data(session: Session) -> Iterator[Session]:
     session.add(slice_obj)
     session.flush()
     yield session
+    session.delete(slice_obj)
 
 
-def test_slice_find_by_id_no_filter(session_with_data: Session) -> None:
+def test_slice_find_by_id_skip_filter(session_with_data: Session) -> None:
     from superset.charts.dao import ChartDAO
     from superset.models.slice import Slice
 
-    result = ChartDAO.find_by_id(1, session=session_with_data, no_filter=True)
+    result = ChartDAO.find_by_id(1, session=session_with_data, skip_filter=True)
 
     assert result
     assert 1 == result.id
@@ -55,8 +56,10 @@ def test_slice_find_by_id_no_filter(session_with_data: Session) -> None:
     assert isinstance(result, Slice)
 
 
-def test_datasource_find_by_id_no_filter_not_found(session_with_data: Session) -> None:
+def test_datasource_find_by_id_skip_filter_not_found(
+    session_with_data: Session,
+) -> None:
     from superset.charts.dao import ChartDAO
 
-    result = ChartDAO.find_by_id(125326326, session=session_with_data, no_filter=True)
+    result = ChartDAO.find_by_id(125326326, session=session_with_data, skip_filter=True)
     assert result is None

--- a/tests/unit_tests/charts/dao/dao_tests.py
+++ b/tests/unit_tests/charts/dao/dao_tests.py
@@ -39,17 +39,16 @@ def session_with_data(session: Session) -> Iterator[Session]:
     )
 
     session.add(slice_obj)
-    session.flush()
-    yield session
-    session.delete(slice_obj)
     session.commit()
+    yield session
+    session.rollback()
 
 
-def test_slice_find_by_id_skip_filter(session_with_data: Session) -> None:
+def test_slice_find_by_id_skip_base_filter(session_with_data: Session) -> None:
     from superset.charts.dao import ChartDAO
     from superset.models.slice import Slice
 
-    result = ChartDAO.find_by_id(1, session=session_with_data, skip_filter=True)
+    result = ChartDAO.find_by_id(1, session=session_with_data, skip_base_filter=True)
 
     assert result
     assert 1 == result.id
@@ -57,10 +56,12 @@ def test_slice_find_by_id_skip_filter(session_with_data: Session) -> None:
     assert isinstance(result, Slice)
 
 
-def test_datasource_find_by_id_skip_filter_not_found(
+def test_datasource_find_by_id_skip_base_filter_not_found(
     session_with_data: Session,
 ) -> None:
     from superset.charts.dao import ChartDAO
 
-    result = ChartDAO.find_by_id(125326326, session=session_with_data, skip_filter=True)
+    result = ChartDAO.find_by_id(
+        125326326, session=session_with_data, skip_base_filter=True
+    )
     assert result is None

--- a/tests/unit_tests/datasets/dao/__init__.py
+++ b/tests/unit_tests/datasets/dao/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/unit_tests/datasets/dao/dao_tests.py
+++ b/tests/unit_tests/datasets/dao/dao_tests.py
@@ -41,19 +41,17 @@ def session_with_data(session: Session) -> Iterator[Session]:
     session.add(sqla_table)
     session.flush()
     yield session
-    session.delete(sqla_table)
-    session.delete(db)
-    session.commit()
+    session.rollback()
 
 
-def test_datasource_find_by_id_skip_filter(session_with_data: Session) -> None:
+def test_datasource_find_by_id_skip_base_filter(session_with_data: Session) -> None:
     from superset.connectors.sqla.models import SqlaTable
     from superset.datasets.dao import DatasetDAO
 
     result = DatasetDAO.find_by_id(
         1,
         session=session_with_data,
-        skip_filter=True,
+        skip_base_filter=True,
     )
 
     assert result
@@ -62,7 +60,7 @@ def test_datasource_find_by_id_skip_filter(session_with_data: Session) -> None:
     assert isinstance(result, SqlaTable)
 
 
-def test_datasource_find_by_id_skip_filter_not_found(
+def test_datasource_find_by_id_skip_base_filter_not_found(
     session_with_data: Session,
 ) -> None:
     from superset.datasets.dao import DatasetDAO
@@ -70,6 +68,6 @@ def test_datasource_find_by_id_skip_filter_not_found(
     result = DatasetDAO.find_by_id(
         125326326,
         session=session_with_data,
-        skip_filter=True,
+        skip_base_filter=True,
     )
     assert result is None

--- a/tests/unit_tests/datasets/dao/dao_tests.py
+++ b/tests/unit_tests/datasets/dao/dao_tests.py
@@ -43,6 +43,7 @@ def session_with_data(session: Session) -> Iterator[Session]:
     yield session
     session.delete(sqla_table)
     session.delete(db)
+    session.commit()
 
 
 def test_datasource_find_by_id_skip_filter(session_with_data: Session) -> None:

--- a/tests/unit_tests/datasets/dao/dao_tests.py
+++ b/tests/unit_tests/datasets/dao/dao_tests.py
@@ -41,16 +41,18 @@ def session_with_data(session: Session) -> Iterator[Session]:
     session.add(sqla_table)
     session.flush()
     yield session
+    session.delete(sqla_table)
+    session.delete(db)
 
 
-def test_datasource_find_by_id_no_filter(session_with_data: Session) -> None:
+def test_datasource_find_by_id_skip_filter(session_with_data: Session) -> None:
     from superset.connectors.sqla.models import SqlaTable
     from superset.datasets.dao import DatasetDAO
 
     result = DatasetDAO.find_by_id(
         1,
         session=session_with_data,
-        no_filter=True,
+        skip_filter=True,
     )
 
     assert result
@@ -59,12 +61,14 @@ def test_datasource_find_by_id_no_filter(session_with_data: Session) -> None:
     assert isinstance(result, SqlaTable)
 
 
-def test_datasource_find_by_id_no_filter_not_found(session_with_data: Session) -> None:
+def test_datasource_find_by_id_skip_filter_not_found(
+    session_with_data: Session,
+) -> None:
     from superset.datasets.dao import DatasetDAO
 
     result = DatasetDAO.find_by_id(
         125326326,
         session=session_with_data,
-        no_filter=True,
+        skip_filter=True,
     )
     assert result is None

--- a/tests/unit_tests/datasets/dao/dao_tests.py
+++ b/tests/unit_tests/datasets/dao/dao_tests.py
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Iterator
+
+import pytest
+from sqlalchemy.orm.session import Session
+
+
+@pytest.fixture
+def session_with_data(session: Session) -> Iterator[Session]:
+    from superset.connectors.sqla.models import SqlaTable
+    from superset.models.core import Database
+
+    engine = session.get_bind()
+    SqlaTable.metadata.create_all(engine)  # pylint: disable=no-member
+
+    db = Database(database_name="my_database", sqlalchemy_uri="sqlite://")
+    sqla_table = SqlaTable(
+        table_name="my_sqla_table",
+        columns=[],
+        metrics=[],
+        database=db,
+    )
+
+    session.add(db)
+    session.add(sqla_table)
+    session.flush()
+    yield session
+
+
+def test_datasource_find_by_id_no_filter(session_with_data: Session) -> None:
+    from superset.connectors.sqla.models import SqlaTable
+    from superset.datasets.dao import DatasetDAO
+
+    result = DatasetDAO.find_by_id(
+        1,
+        session=session_with_data,
+        no_filter=True,
+    )
+
+    assert result
+    assert 1 == result.id
+    assert "my_sqla_table" == result.table_name
+    assert isinstance(result, SqlaTable)
+
+
+def test_datasource_find_by_id_no_filter_not_found(session_with_data: Session) -> None:
+    from superset.datasets.dao import DatasetDAO
+
+    result = DatasetDAO.find_by_id(
+        125326326,
+        session=session_with_data,
+        no_filter=True,
+    )
+    assert result is None


### PR DESCRIPTION
### SUMMARY
Currently the access checks are happening 2ce in the explore flow, once during the object lookup and later doing an explicit check.  Existing implementation was spending  > 500 ms in our deployment on doing object by id lookup and that contributed to ~1 - 1.5 second slowdown of the explore endpoint.

The proposed solution skips the filter on the chart / datasource lookup and let's explore to handle the access checks and return 403 if it was denied. Prior behavior was to return 404.

#### Out of scope
https://github.com/apache/superset/blob/f0ca158989644b793719884b52d04f93c05de1ba/superset/views/utils.py#L104 function takes > 1 second in our deployment, it is part of the explore flow while bootsrapping user data https://github.com/apache/superset/blob/f0ca158989644b793719884b52d04f93c05de1ba/superset/views/utils.py#L72  I will have separate PR to optimize the permissions lookup.

### Before
<img width="940" alt="Screen Shot 2022-08-03 at 1 41 41 PM" src="https://user-images.githubusercontent.com/5727938/182892252-13a4e1eb-0b8e-47ed-885a-5fa0dc9310cd.png">

### After
<img width="952" alt="image" src="https://user-images.githubusercontent.com/5727938/182893558-19e11aa6-2f80-42fe-a54d-0da6928827d2.png">

<img width="933" alt="Screen Shot 2022-08-04 at 8 46 54 AM" src="https://user-images.githubusercontent.com/5727938/182893202-6a543f0b-389e-418c-b72a-cc9a4178ef3a.png">


### TESTING INSTRUCTIONS
[x] Deployed and tested on dropbox staging
### ADDITIONAL INFORMATION
More granular breakdown
```
@classmethod
def find_by_id(
    cls, model_id: Union[str, int], session: Session = None
) -> Optional[Model]:
    """
    Find a model by id, if defined applies `base_filter`
    """
    with newrelic.agent.FunctionTrace("superset.dao.base.find_by_id.session", group="DAO"):
        session = session or db.session
    with newrelic.agent.FunctionTrace("superset.dao.base.find_by_id.query_contruction", group="DAO"):
        query = session.query(cls.model_cls)
        if cls.base_filter:
            data_model = SQLAInterface(cls.model_cls, session)
            query = cls.base_filter(  # pylint: disable=not-callable
                cls.id_column_name, data_model
            ).apply(query, None)
        id_filter = {cls.id_column_name: model_id}
    try:
        with newrelic.agent.FunctionTrace("superset.dao.base.find_by_id.query_execution", group="DAO"):
            return query.filter_by(**id_filter).one_or_none()
    except StatementError:
        # can happen if int is passed instead of a string or similar
        return None
````


![Screen Shot 2022-08-03 at 5 00 28 PM](https://user-images.githubusercontent.com/5727938/182892646-34116d3b-b053-436d-9e0b-bee6371d8302.png)
