### PR TITLE
fix: Columns not passing properly from SQL Lab to Explore

### DIFF
--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
@@ -151,6 +151,7 @@ export const SaveDatasetModal: FunctionComponent<SaveDatasetModalProps> = ({
   openWindow = true,
   formData = {},
 }) => {
+  console.log('FINDME SaveDatasetModal', datasource);
   const defaultVizType = useSelector<SqlLabRootState, string>(
     state => state.common?.conf?.DEFAULT_VIZ_TYPE || 'table',
   );

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
@@ -151,7 +151,6 @@ export const SaveDatasetModal: FunctionComponent<SaveDatasetModalProps> = ({
   openWindow = true,
   formData = {},
 }) => {
-  console.log('FINDME SaveDatasetModal', datasource);
   const defaultVizType = useSelector<SqlLabRootState, string>(
     state => state.common?.conf?.DEFAULT_VIZ_TYPE || 'table',
   );

--- a/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.jsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.jsx
@@ -159,7 +159,7 @@ describe('SavedQuery', () => {
     const closeBtn = screen.getByRole('button', { name: /close/i });
     const saveDatasetHeader = screen.getByText(/save or overwrite dataset/i);
     const saveRadio = screen.getByRole('radio', {
-      name: /save as new untitled dataset/i,
+      name: /save as new untitled/i,
     });
     const saveLabel = screen.getByText(/save as new/i);
     const saveTextbox = screen.getByRole('textbox');

--- a/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
@@ -167,7 +167,6 @@ export default function SaveQuery({
     </Form>
   );
 
-  console.log('FINDME SaveQuery', query, queryPayload());
   return (
     <Styles className="SaveQuery">
       <SaveDatasetActionButton

--- a/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
@@ -26,9 +26,10 @@ import { Form, FormItem } from 'src/components/Form';
 import Modal from 'src/components/Modal';
 import SaveDatasetActionButton from 'src/SqlLab/components/SaveDatasetActionButton';
 import { SaveDatasetModal } from 'src/SqlLab/components/SaveDatasetModal';
+import { getDatasourceAsSaveableDataset } from 'src/utils/datasourceUtils';
 
 interface SaveQueryProps {
-  query: any;
+  query: QueryPayload;
   defaultLabel: string;
   onSave: (arg0: QueryPayload) => void;
   onUpdate: (arg0: QueryPayload) => void;
@@ -166,6 +167,7 @@ export default function SaveQuery({
     </Form>
   );
 
+  console.log('FINDME SaveQuery', query, queryPayload());
   return (
     <Styles className="SaveQuery">
       <SaveDatasetActionButton
@@ -177,7 +179,7 @@ export default function SaveQuery({
         onHide={() => setShowSaveDatasetModal(false)}
         buttonTextOnSave={t('Save & Explore')}
         buttonTextOnOverwrite={t('Overwrite & Explore')}
-        datasource={query}
+        datasource={getDatasourceAsSaveableDataset(query)}
       />
       <Modal
         className="save-query-modal"

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -663,11 +663,6 @@ class SqlEditor extends React.PureComponent {
       </Menu>
     );
 
-    const queryWithColumns = () => ({
-      ...qe,
-      columns: this.props.latestQuery?.results?.columns || [],
-    });
-    console.log('findme SqlEditor', qe, queryWithColumns());
     return (
       <StyledToolbar className="sql-toolbar" id="js-sql-toolbar">
         <div className="leftItems">
@@ -726,7 +721,10 @@ class SqlEditor extends React.PureComponent {
         <div className="rightItems">
           <span>
             <SaveQuery
-              query={queryWithColumns()}
+              query={{
+                ...qe,
+                columns: this.props.latestQuery?.results?.columns || [],
+              }}
               defaultLabel={qe.name || qe.description}
               onSave={this.saveQuery}
               onUpdate={this.props.actions.updateSavedQuery}

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -663,6 +663,11 @@ class SqlEditor extends React.PureComponent {
       </Menu>
     );
 
+    const queryWithColumns = () => ({
+      ...qe,
+      columns: this.props.latestQuery?.results?.columns || [],
+    });
+    console.log('findme SqlEditor', qe, queryWithColumns());
     return (
       <StyledToolbar className="sql-toolbar" id="js-sql-toolbar">
         <div className="leftItems">
@@ -721,7 +726,7 @@ class SqlEditor extends React.PureComponent {
         <div className="rightItems">
           <span>
             <SaveQuery
-              query={qe}
+              query={queryWithColumns()}
               defaultLabel={qe.name || qe.description}
               onSave={this.saveQuery}
               onUpdate={this.props.actions.updateSavedQuery}

--- a/superset-frontend/src/utils/datasourceUtils.js
+++ b/superset-frontend/src/utils/datasourceUtils.js
@@ -19,7 +19,7 @@
 export const getDatasourceAsSaveableDataset = source => ({
   columns: source.columns,
   name: source?.datasource_name || source?.name || 'Untitled',
-  dbId: source.database.id,
+  dbId: source?.database?.id || source?.dbId,
   sql: source?.sql || '',
   schema: source?.schema,
 });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Columns were not passing properly from SQL Lab to Explore. This PR fixes that by passing the columns from `latestQuery.results.columns` into SaveQuery from SqlEditor.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Go to SQL Lab and run a query with columns
- Click the carat `v` button on the save button and click Save Dataset
- Click Save & Explore
- Observe that the columns have passed to the dataset properly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
