### PR TITLE
fix: for series limit comparison on explore with chart = Query

### DIFF
--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -43,6 +43,7 @@ from superset.exceptions import (
 )
 from superset.extensions import cache_manager, security_manager
 from superset.models.helpers import QueryResult
+from superset.models.sql_lab import Query
 from superset.utils import csv
 from superset.utils.cache import generate_cache_key, set_and_log_cache
 from superset.utils.core import (
@@ -307,7 +308,11 @@ class QueryContextProcessor:
             }
             join_keys = [col for col in df.columns if col not in metrics_mapping.keys()]
 
-            result = self._qc_datasource.query(query_object_clone_dct)
+            if isinstance(self._qc_datasource, Query):
+                result = self._qc_datasource.exc_query(query_object_clone_dct)
+            else:
+                result = self._qc_datasource.query(query_object_clone_dct)
+
             queries.append(result.query)
             cache_keys.append(None)
 

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -186,10 +186,6 @@ class QueryContextProcessor:
         # a valid assumption for current setting. In the long term, we may
         # support multiple queries from different data sources.
 
-        # The datasource here can be different backend but the interface is common
-        # pylint: disable=import-outside-toplevel
-        from superset.models.sql_lab import Query
-
         query = ""
         if isinstance(query_context.datasource, Query):
             # todo(hugh): add logic to manage all sip68 models here
@@ -249,7 +245,7 @@ class QueryContextProcessor:
 
         return df
 
-    def processing_time_offsets(  # pylint: disable=too-many-locals
+    def processing_time_offsets(  # pylint: disable=too-many-locals,too-many-statements
         self,
         df: pd.DataFrame,
         query_object: QueryObject,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Duck typing on query context to handle whenever the users is requesting to run a Query vs. SqlaTable in explore. This specifically fixes the issue with time comparisons in time series queries

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
