### PR TITLE
fix: make fips compliant by replacing md5 with sha256 in postgres and usedforsecurity=False for python md5

### DIFF
--- a/superset/key_value/utils.py
+++ b/superset/key_value/utils.py
@@ -61,7 +61,7 @@ def decode_permalink_id(key: str, salt: str) -> int:
 
 
 def get_uuid_namespace(seed: str) -> UUID:
-    md5_obj = md5()
+    md5_obj = md5(usedforsecurity=False)
     md5_obj.update(seed.encode("utf-8"))
     return UUID(md5_obj.hexdigest())
 

--- a/superset/migrations/shared/utils.py
+++ b/superset/migrations/shared/utils.py
@@ -54,7 +54,7 @@ def table_has_column(table: str, column: str) -> bool:
 
 uuid_by_dialect = {
     MySQLDialect: "UNHEX(REPLACE(CONVERT(UUID() using utf8mb4), '-', ''))",
-    PGDialect: "uuid_in(md5(random()::text || clock_timestamp()::text)::cstring)",
+    PGDialect: "uuid_in(sha256(random()::text || clock_timestamp()::text)::cstring)",
 }
 
 

--- a/superset/utils/hashing.py
+++ b/superset/utils/hashing.py
@@ -21,7 +21,7 @@ import simplejson as json
 
 
 def md5_sha_from_str(val: str) -> str:
-    return hashlib.md5(val.encode("utf-8")).hexdigest()
+    return hashlib.md5(val.encode("utf-8"), usedforsecurity=False).hexdigest()
 
 
 def md5_sha_from_dict(

--- a/superset/utils/public_interfaces.py
+++ b/superset/utils/public_interfaces.py
@@ -40,13 +40,13 @@ def compute_hash(obj: Callable[..., Any]) -> str:
 
 
 def compute_func_hash(function: Callable[..., Any]) -> str:
-    hashed = md5()
+    hashed = md5(usedforsecurity=False)
     hashed.update(str(signature(function)).encode())
     return b85encode(hashed.digest()).decode("utf-8")
 
 
 def compute_class_hash(class_: Callable[..., Any]) -> str:
-    hashed = md5()
+    hashed = md5(usedforsecurity=False)
     public_methods = sorted(
         [
             (name, method)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
-->
fix(superset): allows superset to run on fips compliance machines

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
added usedforsecurity=False for md5(..) methods and replaced postgres md5(...) with sha256(..)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Run a fips complaint Linux VM (we used Rocky8) but any Linux with fips enabled should work. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #20904 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
