### PR TITLE
fix(charts): Hide Values greater than Max Y Axis Bound on Mixed Time Series with Bar series

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/number-format/NumberFormats.ts
+++ b/superset-frontend/packages/superset-ui-core/src/number-format/NumberFormats.ts
@@ -52,6 +52,7 @@ const SI = SI_3_DIGIT;
 
 const SMART_NUMBER = 'SMART_NUMBER';
 const SMART_NUMBER_SIGNED = 'SMART_NUMBER_SIGNED';
+const OVER_MAX_HIDDEN = 'OVER_MAX_HIDDEN';
 
 const NumberFormats = {
   DOLLAR,
@@ -82,6 +83,7 @@ const NumberFormats = {
   SI_3_DIGIT,
   SMART_NUMBER,
   SMART_NUMBER_SIGNED,
+  OVER_MAX_HIDDEN,
 };
 
 export default NumberFormats;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -24,6 +24,7 @@ import {
   DTTM_ALIAS,
   ensureIsArray,
   GenericDataType,
+  NumberFormats,
   NumberFormatter,
   TimeFormatter,
 } from '@superset-ui/core';
@@ -325,4 +326,27 @@ export function getAxisType(dataType?: GenericDataType): AxisType {
     return 'time';
   }
   return 'category';
+}
+
+export function getOverMaxHiddenFormatter(
+  config: {
+    max?: number;
+    formatter?: NumberFormatter;
+  } = {},
+) {
+  const { max, formatter } = config;
+  // Only apply this logic if there's a MAX set in the controls
+  const shouldHideIfOverMax = !!max || max === 0;
+
+  return new NumberFormatter({
+    formatFunc: value =>
+      `${
+        shouldHideIfOverMax
+          ? value > max
+            ? ''
+            : formatter?.format(value) || value
+          : formatter?.format(value) || value
+      }`,
+    id: NumberFormats.OVER_MAX_HIDDEN,
+  });
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -341,10 +341,8 @@ export function getOverMaxHiddenFormatter(
   return new NumberFormatter({
     formatFunc: value =>
       `${
-        shouldHideIfOverMax
-          ? value > max
-            ? ''
-            : formatter?.format(value) || value
+        shouldHideIfOverMax && value > max
+          ? ''
           : formatter?.format(value) || value
       }`,
     id: NumberFormats.OVER_MAX_HIDDEN,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -26,6 +26,7 @@ import {
   getLegendProps,
   sanitizeHtml,
   extractShowValueIndexes,
+  getOverMaxHiddenFormatter,
 } from '../../src/utils/series';
 import { LegendOrientation, LegendType } from '../../src/types';
 import { defaultLegendPadding } from '../../src/defaults';
@@ -534,6 +535,18 @@ describe('formatSeriesName', () => {
   describe('sanitizeHtml', () => {
     it('should remove html tags from series name', () => {
       expect(sanitizeHtml(NULL_STRING)).toEqual('&lt;NULL&gt;');
+    });
+  });
+
+  describe('getOverMaxHiddenFormatter', () => {
+    it('should hide value if greater than max', () => {
+      const formatter = getOverMaxHiddenFormatter({ max: 81000 });
+      expect(formatter.format(84500)).toEqual('');
+    });
+    it('should show value if less or equal than max', () => {
+      const formatter = getOverMaxHiddenFormatter({ max: 81000 });
+      expect(formatter.format(81000)).toEqual('81000');
+      expect(formatter.format(50000)).toEqual('50000');
     });
   });
 });


### PR DESCRIPTION
### SUMMARY
- When Bar chart is used as serie type, we need to hide values that are greater than the max Y Axis Bound so users don't get inconsistency problems with other serie types. User can still see the value using the tooltip.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![error](https://user-images.githubusercontent.com/38889534/183497972-1dea39dd-6a1f-4f20-8adf-3ada4a1267b9.gif)

After:
![test](https://user-images.githubusercontent.com/38889534/183498096-158185a9-c5b6-433a-9d5d-4c1a6e37bed7.gif)
<img width="1672" alt="tooltip_1" src="https://user-images.githubusercontent.com/38889534/183498226-64a706f4-101e-4bd8-abf4-e5e73863a366.png">
<img width="1672" alt="tooltip_2" src="https://user-images.githubusercontent.com/38889534/183498241-78928915-5a7a-4a65-a9a4-f0dcca005434.png">


### TESTING INSTRUCTIONS
1. Create a mixed time series chart
2. Make sure value labels are on
3. In your second query, set the Y-Axis Bound Maximum to lower than the initial value in the chart

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
