### PR TITLE
perf: Memoize the common_bootstrap_payload

### DIFF
--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -70,6 +70,7 @@ from superset.exceptions import (
     SupersetException,
     SupersetSecurityException,
 )
+from superset.extensions import cache_manager
 from superset.models.helpers import ImportExportMixin
 from superset.reports.models import ReportRecipientType
 from superset.superset_typing import FlaskResponse
@@ -339,8 +340,13 @@ def menu_data() -> Dict[str, Any]:
     }
 
 
+@cache_manager.cache.memoize(timeout=60)
 def common_bootstrap_payload() -> Dict[str, Any]:
-    """Common data always sent to the client"""
+    """Common data always sent to the client
+
+    The function is memoized as the return value only changes based
+    on configuration and feature flag values.
+    """
     messages = get_flashed_messages(with_categories=True)
     locale = str(get_locale())
 

--- a/tests/integration_tests/core_tests.py
+++ b/tests/integration_tests/core_tests.py
@@ -62,7 +62,7 @@ from superset.connectors.sqla.models import SqlaTable
 from superset.db_engine_specs.base import BaseEngineSpec
 from superset.db_engine_specs.mssql import MssqlEngineSpec
 from superset.exceptions import SupersetException
-from superset.extensions import async_query_manager
+from superset.extensions import async_query_manager, cache_manager
 from superset.models import core as models
 from superset.models.annotations import Annotation, AnnotationLayer
 from superset.models.dashboard import Dashboard
@@ -1397,6 +1397,8 @@ class TestCore(SupersetTestCase):
         """
         Functions in feature flags don't break bootstrap data serialization.
         """
+        # feature flags are cached
+        cache_manager.cache.clear()
         self.login()
 
         encoded = json.dumps(


### PR DESCRIPTION
### SUMMARY
Memoize the common_bootstrap_payload.  The function includes the config settings and the feature flags, those tend to be changed in frequently, this PR adds caching layer with 1 minute TTL. In our staging deployment it yields 10x speedup e.g. 22 ms down from ~250 ms

### BEFORE
![Screen Shot 2022-08-05 at 10 17 57 AM](https://user-images.githubusercontent.com/5727938/183520204-8a7b36e0-114d-4669-9481-51f6f8e7a3e6.png)

### AFTER
<img width="943" alt="image" src="https://user-images.githubusercontent.com/5727938/183723368-bded1c04-6243-4ec5-ab2a-4e497db514ae.png">


### TESTING INSTRUCTIONS
[x] Dropbox staging
