### PR TITLE
fix: Unable to sync columns when dataset name has '+'

### DIFF
--- a/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
@@ -741,7 +741,9 @@ class DatasourceEditor extends React.PureComponent {
       database_name:
         datasource.database.database_name || datasource.database.name,
       schema_name: datasource.schema,
-      table_name: datasource.table_name,
+      table_name: datasource.table_name
+        ? encodeURIComponent(datasource.table_name)
+        : datasource.table_name,
     };
     Object.entries(params).forEach(([key, value]) => {
       // rison can't encode the undefined value

--- a/superset-frontend/src/components/Datasource/DatasourceEditor.test.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceEditor.test.jsx
@@ -39,7 +39,12 @@ describe('DatasourceEditor', () => {
   let isFeatureEnabledMock;
 
   beforeEach(() => {
-    el = <DatasourceEditor {...props} />;
+    el = (
+      <DatasourceEditor
+        {...props}
+        datasource={{ ...props.datasource, table_name: 'Vehicle Sales +' }}
+      />
+    );
     render(el, { useRedux: true });
   });
 
@@ -51,7 +56,7 @@ describe('DatasourceEditor', () => {
     expect(screen.getByTestId('edit-dataset-tabs')).toBeInTheDocument();
   });
 
-  it('makes an async request', () =>
+  it('can sync columns from source', () =>
     new Promise(done => {
       const columnsTab = screen.getByTestId('collection-tab-Columns');
 
@@ -63,6 +68,9 @@ describe('DatasourceEditor', () => {
 
       setTimeout(() => {
         expect(fetchMock.calls(DATASOURCE_ENDPOINT)).toHaveLength(1);
+        expect(fetchMock.calls(DATASOURCE_ENDPOINT)[0][0]).toContain(
+          'Vehicle%20Sales%20%2B%27',
+        );
         fetchMock.reset();
         done();
       }, 0);


### PR DESCRIPTION
### SUMMARY

When editing a dataset, attempting to sync columns from source might fail if the dataset name has special character.
The table name is sent as a query param to the API and it's not properly encoded.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://user-images.githubusercontent.com/17252075/183529728-5d99e05f-468a-4e6b-849d-daed8706bb1e.mov

After:

https://user-images.githubusercontent.com/17252075/183529482-00b7cbf0-58a9-4172-8e9d-2b026f6c72ed.mov

### TESTING INSTRUCTIONS

1. Create a dataset with name “Vehicle Sales +”
2. Edit the dataset
3. Navigate to columns
4. Click on SYNC COLUMNS FROM SOURCE
5. Will get error message: Dataset does not exist

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
