### PR TITLE
test: Fix async tests in SaveDatasetModal and complete overwrite screen test

### DIFF
--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
@@ -24,6 +24,7 @@ import {
   waitFor,
   within,
   cleanup,
+  act,
 } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
@@ -109,7 +110,7 @@ describe('SaveDatasetModal', () => {
     expect(screen.getByRole('button', { name: /overwrite/i })).toBeVisible();
   });
 
-  it('renders the overwrite button as disabled until an existing dataset is selected, confirms overwrite', async () => {
+  it('renders the overwrite button as disabled until an existing dataset is selected, confirms overwrite', () => {
     useSelectorMock.mockReturnValue({ ...user });
     render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
 
@@ -117,7 +118,7 @@ describe('SaveDatasetModal', () => {
     const overwriteRadioBtn = screen.getByRole('radio', {
       name: /overwrite existing/i,
     });
-    await waitFor(async () => {
+    act(() => {
       userEvent.click(overwriteRadioBtn);
     });
 
@@ -129,12 +130,49 @@ describe('SaveDatasetModal', () => {
 
     // Click the select component
     const select = screen.getByRole('combobox', { name: /existing dataset/i })!;
-    await waitFor(async () => userEvent.click(select));
+    act(() => userEvent.click(select));
 
     // Select the first "existing dataset" from the listbox
     const option = within(
       document.querySelector('.rc-virtual-list')!,
     ).getByText('coolest table 0')!;
+    userEvent.click(option);
+
+    // Overwrite button should now be enabled
+    expect(overwriteConfirmationBtn).toBeEnabled();
+
+    // Check Overwrite confirmation functionality
+    userEvent.click(overwriteConfirmationBtn);
+    expect(screen.getByRole('button', { name: /back/i })).toBeVisible();
+    expect(screen.getByRole('button', { name: /overwrite/i })).toBeVisible();
+  });
+
+  it('renders the overwrite button as disabled until an existing dataset is selected, confirms overwrite', async () => {
+    useSelectorMock.mockReturnValue({ ...user });
+    render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
+
+    // Click the overwrite radio button
+    const overwriteRadioBtn = screen.getByRole('radio', {
+      name: /overwrite existing/i,
+    });
+    act(() => {
+      userEvent.click(overwriteRadioBtn);
+    });
+
+    // Overwrite confirmation button should be disabled at this point
+    const overwriteConfirmationBtn = screen.getByRole('button', {
+      name: /overwrite/i,
+    });
+    expect(overwriteConfirmationBtn).toBeDisabled();
+
+    // Click the select component
+    const select = screen.getByRole('combobox', { name: /existing dataset/i })!;
+    act(() => userEvent.click(select));
+
+    // Select the first "existing dataset" from the listbox
+
+    const list = await within(document.querySelector('.rc-virtual-list')!);
+    const option = await list.findByText('coolest table 0')!;
     userEvent.click(option);
 
     // Overwrite button should now be enabled

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
@@ -47,7 +47,7 @@ beforeEach(() => {
 });
 
 describe('SaveDatasetModal', () => {
-  it('renders a "Save as new" field', async () => {
+  it('renders a "Save as new" field', () => {
     render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
 
     const saveRadioBtn = screen.getByRole('radio', {
@@ -64,7 +64,7 @@ describe('SaveDatasetModal', () => {
     expect(inputFieldText).toBeVisible();
   });
 
-  it('renders an "Overwrite existing" field', async () => {
+  it('renders an "Overwrite existing" field', () => {
     render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
 
     const overwriteRadioBtn = screen.getByRole('radio', {
@@ -80,20 +80,20 @@ describe('SaveDatasetModal', () => {
     expect(placeholderText).toBeVisible();
   });
 
-  it('renders a close button', async () => {
+  it('renders a close button', () => {
     render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
 
     expect(screen.getByRole('button', { name: /close/i })).toBeVisible();
   });
 
-  it('renders a save button when "Save as new" is selected', async () => {
+  it('renders a save button when "Save as new" is selected', () => {
     render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
 
     // "Save as new" is selected when the modal opens by default
     expect(screen.getByRole('button', { name: /save/i })).toBeVisible();
   });
 
-  it('renders an overwrite button when "Overwrite existing" is selected', async () => {
+  it('renders an overwrite button when "Overwrite existing" is selected', () => {
     render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
 
     // Click the overwrite radio button to reveal the overwrite confirmation and back buttons


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes the final test in `SaveDatasetModal.test.tsx`. Initially the test for the overwrite screen buttons had to be squashed into the previous test because creating another test after this test would always render incorrectly and fail. The problem was that timers used by the component were being fired after the test ran. The solution was to use `jest.useFakeTimers()` at the top of the file, so that the timers run in the test environment. I also completed testing on the overwrite screen and cleaned up some arbitrary `act` wrappers.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- In your terminal, cd into `superset-frontend`
- Run the command `npm run test superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx`
- Observe that all tests pass with no act errors

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
