### PR TITLE
docs(snowflake): Remove wrong version info for snowflake

### DIFF
--- a/docs/docs/databases/snowflake.mdx
+++ b/docs/docs/databases/snowflake.mdx
@@ -8,7 +8,7 @@ version: 1
 ## Snowflake
 
 The recommended connector library for Snowflake is
-[snowflake-sqlalchemy](https://pypi.org/project/snowflake-sqlalchemy/1.2.4/)<=1.2.4. (This version is required until Superset migrates to sqlalchemy>=1.4.0)
+[snowflake-sqlalchemy](https://pypi.org/project/snowflake-sqlalchemy/).
 
 The connection string for Snowflake looks like this:
 


### PR DESCRIPTION
This removes the part in the documentation for snowflake where it is claimed 1) we do not support sqlalchemy >=1.4 and 2) snowflake connector version must be pinned to an old version. AFAICT none of these are valid now, so removing.

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
