### PR TITLE
fix: unable to show view as table modal

### DIFF
--- a/superset-frontend/src/explore/components/DataTablesPane/components/useResultsPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/useResultsPane.tsx
@@ -35,7 +35,7 @@ const Error = styled.pre`
   margin-top: ${({ theme }) => `${theme.gridUnit * 4}px`};
 `;
 
-const cache = new WeakSet();
+const cache = new WeakMap();
 
 export const useResultsPane = ({
   isRequest,
@@ -59,6 +59,14 @@ export const useResultsPane = ({
   useEffect(() => {
     // it's an invalid formData when gets a errorMessage
     if (errorMessage) return;
+    if (isRequest && cache.has(queryFormData)) {
+      setResultResp(ensureIsArray(cache.get(queryFormData)));
+      setResponseError('');
+      if (queryForce && actions) {
+        actions.setForceQuery(false);
+      }
+      setIsLoading(false);
+    }
     if (isRequest && !cache.has(queryFormData)) {
       setIsLoading(true);
       getChartDataRequest({
@@ -71,7 +79,7 @@ export const useResultsPane = ({
         .then(({ json }) => {
           setResultResp(ensureIsArray(json.result));
           setResponseError('');
-          cache.add(queryFormData);
+          cache.set(queryFormData, json.result);
           if (queryForce && actions) {
             actions.setForceQuery(false);
           }


### PR DESCRIPTION
### SUMMARY
fix the "view as table" in the dashboard is unable to show when the second load.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### Before

https://user-images.githubusercontent.com/2016594/183597857-150195d9-ec93-401c-97fa-9399d58c592c.mov

#### After



https://user-images.githubusercontent.com/2016594/183598309-f0748201-8011-4ff9-a07c-ac3cc8a3a786.mov




### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
