### PR TITLE
fix: take form_data reference for metrics for pivot_v2 table reports

### DIFF
--- a/superset/charts/post_processing.py
+++ b/superset/charts/post_processing.py
@@ -235,7 +235,7 @@ def pivot_table_v2(
         df,
         rows=get_column_names(form_data.get("groupbyRows"), verbose_map),
         columns=get_column_names(form_data.get("groupbyColumns"), verbose_map),
-        metrics=get_metric_names(form_data["metrics"], verbose_map),
+        metrics=get_metric_names(form_data["metrics"]),
         aggfunc=form_data.get("aggregateFunction", "Sum"),
         transpose_pivot=bool(form_data.get("transposePivot")),
         combine_metrics=bool(form_data.get("combineMetric")),

--- a/superset/charts/post_processing.py
+++ b/superset/charts/post_processing.py
@@ -336,7 +336,7 @@ def apply_post_process(
         elif query["result_format"] == ChartDataResultFormat.CSV:
             df = pd.read_csv(StringIO(query["data"]))
 
-        # convert metrics to verbose (label) name
+        # convert all columns to verbose (label) name
         if datasource:
             df.rename(columns=datasource.data["verbose_map"], inplace=True)
 

--- a/superset/charts/post_processing.py
+++ b/superset/charts/post_processing.py
@@ -340,7 +340,6 @@ def apply_post_process(
         if datasource:
             df.rename(columns=datasource.data["verbose_map"], inplace=True)
 
-        # key error raise
         processed_df = post_processor(df, form_data, datasource)
 
         query["colnames"] = list(processed_df.columns)

--- a/superset/charts/post_processing.py
+++ b/superset/charts/post_processing.py
@@ -89,7 +89,7 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
         df = df.pivot_table(
             index=rows,
             columns=columns,
-            values=metrics,
+            values=metrics, # [count] => ["count(*)"]
             aggfunc=pivot_v2_aggfunc_map[aggfunc],
             margins=False,
         )
@@ -230,7 +230,7 @@ def pivot_table_v2(
     verbose_map = datasource.data["verbose_map"] if datasource else None
     if form_data.get("granularity_sqla") == "all" and DTTM_ALIAS in df:
         del df[DTTM_ALIAS]
-
+    
     return pivot_df(
         df,
         rows=get_column_names(form_data.get("groupbyRows"), verbose_map),
@@ -336,6 +336,11 @@ def apply_post_process(
         elif query["result_format"] == ChartDataResultFormat.CSV:
             df = pd.read_csv(StringIO(query["data"]))
 
+        # convert metrics to verbose (label) name
+        if datasource: 
+            df.rename(columns=datasource.data["verbose_map"], inplace=True)
+
+        # key error raise
         processed_df = post_processor(df, form_data, datasource)
 
         query["colnames"] = list(processed_df.columns)

--- a/superset/charts/post_processing.py
+++ b/superset/charts/post_processing.py
@@ -89,7 +89,7 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
         df = df.pivot_table(
             index=rows,
             columns=columns,
-            values=metrics, # [count] => ["count(*)"]
+            values=metrics,
             aggfunc=pivot_v2_aggfunc_map[aggfunc],
             margins=False,
         )
@@ -230,12 +230,12 @@ def pivot_table_v2(
     verbose_map = datasource.data["verbose_map"] if datasource else None
     if form_data.get("granularity_sqla") == "all" and DTTM_ALIAS in df:
         del df[DTTM_ALIAS]
-    
+
     return pivot_df(
         df,
         rows=get_column_names(form_data.get("groupbyRows"), verbose_map),
         columns=get_column_names(form_data.get("groupbyColumns"), verbose_map),
-        metrics=get_metric_names(form_data["metrics"]),
+        metrics=get_metric_names(form_data["metrics"], verbose_map),
         aggfunc=form_data.get("aggregateFunction", "Sum"),
         transpose_pivot=bool(form_data.get("transposePivot")),
         combine_metrics=bool(form_data.get("combineMetric")),
@@ -337,7 +337,7 @@ def apply_post_process(
             df = pd.read_csv(StringIO(query["data"]))
 
         # convert metrics to verbose (label) name
-        if datasource: 
+        if datasource:
             df.rename(columns=datasource.data["verbose_map"], inplace=True)
 
         # key error raise

--- a/tests/unit_tests/charts/test_post_processing.py
+++ b/tests/unit_tests/charts/test_post_processing.py
@@ -20,6 +20,7 @@ import json
 import pandas as pd
 from numpy import True_
 from pytest import raises
+from sqlalchemy.orm.session import Session
 
 from superset.charts.post_processing import apply_post_process, pivot_df, table
 from superset.common.chart_data import ChartDataResultFormat
@@ -1960,3 +1961,64 @@ def test_apply_post_process_json_format_data_is_none():
     assert apply_post_process(result, form_data) == {
         "queries": [{"result_format": ChartDataResultFormat.JSON, "data": None}]
     }
+
+
+def test_apply_post_process_verbose_map(session: Session):
+    from superset.connectors.sqla.models import SqlaTable, SqlMetric
+    from superset.models.core import Database
+
+    engine = session.get_bind()
+    SqlaTable.metadata.create_all(engine)  # pylint: disable=no-member
+    db = Database(database_name="my_database", sqlalchemy_uri="sqlite://")
+    sqla_table = SqlaTable(
+        table_name="my_sqla_table",
+        columns=[],
+        metrics=[
+            SqlMetric(
+                metric_name="count",
+                verbose_name="COUNT(*)",
+                metric_type="count",
+                expression="COUNT(*)",
+            )
+        ],
+        database=db,
+    )
+
+    result = {
+        "queries": [
+            {
+                "result_format": ChartDataResultFormat.JSON,
+                "data": [{"count": 4725}],
+            }
+        ]
+    }
+    form_data = {
+        "datasource": "19__table",
+        "viz_type": "pivot_table_v2",
+        "slice_id": 69,
+        "url_params": {},
+        "granularity_sqla": "time_start",
+        "time_grain_sqla": "P1D",
+        "time_range": "No filter",
+        "groupbyColumns": [],
+        "groupbyRows": [],
+        "metrics": ["COUNT(*)"],
+        "metricsLayout": "COLUMNS",
+        "row_limit": 10000,
+        "order_desc": True,
+        "valueFormat": "SMART_NUMBER",
+        "date_format": "smart_date",
+        "rowOrder": "key_a_to_z",
+        "colOrder": "key_a_to_z",
+        "extra_form_data": {},
+        "force": False,
+        "result_format": "json",
+        "result_type": "results",
+    }
+
+    assert (
+        "COUNT(*)"
+        in apply_post_process(result, form_data, datasource=sqla_table)["queries"][0][
+            "data"
+        ].keys()
+    )

--- a/tests/unit_tests/charts/test_post_processing.py
+++ b/tests/unit_tests/charts/test_post_processing.py
@@ -2016,9 +2016,15 @@ def test_apply_post_process_verbose_map(session: Session):
         "result_type": "results",
     }
 
-    assert (
-        "COUNT(*)"
-        in apply_post_process(result, form_data, datasource=sqla_table)["queries"][0][
-            "data"
-        ].keys()
-    )
+    assert apply_post_process(result, form_data, datasource=sqla_table) == {
+        "queries": [
+            {
+                "result_format": ChartDataResultFormat.JSON,
+                "data": {"COUNT(*)": {"Total (Sum)": 4725}},
+                "colnames": [("COUNT(*)",)],
+                "indexnames": [("Total (Sum)",)],
+                "coltypes": [GenericDataType.NUMERIC],
+                "rowcount": 1,
+            }
+        ]
+    }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When executing pivot v2 table report if the `verbose_map` doesn't match up with the df columns we are throwing this error for metric/values. To fix this for pivot v2 table we won't be using the verbose map to change the values/metrics names to have better alignment.

```
Traceback (most recent call last):
File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 1516, in full_dispatch_request
rv = self.dispatch_request()
File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 1502, in dispatch_request
return self.ensure_sync(self.view_functions[rule.endpoint])(*req.view_args)
File "/usr/local/lib/python3.8/site-packages/flask_appbuilder/security/decorators.py", line 89, in wraps
return f(self, *args, *kwargs)
File "/usr/local/lib/python3.8/site-packages/superset/views/base_api.py", line 113, in wraps
raise ex
File "/usr/local/lib/python3.8/site-packages/superset/views/base_api.py", line 110, in wraps
duration, response = time_function(f, self, args, **kwargs)
File "/usr/local/lib/python3.8/site-packages/superset/utils/core.py", line 1533, in time_function
response = func(*args, *kwargs)
File "/usr/local/lib/python3.8/site-packages/superset/utils/log.py", line 244, in wrapper
value = f(args, **kwargs)
File "/usr/local/lib/python3.8/site-packages/superset/charts/data/api.py", line 160, in get_data
return self._get_data_response(
File "/usr/local/lib/python3.8/site-packages/superset/charts/data/api.py", line 396, in _get_data_response
return self._send_chart_response(result, form_data, datasource)
File "/usr/local/lib/python3.8/site-packages/superset/charts/data/api.py", line 343, in _send_chart_response
result = apply_post_process(result, form_data, datasource)
File "/usr/local/lib/python3.8/site-packages/superset/charts/post_processing.py", line 339, in apply_post_process
processed_df = post_processor(df, form_data, datasource)
File "/usr/local/lib/python3.8/site-packages/superset/charts/post_processing.py", line 234, in pivot_table_v2
return pivot_df(
File "/usr/local/lib/python3.8/site-packages/superset/charts/post_processing.py", line 89, in pivot_df
df = df.pivot_table(
File "/usr/local/lib/python3.8/site-packages/pandas/core/frame.py", line 7951, in pivot_table
return pivot_table(
File "/usr/local/lib/python3.8/site-packages/pandas/core/reshape/pivot.py", line 95, in pivot_table
table = __internal_pivot_table(
File "/usr/local/lib/python3.8/site-packages/pandas/core/reshape/pivot.py", line 141, in __internal_pivot_table
raise KeyError(i)
KeyError: 'COUNT()'
```

[Click here to view exception in pandas](https://github.com/pandas-dev/pandas/commit/8f7ba1baa7514379dbb0a70d6b032fbef9a88eb2)



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
