### PR TITLE
fix: making crossFilter.chartsInScope optional

### DIFF
--- a/superset-frontend/src/dashboard/components/FiltersBadge/selectors.ts
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/selectors.ts
@@ -294,7 +294,7 @@ export const selectNativeIndicatorsForChart = (
     const dashboardLayoutValues = Object.values(dashboardLayout);
     crossFilterIndicators = Object.values(chartConfiguration)
       .filter(chartConfig =>
-        chartConfig.crossFilters.chartsInScope.includes(chartId),
+        chartConfig.crossFilters?.chartsInScope?.includes(chartId),
       )
       .map(chartConfig => {
         const filterState = dataMask[chartConfig.id]?.filterState;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
It seems that these ton'g always exist in imported dashboards, which is causing trouble. Hopefully this allows imports to be upgraded to the latest code more smoothly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
REPRO STEPS:
* Roll back to a SHA earlier than https://github.com/apache/superset/pull/20743
* Import a couple of dashboards
* Update Superset to the above SHA (or newer)
* Open imported dashboard(s) in workspace
* See the error blocking dashboard loading

The above should work without error with this fix, if I'm lucky.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
