### PR TITLE
fix(dashboard): Undefined error when crossFilters.chartsInScope is undefined

### DIFF
--- a/superset-frontend/src/dashboard/components/FiltersBadge/selectors.ts
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/selectors.ts
@@ -294,7 +294,7 @@ export const selectNativeIndicatorsForChart = (
     const dashboardLayoutValues = Object.values(dashboardLayout);
     crossFilterIndicators = Object.values(chartConfiguration)
       .filter(chartConfig =>
-        chartConfig.crossFilters.chartsInScope.includes(chartId),
+        chartConfig.crossFilters.chartsInScope?.includes(chartId),
       )
       .map(chartConfig => {
         const filterState = dataMask[chartConfig.id]?.filterState;


### PR DESCRIPTION

### SUMMARY
Fixes undefined error on imported dashboards. Happens when `crossFilters.chartsInScope` is not defined.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
