### PR TITLE
fix(plugin-chart-echarts): invalid total label location for negative values in stacked bar chart

### DIFF
--- a/superset-frontend/packages/superset-ui-demo/storybook/stories/plugins/plugin-chart-echarts/Timeseries/Stories.tsx
+++ b/superset-frontend/packages/superset-ui-demo/storybook/stories/plugins/plugin-chart-echarts/Timeseries/Stories.tsx
@@ -62,7 +62,9 @@ export const Timeseries = ({ width, height }) => {
       chartType="echarts-timeseries"
       width={width}
       height={height}
-      queriesData={[{ data: queryData }]}
+      queriesData={[
+        { data: queryData, colnames: ['__timestamp'], coltypes: [2] },
+      ]}
       formData={{
         contributionMode: undefined,
         forecastEnabled,
@@ -94,7 +96,9 @@ export const WithNegativeNumbers = ({ width, height }) => (
     chartType="echarts-timeseries"
     width={width}
     height={height}
-    queriesData={[{ data: negativeNumData }]}
+    queriesData={[
+      { data: negativeNumData, colnames: ['__timestamp'], coltypes: [2] },
+    ]}
     formData={{
       contributionMode: undefined,
       colorScheme: 'supersetColors',

--- a/superset-frontend/packages/superset-ui-demo/storybook/stories/plugins/plugin-chart-echarts/Timeseries/Stories.tsx
+++ b/superset-frontend/packages/superset-ui-demo/storybook/stories/plugins/plugin-chart-echarts/Timeseries/Stories.tsx
@@ -25,6 +25,7 @@ import {
   TimeseriesTransformProps,
 } from '@superset-ui/plugin-chart-echarts';
 import data from './data';
+import negativeNumData from './negativeNumData';
 import { withResizableChartDemo } from '../../../../shared/components/ResizableChartDemo';
 
 new EchartsTimeseriesChartPlugin()
@@ -87,3 +88,26 @@ export const Timeseries = ({ width, height }) => {
     />
   );
 };
+
+export const WithNegativeNumbers = ({ width, height }) => (
+  <SuperChart
+    chartType="echarts-timeseries"
+    width={width}
+    height={height}
+    queriesData={[{ data: negativeNumData }]}
+    formData={{
+      contributionMode: undefined,
+      colorScheme: 'supersetColors',
+      seriesType: select(
+        'Line type',
+        ['line', 'scatter', 'smooth', 'bar', 'start', 'middle', 'end'],
+        'line',
+      ),
+      yAxisFormat: '$,.2f',
+      stack: true,
+      showValue: true,
+      showLegend: true,
+      onlyTotal: true,
+    }}
+  />
+);

--- a/superset-frontend/packages/superset-ui-demo/storybook/stories/plugins/plugin-chart-echarts/Timeseries/Stories.tsx
+++ b/superset-frontend/packages/superset-ui-demo/storybook/stories/plugins/plugin-chart-echarts/Timeseries/Stories.tsx
@@ -104,10 +104,15 @@ export const WithNegativeNumbers = ({ width, height }) => (
         'line',
       ),
       yAxisFormat: '$,.2f',
-      stack: true,
+      stack: boolean('Stack', true),
       showValue: true,
       showLegend: true,
-      onlyTotal: true,
+      onlyTotal: boolean('Only Total', true),
+      orientation: select(
+        'Orientation',
+        ['vertical', 'horizontal'],
+        'vertical',
+      ),
     }}
   />
 );

--- a/superset-frontend/packages/superset-ui-demo/storybook/stories/plugins/plugin-chart-echarts/Timeseries/negativeNumData.ts
+++ b/superset-frontend/packages/superset-ui-demo/storybook/stories/plugins/plugin-chart-echarts/Timeseries/negativeNumData.ts
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export default [
+  {
+    __timestamp: 1619827200000,
+    Boston: -0.88,
+    NewYork: null,
+    Washington: -0.3,
+    JerseyCity: -3.05,
+    Denver: -8.25,
+    SF: -0.13,
+  },
+  {
+    __timestamp: 1622505600000,
+    Boston: -0.81,
+    NewYork: null,
+    Washington: -0.29,
+    JerseyCity: -3.54,
+    Denver: -13.4,
+    SF: -0.12,
+  },
+  {
+    __timestamp: 1625097600000,
+    Boston: 0.91,
+    NewYork: null,
+    Washington: 0.25,
+    JerseyCity: 7.17,
+    Denver: 7.69,
+    SF: 0.05,
+  },
+  {
+    __timestamp: 1627776000000,
+    Boston: -1.05,
+    NewYork: -1.04,
+    Washington: -0.19,
+    JerseyCity: -8.99,
+    Denver: -7.99,
+    SF: -0.01,
+  },
+  {
+    __timestamp: 1630454400000,
+    Boston: -0.92,
+    NewYork: -1.09,
+    Washington: -0.17,
+    JerseyCity: -8.75,
+    Denver: -7.55,
+    SF: -0.01,
+  },
+  {
+    __timestamp: 1633046400000,
+    Boston: 0.79,
+    NewYork: -0.85,
+    Washington: 0.13,
+    JerseyCity: 12.59,
+    Denver: 3.34,
+    SF: -0.05,
+  },
+  {
+    __timestamp: 1635724800000,
+    Boston: 0.72,
+    NewYork: 0.54,
+    Washington: 0.15,
+    JerseyCity: 11.03,
+    Denver: 7.24,
+    SF: -0.14,
+  },
+  {
+    __timestamp: 1638316800000,
+    Boston: 0.61,
+    NewYork: 0.73,
+    Washington: 0.15,
+    JerseyCity: 13.45,
+    Denver: 5.98,
+    SF: -0.22,
+  },
+  {
+    __timestamp: 1640995200000,
+    Boston: 0.51,
+    NewYork: 1.8,
+    Washington: 0.15,
+    JerseyCity: 12.96,
+    Denver: 3.22,
+    SF: -0.02,
+  },
+  {
+    __timestamp: 1643673600000,
+    Boston: -0.47,
+    NewYork: null,
+    Washington: -0.18,
+    JerseyCity: -14.27,
+    Denver: -6.24,
+    SF: -0.04,
+  },
+];

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -170,6 +170,7 @@ export default function transformProps(
   });
   const showValueIndexes = extractShowValueIndexes(rawSeries, {
     stack,
+    onlyTotal,
   });
   const seriesContexts = extractForecastSeriesContexts(
     Object.values(rawSeries).map(series => series.name as string),

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -171,6 +171,7 @@ export default function transformProps(
   const showValueIndexes = extractShowValueIndexes(rawSeries, {
     stack,
     onlyTotal,
+    isHorizontal,
   });
   const seriesContexts = extractForecastSeriesContexts(
     Object.values(rawSeries).map(series => series.name as string),

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -242,7 +242,8 @@ export function transformSeries(
         if (!stack || isSelectedLegend) return formatter(numericValue);
         if (!onlyTotal) {
           if (
-            numericValue >= (thresholdValues[dataIndex] ?? Number.MIN_VALUE)
+            numericValue >=
+            (thresholdValues[dataIndex] || Number.MIN_SAFE_INTEGER)
           ) {
             return formatter(numericValue);
           }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -241,7 +241,9 @@ export function transformSeries(
         if (!formatter) return numericValue;
         if (!stack || isSelectedLegend) return formatter(numericValue);
         if (!onlyTotal) {
-          if (numericValue >= thresholdValues[dataIndex]) {
+          if (
+            numericValue >= (thresholdValues[dataIndex] ?? Number.MIN_VALUE)
+          ) {
             return formatter(numericValue);
           }
           return '';

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -78,6 +78,7 @@ export function extractShowValueIndexes(
   opts: {
     stack: StackType;
     onlyTotal: boolean;
+    isHorizontal: boolean;
   },
 ): number[] {
   const showValueIndexes: number[] = [];
@@ -85,14 +86,17 @@ export function extractShowValueIndexes(
     series.forEach((entry, seriesIndex) => {
       const { data = [] } = entry;
       (data as [any, number][]).forEach((datum, dataIndex) => {
-        if (!opts.onlyTotal && datum[1] !== null) {
+        if (!opts.onlyTotal && datum[opts.isHorizontal ? 0 : 1] !== null) {
           showValueIndexes[dataIndex] = seriesIndex;
         }
         if (opts.onlyTotal) {
-          if (datum[1] > 0) {
+          if (datum[opts.isHorizontal ? 0 : 1] > 0) {
             showValueIndexes[dataIndex] = seriesIndex;
           }
-          if (!showValueIndexes[dataIndex] && datum[1] !== null) {
+          if (
+            !showValueIndexes[dataIndex] &&
+            datum[opts.isHorizontal ? 0 : 1] !== null
+          ) {
             showValueIndexes[dataIndex] = seriesIndex;
           }
         }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -89,8 +89,10 @@ export function extractShowValueIndexes(
           showValueIndexes[dataIndex] = seriesIndex;
         }
         if (opts.onlyTotal) {
-          showValueIndexes[dataIndex] = showValueIndexes[dataIndex] ?? 0;
           if (datum[1] > 0) {
+            showValueIndexes[dataIndex] = seriesIndex;
+          }
+          if (!showValueIndexes[dataIndex] && datum[1] !== null) {
             showValueIndexes[dataIndex] = seriesIndex;
           }
         }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -77,8 +77,8 @@ export function extractShowValueIndexes(
   series: SeriesOption[],
   opts: {
     stack: StackType;
-    onlyTotal: boolean;
-    isHorizontal: boolean;
+    onlyTotal?: boolean;
+    isHorizontal?: boolean;
   },
 ): number[] {
   const showValueIndexes: number[] = [];

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -77,6 +77,7 @@ export function extractShowValueIndexes(
   series: SeriesOption[],
   opts: {
     stack: StackType;
+    onlyTotal: boolean;
   },
 ): number[] {
   const showValueIndexes: number[] = [];
@@ -84,8 +85,14 @@ export function extractShowValueIndexes(
     series.forEach((entry, seriesIndex) => {
       const { data = [] } = entry;
       (data as [any, number][]).forEach((datum, dataIndex) => {
-        if (datum[1] !== null) {
+        if (!opts.onlyTotal && datum[1] !== null) {
           showValueIndexes[dataIndex] = seriesIndex;
+        }
+        if (opts.onlyTotal) {
+          showValueIndexes[dataIndex] = showValueIndexes[dataIndex] ?? 0;
+          if (datum[1] > 0) {
+            showValueIndexes[dataIndex] = seriesIndex;
+          }
         }
       });
     });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -25,6 +25,7 @@ import {
   getChartPadding,
   getLegendProps,
   sanitizeHtml,
+  extractShowValueIndexes,
 } from '../../src/utils/series';
 import { LegendOrientation, LegendType } from '../../src/types';
 import { defaultLegendPadding } from '../../src/defaults';
@@ -203,6 +204,124 @@ describe('extractGroupbyLabel', () => {
       }),
     ).toEqual('');
     expect(extractGroupbyLabel({})).toEqual('');
+  });
+});
+
+describe('extractShowValueIndexes', () => {
+  it('should return the latest index for stack', () => {
+    expect(
+      extractShowValueIndexes(
+        [
+          {
+            id: 'abc',
+            name: 'abc',
+            data: [
+              ['2000-01-01', null],
+              ['2000-02-01', 0],
+              ['2000-03-01', 1],
+              ['2000-04-01', 0],
+              ['2000-05-01', null],
+              ['2000-06-01', 0],
+              ['2000-07-01', 2],
+              ['2000-08-01', 3],
+              ['2000-09-01', null],
+              ['2000-10-01', null],
+            ],
+          },
+          {
+            id: 'def',
+            name: 'def',
+            data: [
+              ['2000-01-01', null],
+              ['2000-02-01', 0],
+              ['2000-03-01', null],
+              ['2000-04-01', 0],
+              ['2000-05-01', null],
+              ['2000-06-01', 0],
+              ['2000-07-01', 2],
+              ['2000-08-01', 3],
+              ['2000-09-01', null],
+              ['2000-10-01', 0],
+            ],
+          },
+          {
+            id: 'def',
+            name: 'def',
+            data: [
+              ['2000-01-01', null],
+              ['2000-02-01', null],
+              ['2000-03-01', null],
+              ['2000-04-01', null],
+              ['2000-05-01', null],
+              ['2000-06-01', 3],
+              ['2000-07-01', null],
+              ['2000-08-01', null],
+              ['2000-09-01', null],
+              ['2000-10-01', null],
+            ],
+          },
+        ],
+        { stack: true, onlyTotal: false },
+      ),
+    ).toEqual([undefined, 1, 0, 1, undefined, 2, 1, 1, undefined, 1]);
+  });
+
+  it('should handle the negative numbers for total only', () => {
+    expect(
+      extractShowValueIndexes(
+        [
+          {
+            id: 'abc',
+            name: 'abc',
+            data: [
+              ['2000-01-01', null],
+              ['2000-02-01', 0],
+              ['2000-03-01', -1],
+              ['2000-04-01', 0],
+              ['2000-05-01', null],
+              ['2000-06-01', 0],
+              ['2000-07-01', -2],
+              ['2000-08-01', -3],
+              ['2000-09-01', null],
+              ['2000-10-01', null],
+            ],
+          },
+          {
+            id: 'def',
+            name: 'def',
+            data: [
+              ['2000-01-01', null],
+              ['2000-02-01', 0],
+              ['2000-03-01', null],
+              ['2000-04-01', 0],
+              ['2000-05-01', null],
+              ['2000-06-01', 0],
+              ['2000-07-01', 2],
+              ['2000-08-01', -3],
+              ['2000-09-01', null],
+              ['2000-10-01', 0],
+            ],
+          },
+          {
+            id: 'def',
+            name: 'def',
+            data: [
+              ['2000-01-01', null],
+              ['2000-02-01', 0],
+              ['2000-03-01', null],
+              ['2000-04-01', 0],
+              ['2000-05-01', null],
+              ['2000-06-01', 0],
+              ['2000-07-01', -2],
+              ['2000-08-01', 3],
+              ['2000-09-01', null],
+              ['2000-10-01', 0],
+            ],
+          },
+        ],
+        { stack: true, onlyTotal: true },
+      ),
+    ).toEqual([0, 0, 0, 0, 0, 0, 1, 2, 0, 0]);
   });
 });
 

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -309,7 +309,7 @@ describe('extractShowValueIndexes', () => {
               ['2000-01-01', null],
               ['2000-02-01', 0],
               ['2000-03-01', null],
-              ['2000-04-01', 0],
+              ['2000-04-01', 1],
               ['2000-05-01', null],
               ['2000-06-01', 0],
               ['2000-07-01', -2],
@@ -321,7 +321,7 @@ describe('extractShowValueIndexes', () => {
         ],
         { stack: true, onlyTotal: true },
       ),
-    ).toEqual([0, 0, 0, 0, 0, 0, 1, 2, 0, 0]);
+    ).toEqual([undefined, 1, 0, 2, undefined, 1, 1, 2, undefined, 1]);
   });
 });
 

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -261,7 +261,7 @@ describe('extractShowValueIndexes', () => {
             ],
           },
         ],
-        { stack: true, onlyTotal: false },
+        { stack: true, onlyTotal: false, isHorizontal: false },
       ),
     ).toEqual([undefined, 1, 0, 1, undefined, 2, 1, 1, undefined, 1]);
   });
@@ -319,7 +319,7 @@ describe('extractShowValueIndexes', () => {
             ],
           },
         ],
-        { stack: true, onlyTotal: true },
+        { stack: true, onlyTotal: true, isHorizontal: false },
       ),
     ).toEqual([undefined, 1, 0, 2, undefined, 1, 1, 2, undefined, 1]);
   });


### PR DESCRIPTION
### SUMMARY
A stacked chart sets the total value only, the total label displays on top of the most latest non-null data index item.
When the data contains negative values, the stack chart places the item underneath the positive item.
Therefore the total value can be located within the stack bar when a negative value in the most latest index.
This commit fixes the `extractShowValueIndexes` logic by ignoring the negative values for onlyTotal option.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

<img width="497" alt="Screen Shot 2022-08-08 at 4 17 59 PM" src="https://user-images.githubusercontent.com/1392866/183726417-a9f5d47f-aa1b-43c8-bbe3-28df87ef04a3.png">

After:

<img width="498" alt="Screen Shot 2022-08-08 at 4 18 14 PM" src="https://user-images.githubusercontent.com/1392866/183726412-cc23cf05-7af2-4305-8dd4-413f6ef24914.png">


### TESTING INSTRUCTIONS

Storybook

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
