### PR TITLE
fix: [sc-54864] Adds safety check to provide near term fix to save query 

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/connection/callApi/callApi.ts
+++ b/superset-frontend/packages/superset-ui-core/src/connection/callApi/callApi.ts
@@ -155,7 +155,7 @@ export default async function callApi({
             } catch (e) {
               // eslint-disable-next-line no-console
               console.error(
-                `Unable to convert attribut '${key}' to a String(). ${key} is not part of the formData payload for call to ${url}`,
+                `Unable to convert attribute '${key}' to a String(). ${key} is not part of the formData payload for call to ${url}`,
                 value,
                 e,
               );

--- a/superset-frontend/packages/superset-ui-core/src/connection/callApi/callApi.ts
+++ b/superset-frontend/packages/superset-ui-core/src/connection/callApi/callApi.ts
@@ -146,22 +146,22 @@ export default async function callApi({
         Object.keys(payload).forEach(key => {
           const value = (payload as JsonObject)[key] as JsonValue;
           if (typeof value !== 'undefined') {
-            let val;
+            let valueString;
             try {
               // We have seen instances where casting to String() throws error
               // This check allows all valid attributes to be appended to the formData
               // while logging error to console for any attribute that fails the cast to String
-              val = stringify ? JSON.stringify(value) : String(value);
+              valueString = stringify ? JSON.stringify(value) : String(value);
             } catch (e) {
               // eslint-disable-next-line no-console
               console.error(
-                `Unable to convert attribute '${key}' to a String(). ${key} is not part of the formData payload for call to ${url}`,
+                `Unable to convert attribute '${key}' to a String(). '${key}' was not added to the formData in request.body for call to ${url}`,
                 value,
                 e,
               );
             }
-            if (val) {
-              formData.append(key, val);
+            if (valueString !== undefined) {
+              formData.append(key, valueString);
             }
           }
         });

--- a/superset-frontend/packages/superset-ui-core/src/connection/callApi/callApi.ts
+++ b/superset-frontend/packages/superset-ui-core/src/connection/callApi/callApi.ts
@@ -146,10 +146,23 @@ export default async function callApi({
         Object.keys(payload).forEach(key => {
           const value = (payload as JsonObject)[key] as JsonValue;
           if (typeof value !== 'undefined') {
-            formData.append(
-              key,
-              stringify ? JSON.stringify(value) : String(value),
-            );
+            let val;
+            try {
+              // We have seen instances where casting to String() throws error
+              // This check allows all valid attributes to be appended to the formData
+              // while logging error to console for any attribute that fails the cast to String
+              val = stringify ? JSON.stringify(value) : String(value);
+            } catch (e) {
+              // eslint-disable-next-line no-console
+              console.error(
+                `Unable to convert attribut '${key}' to a String(). ${key} is not part of the formData payload for call to ${url}`,
+                value,
+                e,
+              );
+            }
+            if (val) {
+              formData.append(key, val);
+            }
           }
         });
         request.body = formData;

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -908,9 +908,12 @@ export function updateSavedQuery(query) {
         dispatch(addSuccessToast(t('Your query was updated')));
         dispatch(queryEditorSetTitle(query, query.name));
       })
-      .catch(() =>
-        dispatch(addDangerToast(t('Your query could not be updated'))),
-      )
+      .catch(e => {
+        const message = t('Your query could not be updated');
+        // eslint-disable-next-line no-console
+        console.error(message, e);
+        dispatch(addDangerToast(message));
+      })
       .then(() => dispatch(updateQueryEditor(query)));
 }
 


### PR DESCRIPTION

Adds safety check to provide near term fix to save query
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There is an error when casting the columns array to String() for saving queries where the objects in the array are missing the toString method.   This is a near term rapid patch to fix workflow in production which will have a follow up to identify root cause.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Repro steps:
1, go to sql lab and run query (click "RUN")
2, save query using save split button
3, observe confirmation msg
4, go to saved query list and look for save query

Expect:
user can save query using save split button

Actual:
user saw query can not be saved msg and the query did not show in save query list
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
