### PR TITLE
fix: add plain postgres alias

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,10 +64,11 @@ setup(
     zip_safe=False,
     entry_points={
         "console_scripts": ["superset=superset.cli.main:superset"],
-        # the `postgres+psycopg2://` scheme was removed in SQLAlchemy 1.4, add an alias here
-        # to prevent breaking existing databases
+        # the `postgres` and `postgres+psycopg2://` schemes were removed in SQLAlchemy 1.4
+        # add an alias here to prevent breaking existing databases
         "sqlalchemy.dialects": [
-            "postgres.psycopg2=sqlalchemy.dialects.postgresql:dialect"
+            "postgres.psycopg2 = sqlalchemy.dialects.postgresql:dialect",
+            "postgres = sqlalchemy.dialects.postgresql:dialect",
         ],
     },
     install_requires=[


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

We added an alias so that `postgres+psycopg2://` would continue to work after upgrading to SQLAlchemy 1.4 (where "postgres" should be "postgresql"), but forgot to add one for a plain `postgres://` scheme.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

WIP

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
