### PR TITLE
feat: add role, permission, user APIs

### DIFF
--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -28,6 +28,8 @@ from flask_babel import gettext as __, lazy_gettext as _
 from flask_compress import Compress
 from werkzeug.middleware.proxy_fix import ProxyFix
 
+from flask_appbuilder.security.sqla.apis import PermissionApi, PermissionViewMenuApi, \
+    RoleApi, UserApi, ViewMenuApi
 from superset.constants import CHANGE_ME_SECRET_KEY
 from superset.extensions import (
     _event_logger,
@@ -382,6 +384,11 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
             ),
         )
         appbuilder.add_api(SecurityRestApi)
+        appbuilder.add_api(PermissionApi)
+        appbuilder.add_api(PermissionViewMenuApi)
+        appbuilder.add_api(RoleApi)
+        appbuilder.add_api(UserApi)
+        appbuilder.add_api(ViewMenuApi)
         #
         # Conditionally setup email views
         #


### PR DESCRIPTION
### SUMMARY
Integrate role, permission, user APIs on Flask-AppBuilder into Apache Superset
See https://github.com/apache/superset/issues/21050

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
These APIs can be used on Apache Superset Web Service. See the screenshot below.
![스크린샷 2022-08-11 오후 2 59 57](https://user-images.githubusercontent.com/5166067/184073700-5915bf94-1ae6-493f-a1ba-861fb315e9e8.png)

### TESTING INSTRUCTIONS
N/A

### ADDITIONAL INFORMATION
- [x] Required feature flags: Apache Superset 2.0 with [Flask-AppBuilder 4.1.0](https://github.com/dpgaspar/Flask-AppBuilder/releases/tag/v4.1.0) or later versions
- [x] Introduces new feature or API
