### PR TITLE
fix(databases): GSheets and Clickhouse DBs are not allowed to upload files

### DIFF
--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -3560,6 +3560,9 @@
           },
           "name": {
             "type": "string"
+          },
+          "engine_information": {
+            "type": "object"
           }
         },
         "type": "object"
@@ -3745,6 +3748,9 @@
           "sqlalchemy_uri": {
             "maxLength": 1024,
             "type": "string"
+          },
+          "engine_information": {
+            "readOnly": true
           }
         },
         "required": [
@@ -3828,6 +3834,9 @@
           "id": {
             "format": "int32",
             "type": "integer"
+          },
+          "engine_information": {
+            "readOnly": true
           }
         },
         "required": [
@@ -13653,6 +13662,10 @@
                       "sqlalchemy_uri_placeholder": {
                         "description": "Example placeholder for the SQLAlchemy URI",
                         "type": "string"
+                      },
+                      "engine_information": {
+                        "description": "Object with properties we want to expose from our DB engine",
+                        "type": "object"
                       }
                     },
                     "type": "object"

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
@@ -234,7 +234,7 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
       // with allow_file_upload set as True which is not possible from now on
       const allowedDatabasesWithFileUpload =
         json?.result?.filter(
-          (database: any) => database?.engine_information?.allows_file_upload,
+          (database: any) => database?.engine_information?.supports_file_upload,
         ) || [];
       setAllowUploads(allowedDatabasesWithFileUpload?.length >= 1);
     });

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
@@ -42,7 +42,7 @@ import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
 import type { MenuObjectProps } from 'src/views/components/Menu';
 import DatabaseModal from './DatabaseModal';
 
-import { DatabaseObject } from './types';
+import { DatabaseObject, Engines } from './types';
 
 const PAGE_SIZE = 25;
 
@@ -230,7 +230,15 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
     SupersetClient.get({
       endpoint: `/api/v1/database/?q=${rison.encode(payload)}`,
     }).then(({ json }: Record<string, any>) => {
-      setAllowUploads(json.count >= 1);
+      // There might be some existings Gsheets and Clickhouse DBs
+      // with allow_file_upload set as True which is not possible from now on
+      const allowedDatabasesWithFileUpload =
+        json?.result?.filter(
+          (database: any) =>
+            database?.backend !== Engines.GSheet &&
+            database?.backend !== Engines.ClickHouse,
+        ) || [];
+      setAllowUploads(allowedDatabasesWithFileUpload?.length >= 1);
     });
   };
 

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
@@ -42,7 +42,7 @@ import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
 import type { MenuObjectProps } from 'src/views/components/Menu';
 import DatabaseModal from './DatabaseModal';
 
-import { DatabaseObject, Engines } from './types';
+import { DatabaseObject } from './types';
 
 const PAGE_SIZE = 25;
 
@@ -234,9 +234,7 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
       // with allow_file_upload set as True which is not possible from now on
       const allowedDatabasesWithFileUpload =
         json?.result?.filter(
-          (database: any) =>
-            database?.backend !== Engines.GSheet &&
-            database?.backend !== Engines.ClickHouse,
+          (database: any) => database?.engine_information?.allows_file_upload,
         ) || [];
       setAllowUploads(allowedDatabasesWithFileUpload?.length >= 1);
     });

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx
@@ -48,6 +48,8 @@ const ExtraOptions = ({
 }) => {
   const expandableModalIsOpen = !!db?.expose_in_sqllab;
   const createAsOpen = !!(db?.allow_ctas || db?.allow_cvas);
+  const isFileUploadSupportedByEngine =
+    db?.engine !== Engines.GSheet && db?.engine !== Engines.ClickHouse;
 
   return (
     <Collapse
@@ -382,28 +384,9 @@ const ExtraOptions = ({
             )}
           </div>
         </StyledInputContainer>
-        <StyledInputContainer>
-          <div className="control-label">
-            {t('Schemas allowed for CSV upload')}
-          </div>
-          <div className="input-container">
-            <input
-              type="text"
-              name="schemas_allowed_for_file_upload"
-              value={(
-                db?.extra_json?.schemas_allowed_for_file_upload || []
-              ).join(',')}
-              placeholder="schema1,schema2"
-              onChange={onExtraInputChange}
-            />
-          </div>
-          <div className="helper">
-            {t(
-              'A comma-separated list of schemas that CSVs are allowed to upload to.',
-            )}
-          </div>
-        </StyledInputContainer>
-        <StyledInputContainer css={{ no_margin_bottom }}>
+        <StyledInputContainer
+          css={!isFileUploadSupportedByEngine ? no_margin_bottom : {}}
+        >
           <div className="input-container">
             <IndeterminateCheckbox
               id="impersonate_user"
@@ -425,21 +408,41 @@ const ExtraOptions = ({
             />
           </div>
         </StyledInputContainer>
-        {db?.engine !== Engines.GSheet && db?.engine !== Engines.ClickHouse && (
-          <StyledInputContainer css={{ ...no_margin_bottom }}>
+        {isFileUploadSupportedByEngine && (
+          <StyledInputContainer
+            css={!db?.allow_file_upload ? no_margin_bottom : {}}
+          >
             <div className="input-container">
               <IndeterminateCheckbox
                 id="allow_file_upload"
                 indeterminate={false}
                 checked={!!db?.allow_file_upload}
                 onChange={onInputChange}
-                labelText={t('Allow data upload')}
+                labelText={t('Allow file uploads to database')}
               />
-              <InfoTooltip
-                tooltip={t(
-                  'If selected, please set the schemas allowed for data upload in Extra.',
-                )}
+            </div>
+          </StyledInputContainer>
+        )}
+        {isFileUploadSupportedByEngine && !!db?.allow_file_upload && (
+          <StyledInputContainer css={no_margin_bottom}>
+            <div className="control-label">
+              {t('Schemas allowed for File upload')}
+            </div>
+            <div className="input-container">
+              <input
+                type="text"
+                name="schemas_allowed_for_file_upload"
+                value={(
+                  db?.extra_json?.schemas_allowed_for_file_upload || []
+                ).join(',')}
+                placeholder="schema1,schema2"
+                onChange={onExtraInputChange}
               />
+            </div>
+            <div className="helper">
+              {t(
+                'A comma-separated list of schemas that files are allowed to upload to.',
+              )}
             </div>
           </StyledInputContainer>
         )}

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx
@@ -29,7 +29,7 @@ import {
   antdCollapseStyles,
   no_margin_bottom,
 } from './styles';
-import { DatabaseObject } from '../types';
+import { DatabaseObject, Engines } from '../types';
 
 const ExtraOptions = ({
   db,
@@ -425,22 +425,24 @@ const ExtraOptions = ({
             />
           </div>
         </StyledInputContainer>
-        <StyledInputContainer css={{ ...no_margin_bottom }}>
-          <div className="input-container">
-            <IndeterminateCheckbox
-              id="allow_file_upload"
-              indeterminate={false}
-              checked={!!db?.allow_file_upload}
-              onChange={onInputChange}
-              labelText={t('Allow data upload')}
-            />
-            <InfoTooltip
-              tooltip={t(
-                'If selected, please set the schemas allowed for data upload in Extra.',
-              )}
-            />
-          </div>
-        </StyledInputContainer>
+        {db?.engine !== Engines.GSheet && db?.engine !== Engines.ClickHouse && (
+          <StyledInputContainer css={{ ...no_margin_bottom }}>
+            <div className="input-container">
+              <IndeterminateCheckbox
+                id="allow_file_upload"
+                indeterminate={false}
+                checked={!!db?.allow_file_upload}
+                onChange={onInputChange}
+                labelText={t('Allow data upload')}
+              />
+              <InfoTooltip
+                tooltip={t(
+                  'If selected, please set the schemas allowed for data upload in Extra.',
+                )}
+              />
+            </div>
+          </StyledInputContainer>
+        )}
       </Collapse.Panel>
       <Collapse.Panel
         header={

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx
@@ -49,7 +49,7 @@ const ExtraOptions = ({
   const expandableModalIsOpen = !!db?.expose_in_sqllab;
   const createAsOpen = !!(db?.allow_ctas || db?.allow_cvas);
   const isFileUploadSupportedByEngine =
-    db?.engine_information?.allows_file_upload;
+    db?.engine_information?.supports_file_upload;
 
   return (
     <Collapse

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx
@@ -29,7 +29,7 @@ import {
   antdCollapseStyles,
   no_margin_bottom,
 } from './styles';
-import { DatabaseObject, Engines } from '../types';
+import { DatabaseObject } from '../types';
 
 const ExtraOptions = ({
   db,
@@ -49,7 +49,7 @@ const ExtraOptions = ({
   const expandableModalIsOpen = !!db?.expose_in_sqllab;
   const createAsOpen = !!(db?.allow_ctas || db?.allow_cvas);
   const isFileUploadSupportedByEngine =
-    db?.engine !== Engines.GSheet && db?.engine !== Engines.ClickHouse;
+    db?.engine_information?.allows_file_upload;
 
   return (
     <Collapse

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.test.jsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.test.jsx
@@ -779,9 +779,13 @@ describe('DatabaseModal', () => {
         name: /right security add extra connection information\./i,
       });
       const allowFileUploadCheckbox = screen.getByRole('checkbox', {
-        name: /allow data upload/i,
+        name: /Allow file uploads/i,
       });
-      const allowFileUploadText = screen.getByText(/allow data upload/i);
+      const allowFileUploadText = screen.getByText(/Allow file uploads/i);
+
+      const schemasForFileUploadText = screen.queryByText(
+        /Schemas allowed for File upload/i,
+      );
 
       const visibleComponents = [
         closeButton,
@@ -807,6 +811,91 @@ describe('DatabaseModal', () => {
       invisibleComponents.forEach(component => {
         expect(component).not.toBeVisible();
       });
+      expect(schemasForFileUploadText).not.toBeInTheDocument();
+    });
+
+    it('renders the "Advanced" - SECURITY tab correctly after selecting Allow file uploads', async () => {
+      // ---------- Components ----------
+      // On step 1, click dbButton to access step 2
+      userEvent.click(
+        screen.getByRole('button', {
+          name: /sqlite/i,
+        }),
+      );
+      // Click the "Advanced" tab
+      userEvent.click(screen.getByRole('tab', { name: /advanced/i }));
+      // Click the "Security" tab
+      userEvent.click(
+        screen.getByRole('tab', {
+          name: /right security add extra connection information\./i,
+        }),
+      );
+      // Click the "Allow file uploads" tab
+
+      const allowFileUploadCheckbox = screen.getByRole('checkbox', {
+        name: /Allow file uploads/i,
+      });
+      userEvent.click(allowFileUploadCheckbox);
+
+      // ----- BEGIN STEP 2 (ADVANCED - SECURITY)
+      // <TabHeader> - AntD header
+      const closeButton = screen.getByRole('button', { name: /close/i });
+      const advancedHeader = screen.getByRole('heading', {
+        name: /connect a database/i,
+      });
+      // <ModalHeader> - Connection header
+      const basicHelper = screen.getByText(/step 2 of 2/i);
+      const basicHeaderTitle = screen.getByText(/enter primary credentials/i);
+      const basicHeaderSubtitle = screen.getByText(
+        /need help\? learn how to connect your database \./i,
+      );
+      const basicHeaderLink = within(basicHeaderSubtitle).getByRole('link', {
+        name: /here/i,
+      });
+      // <Tabs> - Basic/Advanced tabs
+      const basicTab = screen.getByRole('tab', { name: /basic/i });
+      const advancedTab = screen.getByRole('tab', { name: /advanced/i });
+      // <ExtraOptions> - Advanced tabs
+      const sqlLabTab = screen.getByRole('tab', {
+        name: /right sql lab adjust how this database will interact with sql lab\./i,
+      });
+      const performanceTab = screen.getByRole('tab', {
+        name: /right performance adjust performance settings of this database\./i,
+      });
+      const securityTab = screen.getByRole('tab', {
+        name: /right security add extra connection information\./i,
+      });
+      const allowFileUploadText = screen.getByText(/Allow file uploads/i);
+
+      const schemasForFileUploadText = screen.queryByText(
+        /Schemas allowed for File upload/i,
+      );
+
+      const visibleComponents = [
+        closeButton,
+        advancedHeader,
+        basicHelper,
+        basicHeaderTitle,
+        basicHeaderSubtitle,
+        basicHeaderLink,
+        basicTab,
+        advancedTab,
+        sqlLabTab,
+        performanceTab,
+        securityTab,
+        allowFileUploadText,
+      ];
+      // These components exist in the DOM but are not visible
+      const invisibleComponents = [allowFileUploadCheckbox];
+
+      // ---------- Assertions ----------
+      visibleComponents.forEach(component => {
+        expect(component).toBeVisible();
+      });
+      invisibleComponents.forEach(component => {
+        expect(component).not.toBeVisible();
+      });
+      expect(schemasForFileUploadText).toBeInTheDocument();
     });
 
     test('renders the "Advanced" - OTHER tab correctly', async () => {
@@ -1143,7 +1232,10 @@ describe('DatabaseModal', () => {
       const impersonateLoggerUserText = screen.getByText(
         /impersonate logged in/i,
       );
-      const allowFileUploadText = screen.queryByText(/allow data upload/i);
+      const allowFileUploadText = screen.queryByText(/Allow file uploads/i);
+      const schemasForFileUploadText = screen.queryByText(
+        /Schemas allowed for File upload/i,
+      );
 
       const visibleComponents = [impersonateLoggerUserText];
       // These components exist in the DOM but are not visible
@@ -1157,6 +1249,7 @@ describe('DatabaseModal', () => {
         expect(component).not.toBeVisible();
       });
       expect(allowFileUploadText).not.toBeInTheDocument();
+      expect(schemasForFileUploadText).not.toBeInTheDocument();
     });
   });
 });

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.test.jsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.test.jsx
@@ -99,12 +99,18 @@ fetchMock.mock(AVAILABLE_DB_ENDPOINT, {
       preferred: true,
       sqlalchemy_uri_placeholder:
         'postgresql://user:password@host:port/dbname[?key=value&key=value...]',
+      engine_information: {
+        allows_file_upload: true,
+      },
     },
     {
       available_drivers: ['rest'],
       engine: 'presto',
       name: 'Presto',
       preferred: true,
+      engine_information: {
+        allows_file_upload: true,
+      },
     },
     {
       available_drivers: ['mysqldb'],
@@ -154,18 +160,27 @@ fetchMock.mock(AVAILABLE_DB_ENDPOINT, {
       preferred: true,
       sqlalchemy_uri_placeholder:
         'mysql://user:password@host:port/dbname[?key=value&key=value...]',
+      engine_information: {
+        allows_file_upload: true,
+      },
     },
     {
       available_drivers: ['pysqlite'],
       engine: 'sqlite',
       name: 'SQLite',
       preferred: true,
+      engine_information: {
+        allows_file_upload: true,
+      },
     },
     {
       available_drivers: ['rest'],
       engine: 'druid',
       name: 'Apache Druid',
       preferred: false,
+      engine_information: {
+        allows_file_upload: true,
+      },
     },
     {
       available_drivers: ['bigquery'],
@@ -187,6 +202,9 @@ fetchMock.mock(AVAILABLE_DB_ENDPOINT, {
       },
       preferred: false,
       sqlalchemy_uri_placeholder: 'bigquery://{project_id}',
+      engine_information: {
+        allows_file_upload: true,
+      },
     },
     {
       available_drivers: ['rest'],
@@ -194,6 +212,9 @@ fetchMock.mock(AVAILABLE_DB_ENDPOINT, {
       engine: 'gsheets',
       name: 'Google Sheets',
       preferred: false,
+      engine_information: {
+        allows_file_upload: false,
+      },
     },
   ],
 });
@@ -779,9 +800,11 @@ describe('DatabaseModal', () => {
         name: /right security add extra connection information\./i,
       });
       const allowFileUploadCheckbox = screen.getByRole('checkbox', {
-        name: /Allow file uploads/i,
+        name: /Allow file uploads to database/i,
       });
-      const allowFileUploadText = screen.getByText(/Allow file uploads/i);
+      const allowFileUploadText = screen.getByText(
+        /Allow file uploads to database/i,
+      );
 
       const schemasForFileUploadText = screen.queryByText(
         /Schemas allowed for File upload/i,
@@ -833,7 +856,7 @@ describe('DatabaseModal', () => {
       // Click the "Allow file uploads" tab
 
       const allowFileUploadCheckbox = screen.getByRole('checkbox', {
-        name: /Allow file uploads/i,
+        name: /Allow file uploads to database/i,
       });
       userEvent.click(allowFileUploadCheckbox);
 
@@ -865,7 +888,9 @@ describe('DatabaseModal', () => {
       const securityTab = screen.getByRole('tab', {
         name: /right security add extra connection information\./i,
       });
-      const allowFileUploadText = screen.getByText(/Allow file uploads/i);
+      const allowFileUploadText = screen.getByText(
+        /Allow file uploads to database/i,
+      );
 
       const schemasForFileUploadText = screen.queryByText(
         /Schemas allowed for File upload/i,
@@ -1232,7 +1257,9 @@ describe('DatabaseModal', () => {
       const impersonateLoggerUserText = screen.getByText(
         /impersonate logged in/i,
       );
-      const allowFileUploadText = screen.queryByText(/Allow file uploads/i);
+      const allowFileUploadText = screen.queryByText(
+        /Allow file uploads to database/i,
+      );
       const schemasForFileUploadText = screen.queryByText(
         /Schemas allowed for File upload/i,
       );

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.test.jsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.test.jsx
@@ -100,7 +100,7 @@ fetchMock.mock(AVAILABLE_DB_ENDPOINT, {
       sqlalchemy_uri_placeholder:
         'postgresql://user:password@host:port/dbname[?key=value&key=value...]',
       engine_information: {
-        allows_file_upload: true,
+        supports_file_upload: true,
       },
     },
     {
@@ -109,7 +109,7 @@ fetchMock.mock(AVAILABLE_DB_ENDPOINT, {
       name: 'Presto',
       preferred: true,
       engine_information: {
-        allows_file_upload: true,
+        supports_file_upload: true,
       },
     },
     {
@@ -161,7 +161,7 @@ fetchMock.mock(AVAILABLE_DB_ENDPOINT, {
       sqlalchemy_uri_placeholder:
         'mysql://user:password@host:port/dbname[?key=value&key=value...]',
       engine_information: {
-        allows_file_upload: true,
+        supports_file_upload: true,
       },
     },
     {
@@ -170,7 +170,7 @@ fetchMock.mock(AVAILABLE_DB_ENDPOINT, {
       name: 'SQLite',
       preferred: true,
       engine_information: {
-        allows_file_upload: true,
+        supports_file_upload: true,
       },
     },
     {
@@ -179,7 +179,7 @@ fetchMock.mock(AVAILABLE_DB_ENDPOINT, {
       name: 'Apache Druid',
       preferred: false,
       engine_information: {
-        allows_file_upload: true,
+        supports_file_upload: true,
       },
     },
     {
@@ -203,7 +203,7 @@ fetchMock.mock(AVAILABLE_DB_ENDPOINT, {
       preferred: false,
       sqlalchemy_uri_placeholder: 'bigquery://{project_id}',
       engine_information: {
-        allows_file_upload: true,
+        supports_file_upload: true,
       },
     },
     {
@@ -213,7 +213,7 @@ fetchMock.mock(AVAILABLE_DB_ENDPOINT, {
       name: 'Google Sheets',
       preferred: false,
       engine_information: {
-        allows_file_upload: false,
+        supports_file_upload: false,
       },
     },
   ],

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -175,6 +175,7 @@ type DBReducerActionType =
         database_name?: string;
         engine?: string;
         configuration_method: CONFIGURATION_METHOD;
+        engine_information?: {};
       };
     }
   | {
@@ -718,7 +719,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
       const selectedDbModel = availableDbs?.databases.filter(
         (db: DatabaseObject) => db.name === database_name,
       )[0];
-      const { engine, parameters } = selectedDbModel;
+      const { engine, parameters, engine_information } = selectedDbModel;
       const isDynamic = parameters !== undefined;
       setDB({
         type: ActionType.dbSelected,
@@ -728,6 +729,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
           configuration_method: isDynamic
             ? CONFIGURATION_METHOD.DYNAMIC_FORM
             : CONFIGURATION_METHOD.SQLALCHEMY_URI,
+          engine_information,
         },
       });
     }

--- a/superset-frontend/src/views/CRUD/data/database/types.ts
+++ b/superset-frontend/src/views/CRUD/data/database/types.ts
@@ -102,6 +102,11 @@ export type DatabaseObject = {
   catalog?: Array<CatalogObject>;
   query_input?: string;
   extra?: string;
+
+  // DB Engine Spec information
+  engine_information?: {
+    allows_file_upload?: boolean;
+  };
 };
 
 export type DatabaseForm = {

--- a/superset-frontend/src/views/CRUD/data/database/types.ts
+++ b/superset-frontend/src/views/CRUD/data/database/types.ts
@@ -105,7 +105,7 @@ export type DatabaseObject = {
 
   // DB Engine Spec information
   engine_information?: {
-    allows_file_upload?: boolean;
+    supports_file_upload?: boolean;
   };
 };
 

--- a/superset-frontend/src/views/components/RightMenu.test.tsx
+++ b/superset-frontend/src/views/components/RightMenu.test.tsx
@@ -100,7 +100,7 @@ const mockNonGSheetsDBs = [...new Array(2)].map((_, i) => ({
   changed_on: new Date().toISOString,
   id: i,
   engine_information: {
-    allows_file_upload: true,
+    supports_file_upload: true,
   },
 }));
 
@@ -119,7 +119,7 @@ const mockGsheetsDbs = [...new Array(2)].map((_, i) => ({
   changed_on: new Date().toISOString,
   id: i,
   engine_information: {
-    allows_file_upload: false,
+    supports_file_upload: false,
   },
 }));
 

--- a/superset-frontend/src/views/components/RightMenu.test.tsx
+++ b/superset-frontend/src/views/components/RightMenu.test.tsx
@@ -1,0 +1,258 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import * as reactRedux from 'react-redux';
+import fetchMock from 'fetch-mock';
+import waitForComponentToPaint from 'spec/helpers/waitForComponentToPaint';
+import { styledMount as mount } from 'spec/helpers/theming';
+import RightMenu from './RightMenu';
+import { RightMenuProps } from './types';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+}));
+
+const createProps = (): RightMenuProps => ({
+  align: 'flex-end',
+  navbarRight: {
+    show_watermark: false,
+    bug_report_url: '/report/',
+    documentation_url: '/docs/',
+    languages: {
+      en: {
+        flag: 'us',
+        name: 'English',
+        url: '/lang/en',
+      },
+      it: {
+        flag: 'it',
+        name: 'Italian',
+        url: '/lang/it',
+      },
+    },
+    show_language_picker: true,
+    user_is_anonymous: true,
+    user_info_url: '/users/userinfo/',
+    user_logout_url: '/logout/',
+    user_login_url: '/login/',
+    user_profile_url: '/profile/',
+    locale: 'en',
+    version_string: '1.0.0',
+    version_sha: 'randomSHA',
+    build_number: 'randomBuildNumber',
+  },
+  settings: [
+    {
+      name: 'Security',
+      icon: 'fa-cogs',
+      label: 'Security',
+      index: 1,
+      childs: [
+        {
+          name: 'List Users',
+          icon: 'fa-user',
+          label: 'List Users',
+          url: '/users/list/',
+          index: 1,
+        },
+      ],
+    },
+  ],
+  isFrontendRoute: () => true,
+});
+
+const useSelectorMock = jest.spyOn(reactRedux, 'useSelector');
+const useStateMock = jest.spyOn(React, 'useState');
+
+let setShowModal: any;
+let setEngine: any;
+let setAllowUploads: any;
+
+const mockNonGSheetsDBs = [...new Array(2)].map((_, i) => ({
+  changed_by: {
+    first_name: `user`,
+    last_name: `${i}`,
+  },
+  database_name: `db ${i}`,
+  backend: 'postgresql',
+  allow_run_async: true,
+  allow_dml: false,
+  allow_file_upload: true,
+  expose_in_sqllab: false,
+  changed_on_delta_humanized: `${i} day(s) ago`,
+  changed_on: new Date().toISOString,
+  id: i,
+}));
+
+const mockGsheetsDbs = [...new Array(2)].map((_, i) => ({
+  changed_by: {
+    first_name: `user`,
+    last_name: `${i}`,
+  },
+  database_name: `db ${i}`,
+  backend: 'gsheets',
+  allow_run_async: true,
+  allow_dml: false,
+  allow_file_upload: true,
+  expose_in_sqllab: false,
+  changed_on_delta_humanized: `${i} day(s) ago`,
+  changed_on: new Date().toISOString,
+  id: i,
+}));
+
+describe('RightMenu', () => {
+  const mockedProps = createProps();
+
+  beforeEach(async () => {
+    useSelectorMock.mockReset();
+    useStateMock.mockReset();
+    fetchMock.get(
+      'glob:*api/v1/database/?q=(filters:!((col:allow_file_upload,opr:upload_is_enabled,value:!t)))',
+      { result: [], database_count: 0 },
+    );
+    // By default we get file extensions to be uploaded
+    useSelectorMock.mockReturnValue({
+      CSV_EXTENSIONS: ['csv'],
+      EXCEL_EXTENSIONS: ['xls', 'xlsx'],
+      COLUMNAR_EXTENSIONS: ['parquet', 'zip'],
+      ALLOWED_EXTENSIONS: ['parquet', 'zip', 'xls', 'xlsx', 'csv'],
+    });
+    setShowModal = jest.fn();
+    setEngine = jest.fn();
+    setAllowUploads = jest.fn();
+    const mockSetStateModal: any = (x: any) => [x, setShowModal];
+    const mockSetStateEngine: any = (x: any) => [x, setEngine];
+    const mockSetStateAllow: any = (x: any) => [x, setAllowUploads];
+    useStateMock.mockImplementationOnce(mockSetStateModal);
+    useStateMock.mockImplementationOnce(mockSetStateEngine);
+    useStateMock.mockImplementationOnce(mockSetStateAllow);
+  });
+  afterEach(fetchMock.restore);
+  it('renders', async () => {
+    const wrapper = mount(<RightMenu {...mockedProps} />);
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.find(RightMenu)).toExist();
+  });
+  it('If user has permission to upload files we query the existing DBs that has allow_file_upload as True', async () => {
+    useSelectorMock.mockReturnValueOnce({
+      createdOn: '2021-04-27T18:12:38.952304',
+      email: 'admin',
+      firstName: 'admin',
+      isActive: true,
+      lastName: 'admin',
+      permissions: {},
+      roles: {
+        Admin: [
+          ['can_this_form_get', 'CsvToDatabaseView'], // So we can upload CSV
+        ],
+      },
+      userId: 1,
+      username: 'admin',
+    });
+    // Second call we get the dashboardId
+    useSelectorMock.mockReturnValueOnce('1');
+    const wrapper = mount(<RightMenu {...mockedProps} />);
+    await waitForComponentToPaint(wrapper);
+    const callsD = fetchMock.calls(/database\/\?q/);
+    expect(callsD).toHaveLength(1);
+    expect(callsD[0][0]).toMatchInlineSnapshot(
+      `"http://localhost/api/v1/database/?q=(filters:!((col:allow_file_upload,opr:upload_is_enabled,value:!t)))"`,
+    );
+  });
+  it('If user has no permission to upload files the query API should not be called', async () => {
+    useSelectorMock.mockReturnValueOnce({
+      createdOn: '2021-04-27T18:12:38.952304',
+      email: 'admin',
+      firstName: 'admin',
+      isActive: true,
+      lastName: 'admin',
+      permissions: {},
+      roles: {
+        Admin: [['can_write', 'Chart']], // no file permissions
+      },
+      userId: 1,
+      username: 'admin',
+    });
+    // Second call we get the dashboardId
+    useSelectorMock.mockReturnValueOnce('1');
+    const wrapper = mount(<RightMenu {...mockedProps} />);
+    await waitForComponentToPaint(wrapper);
+    const callsD = fetchMock.calls(/database\/\?q/);
+    expect(callsD).toHaveLength(0);
+  });
+  it('If user has permission to upload files but there are only gsheets and clickhouse DBs', async () => {
+    fetchMock.get(
+      'glob:*api/v1/database/?q=(filters:!((col:allow_file_upload,opr:upload_is_enabled,value:!t)))',
+      { result: [...mockGsheetsDbs], database_count: 2 },
+      { overwriteRoutes: true },
+    );
+    useSelectorMock.mockReturnValueOnce({
+      createdOn: '2021-04-27T18:12:38.952304',
+      email: 'admin',
+      firstName: 'admin',
+      isActive: true,
+      lastName: 'admin',
+      permissions: {},
+      roles: {
+        Admin: [
+          ['can_this_form_get', 'CsvToDatabaseView'], // So we can upload CSV
+        ],
+      },
+      userId: 1,
+      username: 'admin',
+    });
+    // Second call we get the dashboardId
+    useSelectorMock.mockReturnValueOnce('1');
+    const wrapper = mount(<RightMenu {...mockedProps} />);
+    await waitForComponentToPaint(wrapper);
+    const callsD = fetchMock.calls(/database\/\?q/);
+    expect(callsD).toHaveLength(1);
+    expect(setAllowUploads).toHaveBeenCalledWith(false);
+  });
+  it('If user has permission to upload files and some DBs with allow_file_upload are not gsheets nor clickhouse', async () => {
+    fetchMock.get(
+      'glob:*api/v1/database/?q=(filters:!((col:allow_file_upload,opr:upload_is_enabled,value:!t)))',
+      { result: [...mockNonGSheetsDBs, ...mockGsheetsDbs], database_count: 2 },
+      { overwriteRoutes: true },
+    );
+    useSelectorMock.mockReturnValueOnce({
+      createdOn: '2021-04-27T18:12:38.952304',
+      email: 'admin',
+      firstName: 'admin',
+      isActive: true,
+      lastName: 'admin',
+      permissions: {},
+      roles: {
+        Admin: [
+          ['can_this_form_get', 'CsvToDatabaseView'], // So we can upload CSV
+        ],
+      },
+      userId: 1,
+      username: 'admin',
+    });
+    // Second call we get the dashboardId
+    useSelectorMock.mockReturnValueOnce('1');
+    const wrapper = mount(<RightMenu {...mockedProps} />);
+    await waitForComponentToPaint(wrapper);
+    const callsD = fetchMock.calls(/database\/\?q/);
+    expect(callsD).toHaveLength(1);
+    expect(setAllowUploads).toHaveBeenCalledWith(true);
+  });
+});

--- a/superset-frontend/src/views/components/RightMenu.test.tsx
+++ b/superset-frontend/src/views/components/RightMenu.test.tsx
@@ -76,6 +76,10 @@ const createProps = (): RightMenuProps => ({
     },
   ],
   isFrontendRoute: () => true,
+  environmentTag: {
+    color: 'error.base',
+    text: 'Development',
+  },
 });
 
 const useSelectorMock = jest.spyOn(reactRedux, 'useSelector');

--- a/superset-frontend/src/views/components/RightMenu.test.tsx
+++ b/superset-frontend/src/views/components/RightMenu.test.tsx
@@ -99,6 +99,9 @@ const mockNonGSheetsDBs = [...new Array(2)].map((_, i) => ({
   changed_on_delta_humanized: `${i} day(s) ago`,
   changed_on: new Date().toISOString,
   id: i,
+  engine_information: {
+    allows_file_upload: true,
+  },
 }));
 
 const mockGsheetsDbs = [...new Array(2)].map((_, i) => ({
@@ -115,6 +118,9 @@ const mockGsheetsDbs = [...new Array(2)].map((_, i) => ({
   changed_on_delta_humanized: `${i} day(s) ago`,
   changed_on: new Date().toISOString,
   id: i,
+  engine_information: {
+    allows_file_upload: false,
+  },
 }));
 
 describe('RightMenu', () => {

--- a/superset-frontend/src/views/components/RightMenu.tsx
+++ b/superset-frontend/src/views/components/RightMenu.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { Fragment, useState, useEffect } from 'react';
+import React, { Fragment, useEffect } from 'react';
 import rison from 'rison';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
@@ -48,6 +48,7 @@ import {
   RightMenuProps,
 } from './types';
 import { MenuObjectProps } from './Menu';
+import { Engines } from '../CRUD/data/database/types';
 
 const extensionsRegistry = getExtensionsRegistry();
 
@@ -118,8 +119,8 @@ const RightMenu = ({
     ALLOWED_EXTENSIONS,
     HAS_GSHEETS_INSTALLED,
   } = useSelector<any, ExtentionConfigs>(state => state.common.conf);
-  const [showModal, setShowModal] = useState<boolean>(false);
-  const [engine, setEngine] = useState<string>('');
+  const [showModal, setShowModal] = React.useState<boolean>(false);
+  const [engine, setEngine] = React.useState<string>('');
   const canSql = findPermission('can_sqllab', 'Superset', roles);
   const canDashboard = findPermission('can_write', 'Dashboard', roles);
   const canChart = findPermission('can_write', 'Chart', roles);
@@ -135,7 +136,7 @@ const RightMenu = ({
     );
 
   const showActionDropdown = canSql || canChart || canDashboard;
-  const [allowUploads, setAllowUploads] = useState<boolean>(false);
+  const [allowUploads, setAllowUploads] = React.useState<boolean>(false);
   const isAdmin = isUserAdmin(user);
   const showUploads = allowUploads || isAdmin;
   const dropdownItems: MenuObjectProps[] = [
@@ -207,7 +208,15 @@ const RightMenu = ({
     SupersetClient.get({
       endpoint: `/api/v1/database/?q=${rison.encode(payload)}`,
     }).then(({ json }: Record<string, any>) => {
-      setAllowUploads(json.count >= 1);
+      // There might be some existings Gsheets and Clickhouse DBs
+      // with allow_file_upload set as True which is not possible from now on
+      const allowedDatabasesWithFileUpload =
+        json?.result?.filter(
+          (database: any) =>
+            database?.backend !== Engines.GSheet &&
+            database?.backend !== Engines.ClickHouse,
+        ) || [];
+      setAllowUploads(allowedDatabasesWithFileUpload?.length >= 1);
     });
   };
 

--- a/superset-frontend/src/views/components/RightMenu.tsx
+++ b/superset-frontend/src/views/components/RightMenu.tsx
@@ -211,7 +211,7 @@ const RightMenu = ({
       // with allow_file_upload set as True which is not possible from now on
       const allowedDatabasesWithFileUpload =
         json?.result?.filter(
-          (database: any) => database?.engine_information?.allows_file_upload,
+          (database: any) => database?.engine_information?.supports_file_upload,
         ) || [];
       setAllowUploads(allowedDatabasesWithFileUpload?.length >= 1);
     });

--- a/superset-frontend/src/views/components/RightMenu.tsx
+++ b/superset-frontend/src/views/components/RightMenu.tsx
@@ -48,7 +48,6 @@ import {
   RightMenuProps,
 } from './types';
 import { MenuObjectProps } from './Menu';
-import { Engines } from '../CRUD/data/database/types';
 
 const extensionsRegistry = getExtensionsRegistry();
 
@@ -212,9 +211,7 @@ const RightMenu = ({
       // with allow_file_upload set as True which is not possible from now on
       const allowedDatabasesWithFileUpload =
         json?.result?.filter(
-          (database: any) =>
-            database?.backend !== Engines.GSheet &&
-            database?.backend !== Engines.ClickHouse,
+          (database: any) => database?.engine_information?.allows_file_upload,
         ) || [];
       setAllowUploads(allowedDatabasesWithFileUpload?.length >= 1);
     });
@@ -250,7 +247,7 @@ const RightMenu = ({
   const isDisabled = isAdmin && !allowUploads;
 
   const tooltipText = t(
-    "Enable 'Allow data upload' in any database's settings",
+    "Enable 'Allow file uploads to database' in any database's settings",
   );
 
   const buildMenuItem = (item: Record<string, any>) => {

--- a/superset-frontend/src/views/components/SubMenu.tsx
+++ b/superset-frontend/src/views/components/SubMenu.tsx
@@ -302,7 +302,7 @@ const SubMenuComponent: React.FunctionComponent<SubMenuProps> = props => {
                         <Tooltip
                           placement="top"
                           title={t(
-                            "Enable 'Allow data upload' in any database's settings",
+                            "Enable 'Allow file uploads to database' in any database's settings",
                           )}
                         >
                           {item.label}

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -130,6 +130,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         "server_cert",
         "sqlalchemy_uri",
         "is_managed_externally",
+        "engine_information",
     ]
     list_columns = [
         "allow_file_upload",
@@ -153,6 +154,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         "force_ctas_schema",
         "id",
         "disable_data_preview",
+        "engine_information",
     ]
     add_columns = [
         "database_name",
@@ -1065,6 +1067,13 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
                         parameters:
                           description: JSON schema defining the needed parameters
                           type: object
+                        engine_information:
+                          description: Dict with public properties form the DB Engine
+                          type: object
+                          properties:
+                            allows_file_upload:
+                              description: Whether the engine supports file uploads
+                              type: boolean
             400:
               $ref: '#/components/responses/400'
             500:
@@ -1081,6 +1090,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
                 "engine": engine_spec.engine,
                 "available_drivers": sorted(drivers),
                 "preferred": engine_spec.engine_name in preferred_databases,
+                "engine_information": engine_spec.get_public_information(),
             }
 
             if engine_spec.default_driver:

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -1071,7 +1071,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
                           description: Dict with public properties form the DB Engine
                           type: object
                           properties:
-                            allows_file_upload:
+                            supports_file_upload:
                               description: Whether the engine supports file uploads
                               type: boolean
             400:

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -363,7 +363,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
 
     # Whether the engine supports file uploads
     # if True, database will be listed as option in the upload file form
-    allows_file_upload = True
+    supports_file_upload = True
 
     @classmethod
     def supports_url(cls, url: URL) -> bool:
@@ -1689,10 +1689,10 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         """
         Construct a Dict with properties we want to expose.
 
-        :returns: Dict with properties of our class like allows_file_upload
+        :returns: Dict with properties of our class like supports_file_upload
         """
         return {
-            "allows_file_upload": cls.allows_file_upload,
+            "supports_file_upload": cls.supports_file_upload,
         }
 
 

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1684,6 +1684,17 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         """
         return new
 
+    @classmethod
+    def get_public_information(cls) -> Dict[str, Any]:
+        """
+        Construct a Dict with properties we want to expose.
+
+        :returns: Dict with properties of our class like allows_file_upload
+        """
+        return {
+            "allows_file_upload": cls.allows_file_upload,
+        }
+
 
 # schema for adding a database by providing parameters instead of the
 # full SQLAlchemy URI

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -361,6 +361,10 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         Pattern[str], Tuple[str, SupersetErrorType, Dict[str, Any]]
     ] = {}
 
+    # Whether the engine supports file uploads
+    # if True, database will be listed as option in the upload file form
+    allows_file_upload = True
+
     @classmethod
     def supports_url(cls, url: URL) -> bool:
         """

--- a/superset/db_engine_specs/clickhouse.py
+++ b/superset/db_engine_specs/clickhouse.py
@@ -58,6 +58,8 @@ class ClickHouseEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-method
 
     _show_functions_column = "name"
 
+    allows_file_upload = False
+
     @classmethod
     def get_dbapi_exception_mapping(cls) -> Dict[Type[Exception], Type[Exception]]:
         return {NewConnectionError: SupersetDBAPIDatabaseError}

--- a/superset/db_engine_specs/clickhouse.py
+++ b/superset/db_engine_specs/clickhouse.py
@@ -58,7 +58,7 @@ class ClickHouseEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-method
 
     _show_functions_column = "name"
 
-    allows_file_upload = False
+    supports_file_upload = False
 
     @classmethod
     def get_dbapi_exception_mapping(cls) -> Dict[Type[Exception], Type[Exception]]:

--- a/superset/db_engine_specs/gsheets.py
+++ b/superset/db_engine_specs/gsheets.py
@@ -81,6 +81,8 @@ class GSheetsEngineSpec(SqliteEngineSpec):
         ),
     }
 
+    allows_file_upload = False
+
     @classmethod
     def get_url_for_impersonation(
         cls,

--- a/superset/db_engine_specs/gsheets.py
+++ b/superset/db_engine_specs/gsheets.py
@@ -81,7 +81,7 @@ class GSheetsEngineSpec(SqliteEngineSpec):
         ),
     }
 
-    allows_file_upload = False
+    supports_file_upload = False
 
     @classmethod
     def get_url_for_impersonation(

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -236,6 +236,7 @@ class Database(
             "parameters": self.parameters,
             "disable_data_preview": self.disable_data_preview,
             "parameters_schema": self.parameters_schema,
+            "engine_information": self.engine_information,
         }
 
     @property
@@ -316,6 +317,14 @@ class Database(
     @property
     def connect_args(self) -> Dict[str, Any]:
         return self.get_extra().get("engine_params", {}).get("connect_args", {})
+
+    @property
+    def engine_information(self) -> Dict[str, Any]:
+        try:
+            engine_information = self.db_engine_spec.get_public_information()
+        except Exception:  # pylint: disable=broad-except
+            engine_information = {}
+        return engine_information
 
     @classmethod
     def get_password_masked_url_from_uri(  # pylint: disable=invalid-name

--- a/superset/views/database/forms.py
+++ b/superset/views/database/forms.py
@@ -99,7 +99,7 @@ class UploadToDatabaseForm(DynamicForm):
         New GSheets and Clickhouse DBs won't have the option to set
         allow_file_upload set as True.
         """
-        if database.db_engine_spec.allows_file_upload:
+        if database.db_engine_spec.supports_file_upload:
             return True
         return False
 

--- a/superset/views/database/forms.py
+++ b/superset/views/database/forms.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Contains the logic to create cohesive forms on the explore view"""
+from enum import Enum
 from typing import List
 
 from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
@@ -39,6 +40,12 @@ from superset.forms import (
 )
 from superset.models.core import Database
 
+
+class DatabasesNotAllowedToFileUpload(str, Enum):
+    GSHEETS = "gsheets"
+    CLICKHOUSE = "clickhousedb"
+
+
 config = app.config
 
 
@@ -52,6 +59,7 @@ class UploadToDatabaseForm(DynamicForm):
             file_enabled_db
             for file_enabled_db in file_enabled_dbs
             if UploadToDatabaseForm.at_least_one_schema_is_allowed(file_enabled_db)
+            and UploadToDatabaseForm.is_db_allowed_to_file_upload(file_enabled_db)
         ]
 
     @staticmethod
@@ -88,6 +96,23 @@ class UploadToDatabaseForm(DynamicForm):
         ):
             return True
         return False
+
+    @staticmethod
+    def is_db_allowed_to_file_upload(database: Database) -> bool:
+        """
+        This method is mainly used for existing Gsheets and Clickhouse DBs
+        that have allow_file_upload set as True but they are no longer valid
+        DBs for file uploading.
+        New GSheets and Clickhouse DBs won't have the option to set
+        allow_file_upload set as True.
+        """
+        backend = database.data["backend"]
+        not_allowed_dbs = [
+            db_engine.value for db_engine in DatabasesNotAllowedToFileUpload
+        ]
+        if backend in not_allowed_dbs:
+            return False
+        return True
 
 
 class CsvToDatabaseForm(UploadToDatabaseForm):

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -1944,7 +1944,7 @@ class TestDatabaseApi(SupersetTestCase):
                     "preferred": True,
                     "sqlalchemy_uri_placeholder": "postgresql://user:password@host:port/dbname[?key=value&key=value...]",
                     "engine_information": {
-                        "allows_file_upload": True,
+                        "supports_file_upload": True,
                     },
                 },
                 {
@@ -1966,7 +1966,7 @@ class TestDatabaseApi(SupersetTestCase):
                     "preferred": True,
                     "sqlalchemy_uri_placeholder": "bigquery://{project_id}",
                     "engine_information": {
-                        "allows_file_upload": True,
+                        "supports_file_upload": True,
                     },
                 },
                 {
@@ -2017,7 +2017,7 @@ class TestDatabaseApi(SupersetTestCase):
                     "preferred": False,
                     "sqlalchemy_uri_placeholder": "redshift+psycopg2://user:password@host:port/dbname[?key=value&key=value...]",
                     "engine_information": {
-                        "allows_file_upload": True,
+                        "supports_file_upload": True,
                     },
                 },
                 {
@@ -2039,7 +2039,7 @@ class TestDatabaseApi(SupersetTestCase):
                     "preferred": False,
                     "sqlalchemy_uri_placeholder": "gsheets://",
                     "engine_information": {
-                        "allows_file_upload": False,
+                        "supports_file_upload": False,
                     },
                 },
                 {
@@ -2090,7 +2090,7 @@ class TestDatabaseApi(SupersetTestCase):
                     "preferred": False,
                     "sqlalchemy_uri_placeholder": "mysql://user:password@host:port/dbname[?key=value&key=value...]",
                     "engine_information": {
-                        "allows_file_upload": True,
+                        "supports_file_upload": True,
                     },
                 },
                 {
@@ -2099,7 +2099,7 @@ class TestDatabaseApi(SupersetTestCase):
                     "name": "SAP HANA",
                     "preferred": False,
                     "engine_information": {
-                        "allows_file_upload": True,
+                        "supports_file_upload": True,
                     },
                 },
             ]
@@ -2129,7 +2129,7 @@ class TestDatabaseApi(SupersetTestCase):
                     "name": "MySQL",
                     "preferred": True,
                     "engine_information": {
-                        "allows_file_upload": True,
+                        "supports_file_upload": True,
                     },
                 },
                 {
@@ -2138,7 +2138,7 @@ class TestDatabaseApi(SupersetTestCase):
                     "name": "SAP HANA",
                     "preferred": False,
                     "engine_information": {
-                        "allows_file_upload": True,
+                        "supports_file_upload": True,
                     },
                 },
             ]

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -196,6 +196,7 @@ class TestDatabaseApi(SupersetTestCase):
             "created_by",
             "database_name",
             "disable_data_preview",
+            "engine_information",
             "explore_database_id",
             "expose_in_sqllab",
             "extra",
@@ -1942,6 +1943,9 @@ class TestDatabaseApi(SupersetTestCase):
                     },
                     "preferred": True,
                     "sqlalchemy_uri_placeholder": "postgresql://user:password@host:port/dbname[?key=value&key=value...]",
+                    "engine_information": {
+                        "allows_file_upload": True,
+                    },
                 },
                 {
                     "available_drivers": ["bigquery"],
@@ -1961,6 +1965,9 @@ class TestDatabaseApi(SupersetTestCase):
                     },
                     "preferred": True,
                     "sqlalchemy_uri_placeholder": "bigquery://{project_id}",
+                    "engine_information": {
+                        "allows_file_upload": True,
+                    },
                 },
                 {
                     "available_drivers": ["psycopg2"],
@@ -2009,6 +2016,9 @@ class TestDatabaseApi(SupersetTestCase):
                     },
                     "preferred": False,
                     "sqlalchemy_uri_placeholder": "redshift+psycopg2://user:password@host:port/dbname[?key=value&key=value...]",
+                    "engine_information": {
+                        "allows_file_upload": True,
+                    },
                 },
                 {
                     "available_drivers": ["apsw"],
@@ -2028,6 +2038,9 @@ class TestDatabaseApi(SupersetTestCase):
                     },
                     "preferred": False,
                     "sqlalchemy_uri_placeholder": "gsheets://",
+                    "engine_information": {
+                        "allows_file_upload": False,
+                    },
                 },
                 {
                     "available_drivers": ["mysqlconnector", "mysqldb"],
@@ -2076,12 +2089,18 @@ class TestDatabaseApi(SupersetTestCase):
                     },
                     "preferred": False,
                     "sqlalchemy_uri_placeholder": "mysql://user:password@host:port/dbname[?key=value&key=value...]",
+                    "engine_information": {
+                        "allows_file_upload": True,
+                    },
                 },
                 {
                     "available_drivers": [""],
                     "engine": "hana",
                     "name": "SAP HANA",
                     "preferred": False,
+                    "engine_information": {
+                        "allows_file_upload": True,
+                    },
                 },
             ]
         }
@@ -2109,12 +2128,18 @@ class TestDatabaseApi(SupersetTestCase):
                     "engine": "mysql",
                     "name": "MySQL",
                     "preferred": True,
+                    "engine_information": {
+                        "allows_file_upload": True,
+                    },
                 },
                 {
                     "available_drivers": [""],
                     "engine": "hana",
                     "name": "SAP HANA",
                     "preferred": False,
+                    "engine_information": {
+                        "allows_file_upload": True,
+                    },
                 },
             ]
         }


### PR DESCRIPTION
### SUMMARY
Our users are getting an `Internal Server Error 500` when trying to upload files to `GSheets` databases, that's because such databases don't support file upload nor the `Clickhouse` ones thus we need to stop showing such options to the users and prevent that existing ones get displayed in the upload form.

Additionally,  `schemas allowed` field is dependent on having file upload enabled but doesn't appear that way, so we are rendering it only when user checks the `Allow file upload` checkbox and placing it underneath the file upload checkbox.

Wording changes:
1. Update field name to : "Allow file uploads to database" instead of "Allow data upload" and remove the tooltip
2. On the Schemas Allowed field, we should update "CSV Upload" text to be "File Upload" and "CSVs" to "files", including in the hint text


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![error](https://user-images.githubusercontent.com/38889534/184278578-5969753c-d5a3-4ff3-9895-130cfd51d975.gif)

![error](https://user-images.githubusercontent.com/38889534/184930260-5d380b6a-fb6e-4cd9-b419-c11bba03878a.gif)


After:
![test](https://user-images.githubusercontent.com/38889534/184278136-0788af68-ce22-484a-bc2f-3608517c2b80.gif)

![test](https://user-images.githubusercontent.com/38889534/184930361-9b8230f6-9d52-47ff-aed6-8169c6825f2e.gif)



### TESTING INSTRUCTIONS
1. When selecting a DB type, if GSheet or Clickhouse is selected the `Allow data upload` checkbox is not displayed in the form
2. Enabled the file upload menu only if there is any exiting DB with allow_file_upload flag set to true and that is not `GSheets` nor `Clickhouse`
3. When the form to file upload files is opened, the `Database` dropdown must not contain any `GSheets` nor `Clickhouse` DB.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: https://github.com/apache/superset/issues/19247
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
