### PR TITLE
Fix remapping of chart ids for crossfilters when importing dashboards

### DIFF
--- a/superset/dashboards/commands/importers/v1/utils.py
+++ b/superset/dashboards/commands/importers/v1/utils.py
@@ -96,6 +96,26 @@ def update_id_refs(  # pylint: disable=too-many-locals
                     if old_id in id_map
                 ]
 
+    if "chart_configuration" in metadata:
+        # in chart_configuration the key is the chart ID as a string; we need to udpate
+        # them to be the new ID as a string:
+        metadata["chart_configuration"] = {
+            str(id_map[int(old_id)]): columns
+            for old_id, columns in metadata["chart_configuration"].items()
+            if int(old_id) in id_map
+        }
+
+        # now update columns to use new IDs:
+        for columns in metadata["chart_configuration"].values():
+            columns["id"] = id_map[columns["id"]]
+            if "crossFilters" in columns:
+                for attributes in columns['crossFilters'].values():
+                    attributes["excluded"] = [
+                        id_map[old_id]
+                        for old_id in attributes["excluded"]
+                        if old_id in id_map
+                    ]
+
     if "expanded_slices" in metadata:
         metadata["expanded_slices"] = {
             str(id_map[int(old_id)]): value

--- a/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
+++ b/tests/unit_tests/dashboards/commands/importers/v1/utils_test.py
@@ -121,3 +121,43 @@ def test_update_native_filter_config_scope_excluded():
         },
         "metadata": {"native_filter_configuration": [{"scope": {"excluded": [1, 2]}}]},
     }
+
+def test_update_cross_filter_config_scope_excluded():
+    from superset.dashboards.commands.importers.v1.utils import update_id_refs
+
+    config = {
+        "position": {
+            "CHART1": {
+                "id": "CHART1",
+                "meta": {"chartId": 101, "uuid": "uuid1"},
+                "type": "CHART",
+            },
+            "CHART2": {
+                "id": "CHART2",
+                "meta": {"chartId": 102, "uuid": "uuid2"},
+                "type": "CHART",
+            },
+        },
+        "metadata": {
+            "chart_configuration": {"101": {"id": 101, "crossFilters": {"scope": {"excluded": [101, 102, 103]}}}}
+        },
+    }
+    chart_ids = {"uuid1": 1, "uuid2": 2}
+    dataset_info: Dict[str, Dict[str, Any]] = {}  # not used
+
+    fixed = update_id_refs(config, chart_ids, dataset_info)
+    assert fixed == {
+        "position": {
+            "CHART1": {
+                "id": "CHART1",
+                "meta": {"chartId": 1, "uuid": "uuid1"},
+                "type": "CHART",
+            },
+            "CHART2": {
+                "id": "CHART2",
+                "meta": {"chartId": 2, "uuid": "uuid2"},
+                "type": "CHART",
+            },
+        },
+        "metadata": {"chart_configuration": {"1": {"id": 1, "crossFilters": {"scope": {"excluded": [1, 2]}}}}},        
+    }


### PR DESCRIPTION
### SUMMARY
When importing a dashboards from another superset instance, the importer will ensure that all chart ids are remapped to the new ids. This includes id's in the dashboard metadata such as filter scopes and native filters.
However, the remapping was not implemented for the cross filters configuration. This PR fixes that.

### TESTING INSTRUCTIONS
Unit test have been added to existing `tests/unit_tests/dashboards/commands/importers/v1/utils_test.py`

Can be tested with `tox -e py38 tests/unit_tests/dashboards/commands/importers/v1/utils_test.py`