### PR TITLE
fix: users without write dataset permission can create datasets on sql lab

### DIFF
--- a/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/index.tsx
@@ -71,6 +71,7 @@ export default function SaveDatasetActionButton({
       overlay={overlayMenu}
       icon={
         <Icons.CaretDown
+          data-test="save-dataset-action-dropdown"
           iconColor={theme.colors.grayscale.light5}
           name="caret-down"
         />

--- a/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.jsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.jsx
@@ -28,6 +28,7 @@ const mockedProps = {
     schema: 'main',
     sql: 'SELECT * FROM t',
   },
+  saveDatasetEnabled: false,
   defaultLabel: 'untitled',
   animation: false,
   database: databases.result[0],
@@ -37,6 +38,7 @@ const mockedProps = {
 
 const splitSaveBtnProps = {
   ...mockedProps,
+  saveDatasetEnabled: true,
   database: {
     ...mockedProps.database,
     allows_virtual_table_explore: true,
@@ -44,12 +46,61 @@ const splitSaveBtnProps = {
 };
 
 describe('SavedQuery', () => {
-  it('renders a non-split save button when allows_virtual_table_explore is not enabled', () => {
+  it('renders a non-split save button when allows_virtual_table_explore and saveDatasetEnabled are not enabled', () => {
     render(<SaveQuery {...mockedProps} />, { useRedux: true });
 
     const saveBtn = screen.getByRole('button', { name: /save/i });
 
     expect(saveBtn).toBeVisible();
+    expect(
+      screen.queryByTestId('save-dataset-action-dropdown'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders a non-split save button when allows_virtual_table_explore is not enabled', () => {
+    render(<SaveQuery {...mockedProps} saveDatasetEnabled />, {
+      useRedux: true,
+    });
+
+    const saveBtn = screen.getByRole('button', { name: /save/i });
+
+    expect(saveBtn).toBeVisible();
+    expect(
+      screen.queryByTestId('save-dataset-action-dropdown'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders a non-split save button when saveDatasetEnabled is not enabled', () => {
+    render(
+      <SaveQuery
+        {...mockedProps}
+        database={{
+          ...mockedProps.database,
+          allows_virtual_table_explore: true,
+        }}
+      />,
+      { useRedux: true },
+    );
+
+    const saveBtn = screen.getByRole('button', { name: /save/i });
+
+    expect(saveBtn).toBeVisible();
+    expect(
+      screen.queryByTestId('save-dataset-action-dropdown'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the save button with options when allows_virtual_table_explore and saveDatasetEnabled are enabled', () => {
+    render(<SaveQuery {...splitSaveBtnProps} />, {
+      useRedux: true,
+    });
+
+    const saveBtn = screen.getByRole('button', { name: /save/i });
+
+    expect(saveBtn).toBeVisible();
+    expect(
+      screen.queryByTestId('save-dataset-action-dropdown'),
+    ).toBeInTheDocument();
   });
 
   it('renders a save query modal when user clicks save button', () => {

--- a/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
@@ -34,6 +34,7 @@ interface SaveQueryProps {
   onSave: (arg0: QueryPayload) => void;
   onUpdate: (arg0: QueryPayload) => void;
   saveQueryWarning: string | null;
+  saveDatasetEnabled: boolean;
   database: Record<string, any>;
 }
 
@@ -81,6 +82,7 @@ export default function SaveQuery({
   onSave = () => {},
   onUpdate,
   saveQueryWarning = null,
+  saveDatasetEnabled,
   database,
 }: SaveQueryProps) {
   const [description, setDescription] = useState<string>(
@@ -171,7 +173,9 @@ export default function SaveQuery({
     <Styles className="SaveQuery">
       <SaveDatasetActionButton
         setShowSave={setShowSave}
-        overlayMenu={canExploreDatabase ? overlayMenu : null}
+        overlayMenu={
+          canExploreDatabase && saveDatasetEnabled ? overlayMenu : null
+        }
       />
       <SaveDatasetModal
         visible={showSaveDatasetModal}

--- a/superset/translations/de/LC_MESSAGES/messages.json
+++ b/superset/translations/de/LC_MESSAGES/messages.json
@@ -2687,7 +2687,7 @@
       "One or more parameters specified in the query are missing.": [
         "Ein oder mehrere in der Abfrage angegebene Parameter fehlen."
       ],
-      "One or more required fields are missing in the request. Please try again, and if the problem persists conctact your administrator.": [
+      "One or more required fields are missing in the request. Please try again, and if the problem persists contact your administrator.": [
         "Ein oder mehrere Pflichtfelder fehlen in der Anfrage. Bitte versuchen Sie es erneut, und wenn das Problem weiterhin besteht, wenden Sie sich an Ihre*n Administrator*in."
       ],
       "One ore more annotation layers failed loading.": [

--- a/superset/translations/de/LC_MESSAGES/messages.po
+++ b/superset/translations/de/LC_MESSAGES/messages.po
@@ -8440,7 +8440,7 @@ msgstr "Ein oder mehrere in der Abfrage angegebene Parameter fehlen."
 #: superset/views/core.py:2092
 msgid ""
 "One or more required fields are missing in the request. Please try again,"
-" and if the problem persists conctact your administrator."
+" and if the problem persists contact your administrator."
 msgstr ""
 "Ein oder mehrere Pflichtfelder fehlen in der Anfrage. Bitte versuchen Sie"
 " es erneut, und wenn das Problem weiterhin besteht, wenden Sie sich an "

--- a/superset/translations/en/LC_MESSAGES/messages.po
+++ b/superset/translations/en/LC_MESSAGES/messages.po
@@ -7896,7 +7896,7 @@ msgstr ""
 #: superset/views/core.py:2075
 msgid ""
 "One or more required fields are missing in the request. Please try again,"
-" and if the problem persists conctact your administrator."
+" and if the problem persists contact your administrator."
 msgstr ""
 
 #: superset-frontend/src/dashboard/components/SliceHeader/index.tsx:46

--- a/superset/translations/es/LC_MESSAGES/messages.po
+++ b/superset/translations/es/LC_MESSAGES/messages.po
@@ -8297,7 +8297,7 @@ msgstr "Issue 1006 - Faltan uno o más parámetros especificados en la consulta.
 #: superset/views/core.py:2075
 msgid ""
 "One or more required fields are missing in the request. Please try again,"
-" and if the problem persists conctact your administrator."
+" and if the problem persists contact your administrator."
 msgstr ""
 
 #: superset-frontend/src/dashboard/components/SliceHeader/index.tsx:46

--- a/superset/translations/fr/LC_MESSAGES/messages.json
+++ b/superset/translations/fr/LC_MESSAGES/messages.json
@@ -1359,7 +1359,7 @@
       "Can't find DruidCluster with cluster_name = '%(name)s'": [
         "Impossible de trouver le DruidCluster avec cluster_name = '%(name)s"
       ],
-      "One or more required fields are missing in the request. Please try again, and if the problem persists conctact your administrator.": [
+      "One or more required fields are missing in the request. Please try again, and if the problem persists contact your administrator.": [
         "Un ou plusieurs champs obligatoires manquent dans la requête. Merci de ré essayer et de contacter votre administrateur si le problème persiste."
       ],
       "The database was not found.": ["Base de données non trouvée."],

--- a/superset/translations/fr/LC_MESSAGES/messages.po
+++ b/superset/translations/fr/LC_MESSAGES/messages.po
@@ -8470,7 +8470,7 @@ msgstr "Il manque un ou plusieurs paramêtres dans la requête."
 #: superset/views/core.py:2075
 msgid ""
 "One or more required fields are missing in the request. Please try again,"
-" and if the problem persists conctact your administrator."
+" and if the problem persists contact your administrator."
 msgstr ""
 "Un ou plusieurs champs obligatoires manquent dans la requête. Merci de ré"
 " essayer et de contacter votre administrateur si le problème persiste."

--- a/superset/translations/it/LC_MESSAGES/messages.po
+++ b/superset/translations/it/LC_MESSAGES/messages.po
@@ -8113,7 +8113,7 @@ msgstr ""
 #: superset/views/core.py:2075
 msgid ""
 "One or more required fields are missing in the request. Please try again,"
-" and if the problem persists conctact your administrator."
+" and if the problem persists contact your administrator."
 msgstr ""
 
 #: superset-frontend/src/dashboard/components/SliceHeader/index.tsx:46

--- a/superset/translations/ja/LC_MESSAGES/messages.po
+++ b/superset/translations/ja/LC_MESSAGES/messages.po
@@ -8091,7 +8091,7 @@ msgstr "Issue 1006 - クエリで指定された1つ以上のパラメーター�
 #: superset/views/core.py:2075
 msgid ""
 "One or more required fields are missing in the request. Please try again,"
-" and if the problem persists conctact your administrator."
+" and if the problem persists contact your administrator."
 msgstr ""
 
 #: superset-frontend/src/dashboard/components/SliceHeader/index.tsx:46

--- a/superset/translations/ko/LC_MESSAGES/messages.po
+++ b/superset/translations/ko/LC_MESSAGES/messages.po
@@ -8040,7 +8040,7 @@ msgstr ""
 #: superset/views/core.py:2075
 msgid ""
 "One or more required fields are missing in the request. Please try again,"
-" and if the problem persists conctact your administrator."
+" and if the problem persists contact your administrator."
 msgstr ""
 
 #: superset-frontend/src/dashboard/components/SliceHeader/index.tsx:46

--- a/superset/translations/messages.pot
+++ b/superset/translations/messages.pot
@@ -7901,7 +7901,7 @@ msgstr ""
 #: superset/views/core.py:2075
 msgid ""
 "One or more required fields are missing in the request. Please try again,"
-" and if the problem persists conctact your administrator."
+" and if the problem persists contact your administrator."
 msgstr ""
 
 #: superset-frontend/src/dashboard/components/SliceHeader/index.tsx:46

--- a/superset/translations/nl/LC_MESSAGES/messages.json
+++ b/superset/translations/nl/LC_MESSAGES/messages.json
@@ -1253,7 +1253,7 @@
       ],
       "Can't find user, please ask your admin to create one.": [""],
       "Can't find DruidCluster": [""],
-      "One or more required fields are missing in the request. Please try again, and if the problem persists conctact your administrator.": [
+      "One or more required fields are missing in the request. Please try again, and if the problem persists contact your administrator.": [
         ""
       ],
       "The database was not found.": [""],

--- a/superset/translations/nl/LC_MESSAGES/messages.po
+++ b/superset/translations/nl/LC_MESSAGES/messages.po
@@ -3352,7 +3352,7 @@ msgstr ""
 #: superset/views/core.py:2116
 msgid ""
 "One or more required fields are missing in the request. Please try again,"
-" and if the problem persists conctact your administrator."
+" and if the problem persists contact your administrator."
 msgstr ""
 
 #: superset/views/core.py:2126 superset/views/core.py:2196

--- a/superset/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/superset/translations/pt_BR/LC_MESSAGES/messages.po
@@ -8479,7 +8479,7 @@ msgstr ""
 #: superset/views/core.py:2075
 msgid ""
 "One or more required fields are missing in the request. Please try again,"
-" and if the problem persists conctact your administrator."
+" and if the problem persists contact your administrator."
 msgstr ""
 
 #: superset-frontend/src/dashboard/components/SliceHeader/index.tsx:46

--- a/superset/translations/ru/LC_MESSAGES/messages.po
+++ b/superset/translations/ru/LC_MESSAGES/messages.po
@@ -8393,7 +8393,7 @@ msgstr ""
 #: superset/views/core.py:2075
 msgid ""
 "One or more required fields are missing in the request. Please try again,"
-" and if the problem persists conctact your administrator."
+" and if the problem persists contact your administrator."
 msgstr ""
 
 #: superset-frontend/src/dashboard/components/SliceHeader/index.tsx:46

--- a/superset/translations/sk/LC_MESSAGES/messages.po
+++ b/superset/translations/sk/LC_MESSAGES/messages.po
@@ -7913,7 +7913,7 @@ msgstr ""
 #: superset/views/core.py:2075
 msgid ""
 "One or more required fields are missing in the request. Please try again,"
-" and if the problem persists conctact your administrator."
+" and if the problem persists contact your administrator."
 msgstr ""
 
 #: superset-frontend/src/dashboard/components/SliceHeader/index.tsx:46

--- a/superset/translations/sl/LC_MESSAGES/messages.json
+++ b/superset/translations/sl/LC_MESSAGES/messages.json
@@ -1325,7 +1325,7 @@
       "Can't find DruidCluster with cluster_name = '%(name)s'": [
         "Ni mogoče najti DruidCluster s cluster_name = '%(name)s'"
       ],
-      "One or more required fields are missing in the request. Please try again, and if the problem persists conctact your administrator.": [
+      "One or more required fields are missing in the request. Please try again, and if the problem persists contact your administrator.": [
         "Eno ali več zahtevanih polj manjka v zahtevi. Poskusite znova, če težava ostane, kontaktirajte administratorja."
       ],
       "The database was not found.": ["Podatkovna baza ni bila najdena."],

--- a/superset/translations/sl/LC_MESSAGES/messages.po
+++ b/superset/translations/sl/LC_MESSAGES/messages.po
@@ -8323,7 +8323,7 @@ msgstr "En ali več parametrov v SQL-poizvedbi manjka."
 #: superset/views/core.py:2075
 msgid ""
 "One or more required fields are missing in the request. Please try again,"
-" and if the problem persists conctact your administrator."
+" and if the problem persists contact your administrator."
 msgstr ""
 "Eno ali več zahtevanih polj manjka v zahtevi. Poskusite znova, če težava "
 "ostane, kontaktirajte administratorja."

--- a/superset/translations/zh/LC_MESSAGES/messages.po
+++ b/superset/translations/zh/LC_MESSAGES/messages.po
@@ -8219,7 +8219,7 @@ msgstr "Issue 1006 - 查询中指定的一个或多个参数丢失。"
 #: superset/views/core.py:2075
 msgid ""
 "One or more required fields are missing in the request. Please try again,"
-" and if the problem persists conctact your administrator."
+" and if the problem persists contact your administrator."
 msgstr ""
 
 #: superset-frontend/src/dashboard/components/SliceHeader/index.tsx:46

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2074,6 +2074,17 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @expose("/sqllab_viz/", methods=["POST"])
     @event_logger.log_this
     def sqllab_viz(self) -> FlaskResponse:  # pylint: disable=no-self-use
+        if not self.appbuilder.sm.has_access("can_write", "Dataset"):
+            raise SupersetSecurityException(
+                SupersetError(
+                    error_type=SupersetErrorType.DATASOURCE_SECURITY_ACCESS_ERROR,
+                    message=_(
+                        "You don't have sufficient permissions to save a dataset."
+                    ),
+                    level=ErrorLevel.ERROR,
+                )
+            )
+
         data = json.loads(request.form["data"])
         try:
             table_name = data["datasourceName"]
@@ -2082,7 +2093,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             raise SupersetGenericErrorException(
                 __(
                     "One or more required fields are missing in the request. Please try "
-                    "again, and if the problem persists conctact your administrator."
+                    "again, and if the problem persists contact your administrator."
                 ),
                 status=400,
             ) from ex

--- a/tests/integration_tests/sqllab_tests.py
+++ b/tests/integration_tests/sqllab_tests.py
@@ -517,6 +517,28 @@ class TestSqlLab(SupersetTestCase):
         response = self.client.post(url, data=data, follow_redirects=True)
         assert response.status_code == 400
 
+    def test_sqllab_viz_not_allowed(self):
+        self.login(username="gamma")
+        examples_dbid = get_example_database().id
+        payload = {
+            "chartType": "dist_bar",
+            "datasourceName": f"test_viz_flow_table_{random()}",
+            "schema": "superset",
+            "columns": [
+                {"is_dttm": False, "type": "STRING", "name": f"viz_type_{random()}"},
+                {"is_dttm": False, "type": "OBJECT", "name": f"ccount_{random()}"},
+            ],
+            "sql": """\
+                SELECT *
+                FROM birth_names
+                LIMIT 10""",
+            "dbId": examples_dbid,
+        }
+        data = {"data": json.dumps(payload)}
+        url = "/superset/sqllab_viz/"
+        response = self.client.post(url, data=data, follow_redirects=True)
+        assert response.status_code == 403
+
     def test_sqllab_table_viz(self):
         self.login("admin")
         examples_db = get_example_database()


### PR DESCRIPTION
### SUMMARY

A user without write dataset permissions can still create datasets from SQL Lab.
Gamma users with sql lab permissions for instance.

This PR prevents it at the API level and also removes the possibility on the frontend.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

<img width="1728" alt="Screen Shot 2022-08-16 at 00 37 47" src="https://user-images.githubusercontent.com/17252075/184792880-9e7dd022-997c-471a-95e6-6eb396687c52.png">


After:

<img width="1728" alt="Screen Shot 2022-08-16 at 00 37 30" src="https://user-images.githubusercontent.com/17252075/184792854-cfa6d7c3-c5c1-43b0-9c7f-6269125aaecb.png">

Users with the write permission will still see the UI as the "Before" picture.

### TESTING INSTRUCTIONS

1. Log in with a gamma with sql lab user role
2. Create a dataset from SQL Lab and save it
3. Go to datasets page
4. Can’t see the “Action” column to modify the dataset
5. Open the dataset in Chart Builder mode
6. Edit dataset from here
7. Not able to save changes with message, “Access is Denied”

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
