### PR TITLE
fix(dashboard): Dashboard header overflowing in edit mode

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -149,6 +149,7 @@ const StyledHeader = styled.div`
   position: sticky;
   top: 0;
   z-index: 100;
+  max-width: 100vw;
 `;
 
 const StyledContent = styled.div<{

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -132,6 +132,7 @@ const actionButtonsStyle = theme => css`
   }
 
   .undoRedo {
+    display: flex;
     margin-right: ${theme.gridUnit * 2}px;
   }
 `;


### PR DESCRIPTION
### SUMMARY
When user typed a long dashboard title in edit mode, it overflowed the dashboard instead of truncating.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/15073128/184887051-a96b319f-a781-4743-8ea3-8178c82c8339.png">

After:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/15073128/184887765-a7fb2ded-cdb9-4298-b3a1-893e5c8312a3.png">


### TESTING INSTRUCTIONS
Type long dashboard title, make sure that it doesnt break

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
