### PR TITLE
fix(plugin-chart-table): Upgrade old color formats

### DIFF
--- a/superset/migrations/versions/2022-08-16_15-23_6d3c6f9d665d_fix_table_chart_conditional_formatting_.py
+++ b/superset/migrations/versions/2022-08-16_15-23_6d3c6f9d665d_fix_table_chart_conditional_formatting_.py
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""fix_table_chart_conditional_formatting_colors
+
+Revision ID: 6d3c6f9d665d
+Revises: ffa79af61a56
+Create Date: 2022-08-16 15:23:42.860038
+
+"""
+import json
+
+from alembic import op
+from sqlalchemy import Column, Integer, String, Text
+from sqlalchemy.ext.declarative import declarative_base
+
+from superset import db
+
+# revision identifiers, used by Alembic.
+revision = "6d3c6f9d665d"
+down_revision = "ffa79af61a56"
+
+Base = declarative_base()
+
+
+class Slice(Base):
+    __tablename__ = "slices"
+    id = Column(Integer, primary_key=True)
+    viz_type = Column(String(250))
+    params = Column(Text)
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    for slc in session.query(Slice).filter(Slice.viz_type == "table"):
+        params = json.loads(slc.params)
+        conditional_formatting = params.get("conditional_formatting", [])
+        if conditional_formatting:
+            new_conditional_formatting = []
+            for formatter in conditional_formatting:
+                color_scheme = formatter.get("colorScheme")
+                if color_scheme == "rgb(0,255,0)":
+                    new_color_scheme = "#ACE1C4"
+                elif color_scheme == "rgb(255,255,0)":
+                    new_color_scheme = "#FDE380"
+                else:
+                    new_color_scheme = "#EFA1AA"
+                new_conditional_formatting.append(
+                    {**formatter, "colorScheme": new_color_scheme}
+                )
+            params["conditional_formatting"] = new_conditional_formatting
+            slc.params = json.dumps(params)
+            session.merge(slc)
+            session.commit()
+    session.close()
+
+
+# it fixes a bug, downgrading isn't really needed here
+def downgrade():
+    pass

--- a/superset/migrations/versions/2022-08-16_15-23_6d3c6f9d665d_fix_table_chart_conditional_formatting_.py
+++ b/superset/migrations/versions/2022-08-16_15-23_6d3c6f9d665d_fix_table_chart_conditional_formatting_.py
@@ -56,10 +56,13 @@ def upgrade():
                 color_scheme = formatter.get("colorScheme")
                 new_color_scheme = None
                 if color_scheme == "rgb(0,255,0)":
+                    # supersetTheme.colors.success.light1
                     new_color_scheme = "#ACE1C4"
                 elif color_scheme == "rgb(255,255,0)":
+                    # supersetTheme.colors.alert.light1
                     new_color_scheme = "#FDE380"
                 elif color_scheme == "rgb(255,0,0)":
+                    # supersetTheme.colors.error.light1
                     new_color_scheme = "#EFA1AA"
                 if new_color_scheme:
                     new_conditional_formatting.append(

--- a/superset/migrations/versions/2022-08-16_15-23_6d3c6f9d665d_fix_table_chart_conditional_formatting_.py
+++ b/superset/migrations/versions/2022-08-16_15-23_6d3c6f9d665d_fix_table_chart_conditional_formatting_.py
@@ -54,15 +54,19 @@ def upgrade():
             new_conditional_formatting = []
             for formatter in conditional_formatting:
                 color_scheme = formatter.get("colorScheme")
+                new_color_scheme = None
                 if color_scheme == "rgb(0,255,0)":
                     new_color_scheme = "#ACE1C4"
                 elif color_scheme == "rgb(255,255,0)":
                     new_color_scheme = "#FDE380"
-                else:
+                elif color_scheme == "rgb(255,0,0)":
                     new_color_scheme = "#EFA1AA"
-                new_conditional_formatting.append(
-                    {**formatter, "colorScheme": new_color_scheme}
-                )
+                if new_color_scheme:
+                    new_conditional_formatting.append(
+                        {**formatter, "colorScheme": new_color_scheme}
+                    )
+                else:
+                    new_conditional_formatting.append(formatter)
             params["conditional_formatting"] = new_conditional_formatting
             slc.params = json.dumps(params)
             session.merge(slc)


### PR DESCRIPTION
### SUMMARY
First version of table conditional formatter was using `rgb()` format to describe colors. Later we changed it to hex notation, which broke the existing color formatters. This PR adds a migration of old color formatters to use hex notation.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1792" alt="Screenshot 2022-08-16 at 16 27 48" src="https://user-images.githubusercontent.com/15073128/184908332-0fffde67-769a-41b4-b6e5-a888728cc83f.png">


After:
<img width="1792" alt="Screenshot 2022-08-16 at 16 25 02" src="https://user-images.githubusercontent.com/15073128/184908276-1ecccb7a-3dff-4d9e-b953-79e486911c9e.png">

### TESTING INSTRUCTIONS
1. Open a table chart with conditional formatters using the old color formats (or just manually edit the form data in the database with 1 of `rgb(255,0,0)` for red, `rgb(255,255,0)` for yellow or `rgb(0,255,0)` for green.
2. Run the migration
3. Verify that the conditional formatters apply colors correctly. 
4. The conditional formatters that were already using the new color notation should remain unchanged.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided
    Current: 0.56 s
    10+: 0.85 s
    100+: 0.64 s
    1000+: 0.54 s
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
