### PR TITLE
fix: datetime value should be seconds in sqlite

### DIFF
--- a/superset/db_engine_specs/sqlite.py
+++ b/superset/db_engine_specs/sqlite.py
@@ -110,7 +110,7 @@ class SqliteEngineSpec(BaseEngineSpec):
     ) -> Optional[str]:
         tt = target_type.upper()
         if tt in (utils.TemporalType.TEXT, utils.TemporalType.DATETIME):
-            return f"""'{dttm.isoformat(sep=" ", timespec="microseconds")}'"""
+            return f"""'{dttm.isoformat(sep=" ", timespec="seconds")}'"""
         return None
 
     @classmethod

--- a/tests/unit_tests/db_engine_specs/test_sqlite.py
+++ b/tests/unit_tests/db_engine_specs/test_sqlite.py
@@ -27,13 +27,13 @@ from tests.unit_tests.fixtures.common import dttm
 def test_convert_dttm(dttm: datetime) -> None:
     from superset.db_engine_specs.sqlite import SqliteEngineSpec
 
-    assert SqliteEngineSpec.convert_dttm("TEXT", dttm) == "'2019-01-02 03:04:05.678900'"
+    assert SqliteEngineSpec.convert_dttm("TEXT", dttm) == "'2019-01-02 03:04:05'"
 
 
 def test_convert_dttm_lower(dttm: datetime) -> None:
     from superset.db_engine_specs.sqlite import SqliteEngineSpec
 
-    assert SqliteEngineSpec.convert_dttm("text", dttm) == "'2019-01-02 03:04:05.678900'"
+    assert SqliteEngineSpec.convert_dttm("text", dttm) == "'2019-01-02 03:04:05'"
 
 
 def test_convert_dttm_invalid_type(dttm: datetime) -> None:


### PR DESCRIPTION
### SUMMARY
The DateTime function returns value in SQLite is not able to do a boolean operation. the SQLite function [manual](https://www.sqlite.org/lang_datefunc.html) the operand should be a string as 'YYYY-MM-DD HH:MM:SS'.

This PR intends to resolve the issue in [D2D](https://github.com/apache/superset/pull/20728).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
This PR has to test on the D2D [PR](https://github.com/apache/superset/pull/20728). the [dashboard](http://35.92.54.239:8080/superset/dashboard/11/?native_filters_key=W7WGeRjnBj1JX7oKGNqBAWVspfmYTTfKe4wl5_IP2QlVlk7ZqfwhfKvOAUjwEmZw) should drill after this PR.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
