### PR TITLE
chore(fab): Expose the SqlMetricInlineView extra column listed in the legacy FAB API

### DIFF
--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -209,7 +209,7 @@ class SqlMetricInlineView(  # pylint: disable=too-many-ancestors
     add_title = _("Add Metric")
     edit_title = _("Edit Metric")
 
-    list_columns = ["metric_name", "verbose_name", "metric_type"]
+    list_columns = ["metric_name", "verbose_name", "metric_type", "extra"]
     edit_columns = [
         "metric_name",
         "description",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

As mentioned in Slack we (Airbnb) are experiencing performance issues with the Superset v1 API—in relation to a large dataset—due to an inefficiency in how the underlying FAB API fetch metadata. We're restricted to using the legacy FAB API however not all columns (for our needs) are exposed and thus this PR exposes the metric `extra` column to the list of columns which are included when reading/listing the metric metadata.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Ran http://127.0.0.1:8000/sqlmetricinlineview/api/read?flt_0_table_id=1 and confirmed that the `extra` column was included.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
