### PR TITLE
feat: generate label map on the backend

### DIFF
--- a/superset/utils/pandas_postprocessing/__init__.py
+++ b/superset/utils/pandas_postprocessing/__init__.py
@@ -33,6 +33,10 @@ from superset.utils.pandas_postprocessing.resample import resample
 from superset.utils.pandas_postprocessing.rolling import rolling
 from superset.utils.pandas_postprocessing.select import select
 from superset.utils.pandas_postprocessing.sort import sort
+from superset.utils.pandas_postprocessing.utils import (
+    escape_separator,
+    unescape_separator,
+)
 
 __all__ = [
     "aggregate",
@@ -52,4 +56,6 @@ __all__ = [
     "select",
     "sort",
     "flatten",
+    "escape_separator",
+    "unescape_separator",
 ]

--- a/superset/utils/pandas_postprocessing/flatten.py
+++ b/superset/utils/pandas_postprocessing/flatten.py
@@ -22,6 +22,7 @@ from numpy.distutils.misc_util import is_sequence
 
 from superset.utils.pandas_postprocessing.utils import (
     _is_multi_index_on_columns,
+    escape_separator,
     FLAT_COLUMN_SEPARATOR,
 )
 
@@ -86,8 +87,8 @@ def flatten(
             _cells = []
             for cell in series if is_sequence(series) else [series]:
                 if pd.notnull(cell):
-                    # every cell should be converted to string
-                    _cells.append(str(cell))
+                    # every cell should be converted to string and escape comma
+                    _cells.append(escape_separator(str(cell)))
             _columns.append(FLAT_COLUMN_SEPARATOR.join(_cells))
 
         df.columns = _columns

--- a/superset/utils/pandas_postprocessing/utils.py
+++ b/superset/utils/pandas_postprocessing/utils.py
@@ -198,3 +198,13 @@ def _append_columns(
         return _base_df
     append_df = append_df.rename(columns=columns)
     return pd.concat([base_df, append_df], axis="columns")
+
+
+def escape_separator(plain_str: str, sep: str = FLAT_COLUMN_SEPARATOR) -> str:
+    char = sep.strip()
+    return plain_str.replace(char, "\\" + char)
+
+
+def unescape_separator(escaped_str: str, sep: str = FLAT_COLUMN_SEPARATOR) -> str:
+    char = sep.strip()
+    return escaped_str.replace("\\" + char, char)

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -367,11 +367,11 @@ def virtual_dataset_comma_in_column_value():
     dataset = SqlaTable(
         table_name="virtual_dataset",
         sql=(
-            "SELECT 'col1,row1' as col1, 'col2,row1' as col2 "
+            "SELECT 'col1,row1' as col1, 'col2, row1' as col2 "
             "UNION ALL "
-            "SELECT 'col1,row2' as col1, 'col2,row2' as col2 "
+            "SELECT 'col1,row2' as col1, 'col2, row2' as col2 "
             "UNION ALL "
-            "SELECT 'col1,row3' as col1, 'col2,row3' as col2 "
+            "SELECT 'col1,row3' as col1, 'col2, row3' as col2 "
         ),
         database=get_example_database(),
     )

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -358,3 +358,30 @@ def physical_dataset():
     for ds in dataset:
         db.session.delete(ds)
     db.session.commit()
+
+
+@pytest.fixture
+def virtual_dataset_comma_in_column_value():
+    from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn
+
+    dataset = SqlaTable(
+        table_name="virtual_dataset",
+        sql=(
+            "SELECT 'col1,row1' as col1, 'col2,row1' as col2 "
+            "UNION ALL "
+            "SELECT 'col1,row2' as col1, 'col2,row2' as col2 "
+            "UNION ALL "
+            "SELECT 'col1,row3' as col1, 'col2,row3' as col2 "
+        ),
+        database=get_example_database(),
+    )
+    TableColumn(column_name="col1", type="VARCHAR(255)", table=dataset)
+    TableColumn(column_name="col2", type="VARCHAR(255)", table=dataset)
+
+    SqlMetric(metric_name="count", expression="count(*)", table=dataset)
+    db.session.merge(dataset)
+
+    yield dataset
+
+    db.session.delete(dataset)
+    db.session.commit()

--- a/tests/integration_tests/query_context_tests.py
+++ b/tests/integration_tests/query_context_tests.py
@@ -36,6 +36,7 @@ from superset.utils.core import (
     DatasourceType,
     QueryStatus,
 )
+from superset.utils.pandas_postprocessing.utils import FLAT_COLUMN_SEPARATOR
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.birth_names_dashboard import (
     load_birth_names_dashboard_with_slices,
@@ -717,13 +718,13 @@ def test_get_label_map(app_context, virtual_dataset_comma_in_column_value):
     label_map = qc.get_df_payload(query_object)["label_map"]
     assert list(df.columns.values) == [
         "col1",
-        "count, col2,row1",
-        "count, col2,row2",
-        "count, col2,row3",
+        "count" + FLAT_COLUMN_SEPARATOR + "col2, row1",
+        "count" + FLAT_COLUMN_SEPARATOR + "col2, row2",
+        "count" + FLAT_COLUMN_SEPARATOR + "col2, row3",
     ]
     assert label_map == {
         "col1": ["col1"],
-        "count, col2,row1": ["count", "col2,row1"],
-        "count, col2,row2": ["count", "col2,row2"],
-        "count, col2,row3": ["count", "col2,row3"],
+        "count, col2, row1": ["count", "col2, row1"],
+        "count, col2, row2": ["count", "col2, row2"],
+        "count, col2, row3": ["count", "col2, row3"],
     }

--- a/tests/unit_tests/pandas_postprocessing/test_flatten.py
+++ b/tests/unit_tests/pandas_postprocessing/test_flatten.py
@@ -156,3 +156,22 @@ def test_flat_integer_column_name():
             }
         )
     )
+
+
+def test_escape_column_name():
+    index = pd.to_datetime(["2021-01-01", "2021-01-02", "2021-01-03"])
+    index.name = "__timestamp"
+    columns = pd.MultiIndex.from_arrays(
+        [
+            ["level1,value1", "level1,value2", "level1,value3"],
+            ["level2, value1", "level2, value2", "level2, value3"],
+        ],
+        names=["level1", "level2"],
+    )
+    df = pd.DataFrame(index=index, columns=columns, data=1)
+    assert list(pp.flatten(df).columns.values) == [
+        "__timestamp",
+        "level1\\,value1" + FLAT_COLUMN_SEPARATOR + "level2\\, value1",
+        "level1\\,value2" + FLAT_COLUMN_SEPARATOR + "level2\\, value2",
+        "level1\\,value3" + FLAT_COLUMN_SEPARATOR + "level2\\, value3",
+    ]

--- a/tests/unit_tests/pandas_postprocessing/test_utils.py
+++ b/tests/unit_tests/pandas_postprocessing/test_utils.py
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from superset.utils.pandas_postprocessing import escape_separator, unescape_separator
+
+
+def test_escape_separator():
+    assert escape_separator(r" hell \world ") == r" hell \world "
+    assert unescape_separator(r" hell \world ") == r" hell \world "
+
+    escape_string = escape_separator("hello, world")
+    assert escape_string == r"hello\, world"
+    assert unescape_separator(escape_string) == "hello, world"
+
+    escape_string = escape_separator("hello,world")
+    assert escape_string == r"hello\,world"
+    assert unescape_separator(escape_string) == "hello,world"


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, the **timeseries** chart has a variable `labelMap`, used for mapping result columns(or series) and dimension values. If the result columns contain comma(`,`), this mapping can't reverse calculation dimension values on the frontend. This issue was blocked drill to detail. 

This PR intends to generate `labelMap` on the backend. The frontend only needs to replace the `labelMap` from the chart query response. 


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![image](https://user-images.githubusercontent.com/2016594/185412453-e05f6616-f6e0-4baa-91c2-4a591156f3dc.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Pure backend change, should pass all CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
