### PR TITLE
fix: resample method shouldn't be freeform

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/sections/advancedAnalytics.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/sections/advancedAnalytics.tsx
@@ -178,7 +178,6 @@ export const advancedAnalyticsControls: ControlPanelSectionConfig = {
         name: 'resample_method',
         config: {
           type: 'SelectControl',
-          freeForm: true,
           label: t('Fill method'),
           default: null,
           choices: [


### PR DESCRIPTION
### SUMMARY
The `Fill method` in Advanced Analytics shouldn't be `freeform`. When this control sets to `freeform`, the fill method will be arbitrary.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### Before

https://user-images.githubusercontent.com/2016594/185577321-fc872a98-bb8b-4100-918e-4d2ee3911fe9.mov

#### After


https://user-images.githubusercontent.com/2016594/185577640-db5da783-da82-43ff-a3f0-46df79431656.mov




### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
The `Fill Method` control shouldn't input arbitrary values.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
