### PR TITLE
fix(sql-lab): Allow User Impersonation in SQL Lab

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -398,6 +398,10 @@ class Database(
                 elif "/superset/sqllab/" in request.referrer:
                     source = utils.QuerySource.SQL_LAB
 
+            # Set the effective_username when users issue ad-hoc queries from SQL lab
+            if source == utils.QuerySource.SQL_LAB:
+                effective_username = user_name
+
             sqlalchemy_url, params = DB_CONNECTION_MUTATOR(
                 sqlalchemy_url, params, effective_username, security_manager, source
             )


### PR DESCRIPTION
### SUMMARY
- Previously, when users execute an ad-hoc query through the SQL lab interface,
   their username was not provided, and the `current_user` global was not available.
   This resulted in the error described in #20455

- This patch provides the `DB_CONNECTION_MUTATOR` override the user executing the
   ad-hoc query so that their credentials can be properly looked up.

### TESTING INSTRUCTIONS
Implement `DB_CONNECTION_MUTATOR` method to enable user impersonation when executing ad-hoc queries. Then, issue a query from the SQL-Lab page.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API