### PR TITLE
fix(alert-modal): Radio button is not vertically-aligned

### DIFF
--- a/superset-frontend/src/components/CronPicker/CronPicker.tsx
+++ b/superset-frontend/src/components/CronPicker/CronPicker.tsx
@@ -110,6 +110,9 @@ export const CronPicker = styled((props: CronProps) => (
     <ReactCronPicker locale={LOCALE} {...props} />
   </ConfigProvider>
 ))`
+  .react-js-cron-field {
+    margin-bottom: 0px;
+  }
   .react-js-cron-select:not(.react-js-cron-custom-select) > div:first-of-type,
   .react-js-cron-custom-select {
     border-radius: ${({ theme }) => theme.gridUnit}px;


### PR DESCRIPTION
### SUMMARY
Removing bottom margin to align checkbox with the inputs on his side.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

BEFORE

https://user-images.githubusercontent.com/29920585/185685888-8804c64a-527c-4cc6-be60-72e75a317c72.mov

AFTER

https://user-images.githubusercontent.com/29920585/185685920-7eb7efd6-0624-4079-88e5-bb46e3cd9ecd.mov

### TESTING INSTRUCTIONS

- Click Settings in the top right corner
- Select Alerts & Reports
- Click + Alert OR switch to the Reports tab (using the tab switcher in the top left) and click + Report
