### PR TITLE
fix(sqllab): avoid unexpected re-rendering on DatabaseSelector

### DIFF
--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -291,7 +291,6 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
   function renderDatabaseSelector() {
     return (
       <DatabaseSelector
-        key={currentDatabase?.id}
         db={currentDatabase}
         emptyState={emptyState}
         formMode={formMode}


### PR DESCRIPTION
### SUMMARY
This bug has been accidentally introduced from #17044.

Since DatabaseSelector component has an unnecessary key, DatabaseSelector will be re-mounted  rather than update whenever currentDatabase object is updated. This causes the unexpected duplicate database list api request.
This commit removes this key so will skip unnecessary re-rendering and data fetching.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

![fix--unnecessary-dabaseselector-rerendering](https://user-images.githubusercontent.com/1392866/185713445-a22e86e1-9382-4ecc-81a4-bdb692d016d1.gif)

After:

![Screen Shot 2022-08-19 at 2 50 12 PM](https://user-images.githubusercontent.com/1392866/185713454-b6a05d82-2162-4b6d-9fab-13d36a209401.png)

### TESTING INSTRUCTIONS
go to Sql Editor and check the network list

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @betodealmeida 