### PR TITLE
feat: Adds drill to detail context menu to World Map

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
@@ -50,6 +50,7 @@ const formatter = getNumberFormatter();
 
 function WorldMap(element, props) {
   const {
+    entity,
     data,
     width,
     height,
@@ -61,6 +62,8 @@ function WorldMap(element, props) {
     colorScheme,
     sliceId,
     theme,
+    onContextMenu,
+    inContextMenu,
   } = props;
   const div = d3.select(element);
   div.classed('superset-legacy-chart-world-map', true);
@@ -102,6 +105,22 @@ function WorldMap(element, props) {
     mapData[d.country] = d;
   });
 
+  const handleContextMenu = source => {
+    const pointerEvent = d3.event;
+    pointerEvent.preventDefault();
+    const val = source.id || source.country;
+    const formattedVal = mapData[val].name;
+    const filters = [
+      {
+        col: entity,
+        op: '==',
+        val,
+        formattedVal,
+      },
+    ];
+    onContextMenu(filters, pointerEvent.offsetX, pointerEvent.offsetY);
+  };
+
   const map = new Datamap({
     element,
     width,
@@ -111,8 +130,8 @@ function WorldMap(element, props) {
       defaultFill: theme.colors.grayscale.light2,
     },
     geographyConfig: {
-      popupOnHover: true,
-      highlightOnHover: true,
+      popupOnHover: !inContextMenu,
+      highlightOnHover: !inContextMenu,
       borderWidth: 1,
       borderColor: theme.colors.grayscale.light5,
       highlightBorderColor: theme.colors.grayscale.light5,
@@ -127,7 +146,7 @@ function WorldMap(element, props) {
       borderWidth: 1,
       borderOpacity: 1,
       borderColor: color,
-      popupOnHover: true,
+      popupOnHover: !inContextMenu,
       radius: null,
       popupTemplate: (geo, d) =>
         `<div class="hoverinfo"><strong>${d.name}</strong><br>${formatter(
@@ -135,7 +154,7 @@ function WorldMap(element, props) {
         )}</div>`,
       fillOpacity: 0.5,
       animate: true,
-      highlightOnHover: true,
+      highlightOnHover: !inContextMenu,
       highlightFillColor: color,
       highlightBorderColor: theme.colors.grayscale.dark2,
       highlightBorderWidth: 2,
@@ -143,6 +162,11 @@ function WorldMap(element, props) {
       highlightFillOpacity: 0.85,
       exitDelay: 100,
       key: JSON.stringify,
+    },
+    done: datamap => {
+      datamap.svg
+        .selectAll('.datamaps-subunit')
+        .on('contextmenu', handleContextMenu);
     },
   });
 
@@ -153,7 +177,8 @@ function WorldMap(element, props) {
     div
       .selectAll('circle.datamaps-bubble')
       .style('fill', color)
-      .style('stroke', color);
+      .style('stroke', color)
+      .on('contextmenu', handleContextMenu);
   }
 }
 

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/transformProps.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/transformProps.js
@@ -19,8 +19,11 @@
 import { rgb } from 'd3-color';
 
 export default function transformProps(chartProps) {
-  const { width, height, formData, queriesData } = chartProps;
+  const { width, height, formData, queriesData, hooks, inContextMenu } =
+    chartProps;
+  const { onContextMenu } = hooks;
   const {
+    entity,
     maxBubbleSize,
     showBubbles,
     linearColorScheme,
@@ -32,6 +35,7 @@ export default function transformProps(chartProps) {
   const { r, g, b } = colorPicker;
 
   return {
+    entity,
     data: queriesData[0].data,
     width,
     height,
@@ -42,5 +46,7 @@ export default function transformProps(chartProps) {
     colorBy,
     colorScheme,
     sliceId,
+    onContextMenu,
+    inContextMenu,
   };
 }


### PR DESCRIPTION
### SUMMARY
Adds drill-to-detail context menu to World Map chart. 

World Map is a legacy plugin with some limitations like re-rendering the whole map from scratch for every property change. That's why you will notice a blinking effect when right-clicking a country or changing the color of the bubbles. Is not the objective of this PR to change this behavior. Another limitation is the possibility of keeping a country in a hovered state when interacting with the context menu. Many of these limitations can be resolved by migrating the World Map to ECharts.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/185932508-bc543816-50d2-4bd6-ad90-cc8f18f02d84.mov

### TESTING INSTRUCTIONS
1 - You should be able to right-click both the country and the bubbles
2 - Check the value and formatted value when right-clicking
3 - When the context menu is active, both labels and hovered effects are disabled for other countries

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
