### PR TITLE
fix(sqllab): missing zero values while copy-to-clipboard

### DIFF
--- a/superset-frontend/src/utils/common.js
+++ b/superset-frontend/src/utils/common.js
@@ -97,7 +97,7 @@ export function prepareCopyToClipboardTabularData(data, columns) {
       // JavaScript does not maintain the order of a mixed set of keys (i.e integers and strings)
       // the below function orders the keys based on the column names.
       const key = columns[j].name || columns[j];
-      if (data[i][key]) {
+      if (key in data[i]) {
         row[j] = data[i][key];
       } else {
         row[j] = data[i][parseFloat(key)];

--- a/superset-frontend/src/utils/common.test.jsx
+++ b/superset-frontend/src/utils/common.test.jsx
@@ -59,6 +59,16 @@ describe('utils/common', () => {
         'lorem\tipsum\t\ndolor\tsit\tamet\n',
       );
     });
+    it('includes 0 values', () => {
+      const array = [
+        { column1: 0, column2: 0 },
+        { column1: 1, column2: -1, 0: 0 },
+      ];
+      const column = ['column1', 'column2', '0'];
+      expect(prepareCopyToClipboardTabularData(array, column)).toEqual(
+        '0\t0\t\n1\t-1\t0\n',
+      );
+    });
   });
   describe('applyFormattingToTabularData', () => {
     it('does not mutate empty array', () => {


### PR DESCRIPTION
### SUMMARY
Since JS returns false for zero values, following value existence statement `data[i][key]` skips the zero values.

https://github.com/apache/superset/blob/0bf4e56dc3e129d2b9239f055212249ba95521e4/superset-frontend/src/utils/common.js#L100-L106

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/1392866/185994528-0f50d879-d05b-48b5-a9ee-641e9efa7bd9.mov

### TESTING INSTRUCTIONS

1. Go to Sql Lab
2. Run the following query
```
SELECT 'copy to clipboard',
        0 as zero,
        1 as one
```
3. "Copy to clipboard"
4. Paste to a note

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
