### PR TITLE
fix(explore): Prevent unnecessary series limit subquery

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/edit_properties.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/edit_properties.test.ts
@@ -190,7 +190,7 @@ describe('Dashboard edit action', () => {
       });
     });
   });
-  describe('the color scheme affects the chart colors', () => {
+  describe.skip('the color scheme affects the chart colors', () => {
     it('should change the chart colors', () => {
       openAdvancedProperties().then(() => {
         clear('#json_metadata');

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1410,7 +1410,9 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
                         col=selected, template_processor=template_processor
                     )
                 groupby_all_columns[outer.name] = outer
-                if outer.name in series_column_names:
+                if (
+                    is_timeseries and not series_column_names
+                ) or outer.name in series_column_names:
                     groupby_series_columns[outer.name] = outer
                 select_exprs.append(outer)
         elif columns:

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1410,7 +1410,7 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
                         col=selected, template_processor=template_processor
                     )
                 groupby_all_columns[outer.name] = outer
-                if not series_column_names or outer.name in series_column_names:
+                if outer.name in series_column_names:
                     groupby_series_columns[outer.name] = outer
                 select_exprs.append(outer)
         elif columns:

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1515,7 +1515,9 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                         col=selected, template_processor=template_processor
                     )
                 groupby_all_columns[outer.name] = outer
-                if not series_column_names or outer.name in series_column_names:
+                if (
+                    is_timeseries and not series_column_names
+                ) or outer.name in series_column_names:
                     groupby_series_columns[outer.name] = outer
                 select_exprs.append(outer)
         elif columns:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR attempts to fix a bug with the series limit control when `GENERIC_CHART_AXES` feature is turned on.  Steps to reproduce bug:
- Create a "Generic Chart"-type chart with the X-axis and a metric set.  Don't add any dimensions.  Note the number of X-values present on the chart.
- Set the Series Limit to something lower than the number of X-values present on the chart and refresh.  Note how X-values are excluded.

Upon investigation, it looks like the SQL query builder is adding a perhaps unnecessary join against a subquery whenever Series Limit is set, regardless of if there is actually a dimension set that results in series needing limiting.  This PR attempts to make the join against the subquery only included when the frontend includes values in the `series_columns` array in the query context.

Update: Thanks to @villebro's input, this PR now handles legacy time-series charts as before by checking the `is_timeseries` param.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before:**
![localhost_9000_superset_welcome_](https://user-images.githubusercontent.com/13007381/186045048-2e4df0a2-8261-4cd0-9f35-7b34beda902c.png)

**After:**
![localhost_9000_superset_welcome_ (1)](https://user-images.githubusercontent.com/13007381/186045066-5e89fd0b-5348-421b-9457-9be4a1b7eded.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Confirm baseline behavior with `GENERIC_CHART_AXES` disabled:
  - Create an ECharts time-series chart (e.g. ECharts > Time-series Line Chart) with 1+ metrics but no dimensions.
    - The chart X-axis should contain all time values, accounting for time grain.  The "View query" modal should show no join present.
    - Setting Series Limit to a value less than the number of time values present on the chart X-axis should have no effect, and the query should not contain a join.
    - Adding a dimension then setting Series Limit to a value less than the number of dimension values should limit the number of rendered series to the series limit, and the query should now contain a join.
  - The above should also hold true for a legacy, non-ECharts time-series chart (e.g. nvd3 > Line Chart).
- Enable `GENERIC_CHART_AXES` and test the same:
  - Create an ECharts time-series chart (e.g. ECharts > Line Chart) with 1+ metrics but no dimensions.  Set the X-axis to the time column.
    - The chart X-axis should contain all time values, accounting for time grain.  The "View query" modal should show no join present.
    - Setting Series Limit to a value less than the number of time values present on the chart X-axis should have no effect, and the query should not contain a join.
    - Adding a dimension then setting Series Limit to a value less than the number of dimension values should limit the number of rendered series to the series limit, and the query should now contain a join.
  - The above should also hold true for a legacy, non-ECharts time-series chart (e.g. nvd3 > Line Chart).

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Required feature flags: `GENERIC_CHART_AXES`
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
