### PR TITLE
feat: Adds drill to detail context menu to Table

### DIFF
--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -365,8 +365,8 @@ export default function PivotTableChart(props: PivotTableProps) {
   const handleContextMenu = useCallback(
     (
       e: MouseEvent,
-      colKey: DataRecordValue[] | undefined,
-      rowKey: DataRecordValue[] | undefined,
+      colKey: (string | number | boolean)[] | undefined,
+      rowKey: (string | number | boolean)[] | undefined,
     ) => {
       if (onContextMenu) {
         e.preventDefault();

--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
@@ -66,6 +66,7 @@ export interface DataTableProps<D extends object> extends TableOptions<D> {
   rowCount: number;
   wrapperRef?: MutableRefObject<HTMLDivElement>;
   onColumnOrderChange: () => void;
+  onContextMenu?: (value: D, offsetX: number, offsetY: number) => void;
 }
 
 export interface RenderHTMLCellProps extends HTMLProps<HTMLTableCellElement> {
@@ -98,6 +99,7 @@ export default typedMemo(function DataTable<D extends object>({
   serverPagination,
   wrapperRef: userWrapperRef,
   onColumnOrderChange,
+  onContextMenu,
   ...moreUseTableOptions
 }: DataTableProps<D>): JSX.Element {
   const tableHooks: PluginHook<D>[] = [
@@ -270,7 +272,20 @@ export default typedMemo(function DataTable<D extends object>({
             prepareRow(row);
             const { key: rowKey, ...rowProps } = row.getRowProps();
             return (
-              <tr key={rowKey || row.id} {...rowProps}>
+              <tr
+                key={rowKey || row.id}
+                {...rowProps}
+                onContextMenu={(e: any) => {
+                  if (onContextMenu) {
+                    e.preventDefault();
+                    onContextMenu(
+                      row.original,
+                      e.nativeEvent.layerX,
+                      e.nativeEvent.layerY,
+                    );
+                  }
+                }}
+              >
                 {row.cells.map(cell =>
                   cell.render('Cell', { key: cell.column.id }),
                 )}

--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
@@ -23,6 +23,7 @@ import React, {
   HTMLProps,
   MutableRefObject,
   CSSProperties,
+  MouseEvent,
 } from 'react';
 import {
   useTable,
@@ -66,7 +67,7 @@ export interface DataTableProps<D extends object> extends TableOptions<D> {
   rowCount: number;
   wrapperRef?: MutableRefObject<HTMLDivElement>;
   onColumnOrderChange: () => void;
-  onContextMenu?: (value: D, offsetX: number, offsetY: number) => void;
+  onContextMenu?: (value: D, clientX: number, clientY: number) => void;
 }
 
 export interface RenderHTMLCellProps extends HTMLProps<HTMLTableCellElement> {
@@ -275,13 +276,13 @@ export default typedMemo(function DataTable<D extends object>({
               <tr
                 key={rowKey || row.id}
                 {...rowProps}
-                onContextMenu={(e: any) => {
+                onContextMenu={(e: MouseEvent) => {
                   if (onContextMenu) {
                     e.preventDefault();
                     onContextMenu(
                       row.original,
-                      e.nativeEvent.layerX,
-                      e.nativeEvent.layerY,
+                      e.nativeEvent.clientX,
+                      e.nativeEvent.clientY,
                     );
                   }
                 }}

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -39,6 +39,7 @@ import {
   ensureIsArray,
   GenericDataType,
   getTimeFormatterForGranularity,
+  QueryObjectFilterClause,
   styled,
   t,
   tn,
@@ -205,6 +206,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
     sticky = true, // whether to use sticky header
     columnColorFormatters,
     allowRearrangeColumns = false,
+    onContextMenu,
   } = props;
   const timestampFormatter = useCallback(
     value => getTimeFormatterForGranularity(timeGrain)(value),
@@ -576,6 +578,24 @@ export default function TableChart<D extends DataRecord = DataRecord>(
 
   const { width: widthFromState, height: heightFromState } = tableSize;
 
+  const handleContextMenu =
+    onContextMenu && !isRawRecords
+      ? (value: D, offsetX: number, offsetY: number) => {
+          const filters: QueryObjectFilterClause[] = [];
+          columnsMeta.forEach(col => {
+            if (!col.isMetric) {
+              filters.push({
+                col: col.key,
+                op: '==',
+                val: value[col.key],
+                formattedVal: String(value[col.key]),
+              });
+            }
+          });
+          onContextMenu(filters, offsetX, offsetY);
+        }
+      : undefined;
+
   return (
     <Styles>
       <DataTable<D>
@@ -598,6 +618,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
         selectPageSize={pageSize !== null && SelectPageSize}
         // not in use in Superset, but needed for unit tests
         sticky={sticky}
+        onContextMenu={handleContextMenu}
       />
     </Styles>
   );

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -580,19 +580,19 @@ export default function TableChart<D extends DataRecord = DataRecord>(
 
   const handleContextMenu =
     onContextMenu && !isRawRecords
-      ? (value: D, offsetX: number, offsetY: number) => {
+      ? (value: D, clientX: number, clientY: number) => {
           const filters: QueryObjectFilterClause[] = [];
           columnsMeta.forEach(col => {
             if (!col.isMetric) {
               filters.push({
                 col: col.key,
                 op: '==',
-                val: value[col.key],
+                val: value[col.key] as string | number | boolean,
                 formattedVal: String(value[col.key]),
               });
             }
           });
-          onContextMenu(filters, offsetX, offsetY);
+          onContextMenu(filters, clientX, clientY);
         }
       : undefined;
 

--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -204,7 +204,11 @@ const transformProps = (
     queriesData = [],
     filterState,
     ownState: serverPaginationData,
-    hooks: { onAddFilter: onChangeFilter, setDataMask = () => {} },
+    hooks: {
+      onAddFilter: onChangeFilter,
+      setDataMask = () => {},
+      onContextMenu,
+    },
   } = chartProps;
 
   const {
@@ -274,6 +278,7 @@ const transformProps = (
     columnColorFormatters,
     timeGrain,
     allowRearrangeColumns,
+    onContextMenu,
   };
 };
 

--- a/superset-frontend/plugins/plugin-chart-table/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/types.ts
@@ -30,6 +30,7 @@ import {
   ChartDataResponseResult,
   QueryFormData,
   SetDataMaskHook,
+  QueryObjectFilterClause,
 } from '@superset-ui/core';
 import { ColorFormatters, ColumnConfig } from '@superset-ui/chart-controls';
 
@@ -111,6 +112,11 @@ export interface TableChartTransformedProps<D extends DataRecord = DataRecord> {
   onChangeFilter?: ChartProps['hooks']['onAddFilter'];
   columnColorFormatters?: ColorFormatters;
   allowRearrangeColumns?: boolean;
+  onContextMenu?: (
+    filters: QueryObjectFilterClause[],
+    offsetX: number,
+    offsetY: number,
+  ) => void;
 }
 
 export default {};

--- a/superset-frontend/plugins/plugin-chart-table/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/types.ts
@@ -114,8 +114,8 @@ export interface TableChartTransformedProps<D extends DataRecord = DataRecord> {
   allowRearrangeColumns?: boolean;
   onContextMenu?: (
     filters: QueryObjectFilterClause[],
-    offsetX: number,
-    offsetY: number,
+    clientX: number,
+    clientY: number,
   ) => void;
 }
 


### PR DESCRIPTION
### SUMMARY
Adds drill-to-detail context menu to Table chart when right-clicking on the rows. The context menu is only displayed if the table contains aggregated data.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/186236677-8eb54e4d-1bca-487f-8e2b-cbd0f14937ef.mov

### TESTING INSTRUCTIONS
1 - You should be able to right-click on the rows in a table with aggregated data.
2 - Check the value and formatted value when right-clicking
3 - You should NOT be able to right-click on the rows in a table with raw data.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
