### PR TITLE
fix: improve get_db_engine_spec_for_backend

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -211,7 +211,7 @@ SQLALCHEMY_CUSTOM_PASSWORD_STORE = None
 #
 # e.g.:
 #
-# class AesGcmEncryptedAdapter(  # pylint: disable=too-few-public-methods
+# class AesGcmEncryptedAdapter(
 #     AbstractEncryptedFieldAdapter
 # ):
 #     def create(

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -1083,8 +1083,8 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
                 "preferred": engine_spec.engine_name in preferred_databases,
             }
 
-            if hasattr(engine_spec, "default_driver"):
-                payload["default_driver"] = engine_spec.default_driver  # type: ignore
+            if engine_spec.default_driver:
+                payload["default_driver"] = engine_spec.default_driver
 
             # show configuration parameters for DBs that support it
             if (

--- a/superset/databases/commands/validate.py
+++ b/superset/databases/commands/validate.py
@@ -30,7 +30,6 @@ from superset.databases.commands.exceptions import (
 from superset.databases.dao import DatabaseDAO
 from superset.databases.utils import make_url_safe
 from superset.db_engine_specs import get_engine_spec
-from superset.db_engine_specs.base import BasicParametersMixin
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.extensions import event_logger
 from superset.models.core import Database

--- a/superset/databases/commands/validate.py
+++ b/superset/databases/commands/validate.py
@@ -44,7 +44,7 @@ class ValidateDatabaseParametersCommand(BaseCommand):
 
     def run(self) -> None:
         engine = self._properties["engine"]
-        driver = self._properties["driver"]
+        driver = self._properties.get("driver")
 
         if engine in BYPASS_VALIDATION_ENGINES:
             # Skip engines that are only validated onCreate

--- a/superset/databases/commands/validate.py
+++ b/superset/databases/commands/validate.py
@@ -29,7 +29,7 @@ from superset.databases.commands.exceptions import (
 )
 from superset.databases.dao import DatabaseDAO
 from superset.databases.utils import make_url_safe
-from superset.db_engine_specs import get_engine_specs
+from superset.db_engine_specs import get_engine_spec
 from superset.db_engine_specs.base import BasicParametersMixin
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.extensions import event_logger
@@ -45,25 +45,13 @@ class ValidateDatabaseParametersCommand(BaseCommand):
 
     def run(self) -> None:
         engine = self._properties["engine"]
-        engine_specs = get_engine_specs()
+        driver = self._properties["driver"]
 
         if engine in BYPASS_VALIDATION_ENGINES:
             # Skip engines that are only validated onCreate
             return
 
-        if engine not in engine_specs:
-            raise InvalidEngineError(
-                SupersetError(
-                    message=__(
-                        'Engine "%(engine)s" is not a valid engine.',
-                        engine=engine,
-                    ),
-                    error_type=SupersetErrorType.GENERIC_DB_ENGINE_ERROR,
-                    level=ErrorLevel.ERROR,
-                    extra={"allowed": list(engine_specs), "provided": engine},
-                ),
-            )
-        engine_spec = engine_specs[engine]
+        engine_spec = get_engine_spec(engine, driver)
         if not hasattr(engine_spec, "parameters_schema"):
             raise InvalidEngineError(
                 SupersetError(
@@ -73,14 +61,6 @@ class ValidateDatabaseParametersCommand(BaseCommand):
                     ),
                     error_type=SupersetErrorType.GENERIC_DB_ENGINE_ERROR,
                     level=ErrorLevel.ERROR,
-                    extra={
-                        "allowed": [
-                            name
-                            for name, engine_spec in engine_specs.items()
-                            if issubclass(engine_spec, BasicParametersMixin)
-                        ],
-                        "provided": engine,
-                    },
                 ),
             )
 

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -28,7 +28,7 @@ from sqlalchemy import MetaData
 from superset import db
 from superset.databases.commands.exceptions import DatabaseInvalidError
 from superset.databases.utils import make_url_safe
-from superset.db_engine_specs import BaseEngineSpec, get_engine_specs
+from superset.db_engine_specs import BaseEngineSpec, get_engine_spec
 from superset.exceptions import CertificateException, SupersetSecurityException
 from superset.models.core import ConfigurationMethod, Database, PASSWORD_MASK
 from superset.security.analytics_db_safety import check_sqlalchemy_uri
@@ -231,6 +231,7 @@ class DatabaseParametersSchemaMixin:  # pylint: disable=too-few-public-methods
     """
 
     engine = fields.String(allow_none=True, description="SQLAlchemy engine to use")
+    driver = fields.String(allow_none=True, description="SQLAlchemy driver to use")
     parameters = fields.Dict(
         keys=fields.String(),
         values=fields.Raw(),
@@ -262,10 +263,20 @@ class DatabaseParametersSchemaMixin:  # pylint: disable=too-few-public-methods
             or parameters.pop("engine", None)
             or data.pop("backend", None)
         )
+        if not engine:
+            raise ValidationError(
+                [
+                    _(
+                        "An engine must be specified when passing "
+                        "individual parameters to a database."
+                    )
+                ]
+            )
+        driver = data.pop("driver", None)
 
         configuration_method = data.get("configuration_method")
         if configuration_method == ConfigurationMethod.DYNAMIC_FORM:
-            engine_spec = get_engine_spec(engine)
+            engine_spec = get_engine_spec(engine, driver)
 
             if not hasattr(engine_spec, "build_sqlalchemy_uri") or not hasattr(
                 engine_spec, "parameters_schema"
@@ -295,34 +306,12 @@ class DatabaseParametersSchemaMixin:  # pylint: disable=too-few-public-methods
         return data
 
 
-def get_engine_spec(engine: Optional[str]) -> Type[BaseEngineSpec]:
-    if not engine:
-        raise ValidationError(
-            [
-                _(
-                    "An engine must be specified when passing "
-                    "individual parameters to a database."
-                )
-            ]
-        )
-    engine_specs = get_engine_specs()
-    if engine not in engine_specs:
-        raise ValidationError(
-            [
-                _(
-                    'Engine "%(engine)s" is not a valid engine.',
-                    engine=engine,
-                )
-            ]
-        )
-    return engine_specs[engine]
-
-
 class DatabaseValidateParametersSchema(Schema):
     class Meta:  # pylint: disable=too-few-public-methods
         unknown = EXCLUDE
 
     engine = fields.String(required=True, description="SQLAlchemy engine to use")
+    driver = fields.String(allow_none=True, description="SQLAlchemy driver to use")
     parameters = fields.Dict(
         keys=fields.String(),
         values=fields.Raw(allow_none=True),

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -16,7 +16,7 @@
 # under the License.
 import inspect
 import json
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict
 
 from flask import current_app
 from flask_babel import lazy_gettext as _
@@ -28,7 +28,7 @@ from sqlalchemy import MetaData
 from superset import db
 from superset.databases.commands.exceptions import DatabaseInvalidError
 from superset.databases.utils import make_url_safe
-from superset.db_engine_specs import BaseEngineSpec, get_engine_spec
+from superset.db_engine_specs import get_engine_spec
 from superset.exceptions import CertificateException, SupersetSecurityException
 from superset.models.core import ConfigurationMethod, Database, PASSWORD_MASK
 from superset.security.analytics_db_safety import check_sqlalchemy_uri

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -150,7 +150,7 @@ def sqlalchemy_uri_validator(value: str) -> str:
             [
                 _(
                     "Invalid connection string, a valid string usually follows: "
-                    "driver://user:password@database-host/database-name"
+                    "backend+driver://user:password@database-host/database-name"
                 )
             ]
         ) from ex
@@ -263,19 +263,19 @@ class DatabaseParametersSchemaMixin:  # pylint: disable=too-few-public-methods
             or parameters.pop("engine", None)
             or data.pop("backend", None)
         )
-        if not engine:
-            raise ValidationError(
-                [
-                    _(
-                        "An engine must be specified when passing "
-                        "individual parameters to a database."
-                    )
-                ]
-            )
         driver = data.pop("driver", None)
 
         configuration_method = data.get("configuration_method")
         if configuration_method == ConfigurationMethod.DYNAMIC_FORM:
+            if not engine:
+                raise ValidationError(
+                    [
+                        _(
+                            "An engine must be specified when passing "
+                            "individual parameters to a database."
+                        )
+                    ]
+                )
             engine_spec = get_engine_spec(engine, driver)
 
             if not hasattr(engine_spec, "build_sqlalchemy_uri") or not hasattr(

--- a/superset/db_engine_specs/__init__.py
+++ b/superset/db_engine_specs/__init__.py
@@ -33,27 +33,34 @@ import pkgutil
 from collections import defaultdict
 from importlib import import_module
 from pathlib import Path
-from typing import Any, Dict, List, Set, Type
+from typing import Any, Dict, List, Optional, Set, Type
 
 import sqlalchemy.databases
 import sqlalchemy.dialects
 from pkg_resources import iter_entry_points
 from sqlalchemy.engine.default import DefaultDialect
+from sqlalchemy.engine.url import URL
 
 from superset.db_engine_specs.base import BaseEngineSpec
 
 logger = logging.getLogger(__name__)
 
 
-def is_engine_spec(attr: Any) -> bool:
+def is_engine_spec(obj: Any) -> bool:
+    """
+    Return true if a given object is a DB engine spec.
+    """
     return (
-        inspect.isclass(attr)
-        and issubclass(attr, BaseEngineSpec)
-        and attr != BaseEngineSpec
+        inspect.isclass(obj)
+        and issubclass(obj, BaseEngineSpec)
+        and obj != BaseEngineSpec
     )
 
 
 def load_engine_specs() -> List[Type[BaseEngineSpec]]:
+    """
+    Load all engine specs, native and 3rd party.
+    """
     engine_specs: List[Type[BaseEngineSpec]] = []
 
     # load standard engines
@@ -78,20 +85,18 @@ def load_engine_specs() -> List[Type[BaseEngineSpec]]:
     return engine_specs
 
 
-def get_engine_specs() -> Dict[str, Type[BaseEngineSpec]]:
+def get_engine_spec(backend: str, driver: Optional[str] = None) -> Type[BaseEngineSpec]:
+    """
+    Return the DB engine spec associated with a given SQLAlchemy URL.
+    """
     engine_specs = load_engine_specs()
 
-    # build map from name/alias -> spec
-    engine_specs_map: Dict[str, Type[BaseEngineSpec]] = {}
     for engine_spec in engine_specs:
-        names = [engine_spec.engine]
-        if engine_spec.engine_aliases:
-            names.extend(engine_spec.engine_aliases)
+        if engine_spec.supports_backend(backend, driver):
+            return engine_spec
 
-        for name in names:
-            engine_specs_map[name] = engine_spec
-
-    return engine_specs_map
+    # default to the generic DB engine spec
+    return BaseEngineSpec
 
 
 # there's a mismatch between the dialect name reported by the driver in these

--- a/superset/db_engine_specs/__init__.py
+++ b/superset/db_engine_specs/__init__.py
@@ -95,6 +95,12 @@ def get_engine_spec(backend: str, driver: Optional[str] = None) -> Type[BaseEngi
         if engine_spec.supports_backend(backend, driver):
             return engine_spec
 
+    # check ignoring the driver, in order to support new drivers; this will return a
+    # random DB engine spec that supports the engine
+    for engine_spec in engine_specs:
+        if engine_spec.supports_backend(backend):
+            return engine_spec
+
     # default to the generic DB engine spec
     return BaseEngineSpec
 

--- a/superset/db_engine_specs/__init__.py
+++ b/superset/db_engine_specs/__init__.py
@@ -88,12 +88,19 @@ def load_engine_specs() -> List[Type[BaseEngineSpec]]:
 def get_engine_spec(backend: str, driver: Optional[str] = None) -> Type[BaseEngineSpec]:
     """
     Return the DB engine spec associated with a given SQLAlchemy URL.
+
+    Note that if a driver is not specified the function returns the first DB engine spec
+    that supports the backend. Also, if a driver is specified but no DB engine explicitly
+    supporting that driver exists then a backend-only match is done, in order to allow new
+    drivers to work with Superset even if they are not listed in the DB engine spec
+    drivers.
     """
     engine_specs = load_engine_specs()
 
-    for engine_spec in engine_specs:
-        if engine_spec.supports_backend(backend, driver):
-            return engine_spec
+    if driver is not None:
+        for engine_spec in engine_specs:
+            if engine_spec.supports_backend(backend, driver):
+                return engine_spec
 
     # check ignoring the driver, in order to support new drivers; this will return a
     # random DB engine spec that supports the engine

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -185,15 +185,18 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
 
     engine_name: Optional[str] = None  # for user messages, overridden in child classes
 
-    # Associate the DB engine spec to one or more SQLAlchemy dialects/drivers. For
-    # example, if a given DB engine spec has:
+    # These attributes map the DB engine spec to one or more SQLAlchemy dialects/drivers.
+    # For example, if a given DB engine spec has:
     #
     #     class PostgresDBEngineSpec:
-    #         engine = 'postgresql'
-    #         engine_aliases = 'postgres'
-    #         drivers = {'psycopg2', 'asyncpg'}
+    #         engine = "postgresql"
+    #         engine_aliases = "postgres"
+    #         drivers = {
+    #             "psycopg2": "The default Postgres driver",
+    #             "asyncpg": "An asynchronous Postgres driver",
+    #         }
     #
-    # It would be used for all the following SQLALchemy URIs:
+    # It would be used for all the following SQLAlchemy URIs:
     #
     #   - postgres://user:password@host/db
     #   - postgresql://user:password@host/db
@@ -450,7 +453,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     @classmethod
     def get_text_clause(cls, clause: str) -> TextClause:
         """
-        SQLALchemy wrapper to ensure text clauses are escaped properly
+        SQLAlchemy wrapper to ensure text clauses are escaped properly
 
         :param clause: string clause with potentially unescaped characters
         :return: text clause with escaped characters

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -185,35 +185,8 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
 
     engine_name: Optional[str] = None  # for user messages, overridden in child classes
 
-    # These attributes map the DB engine spec to one or more SQLAlchemy dialects/drivers.
-    # For example, if a given DB engine spec has:
-    #
-    #     class PostgresDBEngineSpec:
-    #         engine = "postgresql"
-    #         engine_aliases = "postgres"
-    #         drivers = {
-    #             "psycopg2": "The default Postgres driver",
-    #             "asyncpg": "An asynchronous Postgres driver",
-    #         }
-    #
-    # It would be used for all the following SQLAlchemy URIs:
-    #
-    #   - postgres://user:password@host/db
-    #   - postgresql://user:password@host/db
-    #   - postgres+asyncpg://user:password@host/db
-    #   - postgres+psycopg2://user:password@host/db
-    #   - postgresql+asyncpg://user:password@host/db
-    #   - postgresql+psycopg2://user:password@host/db
-    #
-    # Note that SQLAlchemy has a default driver when one is not specified:
-    #
-    #     >>> from sqlalchemy.engine.url import make_url
-    #     >>> make_url('postgres://').get_driver_name()
-    #     'psycopg2'
-    #
-    # The ``default_driver`` should point to the recomended driver, and is used by
-    # database creation modals where the user provides parameters to connect to the
-    # database, instead of providing the SQLAlchemy URI.
+    # These attributes map the DB engine spec to one or more SQLAlchemy dialects/drivers;
+    # see the ``supports_url`` and ``supports_backend`` methods below.
     engine = "base"  # str as defined in sqlalchemy.engine.engine
     engine_aliases: Set[str] = set()
     drivers: Dict[str, str] = {}
@@ -392,6 +365,32 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     def supports_url(cls, url: URL) -> bool:
         """
         Returns true if the DB engine spec supports a given SQLAlchemy URL.
+
+        As an example, if a given DB engine spec has:
+
+            class PostgresDBEngineSpec:
+                engine = "postgresql"
+                engine_aliases = "postgres"
+                drivers = {
+                    "psycopg2": "The default Postgres driver",
+                    "asyncpg": "An asynchronous Postgres driver",
+                }
+
+        It would be used for all the following SQLAlchemy URIs:
+
+            - postgres://user:password@host/db
+            - postgresql://user:password@host/db
+            - postgres+asyncpg://user:password@host/db
+            - postgres+psycopg2://user:password@host/db
+            - postgresql+asyncpg://user:password@host/db
+            - postgresql+psycopg2://user:password@host/db
+
+        Note that SQLAlchemy has a default driver even if one is not specified:
+
+            >>> from sqlalchemy.engine.url import make_url
+            >>> make_url('postgres://').get_driver_name()
+            'psycopg2'
+
         """
         backend = url.get_backend_name()
         driver = url.get_driver_name()

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -183,9 +183,39 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
                                        having to add the same aggregation in SELECT.
     """
 
+    engine_name: Optional[str] = None  # for user messages, overridden in child classes
+
+    # Associate the DB engine spec to one or more SQLAlchemy dialects/drivers. For
+    # example, if a given DB engine spec has:
+    #
+    #     class PostgresDBEngineSpec:
+    #         engine = 'postgresql'
+    #         engine_aliases = 'postgres'
+    #         drivers = {'psycopg2', 'asyncpg'}
+    #
+    # It would be used for all the following SQLALchemy URIs:
+    #
+    #   - postgres://user:password@host/db
+    #   - postgresql://user:password@host/db
+    #   - postgres+asyncpg://user:password@host/db
+    #   - postgres+psycopg2://user:password@host/db
+    #   - postgresql+asyncpg://user:password@host/db
+    #   - postgresql+psycopg2://user:password@host/db
+    #
+    # Note that SQLAlchemy has a default driver when one is not specified:
+    #
+    #     >>> from sqlalchemy.engine.url import make_url
+    #     >>> make_url('postgres://').get_driver_name()
+    #     'psycopg2'
+    #
+    # The ``default_driver`` should point to the recomended driver, and is used by
+    # database creation modals where the user provides parameters to connect to the
+    # database, instead of providing the SQLAlchemy URI.
     engine = "base"  # str as defined in sqlalchemy.engine.engine
     engine_aliases: Set[str] = set()
-    engine_name: Optional[str] = None  # for user messages, overridden in child classes
+    drivers: Dict[str, str] = {}
+    default_driver: Optional[str] = None
+
     _date_trunc_functions: Dict[str, str] = {}
     _time_grain_expressions: Dict[Optional[str], str] = {}
     column_type_mappings: Tuple[ColumnTypeMapping, ...] = (
@@ -354,6 +384,32 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     custom_errors: Dict[
         Pattern[str], Tuple[str, SupersetErrorType, Dict[str, Any]]
     ] = {}
+
+    @classmethod
+    def supports_url(cls, url: URL) -> bool:
+        """
+        Returns true if the DB engine spec supports a given SQLAlchemy URL.
+        """
+        backend = url.get_backend_name()
+        driver = url.get_driver_name()
+        return cls.supports_backend(backend, driver)
+
+    @classmethod
+    def supports_backend(cls, backend: str, driver: Optional[str] = None) -> bool:
+        """
+        Returns true if the DB engine spec supports a given SQLAlchemy backend/driver.
+        """
+        # check the backend first
+        if backend != cls.engine and backend not in cls.engine_aliases:
+            return False
+
+        # originally DB engine specs didn't declare any drivers and the check was made
+        # only on the engine; if that's the case, ignore the driver for backwards
+        # compatibility
+        if not cls.drivers or driver is None:
+            return True
+
+        return driver in cls.drivers
 
     @classmethod
     def get_dbapi_exception_mapping(cls) -> Dict[Type[Exception], Type[Exception]]:

--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -47,18 +47,23 @@ time_grain_expressions = {
 
 
 class DatabricksHiveEngineSpec(HiveEngineSpec):
-    engine = "databricks"
     engine_name = "Databricks Interactive Cluster"
-    driver = "pyhive"
+
+    engine = "databricks"
+    drivers = {"pyhive": "Hive driver for Interactive Cluster"}
+    default_driver = "pyhive"
+
     _show_functions_column = "function"
 
     _time_grain_expressions = time_grain_expressions
 
 
 class DatabricksODBCEngineSpec(BaseEngineSpec):
-    engine = "databricks"
     engine_name = "Databricks SQL Endpoint"
-    driver = "pyodbc"
+
+    engine = "databricks"
+    drivers = {"pyodbc": "ODBC driver for SQL endpoint"}
+    default_driver = "pyodbc"
 
     _time_grain_expressions = time_grain_expressions
 
@@ -74,9 +79,11 @@ class DatabricksODBCEngineSpec(BaseEngineSpec):
 
 
 class DatabricksNativeEngineSpec(DatabricksODBCEngineSpec):
-    engine = "databricks"
     engine_name = "Databricks Native Connector"
-    driver = "connector"
+
+    engine = "databricks"
+    drivers = {"connector": "Native all-purpose driver"}
+    default_driver = "connector"
 
     @staticmethod
     def get_extra_params(database: "Database") -> Dict[str, Any]:

--- a/superset/db_engine_specs/shillelagh.py
+++ b/superset/db_engine_specs/shillelagh.py
@@ -20,7 +20,11 @@ from superset.db_engine_specs.sqlite import SqliteEngineSpec
 class ShillelaghEngineSpec(SqliteEngineSpec):
     """Engine for shillelagh"""
 
-    engine = "shillelagh"
     engine_name = "Shillelagh"
+    engine = "shillelagh"
+    drivers = {"apsw": "SQLite driver"}
+    default_driver = "apsw"
+    sqlalchemy_uri_placeholder = "shillelagh://"
+
     allows_joins = True
     allows_subqueries = True

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     from superset.models.core import Database
 
     try:
-        from trino.dbapi import Cursor  # pylint: disable=unused-import
+        from trino.dbapi import Cursor
     except ImportError:
         pass
 

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -635,15 +635,16 @@ class Database(
 
     @property
     def db_engine_spec(self) -> Type[db_engine_specs.BaseEngineSpec]:
-        return self.get_db_engine_spec_for_backend(self.backend)
+        url = make_url_safe(self.sqlalchemy_uri_decrypted)
+        return self.get_db_engine_spec(url)
 
     @classmethod
     @memoized
-    def get_db_engine_spec_for_backend(
-        cls, backend: str
-    ) -> Type[db_engine_specs.BaseEngineSpec]:
-        engines = db_engine_specs.get_engine_specs()
-        return engines.get(backend, db_engine_specs.BaseEngineSpec)
+    def get_db_engine_spec(cls, url: URL) -> Type[db_engine_specs.BaseEngineSpec]:
+        backend = url.get_backend_name()
+        driver = url.get_driver_name()
+
+        return db_engine_specs.get_engine_spec(backend, driver)
 
     def grains(self) -> Tuple[TimeGrain, ...]:
         """Defines time granularity database-specific expressions.

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -646,7 +646,7 @@ class Database(
             driver = url.get_driver_name()
         except NoSuchModuleError:
             # can't load the driver, fallback for backwards compatibility
-            return db_engine_specs.BaseEngineSpec
+            driver = None
 
         return db_engine_specs.get_engine_spec(backend, driver)
 

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -46,7 +46,7 @@ from sqlalchemy import (
 from sqlalchemy.engine import Connection, Dialect, Engine
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.engine.url import URL
-from sqlalchemy.exc import ArgumentError
+from sqlalchemy.exc import ArgumentError, NoSuchModuleError
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
 from sqlalchemy.pool import NullPool
@@ -642,7 +642,11 @@ class Database(
     @memoized
     def get_db_engine_spec(cls, url: URL) -> Type[db_engine_specs.BaseEngineSpec]:
         backend = url.get_backend_name()
-        driver = url.get_driver_name()
+        try:
+            driver = url.get_driver_name()
+        except NoSuchModuleError:
+            # can't load the driver, fallback for backwards compatibility
+            return db_engine_specs.BaseEngineSpec
 
         return db_engine_specs.get_engine_spec(backend, driver)
 

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -1425,7 +1425,7 @@ class TestDatabaseApi(SupersetTestCase):
         expected_response = {
             "errors": [
                 {
-                    "message": "Could not load database driver: AzureSynapseSpec",
+                    "message": "Could not load database driver: MssqlEngineSpec",
                     "error_type": "GENERIC_COMMAND_ERROR",
                     "level": "warning",
                     "extra": {

--- a/tests/integration_tests/db_engine_specs/base_engine_spec_tests.py
+++ b/tests/integration_tests/db_engine_specs/base_engine_spec_tests.py
@@ -20,7 +20,7 @@ from unittest import mock
 import pytest
 
 from superset.connectors.sqla.models import TableColumn
-from superset.db_engine_specs import get_engine_specs
+from superset.db_engine_specs import load_engine_specs
 from superset.db_engine_specs.base import (
     BaseEngineSpec,
     BasicParametersMixin,
@@ -195,7 +195,7 @@ class TestDbEngineSpecs(TestDbEngineSpec):
     def test_engine_time_grain_validity(self):
         time_grains = set(builtin_time_grains.keys())
         # loop over all subclasses of BaseEngineSpec
-        for engine in get_engine_specs().values():
+        for engine in load_engine_specs():
             if engine is not BaseEngineSpec:
                 # make sure time grain functions have been defined
                 self.assertGreater(len(engine.get_time_grain_expressions()), 0)

--- a/tests/integration_tests/db_engine_specs/postgres_tests.py
+++ b/tests/integration_tests/db_engine_specs/postgres_tests.py
@@ -137,7 +137,11 @@ class TestPostgresDbEngineSpec(TestDbEngineSpec):
         """
         DB Eng Specs (postgres): Test "postgres" in engine spec
         """
-        self.assertIn("postgres", [engine.engine for engine in load_engine_specs()])
+        backends = set()
+        for engine in load_engine_specs():
+            backends.add(engine.engine)
+            backends.update(engine.engine_aliases)
+        assert "postgres" in backends
 
     def test_extras_without_ssl(self):
         db = mock.Mock()

--- a/tests/integration_tests/db_engine_specs/postgres_tests.py
+++ b/tests/integration_tests/db_engine_specs/postgres_tests.py
@@ -20,7 +20,7 @@ from unittest import mock
 from sqlalchemy import column, literal_column
 from sqlalchemy.dialects import postgresql
 
-from superset.db_engine_specs import get_engine_specs
+from superset.db_engine_specs import load_engine_specs
 from superset.db_engine_specs.postgres import PostgresEngineSpec
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.models.sql_lab import Query
@@ -137,7 +137,7 @@ class TestPostgresDbEngineSpec(TestDbEngineSpec):
         """
         DB Eng Specs (postgres): Test "postgres" in engine spec
         """
-        self.assertIn("postgres", get_engine_specs())
+        self.assertIn("postgres", [engine.engine for engine in load_engine_specs()])
 
     def test_extras_without_ssl(self):
         db = mock.Mock()

--- a/tests/unit_tests/models/core_test.py
+++ b/tests/unit_tests/models/core_test.py
@@ -59,7 +59,7 @@ def test_get_metrics(mocker: MockFixture) -> None:
                 },
             ]
 
-    database.get_db_engine_spec_for_backend = mocker.MagicMock(  # type: ignore
+    database.get_db_engine_spec = mocker.MagicMock(  # type: ignore
         return_value=CustomSqliteEngineSpec
     )
     assert database.get_metrics("table") == [
@@ -70,3 +70,66 @@ def test_get_metrics(mocker: MockFixture) -> None:
             "verbose_name": "COUNT(DISTINCT user_id)",
         },
     ]
+
+
+def test_get_db_engine_spec(mocker: MockFixture) -> None:
+    """
+    Tests for ``get_db_engine_spec``.
+    """
+    from superset.db_engine_specs import BaseEngineSpec
+    from superset.models.core import Database
+
+    # pylint: disable=abstract-method
+    class PostgresDBEngineSpec(BaseEngineSpec):
+        """
+        A DB engine spec with drivers and a default driver.
+        """
+
+        engine = "postgresql"
+        engine_aliases = {"postgres"}
+        drivers = {
+            "psycopg2": "The default Postgres driver",
+            "asyncpg": "An async Postgres driver",
+        }
+        default_driver = "psycopg2"
+
+    # pylint: disable=abstract-method
+    class OldDBEngineSpec(BaseEngineSpec):
+        """
+        And old DB engine spec without drivers nor a default driver.
+        """
+
+        engine = "mysql"
+
+    load_engine_specs = mocker.patch("superset.db_engine_specs.load_engine_specs")
+    load_engine_specs.return_value = [
+        PostgresDBEngineSpec,
+        OldDBEngineSpec,
+    ]
+
+    assert (
+        Database(database_name="db", sqlalchemy_uri="postgresql://").db_engine_spec
+        == PostgresDBEngineSpec
+    )
+    assert (
+        Database(
+            database_name="db", sqlalchemy_uri="postgresql+psycopg2://"
+        ).db_engine_spec
+        == PostgresDBEngineSpec
+    )
+    assert (
+        Database(
+            database_name="db", sqlalchemy_uri="postgresql+asyncpg://"
+        ).db_engine_spec
+        == PostgresDBEngineSpec
+    )
+    assert (
+        Database(database_name="db", sqlalchemy_uri="mysql://").db_engine_spec
+        == OldDBEngineSpec
+    )
+    assert (
+        Database(
+            database_name="db", sqlalchemy_uri="mysql+mysqlconnector://"
+        ).db_engine_spec
+        == OldDBEngineSpec
+    )

--- a/tests/unit_tests/models/core_test.py
+++ b/tests/unit_tests/models/core_test.py
@@ -124,12 +124,24 @@ def test_get_db_engine_spec(mocker: MockFixture) -> None:
         == PostgresDBEngineSpec
     )
     assert (
+        Database(
+            database_name="db", sqlalchemy_uri="postgresql+fancynewdriver://"
+        ).db_engine_spec
+        == PostgresDBEngineSpec
+    )
+    assert (
         Database(database_name="db", sqlalchemy_uri="mysql://").db_engine_spec
         == OldDBEngineSpec
     )
     assert (
         Database(
             database_name="db", sqlalchemy_uri="mysql+mysqlconnector://"
+        ).db_engine_spec
+        == OldDBEngineSpec
+    )
+    assert (
+        Database(
+            database_name="db", sqlalchemy_uri="mysql+fancynewdriver://"
         ).db_engine_spec
         == OldDBEngineSpec
     )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

How does Superset map from a SQLAlchemy URI — eg, `postgres+psycopg2://user:password@host/db` — to a DB engine spec? Currently **the mapping is done using only the backend** part of the URI; in this example `postgres` matches the `PostgresEngineSpec` engine spec since it's listed in the `engine_aliases` class attribute:

https://github.com/apache/superset/blob/d408393ba9bb6c81c661248521be93dd70c9e19b/superset/db_engine_specs/postgres.py#L166-L168

This matching has worked perfectly until the introduction of new DB engine specs that share the backend but have different drivers. Eg, for Databricks we currently have 3 DB engine specs:

https://github.com/apache/superset/blob/d408393ba9bb6c81c661248521be93dd70c9e19b/superset/db_engine_specs/databricks.py#L49-L52

https://github.com/apache/superset/blob/d408393ba9bb6c81c661248521be93dd70c9e19b/superset/db_engine_specs/databricks.py#L58-L61

https://github.com/apache/superset/blob/d408393ba9bb6c81c661248521be93dd70c9e19b/superset/db_engine_specs/databricks.py#L76-L79

Whenever we encounter a database configured with a `databricks` backend — be it `databricks+pyhive://`, `databricks+pyodbc://` or `databricsk+connector://` we discard the driver part, and perform a match using only the backend. The end result is that **one of the 3 DB engine specs is chosen at random** every time!

To fix the problem, I extended the base DB engine spec with 2 new class attributes:

- `drivers: Dict[str, str] = {}`, a dictionary with driver names ("psycopg2") and their descriptions
- `default_driver: Optional[str] = None`, the recommended driver to be used when one is not selected (used only when the SQLAlchemy URI is not entered directly)

With these new attributes, instead of simply matching the backend of a URI (`databricks`) we can use the driver as well (`pyhive`) to find the associated DB engine spec.

A few things of note: first, if the backend matches but no driver matches the new flow will still return a random DB engine specs from the ones that support the backend. This preserves the old behavior and allows people to use drivers that Superset is not aware of. Eg, someone could configure a database with the `postgres+newfancydriver://` URI and Superset would still use `PostgresEngineSpec` as the engine spec.

Second, if no backend matches we also preserve the old behavior of returning the `BaseEngineSpec`, since this allows users to explore databases that Superset is not aware of, though at limited functionality (no time grains, for example).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

WIP

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
