### PR TITLE
chore: migrate available_domains to api/v1

### DIFF
--- a/superset/available_domains/__init__.py
+++ b/superset/available_domains/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/superset/available_domains/api.py
+++ b/superset/available_domains/api.py
@@ -30,7 +30,7 @@ class AvailableDomainsRestApi(BaseApi):
     method_permission_name = MODEL_API_RW_METHOD_PERMISSION_MAP
     include_route_methods = {RouteMethod.GET}
     allow_browser_login = True
-    class_permission_name = "AvailableDomain"
+    class_permission_name = "AvailableDomains"
     resource_name = "available_domains"
     openapi_spec_tag = "Available Domains"
     openapi_spec_component_schemas = ()

--- a/superset/available_domains/api.py
+++ b/superset/available_domains/api.py
@@ -64,14 +64,10 @@ class AvailableDomainsRestApi(BaseApi):
                     properties:
                       result:
                         $ref: '#/components/schemas/AvailableDomainsSchema'
-            400:
-              $ref: '#/components/responses/400'
             401:
               $ref: '#/components/responses/401'
             403:
               $ref: '#/components/responses/403'
-            404:
-              $ref: '#/components/responses/404'
         """
         result = self.available_domains_schema.dump(
             {"domains": conf.get("SUPERSET_WEBSERVER_DOMAINS")}

--- a/superset/available_domains/api.py
+++ b/superset/available_domains/api.py
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import logging
+
+from flask import Response
+from flask_appbuilder.api import BaseApi, expose, protect, safe
+
+from superset import conf
+from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP, RouteMethod
+from superset.extensions import event_logger
+
+logger = logging.getLogger(__name__)
+
+
+class AvailableDomainsRestApi(BaseApi):
+    method_permission_name = MODEL_API_RW_METHOD_PERMISSION_MAP
+    include_route_methods = {RouteMethod.GET}
+    allow_browser_login = True
+    class_permission_name = "AvailableDomain"
+    resource_name = "available_domains"
+    openapi_spec_tag = "Available Domains"
+    openapi_spec_component_schemas = ()
+
+    @expose("/", methods=["GET"])
+    @protect()
+    @safe
+    @event_logger.log_this_with_context(
+        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.get",
+        log_to_statsd=True,
+    )
+    def get(self) -> Response:
+        """
+        Returns the list of available Superset Webserver domains (if any)
+        defined in config. This enables charts embedded in other apps to
+        leverage domain sharding if appropriately configured.
+        """
+        return self.response(200, result=conf.get("SUPERSET_WEBSERVER_DOMAINS"))

--- a/superset/available_domains/schemas.py
+++ b/superset/available_domains/schemas.py
@@ -3,14 +3,19 @@
 # distributed with this work for additional information
 # regarding copyright ownership.  The ASF licenses this file
 # to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
+#  License ); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
 #   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  AS IS  BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from marshmallow import fields, Schema
+
+
+class AvailableDomainsSchema(Schema):
+    domains = fields.List(fields.String())

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -116,6 +116,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         from superset.annotation_layers.annotations.api import AnnotationRestApi
         from superset.annotation_layers.api import AnnotationLayerRestApi
         from superset.async_events.api import AsyncEventsRestApi
+        from superset.available_domains.api import AvailableDomainsRestApi
         from superset.cachekeys.api import CacheRestApi
         from superset.charts.api import ChartRestApi
         from superset.charts.data.api import ChartDataRestApi
@@ -193,6 +194,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         appbuilder.add_api(AnnotationLayerRestApi)
         appbuilder.add_api(AsyncEventsRestApi)
         appbuilder.add_api(AdvancedDataTypeRestApi)
+        appbuilder.add_api(AvailableDomainsRestApi)
         appbuilder.add_api(CacheRestApi)
         appbuilder.add_api(ChartRestApi)
         appbuilder.add_api(ChartDataRestApi)

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1570,6 +1570,11 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         defined in config. This enables charts embedded in other apps to
         leverage domain sharding if appropriately configured.
         """
+        logger.warning(
+            "%s.available_domains "
+            "This API endpoint is deprecated and will be removed in version 3.0.0",
+            self.__class__.__name__,
+        )
         return Response(
             json.dumps(conf.get("SUPERSET_WEBSERVER_DOMAINS")), mimetype="text/json"
         )

--- a/tests/integration_tests/available_domains/api_tests.py
+++ b/tests/integration_tests/available_domains/api_tests.py
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import json
+
+import pytest
+
+from tests.integration_tests.test_app import app
+
+
+@pytest.mark.usefixtures("login_as_admin")
+def test_get_available_domains(test_client):
+    app.config["SUPERSET_WEBSERVER_DOMAINS"] = ["a", "b"]
+    resp = test_client.get(f"api/v1/available_domains/")
+    assert resp.status_code == 200
+    data = json.loads(resp.data.decode("utf-8"))
+    result = data.get("result")
+    assert result == ["a", "b"]

--- a/tests/integration_tests/available_domains/api_tests.py
+++ b/tests/integration_tests/available_domains/api_tests.py
@@ -16,15 +16,12 @@
 # under the License.
 import json
 
-import pytest
-
 from tests.integration_tests.test_app import app
 
 
-@pytest.mark.usefixtures("login_as_admin")
-def test_get_available_domains(test_client):
+def test_get_available_domains(test_client, login_as_admin):
     app.config["SUPERSET_WEBSERVER_DOMAINS"] = ["a", "b"]
-    resp = test_client.get(f"api/v1/available_domains/")
+    resp = test_client.get("api/v1/available_domains/")
     assert resp.status_code == 200
     data = json.loads(resp.data.decode("utf-8"))
     result = data.get("result")

--- a/tests/integration_tests/available_domains/api_tests.py
+++ b/tests/integration_tests/available_domains/api_tests.py
@@ -20,9 +20,11 @@ from tests.integration_tests.test_app import app
 
 
 def test_get_available_domains(test_client, login_as_admin):
+    cached = app.config["SUPERSET_WEBSERVER_DOMAINS"]
     app.config["SUPERSET_WEBSERVER_DOMAINS"] = ["a", "b"]
     resp = test_client.get("api/v1/available_domains/")
     assert resp.status_code == 200
     data = json.loads(resp.data.decode("utf-8"))
     result = data.get("result")
-    assert result == ["a", "b"]
+    assert result == {"domains": ["a", "b"]}
+    app.config["SUPERSET_WEBSERVER_DOMAINS"] = cached

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -83,6 +83,7 @@ GAMMA_ROLE_PERMISSIONS = {
         ["can_write", "CssTemplate"],
         ["can_read", "ReportSchedule"],
         ["can_write", "ReportSchedule"],
+        ["can_read", "AvailableDomains"],
         ["can_read", "Chart"],
         ["can_write", "Chart"],
         ["can_read", "Annotation"],


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Migrate `/available_domains/` to `api/v1/available_domains/`
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
