### PR TITLE
fix(sqllab): reverts #21141

### DIFF
--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -292,6 +292,7 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
   function renderDatabaseSelector() {
     return (
       <DatabaseSelector
+        key={currentDatabase?.id}
         db={currentDatabase}
         emptyState={emptyState}
         formMode={formMode}


### PR DESCRIPTION
### SUMMARY
This reverts #21141 because of initial database selection has gone.
I'll work on database selector side effect clean up and then re-merge this.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

![Screen Shot 2022-08-23 at 9 05 33 PM](https://user-images.githubusercontent.com/1392866/186326513-16237ea1-e1ea-4652-ad98-350aaea47dfe.png)

After:

![Screen Shot 2022-08-23 at 9 05 42 PM](https://user-images.githubusercontent.com/1392866/186326518-4e6a0ce0-285a-4a27-a6cf-9a006ea5b9fc.png)

### TESTING INSTRUCTIONS
1 - Execute all tests
2 - All tests should pass

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
