### PR TITLE
chore: Add new e2e tests for Explore

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dataset/dataset_list.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dataset/dataset_list.test.ts
@@ -32,7 +32,7 @@ describe('Dataset list', () => {
       .click();
     cy.wait('@explore');
     cy.get('[data-test="datasource-control"] .title-select').contains(
-      'main.birth_names',
+      'birth_names',
     );
     cy.get('.metric-option-label').first().contains('COUNT(*)');
     cy.get('.column-option-label').first().contains('ds');

--- a/superset-frontend/cypress-base/cypress/integration/dataset/dataset_list.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dataset/dataset_list.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const DATASET_LIST_PATH = 'tablemodelview/list';
+
+describe('Dataset list', () => {
+  beforeEach(() => {
+    cy.login();
+    cy.visit(DATASET_LIST_PATH);
+  });
+
+  it('should open Explore on dataset name click', () => {
+    cy.intercept('**/api/v1/explore/**').as('explore');
+    cy.get('[data-test="listview-table"] [data-test="internal-link"]')
+      .contains('birth_names')
+      .click();
+    cy.wait('@explore');
+    cy.get('[data-test="datasource-control"] .title-select').contains(
+      'main.birth_names',
+    );
+    cy.get('.metric-option-label').first().contains('COUNT(*)');
+    cy.get('.column-option-label').first().contains('ds');
+    cy.get('[data-test="fast-viz-switcher"] > div:not([role="button"]')
+      .contains('Table')
+      .should('be.visible');
+  });
+});

--- a/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
@@ -25,17 +25,15 @@ import { FORM_DATA_DEFAULTS, NUM_METRIC } from './visualizations/shared.helper';
 describe('Datasource control', () => {
   const newMetricName = `abc${Date.now()}`;
 
-  // TODO: uncomment when adding metrics from dataset is fixed
-  xit('should allow edit dataset', () => {
+  it('should allow edit dataset', () => {
     let numScripts = 0;
 
     cy.login();
-    interceptChart({ legacy: false }).as('chartData');
+    interceptChart({ legacy: true }).as('chartData');
 
     cy.visitChartByName('Num Births Trend');
     cy.verifySliceSuccess({ waitAlias: '@chartData' });
 
-    cy.get('[data-test="open-datasource-tab').click({ force: true });
     cy.get('[data-test="datasource-menu-trigger"]').click();
 
     cy.get('script').then(nodes => {
@@ -53,21 +51,31 @@ describe('Datasource control', () => {
     });
     // create new metric
     cy.get('[data-test="crud-add-table-item"]', { timeout: 10000 }).click();
-    cy.get('[data-test="table-content-rows"]')
-      .find('input[value="<new metric>"]')
+    cy.wait(1000);
+    cy.get(
+      '[data-test="table-content-rows"] [data-test="editable-title-input"]',
+    )
+      .first()
       .click();
-    cy.get('[data-test="table-content-rows"]')
-      .find('input[value="<new metric>"]')
+
+    cy.get(
+      '[data-test="table-content-rows"] [data-test="editable-title-input"]',
+    )
+      .first()
       .focus()
       .clear()
       .type(`${newMetricName}{enter}`);
+
     cy.get('[data-test="datasource-modal-save"]').click();
     cy.get('.ant-modal-confirm-btns button').contains('OK').click();
     // select new metric
     cy.get('[data-test=metrics]')
-      .find('.Select__control input')
-      .focus()
-      .type(newMetricName, { force: true });
+      .contains('Drop columns/metrics here or click')
+      .click();
+
+    cy.get('input[aria-label="Select saved metrics"]').type(
+      `${newMetricName}{enter}`,
+    );
     // delete metric
     cy.get('[data-test="datasource-menu-trigger"]').click();
     cy.get('[data-test="edit-dataset"]').click();
@@ -78,13 +86,11 @@ describe('Datasource control', () => {
     });
     cy.get(`input[value="${newMetricName}"]`)
       .closest('tr')
-      .find('.fa-trash')
+      .find('[data-test="crud-delete-icon"]')
       .click();
     cy.get('[data-test="datasource-modal-save"]').click();
     cy.get('.ant-modal-confirm-btns button').contains('OK').click();
-    cy.get('.Select__multi-value__label')
-      .contains(newMetricName)
-      .should('not.exist');
+    cy.get('[data-test="metrics"]').contains(newMetricName).should('not.exist');
   });
 });
 

--- a/superset-frontend/cypress-base/cypress/integration/sqllab/query.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/sqllab/query.test.ts
@@ -161,7 +161,7 @@ describe('SqlLab query panel', () => {
       });
     });
 
-    const query = 'SELECT gender, name FROM main.birth_names';
+    const query = 'SELECT gender, name FROM birth_names';
 
     cy.get('.ace_text-input')
       .focus()

--- a/superset-frontend/cypress-base/cypress/integration/sqllab/query.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/sqllab/query.test.ts
@@ -34,19 +34,9 @@ describe('SqlLab query panel', () => {
     // are fetched below (because React _Virtualized_ does not render all rows)
     let clockTime = 0;
 
-    const sampleResponse = {
-      status: 'success',
-      data: [{ '?column?': 1 }],
-      columns: [{ name: '?column?', type: 'INT', is_dttm: false }],
-      selected_columns: [{ name: '?column?', type: 'INT', is_dttm: false }],
-      expanded_columns: [],
-    };
-
     cy.intercept({
       method: 'POST',
       url: '/superset/sql_json/',
-      delay: 1000,
-      response: () => sampleResponse,
     }).as('mockSQLResponse');
 
     cy.get('.TableSelector .Select:eq(0)').click();
@@ -166,6 +156,7 @@ describe('SqlLab query panel', () => {
     // cypress doesn't handle opening a new tab, override window.open to open in the same tab
     cy.window().then(win => {
       cy.stub(win, 'open', url => {
+        // eslint-disable-next-line no-param-reassign
         win.location.href = url;
       });
     });


### PR DESCRIPTION
### SUMMARY

1. Creating a chart from dataset list:
- Open dataset list
- Click on dataset name
- Explore should open with the clicked dataset selected and table chart set by default

2. Creating a chart from SqlLab
- Open SqlLab run type a query
- Click Create Chart
- Explore should open with the query from SqlLab as source, table chart set by default and columns selected in the query set as columns in table chart

3. Editing dataset from Explore (re-enable and fix skipped test):
- Click Edit dataset
- Add new metric
- Add the new metric to metrics control
- Click Edit dataset
- Delete the newly added metric
- Verify that it was removed from metrics control

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
