### PR TITLE
fix: World Map right-click value

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
@@ -108,14 +108,13 @@ function WorldMap(element, props) {
   const handleContextMenu = source => {
     const pointerEvent = d3.event;
     pointerEvent.preventDefault();
-    const val = source.id || source.country;
-    const formattedVal = mapData[val].name;
+    const val = mapData[source.id || source.country].name;
     const filters = [
       {
         col: entity,
         op: '==',
         val,
-        formattedVal,
+        formattedVal: val,
       },
     ];
     onContextMenu(filters, pointerEvent.clientX, pointerEvent.clientY);


### PR DESCRIPTION
### SUMMARY
Fixes the value sent to the drill to detail modal when right-clicking on World Map.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/186897531-1d25b133-abd3-4499-ab98-fd0089254846.mov

https://user-images.githubusercontent.com/70410625/186897574-6c262cf2-5b51-4576-a8a3-7b2fb6f4bffe.mov

### TESTING INSTRUCTIONS
Check the videos for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
