### PR TITLE
chore: Keeps context menu in viewport

### DIFF
--- a/superset-frontend/src/components/Chart/ChartContextMenu.tsx
+++ b/superset-frontend/src/components/Chart/ChartContextMenu.tsx
@@ -27,6 +27,9 @@ import { QueryObjectFilterClause, t, styled } from '@superset-ui/core';
 import { Menu } from 'src/components/Menu';
 import { AntdDropdown as Dropdown } from 'src/components';
 
+const MENU_ITEM_HEIGHT = 32;
+const MENU_VERTICAL_SPACING = 32;
+
 export interface ChartContextMenuProps {
   id: string;
   onSelection: (filters: QueryObjectFilterClause[]) => void;
@@ -82,7 +85,19 @@ const ChartContextMenu = (
 
   const open = useCallback(
     (filters: QueryObjectFilterClause[], clientX: number, clientY: number) => {
-      setState({ filters, clientX, clientY });
+      // Viewport height
+      const vh = Math.max(
+        document.documentElement.clientHeight || 0,
+        window.innerHeight || 0,
+      );
+
+      // +1 for automatically added options such as 'All' and 'Drill to detail'
+      const itemsCount = filters.length + 1;
+      const menuHeight = MENU_ITEM_HEIGHT * itemsCount + MENU_VERTICAL_SPACING;
+      // Always show the context menu inside the viewport
+      const adjustedY = vh - clientY < menuHeight ? vh - menuHeight : clientY;
+
+      setState({ filters, clientX, clientY: adjustedY });
 
       // Since Ant Design's Dropdown does not offer an imperative API
       // and we can't attach event triggers to charts SVG elements, we


### PR DESCRIPTION
### SUMMARY
This PR is an improvement to the right-click interactions on charts. It makes the context menu always display in the viewport to avoid the need for scrolling and to keep all options always visible.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/186914003-8cdc1e65-687f-4a6a-9b58-30ab3692d8b3.mov

### TESTING INSTRUCTIONS
Check the video for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
