### PR TITLE
feat(nav): Update Tabbed Nav on CRUD Pages

### DIFF
--- a/superset-frontend/src/views/CRUD/data/common.ts
+++ b/superset-frontend/src/views/CRUD/data/common.ts
@@ -19,20 +19,8 @@
 import { t } from '@superset-ui/core';
 
 export const commonMenuData = {
-  name: t('Data'),
+  name: t('SQL'),
   tabs: [
-    {
-      name: 'Databases',
-      label: t('Databases'),
-      url: '/databaseview/list/',
-      usesRouter: true,
-    },
-    {
-      name: 'Datasets',
-      label: t('Datasets'),
-      url: '/tablemodelview/list/',
-      usesRouter: true,
-    },
     {
       name: 'Saved queries',
       label: t('Saved queries'),

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseList.test.jsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseList.test.jsx
@@ -139,6 +139,10 @@ describe('Admin DatabaseList', () => {
     expect(wrapper.find(SubMenu)).toExist();
   });
 
+  it('renders a SubMenu with no tabs', () => {
+    expect(wrapper.find(SubMenu).props().tabs).toBeUndefined();
+  });
+
   it('renders a DatabaseModal', () => {
     expect(wrapper.find(DatabaseModal)).toExist();
   });

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
@@ -35,7 +35,6 @@ import { Tooltip } from 'src/components/Tooltip';
 import Icons from 'src/components/Icons';
 import { isUserAdmin } from 'src/dashboard/util/permissionUtils';
 import ListView, { FilterOperator, Filters } from 'src/components/ListView';
-import { commonMenuData } from 'src/views/CRUD/data/common';
 import handleResourceExport from 'src/utils/export';
 import { ExtentionConfigs } from 'src/views/components/types';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
@@ -247,7 +246,7 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
   const menuData: SubMenuProps = {
     activeChild: 'Databases',
     dropDownLinks: filteredDropDown,
-    ...commonMenuData,
+    name: t('Databases'),
   };
 
   if (canCreate) {

--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetList.test.jsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetList.test.jsx
@@ -33,6 +33,7 @@ import Button from 'src/components/Button';
 import IndeterminateCheckbox from 'src/components/IndeterminateCheckbox';
 import waitForComponentToPaint from 'spec/helpers/waitForComponentToPaint';
 import { act } from 'react-dom/test-utils';
+import SubMenu from 'src/views/components/SubMenu';
 
 // store needed for withToasts(DatasetList)
 const mockStore = configureStore([thunk]);
@@ -222,6 +223,14 @@ describe('DatasetList', () => {
         .onPressEnter();
     });
     expect(fetchMock.calls(/dataset\/duplicate/)).toHaveLength(1);
+  });
+
+  it('renders a SubMenu', () => {
+    expect(wrapper.find(SubMenu)).toExist();
+  });
+
+  it('renders a SubMenu with no tabs', () => {
+    expect(wrapper.find(SubMenu).props().tabs).toBeUndefined();
   });
 });
 

--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
@@ -48,7 +48,6 @@ import SubMenu, {
   SubMenuProps,
   ButtonProps,
 } from 'src/views/components/SubMenu';
-import { commonMenuData } from 'src/views/CRUD/data/common';
 import Owner from 'src/types/Owner';
 import withToasts from 'src/components/MessageToasts/withToasts';
 import { Tooltip } from 'src/components/Tooltip';
@@ -585,7 +584,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
 
   const menuData: SubMenuProps = {
     activeChild: 'Datasets',
-    ...commonMenuData,
+    name: t('Datasets'),
   };
 
   const buttonArr: Array<ButtonProps> = [];

--- a/superset-frontend/src/views/CRUD/data/query/QueryList.test.tsx
+++ b/superset-frontend/src/views/CRUD/data/query/QueryList.test.tsx
@@ -32,6 +32,7 @@ import { QueryObject } from 'src/views/CRUD/types';
 import ListView from 'src/components/ListView';
 import Filters from 'src/components/ListView/Filters';
 import SyntaxHighlighter from 'react-syntax-highlighter/dist/cjs/light';
+import SubMenu from 'src/views/components/SubMenu';
 
 // store needed for withToasts
 const mockStore = configureStore([thunk]);
@@ -145,6 +146,28 @@ describe('QueryList', () => {
     await waitForComponentToPaint(wrapper);
     expect((fetchMock.lastCall() ?? [])[0]).toMatchInlineSnapshot(
       `"http://localhost/api/v1/query/?q=(filters:!((col:sql,opr:ct,value:fooo)),order_column:start_time,order_direction:desc,page:0,page_size:25)"`,
+    );
+  });
+
+  it('renders a SubMenu', () => {
+    expect(wrapper.find(SubMenu)).toExist();
+  });
+
+  it('renders a SubMenu with Saved queries and Query History links', () => {
+    expect(wrapper.find(SubMenu).props().tabs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: 'Saved queries' }),
+        expect.objectContaining({ label: 'Query history' }),
+      ]),
+    );
+  });
+
+  it('renders a SubMenu without Databases and Datasets links', () => {
+    expect(wrapper.find(SubMenu).props().tabs).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: 'Databases' }),
+        expect.objectContaining({ label: 'Datasets' }),
+      ]),
     );
   });
 });

--- a/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.test.jsx
+++ b/superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.test.jsx
@@ -153,6 +153,24 @@ describe('SavedQueryList', () => {
     expect(wrapper.find(SubMenu)).toExist();
   });
 
+  it('renders a SubMenu with Saved queries and Query History links', () => {
+    expect(wrapper.find(SubMenu).props().tabs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: 'Saved queries' }),
+        expect.objectContaining({ label: 'Query history' }),
+      ]),
+    );
+  });
+
+  it('renders a SubMenu without Databases and Datasets links', () => {
+    expect(wrapper.find(SubMenu).props().tabs).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: 'Databases' }),
+        expect.objectContaining({ label: 'Datasets' }),
+      ]),
+    );
+  });
+
   it('renders a ListView', () => {
     expect(wrapper.find(ListView)).toExist();
   });


### PR DESCRIPTION
### SUMMARY
These changes are part of a bigger collection of changes we are introducing to navigation in our menu to direct users to more useful flows. 

- Updates to tab menus for Databases, Datasets, Saved Queries and Query History menu
- Including new tests to cover changes

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![error](https://user-images.githubusercontent.com/38889534/186922697-539e581a-54bd-4cf4-8ce0-347f4110aa04.gif)

After:
![test](https://user-images.githubusercontent.com/38889534/186922865-91113558-4487-4524-955c-300696b4a8a0.gif)


### TESTING INSTRUCTIONS
1. Load the app
2. Check all the new changes:
```
1. Databases page no longer shows the tabbed nav for Databases / Datasets / Saved queries / Query History
2. Datasets page no longer shows the tabbed nav for Databases / Datasets / Saved queries / Query History
3. Rename page header on Databases from "Data" to "Databases"
4. Rename page header on Datasets from "Data" to "Datasets"
5. Saved query and Query history pages both show tabbed nav with the header as "SQL" in place of what used to be "Data"
6. Databases and Datasets are removed from the SQL tabbed nav (remaining menu items are Saved queries / Query history)
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
