### PR TITLE
fix(database-list): hide upload file button if no permission

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseList.test.jsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseList.test.jsx
@@ -96,7 +96,7 @@ fetchMock.get(
 const useSelectorMock = jest.spyOn(reactRedux, 'useSelector');
 const userSelectorMock = jest.spyOn(reactRedux, 'useSelector');
 
-describe('DatabaseList', () => {
+describe('Admin DatabaseList', () => {
   useSelectorMock.mockReturnValue({
     CSV_EXTENSIONS: ['csv'],
     EXCEL_EXTENSIONS: ['xls', 'xlsx'],
@@ -211,5 +211,31 @@ describe('DatabaseList', () => {
     expect(fetchMock.lastCall()[0]).toMatchInlineSnapshot(
       `"http://localhost/api/v1/database/?q=(filters:!((col:expose_in_sqllab,opr:eq,value:!t),(col:allow_run_async,opr:eq,value:!f),(col:database_name,opr:ct,value:fooo)),order_column:changed_on_delta_humanized,order_direction:desc,page:0,page_size:25)"`,
     );
+  });
+
+  it('should not render dropdown menu button if user is not admin', () => {
+    userSelectorMock.mockReturnValue({
+      createdOn: '2021-05-27T18:12:38.952304',
+      email: 'alpha@gmail.com',
+      firstName: 'alpha',
+      isActive: true,
+      lastName: 'alpha',
+      permissions: {},
+      roles: {
+        Alpha: [
+          ['can_sqllab', 'Superset'],
+          ['can_write', 'Dashboard'],
+          ['can_write', 'Chart'],
+        ],
+      },
+      userId: 2,
+      username: 'alpha',
+    });
+    const newWrapper = mount(
+      <Provider store={store}>
+        <DatabaseList />
+      </Provider>,
+    );
+    expect(newWrapper.find('.dropdown-menu-links')).not.toExist();
   });
 });

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseList.tsx
@@ -39,6 +39,7 @@ import { commonMenuData } from 'src/views/CRUD/data/common';
 import handleResourceExport from 'src/utils/export';
 import { ExtentionConfigs } from 'src/views/components/types';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
+import type { MenuObjectProps } from 'src/views/components/Menu';
 import DatabaseModal from './DatabaseModal';
 
 import { DatabaseObject } from './types';
@@ -235,11 +236,13 @@ function DatabaseList({ addDangerToast, addSuccessToast }: DatabaseListProps) {
 
   useEffect(() => hasFileUploadEnabled(), [databaseModalOpen]);
 
-  const filteredDropDown = uploadDropdownMenu.map(link => {
+  const filteredDropDown = uploadDropdownMenu.reduce((prev, cur) => {
     // eslint-disable-next-line no-param-reassign
-    link.childs = link.childs.filter(item => item.perm);
-    return link;
-  });
+    cur.childs = cur.childs.filter(item => item.perm);
+    if (!cur.childs.length) return prev;
+    prev.push(cur);
+    return prev;
+  }, [] as MenuObjectProps[]);
 
   const menuData: SubMenuProps = {
     activeChild: 'Databases',


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We should hide the upload file button If no upload options are available.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### before

https://user-images.githubusercontent.com/11830681/186953586-afde04f9-cbf9-4161-8443-9d18b9a896d5.mov


#### after

https://user-images.githubusercontent.com/11830681/186953455-db8b3ec1-dacf-47ac-8035-d32793dc8b37.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Change a user to Alpha role
- Go to the database
- Make sure all database CSV upload is not allowed
- Using. the Alpha role account, see the result

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
