### PR TITLE
chore: missing IconType on Icons

### DIFF
--- a/superset-frontend/src/components/Icons/index.tsx
+++ b/superset-frontend/src/components/Icons/index.tsx
@@ -166,7 +166,7 @@ const IconFileNames = [
   'redo',
 ];
 
-const iconOverrides: Record<string, React.FC> = {};
+const iconOverrides: Record<string, React.FC<IconType>> = {};
 IconFileNames.forEach(fileName => {
   const keyName = _.startCase(fileName).replace(/ /g, '');
   iconOverrides[keyName] = (props: IconType) => (


### PR DESCRIPTION
### SUMMARY
This commit updates the IconType for Icons component to fix the type error. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

- Before:

<img width="416" alt="Screen Shot 2022-08-26 at 2 19 11 PM" src="https://user-images.githubusercontent.com/1392866/186992529-f8438d5b-7e78-4a91-9247-c158f88e472e.png">

- After:

<img width="402" alt="Screen Shot 2022-08-26 at 2 19 19 PM" src="https://user-images.githubusercontent.com/1392866/186992528-d25c4113-31f6-4260-9a81-53297ec9c342.png">


### TESTING INSTRUCTIONS
N/A

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
