### PR TITLE
fix: Update chromatic PR action to have access to Job outputs

### DIFF
--- a/.github/workflows/chromatic-pr.yml
+++ b/.github/workflows/chromatic-pr.yml
@@ -42,8 +42,13 @@ jobs:
   chromatic-deployment:
     # Operating System
     runs-on: ubuntu-latest
+    # define outputs that can be used in the storybook-link-comment job
+    outputs:
+      storybookUrl: ${{ steps.chromatic-deploy.outputs.storybookUrl }}
+      buildUrl: ${{ steps.chromatic-deploy.outputs.buildUrl }}
     # Job steps
     steps:
+      - id: chromatic-deploy
       - uses: actions/checkout@v1
       - name: Install dependencies
         run: npm ci
@@ -76,5 +81,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Storybook has completed and can be viewed at ${{ needs.chromatic-deployment.outputs.storybookUrl }}.  Chromatic visual test results can be viewed at ${{ needs.chromatic-deployment.outputs.buildUrl }} '
+              body: 'Storybook has completed and can be viewed at ${{ needs.chromatic-deployment.outputs.storybookUrl }}  Chromatic visual test results can be viewed at ${{ needs.chromatic-deployment.outputs.buildUrl }}'
             })


### PR DESCRIPTION
Update chromatic PR action to have access to Job outputs

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adjusting to follow docs at: https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
