### PR TITLE
chore(deps): set correct version of flask_caching

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
         "deprecation>=2.1.0, <2.2.0",
         "flask>=2.0.0, <3.0.0",
         "flask-appbuilder>=4.1.3, <5.0.0",
-        "flask-caching>=1.10.0",
+        "flask-caching>=1.10.0, <2.0.0",
         "flask-compress",
         "flask-talisman",
         "flask-migrate",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We need to set the highest version of flask-caching lower than v2.0.0, because it need "cachelib >= 0.9.0" since v2.0 which is not compatible with requirements of superset("cachelib>=0.4.1,<0.5").
Ref: https://github.com/pallets-eco/flask-caching/blob/v2.0.0/setup.py

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
It failed down if building with flask-caching2.0.0+.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
