### PR TITLE
feat(helm): Added env variable SERVER_WORKER_AMOUNT

### DIFF
--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
   - name: craig-rueda
     email: craig@craigrueda.com
     url: https://github.com/craig-rueda
-version: 0.7.1
+version: 0.7.2
 dependencies:
 - name: postgresql
   version: 11.1.22

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -55,6 +55,8 @@ envFromSecrets: []
 extraEnv: {}
   # Different gunicorn settings, refer to the gunicorn documentation
   # https://docs.gunicorn.org/en/stable/settings.html#
+  # These variables are used as Flags at the gunicorn startup
+  # https://github.com/apache/superset/blob/master/docker/run-server.sh#L22
   # Extend timeout to allow long running queries.
   # GUNICORN_TIMEOUT: 300
   # Increase the gunicorn worker amount, can improve performance drastically

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -53,11 +53,19 @@ envFromSecrets: []
 ## Extra environment variables that will be passed into pods
 ##
 extraEnv: {}
+  # Different gunicorn settings, refer to the gunicorn documentation
+  # https://docs.gunicorn.org/en/stable/settings.html#
   # Extend timeout to allow long running queries.
   # GUNICORN_TIMEOUT: 300
   # Increase the gunicorn worker amount, can improve performance drastically
-  # See: https://docs.gunicorn.org/en/stable/design.html#:~:text=Gunicorn%20should%20only%20need%204,workers%20to%20start%20off%20with.
+  # See: https://docs.gunicorn.org/en/stable/design.html#how-many-workers
   # SERVER_WORKER_AMOUNT: 4
+  # WORKER_MAX_REQUESTS: 0
+  # WORKER_MAX_REQUESTS_JITTER: 0
+  # SERVER_THREADS_AMOUNT: 20
+  # GUNICORN_KEEPALIVE: 2
+  # SERVER_LIMIT_REQUEST_LINE: 0
+  # SERVER_LIMIT_REQUEST_FIELD_SIZE: 0
 
   # OAUTH_HOME_DOMAIN: ..
   # # If a whitelist is not set, any address that can use your OAuth2 endpoint will be able to login.

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -55,7 +55,9 @@ envFromSecrets: []
 extraEnv: {}
   # Extend timeout to allow long running queries.
   # GUNICORN_TIMEOUT: 300
-
+  # Increase the gunicorn worker amount, can improve performance drastically
+  # See: https://docs.gunicorn.org/en/stable/design.html#:~:text=Gunicorn%20should%20only%20need%204,workers%20to%20start%20off%20with.
+  # SERVER_WORKER_AMOUNT: 4
 
   # OAUTH_HOME_DOMAIN: ..
   # # If a whitelist is not set, any address that can use your OAuth2 endpoint will be able to login.


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I added the environment variable SERVER_WORKER_AMOUNT to the helm values file. It is commented out so it won't affect any running instances. We had severe performance problems caused by superset workers timing out. This was solved and the general Superset performance was improved by increasing the Server Worker Amount. Although this variable can have a huge impact on performance it is never mentioned, neither in the docs nor in the helm chart. 
The standard value of 1 is set in [run-server.sh](https://github.com/apache/superset/blob/master/docker/run-server.sh#L26).  


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Change the variable, at the start of the containers you can see the workers starting up in the logs.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
