### PR TITLE
refactor: introduce react-query on api resource hook

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -111,6 +111,7 @@
         "react-lines-ellipsis": "^0.15.0",
         "react-loadable": "^5.5.0",
         "react-markdown": "^4.3.1",
+        "react-query": "^3.39.2",
         "react-redux": "^7.2.0",
         "react-resize-detector": "^6.7.6",
         "react-reverse-portal": "^2.0.1",
@@ -37290,6 +37291,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
     "node_modules/js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -45582,6 +45588,55 @@
       "peerDependencies": {
         "react": "^16.6.0 || ^17.0.0",
         "react-dom": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/react-query": {
+      "version": "3.39.2",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.2.tgz",
+      "integrity": "sha512-F6hYDKyNgDQfQOuR1Rsp3VRzJnWHx6aRnnIZHMNGGgbL3SBgpZTDg8MQwmxOgpCAoqZJA+JSNCydF1xGJqKOCA==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "broadcast-channel": "^3.4.1",
+        "match-sorter": "^6.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-query/node_modules/broadcast-channel": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
+      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "detect-node": "^2.1.0",
+        "js-sha3": "0.8.0",
+        "microseconds": "0.2.0",
+        "nano-time": "1.0.0",
+        "oblivious-set": "1.0.0",
+        "rimraf": "3.0.2",
+        "unload": "2.2.0"
+      }
+    },
+    "node_modules/react-query/node_modules/unload": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
+      "dependencies": {
+        "@babel/runtime": "^7.6.2",
+        "detect-node": "^2.0.4"
       }
     },
     "node_modules/react-redux": {
@@ -86719,6 +86774,11 @@
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
       "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="
     },
+    "js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
     "js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -93217,6 +93277,42 @@
         "@babel/runtime": "^7.12.5",
         "@popperjs/core": "^2.5.4",
         "react-popper": "^2.2.4"
+      }
+    },
+    "react-query": {
+      "version": "3.39.2",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.2.tgz",
+      "integrity": "sha512-F6hYDKyNgDQfQOuR1Rsp3VRzJnWHx6aRnnIZHMNGGgbL3SBgpZTDg8MQwmxOgpCAoqZJA+JSNCydF1xGJqKOCA==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "broadcast-channel": "^3.4.1",
+        "match-sorter": "^6.0.2"
+      },
+      "dependencies": {
+        "broadcast-channel": {
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
+          "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "detect-node": "^2.1.0",
+            "js-sha3": "0.8.0",
+            "microseconds": "0.2.0",
+            "nano-time": "1.0.0",
+            "oblivious-set": "1.0.0",
+            "rimraf": "3.0.2",
+            "unload": "2.2.0"
+          }
+        },
+        "unload": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+          "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
+          "requires": {
+            "@babel/runtime": "^7.6.2",
+            "detect-node": "^2.0.4"
+          }
+        }
       }
     },
     "react-redux": {

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -175,6 +175,7 @@
     "react-lines-ellipsis": "^0.15.0",
     "react-loadable": "^5.5.0",
     "react-markdown": "^4.3.1",
+    "react-query": "^3.39.2",
     "react-redux": "^7.2.0",
     "react-resize-detector": "^6.7.6",
     "react-reverse-portal": "^2.0.1",

--- a/superset-frontend/spec/helpers/testing-library.tsx
+++ b/superset-frontend/spec/helpers/testing-library.tsx
@@ -34,12 +34,14 @@ import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import reducerIndex from 'spec/helpers/reducerIndex';
 import { QueryParamProvider } from 'use-query-params';
+import QueryProvider from 'src/views/QueryProvider';
 
 type Options = Omit<RenderOptions, 'queries'> & {
   useRedux?: boolean;
   useDnd?: boolean;
   useQueryParams?: boolean;
   useRouter?: boolean;
+  useQuery?: boolean;
   initialState?: {};
   reducers?: {};
   store?: Store;
@@ -50,6 +52,7 @@ function createWrapper(options?: Options) {
     useDnd,
     useRedux,
     useQueryParams,
+    useQuery = true,
     useRouter,
     initialState,
     reducers,
@@ -83,6 +86,10 @@ function createWrapper(options?: Options) {
 
     if (useRouter) {
       result = <BrowserRouter>{result}</BrowserRouter>;
+    }
+
+    if (useQuery) {
+      result = <QueryProvider>{result}</QueryProvider>;
     }
 
     return result;

--- a/superset-frontend/src/SqlLab/App.jsx
+++ b/superset-frontend/src/SqlLab/App.jsx
@@ -23,6 +23,7 @@ import thunkMiddleware from 'redux-thunk';
 import { hot } from 'react-hot-loader/root';
 import { ThemeProvider } from '@superset-ui/core';
 import { GlobalStyles } from 'src/GlobalStyles';
+import QueryProvider from 'src/views/QueryProvider';
 import {
   initFeatureFlags,
   isFeatureEnabled,
@@ -134,12 +135,14 @@ if (sqlLabMenu) {
 }
 
 const Application = () => (
-  <Provider store={store}>
-    <ThemeProvider theme={theme}>
-      <GlobalStyles />
-      <App />
-    </ThemeProvider>
-  </Provider>
+  <QueryProvider>
+    <Provider store={store}>
+      <ThemeProvider theme={theme}>
+        <GlobalStyles />
+        <App />
+      </ThemeProvider>
+    </Provider>
+  </QueryProvider>
 );
 
 export default hot(Application);

--- a/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.jsx
@@ -31,6 +31,7 @@ import {
 import AceEditorWrapper from 'src/SqlLab/components/AceEditorWrapper';
 import ConnectedSouthPane from 'src/SqlLab/components/SouthPane/state';
 import SqlEditor from 'src/SqlLab/components/SqlEditor';
+import QueryProvider from 'src/views/QueryProvider';
 import SqlEditorLeftBar from 'src/SqlLab/components/SqlEditorLeftBar';
 import { AntdDropdown } from 'src/components';
 import {
@@ -101,9 +102,11 @@ describe('SqlEditor', () => {
 
   const buildWrapper = (props = {}) =>
     mount(
-      <Provider store={store}>
-        <SqlEditor {...mockedProps} {...props} />
-      </Provider>,
+      <QueryProvider>
+        <Provider store={store}>
+          <SqlEditor {...mockedProps} {...props} />
+        </Provider>
+      </QueryProvider>,
       {
         wrappingComponent: ThemeProvider,
         wrappingComponentProps: { theme: supersetTheme },

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors/TabbedSqlEditors.test.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors/TabbedSqlEditors.test.jsx
@@ -31,6 +31,7 @@ import TabbedSqlEditors from 'src/SqlLab/components/TabbedSqlEditors';
 import SqlEditor from 'src/SqlLab/components/SqlEditor';
 import { table, initialState } from 'src/SqlLab/fixtures';
 import { newQueryTabName } from 'src/SqlLab/utils/newQueryTabName';
+import QueryProvider from 'src/views/QueryProvider';
 
 fetchMock.get('glob:*/api/v1/database/*', {});
 fetchMock.get('glob:*/savedqueryviewapi/api/get/*', {});
@@ -89,9 +90,11 @@ describe('TabbedSqlEditors', () => {
   const mountWithAct = async () =>
     act(async () => {
       mount(
-        <Provider store={store}>
-          <TabbedSqlEditors {...mockedProps} />
-        </Provider>,
+        <QueryProvider>
+          <Provider store={store}>
+            <TabbedSqlEditors {...mockedProps} />
+          </Provider>
+        </QueryProvider>,
         {
           wrappingComponent: ThemeProvider,
           wrappingComponentProps: { theme: supersetTheme },

--- a/superset-frontend/src/components/Datasource/DatasourceModal.test.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal.test.jsx
@@ -32,6 +32,7 @@ import { DatasourceModal } from 'src/components/Datasource';
 import DatasourceEditor from 'src/components/Datasource/DatasourceEditor';
 import * as featureFlags from 'src/featureFlags';
 import mockDatasource from 'spec/fixtures/mockDatasource';
+import QueryProvider from 'src/views/QueryProvider';
 
 const mockStore = configureStore([thunk]);
 const store = mockStore({});
@@ -53,9 +54,11 @@ const mockedProps = {
 
 async function mountAndWait(props = mockedProps) {
   const mounted = mount(
-    <Provider store={store}>
-      <DatasourceModal {...props} />
-    </Provider>,
+    <QueryProvider>
+      <Provider store={store}>
+        <DatasourceModal {...props} />
+      </Provider>
+    </QueryProvider>,
     {
       wrappingComponent: ThemeProvider,
       wrappingComponentProps: { theme: supersetTheme },

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -25,7 +25,7 @@ import React, {
 } from 'react';
 import { SelectValue } from 'antd/lib/select';
 
-import { styled, SupersetClient, t } from '@superset-ui/core';
+import { styled, t } from '@superset-ui/core';
 import { Select } from 'src/components';
 import { FormLabel } from 'src/components/Form';
 import Icons from 'src/components/Icons';
@@ -37,6 +37,7 @@ import CertifiedBadge from 'src/components/CertifiedBadge';
 import WarningIconWithTooltip from 'src/components/WarningIconWithTooltip';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
 import { SchemaOption } from 'src/SqlLab/types';
+import { useTables } from 'src/hooks/apiResources';
 
 const TableSelectorWrapper = styled.div`
   ${({ theme }) => `
@@ -147,6 +148,15 @@ const TableOption = ({ table }: { table: Table }) => {
   );
 };
 
+function renderSelectRow(select: ReactNode, refreshBtn: ReactNode) {
+  return (
+    <div className="section">
+      <span className="select">{select}</span>
+      <span className="refresh">{refreshBtn}</span>
+    </div>
+  );
+}
+
 const TableSelector: FunctionComponent<TableSelectorProps> = ({
   database,
   emptyState,
@@ -166,33 +176,46 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
   tableValue = undefined,
   onTableSelectChange,
 }) => {
-  const [currentDatabase, setCurrentDatabase] = useState<
-    DatabaseObject | null | undefined
-  >(database);
+  const { addSuccessToast } = useToasts();
   const [currentSchema, setCurrentSchema] = useState<string | undefined>(
     schema,
   );
-  const [tableOptions, setTableOptions] = useState<TableOption[]>([]);
   const [tableSelectValue, setTableSelectValue] = useState<
     SelectValue | undefined
   >(undefined);
-  const [refresh, setRefresh] = useState(0);
-  const [previousRefresh, setPreviousRefresh] = useState(0);
-  const [loadingTables, setLoadingTables] = useState(false);
-  const { addSuccessToast } = useToasts();
+  const {
+    data,
+    isFetching: loadingTables,
+    isFetchedAfterMount,
+    refetch,
+  } = useTables(database?.id || '', currentSchema || '', {
+    onSuccess: (data: Table[]) => {
+      onTablesLoad?.(data);
+      if (isFetchedAfterMount) {
+        addSuccessToast('List updated');
+      }
+    },
+    onError: () => handleError(t('There was an error loading the tables')),
+  });
+  const tableOptions = useMemo<Table[]>(
+    () =>
+      data
+        ? data.map((table: Table) => ({
+            value: table.value,
+            label: <TableOption table={table} />,
+            text: table.label,
+          }))
+        : [],
+    [data],
+  );
 
   useEffect(() => {
     // reset selections
     if (database === undefined) {
-      setCurrentDatabase(undefined);
       setCurrentSchema(undefined);
       setTableSelectValue(undefined);
     }
   }, [database, tableSelectMode]);
-
-  useEffect(() => {
-    setCurrentDatabase(database);
-  }, [database]);
 
   useEffect(() => {
     if (tableSelectMode === 'single') {
@@ -207,56 +230,6 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
       );
     }
   }, [tableOptions, tableValue, tableSelectMode]);
-
-  useEffect(() => {
-    if (currentDatabase && currentSchema) {
-      setLoadingTables(true);
-      const encodedSchema = encodeURIComponent(currentSchema);
-      const forceRefresh = refresh !== previousRefresh;
-      // TODO: Would be nice to add pagination in a follow-up. Needs endpoint changes.
-      const endpoint = encodeURI(
-        `/superset/tables/${currentDatabase.id}/${encodedSchema}/undefined/${forceRefresh}/`,
-      );
-
-      if (previousRefresh !== refresh) {
-        setPreviousRefresh(refresh);
-      }
-
-      SupersetClient.get({ endpoint })
-        .then(({ json }) => {
-          const options: TableOption[] = json.options.map((table: Table) => {
-            const option: TableOption = {
-              value: table.value,
-              label: <TableOption table={table} />,
-              text: table.label,
-            };
-
-            return option;
-          });
-
-          onTablesLoad?.(json.options);
-          setTableOptions(options);
-          setLoadingTables(false);
-          if (forceRefresh) addSuccessToast('List updated');
-        })
-        .catch(() => {
-          setLoadingTables(false);
-          handleError(t('There was an error loading the tables'));
-        });
-    }
-    // We are using the refresh state to re-trigger the query
-    // previousRefresh should be out of dependencies array
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentDatabase, currentSchema, onTablesLoad, setTableOptions, refresh]);
-
-  function renderSelectRow(select: ReactNode, refreshBtn: ReactNode) {
-    return (
-      <div className="section">
-        <span className="select">{select}</span>
-        <span className="refresh">{refreshBtn}</span>
-      </div>
-    );
-  }
 
   const internalTableChange = (
     selectedOptions: TableOption | TableOption[] | undefined,
@@ -274,7 +247,6 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
   };
 
   const internalDbChange = (db: DatabaseObject) => {
-    setCurrentDatabase(db);
     if (onDbChange) {
       onDbChange(db);
     }
@@ -286,14 +258,15 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
       onSchemaChange(schema);
     }
 
-    internalTableChange(undefined);
+    const value = tableSelectMode === 'single' ? undefined : [];
+    internalTableChange(value);
   };
 
   function renderDatabaseSelector() {
     return (
       <DatabaseSelector
-        key={currentDatabase?.id}
-        db={currentDatabase}
+        key={database?.id}
+        db={database}
         emptyState={emptyState}
         formMode={formMode}
         getDbList={getDbList}
@@ -353,7 +326,7 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
 
     const refreshLabel = !formMode && !readOnly && (
       <RefreshLabel
-        onClick={() => setRefresh(refresh + 1)}
+        onClick={() => refetch()}
         tooltipContent={t('Force refresh table list')}
       />
     );

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -37,7 +37,7 @@ import CertifiedBadge from 'src/components/CertifiedBadge';
 import WarningIconWithTooltip from 'src/components/WarningIconWithTooltip';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
 import { SchemaOption } from 'src/SqlLab/types';
-import { useTables } from 'src/hooks/apiResources';
+import { useTables, Table } from 'src/hooks/apiResources';
 
 const TableSelectorWrapper = styled.div`
   ${({ theme }) => `
@@ -100,19 +100,6 @@ interface TableSelectorProps {
   tableValue?: string | string[];
   onTableSelectChange?: (value?: string | string[], schema?: string) => void;
   tableSelectMode?: 'single' | 'multiple';
-}
-
-interface Table {
-  label: string;
-  value: string;
-  type: string;
-  extra?: {
-    certification?: {
-      certified_by: string;
-      details: string;
-    };
-    warning_markdown?: string;
-  };
 }
 
 interface TableOption {
@@ -191,18 +178,19 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
   } = useTables({
     dbId: database?.id,
     schema: currentSchema,
-    onSuccess: (data: Table[]) => {
-      onTablesLoad?.(data);
+    onSuccess: (data: { options: Table[] }) => {
+      onTablesLoad?.(data.options);
       if (isFetched) {
         addSuccessToast('List updated');
       }
     },
     onError: () => handleError(t('There was an error loading the tables')),
   });
-  const tableOptions = useMemo<Table[]>(
+
+  const tableOptions = useMemo<TableOption[]>(
     () =>
       data
-        ? data.map((table: Table) => ({
+        ? data.options.map(table => ({
             value: table.value,
             label: <TableOption table={table} />,
             text: table.label,
@@ -309,7 +297,7 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
       <Select
         ariaLabel={t('Select table or type table name')}
         disabled={disabled}
-        filterOption={handleFilterOption}
+        filterOption={keyword ? true : handleFilterOption}
         header={header}
         labelInValue
         loading={loadingTables}

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -297,7 +297,7 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
       <Select
         ariaLabel={t('Select table or type table name')}
         disabled={disabled}
-        filterOption={keyword ? true : handleFilterOption}
+        filterOption={handleFilterOption}
         header={header}
         labelInValue
         loading={loadingTables}

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -188,7 +188,9 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
     isFetching: loadingTables,
     isFetchedAfterMount,
     refetch,
-  } = useTables(database?.id || '', currentSchema || '', {
+  } = useTables({
+    dbId: database?.id,
+    schema: currentSchema,
     onSuccess: (data: Table[]) => {
       onTablesLoad?.(data);
       if (isFetchedAfterMount) {

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -186,14 +186,14 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
   const {
     data,
     isFetching: loadingTables,
-    isFetchedAfterMount,
+    isFetched,
     refetch,
   } = useTables({
     dbId: database?.id,
     schema: currentSchema,
     onSuccess: (data: Table[]) => {
       onTablesLoad?.(data);
-      if (isFetchedAfterMount) {
+      if (isFetched) {
         addSuccessToast('List updated');
       }
     },

--- a/superset-frontend/src/hooks/apiResources/tables.test.ts
+++ b/superset-frontend/src/hooks/apiResources/tables.test.ts
@@ -60,7 +60,11 @@ describe('useTables hook', () => {
     const expectedSchema = 'schemaA';
     const forceRefresh = false;
     const { result } = renderHook(
-      () => useTables(expectDbId, expectedSchema, {}),
+      () =>
+        useTables({
+          dbId: expectDbId,
+          schema: expectedSchema,
+        }),
       {
         wrapper: QueryProvider,
       },
@@ -87,7 +91,11 @@ describe('useTables hook', () => {
     const expectDbId = 'db1';
     const expectedSchema = 'schemaA';
     const { result, rerender } = renderHook(
-      () => useTables(expectDbId, expectedSchema, {}),
+      () =>
+        useTables({
+          dbId: expectDbId,
+          schema: expectedSchema,
+        }),
       {
         wrapper: QueryProvider,
       },
@@ -104,9 +112,12 @@ describe('useTables hook', () => {
   it('returns refreshed data after expires', async () => {
     const expectDbId = 'db1';
     const expectedSchema = 'schemaA';
-    jest.setSystemTime(new Date('2021-01-01 00:00:00'));
     const { result, rerender } = renderHook(
-      () => useTables(expectDbId, expectedSchema, {}),
+      () =>
+        useTables({
+          dbId: expectDbId,
+          schema: expectedSchema,
+        }),
       {
         wrapper: QueryProvider,
       },

--- a/superset-frontend/src/hooks/apiResources/tables.test.ts
+++ b/superset-frontend/src/hooks/apiResources/tables.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { act, renderHook } from '@testing-library/react-hooks';
+import { SupersetClient } from '@superset-ui/core';
+import QueryProvider, { queryClient } from 'src/views/QueryProvider';
+import { useTables } from './tables';
+
+const fakeApiResult = {
+  json: {
+    options: [
+      {
+        id: 1,
+        name: 'fake api result1',
+        label: 'fake api label1',
+      },
+      {
+        id: 2,
+        name: 'fake api result2',
+        label: 'fake api label2',
+      },
+    ],
+  },
+};
+
+jest.mock('@superset-ui/core', () => ({
+  SupersetClient: {
+    get: jest.fn().mockResolvedValue(fakeApiResult),
+  },
+}));
+
+describe('useTables hook', () => {
+  beforeEach(() => {
+    (SupersetClient.get as jest.Mock).mockClear();
+    queryClient.clear();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns api response mapping json options', async () => {
+    const expectDbId = 'db1';
+    const expectedSchema = 'schemaA';
+    const forceRefresh = false;
+    const { result } = renderHook(
+      () => useTables(expectDbId, expectedSchema, {}),
+      {
+        wrapper: QueryProvider,
+      },
+    );
+    await act(async () => {
+      jest.runAllTimers();
+    });
+    expect(SupersetClient.get).toHaveBeenCalledTimes(1);
+    expect(SupersetClient.get).toHaveBeenCalledWith({
+      endpoint: `/superset/tables/${expectDbId}/${expectedSchema}/undefined/${forceRefresh}/`,
+    });
+    expect(result.current.data).toEqual(fakeApiResult.json.options);
+    await act(async () => {
+      result.current.refetch();
+    });
+    expect(SupersetClient.get).toHaveBeenCalledTimes(2);
+    expect(SupersetClient.get).toHaveBeenCalledWith({
+      endpoint: `/superset/tables/${expectDbId}/${expectedSchema}/undefined/true/`,
+    });
+    expect(result.current.data).toEqual(fakeApiResult.json.options);
+  });
+
+  it('returns cached data without api request', async () => {
+    const expectDbId = 'db1';
+    const expectedSchema = 'schemaA';
+    const { result, rerender } = renderHook(
+      () => useTables(expectDbId, expectedSchema, {}),
+      {
+        wrapper: QueryProvider,
+      },
+    );
+    await act(async () => {
+      jest.runAllTimers();
+    });
+    expect(SupersetClient.get).toHaveBeenCalledTimes(1);
+    rerender();
+    expect(SupersetClient.get).toHaveBeenCalledTimes(1);
+    expect(result.current.data).toEqual(fakeApiResult.json.options);
+  });
+
+  it('returns refreshed data after expires', async () => {
+    const expectDbId = 'db1';
+    const expectedSchema = 'schemaA';
+    jest.setSystemTime(new Date('2021-01-01 00:00:00'));
+    const { result, rerender } = renderHook(
+      () => useTables(expectDbId, expectedSchema, {}),
+      {
+        wrapper: QueryProvider,
+      },
+    );
+    await act(async () => {
+      jest.runAllTimers();
+    });
+    expect(SupersetClient.get).toHaveBeenCalledTimes(1);
+    rerender();
+    await act(async () => {
+      jest.runAllTimers();
+    });
+    expect(SupersetClient.get).toHaveBeenCalledTimes(1);
+    queryClient.clear();
+    rerender();
+    await act(async () => {
+      jest.runAllTimers();
+    });
+    expect(SupersetClient.get).toHaveBeenCalledTimes(2);
+    expect(result.current.data).toEqual(fakeApiResult.json.options);
+  });
+});

--- a/superset-frontend/src/hooks/apiResources/tables.ts
+++ b/superset-frontend/src/hooks/apiResources/tables.ts
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useEffect, useState } from 'react';
+import { useQuery, UseQueryOptions } from 'react-query';
+import { SupersetClient } from '@superset-ui/core';
+
+export type FetchTablesQueryParams = {
+  dbId: string | number;
+  schema: string;
+  forceRefresh?: boolean;
+};
+
+export function fetchTables({
+  dbId,
+  schema,
+  forceRefresh,
+}: FetchTablesQueryParams) {
+  const encodedSchema = encodeURIComponent(schema);
+  // TODO: Would be nice to add pagination in a follow-up. Needs endpoint changes.
+  const endpoint = `/superset/tables/${dbId}/${encodedSchema}/undefined/${forceRefresh}/`;
+  return SupersetClient.get({ endpoint });
+}
+
+type Params = Pick<UseQueryOptions, 'onSuccess' | 'onError'>;
+
+export function useTables(
+  dbId: string,
+  schema: string,
+  { onSuccess, onError }: Params,
+) {
+  const [forceRefresh, setForceRefresh] = useState(false);
+  const params = { dbId, schema, forceRefresh };
+  const result = useQuery(
+    ['tables', { dbId, schema }],
+    () => fetchTables(params),
+    {
+      select: ({ json }) => json.options,
+      enabled: Boolean(dbId && schema),
+      onSuccess,
+      onError,
+    },
+  );
+
+  const { isFetched } = result;
+
+  useEffect(() => {
+    if (isFetched) {
+      setForceRefresh(true);
+    }
+  }, [isFetched]);
+
+  return result;
+}

--- a/superset-frontend/src/hooks/apiResources/tables.ts
+++ b/superset-frontend/src/hooks/apiResources/tables.ts
@@ -39,11 +39,8 @@ export function fetchTables({
 
 type Params = Pick<UseQueryOptions, 'onSuccess' | 'onError'>;
 
-export function useTables(
-  dbId: string,
-  schema: string,
-  { onSuccess, onError }: Params,
-) {
+export function useTables(dbId: string, schema: string, options?: Params) {
+  const { onSuccess, onError } = options || {};
   const [forceRefresh, setForceRefresh] = useState(false);
   const params = { dbId, schema, forceRefresh };
   const result = useQuery(

--- a/superset-frontend/src/hooks/apiResources/tables.ts
+++ b/superset-frontend/src/hooks/apiResources/tables.ts
@@ -21,8 +21,8 @@ import { useQuery, UseQueryOptions } from 'react-query';
 import { SupersetClient } from '@superset-ui/core';
 
 export type FetchTablesQueryParams = {
-  dbId: string | number;
-  schema: string;
+  dbId?: string | number;
+  schema?: string;
   forceRefresh?: boolean;
 };
 
@@ -31,16 +31,19 @@ export function fetchTables({
   schema,
   forceRefresh,
 }: FetchTablesQueryParams) {
-  const encodedSchema = encodeURIComponent(schema);
+  const encodedSchema = schema ? encodeURIComponent(schema) : '';
   // TODO: Would be nice to add pagination in a follow-up. Needs endpoint changes.
-  const endpoint = `/superset/tables/${dbId}/${encodedSchema}/undefined/${forceRefresh}/`;
+  const endpoint = `/superset/tables/${
+    dbId ?? 'undefined'
+  }/${encodedSchema}/undefined/${forceRefresh}/`;
   return SupersetClient.get({ endpoint });
 }
 
-type Params = Pick<UseQueryOptions, 'onSuccess' | 'onError'>;
+type Params = FetchTablesQueryParams &
+  Pick<UseQueryOptions, 'onSuccess' | 'onError'>;
 
-export function useTables(dbId: string, schema: string, options?: Params) {
-  const { onSuccess, onError } = options || {};
+export function useTables(options: Params) {
+  const { dbId, schema, onSuccess, onError } = options || {};
   const [forceRefresh, setForceRefresh] = useState(false);
   const params = { dbId, schema, forceRefresh };
   const result = useQuery(

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -36,6 +36,7 @@ import { routes, isFrontendRoute } from 'src/views/routes';
 import { Logger } from 'src/logger/LogUtils';
 import { RootContextProviders } from './RootContextProviders';
 import { ScrollToTop } from './ScrollToTop';
+import QueryProvider from './QueryProvider';
 
 setupApp();
 setupPlugins();
@@ -60,26 +61,28 @@ const LocationPathnameLogger = () => {
 };
 
 const App = () => (
-  <Router>
-    <ScrollToTop />
-    <LocationPathnameLogger />
-    <RootContextProviders>
-      <GlobalStyles />
-      <Menu data={menu} isFrontendRoute={isFrontendRoute} />
-      <Switch>
-        {routes.map(({ path, Component, props = {}, Fallback = Loading }) => (
-          <Route path={path} key={path}>
-            <Suspense fallback={<Fallback />}>
-              <ErrorBoundary>
-                <Component user={user} {...props} />
-              </ErrorBoundary>
-            </Suspense>
-          </Route>
-        ))}
-      </Switch>
-      <ToastContainer />
-    </RootContextProviders>
-  </Router>
+  <QueryProvider>
+    <Router>
+      <ScrollToTop />
+      <LocationPathnameLogger />
+      <RootContextProviders>
+        <GlobalStyles />
+        <Menu data={menu} isFrontendRoute={isFrontendRoute} />
+        <Switch>
+          {routes.map(({ path, Component, props = {}, Fallback = Loading }) => (
+            <Route path={path} key={path}>
+              <Suspense fallback={<Fallback />}>
+                <ErrorBoundary>
+                  <Component user={user} {...props} />
+                </ErrorBoundary>
+              </Suspense>
+            </Route>
+          ))}
+        </Switch>
+        <ToastContainer />
+      </RootContextProviders>
+    </Router>
+  </QueryProvider>
 );
 
 export default hot(App);

--- a/superset-frontend/src/views/QueryProvider.tsx
+++ b/superset-frontend/src/views/QueryProvider.tsx
@@ -16,16 +16,28 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
 
-export {
-  useApiResourceFullBody,
-  useApiV1Resource,
-  useTransformedResource,
-} from './apiResources';
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: Infinity,
+      retry: false,
+      retryOnMount: false,
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
 
-// A central catalog of API Resource hooks.
-// Add new API hooks here, organized under
-// different files for different resource types.
-export * from './charts';
-export * from './dashboards';
-export * from './tables';
+type Props = {
+  children: React.ReactNode;
+};
+
+const Queryprovider: React.FC<Props> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+export default Queryprovider;


### PR DESCRIPTION
### SUMMARY

#13218 introduced a hook for api resources. The main purpose of the hook is for a state management for async api request and transformed a return data to a desired format. As @ktmud suggested, react-query includes these specs and also provides the global cache storage. 

This commit introduces `react-query` to design a new api resource for tables query first.
With the react-query hook, sqlLab can skip the duplicate request for table list on switching each tab. (And it can save the request table query in dataset configuration modal)

After this commit merged, we can replace existing charts and database hooks by `react-query` too.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

-Before:

https://user-images.githubusercontent.com/1392866/187002976-b5e1cc85-c29e-4794-bece-a4393ff62098.mov

- After:

https://user-images.githubusercontent.com/1392866/187002973-fa5c2a69-f828-4c1a-a7f5-cbc5edc9edaa.mov


### TESTING INSTRUCTIONS

unit tests

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @suddjian 