### PR TITLE
fix(ViewQuery-Modal): Copy icon is out of box when resize query modal

### DIFF
--- a/superset-frontend/src/components/Modal/Modal.tsx
+++ b/superset-frontend/src/components/Modal/Modal.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { isNil } from 'lodash';
 import { styled, t } from '@superset-ui/core';
 import { css } from '@emotion/react';
@@ -29,6 +29,7 @@ import Draggable, {
   DraggableEvent,
   DraggableProps,
 } from 'react-draggable';
+import { cli } from 'webpack';
 
 export interface ModalProps {
   className?: string;
@@ -201,6 +202,24 @@ export const StyledModal = styled(BaseModal)<StyledModalProps>`
     }
   `}
 `;
+const defaultResizableConfig = (hideFooter: boolean | undefined) => ({
+  maxHeight: RESIZABLE_MAX_HEIGHT,
+  maxWidth: RESIZABLE_MAX_WIDTH,
+  minHeight: hideFooter
+    ? RESIZABLE_MIN_HEIGHT
+    : RESIZABLE_MIN_HEIGHT + MODAL_FOOTER_HEIGHT,
+  minWidth: RESIZABLE_MIN_WIDTH,
+  enable: {
+    bottom: true,
+    bottomLeft: false,
+    bottomRight: true,
+    left: false,
+    top: false,
+    topLeft: false,
+    topRight: false,
+    right: true,
+  },
+});
 
 const CustomModal = ({
   children,
@@ -222,24 +241,7 @@ const CustomModal = ({
   wrapProps,
   draggable = false,
   resizable = false,
-  resizableConfig = {
-    maxHeight: RESIZABLE_MAX_HEIGHT,
-    maxWidth: RESIZABLE_MAX_WIDTH,
-    minHeight: hideFooter
-      ? RESIZABLE_MIN_HEIGHT
-      : RESIZABLE_MIN_HEIGHT + MODAL_FOOTER_HEIGHT,
-    minWidth: RESIZABLE_MIN_WIDTH,
-    enable: {
-      bottom: true,
-      bottomLeft: false,
-      bottomRight: true,
-      left: false,
-      top: false,
-      topLeft: false,
-      topRight: false,
-      right: true,
-    },
-  },
+  resizableConfig = defaultResizableConfig(hideFooter),
   draggableConfig,
   destroyOnClose,
   ...rest
@@ -289,6 +291,13 @@ const CustomModal = ({
     }
   };
 
+  const getResizableConfig = () => {
+    if (Object.keys(resizableConfig).length === 0) {
+      return defaultResizableConfig(hideFooter);
+    }
+    return resizableConfig;
+  };
+
   const ModalTitle = () =>
     draggable ? (
       <div
@@ -329,7 +338,7 @@ const CustomModal = ({
             {...draggableConfig}
           >
             {resizable ? (
-              <Resizable className="resizable" {...resizableConfig}>
+              <Resizable className="resizable" {...getResizableConfig()}>
                 <div className="resizable-wrapper" ref={draggableRef}>
                   {modal}
                 </div>

--- a/superset-frontend/src/components/Modal/Modal.tsx
+++ b/superset-frontend/src/components/Modal/Modal.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState } from 'react';
 import { isNil } from 'lodash';
 import { styled, t } from '@superset-ui/core';
 import { css } from '@emotion/react';
@@ -29,7 +29,6 @@ import Draggable, {
   DraggableEvent,
   DraggableProps,
 } from 'react-draggable';
-import { cli } from 'webpack';
 
 export interface ModalProps {
   className?: string;

--- a/superset-frontend/src/components/Modal/Modal.tsx
+++ b/superset-frontend/src/components/Modal/Modal.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useRef, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import { isNil } from 'lodash';
 import { styled, t } from '@superset-ui/core';
 import { css } from '@emotion/react';
@@ -290,12 +290,12 @@ const CustomModal = ({
     }
   };
 
-  const getResizableConfig = () => {
+  const getResizableConfig = useMemo(() => {
     if (Object.keys(resizableConfig).length === 0) {
       return defaultResizableConfig(hideFooter);
     }
     return resizableConfig;
-  };
+  }, [hideFooter, resizableConfig]);
 
   const ModalTitle = () =>
     draggable ? (
@@ -337,7 +337,7 @@ const CustomModal = ({
             {...draggableConfig}
           >
             {resizable ? (
-              <Resizable className="resizable" {...getResizableConfig()}>
+              <Resizable className="resizable" {...getResizableConfig}>
                 <div className="resizable-wrapper" ref={draggableRef}>
                   {modal}
                 </div>


### PR DESCRIPTION
### SUMMARY
Adding a fail safe to get default resize config when receive an empty object.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

BEFORE

https://user-images.githubusercontent.com/29920585/187294675-11e487cd-a0e9-4765-b7d0-85cb0b390e44.mov

AFTER

https://user-images.githubusercontent.com/29920585/187294701-2326cd95-b7be-4978-b899-1198cb03729a.mov

### TESTING INSTRUCTIONS

- open a chart in explore, click on ... menu in the top right and select 'View query'
- Minimize the view query window and observe
