### PR TITLE
fix: dataset exists error in save Dataset modal

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -1425,7 +1425,10 @@ export function createDatasource(vizOptions) {
 
         return Promise.resolve(json);
       })
-      .catch(() => {
+      .catch(error => {
+        getClientErrorObject(error).then(e => {
+          dispatch(addDangerToast(e.error));
+        });
         dispatch(
           createDatasourceFailed(
             t('An error occurred while creating the data source'),

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
@@ -304,15 +304,12 @@ export const SaveDatasetModal: FunctionComponent<SaveDatasetModalProps> = ({
           [URL_PARAMS.formDataKey.name]: key,
         });
         createWindow(url);
+        setDatasetName(getDefaultDatasetName());
+        onHide();
       })
       .catch(() => {
         addDangerToast(t('An error occurred saving dataset'));
-        onHide();
       });
-
-    setDatasetName(getDefaultDatasetName());
-    console.log(formData);
-    onHide();
   };
 
   const handleOverwriteDatasetOption = (value: SelectValue, option: any) => {

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
@@ -307,9 +307,11 @@ export const SaveDatasetModal: FunctionComponent<SaveDatasetModalProps> = ({
       })
       .catch(() => {
         addDangerToast(t('An error occurred saving dataset'));
+        onHide();
       });
 
     setDatasetName(getDefaultDatasetName());
+    console.log(formData);
     onHide();
   };
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When a user tried to create a dataset with an already existing name, the current SaveDatasetModal was soft failing. This adds a danger toast to the action that creates datasources. 


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

https://user-images.githubusercontent.com/48933336/187299101-4994c359-358c-4634-9243-9653f00a39c0.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
