### PR TITLE
fix(sqllab): sql editor's name has lost after reload

### DIFF
--- a/superset-frontend/src/SqlLab/utils/reduxStateToLocalStorageHelper.js
+++ b/superset-frontend/src/SqlLab/utils/reduxStateToLocalStorageHelper.js
@@ -32,7 +32,7 @@ const PERSISTENT_QUERY_EDITOR_KEYS = new Set([
   'southPercent',
   'sql',
   'templateParams',
-  'title',
+  'name',
   'hideLeftBar',
 ]);
 


### PR DESCRIPTION
### SUMMARY

This bug was introduced by #20852 
Since the editorQuery updates the title key by name but `PERSISTENT_QUERY_EDITOR_KEYS` hasn't updated, the queryEditor name value in localStorage has been discarded.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

<img width="834" alt="Screen Shot 2022-08-29 at 3 38 56 PM" src="https://user-images.githubusercontent.com/1392866/187312487-2063b8ff-d8b0-4ab4-8c1d-63527751dd40.png">

After:

<img width="703" alt="Screen Shot 2022-08-29 at 3 46 35 PM" src="https://user-images.githubusercontent.com/1392866/187312484-7f658313-e623-47f8-82ac-c8efa6120baa.png">

### TESTING INSTRUCTIONS
- set false to SQLLAB_BACKEND_PERSISTENCE
- Go to SqlLab
- Add/Edit editor's name
- refresh the page

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @lyndsiWilliams  