### PR TITLE
fix(sqllab): unable to create new tabs

### DIFF
--- a/superset-frontend/src/SqlLab/utils/newQueryTabName.ts
+++ b/superset-frontend/src/SqlLab/utils/newQueryTabName.ts
@@ -31,7 +31,7 @@ export const newQueryTabName = (
 
   if (queryEditors.length > 0) {
     const mappedUntitled = queryEditors.filter(qe =>
-      qe.name.match(untitledQueryRegex),
+      qe.name?.match(untitledQueryRegex),
     );
     const untitledQueryNumbers = mappedUntitled.map(
       qe => +qe.name.replace(untitledQuery, ''),


### PR DESCRIPTION
### SUMMARY
The queryEditor's name can be `undefined` during localStorage hydration.
This commit skips the `mappedUntitled` case rather than throwing an error for this case.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image (8)](https://user-images.githubusercontent.com/1392866/187530660-2d225f72-9784-4c08-9198-2c9c9d15478d.png)

### TESTING INSTRUCTIONS
N/A

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
