### PR TITLE
fix(sqllab): table list exceeds MAX_TABLE_NAMES

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1202,11 +1202,8 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
         max_items = config["MAX_TABLE_NAMES"] or len(tables)
         total_items = len(tables) + len(views)
-        max_tables = len(tables)
-        max_views = len(views)
-        if total_items and substr_parsed:
-            max_tables = max_items * len(tables) // total_items
-            max_views = max_items * len(views) // total_items
+        max_tables = max_items or len(tables)
+        max_views = max_items or len(views)
 
         extra_dict_by_name = {
             table.name: table.extra_dict
@@ -1243,7 +1240,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             ]
         )
         table_options.sort(key=lambda value: value["label"])
-        payload = {"tableLength": len(tables) + len(views), "options": table_options}
+        payload = {"tableLength": total_items, "options": table_options}
         return json_success(json.dumps(payload))
 
     @api

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1200,10 +1200,10 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             tables = [tn for tn in tables if tn.schema in valid_schemas]
             views = [vn for vn in views if vn.schema in valid_schemas]
 
-        max_items = config["MAX_TABLE_NAMES"] or len(tables)
+        max_tables = len(tables)
+        max_views = len(views)
         total_items = len(tables) + len(views)
-        max_tables = max_items or len(tables)
-        max_views = max_items or len(views)
+        max_items = config["MAX_TABLE_NAMES"] or total_items
 
         extra_dict_by_name = {
             table.name: table.extra_dict
@@ -1240,7 +1240,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             ]
         )
         table_options.sort(key=lambda value: value["label"])
-        payload = {"tableLength": total_items, "options": table_options}
+        payload = {"tableLength": total_items, "options": table_options[:max_items]}
         return json_success(json.dumps(payload))
 
     @api


### PR DESCRIPTION
### SUMMARY
Since `max_tables` logic multiplies (would have intended to `or`) max_items by the current size, it always returns entire list.
(i.e. `config["MAX_TABLE_NAMES"] = 1000` and `len(tables) = 40000` then `max_tables = 40000 * 1000 = 40,000,000`) 
The previous logic also cuts out only if substr passed.
This commit always follows the `MAX_TABLE_NAMES` for both cases. (must set MAX_TABLE_NAMES to 0 if full table list needed)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
Set MAX_TABLE_NAMES to a small number
Go to Sqllab and check the count of table list

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
cc: @john-bodley @ktmud 