### PR TITLE
chore: update release docs

### DIFF
--- a/RELEASING/README.md
+++ b/RELEASING/README.md
@@ -290,10 +290,6 @@ git tag ${SUPERSET_VERSION_RC}
 git push origin ${SUPERSET_VERSION_RC}
 ```
 
-### Create a release on Github
-
-After submitting the tag, follow the steps [here](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) to create the release. Use the vote email text as the content for the release description. Make sure to check the "This is a pre-release" checkbox for release canditates. You can check previous releases if you need an example.
-
 ## Preparing the release candidate
 
 The first step of preparing an Apache Release is packaging a release candidate
@@ -347,7 +343,11 @@ To build and run the recently created tarball **from SVN**:
 # login using admin/admin
 ```
 
-### Voting
+## Create a release on Github
+
+After submitting the tag and testing the release candidate, follow the steps [here](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) to create the release on GitHub. Use the vote email text as the content for the release description. Make sure to check the "This is a pre-release" checkbox for release candidates. You can check previous releases if you need an example.
+
+## Voting
 
 Now you're ready to start the [VOTE] thread. Here's an example of a
 previous release vote thread:
@@ -385,7 +385,7 @@ A List of people with -1 vote (ex: John):
 
 The script will generate the email text that should be sent to dev@superset.apache.org using an email client. The release version and release candidate number are fetched from the previously set environment variables.
 
-### Validating a release
+## Validating a release
 
 https://www.apache.org/info/verification.html
 


### PR DESCRIPTION
### SUMMARY
Updates the release docs by moving the `Create a release on Github` section after the `Preparing the release candidate` section. This avoids the scenario where we have errors when generating the tarball file and need to re-generate the release candidate after it was already published on GitHub.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
