### PR TITLE
fix: adds TLS certificate validation option for SMTP

### DIFF
--- a/docs/docs/installation/alerts-reports.mdx
+++ b/docs/docs/installation/alerts-reports.mdx
@@ -126,7 +126,7 @@ SLACK_API_TOKEN = "xoxb-"
 # Email configuration
 SMTP_HOST = "smtp.sendgrid.net" #change to your host
 SMTP_STARTTLS = True
-SMTP_TLS_SERVER_AUTH = True # If your using an SMTP server with a valid certificate
+SMTP_SSL_SERVER_AUTH = True # If your using an SMTP server with a valid certificate
 SMTP_SSL = False
 SMTP_USER = "your_user"
 SMTP_PORT = 2525 # your port eg. 587

--- a/docs/docs/installation/alerts-reports.mdx
+++ b/docs/docs/installation/alerts-reports.mdx
@@ -126,6 +126,7 @@ SLACK_API_TOKEN = "xoxb-"
 # Email configuration
 SMTP_HOST = "smtp.sendgrid.net" #change to your host
 SMTP_STARTTLS = True
+SMTP_TLS_SERVER_AUTH = True # If your using an SMTP server with a valid certificate
 SMTP_SSL = False
 SMTP_USER = "your_user"
 SMTP_PORT = 2525 # your port eg. 587

--- a/superset/config.py
+++ b/superset/config.py
@@ -988,8 +988,8 @@ SMTP_PORT = 25
 SMTP_PASSWORD = "superset"
 SMTP_MAIL_FROM = "superset@superset.com"
 # If True creates a default SSL context with ssl.Purpose.CLIENT_AUTH using the
-# default system root CA certificates. Only used when SMTP_STARTTLS is True
-SMTP_TLS_SERVER_AUTH = False
+# default system root CA certificates.
+SMTP_SSL_SERVER_AUTH = False
 ENABLE_CHUNK_ENCODING = False
 
 # Whether to bump the logging level to ERROR on the flask_appbuilder package

--- a/superset/config.py
+++ b/superset/config.py
@@ -987,7 +987,9 @@ SMTP_USER = "superset"
 SMTP_PORT = 25
 SMTP_PASSWORD = "superset"
 SMTP_MAIL_FROM = "superset@superset.com"
-
+# If True creates a default SSL context with ssl.Purpose.CLIENT_AUTH using the
+# default system root CA certificates. Only used when SMTP_STARTTLS is True
+SMTP_TLS_SERVER_AUTH = False
 ENABLE_CHUNK_ENCODING = False
 
 # Whether to bump the logging level to ERROR on the flask_appbuilder package

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -995,29 +995,28 @@ def send_mime_email(
     smtp_password = config["SMTP_PASSWORD"]
     smtp_starttls = config["SMTP_STARTTLS"]
     smtp_ssl = config["SMTP_SSL"]
-    smtp_tls_server_auth = config["SMTP_TLS_SERVER_AUTH"]
+    smpt_ssl_server_auth = config["SMTP_SSL_SERVER_AUTH"]
 
-    if not dryrun:
-        smtp = (
-            smtplib.SMTP_SSL(smtp_host, smtp_port)
-            if smtp_ssl
-            else smtplib.SMTP(smtp_host, smtp_port)
-        )
-        if smtp_starttls:
-            ssl_context = None
-            if smtp_tls_server_auth:
-                # Default ssl context is SERVER_AUTH using the default system
-                # root CA certificates
-                ssl_context = ssl.create_default_context()
-            smtp.starttls(context=ssl_context)
-        if smtp_user and smtp_password:
-            smtp.login(smtp_user, smtp_password)
-        logger.debug("Sent an email to %s", str(e_to))
-        smtp.sendmail(e_from, e_to, mime_msg.as_string())
-        smtp.quit()
-    else:
+    if dryrun:
         logger.info("Dryrun enabled, email notification content is below:")
         logger.info(mime_msg.as_string())
+        return
+
+    # Default ssl context is SERVER_AUTH using the default system
+    # root CA certificates
+    ssl_context = ssl.create_default_context() if smpt_ssl_server_auth else None
+    smtp = (
+        smtplib.SMTP_SSL(smtp_host, smtp_port, context=ssl_context)
+        if smtp_ssl
+        else smtplib.SMTP(smtp_host, smtp_port)
+    )
+    if smtp_starttls:
+        smtp.starttls(context=ssl_context)
+    if smtp_user and smtp_password:
+        smtp.login(smtp_user, smtp_password)
+    logger.debug("Sent an email to %s", str(e_to))
+    smtp.sendmail(e_from, e_to, mime_msg.as_string())
+    smtp.quit()
 
 
 def get_email_address_list(address_string: str) -> List[str]:

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -27,6 +27,7 @@ import platform
 import re
 import signal
 import smtplib
+import ssl
 import tempfile
 import threading
 import traceback
@@ -994,6 +995,7 @@ def send_mime_email(
     smtp_password = config["SMTP_PASSWORD"]
     smtp_starttls = config["SMTP_STARTTLS"]
     smtp_ssl = config["SMTP_SSL"]
+    smtp_tls_server_auth = config["SMTP_TLS_SERVER_AUTH"]
 
     if not dryrun:
         smtp = (
@@ -1002,7 +1004,12 @@ def send_mime_email(
             else smtplib.SMTP(smtp_host, smtp_port)
         )
         if smtp_starttls:
-            smtp.starttls()
+            ssl_context = None
+            if smtp_tls_server_auth:
+                # Default ssl context is SERVER_AUTH using the default system
+                # root CA certificates
+                ssl_context = ssl.create_default_context()
+            smtp.starttls(context=ssl_context)
         if smtp_user and smtp_password:
             smtp.login(smtp_user, smtp_password)
         logger.debug("Sent an email to %s", str(e_to))

--- a/tests/integration_tests/email_tests.py
+++ b/tests/integration_tests/email_tests.py
@@ -178,6 +178,15 @@ class TestEmailSmtp(SupersetTestCase):
             app.config["SMTP_HOST"], app.config["SMTP_PORT"]
         )
 
+    @mock.patch("smtplib.SMTP")
+    def test_send_mime_tls_server_auth(self, mock_smtp):
+        app.config["SMTP_STARTTLS"] = True
+        app.config["SMTP_TLS_SERVER_AUTH"] = True
+        mock_smtp.return_value = mock.Mock()
+        mock_smtp.return_value.starttls.return_value = mock.Mock()
+        utils.send_mime_email("from", "to", MIMEMultipart(), app.config, dryrun=False)
+        mock_smtp.return_value.starttls.assert_called_with(context=mock.ANY)
+
     @mock.patch("smtplib.SMTP_SSL")
     @mock.patch("smtplib.SMTP")
     def test_send_mime_noauth(self, mock_smtp, mock_smtp_ssl):

--- a/tests/integration_tests/email_tests.py
+++ b/tests/integration_tests/email_tests.py
@@ -17,6 +17,7 @@
 # under the License.
 """Unit tests for email service in Superset"""
 import logging
+import ssl
 import tempfile
 import unittest
 from email.mime.application import MIMEApplication
@@ -175,17 +176,34 @@ class TestEmailSmtp(SupersetTestCase):
         utils.send_mime_email("from", "to", MIMEMultipart(), app.config, dryrun=False)
         assert not mock_smtp.called
         mock_smtp_ssl.assert_called_with(
-            app.config["SMTP_HOST"], app.config["SMTP_PORT"]
+            app.config["SMTP_HOST"], app.config["SMTP_PORT"], context=None
         )
+
+    @mock.patch("smtplib.SMTP_SSL")
+    @mock.patch("smtplib.SMTP")
+    def test_send_mime_ssl_server_auth(self, mock_smtp, mock_smtp_ssl):
+        app.config["SMTP_SSL"] = True
+        app.config["SMTP_SSL_SERVER_AUTH"] = True
+        mock_smtp.return_value = mock.Mock()
+        mock_smtp_ssl.return_value = mock.Mock()
+        utils.send_mime_email("from", "to", MIMEMultipart(), app.config, dryrun=False)
+        assert not mock_smtp.called
+        mock_smtp_ssl.assert_called_with(
+            app.config["SMTP_HOST"], app.config["SMTP_PORT"], context=mock.ANY
+        )
+        called_context = mock_smtp_ssl.call_args.kwargs["context"]
+        self.assertEqual(called_context.verify_mode, ssl.CERT_REQUIRED)
 
     @mock.patch("smtplib.SMTP")
     def test_send_mime_tls_server_auth(self, mock_smtp):
         app.config["SMTP_STARTTLS"] = True
-        app.config["SMTP_TLS_SERVER_AUTH"] = True
+        app.config["SMTP_SSL_SERVER_AUTH"] = True
         mock_smtp.return_value = mock.Mock()
         mock_smtp.return_value.starttls.return_value = mock.Mock()
         utils.send_mime_email("from", "to", MIMEMultipart(), app.config, dryrun=False)
         mock_smtp.return_value.starttls.assert_called_with(context=mock.ANY)
+        called_context = mock_smtp.return_value.starttls.call_args.kwargs["context"]
+        self.assertEqual(called_context.verify_mode, ssl.CERT_REQUIRED)
 
     @mock.patch("smtplib.SMTP_SSL")
     @mock.patch("smtplib.SMTP")


### PR DESCRIPTION
### SUMMARY

By default python's standard library will not validate SMTP server certificates, more info here: 
context: https://github.com/python/cpython/issues/91826

This PR adds a new config key name `SMTP_SSL_SERVER_AUTH` that enforces smtp server certificate validation, 
using the default system CA certificates.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
