### PR TITLE
fix: Fix console errors about feature flags when running tests

### DIFF
--- a/superset-frontend/packages/superset-ui-core/test/utils/featureFlag.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/utils/featureFlag.test.ts
@@ -19,17 +19,45 @@
 
 import { FeatureFlag, isFeatureEnabled } from '@superset-ui/core';
 
-describe('isFeatureFlagEnabled', () => {
+const originalFeatureFlags = window.featureFlags;
+// eslint-disable-next-line no-console
+const originalConsoleError = console.error;
+const reset = () => {
+  window.featureFlags = originalFeatureFlags;
+  // eslint-disable-next-line no-console
+  console.error = originalConsoleError;
+};
+
+it('returns false and raises console error if feature flags have not been initialized', () => {
+  // eslint-disable-next-line no-console
+  console.error = jest.fn();
+  delete (window as any).featureFlags;
+  expect(isFeatureEnabled(FeatureFlag.ALLOW_DASHBOARD_DOMAIN_SHARDING)).toEqual(
+    false,
+  );
+
+  // eslint-disable-next-line no-console
+  expect(console.error).toHaveBeenNthCalledWith(
+    1,
+    'Failed to query feature flag ALLOW_DASHBOARD_DOMAIN_SHARDING (see error below)',
+  );
+
+  reset();
+});
+
+it('returns false for unset feature flag', () => {
+  expect(isFeatureEnabled(FeatureFlag.ALLOW_DASHBOARD_DOMAIN_SHARDING)).toEqual(
+    false,
+  );
+
+  reset();
+});
+
+it('returns true for set feature flag', () => {
   window.featureFlags = {
     [FeatureFlag.CLIENT_CACHE]: true,
   };
-  it('returns false for unset feature flag', () => {
-    expect(
-      isFeatureEnabled(FeatureFlag.ALLOW_DASHBOARD_DOMAIN_SHARDING),
-    ).toEqual(false);
-  });
 
-  it('returns true for set feature flag', () => {
-    expect(isFeatureEnabled(FeatureFlag.CLIENT_CACHE)).toEqual(true);
-  });
+  expect(isFeatureEnabled(FeatureFlag.CLIENT_CACHE)).toEqual(true);
+  reset();
 });

--- a/superset-frontend/spec/helpers/shim.ts
+++ b/superset-frontend/spec/helpers/shim.ts
@@ -53,6 +53,7 @@ g.window.performance = { now: () => new Date().getTime() };
 g.window.Worker = Worker;
 g.window.IntersectionObserver = IntersectionObserver;
 g.window.ResizeObserver = ResizeObserver;
+g.window.featureFlags = {};
 g.URL.createObjectURL = () => '';
 g.caches = new CacheStorage();
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
#21201 added a console error if feature flags are read before initialization, but the Jest test environment doesn't include a feature flag initialization step, so all tests that render components that check feature flags were printing lots of these console errors (though still passing).  This PR sets `featureFlags` to an empty object in the global window shim object used by Jest.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Run Jest tests and search the output for any console errors with "feature flag".  After this update, there should be none.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
