### PR TITLE
chore: Renaming Line Chart to Line Chart v2

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/index.ts
@@ -74,7 +74,7 @@ export default class EchartsTimeseriesLineChartPlugin extends ChartPlugin<
           AnnotationType.Timeseries,
         ],
         name: isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES)
-          ? t('Line Chart')
+          ? t('Line Chart v2')
           : t('Time-series Line Chart'),
         tags: [
           t('ECharts'),


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
If you have generic x-axis on, there are two charts called "Line Chart." This is confusing and incorrect since they are different charts. This update creates a naming distinction by updating the e-charts version to be "Line Chart v2."

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
n/a

### TESTING INSTRUCTIONS
* Turn on the feature flag
* Go to the visualization picker
* Observe that the label now contains the 'v2' indicator

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags: GENERIC_CHART_AXES
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
