### PR TITLE
chore(sqllab): Remove max-width on side panel

### DIFF
--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -287,7 +287,6 @@ div.Workspace {
 
   .schemaPane {
     flex: 0 0 400px;
-    max-width: 400px;
     transition: transform @timing-normal ease-in-out;
   }
 


### PR DESCRIPTION
### SUMMARY

When a long table option is selected, the selection chip can be overlaps the main editor's panel.
Sometime it can cover the "Run" cta button so hard to run the query.

This commit removes the `max-width` on sidebar so it can be extended for the overflowing case.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

- Before:

https://user-images.githubusercontent.com/1392866/187795291-014b2a4b-8c18-423a-8572-2c5fffe7dc6c.mov

- After:

https://user-images.githubusercontent.com/1392866/187795286-045e9f52-5223-4bd5-a95c-da9e3ae794a2.mov

### TESTING INSTRUCTIONS

- Go to sqllab
- Choose a long table name option

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
