### PR TITLE
fix(dashboard): Fix scrolling on "View as table" modal

### DIFF
--- a/superset-frontend/src/explore/components/DataTablesPane/components/ResultsPaneOnDashboard.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/ResultsPaneOnDashboard.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { t } from '@superset-ui/core';
+import { t, css } from '@superset-ui/core';
 import Tabs from 'src/components/Tabs';
 import { ResultTypes, ResultsPaneProps } from '../types';
 import { useResultsPane } from './useResultsPane';
@@ -43,7 +43,20 @@ export const ResultsPaneOnDashboard = ({
     isVisible,
   });
   if (resultsPanes.length === 1) {
-    return resultsPanes[0];
+    return (
+      <div
+        css={css`
+          display: flex;
+          flex-direction: column;
+          height: 100%;
+          .table-condensed {
+            overflow: auto;
+          }
+        `}
+      >
+        {resultsPanes[0]}
+      </div>
+    );
   }
 
   const panes = resultsPanes.map((pane, idx) => {

--- a/superset-frontend/src/explore/components/DataTablesPane/components/ResultsPaneOnDashboard.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/ResultsPaneOnDashboard.tsx
@@ -42,41 +42,59 @@ export const ResultsPaneOnDashboard = ({
     dataSize,
     isVisible,
   });
-  if (resultsPanes.length === 1) {
-    return (
-      <div
-        css={css`
-          display: flex;
-          flex-direction: column;
-          height: 100%;
-          .table-condensed {
-            overflow: auto;
-          }
-        `}
-      >
-        {resultsPanes[0]}
-      </div>
-    );
-  }
 
-  const panes = resultsPanes.map((pane, idx) => {
-    if (idx === 0) {
+  let resultsPane;
+  if (resultsPanes.length === 1) {
+    resultsPane = resultsPanes[0];
+  } else {
+    const panes = resultsPanes.map((pane, idx) => {
+      if (idx === 0) {
+        return (
+          <Tabs.TabPane tab={t('Results')} key={ResultTypes.Results}>
+            {pane}
+          </Tabs.TabPane>
+        );
+      }
+
       return (
-        <Tabs.TabPane tab={t('Results')} key={ResultTypes.Results}>
+        <Tabs.TabPane
+          tab={t('Results %s', idx + 1)}
+          key={`${ResultTypes.Results} ${idx + 1}`}
+        >
           {pane}
         </Tabs.TabPane>
       );
-    }
+    });
 
-    return (
-      <Tabs.TabPane
-        tab={t('Results %s', idx + 1)}
-        key={`${ResultTypes.Results} ${idx + 1}`}
-      >
-        {pane}
-      </Tabs.TabPane>
-    );
-  });
+    resultsPane = <Tabs fullWidth={false}>{panes}</Tabs>;
+  }
 
-  return <Tabs fullWidth={false}> {panes} </Tabs>;
+  return (
+    <div
+      css={css`
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+
+        .ant-tabs {
+          height: 100%;
+        }
+
+        .ant-tabs-content {
+          height: 100%;
+        }
+
+        .ant-tabs-tabpane {
+          display: flex;
+          flex-direction: column;
+        }
+
+        .table-condensed {
+          overflow: auto;
+        }
+      `}
+    >
+      {resultsPane}
+    </div>
+  );
 };

--- a/superset-frontend/src/explore/components/DataTablesPane/components/ResultsPaneOnDashboard.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/ResultsPaneOnDashboard.tsx
@@ -17,10 +17,33 @@
  * under the License.
  */
 import React from 'react';
-import { t, css } from '@superset-ui/core';
+import { t, styled } from '@superset-ui/core';
 import Tabs from 'src/components/Tabs';
 import { ResultTypes, ResultsPaneProps } from '../types';
 import { useResultsPane } from './useResultsPane';
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+
+  .ant-tabs {
+    height: 100%;
+  }
+
+  .ant-tabs-content {
+    height: 100%;
+  }
+
+  .ant-tabs-tabpane {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .table-condensed {
+    overflow: auto;
+  }
+`;
 
 export const ResultsPaneOnDashboard = ({
   isRequest,
@@ -43,58 +66,32 @@ export const ResultsPaneOnDashboard = ({
     isVisible,
   });
 
-  let resultsPane;
   if (resultsPanes.length === 1) {
-    resultsPane = resultsPanes[0];
-  } else {
-    const panes = resultsPanes.map((pane, idx) => {
-      if (idx === 0) {
-        return (
-          <Tabs.TabPane tab={t('Results')} key={ResultTypes.Results}>
-            {pane}
-          </Tabs.TabPane>
-        );
-      }
+    return <Wrapper>{resultsPanes[0]}</Wrapper>;
+  }
 
+  const panes = resultsPanes.map((pane, idx) => {
+    if (idx === 0) {
       return (
-        <Tabs.TabPane
-          tab={t('Results %s', idx + 1)}
-          key={`${ResultTypes.Results} ${idx + 1}`}
-        >
+        <Tabs.TabPane tab={t('Results')} key={ResultTypes.Results}>
           {pane}
         </Tabs.TabPane>
       );
-    });
+    }
 
-    resultsPane = <Tabs fullWidth={false}>{panes}</Tabs>;
-  }
+    return (
+      <Tabs.TabPane
+        tab={t('Results %s', idx + 1)}
+        key={`${ResultTypes.Results} ${idx + 1}`}
+      >
+        {pane}
+      </Tabs.TabPane>
+    );
+  });
 
   return (
-    <div
-      css={css`
-        display: flex;
-        flex-direction: column;
-        height: 100%;
-
-        .ant-tabs {
-          height: 100%;
-        }
-
-        .ant-tabs-content {
-          height: 100%;
-        }
-
-        .ant-tabs-tabpane {
-          display: flex;
-          flex-direction: column;
-        }
-
-        .table-condensed {
-          overflow: auto;
-        }
-      `}
-    >
-      {resultsPane}
-    </div>
+    <Wrapper>
+      <Tabs fullWidth={false}>{panes}</Tabs>
+    </Wrapper>
   );
 };


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In the "View as table" modal, accessed by clicking the three dots on a dashboard chart, results scroll behind/with the header and pagination.  This PR fixes layout so header and pagination stay in place, for both the single-query and multi-query version of the modal.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
**Before, single query:**

https://user-images.githubusercontent.com/13007381/187799270-c658c2e5-4ba7-435e-8279-2c10ed616bf3.mov

**Before, multiple query:**

https://user-images.githubusercontent.com/13007381/187799307-0ad0440e-2993-4d34-8958-881d455e74ed.mov

**After, single query:**

https://user-images.githubusercontent.com/13007381/187799322-76b48225-fcce-44e7-88c2-eca51e8fc0a3.mov

**After, multiple query:**

https://user-images.githubusercontent.com/13007381/187799329-6129328f-756f-4677-acf2-8723e77edebd.mov

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Open the "View as table" modal for single- and multiple-query charts and ensure scrolling works as expected.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
