### PR TITLE
fix(explore): Incorrect conversion from simple bool filter to custom sql

### DIFF
--- a/superset-frontend/src/utils/common.js
+++ b/superset-frontend/src/utils/common.js
@@ -66,10 +66,10 @@ export function optionLabel(opt) {
     return EMPTY_STRING;
   }
   if (opt === true) {
-    return 'true';
+    return TRUE_STRING;
   }
   if (opt === false) {
-    return 'false';
+    return FALSE_STRING;
   }
   if (typeof opt !== 'string' && opt.toString) {
     return opt.toString();

--- a/superset-frontend/src/utils/common.js
+++ b/superset-frontend/src/utils/common.js
@@ -66,10 +66,10 @@ export function optionLabel(opt) {
     return EMPTY_STRING;
   }
   if (opt === true) {
-    return '<true>';
+    return 'true';
   }
   if (opt === false) {
-    return '<false>';
+    return 'false';
   }
   if (typeof opt !== 'string' && opt.toString) {
     return opt.toString();

--- a/superset-frontend/src/utils/common.test.jsx
+++ b/superset-frontend/src/utils/common.test.jsx
@@ -21,6 +21,8 @@ import {
   optionFromValue,
   prepareCopyToClipboardTabularData,
   NULL_STRING,
+  TRUE_STRING,
+  FALSE_STRING,
 } from 'src/utils/common';
 
 describe('utils/common', () => {
@@ -28,9 +30,12 @@ describe('utils/common', () => {
     it('converts values as expected', () => {
       expect(optionFromValue(false)).toEqual({
         value: false,
-        label: 'false',
+        label: FALSE_STRING,
       });
-      expect(optionFromValue(true)).toEqual({ value: true, label: 'true' });
+      expect(optionFromValue(true)).toEqual({
+        value: true,
+        label: TRUE_STRING,
+      });
       expect(optionFromValue(null)).toEqual({
         value: NULL_STRING,
         label: NULL_STRING,

--- a/superset-frontend/src/utils/common.test.jsx
+++ b/superset-frontend/src/utils/common.test.jsx
@@ -28,9 +28,9 @@ describe('utils/common', () => {
     it('converts values as expected', () => {
       expect(optionFromValue(false)).toEqual({
         value: false,
-        label: '<false>',
+        label: 'false',
       });
-      expect(optionFromValue(true)).toEqual({ value: true, label: '<true>' });
+      expect(optionFromValue(true)).toEqual({ value: true, label: 'true' });
       expect(optionFromValue(null)).toEqual({
         value: NULL_STRING,
         label: NULL_STRING,


### PR DESCRIPTION

### SUMMARY
This PR removes brackets around `true` and `false` when automatically converting boolean simple adhoc filter to a custom sql filter.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/15073128/187921621-bbc322da-7d23-4a78-b1a3-5be9c35fdad0.mov

After:

https://user-images.githubusercontent.com/15073128/187921686-3fbcd7bd-3db6-44bd-9d85-4ce9235e34e4.mov

### TESTING INSTRUCTIONS
1. Add a simple adhoc filter with a boolean column
2. Covert it to custom sql
3. Verify that there are no brackets around `true` or `false` and that query works correctly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
