### PR TITLE
fix(explore): Time column label not formatted when GENERIC_X_AXES enabled

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -167,7 +167,7 @@ export default function transformProps(
   });
 
   const dataTypes = getColtypesMapping(queriesData[0]);
-  const xAxisDataType = dataTypes?.[xAxisCol];
+  const xAxisDataType = dataTypes?.[xAxisCol] ?? dataTypes?.[xAxisOrig];
   const xAxisType = getAxisType(xAxisDataType);
   const series: SeriesOption[] = [];
   const formatter = getNumberFormatter(contributionMode ? ',.0%' : yAxisFormat);


### PR DESCRIPTION

### SUMMARY
When user has `GENERIC_CHART_AXES` enabled and adds a custom label to a time column, the timestamps on the chart's x axis are not formatted.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/15073128/187944758-00e26588-f0e0-4881-b1e1-8e861702dd70.png">

After:

<img width="1790" alt="image" src="https://user-images.githubusercontent.com/15073128/187944389-e0fbde6a-aaed-4073-b4d3-42267fc8fb3e.png">


### TESTING INSTRUCTIONS
1. Enable `GENERIC_CHART_AXES`
2. Create a Mixed Chart
3. Set a custom label for a time column and use it as x axis
4. Verify that timestamps on x axis are formatted

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
