### PR TITLE
fix(sqllab): invalid table metadata request

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -1137,8 +1137,9 @@ function getTableExtendedMetadata(table, query, dispatch) {
     );
 }
 
-export function addTable(query, database, tableName, schemaName) {
-  return function (dispatch) {
+export function addTable(queryEditor, database, tableName, schemaName) {
+  return function (dispatch, getState) {
+    const query = getUpToDateQuery(getState(), queryEditor, queryEditor.id);
     const table = {
       dbId: query.dbId,
       queryEditorId: query.id,

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/SqlEditorLeftBar.test.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/SqlEditorLeftBar.test.jsx
@@ -19,14 +19,12 @@
 import React from 'react';
 import configureStore from 'redux-mock-store';
 import fetchMock from 'fetch-mock';
-import { shallow } from 'enzyme';
 import { render, screen } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
 import '@testing-library/jest-dom/extend-expect';
 import thunk from 'redux-thunk';
 import SqlEditorLeftBar from 'src/SqlLab/components/SqlEditorLeftBar';
-import TableElement from 'src/SqlLab/components/TableElement';
 import { supersetTheme, ThemeProvider } from '@superset-ui/core';
 import {
   table,
@@ -46,74 +44,86 @@ const mockedProps = {
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
 const store = mockStore(initialState);
+
 fetchMock.get('glob:*/api/v1/database/*/schemas/?*', { result: [] });
-describe('SqlEditorLeftBar', () => {
-  let wrapper;
-
-  beforeEach(() => {
-    wrapper = shallow(<SqlEditorLeftBar {...mockedProps} />, {
-      context: { store },
-    });
-  });
-
-  afterEach(() => {
-    wrapper.unmount();
-  });
-
-  it('is valid', () => {
-    expect(React.isValidElement(<SqlEditorLeftBar {...mockedProps} />)).toBe(
-      true,
-    );
-  });
-
-  it('renders a TableElement', () => {
-    expect(wrapper.find(TableElement)).toExist();
-  });
+fetchMock.get('glob:*/superset/tables/**', {
+  json: {
+    options: [
+      {
+        label: 'ab_user',
+        value: 'ab_user',
+      },
+    ],
+    tableLength: 1,
+  },
 });
 
 describe('Left Panel Expansion', () => {
-  it('table should be visible when expanded is true', () => {
-    const { container } = render(
+  it('is valid', () => {
+    expect(
+      React.isValidElement(
+        <Provider store={store}>
+          <SqlEditorLeftBar {...mockedProps} />
+        </Provider>,
+      ),
+    ).toBe(true);
+  });
+
+  it('renders a TableElement', () => {
+    const { queryAllByTestId } = render(
       <ThemeProvider theme={supersetTheme}>
         <Provider store={store}>
           <SqlEditorLeftBar {...mockedProps} />
         </Provider>
       </ThemeProvider>,
     );
-    const dbSelect = screen.getByRole('combobox', {
-      name: 'Select database or type database name',
-    });
-    const schemaSelect = screen.getByRole('combobox', {
-      name: 'Select schema or type schema name',
-    });
-    const dropdown = screen.getByText(/Select table or type table name/i);
-    const abUser = screen.getByText(/ab_user/i);
-    expect(dbSelect).toBeInTheDocument();
-    expect(schemaSelect).toBeInTheDocument();
-    expect(dropdown).toBeInTheDocument();
-    expect(abUser).toBeInTheDocument();
-    expect(
-      container.querySelector('.ant-collapse-content-active'),
-    ).toBeInTheDocument();
+    expect(queryAllByTestId('table-element').length).toBeGreaterThanOrEqual(1);
   });
 
-  it('should toggle the table when the header is clicked', async () => {
-    const collapseMock = jest.fn();
-    render(
-      <ThemeProvider theme={supersetTheme}>
-        <Provider store={store}>
-          <SqlEditorLeftBar
-            actions={{ ...mockedActions, collapseTable: collapseMock }}
-            tables={[table]}
-            queryEditor={defaultQueryEditor}
-            database={databases}
-            height={0}
-          />
-        </Provider>
-      </ThemeProvider>,
-    );
-    const header = screen.getByText(/ab_user/);
-    userEvent.click(header);
-    expect(collapseMock).toHaveBeenCalled();
+  describe('Left Panel Expansion', () => {
+    it('table should be visible when expanded is true', () => {
+      const { container } = render(
+        <ThemeProvider theme={supersetTheme}>
+          <Provider store={store}>
+            <SqlEditorLeftBar {...mockedProps} />
+          </Provider>
+        </ThemeProvider>,
+      );
+      const dbSelect = screen.getByRole('combobox', {
+        name: 'Select database or type database name',
+      });
+      const schemaSelect = screen.getByRole('combobox', {
+        name: 'Select schema or type schema name',
+      });
+      const dropdown = screen.getByText(/Select table or type table name/i);
+      const abUser = screen.getByText(/ab_user/i);
+      expect(dbSelect).toBeInTheDocument();
+      expect(schemaSelect).toBeInTheDocument();
+      expect(dropdown).toBeInTheDocument();
+      expect(abUser).toBeInTheDocument();
+      expect(
+        container.querySelector('.ant-collapse-content-active'),
+      ).toBeInTheDocument();
+    });
+
+    it('should toggle the table when the header is clicked', async () => {
+      const collapseMock = jest.fn();
+      render(
+        <ThemeProvider theme={supersetTheme}>
+          <Provider store={store}>
+            <SqlEditorLeftBar
+              actions={{ ...mockedActions, collapseTable: collapseMock }}
+              tables={[table]}
+              queryEditor={defaultQueryEditor}
+              database={databases}
+              height={0}
+            />
+          </Provider>
+        </ThemeProvider>,
+      );
+      const header = screen.getByText(/ab_user/);
+      userEvent.click(header);
+      expect(collapseMock).toHaveBeenCalled();
+    });
   });
 });

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
@@ -25,6 +25,7 @@ import React, {
   Dispatch,
   SetStateAction,
 } from 'react';
+import { useSelector } from 'react-redux';
 import querystring from 'query-string';
 import Button from 'src/components/Button';
 import { t, styled, css, SupersetTheme } from '@superset-ui/core';
@@ -32,7 +33,7 @@ import Collapse from 'src/components/Collapse';
 import Icons from 'src/components/Icons';
 import { TableSelectorMultiple } from 'src/components/TableSelector';
 import { IconTooltip } from 'src/components/IconTooltip';
-import { QueryEditor, SchemaOption } from 'src/SqlLab/types';
+import { QueryEditor, SchemaOption, SqlLabRootState } from 'src/SqlLab/types';
 import { DatabaseObject } from 'src/components/DatabaseSelector';
 import { EmptyStateSmall } from 'src/components/EmptyState';
 import {
@@ -115,6 +116,15 @@ export default function SqlEditorLeftBar({
   const [emptyResultsWithSearch, setEmptyResultsWithSearch] = useState(false);
   const [userSelectedDb, setUserSelected] = useState<DatabaseObject | null>(
     null,
+  );
+  const schema = useSelector<SqlLabRootState, string>(
+    ({ sqlLab: { unsavedQueryEditor } }) => {
+      const updatedQueryEditor = {
+        ...queryEditor,
+        ...(unsavedQueryEditor.id === queryEditor.id && unsavedQueryEditor),
+      };
+      return updatedQueryEditor.schema;
+    },
   );
 
   useEffect(() => {
@@ -263,7 +273,7 @@ export default function SqlEditorLeftBar({
         onSchemasLoad={handleSchemasLoad}
         onTableSelectChange={onTablesChange}
         onTablesLoad={handleTablesLoad}
-        schema={queryEditor.schema}
+        schema={schema}
         tableValue={selectedTableNames}
         sqlLabMode
       />

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.jsx
@@ -262,6 +262,9 @@ class TabbedSqlEditors extends React.PureComponent {
     const qeid = this.props.tabHistory[this.props.tabHistory.length - 1];
     if (key !== qeid) {
       const queryEditor = this.props.queryEditors.find(qe => qe.id === key);
+      if (!queryEditor) {
+        return;
+      }
       this.props.actions.switchQueryEditor(
         queryEditor,
         this.props.displayLimit,

--- a/superset-frontend/src/SqlLab/components/TableElement/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TableElement/index.tsx
@@ -270,6 +270,7 @@ const TableElement = ({ table, actions, ...props }: TableElementProps) => {
 
     const metadata = (
       <div
+        data-test="table-element"
         onMouseEnter={() => setHover(true)}
         onMouseLeave={() => setHover(false)}
         css={{ paddingTop: 6 }}

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -110,7 +110,12 @@ export default function sqlLabReducer(state = {}, action) {
       );
     },
     [actions.REMOVE_QUERY_EDITOR]() {
-      let newState = removeFromArr(state, 'queryEditors', action.queryEditor);
+      const queryEditor = {
+        ...action.queryEditor,
+        ...(action.queryEditor.id === state.unsavedQueryEditor.id &&
+          state.unsavedQueryEditor),
+      };
+      let newState = removeFromArr(state, 'queryEditors', queryEditor);
       // List of remaining queryEditor ids
       const qeIds = newState.queryEditors.map(qe => qe.id);
 
@@ -127,10 +132,19 @@ export default function sqlLabReducer(state = {}, action) {
 
       // Remove associated table schemas
       const tables = state.tables.filter(
-        table => table.queryEditorId !== action.queryEditor.id,
+        table => table.queryEditorId !== queryEditor.id,
       );
 
-      newState = { ...newState, tabHistory, tables, queries };
+      newState = {
+        ...newState,
+        tabHistory,
+        tables,
+        queries,
+        unsavedQueryEditor: {
+          ...(action.queryEditor.id !== state.unsavedQueryEditor.id &&
+            state.unsavedQueryEditor),
+        },
+      };
       return newState;
     },
     [actions.REMOVE_QUERY]() {

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
@@ -75,6 +75,28 @@ describe('sqlLabReducer', () => {
         initialState.queryEditors.length,
       );
     });
+    it('should remove a query editor including unsaved changes', () => {
+      expect(newState.queryEditors).toHaveLength(
+        initialState.queryEditors.length + 1,
+      );
+      let action = {
+        type: actions.QUERY_EDITOR_SETDB,
+        queryEditor: qe,
+        dbId: 123,
+      };
+      newState = sqlLabReducer(newState, action);
+      expect(newState.unsavedQueryEditor.dbId).toEqual(action.dbId);
+      action = {
+        type: actions.REMOVE_QUERY_EDITOR,
+        queryEditor: qe,
+      };
+      newState = sqlLabReducer(newState, action);
+      expect(newState.queryEditors).toHaveLength(
+        initialState.queryEditors.length,
+      );
+      expect(newState.unsavedQueryEditor.dbId).toBeUndefined();
+      expect(newState.unsavedQueryEditor.id).toBeUndefined();
+    });
     it('should set q query editor active', () => {
       const expectedTitle = 'new updated title';
       const addQueryEditorAction = {


### PR DESCRIPTION
### SUMMARY
This is a hotfix for #21298 
TableSelector didn't get the database selection from unsaved changes, so the table metadata fetches with old dbId.
This commit updates the `addTable` action to sync the queryEditor from unsaved changes.
This commit also sync `schema` data in SqlEditorLeftBar and reset unsaved changes on closing a tab.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
- Go to SqlLab
- Choose a schema and a table
- verify the table schema fetched accordingly
- change other database option (to make unsaved changes)
- Choose a schema and a table
- verify the table schema fetched accordingly

### ADDITIONAL INFORMATION
- [x] Has associated issue: #20877
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @hughhhh @ktmud @EugeneTorap 