### PR TITLE
[WIP]fix(cursor-dragging): Changing cursor while dragging component on charts page

### DIFF
--- a/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanelDragOption/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanelDragOption/index.tsx
@@ -50,10 +50,6 @@ const DatasourceItemContainer = styled.div`
   `}
 `;
 
-const style = (dragging: boolean) => ({
-  cursor: dragging ? 'grabbing' : 'pointer',
-});
-
 interface DatasourcePanelDragOptionProps extends DatasourcePanelDndItem {
   labelRef?: React.RefObject<any>;
   showTooltip?: boolean;

--- a/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanelDragOption/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanelDragOption/index.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useDrag } from 'react-dnd';
 import { css, Metric, styled } from '@superset-ui/core';
 import { ColumnMeta } from '@superset-ui/chart-controls';
@@ -50,6 +50,10 @@ const DatasourceItemContainer = styled.div`
   `}
 `;
 
+const style = (dragging: boolean) => ({
+  cursor: dragging ? 'grabbing' : 'pointer',
+});
+
 interface DatasourcePanelDragOptionProps extends DatasourcePanelDndItem {
   labelRef?: React.RefObject<any>;
   showTooltip?: boolean;
@@ -80,7 +84,11 @@ export default function DatasourcePanelDragOption(
   };
 
   return (
-    <DatasourceItemContainer data-test="DatasourcePanelDragOption" ref={drag}>
+    <DatasourceItemContainer
+      style={isDragging ? { cursor: 'grabbing' } : { cursor: 'pointer' }}
+      data-test="DatasourcePanelDragOption"
+      ref={drag}
+    >
       {type === DndItemType.Column ? (
         <StyledColumnOption column={value as ColumnMeta} {...optionProps} />
       ) : (


### PR DESCRIPTION
### SUMMARY
So, created a workaround to change cursor to grabbing while dragging

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
- Click Charts in the top nav
- Open up a chart from the list view
- Drag an item to check cursor behavior

