### PR TITLE
fix(sqllab): avoid unexpected re-rendering on DatabaseSelector

### DIFF
--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -132,17 +132,7 @@ export default function DatabaseSelector({
 }: DatabaseSelectorProps) {
   const [loadingSchemas, setLoadingSchemas] = useState(false);
   const [schemaOptions, setSchemaOptions] = useState<SchemaValue[]>([]);
-  const [currentDb, setCurrentDb] = useState<DatabaseValue | undefined>(
-    db
-      ? {
-          label: (
-            <SelectLabel backend={db.backend} databaseName={db.database_name} />
-          ),
-          value: db.id,
-          ...db,
-        }
-      : undefined,
-  );
+  const [currentDb, setCurrentDb] = useState<DatabaseValue | undefined>();
   const [currentSchema, setCurrentSchema] = useState<SchemaValue | undefined>(
     schema ? { label: schema, value: schema } : undefined,
   );
@@ -207,6 +197,25 @@ export default function DatabaseSelector({
       },
     [formMode, getDbList, sqlLabMode],
   );
+
+  useEffect(() => {
+    setCurrentDb(current =>
+      current?.id !== db?.id
+        ? db
+          ? {
+              label: (
+                <SelectLabel
+                  backend={db.backend}
+                  databaseName={db.database_name}
+                />
+              ),
+              value: db.id,
+              ...db,
+            }
+          : undefined
+        : current,
+    );
+  }, [db]);
 
   useEffect(() => {
     if (currentDb) {

--- a/superset-frontend/src/components/Select/AsyncSelect.tsx
+++ b/superset-frontend/src/components/Select/AsyncSelect.tsx
@@ -299,25 +299,21 @@ const AsyncSelect = forwardRef(
       [onError],
     );
 
-    const mergeData = useCallback(
-      (data: SelectOptionsType) => {
-        let mergedData: SelectOptionsType = [];
-        if (data && Array.isArray(data) && data.length) {
-          // unique option values should always be case sensitive so don't lowercase
-          const dataValues = new Set(data.map(opt => opt.value));
-          // merges with existing and creates unique options
-          setSelectOptions(prevOptions => {
-            mergedData = prevOptions
-              .filter(previousOption => !dataValues.has(previousOption.value))
-              .concat(data)
-              .sort(sortComparatorForNoSearch);
-            return mergedData;
-          });
-        }
-        return mergedData;
-      },
-      [sortComparatorForNoSearch],
-    );
+    const mergeData = useCallback((data: SelectOptionsType) => {
+      let mergedData: SelectOptionsType = [];
+      if (data && Array.isArray(data) && data.length) {
+        // unique option values should always be case sensitive so don't lowercase
+        const dataValues = new Set(data.map(opt => opt.value));
+        // merges with existing and creates unique options
+        setSelectOptions(prevOptions => {
+          mergedData = prevOptions
+            .filter(previousOption => !dataValues.has(previousOption.value))
+            .concat(data);
+          return mergedData;
+        });
+      }
+      return mergedData;
+    }, []);
 
     const fetchPage = useMemo(
       () => (search: string, page: number) => {
@@ -334,6 +330,7 @@ const AsyncSelect = forwardRef(
           return;
         }
         setIsLoading(true);
+
         const fetchOptions = options as SelectOptionsPagePromise;
         fetchOptions(search, page, pageSize)
           .then(({ data, totalCount }: SelectOptionsTypePage) => {
@@ -342,7 +339,7 @@ const AsyncSelect = forwardRef(
             setTotalCount(totalCount);
             if (
               !fetchOnlyOnSearch &&
-              value === '' &&
+              search === '' &&
               mergedData.length >= totalCount
             ) {
               setAllValuesLoaded(true);
@@ -360,7 +357,6 @@ const AsyncSelect = forwardRef(
         internalOnError,
         options,
         pageSize,
-        value,
       ],
     );
 
@@ -511,10 +507,6 @@ const AsyncSelect = forwardRef(
       }),
       [ref],
     );
-
-    useEffect(() => {
-      setSelectValue(value);
-    }, [value]);
 
     return (
       <StyledContainer>

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -258,7 +258,6 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
   function renderDatabaseSelector() {
     return (
       <DatabaseSelector
-        key={database?.id}
         db={database}
         emptyState={emptyState}
         formMode={formMode}


### PR DESCRIPTION
### SUMMARY

Reopen: #21141

Since DatabaseSelector component has an unnecessary key, DatabaseSelector will be re-mounted  rather than update whenever currentDatabase object is updated. This causes the unexpected duplicate database list api request.
This commit removes this key so will skip unnecessary re-rendering and data fetching.
It also fixes the logic for currentDb that directly transform from db instead of useState. (This resolves the issue for #21174)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

![fix--unnecessary-dabaseselector-rerendering](https://user-images.githubusercontent.com/1392866/185713445-a22e86e1-9382-4ecc-81a4-bdb692d016d1.gif)

After:

![Screen Shot 2022-08-19 at 2 50 12 PM](https://user-images.githubusercontent.com/1392866/185713454-b6a05d82-2162-4b6d-9fab-13d36a209401.png)

### TESTING INSTRUCTIONS
go to Sql Editor and check the network list

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @ktmud 