### PR TITLE
feat(explore-popover): Show disabled 'Save' button in explore popover

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
@@ -407,9 +407,7 @@ const ColumnSelectPopover = ({
         </Button>
         <Button
           disabled={stateIsValid && !hasUnsavedChanges}
-          buttonStyle={
-            hasUnsavedChanges && stateIsValid ? 'default' : 'primary'
-          }
+          buttonStyle="primary"
           buttonSize="small"
           onClick={onSave}
           data-test="ColumnEdit#save"

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
@@ -406,7 +406,7 @@ const ColumnSelectPopover = ({
           {t('Close')}
         </Button>
         <Button
-          disabled={stateIsValid && !hasUnsavedChanges}
+          disabled={!stateIsValid || !hasUnsavedChanges}
           buttonStyle="primary"
           buttonSize="small"
           onClick={onSave}

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
@@ -406,9 +406,9 @@ const ColumnSelectPopover = ({
           {t('Close')}
         </Button>
         <Button
-          disabled={!stateIsValid}
+          disabled={stateIsValid && !hasUnsavedChanges}
           buttonStyle={
-            hasUnsavedChanges && stateIsValid ? 'primary' : 'default'
+            hasUnsavedChanges && stateIsValid ? 'default' : 'primary'
           }
           buttonSize="small"
           onClick={onSave}

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/AdhocFilterEditPopover.test.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/AdhocFilterEditPopover.test.jsx
@@ -122,18 +122,17 @@ describe('AdhocFilterEditPopover', () => {
 
   it('prevents saving if the filter is invalid', () => {
     const { wrapper } = setup();
-    expect(wrapper.find(Button).find({ disabled: true })).not.toExist();
+    expect(wrapper.find(Button).find({ disabled: false })).not.toExist();
     wrapper
       .instance()
       .onAdhocFilterChange(simpleAdhocFilter.duplicateWith({ operator: null }));
-    expect(wrapper.find(Button).find({ disabled: true })).toExist();
+    expect(wrapper.find(Button).find({ disabled: false })).toExist();
     wrapper.instance().onAdhocFilterChange(sqlAdhocFilter);
     expect(wrapper.find(Button).find({ disabled: true })).not.toExist();
   });
 
   it('highlights save if changes are present', () => {
     const { wrapper } = setup();
-    expect(wrapper.find(Button).find({ buttonStyle: 'primary' })).not.toExist();
     wrapper.instance().onAdhocFilterChange(sqlAdhocFilter);
     expect(wrapper.find(Button).find({ buttonStyle: 'primary' })).toExist();
   });

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/AdhocFilterEditPopover.test.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/AdhocFilterEditPopover.test.jsx
@@ -126,7 +126,7 @@ describe('AdhocFilterEditPopover', () => {
     wrapper
       .instance()
       .onAdhocFilterChange(simpleAdhocFilter.duplicateWith({ operator: null }));
-    expect(wrapper.find(Button).find({ disabled: false })).toExist();
+    expect(wrapper.find(Button).find({ disabled: true })).toExist();
     wrapper.instance().onAdhocFilterChange(sqlAdhocFilter);
     expect(wrapper.find(Button).find({ disabled: true })).not.toExist();
   });

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/AdhocFilterEditPopover.test.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/AdhocFilterEditPopover.test.jsx
@@ -122,7 +122,7 @@ describe('AdhocFilterEditPopover', () => {
 
   it('prevents saving if the filter is invalid', () => {
     const { wrapper } = setup();
-    expect(wrapper.find(Button).find({ disabled: false })).not.toExist();
+    expect(wrapper.find(Button).find({ disabled: true })).toExist();
     wrapper
       .instance()
       .onAdhocFilterChange(simpleAdhocFilter.duplicateWith({ operator: null }));

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.jsx
@@ -245,10 +245,11 @@ export default class AdhocFilterEditPopover extends React.Component {
           </Button>
           <Button
             data-test="adhoc-filter-edit-popover-save-button"
-            disabled={!stateIsValid || !this.state.isSimpleTabValid}
-            buttonStyle={
-              hasUnsavedChanges && stateIsValid ? 'primary' : 'default'
+            disabled={
+              (stateIsValid || !this.state.isSimpleTabValid) &&
+              !hasUnsavedChanges
             }
+            buttonStyle="primary"
             buttonSize="small"
             className="m-r-5"
             onClick={this.onSave}

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.jsx
@@ -246,7 +246,8 @@ export default class AdhocFilterEditPopover extends React.Component {
           <Button
             data-test="adhoc-filter-edit-popover-save-button"
             disabled={
-              (stateIsValid || !this.state.isSimpleTabValid) &&
+              !stateIsValid ||
+              !this.state.isSimpleTabValid ||
               !hasUnsavedChanges
             }
             buttonStyle="primary"

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/AdhocMetricEditPopover.test.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/AdhocMetricEditPopover.test.jsx
@@ -100,17 +100,18 @@ describe('AdhocMetricEditPopover', () => {
     const { wrapper } = setup();
     expect(wrapper.find(Button).find({ disabled: false })).not.toExist();
     wrapper.instance().onColumnChange(null);
-    expect(wrapper.find(Button).find({ disabled: true })).not.toExist();
+    expect(wrapper.find(Button).find({ disabled: true })).toExist();
     wrapper.instance().onColumnChange(columns[0].column_name);
     expect(wrapper.find(Button).find({ disabled: true })).not.toExist();
     wrapper.instance().onAggregateChange(null);
-    expect(wrapper.find(Button).find({ disabled: true })).not.toExist();
+    expect(wrapper.find(Button).find({ disabled: true })).toExist();
   });
 
   it('highlights save if changes are present', () => {
     const { wrapper } = setup();
+    expect(wrapper.find(Button).find({ disabled: true })).toExist();
     wrapper.instance().onColumnChange(columns[1].column_name);
-    expect(wrapper.find(Button).find({ buttonStyle: 'primary' })).toExist();
+    expect(wrapper.find(Button).find({ disabled: true })).not.toExist();
   });
 
   it('will initiate a drag when clicked', () => {

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/AdhocMetricEditPopover.test.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/AdhocMetricEditPopover.test.jsx
@@ -98,18 +98,17 @@ describe('AdhocMetricEditPopover', () => {
 
   it('prevents saving if no column or aggregate is chosen', () => {
     const { wrapper } = setup();
-    expect(wrapper.find(Button).find({ disabled: true })).not.toExist();
+    expect(wrapper.find(Button).find({ disabled: false })).not.toExist();
     wrapper.instance().onColumnChange(null);
-    expect(wrapper.find(Button).find({ disabled: true })).toExist();
+    expect(wrapper.find(Button).find({ disabled: true })).not.toExist();
     wrapper.instance().onColumnChange(columns[0].column_name);
     expect(wrapper.find(Button).find({ disabled: true })).not.toExist();
     wrapper.instance().onAggregateChange(null);
-    expect(wrapper.find(Button).find({ disabled: true })).toExist();
+    expect(wrapper.find(Button).find({ disabled: true })).not.toExist();
   });
 
   it('highlights save if changes are present', () => {
     const { wrapper } = setup();
-    expect(wrapper.find(Button).find({ buttonStyle: 'primary' })).not.toExist();
     wrapper.instance().onColumnChange(columns[1].column_name);
     expect(wrapper.find(Button).find({ buttonStyle: 'primary' })).toExist();
   });

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/AdhocMetricEditPopover.test.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/AdhocMetricEditPopover.test.tsx
@@ -118,26 +118,14 @@ test('Clicking on "Close" should call onClose', () => {
   expect(props.onClose).toBeCalledTimes(1);
 });
 
-test('Clicking on "Save" should call onChange and onClose', () => {
+test('Clicking on "Save" should not call onChange and onClose', () => {
   const props = createProps();
   render(<AdhocMetricEditPopover {...props} />);
   expect(props.onChange).toBeCalledTimes(0);
   expect(props.onClose).toBeCalledTimes(0);
   userEvent.click(screen.getByRole('button', { name: 'Save' }));
-  expect(props.onChange).toBeCalledTimes(1);
-  expect(props.onChange).toBeCalledWith(
-    {
-      id: 64,
-      metric_name: 'count',
-      expression: 'COUNT(*)',
-    },
-    {
-      id: 64,
-      metric_name: 'count',
-      expression: 'COUNT(*)',
-    },
-  );
-  expect(props.onClose).toBeCalledTimes(1);
+  expect(props.onChange).toBeCalledTimes(0);
+  expect(props.onClose).toBeCalledTimes(0);
 });
 
 test('Should switch to tab:Simple', () => {

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/AdhocMetricEditPopover.test.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/AdhocMetricEditPopover.test.tsx
@@ -18,7 +18,7 @@
  */
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { render, screen } from 'spec/helpers/testing-library';
+import { render, screen, waitFor, within } from 'spec/helpers/testing-library';
 import AdhocMetric from 'src/explore/components/controls/MetricControl/AdhocMetric';
 import AdhocMetricEditPopover from '.';
 
@@ -35,9 +35,14 @@ const createProps = () => ({
   },
   savedMetricsOptions: [
     {
-      id: 65,
+      id: 64,
       metric_name: 'count',
       expression: 'COUNT(*)',
+    },
+    {
+      id: 65,
+      metric_name: 'sum',
+      expression: 'sum(num)',
     },
   ],
   adhocMetric: new AdhocMetric({ isNew: true }),
@@ -118,18 +123,20 @@ test('Clicking on "Close" should call onClose', () => {
   expect(props.onClose).toBeCalledTimes(1);
 });
 
-test('Clicking on "Save" should call onChange and onClose', () => {
-  const props = {
-    ...createProps(),
-    savedMetric: {},
-  };
+test('Clicking on "Save" should call onChange and onClose', async () => {
+  const props = createProps();
   render(<AdhocMetricEditPopover {...props} />);
   expect(props.onChange).toBeCalledTimes(0);
   expect(props.onClose).toBeCalledTimes(0);
-  const element = screen.getByRole('combobox', {
-    name: 'Select saved metrics',
-  });
-  expect(element).toBeVisible();
+  userEvent.click(
+    screen.getByRole('combobox', {
+      name: 'Select saved metrics',
+    }),
+  );
+  const sumOption = await waitFor(() =>
+    within(document.querySelector('.rc-virtual-list')!).getByText('sum'),
+  );
+  userEvent.click(sumOption);
   userEvent.click(screen.getByRole('button', { name: 'Save' }));
   expect(props.onChange).toBeCalledTimes(1);
   expect(props.onClose).toBeCalledTimes(1);

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/AdhocMetricEditPopover.test.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/AdhocMetricEditPopover.test.tsx
@@ -118,6 +118,23 @@ test('Clicking on "Close" should call onClose', () => {
   expect(props.onClose).toBeCalledTimes(1);
 });
 
+test('Clicking on "Save" should call onChange and onClose', () => {
+  const props = {
+    ...createProps(),
+    savedMetric: {},
+  };
+  render(<AdhocMetricEditPopover {...props} />);
+  expect(props.onChange).toBeCalledTimes(0);
+  expect(props.onClose).toBeCalledTimes(0);
+  const element = screen.getByRole('combobox', {
+    name: 'Select saved metrics',
+  });
+  expect(element).toBeVisible();
+  userEvent.click(screen.getByRole('button', { name: 'Save' }));
+  expect(props.onChange).toBeCalledTimes(1);
+  expect(props.onClose).toBeCalledTimes(1);
+});
+
 test('Clicking on "Save" should not call onChange and onClose', () => {
   const props = createProps();
   render(<AdhocMetricEditPopover {...props} />);

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
@@ -487,7 +487,7 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
             {t('Close')}
           </Button>
           <Button
-            disabled={stateIsValid && !hasUnsavedChanges}
+            disabled={!stateIsValid || !hasUnsavedChanges}
             buttonStyle="primary"
             buttonSize="small"
             data-test="AdhocMetricEdit#save"

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
@@ -487,10 +487,8 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
             {t('Close')}
           </Button>
           <Button
-            disabled={!stateIsValid}
-            buttonStyle={
-              hasUnsavedChanges && stateIsValid ? 'primary' : 'default'
-            }
+            disabled={stateIsValid && !hasUnsavedChanges}
+            buttonStyle="primary"
             buttonSize="small"
             data-test="AdhocMetricEdit#save"
             onClick={this.onSave}


### PR DESCRIPTION
### SUMMARY
In the popover that we show in control panel, if there are no changes made we turn it into secondary button and user is still able to "save" the popover.

If there are no changes made in the popover use primary button in state "disabled"

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before:**
<img width="651" alt="Clipboard 2022-28-07 at 4 18 57 PM" src="https://user-images.githubusercontent.com/1985940/188252689-fb7781ff-1f47-4c3f-a52e-788264a46bdf.png">

**After:**
![image](https://user-images.githubusercontent.com/1985940/188252665-d2f23e67-7677-4bb5-916f-d6a1df9fef19.png)

![image](https://user-images.githubusercontent.com/1985940/192386727-7fd5fc4b-fc3d-4f82-a901-27a6b3ef2173.png)


### TESTING INSTRUCTIONS
- Click on 'Charts' in the top menu bar
- Select on option which shows a Popover

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
