### PR TITLE
fix(dashboard): padding between rows within tabs

### DIFF
--- a/superset-frontend/src/dashboard/stylesheets/components/row.less
+++ b/superset-frontend/src/dashboard/stylesheets/components/row.less
@@ -66,6 +66,11 @@
   }
 }
 
+/* gutters between rows within tab */
+.dashboard-component-tabs-content > div:not(:only-child):not(:last-child):not(.empty-droptarget) {
+  margin-bottom: 16px;
+}
+
 .grid-row.grid-row--empty {
   /* this centers the empty note content */
   align-items: center;

--- a/superset-frontend/src/dashboard/stylesheets/components/row.less
+++ b/superset-frontend/src/dashboard/stylesheets/components/row.less
@@ -67,7 +67,8 @@
 }
 
 /* gutters between rows within tab */
-.dashboard-component-tabs-content > div:not(:only-child):not(:last-child):not(.empty-droptarget) {
+.dashboard-component-tabs-content
+  > div:not(:only-child):not(:last-child):not(.empty-droptarget) {
   margin-bottom: 16px;
 }
 


### PR DESCRIPTION
*Note:* It's the same PR as #20366. However, there were some issues with formatting and the pipelines (mainly because of lacking understanding on my side). So for this few-lines change, I guess it is easier I open a new PR and close the old one, rather than trying to fix the messed up old one...

## SUMMARY

There should be padding between rows in a dashboard. Before, this did not work when the rows where within tabs. This is fixed here.
See this issue: #20303

## BEFORE SCREENSHOT

<img width="1052" alt="173444283-a448a1d8-4217-44ef-998a-64bab1ee42b5" src="https://user-images.githubusercontent.com/16560193/188325508-ac895e15-274a-4656-9435-ec97d6d45457.png">

## AFTER SCREENSHOT

<img width="1052" alt="173444094-e4447879-64d1-494f-bcf3-6ee67ca5ce9a" src="https://user-images.githubusercontent.com/16560193/188325522-752601e9-ed14-484f-82c8-a41ede07c067.png">


## TESTING INSTRUCTIONS

* Insert two charts into a new dashboard
* Add a filter. When hovering over a filter, the selection box shows some space between the plots
* When you move the charts into tabs, there is no space between plots any more (see first screenshot) 
* AFTER APPLYING CHANGES FROM PR:
* Now there is also some space when the charts are within tabs (see second screenshot).



