### PR TITLE
chore(connector): Expose table_id as a listable column for various table model views

### DIFF
--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -394,7 +394,13 @@ class TableModelView(  # pylint: disable=too-many-ancestors
     add_title = _("Import a table definition")
     edit_title = _("Edit Table")
 
-    list_columns = ["link", "database_name", "changed_by_", "modified"]
+    list_columns = [
+        "changed_by_",
+        "database_id",
+        "database_name",
+        "link",
+        "modified",
+    ]
     order_columns = ["modified"]
     add_columns = ["database", "schema", "table_name"]
     edit_columns = [

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -93,14 +93,15 @@ class TableColumnInlineView(  # pylint: disable=too-many-ancestors
     ]
     add_columns = edit_columns
     list_columns = [
-        "column_name",
-        "verbose_name",
-        "type",
         "advanced_data_type",
-        "groupby",
-        "filterable",
-        "is_dttm",
+        "column_name",
         "extra",
+        "filterable",
+        "groupby",
+        "is_dttm",
+        "table_id",
+        "type",
+        "verbose_name",
     ]
     page_size = 500
     description_columns = {
@@ -210,7 +211,13 @@ class SqlMetricInlineView(  # pylint: disable=too-many-ancestors
     add_title = _("Add Metric")
     edit_title = _("Edit Metric")
 
-    list_columns = ["metric_name", "verbose_name", "metric_type", "extra"]
+    list_columns = [
+        "extra",
+        "metric_name",
+        "metric_type",
+        "table_id",
+        "verbose_name",
+    ]
     edit_columns = [
         "metric_name",
         "description",

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -394,13 +394,7 @@ class TableModelView(  # pylint: disable=too-many-ancestors
     add_title = _("Import a table definition")
     edit_title = _("Edit Table")
 
-    list_columns = [
-        "changed_by_",
-        "database_id",
-        "database_name",
-        "link",
-        "modified",
-    ]
+    list_columns = ["link", "database_name", "changed_by_", "modified"]
     order_columns = ["modified"]
     add_columns = ["database", "schema", "table_name"]
     edit_columns = [


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

As noted in [this](https://apache-superset.slack.com/archives/G013HAE6Y0K/p1662183800347719) Slack thread Airbnb ran into an issue where a regression in the FAB API resulted in us deleting almost all our metrics in the metadata database rather than those associated with the table we believed we were filtering by.

This PR doesn't remedy said issue, however it exposes the `table_id` column as a listable column for the SqlMetricInlineView and TableColumnInlineView classes so we can validate that the response payload is correct, i.e., if we have a query like `/tablecolumninlineview/api/read?_flt_0_table_id=1` we can then assert that all the `table_id`s match the specified filter.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Tested the two API read endpoints locally and confirmed the `table_id` column was included.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
