### PR TITLE
feat(plugin-chart-echarts): able to sort bar on the bar chart V2

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/sortOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/sortOperator.ts
@@ -17,24 +17,30 @@
  * specific language governing permissions and limitationsxw
  * under the License.
  */
-import { DTTM_ALIAS, PostProcessingSort, RollingType } from '@superset-ui/core';
+import {
+  ensureIsArray,
+  getColumnLabel,
+  getMetricLabel,
+  PostProcessingSort,
+} from '@superset-ui/core';
 import { PostProcessingFactory } from './types';
 
 export const sortOperator: PostProcessingFactory<PostProcessingSort> = (
   formData,
   queryObject,
 ) => {
-  const { x_axis: xAxis } = formData;
-  if (
-    (xAxis || queryObject.is_timeseries) &&
-    Object.values(RollingType).includes(formData.rolling_type)
-  ) {
-    const index = xAxis || DTTM_ALIAS;
+  const { columns, metrics, timeseries_limit_metric, order_desc } = queryObject;
+  const metricLabels = ensureIsArray(metrics).map(getMetricLabel);
+  const columnLabels = ensureIsArray(columns).map(getColumnLabel);
+  const column: string[] = ensureIsArray(timeseries_limit_metric).map(
+    getMetricLabel,
+  );
+  if (metricLabels.includes(column[0]) || columnLabels.includes(column[0])) {
     return {
       operation: 'sort',
       options: {
         columns: {
-          [index]: true,
+          [column[0]]: !order_desc,
         },
       },
     };

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/sortOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/sortOperator.test.ts
@@ -34,6 +34,7 @@ const queryObject: QueryObject = {
     'count(*)',
     { label: 'sum(val)', expressionType: 'SQL', sqlExpression: 'sum(val)' },
   ],
+  columns: ['state'],
   time_range: '2015 : 2016',
   granularity: 'month',
   post_processing: [
@@ -55,88 +56,89 @@ const queryObject: QueryObject = {
 test('skip sort', () => {
   expect(sortOperator(formData, queryObject)).toEqual(undefined);
   expect(
-    sortOperator(formData, { ...queryObject, is_timeseries: false }),
-  ).toEqual(undefined);
-  expect(
-    sortOperator(
-      { ...formData, rolling_type: 'xxxx' },
-      { ...queryObject, is_timeseries: true },
-    ),
-  ).toEqual(undefined);
-  expect(
-    sortOperator(formData, { ...queryObject, is_timeseries: true }),
+    sortOperator(formData, { ...queryObject, timeseries_limit_metric: 'bar' }),
   ).toEqual(undefined);
 });
 
-test('sort by __timestamp', () => {
+test('sort by metric', () => {
   expect(
-    sortOperator(
-      { ...formData, rolling_type: 'cumsum' },
-      { ...queryObject, is_timeseries: true },
-    ),
+    sortOperator(formData, {
+      ...queryObject,
+      timeseries_limit_metric: 'count(*)',
+    }),
   ).toEqual({
     operation: 'sort',
     options: {
       columns: {
-        __timestamp: true,
+        'count(*)': true,
       },
     },
   });
 
   expect(
-    sortOperator(
-      { ...formData, rolling_type: 'sum' },
-      { ...queryObject, is_timeseries: true },
-    ),
+    sortOperator(formData, {
+      ...queryObject,
+      timeseries_limit_metric: 'count(*)',
+      order_desc: true,
+    }),
   ).toEqual({
     operation: 'sort',
     options: {
       columns: {
-        __timestamp: true,
+        'count(*)': false,
       },
     },
   });
 
   expect(
-    sortOperator(
-      { ...formData, rolling_type: 'mean' },
-      { ...queryObject, is_timeseries: true },
-    ),
+    sortOperator(formData, {
+      ...queryObject,
+      timeseries_limit_metric: {
+        label: 'sum(val)',
+        expressionType: 'SQL',
+        sqlExpression: 'sum(val)',
+      },
+    }),
   ).toEqual({
     operation: 'sort',
     options: {
       columns: {
-        __timestamp: true,
+        'sum(val)': true,
       },
     },
   });
 
   expect(
-    sortOperator(
-      { ...formData, rolling_type: 'std' },
-      { ...queryObject, is_timeseries: true },
-    ),
+    sortOperator(formData, {
+      ...queryObject,
+      timeseries_limit_metric: {
+        label: 'sum(val)',
+        expressionType: 'SQL',
+        sqlExpression: 'sum(val)',
+      },
+      order_desc: false,
+    }),
   ).toEqual({
     operation: 'sort',
     options: {
       columns: {
-        __timestamp: true,
+        'sum(val)': true,
       },
     },
   });
 });
 
-test('sort by named x-axis', () => {
+test('sort by column', () => {
   expect(
-    sortOperator(
-      { ...formData, x_axis: 'ds', rolling_type: 'cumsum' },
-      { ...queryObject },
-    ),
+    sortOperator(formData, {
+      ...queryObject,
+      timeseries_limit_metric: 'state',
+    }),
   ).toEqual({
     operation: 'sort',
     options: {
       columns: {
-        ds: true,
+        state: true,
       },
     },
   });

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/buildQuery.ts
@@ -35,6 +35,7 @@ import {
   prophetOperator,
   timeComparePivotOperator,
   flattenOperator,
+  sortOperator,
 } from '@superset-ui/chart-controls';
 
 export default function buildQuery(formData: QueryFormData) {
@@ -97,6 +98,7 @@ export default function buildQuery(formData: QueryFormData) {
             is_timeseries,
           }),
           contributionOperator(formData, baseQueryObject),
+          sortOperator(formData, baseQueryObject),
           flattenOperator(formData, baseQueryObject),
           // todo: move prophet before flatten
           prophetOperator(formData, baseQueryObject),


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR supports sorting bar on the bar chart V2. The key point is using the label in metrcs or columns to sort. If orderBy can't find these lists, just don't use the sort operator, it's a limitation.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### after

https://user-images.githubusercontent.com/11830681/188881948-d9d211df-caff-40cc-8fce-72a22f444cf8.mov



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
