### PR TITLE
fix: Dataset duplication fatal error

### DIFF
--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
@@ -702,7 +702,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
 
     SupersetClient.post({
       endpoint: `/api/v1/dataset/duplicate`,
-      postPayload: {
+      jsonPayload: {
         base_model_id: datasetCurrentlyDuplicating?.id,
         table_name: newDatasetName,
       },


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Minor fix for dataset duplication.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://user-images.githubusercontent.com/10563996/188932658-a8f57410-79a0-4a8a-a93c-6e5be0e19712.png)

![image](https://user-images.githubusercontent.com/10563996/188932691-7117da11-b686-4972-9b6a-8b7e3190fe25.png)

### TESTING INSTRUCTIONS
Try duplicating a dataset. It should work now.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #21281 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
