### PR TITLE
fix(explore): disable resize bar when the results area is collapsed

### DIFF
--- a/superset-frontend/src/explore/components/ExploreChartPanel.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.jsx
@@ -98,6 +98,7 @@ const Styles = styled.div`
   }
 
   .gutter.gutter-vertical {
+    display: ${({ showSplite }) => (showSplite ? 'block' : 'none')};
     cursor: row-resize;
   }
 
@@ -148,6 +149,9 @@ const ExploreChartPanel = ({
   });
   const [splitSizes, setSplitSizes] = useState(
     getItem(LocalStorageKeys.chart_split_sizes, INITIAL_SIZES),
+  );
+  const [showSplite, setShowSplit] = useState(
+    getItem(LocalStorageKeys.is_datapanel_open, false),
   );
 
   const [showDatasetModal, setShowDatasetModal] = useState(false);
@@ -225,6 +229,7 @@ const ExploreChartPanel = ({
       ];
     }
     setSplitSizes(splitSizes);
+    setShowSplit(isOpen);
   }, []);
 
   const renderChart = useCallback(
@@ -411,7 +416,10 @@ const ExploreChartPanel = ({
   }
 
   return (
-    <Styles className="panel panel-default chart-container">
+    <Styles
+      className="panel panel-default chart-container"
+      showSplite={showSplite}
+    >
       {vizType === 'filter_box' ? (
         panelBody
       ) : (

--- a/superset-frontend/src/explore/components/ExploreChartPanel.test.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.test.jsx
@@ -147,14 +147,15 @@ describe('ChartContainer', () => {
     expect(screen.queryByText('Cached')).not.toBeInTheDocument();
   });
 
-  it('hide gutter when collapse panel', async () => {
+  it('hides gutter when collapsing data panel', async () => {
     const props = createProps();
     setItem(LocalStorageKeys.is_datapanel_open, true);
     const { container } = render(<ChartContainer {...props} />, {
       useRedux: true,
     });
-    userEvent.click(screen.getByLabelText('Collapse data panel'));
     const gutter = container.querySelector('.gutter');
+    expect(window.getComputedStyle(gutter).display).toBe('block');
+    userEvent.click(screen.getByLabelText('Collapse data panel'));
     expect(window.getComputedStyle(gutter).display).toBe('none');
   });
 });

--- a/superset-frontend/src/explore/components/ExploreChartPanel.test.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel.test.jsx
@@ -21,6 +21,7 @@ import userEvent from '@testing-library/user-event';
 import { render, screen } from 'spec/helpers/testing-library';
 import { getChartMetadataRegistry, ChartMetadata } from '@superset-ui/core';
 import ChartContainer from 'src/explore/components/ExploreChartPanel';
+import { setItem, LocalStorageKeys } from 'src/utils/localStorageHelpers';
 
 const createProps = (overrides = {}) => ({
   sliceName: 'Trend Line',
@@ -144,5 +145,16 @@ describe('ChartContainer', () => {
     });
     render(<ChartContainer {...props} />, { useRedux: true });
     expect(screen.queryByText('Cached')).not.toBeInTheDocument();
+  });
+
+  it('hide gutter when collapse panel', async () => {
+    const props = createProps();
+    setItem(LocalStorageKeys.is_datapanel_open, true);
+    const { container } = render(<ChartContainer {...props} />, {
+      useRedux: true,
+    });
+    userEvent.click(screen.getByLabelText('Collapse data panel'));
+    const gutter = container.querySelector('.gutter');
+    expect(window.getComputedStyle(gutter).display).toBe('none');
   });
 });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
If the data section (results/samples) is collapsed, user can still drag the icon/object between chart and data section header to resize the chart. This behavior is confusing as in this case the data section remains collapsed and empty.

So we remove drag indicator/feature if the data section is collapsed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### before

https://user-images.githubusercontent.com/11830681/189017103-24c2c272-2fba-42dd-8b56-0fd87108395c.mov


#### after
https://user-images.githubusercontent.com/11830681/189016760-60e1de08-8d63-408a-9c8f-2903137a7366.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
