### PR TITLE
chore(database): raised version of sqlalchemy-kusto

### DIFF
--- a/docs/docs/databases/kusto.mdx
+++ b/docs/docs/databases/kusto.mdx
@@ -1,0 +1,26 @@
+---
+name: Kusto
+hide_title: true
+sidebar_position: 41
+version: 2
+---
+
+## Kusto
+
+The recommended connector library for Kusto is
+[sqlalchemy-kusto](https://pypi.org/project/sqlalchemy-kusto/2.0.0/)>=2.0.0.
+
+The connection string for Kusto (sql dialect) looks like this:
+
+```
+kustosql+https://{cluster_url}/{database}?azure_ad_client_id={azure_ad_client_id}&azure_ad_client_secret={azure_ad_client_secret}&azure_ad_tenant_id={azure_ad_tenant_id}&msi=False
+```
+
+The connection string for Kusto (kql dialect) looks like this:
+
+```
+kustokql+https://{cluster_url}/{database}?azure_ad_client_id={azure_ad_client_id}&azure_ad_client_secret={azure_ad_client_secret}&azure_ad_tenant_id={azure_ad_tenant_id}&msi=False
+```
+
+Make sure the user has privileges to access and use all required
+databases/tables/views.

--- a/setup.py
+++ b/setup.py
@@ -153,7 +153,7 @@ setup(
         "hana": ["hdbcli==2.4.162", "sqlalchemy_hana==0.4.0"],
         "hive": ["pyhive[hive]>=0.6.5", "tableschema", "thrift>=0.14.1, <1.0.0"],
         "impala": ["impyla>0.16.2, <0.17"],
-        "kusto": ["sqlalchemy-kusto>=1.0.1, <2"],
+        "kusto": ["sqlalchemy-kusto>=2.0.0, <3"],
         "kylin": ["kylinpy>=2.8.1, <2.9"],
         "mssql": ["pymssql>=2.1.4, <2.2"],
         "mysql": ["mysqlclient>=2.1.0, <3"],


### PR DESCRIPTION
* Raised version of sqlalchemy-kusto to 2.0.0.
* Added information about kusto connection in docs/databases.

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Since `sqlalchemy` version was raised to >=1.4 we need to use `sqlalchemy-kusto>=2.0.0` which is [compatible](https://github.com/dodopizza/sqlalchemy-kusto/pull/11) with `sqlalchemy>=1.4`.

