### PR TITLE
fix: should be able to remove selection from X-AXIS control

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -221,6 +221,7 @@ export interface BaseControlConfig<
         chartState?: AnyDict,
       ) => ReactNode);
   default?: V;
+  initialValue?: V;
   renderTrigger?: boolean;
   validators?: ControlValueValidator<T, O, V>[];
   warning?: ReactNode;

--- a/superset-frontend/src/explore/controlUtils/getControlState.ts
+++ b/superset-frontend/src/explore/controlUtils/getControlState.ts
@@ -98,6 +98,21 @@ export function applyMapStateToPropsToControl<T = ControlType>(
     // `mapStateToProps` may also provide a value
     value = value || state.value;
   }
+
+  // InitialValue is used for setting value for the control,
+  // this value is not recalculated. The default value will override it.
+  if (typeof state.initialValue === 'function') {
+    state.initialValue = state.initialValue(state, controlPanelState);
+    // if default is still a function, discard
+    if (typeof state.initialValue === 'function') {
+      delete state.initialValue;
+    }
+  }
+  if (state.initialValue) {
+    value = state.initialValue;
+    delete state.initialValue;
+  }
+
   // If default is a function, evaluate it
   if (typeof state.default === 'function') {
     state.default = state.default(state, controlPanelState);


### PR DESCRIPTION
### SUMMARY
Should be able to remove a column from X-AXIS control, since the x-axis control has supported categorical or date columns.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

#### Before




https://user-images.githubusercontent.com/2016594/189348262-ecfbbb2c-3754-443e-bf0b-6245c8a04885.mov





#### After

https://user-images.githubusercontent.com/2016594/189077236-43622649-7f32-452a-a692-25ea251392a1.mov



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
