### PR TITLE
fix(big number): time grain control is useless in BigNumber Viz

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/controlPanel.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/controlPanel.ts
@@ -28,7 +28,7 @@ import { headerFontSize, subheaderFontSize } from '../sharedControls';
 
 export default {
   controlPanelSections: [
-    sections.legacyTimeseriesTime,
+    sections.legacyRegularTime,
     {
       label: t('Query'),
       expanded: true,


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The Time Grain control is useless in BigNumber Viz(without trendline).



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
#### Before
![image](https://user-images.githubusercontent.com/2016594/189084719-41111086-c962-42c5-8c4d-3516f6e60fdf.png)


#### After
![image](https://user-images.githubusercontent.com/2016594/189083350-2afde26f-6e0d-4a19-afec-3dc83a76674e.png)



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
