### PR TITLE
fix: Time Offset in SQLite and refine logic in Date Type conversion

### DIFF
--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -255,9 +255,7 @@ class QueryContextProcessor:
                 *get_base_axis_labels(query_object.columns),
                 query_object.granularity,
             ]
-            if query_object.datasource
-            and (col := query_object.datasource.get_column(label))
-            and col.is_dttm
+            if datasource and (col := datasource.get_column(label)) and col.is_dttm
         )
         dttm_cols = [
             DateColumn(

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -241,9 +241,9 @@ class QueryContextProcessor:
 
     def normalize_df(self, df: pd.DataFrame, query_object: QueryObject) -> pd.DataFrame:
         def _get_timestamp_format(
-            ds: BaseDatasource, column: Optional[str]
+            source: BaseDatasource, column: Optional[str]
         ) -> Optional[str]:
-            column_obj = ds.get_column(column)
+            column_obj = source.get_column(column)
             if column_obj and (formatter := column_obj.python_date_format):
                 return str(formatter)
             return None

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -244,12 +244,13 @@ class QueryContextProcessor:
             source: BaseDatasource, column: Optional[str]
         ) -> Optional[str]:
             column_obj = source.get_column(column)
-            try:
-                if column_obj and (formatter := column_obj.python_date_format):
-                    return str(formatter)
-            except NotImplemented:  # type: ignore
-                # The `python_date_format` might raise NotImplemented
-                pass
+            if (
+                column_obj
+                and hasattr(column_obj, "python_date_format")
+                and (formatter := column_obj.python_date_format)
+            ):
+                return str(formatter)
+
             return None
 
         datasource = self._qc_datasource

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -52,7 +52,6 @@ from superset.utils.core import (
     DTTM_ALIAS,
     error_msg_from_exception,
     get_base_axis_label,
-    get_column_name,
     get_column_names_from_columns,
     get_column_names_from_metrics,
     get_metric_names,

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -240,12 +240,14 @@ class QueryContextProcessor:
         return result
 
     def normalize_df(self, df: pd.DataFrame, query_object: QueryObject) -> pd.DataFrame:
+        # todo: should support "python_date_format" and "get_column" in each datasouce
         def _get_timestamp_format(
             source: BaseDatasource, column: Optional[str]
         ) -> Optional[str]:
             column_obj = source.get_column(column)
             if (
                 column_obj
+                # only sqla column was supported
                 and hasattr(column_obj, "python_date_format")
                 and (formatter := column_obj.python_date_format)
             ):
@@ -260,7 +262,11 @@ class QueryContextProcessor:
                 *get_base_axis_labels(query_object.columns),
                 query_object.granularity,
             ]
-            if datasource and (col := datasource.get_column(label)) and col.is_dttm
+            if datasource
+            # Query datasource didn't supported `get_column`
+            and hasattr(datasource, "get_column")
+            and (col := datasource.get_column(label))
+            and col.is_dttm
         )
         dttm_cols = [
             DateColumn(

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -240,7 +240,7 @@ class QueryContextProcessor:
         return result
 
     def normalize_df(self, df: pd.DataFrame, query_object: QueryObject) -> pd.DataFrame:
-        # todo: should support "python_date_format" and "get_column" in each datasouce
+        # todo: should support "python_date_format" and "get_column" in each datasource
         def _get_timestamp_format(
             source: BaseDatasource, column: Optional[str]
         ) -> Optional[str]:
@@ -263,7 +263,7 @@ class QueryContextProcessor:
                 query_object.granularity,
             ]
             if datasource
-            # Query datasource didn't supported `get_column`
+            # Query datasource didn't support `get_column`
             and hasattr(datasource, "get_column")
             and (col := datasource.get_column(label))
             and col.is_dttm

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -244,8 +244,12 @@ class QueryContextProcessor:
             source: BaseDatasource, column: Optional[str]
         ) -> Optional[str]:
             column_obj = source.get_column(column)
-            if column_obj and (formatter := column_obj.python_date_format):
-                return str(formatter)
+            try:
+                if column_obj and (formatter := column_obj.python_date_format):
+                    return str(formatter)
+            except NotImplemented:  # type: ignore
+                # The `python_date_format` might raise NotImplemented
+                pass
             return None
 
         datasource = self._qc_datasource

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -16,6 +16,8 @@
 # under the License.
 """Utility functions used across Superset"""
 # pylint: disable=too-many-lines
+from __future__ import annotations
+
 import _thread
 import collections
 import decimal
@@ -34,6 +36,7 @@ import traceback
 import uuid
 import zlib
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta
 from distutils.util import strtobool
 from email.mime.application import MIMEApplication
@@ -1846,39 +1849,64 @@ def remove_duplicates(
     return result
 
 
+@dataclass
+class DateColumn:
+    col_label: str
+    timestamp_format: Optional[str] = None
+    offset: Optional[int] = None
+    time_shift: Optional[timedelta] = None
+
+    def __hash__(self) -> int:
+        return hash(self.col_label)
+
+    def __eq__(self, other: object) -> bool:
+        return hash(self) == hash(other)
+
+    @classmethod
+    def get_legacy_time_column(
+        cls,
+        timestamp_format: Optional[str],
+        offset: Optional[int],
+        time_shift: Optional[timedelta],
+    ) -> DateColumn:
+        return cls(
+            timestamp_format=timestamp_format,
+            offset=offset,
+            time_shift=time_shift,
+            col_label=DTTM_ALIAS,
+        )
+
+
 def normalize_dttm_col(
     df: pd.DataFrame,
-    timestamp_format: Optional[str],
-    offset: int,
-    time_shift: Optional[timedelta],
-    dttm_cols: Optional[Tuple[str, ...]] = None,
+    dttm_cols: Tuple[DateColumn, ...] = tuple(),
 ) -> None:
-    if not dttm_cols:
-        _dttm_cols = tuple([DTTM_ALIAS])
-    else:
-        _dttm_cols = dttm_cols
-    for _dttm_col in _dttm_cols:
-        if _dttm_col not in df.columns:
+    for _col in dttm_cols:
+        if _col.col_label not in df.columns:
             continue
-        if timestamp_format in ("epoch_s", "epoch_ms"):
-            dttm_col = df[_dttm_col]
-            if is_numeric_dtype(dttm_col):
+
+        if _col.timestamp_format in ("epoch_s", "epoch_ms"):
+            dttm_series = df[_col.col_label]
+            if is_numeric_dtype(dttm_series):
                 # Column is formatted as a numeric value
-                unit = timestamp_format.replace("epoch_", "")
-                df[_dttm_col] = pd.to_datetime(
-                    dttm_col, utc=False, unit=unit, origin="unix", errors="coerce"
+                unit = _col.timestamp_format.replace("epoch_", "")
+                df[_col.col_label] = pd.to_datetime(
+                    dttm_series, utc=False, unit=unit, origin="unix", errors="coerce"
                 )
             else:
                 # Column has already been formatted as a timestamp.
-                df[_dttm_col] = dttm_col.apply(pd.Timestamp)
+                df[_col.col_label] = dttm_series.apply(pd.Timestamp)
         else:
-            df[_dttm_col] = pd.to_datetime(
-                df[_dttm_col], utc=False, format=timestamp_format, errors="coerce"
+            df[_col.col_label] = pd.to_datetime(
+                df[_col.col_label],
+                utc=False,
+                format=_col.timestamp_format,
+                errors="coerce",
             )
-        if offset:
-            df[_dttm_col] += timedelta(hours=offset)
-        if time_shift is not None:
-            df[_dttm_col] += time_shift
+        if _col.offset:
+            df[_col.col_label] += timedelta(hours=_col.offset)
+        if _col.time_shift is not None:
+            df[_col.col_label] += _col.time_shift
 
 
 def parse_boolean_string(bool_str: Optional[str]) -> bool:

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1860,7 +1860,7 @@ class DateColumn:
         return hash(self.col_label)
 
     def __eq__(self, other: object) -> bool:
-        return hash(self) == hash(other)
+        return isinstance(other, DateColumn) and hash(self) == hash(other)
 
     @classmethod
     def get_legacy_time_column(

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1854,7 +1854,7 @@ def normalize_dttm_col(
     dttm_cols: Optional[Tuple[str, ...]] = None,
 ) -> None:
     if not dttm_cols:
-        _dttm_cols = tuple(DTTM_ALIAS)
+        _dttm_cols = tuple([DTTM_ALIAS])
     else:
         _dttm_cols = dttm_cols
     for _dttm_col in _dttm_cols:

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -80,6 +80,7 @@ from superset.utils import core as utils, csv
 from superset.utils.cache import set_and_log_cache
 from superset.utils.core import (
     apply_max_row_limit,
+    DateColumn,
     DTTM_ALIAS,
     ExtraFiltersReasonType,
     get_column_name,
@@ -301,9 +302,15 @@ class BaseViz:  # pylint: disable=too-many-public-methods
         if not df.empty:
             utils.normalize_dttm_col(
                 df=df,
-                timestamp_format=timestamp_format,
-                offset=self.datasource.offset,
-                time_shift=self.time_shift,
+                dttm_cols=tuple(
+                    [
+                        DateColumn.get_legacy_time_column(
+                            timestamp_format=timestamp_format,
+                            offset=self.datasource.offset,
+                            time_shift=self.time_shift,
+                        )
+                    ]
+                ),
             )
 
             if self.enforce_numerical_metrics:

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -407,3 +407,8 @@ only_sqlite = pytest.mark.skipif(
     "sqlite" not in os.environ.get("SUPERSET__SQLALCHEMY_DATABASE_URI", ""),
     reason="Only run test case in SQLite",
 )
+
+only_mysql = pytest.mark.skipif(
+    "mysql" not in os.environ.get("SUPERSET__SQLALCHEMY_DATABASE_URI", ""),
+    reason="Only run test case in MySQL",
+)

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -402,3 +402,8 @@ only_postgresql = pytest.mark.skipif(
     "postgresql" not in os.environ.get("SUPERSET__SQLALCHEMY_DATABASE_URI", ""),
     reason="Only run test case in Postgresql",
 )
+
+only_sqlite = pytest.mark.skipif(
+    "sqlite" not in os.environ.get("SUPERSET__SQLALCHEMY_DATABASE_URI", ""),
+    reason="Only run test case in SQLite",
+)

--- a/tests/integration_tests/query_context_tests.py
+++ b/tests/integration_tests/query_context_tests.py
@@ -914,7 +914,6 @@ def test_non_date_adhoc_column(app_context, physical_dataset):
     assert df["ADHOC COLUMN"][1] == 10
 
 
-@only_postgresql
 @only_sqlite
 def test_time_grain_and_time_offset_with_base_axis(app_context, physical_dataset):
     column_on_axis: AdhocColumn = {

--- a/tests/integration_tests/query_context_tests.py
+++ b/tests/integration_tests/query_context_tests.py
@@ -18,6 +18,8 @@ import re
 import time
 from typing import Any, Dict
 
+import numpy as np
+import pandas as pd
 import pytest
 from pandas import DateOffset
 
@@ -910,3 +912,55 @@ def test_non_date_adhoc_column(app_context, physical_dataset):
     df = qc.get_df_payload(query_object)["df"]
     assert df["ADHOC COLUMN"][0] == 0
     assert df["ADHOC COLUMN"][1] == 10
+
+
+def test_time_grain_and_time_offset_with_base_axis(app_context, physical_dataset):
+    column_on_axis: AdhocColumn = {
+        "label": "col6",
+        "sqlExpression": "col6",
+        "columnType": "BASE_AXIS",
+        "timeGrain": "P3M",
+    }
+    qc = QueryContextFactory().create(
+        datasource={
+            "type": physical_dataset.type,
+            "id": physical_dataset.id,
+        },
+        queries=[
+            {
+                "columns": [column_on_axis],
+                "metrics": [
+                    {
+                        "label": "SUM(col1)",
+                        "expressionType": "SQL",
+                        "sqlExpression": "SUM(col1)",
+                    }
+                ],
+                "time_offsets": ["3 month ago"],
+                "granularity": "col6",
+                "time_range": "2002-01 : 2003-01",
+            }
+        ],
+        result_type=ChartDataResultType.FULL,
+        force=True,
+    )
+    query_object = qc.queries[0]
+    df = qc.get_df_payload(query_object)["df"]
+    """
+        col6  SUM(col1)  SUM(col1)__3 month ago
+0 2002-01-01          3                     NaN
+1 2002-04-01         12                     3.0
+2 2002-07-01         21                    12.0
+3 2002-10-01          9                    21.0
+    """
+    assert df.equals(
+        pd.DataFrame(
+            data={
+                "col6": pd.to_datetime(
+                    ["2002-01-01", "2002-04-01", "2002-07-01", "2002-10-01"]
+                ),
+                "SUM(col1)": [3, 12, 21, 9],
+                "SUM(col1)__3 month ago": [np.nan, 3, 12, 21],
+            }
+        )
+    )

--- a/tests/integration_tests/query_context_tests.py
+++ b/tests/integration_tests/query_context_tests.py
@@ -41,7 +41,7 @@ from superset.utils.core import (
 )
 from superset.utils.pandas_postprocessing.utils import FLAT_COLUMN_SEPARATOR
 from tests.integration_tests.base_tests import SupersetTestCase
-from tests.integration_tests.conftest import only_postgresql
+from tests.integration_tests.conftest import only_postgresql, only_sqlite
 from tests.integration_tests.fixtures.birth_names_dashboard import (
     load_birth_names_dashboard_with_slices,
     load_birth_names_data,
@@ -914,6 +914,8 @@ def test_non_date_adhoc_column(app_context, physical_dataset):
     assert df["ADHOC COLUMN"][1] == 10
 
 
+@only_postgresql
+@only_sqlite
 def test_time_grain_and_time_offset_with_base_axis(app_context, physical_dataset):
     column_on_axis: AdhocColumn = {
         "label": "col6",
@@ -946,6 +948,7 @@ def test_time_grain_and_time_offset_with_base_axis(app_context, physical_dataset
     )
     query_object = qc.queries[0]
     df = qc.get_df_payload(query_object)["df"]
+    # todo: MySQL returns integer and float column as object type
     """
         col6  SUM(col1)  SUM(col1)__3 month ago
 0 2002-01-01          3                     NaN

--- a/tests/integration_tests/utils_tests.py
+++ b/tests/integration_tests/utils_tests.py
@@ -70,6 +70,7 @@ from superset.utils.core import (
     validate_json,
     zlib_compress,
     zlib_decompress,
+    DateColumn,
 )
 from superset.utils.database import get_or_create_db
 from superset.utils import schema
@@ -1062,7 +1063,18 @@ class TestUtils(SupersetTestCase):
             time_shift: Optional[timedelta],
         ) -> pd.DataFrame:
             df = df.copy()
-            normalize_dttm_col(df, timestamp_format, offset, time_shift)
+            normalize_dttm_col(
+                df,
+                tuple(
+                    [
+                        DateColumn.get_legacy_time_column(
+                            timestamp_format=timestamp_format,
+                            offset=offset,
+                            time_shift=time_shift,
+                        )
+                    ]
+                ),
+            )
             return df
 
         ts = pd.Timestamp(2021, 2, 15, 19, 0, 0, 0)


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, The Time Offset can't be used in SQLite as datasouce, it's because the Pandas + SQLAlchemy query from SQLite will return `datetime` column as `object` rather than `datetime`.


```Python
... from sqlalchemy import create_engine
... import pandas as pd

... sqlite_engine = create_engine("sqlite:////some-path/examples_sqlite.db")
... sql_sqlite = '''
SELECT * FROM main.birth_names_sqlite
limit 1
'''
... df = pd.read_sql(sql_sqlite, sqlite_engine)
... df.dtypes
...
ds        object
gender    object
name      object
num        int64
state     object
dtype: object
```


This PR uses the original `normalize_dttm_col` function but adds a new argument for it. the `normalize_dttm_col` will convert the old `__timestamp` column or the new `BASE_AXIS` to the Timestamp series in pandas.

In addition, added a new unit test for Time Grain and Time Offset in the QueryObject.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### After
FF Enabled
![image](https://user-images.githubusercontent.com/2016594/190138388-3b075bd4-d0fc-4817-acb3-f7019afeed19.png)

FF Disabled

![image](https://user-images.githubusercontent.com/2016594/190138639-2ea131f3-10ee-48fd-8faa-a482663bd1d7.png)


#### Before
FF Enabled
![image](https://user-images.githubusercontent.com/2016594/190139118-361d9824-f069-4db9-a32e-07b054fffabb.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
