### PR TITLE
ci(websocket): publish websocket docker image to dockerhub

### DIFF
--- a/.github/workflows/docker_build_push.sh
+++ b/.github/workflows/docker_build_push.sh
@@ -57,6 +57,19 @@ docker build --target lean \
   .
 
 #
+# Build the "websocket" image
+#
+docker build \
+  -t "${REPO_NAME}-websocket:${SHA}" \
+  -t "${REPO_NAME}-websocket:${REFSPEC}" \
+  -t "${REPO_NAME}-websocket:${LATEST_TAG}" \
+  --label "sha=${SHA}" \
+  --label "built_at=$(date)" \
+  --label "target=lean" \
+  --label "build_actor=${GITHUB_ACTOR}" \
+  superset-websocket
+
+#
 # Build the dev image
 #
 docker build --target dev \


### PR DESCRIPTION
### SUMMARY
Allow apache/superset-websocket image to dockerhub with the same tag as main image

### TESTING INSTRUCTIONS
Github Actions

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #21373
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
