### PR TITLE
fix(sqllab): Fix cursor alignment in SQL lab editor by avoiding Lucida Console font on Windows

### DIFF
--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -367,8 +367,8 @@ div.tablePopover {
   border: 1px solid @gray-light;
   font-feature-settings: @font-feature-settings;
   // Fira Code causes problem with Ace under Firefox
-  font-family: 'Menlo', 'Lucida Console', 'Courier New', 'Ubuntu Mono',
-    'Consolas', 'source-code-pro', monospace;
+  font-family: 'Menlo', 'Consolas', 'Courier New', 'Ubuntu Mono',
+    'source-code-pro', 'Lucida Console', monospace;
 
   &.ace_autocomplete {
     // Use !important because Ace Editor applies extra CSS at the last second


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Windows does not have a bold version of `Lucida Console` installed by default. [[1]](https://github.com/wez/wezterm/issues/2074#:~:text=Lucida%20Console%20is%20a%20preinstalled%20font%20in%20Windows.%20It%20does%20not%20have%20a%20built%20in%20bold%20version.%20Compare%20with%20Courier%20New%3A) [[2]](https://docs.microsoft.com/en-us/typography/fonts/windows_10_font_list#:~:text=5.05-,Lucida%20Console,-Lucida%20Console)
Instead, Windows creates a fake bold version of the font, which is slightly wider. [[3]](https://forums.allroundautomations.com/ubb/ubbthreads.php?ubb=showflat&Number=29702#:~:text=issue%20with%20in%20the%20font)

In the SQL lab editor this leads to the cursor alignment issues linked below.

`Consolas` and `Courier New` both come with bold monospaced version pre-installed on Windows [[2]](https://docs.microsoft.com/en-us/typography/fonts/windows_10_font_list#:~:text=5.05-,Lucida%20Console,-Lucida%20Console) and cause no issues with cursor alignment. That is why I am proposing to change the order of the fonts.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Available in any of the linked issues

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Requirement: Windows machine with standard fonts, meaning `Menlo` is not installed, `Lucida Console` is installed, but missing the bold version.

Then just type any SQL keyword the SQL lab editor, such as `SELECT * FROM table_name`.
The cursor is no longer aligned over the word table_name. 
This is fixed when the font order is changed via the browser's development tools

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
Fixes #9253
Fixes #15749
Fixes #19094
Fixes #19580
Fixes #20436
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
