### PR TITLE
test: Fix act errors in LeftPanel test

### DIFF
--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/LeftPanel.test.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/LeftPanel.test.tsx
@@ -21,7 +21,6 @@ import { SupersetClient } from '@superset-ui/core';
 import userEvent from '@testing-library/user-event';
 import { render, screen, waitFor } from 'spec/helpers/testing-library';
 import LeftPanel from 'src/views/CRUD/data/dataset/AddDataset/LeftPanel';
-import { act } from 'react-dom/test-utils';
 
 describe('LeftPanel', () => {
   const mockFun = jest.fn();
@@ -160,17 +159,21 @@ describe('LeftPanel', () => {
       },
     } as any);
 
-  it('should render', () => {
+  test('should render', async () => {
     const { container } = render(<LeftPanel setDataset={mockFun} />, {
       useRedux: true,
     });
+
+    expect(
+      await screen.findByText(/select database & schema/i),
+    ).toBeInTheDocument();
     expect(container).toBeInTheDocument();
   });
 
-  it('should render tableselector and databaselector container and selects', () => {
+  test('should render tableselector and databaselector container and selects', async () => {
     render(<LeftPanel setDataset={mockFun} />, { useRedux: true });
 
-    expect(screen.getByText(/select database & schema/i)).toBeVisible();
+    expect(await screen.findByText(/select database & schema/i)).toBeVisible();
 
     const databaseSelect = screen.getByRole('combobox', {
       name: 'Select database or type database name',
@@ -181,12 +184,18 @@ describe('LeftPanel', () => {
     expect(databaseSelect).toBeInTheDocument();
     expect(schemaSelect).toBeInTheDocument();
   });
-  it('does not render blank state if there is nothing selected', () => {
+
+  test('does not render blank state if there is nothing selected', async () => {
     render(<LeftPanel setDataset={mockFun} />, { useRedux: true });
+
+    expect(
+      await screen.findByText(/select database & schema/i),
+    ).toBeInTheDocument();
     const emptyState = screen.queryByRole('img', { name: /empty/i });
     expect(emptyState).not.toBeInTheDocument();
   });
-  it('renders list of options when user clicks on schema', async () => {
+
+  test('renders list of options when user clicks on schema', async () => {
     render(<LeftPanel setDataset={mockFun} schema="schema_a" dbId={1} />, {
       useRedux: true,
     });
@@ -197,9 +206,7 @@ describe('LeftPanel', () => {
     userEvent.click(databaseSelect);
     expect(await screen.findByText('test-postgres')).toBeInTheDocument();
 
-    act(() => {
-      userEvent.click(screen.getAllByText('test-postgres')[0]);
-    });
+    userEvent.click(screen.getAllByText('test-postgres')[0]);
     const tableSelect = screen.getByRole('combobox', {
       name: /select schema or type schema name/i,
     });
@@ -217,11 +224,9 @@ describe('LeftPanel', () => {
     ).toBeInTheDocument();
 
     SupersetClientGet.mockImplementation(getTableMockFunction);
-    act(() => {
-      userEvent.click(screen.getAllByText('public')[1]);
-    });
 
     // Todo: (Phillip) finish testing for showing list of options once table is implemented
+    // userEvent.click(screen.getAllByText('public')[1]);
     // expect(screen.getByTestId('options-list')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes 22 act errors in `superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/LeftPanel.test.tsx`

Note: I moved the last `userEvent.click` line into the "to do" comment since it's part of that to do's functionality and it was causing 10 act errors.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- cd into `superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel`
- run `npm run test superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/LeftPanel.test.tsx`
- Observe that there are no act errors in the console

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
