### PR TITLE
test: Fix act errors in SelectFilterPlugin test

### DIFF
--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
@@ -24,6 +24,8 @@ import { NULL_STRING } from 'src/utils/common';
 import SelectFilterPlugin from './SelectFilterPlugin';
 import transformProps from './transformProps';
 
+jest.useFakeTimers();
+
 const selectMultipleProps = {
   formData: {
     sortAscending: true,
@@ -86,7 +88,7 @@ describe('SelectFilterPlugin', () => {
     jest.clearAllMocks();
   });
 
-  it('Add multiple values with first render', () => {
+  test('Add multiple values with first render', async () => {
     getWrapper();
     expect(setDataMask).toHaveBeenCalledWith({
       extraFormData: {},
@@ -114,6 +116,7 @@ describe('SelectFilterPlugin', () => {
     });
     userEvent.click(screen.getByRole('combobox'));
     userEvent.click(screen.getByTitle('girl'));
+    expect(await screen.findByTitle(/girl/i)).toBeInTheDocument();
     expect(setDataMask).toHaveBeenCalledWith({
       __cache: {
         value: ['boy'],
@@ -134,9 +137,14 @@ describe('SelectFilterPlugin', () => {
     });
   });
 
-  it('Remove multiple values when required', () => {
+  test('Remove multiple values when required', () => {
     getWrapper();
-    userEvent.click(document.querySelector('[data-icon="close"]')!);
+    userEvent.click(
+      screen.getByRole('img', {
+        name: /close-circle/i,
+        hidden: true,
+      }),
+    );
     expect(setDataMask).toHaveBeenCalledWith({
       __cache: {
         value: ['boy'],
@@ -157,9 +165,14 @@ describe('SelectFilterPlugin', () => {
     });
   });
 
-  it('Remove multiple values when not required', () => {
+  test('Remove multiple values when not required', () => {
     getWrapper({ enableEmptyFilter: false });
-    userEvent.click(document.querySelector('[data-icon="close"]')!);
+    userEvent.click(
+      screen.getByRole('img', {
+        name: /close-circle/i,
+        hidden: true,
+      }),
+    );
     expect(setDataMask).toHaveBeenCalledWith({
       __cache: {
         value: ['boy'],
@@ -172,9 +185,10 @@ describe('SelectFilterPlugin', () => {
     });
   });
 
-  it('Select single values with inverse', () => {
+  test('Select single values with inverse', async () => {
     getWrapper({ multiSelect: false, inverseSelection: true });
     userEvent.click(screen.getByRole('combobox'));
+    expect(await screen.findByTitle('girl')).toBeInTheDocument();
     userEvent.click(screen.getByTitle('girl'));
     expect(setDataMask).toHaveBeenCalledWith({
       __cache: {
@@ -196,9 +210,10 @@ describe('SelectFilterPlugin', () => {
     });
   });
 
-  it('Select single null (empty) value', () => {
+  test('Select single null (empty) value', async () => {
     getWrapper();
     userEvent.click(screen.getByRole('combobox'));
+    expect(await screen.findByRole('combobox')).toBeInTheDocument();
     userEvent.click(screen.getByTitle(NULL_STRING));
     expect(setDataMask).toHaveBeenLastCalledWith({
       __cache: {
@@ -220,9 +235,10 @@ describe('SelectFilterPlugin', () => {
     });
   });
 
-  it('Add ownState with column types when search all options', () => {
+  test('Add ownState with column types when search all options', async () => {
     getWrapper({ searchAllOptions: true, multiSelect: false });
     userEvent.click(screen.getByRole('combobox'));
+    expect(await screen.findByRole('combobox')).toBeInTheDocument();
     userEvent.click(screen.getByTitle('girl'));
     expect(setDataMask).toHaveBeenCalledWith({
       __cache: {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes 4 act errors in `superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx`

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- cd into `superset-frontend/src/filters/components/Select`
- run `npm run test superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx`
- Observe that there are no act errors in the console

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
