### PR TITLE
fix(ui): Quick Fix for app_icon

### DIFF
--- a/superset/templates/superset/basic.html
+++ b/superset/templates/superset/basic.html
@@ -40,7 +40,7 @@
           rel="{{favicon.rel if favicon.rel else "icon"}}"
           type="{{favicon.type if favicon.type else "image/png"}}"
           {% if favicon.sizes %}sizes={{favicon.sizes}}{% endif %}
-          href="{{ assets_prefix }}{{favicon.href}}"
+          href="{{ "" if favicon.href.startswith("http") else assets_prefix }}{{favicon.href}}"
         >
       {% endfor %}
       <link rel="stylesheet" type="text/css" href="{{ assets_prefix }}/static/appbuilder/css/flags/flags16.css" />


### PR DESCRIPTION
### SUMMARY
Quick fix for broken favicon when using a CDN to serve up images. If FAVICON is an absolute URL, we shouldn't add the `assets_prefix`