### PR TITLE
fix(db-migration): new_dataset_models_take_2 error on postgres

### DIFF
--- a/superset/migrations/versions/2022-04-01_14-38_a9422eeaae74_new_dataset_models_take_2.py
+++ b/superset/migrations/versions/2022-04-01_14-38_a9422eeaae74_new_dataset_models_take_2.py
@@ -636,30 +636,37 @@ def postprocess_columns(session: Session) -> None:
         return
 
     def get_joined_tables(offset, limit):
+
         # Import aliased from sqlalchemy
         from sqlalchemy.orm import aliased
+
         # Create alias of NewColumn
         new_column_alias = aliased(NewColumn)
         # Get subquery and give it the alias "sl_colums_2"
-        subquery = session.query(new_column_alias).offset(offset).limit(limit).subquery(
-            "sl_columns_2")
+        subquery = (
+            session.query(new_column_alias)
+            .offset(offset)
+            .limit(limit)
+            .subquery("sl_columns_2")
+        )
 
         return (
             sa.join(
                 subquery,
                 NewColumn,
                 # Use column id from subquery
-                subquery.c.id == NewColumn.id
-            )  .join(
+                subquery.c.id == NewColumn.id,
+            )
+            .join(
                 dataset_column_association_table,
                 # Use column id from subquery
                 dataset_column_association_table.c.column_id == subquery.c.id,
-                )
-                .join(
+            )
+            .join(
                 NewDataset,
                 NewDataset.id == dataset_column_association_table.c.dataset_id,
             )
-                .join(
+            .join(
                 dataset_table_association_table,
                 # Join tables with physical datasets
                 and_(
@@ -668,14 +675,14 @@ def postprocess_columns(session: Session) -> None:
                 ),
                 isouter=True,
             )
-                .join(Database, Database.id == NewDataset.database_id)
-                .join(
+            .join(Database, Database.id == NewDataset.database_id)
+            .join(
                 TableColumn,
                 # Use column uuid from subquery
                 TableColumn.uuid == subquery.c.uuid,
                 isouter=True,
             )
-                .join(
+            .join(
                 SqlMetric,
                 # Use column uuid from subquery
                 SqlMetric.uuid == subquery.c.uuid,

--- a/superset/migrations/versions/2022-04-01_14-38_a9422eeaae74_new_dataset_models_take_2.py
+++ b/superset/migrations/versions/2022-04-01_14-38_a9422eeaae74_new_dataset_models_take_2.py
@@ -636,20 +636,30 @@ def postprocess_columns(session: Session) -> None:
         return
 
     def get_joined_tables(offset, limit):
+        # Import aliased from sqlalchemy
+        from sqlalchemy.orm import aliased
+        # Create alias of NewColumn
+        new_column_alias = aliased(NewColumn)
+        # Get subquery and give it the alias "sl_colums_2"
+        subquery = session.query(new_column_alias).offset(offset).limit(limit).subquery(
+            "sl_columns_2")
+
         return (
             sa.join(
-                session.query(NewColumn)
-                .offset(offset)
-                .limit(limit)
-                .subquery("sl_columns"),
+                subquery,
+                NewColumn,
+                # Use column id from subquery
+                subquery.c.id == NewColumn.id
+            )  .join(
                 dataset_column_association_table,
-                dataset_column_association_table.c.column_id == NewColumn.id,
-            )
-            .join(
+                # Use column id from subquery
+                dataset_column_association_table.c.column_id == subquery.c.id,
+                )
+                .join(
                 NewDataset,
                 NewDataset.id == dataset_column_association_table.c.dataset_id,
             )
-            .join(
+                .join(
                 dataset_table_association_table,
                 # Join tables with physical datasets
                 and_(
@@ -658,15 +668,17 @@ def postprocess_columns(session: Session) -> None:
                 ),
                 isouter=True,
             )
-            .join(Database, Database.id == NewDataset.database_id)
-            .join(
+                .join(Database, Database.id == NewDataset.database_id)
+                .join(
                 TableColumn,
-                TableColumn.uuid == NewColumn.uuid,
+                # Use column uuid from subquery
+                TableColumn.uuid == subquery.c.uuid,
                 isouter=True,
             )
-            .join(
+                .join(
                 SqlMetric,
-                SqlMetric.uuid == NewColumn.uuid,
+                # Use column uuid from subquery
+                SqlMetric.uuid == subquery.c.uuid,
                 isouter=True,
             )
         )


### PR DESCRIPTION
Previous code is not working. It is showing an error because the subquery is making a reference to the same table sl_columns. This code makes explicit the alias and join the tables NewColumn with the subquery. https://github.com/apache/superset/issues/20790 

fix(superset db upgrade)
### SUMMARY
Previous code is not working. It is showing an error because the subquery is making a reference to the same table sl_columns. This code makes explicit the alias and join the tables NewColumn with the subquery.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
### TESTING INSTRUCTIONS
run docker, and exec superset update db using a database with data from superset 1.x.x
### ADDITIONAL INFORMATION
- [X] Has associated issue: closes #20790 , closes #21197
