### PR TITLE
fix(dashboard): JS error when editing charts

### DIFF
--- a/superset-frontend/src/explore/ExplorePage.tsx
+++ b/superset-frontend/src/explore/ExplorePage.tsx
@@ -61,11 +61,20 @@ const fetchExploreData = async (exploreUrlParams: URLSearchParams) => {
   }
 };
 
+const getDashboardPageContext = (pageId?: string | null) => {
+  if (!pageId) {
+    return null;
+  }
+  return (
+    getItem(LocalStorageKeys.dashboard__explore_context, {})[pageId] || null
+  );
+};
+
 const getDashboardContextFormData = () => {
   const dashboardPageId = getUrlParam(URL_PARAMS.dashboardPageId);
-  const sliceId = getUrlParam(URL_PARAMS.sliceId) || 0;
-  let dashboardContextWithFilters = {};
-  if (dashboardPageId) {
+  const dashboardContext = getDashboardPageContext(dashboardPageId);
+  if (dashboardContext) {
+    const sliceId = getUrlParam(URL_PARAMS.sliceId) || 0;
     const {
       labelColors,
       sharedLabelColors,
@@ -75,11 +84,8 @@ const getDashboardContextFormData = () => {
       filterBoxFilters,
       dataMask,
       dashboardId,
-    } =
-      getItem(LocalStorageKeys.dashboard__explore_context, {})[
-        dashboardPageId
-      ] || {};
-    dashboardContextWithFilters = getFormDataWithExtraFilters({
+    } = dashboardContext;
+    const dashboardContextWithFilters = getFormDataWithExtraFilters({
       chart: { id: sliceId },
       filters: getAppliedFilterValues(sliceId, filterBoxFilters),
       nativeFilters,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

"Edit chart" from dashboard may throw an JS error if the dashboard context is not found in `localStorage`. This could happen when users either don't have `localStorage` enabled in there browser (unlikely) or when localStorage has run out of space (for example, if `SQLLAB_BACKEND_PERSISTENCE` isn't enabled in SQL Lab).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<img width="814" alt="image" src="https://user-images.githubusercontent.com/335541/189406222-024cc94f-ca63-4238-ae86-020cdb1973b4.png">

<img width="674" alt="image" src="https://user-images.githubusercontent.com/335541/189405975-55b23eb2-126a-42e4-a46b-f415f2eac879.png">


### TESTING INSTRUCTIONS

To reproduce the JS error

1. Go to a Dashboard page
2. Delete localStorage item `dashboard__explore_context`:

    <img width="754" alt="image" src="https://user-images.githubusercontent.com/335541/189406771-6c9a8867-91dd-4aca-99ab-789d1d9ce6f3.png">

3. Go edit any chart in the dashboard

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
