### PR TITLE
fix(dashboard): drag preview not working

### DIFF
--- a/superset-frontend/src/components/Chart/ChartContextMenu.tsx
+++ b/superset-frontend/src/components/Chart/ChartContextMenu.tsx
@@ -26,6 +26,7 @@ import React, {
 import { QueryObjectFilterClause, t, styled } from '@superset-ui/core';
 import { Menu } from 'src/components/Menu';
 import { AntdDropdown as Dropdown } from 'src/components';
+import ReactDOM from 'react-dom';
 
 const MENU_ITEM_HEIGHT = 32;
 const MENU_VERTICAL_SPACING = 32;
@@ -116,7 +117,7 @@ const ChartContextMenu = (
     [open],
   );
 
-  return (
+  return ReactDOM.createPortal(
     <Dropdown
       overlay={menu}
       trigger={['click']}
@@ -133,7 +134,8 @@ const ChartContextMenu = (
           height: 1,
         }}
       />
-    </Dropdown>
+    </Dropdown>,
+    document.body,
   );
 };
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently the drag preview of `react-dnd` was broken since we introduce `position: 'fixed'` inside the drag container from   [#21198](https://github.com/apache/superset/pull/21198/files#diff-ea949f68550922078a8f7fb0b3d73d166697eaa03d01d6b0178cfa66feb1ac06L114). To fix this, we use `createPortal` to ensure that the parent container is not affected and that the dropdown is also displayed properly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### before

https://user-images.githubusercontent.com/11830681/189573591-61756ae5-ab2d-4944-add2-fd7408c29ee0.mov


#### after

https://user-images.githubusercontent.com/11830681/189573411-91bb0976-37b7-4a38-9b4a-340ba19efccf.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
