### PR TITLE
fix(datasets): Stop showing alert when saving from query

### DIFF
--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -272,6 +272,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
   useEffect(() => {
     if (
       prevDatasource &&
+      prevDatasource.type !== DatasourceType.Query &&
       (props.exploreState.datasource?.id !== prevDatasource.id ||
         props.exploreState.datasource?.type !== prevDatasource.type)
     ) {


### PR DESCRIPTION
### SUMMARY
When user saves from a query we should not display the alert saying that changes were retained. (Blue message)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![error](https://user-images.githubusercontent.com/38889534/189748498-b547acab-9b4d-4efa-adc4-16f0a00292e0.gif)


After:
![test](https://user-images.githubusercontent.com/38889534/189748553-9789c987-ce86-45e9-87be-555aa4674b13.gif)

### TESTING INSTRUCTIONS
1. Create a chart from SQL Lab with source = query
2. Save the dataset in Explore

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
