### PR TITLE
feat(embedded): +2 functions: getDashboardPermalink, getActiveTabs

### DIFF
--- a/superset-frontend/src/embedded/api.tsx
+++ b/superset-frontend/src/embedded/api.tsx
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 import { store } from '../views/store';
 import { bootstrapData } from '../preamble';
 import { getDashboardPermalink as getDashboardPermalinkUtil } from '../utils/urlUtils';
@@ -18,10 +36,15 @@ const getScrollSize = (): Size => ({
   height: document.body.scrollHeight,
 });
 
-const getDashboardPermalink = async ({ anchor }: { anchor: string }): Promise<string> => {
+const getDashboardPermalink = async ({
+  anchor,
+}: {
+  anchor: string;
+}): Promise<string> => {
   const state = store?.getState();
   const { dashboardId, dataMask, activeTabs } = {
-    dashboardId: state?.dashboardInfo?.id || bootstrapData?.embedded!.dashboard_id,
+    dashboardId:
+      state?.dashboardInfo?.id || bootstrapData?.embedded!.dashboard_id,
     dataMask: state?.dataMask,
     activeTabs: state.dashboardState?.activeTabs,
   };

--- a/superset-frontend/src/embedded/api.tsx
+++ b/superset-frontend/src/embedded/api.tsx
@@ -1,29 +1,30 @@
 import { store } from '../views/store';
 import { bootstrapData } from '../preamble';
-import { getDashboardPermalink as getDashboardPermalinkUtil } from "../utils/urlUtils";
+import { getDashboardPermalink as getDashboardPermalinkUtil } from '../utils/urlUtils';
 
 type Size = {
-  width: number, height: number
-}
+  width: number;
+  height: number;
+};
 
 type EmbeddedSupersetApi = {
   getScrollSize: () => Size;
   getDashboardPermalink: ({ anchor }: { anchor: string }) => Promise<string>;
   getActiveTabs: () => string[];
-}
+};
 
 const getScrollSize = (): Size => ({
   width: document.body.scrollWidth,
   height: document.body.scrollHeight,
-})
+});
 
-const getDashboardPermalink = async ({anchor}: {anchor: string}): Promise<string> => {
+const getDashboardPermalink = async ({ anchor }: { anchor: string }): Promise<string> => {
   const state = store?.getState();
   const { dashboardId, dataMask, activeTabs } = {
     dashboardId: state?.dashboardInfo?.id || bootstrapData?.embedded!.dashboard_id,
     dataMask: state?.dataMask,
     activeTabs: state.dashboardState?.activeTabs,
-  }
+  };
 
   return getDashboardPermalinkUtil({
     dashboardId,
@@ -31,12 +32,12 @@ const getDashboardPermalink = async ({anchor}: {anchor: string}): Promise<string
     activeTabs,
     anchor,
   });
-}
+};
 
 const getActiveTabs = () => store?.getState()?.dashboardState?.activeTabs || [];
 
 export const embeddedApi: EmbeddedSupersetApi = {
   getScrollSize,
   getDashboardPermalink,
-  getActiveTabs
+  getActiveTabs,
 };

--- a/superset-frontend/src/embedded/api.tsx
+++ b/superset-frontend/src/embedded/api.tsx
@@ -1,0 +1,42 @@
+import { store } from '../views/store';
+import { bootstrapData } from '../preamble';
+import { getDashboardPermalink as getDashboardPermalinkUtil } from "../utils/urlUtils";
+
+type Size = {
+  width: number, height: number
+}
+
+type EmbeddedSupersetApi = {
+  getScrollSize: () => Size;
+  getDashboardPermalink: ({ anchor }: { anchor: string }) => Promise<string>;
+  getActiveTabs: () => string[];
+}
+
+const getScrollSize = (): Size => ({
+  width: document.body.scrollWidth,
+  height: document.body.scrollHeight,
+})
+
+const getDashboardPermalink = async ({anchor}: {anchor: string}): Promise<string> => {
+  const state = store?.getState();
+  const { dashboardId, dataMask, activeTabs } = {
+    dashboardId: state?.dashboardInfo?.id || bootstrapData?.embedded!.dashboard_id,
+    dataMask: state?.dataMask,
+    activeTabs: state.dashboardState?.activeTabs,
+  }
+
+  return getDashboardPermalinkUtil({
+    dashboardId,
+    dataMask,
+    activeTabs,
+    anchor,
+  });
+}
+
+const getActiveTabs = () => store?.getState()?.dashboardState?.activeTabs || [];
+
+export const embeddedApi: EmbeddedSupersetApi = {
+  getScrollSize,
+  getDashboardPermalink,
+  getActiveTabs
+};

--- a/superset-frontend/src/embedded/index.tsx
+++ b/superset-frontend/src/embedded/index.tsx
@@ -184,16 +184,22 @@ window.addEventListener('message', function embeddedPageInitializer(event) {
 
     let started = false;
 
-    switchboard.defineMethod('guestToken', ({ guestToken }: { guestToken: string }) => {
-      setupGuestClient(guestToken);
-      if (!started) {
-        start();
-        started = true;
-      }
-    });
+    switchboard.defineMethod(
+      'guestToken',
+      ({ guestToken }: { guestToken: string }) => {
+        setupGuestClient(guestToken);
+        if (!started) {
+          start();
+          started = true;
+        }
+      },
+    );
 
     switchboard.defineMethod('getScrollSize', embeddedApi.getScrollSize);
-    switchboard.defineMethod('getDashboardPermalink', embeddedApi.getDashboardPermalink);
+    switchboard.defineMethod(
+      'getDashboardPermalink',
+      embeddedApi.getDashboardPermalink,
+    );
     switchboard.defineMethod('getActiveTabs', embeddedApi.getActiveTabs);
     switchboard.start();
   }

--- a/superset-frontend/src/embedded/index.tsx
+++ b/superset-frontend/src/embedded/index.tsx
@@ -30,6 +30,7 @@ import Loading from 'src/components/Loading';
 import { addDangerToast } from 'src/components/MessageToasts/actions';
 import ToastContainer from 'src/components/MessageToasts/ToastContainer';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
+import { embeddedApi } from './api';
 
 const debugMode = process.env.WEBPACK_MODE === 'development';
 
@@ -183,7 +184,7 @@ window.addEventListener('message', function embeddedPageInitializer(event) {
 
     let started = false;
 
-    switchboard.defineMethod('guestToken', ({ guestToken }) => {
+    switchboard.defineMethod('guestToken', ({ guestToken }: { guestToken: string }) => {
       setupGuestClient(guestToken);
       if (!started) {
         start();
@@ -191,11 +192,9 @@ window.addEventListener('message', function embeddedPageInitializer(event) {
       }
     });
 
-    switchboard.defineMethod('getScrollSize', () => ({
-      width: document.body.scrollWidth,
-      height: document.body.scrollHeight,
-    }));
-
+    switchboard.defineMethod('getScrollSize', embeddedApi.getScrollSize);
+    switchboard.defineMethod('getDashboardPermalink', embeddedApi.getDashboardPermalink);
+    switchboard.defineMethod('getActiveTabs', embeddedApi.getActiveTabs);
     switchboard.start();
   }
 });


### PR DESCRIPTION
Added 2 more functions in embedded superset: getDashboardPermalinkForAnchor, getActiveTabs

### SUMMARY
Ability to request the following information from the parent app to embedded superset
* Get active tabs
* Get dashboard permalink by anchor (example of an anchor - a chart id, for example CHART-a4qv8d)

### TESTING INSTRUCTIONS
Embed dashboard using embedded sdk
Make calls to get active tabs
Make calls to get a chart permalink

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Required feature flags: EMBEDDED_SUPERSET = True
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

