### PR TITLE
docs: Fix package name for Databricks dependency bundle

### DIFF
--- a/docs/docs/databases/databricks.mdx
+++ b/docs/docs/databases/databricks.mdx
@@ -10,7 +10,7 @@ version: 1
 Databricks now offer a native DB API 2.0 driver, `databricks-sql-connector`, that can be used with the `sqlalchemy-databricks` dialect. You can install both with:
 
 ```bash
-pip install "superset[databricks]"
+pip install "apache-superset[databricks]"
 ```
 
 To use the Hive connector you need the following information from your cluster:


### PR DESCRIPTION
### SUMMARY
Instructions for Databricks database setup referred to the pre-Apache-Incubator `superset` repository `superset[databricks]`. Following this part of the current instructions results in a failed setup. This PR updates the reference to point to `apache-superset[databricks]`.

### TESTING INSTRUCTIONS
#### Failing workflow
1. Add `superset[databricks]` to `requirements/base.txt`
2. Build Superset from `Dockerfile`
3. Launch built image with `docker-compose`

#### Successful workflow
1. Add `apache-superset[databricks]` to `requirements/base.txt`
2. Build Superset from `Dockerfile`
3. Launch built image with `docker-compose`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
