### PR TITLE
refactor: get Axis from a helper function

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/pivotOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/pivotOperator.ts
@@ -17,27 +17,26 @@
  * under the License.
  */
 import {
-  DTTM_ALIAS,
   ensureIsArray,
   getColumnLabel,
   getMetricLabel,
   PostProcessingPivot,
 } from '@superset-ui/core';
 import { PostProcessingFactory } from './types';
+import { getAxis } from './utils';
 
 export const pivotOperator: PostProcessingFactory<PostProcessingPivot> = (
   formData,
   queryObject,
 ) => {
   const metricLabels = ensureIsArray(queryObject.metrics).map(getMetricLabel);
-  const { x_axis: xAxis } = formData;
+  const xAxis = getAxis(formData);
 
-  if ((xAxis || queryObject.is_timeseries) && metricLabels.length) {
-    const index = [getColumnLabel(xAxis || DTTM_ALIAS)];
+  if (xAxis && metricLabels.length) {
     return {
       operation: 'pivot',
       options: {
-        index,
+        index: [xAxis],
         columns: ensureIsArray(queryObject.columns).map(getColumnLabel),
         // Create 'dummy' mean aggregates to assign cell values in pivot table
         // use the 'mean' aggregates to avoid drop NaN. PR: https://github.com/apache-superset/superset-ui/pull/1231

--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/prophetOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/prophetOperator.ts
@@ -16,19 +16,16 @@
  * specific language governing permissions and limitationsxw
  * under the License.
  */
-import {
-  DTTM_ALIAS,
-  getColumnLabel,
-  PostProcessingProphet,
-} from '@superset-ui/core';
+import { PostProcessingProphet } from '@superset-ui/core';
 import { PostProcessingFactory } from './types';
+import { getAxis } from './utils';
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 export const prophetOperator: PostProcessingFactory<PostProcessingProphet> = (
   formData,
   queryObject,
 ) => {
-  const index = getColumnLabel(formData.x_axis || DTTM_ALIAS);
+  const xAxis = getAxis(formData);
   if (formData.forecastEnabled) {
     return {
       operation: 'prophet',
@@ -39,7 +36,7 @@ export const prophetOperator: PostProcessingFactory<PostProcessingProphet> = (
         yearly_seasonality: formData.forecastSeasonalityYearly,
         weekly_seasonality: formData.forecastSeasonalityWeekly,
         daily_seasonality: formData.forecastSeasonalityDaily,
-        index,
+        xAxis,
       },
     };
   }

--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/prophetOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/prophetOperator.ts
@@ -26,7 +26,7 @@ export const prophetOperator: PostProcessingFactory<PostProcessingProphet> = (
   queryObject,
 ) => {
   const xAxis = getAxis(formData);
-  if (formData.forecastEnabled) {
+  if (formData.forecastEnabled && xAxis) {
     return {
       operation: 'prophet',
       options: {
@@ -36,7 +36,7 @@ export const prophetOperator: PostProcessingFactory<PostProcessingProphet> = (
         yearly_seasonality: formData.forecastSeasonalityYearly,
         weekly_seasonality: formData.forecastSeasonalityWeekly,
         daily_seasonality: formData.forecastSeasonalityDaily,
-        xAxis,
+        index: xAxis,
       },
     };
   }

--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/timeComparePivotOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/timeComparePivotOperator.ts
@@ -18,13 +18,12 @@
  * under the License.
  */
 import {
-  DTTM_ALIAS,
   ensureIsArray,
   getColumnLabel,
   NumpyFunction,
   PostProcessingPivot,
 } from '@superset-ui/core';
-import { getMetricOffsetsMap, isTimeComparison } from './utils';
+import { getMetricOffsetsMap, isTimeComparison, getAxis } from './utils';
 import { PostProcessingFactory } from './types';
 
 export const timeComparePivotOperator: PostProcessingFactory<PostProcessingPivot> =
@@ -39,12 +38,12 @@ export const timeComparePivotOperator: PostProcessingFactory<PostProcessingPivot
           { operator: 'mean' as NumpyFunction },
         ]),
       );
-      const index = [getColumnLabel(formData.x_axis || DTTM_ALIAS)];
+      const xAxis = getAxis(formData);
 
       return {
         operation: 'pivot',
         options: {
-          index,
+          index: [xAxis],
           columns: ensureIsArray(queryObject.columns).map(getColumnLabel),
           drop_missing_columns: !formData?.show_empty_columns,
           aggregates,

--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/timeComparePivotOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/timeComparePivotOperator.ts
@@ -29,8 +29,9 @@ import { PostProcessingFactory } from './types';
 export const timeComparePivotOperator: PostProcessingFactory<PostProcessingPivot> =
   (formData, queryObject) => {
     const metricOffsetMap = getMetricOffsetsMap(formData, queryObject);
+    const xAxis = getAxis(formData);
 
-    if (isTimeComparison(formData, queryObject)) {
+    if (isTimeComparison(formData, queryObject) && xAxis) {
       const aggregates = Object.fromEntries(
         [...metricOffsetMap.values(), ...metricOffsetMap.keys()].map(metric => [
           metric,
@@ -38,7 +39,6 @@ export const timeComparePivotOperator: PostProcessingFactory<PostProcessingPivot
           { operator: 'mean' as NumpyFunction },
         ]),
       );
-      const xAxis = getAxis(formData);
 
       return {
         operation: 'pivot',

--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/utils/getAxis.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/utils/getAxis.ts
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -14,11 +13,22 @@
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitationsxw
+ * specific language governing permissions and limitations
  * under the License.
  */
-export { getMetricOffsetsMap } from './getMetricOffsetsMap';
-export { isTimeComparison } from './isTimeComparison';
-export { isDerivedSeries } from './isDerivedSeries';
-export { TIME_COMPARISON_SEPARATOR } from './constants';
-export { getAxis } from './getAxis';
+import {
+  DTTM_ALIAS,
+  getColumnLabel,
+  QueryFormColumn,
+  QueryFormData,
+} from '@superset-ui/core';
+
+export const getAxis = (formData: QueryFormData): string => {
+  // The formData should be "raw form_data" -- the snake_case version of formData rather than camelCase.
+  let col: QueryFormColumn = DTTM_ALIAS;
+  if (formData.x_axis && formData.granularity_sqla) {
+    col = formData.x_axis;
+  }
+
+  return getColumnLabel(col);
+};

--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/utils/getAxis.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/utils/getAxis.ts
@@ -19,16 +19,17 @@
 import {
   DTTM_ALIAS,
   getColumnLabel,
-  QueryFormColumn,
+  isDefined,
   QueryFormData,
 } from '@superset-ui/core';
 
-export const getAxis = (formData: QueryFormData): string => {
+export const getAxis = (formData: QueryFormData): string | undefined => {
   // The formData should be "raw form_data" -- the snake_case version of formData rather than camelCase.
-  let col: QueryFormColumn = DTTM_ALIAS;
-  if (formData.x_axis && formData.granularity_sqla) {
-    col = formData.x_axis;
+  if (!(formData.granularity_sqla || formData.x_axis)) {
+    return undefined;
   }
 
-  return getColumnLabel(col);
+  return isDefined(formData.x_axis)
+    ? getColumnLabel(formData.x_axis)
+    : DTTM_ALIAS;
 };

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/pivotOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/pivotOperator.test.ts
@@ -57,12 +57,8 @@ const queryObject: QueryObject = {
 test('skip pivot', () => {
   expect(pivotOperator(formData, queryObject)).toEqual(undefined);
   expect(
-    pivotOperator(formData, { ...queryObject, is_timeseries: false }),
-  ).toEqual(undefined);
-  expect(
     pivotOperator(formData, {
       ...queryObject,
-      is_timeseries: true,
       metrics: [],
     }),
   ).toEqual(undefined);
@@ -70,7 +66,10 @@ test('skip pivot', () => {
 
 test('pivot by __timestamp without groupby', () => {
   expect(
-    pivotOperator(formData, { ...queryObject, is_timeseries: true }),
+    pivotOperator(
+      { ...formData, granularity_sqla: 'time_column' },
+      queryObject,
+    ),
   ).toEqual({
     operation: 'pivot',
     options: {
@@ -87,11 +86,13 @@ test('pivot by __timestamp without groupby', () => {
 
 test('pivot by __timestamp with groupby', () => {
   expect(
-    pivotOperator(formData, {
-      ...queryObject,
-      columns: ['foo', 'bar'],
-      is_timeseries: true,
-    }),
+    pivotOperator(
+      { ...formData, granularity_sqla: 'time_column' },
+      {
+        ...queryObject,
+        columns: ['foo', 'bar'],
+      },
+    ),
   ).toEqual({
     operation: 'pivot',
     options: {

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/prophetOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/prophetOperator.test.ts
@@ -47,6 +47,7 @@ test('should do prophetOperator with default index', () => {
     prophetOperator(
       {
         ...formData,
+        granularity_sqla: 'time_column',
         forecastEnabled: true,
         forecastPeriods: '3',
         forecastInterval: '5',

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/timeComparePivotOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/timeComparePivotOperator.test.ts
@@ -72,10 +72,10 @@ test('should pivot on any type of timeCompare', () => {
           ...formData,
           comparison_type: cType,
           time_compare: ['1 year ago', '1 year later'],
+          granularity_sqla: 'time_column',
         },
         {
           ...queryObject,
-          is_timeseries: true,
         },
       ),
     ).toEqual({

--- a/superset-frontend/packages/superset-ui-core/src/query/normalizeTimeColumn.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/normalizeTimeColumn.ts
@@ -32,6 +32,7 @@ export function normalizeTimeColumn(
   formData: QueryFormData,
   queryObject: QueryObject,
 ): QueryObject {
+  // The formData should be "raw form_data" -- the snake_case version of formData rather than camelCase.
   if (!(isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) && formData.x_axis)) {
     return queryObject;
   }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -20,9 +20,7 @@
 import {
   AnnotationLayer,
   CategoricalColorNamespace,
-  DTTM_ALIAS,
   GenericDataType,
-  getColumnLabel,
   getNumberFormatter,
   isEventAnnotationLayer,
   isFormulaAnnotationLayer,
@@ -31,7 +29,7 @@ import {
   TimeseriesChartDataResponseResult,
   t,
 } from '@superset-ui/core';
-import { isDerivedSeries } from '@superset-ui/chart-controls';
+import { getAxis, isDerivedSeries } from '@superset-ui/chart-controls';
 import { EChartsCoreOption, SeriesOption } from 'echarts';
 import { ZRLineType } from 'echarts/types/src/util/types';
 import {
@@ -149,8 +147,7 @@ export default function transformProps(
 
   const colorScale = CategoricalColorNamespace.getScale(colorScheme as string);
   const rebasedData = rebaseForecastDatum(data, verboseMap);
-  const xAxisCol =
-    verboseMap[xAxisOrig] || getColumnLabel(xAxisOrig || DTTM_ALIAS);
+  const xAxisCol = verboseMap[xAxisOrig] || getAxis(chartProps.rawFormData);
   const isHorizontal = orientation === OrientationType.horizontal;
   const { totalStackedValues, thresholdValues } = extractDataTotalValues(
     rebasedData,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -28,6 +28,7 @@ import {
   isTimeseriesAnnotationLayer,
   TimeseriesChartDataResponseResult,
   t,
+  DTTM_ALIAS,
 } from '@superset-ui/core';
 import { getAxis, isDerivedSeries } from '@superset-ui/chart-controls';
 import { EChartsCoreOption, SeriesOption } from 'echarts';
@@ -147,7 +148,9 @@ export default function transformProps(
 
   const colorScale = CategoricalColorNamespace.getScale(colorScheme as string);
   const rebasedData = rebaseForecastDatum(data, verboseMap);
-  const xAxisCol = verboseMap[xAxisOrig] || getAxis(chartProps.rawFormData);
+  // todo: if the both granularity_sqla and x_axis are `null`, should throw an error
+  const xAxisCol =
+    verboseMap[xAxisOrig] || getAxis(chartProps.rawFormData) || DTTM_ALIAS;
   const isHorizontal = orientation === OrientationType.horizontal;
   const { totalStackedValues, thresholdValues } = extractDataTotalValues(
     rebasedData,


### PR DESCRIPTION
### SUMMARY
Currently, the new version of Charts especially Echart VIZs supported a Time or Categorical column as the X-Axis when the Feature Flag `GENERIC_CHART_AXES` was enabled. This feature would be disabled if FF was disabled, so the _Pivot Index_ in some `Post Processing operators` would be set to `__timestamp` for backward compatibility.

This PR intends to move related codes into a helper function and removed unused property: `is_timeseries` in query_object. The `is_timeseries` only was used for the legacy Viz endpoint rather than the V1 Viz endpoint, so it's a safe refactor.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. The AA should work as before.
2. The CI should pass.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
