### PR TITLE
fix: remove extras from all adhoc_filters controls

### DIFF
--- a/superset-frontend/src/explore/actions/saveModalActions.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.js
@@ -20,6 +20,8 @@ import { SupersetClient, t } from '@superset-ui/core';
 import { addSuccessToast } from 'src/components/MessageToasts/actions';
 import { buildV1ChartDataPayload } from '../exploreUtils';
 
+const ADHOC_FILTER_REGEX = /^adhoc_filters/;
+
 export const FETCH_DASHBOARDS_SUCCEEDED = 'FETCH_DASHBOARDS_SUCCEEDED';
 export function fetchDashboardsSucceeded(choices) {
   return { type: FETCH_DASHBOARDS_SUCCEEDED, choices };
@@ -66,11 +68,16 @@ export const getSlicePayload = (
   formDataWithNativeFilters,
   owners,
 ) => {
+  const adhocFilters = Object.entries(formDataWithNativeFilters).reduce(
+    (acc, [key, value]) =>
+      ADHOC_FILTER_REGEX.test(key)
+        ? { ...acc, [key]: value?.filter(f => !f.isExtra) }
+        : acc,
+    {},
+  );
   const formData = {
     ...formDataWithNativeFilters,
-    adhoc_filters: formDataWithNativeFilters.adhoc_filters?.filter(
-      f => !f.isExtra,
-    ),
+    ...adhocFilters,
   };
 
   const [datasourceId, datasourceType] = formData.datasource.split('__');

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1946,8 +1946,9 @@ def remove_extra_adhoc_filters(form_data: Dict[str, Any]) -> None:
     Remove filters from slice data that originate from a filter box or native filter
     """
     adhoc_filters = {
-        key: value
-        for key, value in form_data.items() if ADHOC_FILTERS_REGEX.match(key)
+        key: value for key, value in form_data.items() if ADHOC_FILTERS_REGEX.match(key)
     }
     for key, value in adhoc_filters.items():
-        form_data[key] = [filter_ for filter_ in value or [] if not filter_.get("isExtra")]
+        form_data[key] = [
+            filter_ for filter_ in value or [] if not filter_.get("isExtra")
+        ]

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -136,6 +136,8 @@ JS_MAX_INTEGER = 9007199254740991  # Largest int Java Script can handle 2^53-1
 
 InputType = TypeVar("InputType")
 
+ADHOC_FILTERS_REGEX = re.compile("^adhoc_filters")
+
 
 class LenientEnum(Enum):
     """Enums with a `get` method that convert a enum value to `Enum` if it is a
@@ -1937,3 +1939,15 @@ def create_zip(files: Dict[str, Any]) -> BytesIO:
                 fp.write(contents)
     buf.seek(0)
     return buf
+
+
+def remove_extra_adhoc_filters(form_data: Dict[str, Any]) -> None:
+    """
+    Remove filters from slice data that originate from a filter box or native filter
+    """
+    adhoc_filters = {
+        key: value
+        for key, value in form_data.items() if ADHOC_FILTERS_REGEX.match(key)
+    }
+    for key, value in adhoc_filters.items():
+        form_data[key] = [filter_ for filter_ in value or [] if not filter_.get("isExtra")]

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -986,12 +986,6 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         )
         return json_success(payload)
 
-    @staticmethod
-    def remove_extra_filters(filters: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """Extra filters are ones inherited from the dashboard's temporary context
-        Those should not be saved when saving the chart"""
-        return [f for f in filters if not f.get("isExtra")]
-
     def save_or_overwrite_slice(
         # pylint: disable=too-many-arguments,too-many-locals
         self,
@@ -1014,9 +1008,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
                 form_data.pop("slice_id")  # don't save old slice_id
             slc = Slice(owners=[g.user] if g.user else [])
 
-        form_data["adhoc_filters"] = self.remove_extra_filters(
-            form_data.get("adhoc_filters") or []
-        )
+        utils.remove_extra_adhoc_filters(form_data)
 
         assert slc
         slc.params = json.dumps(form_data, indent=2, sort_keys=True)

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -986,9 +986,9 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         )
         return json_success(payload)
 
+    @staticmethod
     def save_or_overwrite_slice(
         # pylint: disable=too-many-arguments,too-many-locals
-        self,
         slc: Optional[Slice],
         slice_add_perm: bool,
         slice_overwrite_perm: bool,
@@ -1556,7 +1556,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @has_access_api
     @event_logger.log_this
     @expose("/available_domains/", methods=["GET"])
-    def available_domains(self) -> FlaskResponse:  # pylint: disable=no-self-use
+    def available_domains(self) -> FlaskResponse:
         """
         Returns the list of available Superset Webserver domains (if any)
         defined in config. This enables charts embedded in other apps to

--- a/tests/unit_tests/utils/test_core.py
+++ b/tests/unit_tests/utils/test_core.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import pytest
+
+from superset.utils.core import QueryObjectFilterClause, remove_extra_adhoc_filters
+
+ADHOC_FILTER: QueryObjectFilterClause = {
+    "col": "foo",
+    "op": "==",
+    "val": "bar",
+}
+
+
+@pytest.mark.parametrize(
+    "original,expected",
+    [
+        ({"foo": "bar"}, {"foo": "bar"}),
+        (
+            {"foo": "bar", "adhoc_filters": [ADHOC_FILTER]},
+            {"foo": "bar", "adhoc_filters": [ADHOC_FILTER]}
+        ),
+        (
+            {"foo": "bar", "adhoc_filters": [{**ADHOC_FILTER, "isExtra": True}]},
+            {"foo": "bar", "adhoc_filters": []},
+        ),
+        (
+            {"foo": "bar", "adhoc_filters": [ADHOC_FILTER, {**ADHOC_FILTER, "isExtra": True}]},
+            {"foo": "bar", "adhoc_filters": [ADHOC_FILTER]},
+        ),
+        (
+            {"foo": "bar",
+             "adhoc_filters_b": [ADHOC_FILTER, {**ADHOC_FILTER, "isExtra": True}]},
+            {"foo": "bar", "adhoc_filters_b": [ADHOC_FILTER]},
+        ),
+        (
+            {"foo": "bar",
+             "custom_adhoc_filters": [ADHOC_FILTER, {**ADHOC_FILTER, "isExtra": True}]},
+            {"foo": "bar",  "custom_adhoc_filters": [ADHOC_FILTER, {**ADHOC_FILTER, "isExtra": True}]},
+        ),
+    ],
+)
+def test_remove_extra_adhoc_filters(original, expected):
+    remove_extra_adhoc_filters(original)
+    assert expected == original

--- a/tests/unit_tests/utils/test_core.py
+++ b/tests/unit_tests/utils/test_core.py
@@ -15,6 +15,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Any, Dict
+
 import pytest
 
 from superset.utils.core import QueryObjectFilterClause, remove_extra_adhoc_filters
@@ -25,6 +27,13 @@ ADHOC_FILTER: QueryObjectFilterClause = {
     "val": "bar",
 }
 
+EXTRA_FILTER: QueryObjectFilterClause = {
+    "col": "foo",
+    "op": "==",
+    "val": "bar",
+    "isExtra": True,
+}
+
 
 @pytest.mark.parametrize(
     "original,expected",
@@ -32,28 +41,46 @@ ADHOC_FILTER: QueryObjectFilterClause = {
         ({"foo": "bar"}, {"foo": "bar"}),
         (
             {"foo": "bar", "adhoc_filters": [ADHOC_FILTER]},
-            {"foo": "bar", "adhoc_filters": [ADHOC_FILTER]}
-        ),
-        (
-            {"foo": "bar", "adhoc_filters": [{**ADHOC_FILTER, "isExtra": True}]},
-            {"foo": "bar", "adhoc_filters": []},
-        ),
-        (
-            {"foo": "bar", "adhoc_filters": [ADHOC_FILTER, {**ADHOC_FILTER, "isExtra": True}]},
             {"foo": "bar", "adhoc_filters": [ADHOC_FILTER]},
         ),
         (
-            {"foo": "bar",
-             "adhoc_filters_b": [ADHOC_FILTER, {**ADHOC_FILTER, "isExtra": True}]},
+            {"foo": "bar", "adhoc_filters": [EXTRA_FILTER]},
+            {"foo": "bar", "adhoc_filters": []},
+        ),
+        (
+            {
+                "foo": "bar",
+                "adhoc_filters": [ADHOC_FILTER, EXTRA_FILTER],
+            },
+            {"foo": "bar", "adhoc_filters": [ADHOC_FILTER]},
+        ),
+        (
+            {
+                "foo": "bar",
+                "adhoc_filters_b": [ADHOC_FILTER, EXTRA_FILTER],
+            },
             {"foo": "bar", "adhoc_filters_b": [ADHOC_FILTER]},
         ),
         (
-            {"foo": "bar",
-             "custom_adhoc_filters": [ADHOC_FILTER, {**ADHOC_FILTER, "isExtra": True}]},
-            {"foo": "bar",  "custom_adhoc_filters": [ADHOC_FILTER, {**ADHOC_FILTER, "isExtra": True}]},
+            {
+                "foo": "bar",
+                "custom_adhoc_filters": [
+                    ADHOC_FILTER,
+                    EXTRA_FILTER,
+                ],
+            },
+            {
+                "foo": "bar",
+                "custom_adhoc_filters": [
+                    ADHOC_FILTER,
+                    EXTRA_FILTER,
+                ],
+            },
         ),
     ],
 )
-def test_remove_extra_adhoc_filters(original, expected):
+def test_remove_extra_adhoc_filters(
+    original: Dict[str, Any], expected: Dict[str, Any]
+) -> None:
     remove_extra_adhoc_filters(original)
     assert expected == original


### PR DESCRIPTION
### SUMMARY
When setting native or filter box filters in a dashboard and then exploring a Mixed Timeseries chart and then saving the chart, the extra filters are only removed from the first query. This PR changes the removal logic so that all controls that start with the text `adhoc_filters` are cleaned from extra filters before saving. The logic is added both to the deprecated backend logic (set for removal in 3.0) and the new frontend logic which cleans the extra adhoc filters before sending the request to the v1 chart API.

### AFTER
With this fix the extra filters are removed from the second query of the mixed chart (notice there are no extra filters in the adhoc filter control):
<img width="934" alt="image" src="https://user-images.githubusercontent.com/33317356/189840746-da6f01da-ecc0-447c-8fe9-75b52bd899cc.png">

### BEFORE
Previously saving the mixed chart with an extra filter would persist the extra filters in the chart metadata:
<img width="944" alt="image" src="https://user-images.githubusercontent.com/33317356/189840416-eb1edb37-77b1-480a-ae51-4051a7deed29.png">


### TESTING INSTRUCTIONS
1. Create a Mixed chart
2. Add it to a dashboard and create a native filter
3. Apply the native filter to the chart and edit the chart
4. Save the chart and notice that the extra filter is removed from Query A but is still present in Query B after saving.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
