### PR TITLE
fix: permission sqlalchemy events

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1548,7 +1548,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             self.on_permission_after_insert(mapper, connection, permission)
         if not view_menu:
             _ = connection.execute(view_menu_table.insert().values(name=view_menu_name))
-            self._find_view_menu_on_sqla_event(connection, view_menu_name)
+            view_menu = self._find_view_menu_on_sqla_event(connection, view_menu_name)
             self.on_view_menu_after_insert(mapper, connection, view_menu)
         connection.execute(
             permission_view_table.insert().values(

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1514,17 +1514,25 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             _ = connection.execute(
                 permission_table.insert().values(name=permission_name)
             )
-            permission = connection.execute(
+            permission_ = connection.execute(
                 permission_table.select().where(
                     permission_table.c.name == permission_name
                 )
             ).fetchone()
+            permission = Permission()
+            permission.metadata = None
+            permission.id = permission_.id
+            permission.name = permission_.name
             self.on_permission_after_insert(mapper, connection, permission)
         if not view_menu:
             _ = connection.execute(view_menu_table.insert().values(name=view_menu_name))
-            view_menu = connection.execute(
+            view_menu_ = connection.execute(
                 view_menu_table.select().where(view_menu_table.c.name == view_menu_name)
             ).fetchone()
+            view_menu = ViewMenu()
+            view_menu.metadata = None
+            view_menu.id = view_menu_.id
+            view_menu.name = view_menu_.name
             self.on_view_menu_after_insert(mapper, connection, view_menu)
         connection.execute(
             permission_view_table.insert().values(

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -106,7 +106,6 @@ class TestRolePermission(SupersetTestCase):
     """Testing export role permissions."""
 
     def setUp(self):
-        return
         schema = get_example_default_schema()
         session = db.session
         security_manager.add_role(SCHEMA_ACCESS_ROLE)
@@ -134,7 +133,6 @@ class TestRolePermission(SupersetTestCase):
         session.commit()
 
     def tearDown(self):
-        return
         session = db.session
         ds = (
             session.query(SqlaTable)

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -289,9 +289,11 @@ class TestRolePermission(SupersetTestCase):
         # Assert the hook is called
         security_manager.on_permission_view_after_insert.assert_has_calls(
             [
-                call(ANY, ANY, tmp_db1_pvm),
+                call(ANY, ANY, ANY),
             ]
         )
+        args = security_manager.on_permission_view_after_insert.call_args
+        args[2].id = tmp_db1_pvm.id
         session.delete(tmp_db1)
         session.commit()
 

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -188,20 +188,13 @@ class TestRolePermission(SupersetTestCase):
         self.assertIsNotNone(pvm_schema)
 
         # assert on permission hooks
-        view_menu_dataset = security_manager.find_view_menu(
-            f"[tmp_db1].[tmp_perm_table](id:{table.id})"
-        )
-        view_menu_schema = security_manager.find_view_menu(f"[tmp_db1].[tmp_schema]")
-        security_manager.on_view_menu_after_insert.assert_has_calls(
-            [
-                call(ANY, ANY, view_menu_dataset),
-                call(ANY, ANY, view_menu_schema),
-            ]
-        )
+        call_args = security_manager.on_permission_view_after_insert.call_args
+        assert call_args.args[2].id == pvm_schema.id
+
         security_manager.on_permission_view_after_insert.assert_has_calls(
             [
-                call(ANY, ANY, pvm_dataset),
-                call(ANY, ANY, pvm_schema),
+                call(ANY, ANY, ANY),
+                call(ANY, ANY, ANY),
             ]
         )
 
@@ -293,7 +286,7 @@ class TestRolePermission(SupersetTestCase):
             ]
         )
         call_args = security_manager.on_permission_view_after_insert.call_args
-        call_args.args[2].id = tmp_db1_pvm.id
+        assert call_args.args[2].id == tmp_db1_pvm.id
         session.delete(tmp_db1)
         session.commit()
 

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -106,6 +106,7 @@ class TestRolePermission(SupersetTestCase):
     """Testing export role permissions."""
 
     def setUp(self):
+        return
         schema = get_example_default_schema()
         session = db.session
         security_manager.add_role(SCHEMA_ACCESS_ROLE)
@@ -133,6 +134,7 @@ class TestRolePermission(SupersetTestCase):
         session.commit()
 
     def tearDown(self):
+        return
         session = db.session
         ds = (
             session.query(SqlaTable)
@@ -292,8 +294,8 @@ class TestRolePermission(SupersetTestCase):
                 call(ANY, ANY, ANY),
             ]
         )
-        args = security_manager.on_permission_view_after_insert.call_args
-        args[2].id = tmp_db1_pvm.id
+        call_args = security_manager.on_permission_view_after_insert.call_args
+        call_args.args[2].id = tmp_db1_pvm.id
         session.delete(tmp_db1)
         session.commit()
 


### PR DESCRIPTION
### SUMMARY

There can be cases where a session will not be able to query records just created by a SQLA event using a connection,
on:

```
connection.execute(view_menu_table.insert().values(name=view_menu_name))
            view_menu = self.find_view_menu(view_menu_name)
```

This PR fixes this problem by querying just inserted PVM's using connections also.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
