### PR TITLE
fix: dashboard filter value is cleared when 2 similar dashboards opened in succession

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -250,6 +250,7 @@ const FilterBar: React.FC<FiltersBarProps> = ({
   const dashboardId = useSelector<any, string>(
     ({ dashboardInfo }) => dashboardInfo?.id,
   );
+  const previousDashboardId = usePrevious(dashboardId);
   const canEdit = useSelector<RootState, boolean>(
     ({ dashboardInfo }) => dashboardInfo.dash_edit_perm,
   );
@@ -283,7 +284,7 @@ const FilterBar: React.FC<FiltersBarProps> = ({
   );
 
   useEffect(() => {
-    if (previousFilters) {
+    if (previousFilters && dashboardId === previousDashboardId) {
       const updates = {};
       Object.values(filters).forEach(currentFilter => {
         const previousFilter = previousFilters?.[currentFilter.id];
@@ -310,7 +311,11 @@ const FilterBar: React.FC<FiltersBarProps> = ({
         Object.keys(updates).forEach(key => dispatch(clearDataMask(key)));
       }
     }
-  }, [JSON.stringify(filters), JSON.stringify(previousFilters)]);
+  }, [
+    JSON.stringify(filters),
+    JSON.stringify(previousFilters),
+    previousDashboardId,
+  ]);
 
   const dataMaskAppliedText = JSON.stringify(dataMaskApplied);
 


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fixes: https://github.com/apache/superset/issues/21353

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before: check the issue description

After:
[Screencast from 14-09-22 08:36:50 AM IST.webm](https://user-images.githubusercontent.com/12967587/190049473-4ff1fc3f-b4f9-4f92-8c92-e4e09f4ab59b.webm)



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. open 1 dashboard add 1 native filter of type value on any column and set any default value and save it
2. save that dashboard by overwriting itself.
3. save it again creating a new copy
4. change the default value for that filter to something else
5. save this dashboard by overwriting itself.
6. now go to dashboard list
7. open original dashboard
8. should apply default value of its filter

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/21353
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
