### PR TITLE
fix: hide time_grain when x_axis value is undefined

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
@@ -332,7 +332,7 @@ const time_grain_sqla: SharedControlConfig<'SelectControl'> = {
 
     const xAxis = controls?.x_axis;
     const xAxisValue = xAxis?.value;
-    if (xAxisValue === undefined || isAdhocColumn(xAxisValue)) {
+    if (isAdhocColumn(xAxisValue)) {
       return true;
     }
     if (isPhysicalColumn(xAxisValue)) {


### PR DESCRIPTION
### SUMMARY
The Time Grain Control **will be hidden** when the value of X_Axis `is undefined`. Previously, when x_axis `is undefined` the Time Grain Control **would be shown**.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### After
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/2016594/190096723-58106838-8bee-420b-a887-feeb9714f8cb.png">


#### Before
<img width="1465" alt="image" src="https://user-images.githubusercontent.com/2016594/190096895-0b7ffb62-80a3-4da2-a5e5-26d72f7ffa28.png">



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
