### PR TITLE
fix: Supports form_data param in old Explore endpoint

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -738,7 +738,8 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             "superset/import_dashboards.html", databases=databases
         )
 
-    def get_redirect_url(self) -> str:
+    @staticmethod
+    def get_redirect_url() -> str:
         """Assembles the redirect URL to the new endpoint. It also replaces
         the form_data param with a form_data_key by saving the original content
         to the cache layer.
@@ -787,7 +788,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             self.__class__.__name__,
         )
         if request.method == "GET":
-            return redirect(self.get_redirect_url())
+            return redirect(Superset.get_redirect_url())
 
         initial_form_data = {}
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -90,6 +90,7 @@ from superset.exceptions import (
     SupersetSecurityException,
     SupersetTimeoutException,
 )
+from superset.explore.form_data.commands.create import CreateFormDataCommand
 from superset.explore.form_data.commands.get import GetFormDataCommand
 from superset.explore.form_data.commands.parameters import CommandParameters
 from superset.explore.permalink.commands.get import GetExplorePermalinkCommand
@@ -164,6 +165,7 @@ from superset.views.utils import (
     get_datasource_info,
     get_form_data,
     get_viz,
+    loads_request_json,
     sanitize_datasource_data,
 )
 from superset.viz import BaseViz
@@ -736,6 +738,40 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             "superset/import_dashboards.html", databases=databases
         )
 
+    def get_redirect_url(self) -> str:
+        """Assembles the redirect URL to the new endpoint. It also replaces
+        the form_data param with a form_data_key by saving the original content
+        to the cache layer.
+        """
+        redirect_url = request.url.replace("/superset/explore", "/explore")
+        form_data_key = None
+        request_form_data = request.args.get("form_data")
+        if request_form_data:
+            parsed_form_data = loads_request_json(request_form_data)
+            slice_id = parsed_form_data.get(
+                "slice_id", int(request.args.get("slice_id", 0))
+            )
+            datasource = parsed_form_data.get("datasource")
+            if datasource:
+                parts = datasource.split("__")
+                datasource_id = parts[0]
+                datasource_type = parts[1]
+                parameters = CommandParameters(
+                    datasource_id=datasource_id,
+                    datasource_type=datasource_type,
+                    chart_id=slice_id,
+                    form_data=request_form_data,
+                )
+                form_data_key = CreateFormDataCommand(parameters).run()
+        if form_data_key:
+            url = parse.urlparse(redirect_url)
+            query = parse.parse_qs(url.query)
+            query.pop("form_data")
+            query["form_data_key"] = [form_data_key]
+            url = url._replace(query=parse.urlencode(query, True))
+            redirect_url = parse.urlunparse(url)
+        return redirect_url
+
     @has_access
     @event_logger.log_this
     @expose("/explore/<datasource_type>/<int:datasource_id>/", methods=["GET", "POST"])
@@ -753,7 +789,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             self.__class__.__name__,
         )
         if request.method == "GET":
-            return redirect(request.url.replace("/superset/explore", "/explore"))
+            return redirect(self.get_redirect_url())
 
         initial_form_data = {}
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -753,9 +753,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             )
             datasource = parsed_form_data.get("datasource")
             if datasource:
-                parts = datasource.split("__")
-                datasource_id = parts[0]
-                datasource_type = parts[1]
+                datasource_id, datasource_type = datasource.split("__")
                 parameters = CommandParameters(
                     datasource_id=datasource_id,
                     datasource_type=datasource_type,

--- a/tests/integration_tests/core_tests.py
+++ b/tests/integration_tests/core_tests.py
@@ -1694,6 +1694,20 @@ class TestCore(SupersetTestCase):
 
         assert rv.status_code == 422
 
+    @pytest.mark.usefixtures("load_energy_table_with_slice")
+    @mock.patch("superset.explore.form_data.commands.create.CreateFormDataCommand.run")
+    def test_explore_redirect(self, mock_command: mock.Mock):
+        self.login(username="admin")
+        random_key = "random_key"
+        mock_command.return_value = random_key
+        slice_name = f"Energy Sankey"
+        slice_id = self.get_slice(slice_name, db.session).id
+        form_data = {"slice_id": slice_id, "viz_type": "line", "datasource": "1__table"}
+        rv = self.client.get(
+            f"/superset/explore/?form_data={quote(json.dumps(form_data))}"
+        )
+        self.assertRedirects(rv, f"/explore/?form_data_key={random_key}")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### SUMMARY
This PR improves the support for the `form_data` param in the old `/superset/explore` endpoint. Previously, the old endpoint only redirected the user to the new endpoint with the same original request parameters. Now, if `form_data` is present, the endpoint will persist that information in the cache and replace the parameter with `form_data_key`, the new supported format.

Example:

```
GET /superset/explore/?form_data=<object>
```

will be redirected to

```
GET /explore/?form_data_key=<key>
```

### TESTING INSTRUCTIONS
Check that GET requests to the old endpoint are correctly redirected to the new endpoint with the correct parameters.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
