### PR TITLE
fix: Address regression introduced in #21284

### DIFF
--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -196,7 +196,7 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
         ? data.options.map(table => ({
             value: table.value,
             label: <TableOption table={table} />,
-            text: table.label,
+            text: table.value,
           }))
         : [],
     [data],

--- a/superset-frontend/src/hooks/apiResources/tables.test.ts
+++ b/superset-frontend/src/hooks/apiResources/tables.test.ts
@@ -103,7 +103,7 @@ describe('useTables hook', () => {
     });
     expect(SupersetClient.get).toHaveBeenCalledTimes(1);
     expect(SupersetClient.get).toHaveBeenCalledWith({
-      endpoint: `/superset/tables/${expectDbId}/${expectedSchema}/undefined/${forceRefresh}/`,
+      endpoint: `/superset/tables/${expectDbId}/${expectedSchema}/${forceRefresh}/`,
     });
     expect(result.current.data).toEqual(expectedData);
     await act(async () => {
@@ -111,36 +111,9 @@ describe('useTables hook', () => {
     });
     expect(SupersetClient.get).toHaveBeenCalledTimes(2);
     expect(SupersetClient.get).toHaveBeenCalledWith({
-      endpoint: `/superset/tables/${expectDbId}/${expectedSchema}/undefined/true/`,
+      endpoint: `/superset/tables/${expectDbId}/${expectedSchema}/true/`,
     });
     expect(result.current.data).toEqual(expectedData);
-  });
-
-  it('returns api response for search keyword', async () => {
-    const expectDbId = 'db1';
-    const expectedSchema = 'schemaA';
-    const expectedKeyword = 'my work';
-    const forceRefresh = false;
-    renderHook(
-      () =>
-        useTables({
-          dbId: expectDbId,
-          schema: expectedSchema,
-          keyword: expectedKeyword,
-        }),
-      {
-        wrapper: QueryProvider,
-      },
-    );
-    await act(async () => {
-      jest.runAllTimers();
-    });
-    expect(SupersetClient.get).toHaveBeenCalledTimes(1);
-    expect(SupersetClient.get).toHaveBeenCalledWith({
-      endpoint: `/superset/tables/${expectDbId}/${expectedSchema}/${encodeURIComponent(
-        expectedKeyword,
-      )}/${forceRefresh}/`,
-    });
   });
 
   it('returns hasMore when total is larger than result size', async () => {

--- a/superset-frontend/src/hooks/apiResources/tables.ts
+++ b/superset-frontend/src/hooks/apiResources/tables.ts
@@ -24,7 +24,6 @@ export type FetchTablesQueryParams = {
   dbId?: string | number;
   schema?: string;
   forceRefresh?: boolean;
-  keyword?: string;
 };
 export interface Table {
   label: string;
@@ -52,14 +51,12 @@ export function fetchTables({
   dbId,
   schema,
   forceRefresh,
-  keyword,
 }: FetchTablesQueryParams) {
   const encodedSchema = schema ? encodeURIComponent(schema) : '';
-  const encodedKeyword = keyword ? encodeURIComponent(keyword) : 'undefined';
   // TODO: Would be nice to add pagination in a follow-up. Needs endpoint changes.
   const endpoint = `/superset/tables/${
     dbId ?? 'undefined'
-  }/${encodedSchema}/${encodedKeyword}/${forceRefresh}/`;
+  }/${encodedSchema}/${forceRefresh}/`;
   return SupersetClient.get({ endpoint }) as Promise<QueryData>;
 }
 
@@ -67,11 +64,11 @@ type Params = FetchTablesQueryParams &
   Pick<UseQueryOptions, 'onSuccess' | 'onError'>;
 
 export function useTables(options: Params) {
-  const { dbId, schema, keyword, onSuccess, onError } = options || {};
+  const { dbId, schema, onSuccess, onError } = options || {};
   const forceRefreshRef = useRef(false);
-  const params = { dbId, schema, keyword };
+  const params = { dbId, schema };
   const result = useQuery<QueryData, Error, Data>(
-    ['tables', { dbId, schema, keyword }],
+    ['tables', { dbId, schema }],
     () => fetchTables({ ...params, forceRefresh: forceRefreshRef.current }),
     {
       select: ({ json }) => ({

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/index.tsx
@@ -188,8 +188,6 @@ export default function LeftPanel({
   const search = useMemo(
     () =>
       debounce((value: string) => {
-        const encodeTableName =
-          value === '' ? undefined : encodeURIComponent(value);
         const endpoint = encodeURI(
           `/superset/tables/${dbId}/${encodedSchema}/`,
         );

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/index.tsx
@@ -172,7 +172,7 @@ export default function LeftPanel({
   useEffect(() => {
     if (loadTables) {
       const endpoint = encodeURI(
-        `/superset/tables/${dbId}/${encodedSchema}/undefined/${refresh}/`,
+        `/superset/tables/${dbId}/${encodedSchema}/${refresh}/`,
       );
       getTablesList(endpoint);
     }
@@ -191,7 +191,7 @@ export default function LeftPanel({
         const encodeTableName =
           value === '' ? undefined : encodeURIComponent(value);
         const endpoint = encodeURI(
-          `/superset/tables/${dbId}/${encodedSchema}/${encodeTableName}/`,
+          `/superset/tables/${dbId}/${encodedSchema}/`,
         );
         getTablesList(endpoint);
       }, FAST_DEBOUNCE),


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Addresses regression introduced in https://github.com/apache/superset/pull/21284. 

cc: @EugeneTorap 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### AFTER
<img width="395" alt="Screen Shot 2022-09-14 at 11 22 08 AM" src="https://user-images.githubusercontent.com/4567245/190237801-f20d6805-f199-410f-a02a-5061856ddc87.png">
<img width="595" alt="Screen Shot 2022-09-14 at 11 17 46 AM" src="https://user-images.githubusercontent.com/4567245/190237812-6b76a653-5621-4d3c-8048-c9be414261cb.png">
<img width="874" alt="Screen Shot 2022-09-14 at 11 16 17 AM" src="https://user-images.githubusercontent.com/4567245/190237818-062414c3-ce61-4142-bfb6-13ea3a70cd22.png">


### TESTING INSTRUCTIONS

CI and verified the table selector worked in various surfaces.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #21476
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
