### PR TITLE
fix: BigQuery cannot accept Time Grain

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
@@ -57,7 +57,7 @@ import {
   DEFAULT_NUMBER_FORMAT,
 } from '../utils';
 import { TIME_FILTER_LABELS } from '../constants';
-import { SharedControlConfig, Dataset } from '../types';
+import { SharedControlConfig, Dataset, ColumnMeta } from '../types';
 
 import {
   dndAdhocFilterControl,
@@ -197,12 +197,10 @@ const time_grain_sqla: SharedControlConfig<'SelectControl'> = {
     if (isAdhocColumn(xAxisValue)) {
       return true;
     }
-    if (isPhysicalColumn(xAxisValue) && Array.isArray(xAxis?.options)) {
-      for (let i = 0; i < xAxis.options.length; i += 1) {
-        if (xAxis.options[i].column_name === xAxisValue) {
-          return !!xAxis.options[i].is_dttm;
-        }
-      }
+    if (isPhysicalColumn(xAxisValue)) {
+      return !!(xAxis?.options ?? []).find(
+        (col: ColumnMeta) => col?.column_name === xAxisValue,
+      )?.is_dttm;
     }
     return false;
   },

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1144,9 +1144,10 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
             and (time_grain := col.get("timeGrain"))
         ):
             sqla_column = self.db_engine_spec.get_timestamp_expr(
-                sqla_column,
-                None,
-                time_grain,
+                col=sqla_column,
+                pdf=None,
+                time_grain=time_grain,
+                type_=str(getattr(sqla_column, "type", "")),
             )
         return self.make_sqla_column_compatible(sqla_column, label)
 


### PR DESCRIPTION
### SUMMARY
This PR fixes Time Grain in the BigQuery as datasource and FF `GENERIC_CHART_AXES` is enabled.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### After
<img width="1322" alt="image" src="https://user-images.githubusercontent.com/2016594/190571129-2b6d229d-8af3-4bc2-a12d-390b3654284c.png">


#### Before
<img width="1323" alt="image" src="https://user-images.githubusercontent.com/2016594/190571274-e22dd401-7687-4dde-9988-2b15837bbfa6.png">



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
