### PR TITLE
docs: wording in template

### DIFF
--- a/superset-frontend/packages/generator-superset/generators/plugin-chart/templates/src/MyChart.erb
+++ b/superset-frontend/packages/generator-superset/generators/plugin-chart/templates/src/MyChart.erb
@@ -64,7 +64,7 @@ export default function <%= packageLabel %>(props: <%= packageLabel %>Props) {
 
   const rootElem = createRef<HTMLDivElement>();
 
-  // Often, you just want to get a hold of the DOM and go nuts.
+  // Often, you just want to access the DOM and do whatever you want.
   // Here, you can do that with createRef, and the useEffect hook.
   useEffect(() => {
     const root = rootElem.current as HTMLElement;


### PR DESCRIPTION
### SUMMARY

- Change the wording of a comment in the template for charting plugins. 
- I found the previous wording not understandable, therefore I suggest this change
