### PR TITLE
fix: dataset after insert when db relation does not exist

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1198,7 +1198,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         :param target: The changed dataset object
         :return:
         """
-        from superset.models.core import (  # pylint disable=import-outside-toplevel
+        from superset.models.core import (  # pylint: disable=import-outside-toplevel
             Database,
         )
 

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1198,7 +1198,9 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         :param target: The changed dataset object
         :return:
         """
-        from superset.models.core import Database  # pylint disable=import-outside-toplevel
+        from superset.models.core import (  # pylint disable=import-outside-toplevel
+            Database,
+        )
 
         try:
             dataset_perm = target.get_perm()

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1198,7 +1198,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         :param target: The changed dataset object
         :return:
         """
-        from superset.models.core import Database
+        from superset.models.core import Database  # pylint disable=import-outside-toplevel
 
         try:
             dataset_perm = target.get_perm()

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1101,7 +1101,9 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             .where(view_menu_table.c.id == db_pvm.view_menu_id)
             .values(name=new_view_menu_name)
         )
-        new_db_view_menu = self.find_view_menu(new_view_menu_name)
+        new_db_view_menu = self._find_view_menu_on_sqla_event(
+            connection, new_view_menu_name
+        )
 
         self.on_view_menu_after_update(mapper, connection, new_db_view_menu)
         return new_db_view_menu
@@ -1155,7 +1157,9 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                 .values(name=new_dataset_vm_name)
             )
             # After update refresh
-            new_dataset_view_menu = self.find_view_menu(new_dataset_vm_name)
+            new_dataset_view_menu = self._find_view_menu_on_sqla_event(
+                connection, new_dataset_vm_name
+            )
 
             # Update dataset (SqlaTable perm field)
             connection.execute(
@@ -1194,11 +1198,19 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         :param target: The changed dataset object
         :return:
         """
+        from superset.models.core import Database
+
         try:
             dataset_perm = target.get_perm()
+            database = target.database
         except DatasetInvalidPermissionEvaluationException:
-            logger.warning("Dataset has no database refusing to set permission")
-            return
+            logger.warning(
+                "Dataset has no database will retry with database_id to set permission"
+            )
+            database = self.get_session.query(Database).get(target.database_id)
+            dataset_perm = self.get_dataset_perm(
+                target.id, target.table_name, database.database_name
+            )
         dataset_table = target.__table__
 
         self._insert_pvm_on_sqla_event(
@@ -1214,7 +1226,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
 
         if target.schema:
             dataset_schema_perm = self.get_schema_perm(
-                target.database.database_name, target.schema
+                database.database_name, target.schema
             )
             self._insert_pvm_on_sqla_event(
                 mapper, connection, "schema_access", dataset_schema_perm
@@ -1484,12 +1496,23 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
     def _find_permission_on_sqla_event(
         self, connection: Connection, name: str
     ) -> Permission:
+        """
+        Find a FAB Permission using a SQLA connection.
+
+        A session.query may not return the latest results on newly created/updated
+        objects/rows using connection. On this case we should use a connection also
+
+        :param connection: SQLAlchemy connection
+        :param name: The permission name (it's unique)
+        :return: Permission
+        """
         permission_table = self.permission_model.__table__  # pylint: disable=no-member
 
         permission_ = connection.execute(
             permission_table.select().where(permission_table.c.name == name)
         ).fetchone()
         permission = Permission()
+        # ensures this object is never persisted
         permission.metadata = None
         permission.id = permission_.id
         permission.name = permission_.name
@@ -1498,12 +1521,23 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
     def _find_view_menu_on_sqla_event(
         self, connection: Connection, name: str
     ) -> ViewMenu:
+        """
+        Find a FAB ViewMenu using a SQLA connection.
+
+        A session.query may not return the latest results on newly created/updated
+        objects/rows using connection. On this case we should use a connection also
+
+        :param connection: SQLAlchemy connection
+        :param name: The ViewMenu name (it's unique)
+        :return: ViewMenu
+        """
         view_menu_table = self.viewmenu_model.__table__  # pylint: disable=no-member
 
         view_menu_ = connection.execute(
             view_menu_table.select().where(view_menu_table.c.name == name)
         ).fetchone()
         view_menu = ViewMenu()
+        # ensures this object is never persisted
         view_menu.metadata = None
         view_menu.id = view_menu_.id
         view_menu.name = view_menu_.name

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -106,6 +106,7 @@ class TestRolePermission(SupersetTestCase):
     """Testing export role permissions."""
 
     def setUp(self):
+        return
         schema = get_example_default_schema()
         session = db.session
         security_manager.add_role(SCHEMA_ACCESS_ROLE)
@@ -133,6 +134,7 @@ class TestRolePermission(SupersetTestCase):
         session.commit()
 
     def tearDown(self):
+        return
         session = db.session
         ds = (
             session.query(SqlaTable)
@@ -249,7 +251,7 @@ class TestRolePermission(SupersetTestCase):
             session.query(SqlaTable).filter_by(table_name="tmp_perm_table").one()
         )
         # Assert no permission is created
-        self.assertIsNone(
+        self.assertIsNotNone(
             security_manager.find_permission_view_menu(
                 "datasource_access", stored_table.perm
             )

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -106,7 +106,6 @@ class TestRolePermission(SupersetTestCase):
     """Testing export role permissions."""
 
     def setUp(self):
-        return
         schema = get_example_default_schema()
         session = db.session
         security_manager.add_role(SCHEMA_ACCESS_ROLE)
@@ -134,7 +133,6 @@ class TestRolePermission(SupersetTestCase):
         session.commit()
 
     def tearDown(self):
-        return
         session = db.session
         ds = (
             session.query(SqlaTable)

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -248,7 +248,7 @@ class TestRolePermission(SupersetTestCase):
         stored_table = (
             session.query(SqlaTable).filter_by(table_name="tmp_perm_table").one()
         )
-        # Assert no permission is created
+        # Assert permission is created
         self.assertIsNotNone(
             security_manager.find_permission_view_menu(
                 "datasource_access", stored_table.perm


### PR DESCRIPTION
### SUMMARY

Fixes a regression when loading examples would trigger dataset `after_insert` SQLAlchemy event with `dataset.database` as `None`, previously these triggers for creating new permissions were a noop and a second trigger would occur with the expected database relation. Currently the second event does not occur, so this PR will handle `dataset.database` as `None` by fetching the database model itself.
 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before**: after loading examples, not all datasource access permissions would be created (the number could vary)
<img width="1197" alt="Screenshot 2022-09-16 at 14 03 37" src="https://user-images.githubusercontent.com/4025227/190645236-4f40517e-dbaf-4b19-99a1-b9cc7df5090f.png">

**After**: All permissions are created has expected (23 datasets create 23 datasource access permissions)
<img width="1192" alt="Screenshot 2022-09-16 at 11 52 27" src="https://user-images.githubusercontent.com/4025227/190623313-62fbd232-20c9-4466-9623-2f5e8042c3ab.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
