### PR TITLE
fix: can't show duckdb table names in the "SEE TABLE SCHEMA" dropdown list

### DIFF
--- a/superset/db_engine_specs/duckdb.py
+++ b/superset/db_engine_specs/duckdb.py
@@ -76,5 +76,4 @@ class DuckDBEngineSpec(BaseEngineSpec):
     def get_table_names(
         cls, database: Database, inspector: Inspector, schema: Optional[str]
     ) -> List[str]:
-        """Need to disregard the schema for DuckDB"""
-        return sorted(inspector.get_table_names())
+        return sorted(inspector.get_table_names(schema))


### PR DESCRIPTION
 fix bug: #21210 
the previous approach inspector.get_table_names() always gets table name in default "main" schema instead of getting table name from an input schema specified in superset UI

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
fix bug #21210: can't show duckdb table names in the "SEE TABLE SCHEMA" dropdown list 


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1.  create a duckdb file connection 
2.  create a schema in the duckdb. e.g.  "foo"
3.  create a table "tab1" in schema "foo"
4.  in sql lab, choose the duckdb connection,  choose schema "foo" or any other
5. it is expected table "tabi1" (or other) in the  "SEE TABLE SCHEMA" dropdown list , before fixing , it is not showed anything

after installing duckdb_engine >=0.6.3 and the applying the fix in the PR,  in step5,  it can show the expected tables

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [Y] Has associated issue:  fix #21210
- [ N] Required feature flags:
- [ N] Changes UI
- [ N] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ N] Migration is atomic, supports rollback & is backwards-compatible
  - [ N] Confirm DB migration upgrade and downgrade tested
  - [ N] Runtime estimates and downtime expectations provided
- [ N] Introduces new feature or API
- [N ] Removes existing feature or API
