### PR TITLE
fix(explore): fix chart save when dashboard deleted

### DIFF
--- a/superset-frontend/src/explore/actions/hydrateExplore.ts
+++ b/superset-frontend/src/explore/actions/hydrateExplore.ts
@@ -123,7 +123,6 @@ export const hydrateExplore =
       controlsTransferred: explore.controlsTransferred,
       standalone: getUrlParam(URL_PARAMS.standalone),
       force: getUrlParam(URL_PARAMS.force),
-      sliceDashboards: initialFormData.dashboards,
     };
 
     // apply initial mapStateToProps for all controls, must execute AFTER

--- a/superset-frontend/src/explore/actions/saveModalActions.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.js
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import rison from 'rison';
 import { SupersetClient, t } from '@superset-ui/core';
 import { addSuccessToast } from 'src/components/MessageToasts/actions';
 import { buildV1ChartDataPayload } from '../exploreUtils';
@@ -66,6 +67,7 @@ export function removeSaveModalAlert() {
 export const getSlicePayload = (
   sliceName,
   formDataWithNativeFilters,
+  dashboards,
   owners,
 ) => {
   const adhocFilters = Object.entries(formDataWithNativeFilters).reduce(
@@ -78,6 +80,7 @@ export const getSlicePayload = (
   const formData = {
     ...formDataWithNativeFilters,
     ...adhocFilters,
+    dashboards,
   };
 
   const [datasourceId, datasourceType] = formData.datasource.split('__');
@@ -87,7 +90,7 @@ export const getSlicePayload = (
     viz_type: formData.viz_type,
     datasource_id: parseInt(datasourceId, 10),
     datasource_type: datasourceType,
-    dashboards: formData.dashboards,
+    dashboards,
     owners,
     query_context: JSON.stringify(
       buildV1ChartDataPayload({
@@ -142,7 +145,7 @@ const addToasts = (isNewSlice, sliceName, addedToDashboard) => {
 
 //  Update existing slice
 export const updateSlice =
-  ({ slice_id: sliceId, owners }, sliceName, addedToDashboard) =>
+  ({ slice_id: sliceId, owners }, sliceName, dashboards, addedToDashboard) =>
   async (dispatch, getState) => {
     const {
       explore: {
@@ -152,7 +155,7 @@ export const updateSlice =
     try {
       const response = await SupersetClient.put({
         endpoint: `/api/v1/chart/${sliceId}`,
-        jsonPayload: getSlicePayload(sliceName, formData, owners),
+        jsonPayload: getSlicePayload(sliceName, formData, dashboards, owners),
       });
 
       dispatch(saveSliceSuccess());
@@ -166,7 +169,7 @@ export const updateSlice =
 
 //  Create new slice
 export const createSlice =
-  (sliceName, addedToDashboard) => async (dispatch, getState) => {
+  (sliceName, dashboards, addedToDashboard) => async (dispatch, getState) => {
     const {
       explore: {
         form_data: { url_params: _, ...formData },
@@ -175,7 +178,7 @@ export const createSlice =
     try {
       const response = await SupersetClient.post({
         endpoint: `/api/v1/chart/`,
-        jsonPayload: getSlicePayload(sliceName, formData),
+        jsonPayload: getSlicePayload(sliceName, formData, dashboards),
       });
 
       dispatch(saveSliceSuccess());
@@ -214,4 +217,24 @@ export const getDashboard = dashboardId => async dispatch => {
     dispatch(saveSliceFailed());
     throw error;
   }
+};
+
+//  Get dashboards the slice is added to
+export const getSliceDashboards = slice => async dispatch => {
+  if (slice) {
+    try {
+      const response = await SupersetClient.get({
+        endpoint: `/api/v1/chart/${slice.slice_id}?q=${rison.encode({
+          columns: ['dashboards.id'],
+        })}`,
+      });
+
+      return response.json.result.dashboards.map(({ id }) => id);
+    } catch (error) {
+      dispatch(saveSliceFailed());
+      throw error;
+    }
+  }
+
+  return [];
 };

--- a/superset-frontend/src/explore/actions/saveModalActions.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.js
@@ -221,20 +221,16 @@ export const getDashboard = dashboardId => async dispatch => {
 
 //  Get dashboards the slice is added to
 export const getSliceDashboards = slice => async dispatch => {
-  if (slice) {
-    try {
-      const response = await SupersetClient.get({
-        endpoint: `/api/v1/chart/${slice.slice_id}?q=${rison.encode({
-          columns: ['dashboards.id'],
-        })}`,
-      });
+  try {
+    const response = await SupersetClient.get({
+      endpoint: `/api/v1/chart/${slice.slice_id}?q=${rison.encode({
+        columns: ['dashboards.id'],
+      })}`,
+    });
 
-      return response.json.result.dashboards.map(({ id }) => id);
-    } catch (error) {
-      dispatch(saveSliceFailed());
-      throw error;
-    }
+    return response.json.result.dashboards.map(({ id }) => id);
+  } catch (error) {
+    dispatch(saveSliceFailed());
+    throw error;
   }
-
-  return [];
 };

--- a/superset-frontend/src/explore/actions/saveModalActions.test.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.test.js
@@ -27,6 +27,7 @@ import {
   FETCH_DASHBOARDS_FAILED,
   FETCH_DASHBOARDS_SUCCEEDED,
   getDashboard,
+  getSliceDashboards,
   SAVE_SLICE_FAILED,
   SAVE_SLICE_SUCCESS,
   updateSlice,
@@ -97,10 +98,11 @@ test('updateSlice handles success', async () => {
   fetchMock.put(updateSliceEndpoint, sliceResponsePayload);
   const dispatch = sinon.spy();
   const getState = sinon.spy(() => mockExploreState);
-  const slice = await updateSlice({ slice_id: sliceId }, sliceName)(
-    dispatch,
-    getState,
-  );
+  const slice = await updateSlice(
+    { slice_id: sliceId },
+    sliceName,
+    [],
+  )(dispatch, getState);
 
   expect(fetchMock.calls(updateSliceEndpoint)).toHaveLength(1);
   expect(dispatch.callCount).toBe(2);
@@ -121,7 +123,7 @@ test('updateSlice handles failure', async () => {
   const getState = sinon.spy(() => mockExploreState);
   let caughtError;
   try {
-    await updateSlice({ slice_id: sliceId }, sliceName)(dispatch, getState);
+    await updateSlice({ slice_id: sliceId }, sliceName, [])(dispatch, getState);
   } catch (error) {
     caughtError = error;
   }
@@ -142,7 +144,7 @@ test('createSlice handles success', async () => {
   fetchMock.post(createSliceEndpoint, sliceResponsePayload);
   const dispatch = sinon.spy();
   const getState = sinon.spy(() => mockExploreState);
-  const slice = await createSlice(sliceName)(dispatch, getState);
+  const slice = await createSlice(sliceName, [])(dispatch, getState);
   expect(fetchMock.calls(createSliceEndpoint)).toHaveLength(1);
   expect(dispatch.callCount).toBe(2);
   expect(dispatch.getCall(0).args[0].type).toBe(SAVE_SLICE_SUCCESS);
@@ -162,7 +164,7 @@ test('createSlice handles failure', async () => {
   const getState = sinon.spy(() => mockExploreState);
   let caughtError;
   try {
-    await createSlice(sliceName)(dispatch, getState);
+    await createSlice(sliceName, [])(dispatch, getState);
   } catch (error) {
     caughtError = error;
   }
@@ -248,7 +250,7 @@ test('updateSlice with add to new dashboard handles success', async () => {
   fetchMock.put(updateSliceEndpoint, sliceResponsePayload);
   const dispatch = sinon.spy();
   const getState = sinon.spy(() => mockExploreState);
-  const slice = await updateSlice({ slice_id: sliceId }, sliceName, {
+  const slice = await updateSlice({ slice_id: sliceId }, sliceName, [], {
     new: true,
     title: dashboardName,
   })(dispatch, getState);
@@ -275,7 +277,7 @@ test('updateSlice with add to existing dashboard handles success', async () => {
   fetchMock.put(updateSliceEndpoint, sliceResponsePayload);
   const dispatch = sinon.spy();
   const getState = sinon.spy(() => mockExploreState);
-  const slice = await updateSlice({ slice_id: sliceId }, sliceName, {
+  const slice = await updateSlice({ slice_id: sliceId }, sliceName, [], {
     new: false,
     title: dashboardName,
   })(dispatch, getState);
@@ -295,4 +297,55 @@ test('updateSlice with add to existing dashboard handles success', async () => {
   );
 
   expect(slice).toEqual(sliceResponsePayload);
+});
+
+const slice = { slice_id: 10 };
+const dashboardSlicesResponsePayload = {
+  result: {
+    dashboards: [{ id: 21 }, { id: 22 }, { id: 23 }],
+  },
+};
+
+const getDashboardSlicesReturnValue = [21, 22, 23];
+
+/**
+ * Tests getSliceDashboards action
+ */
+
+const getSliceDashboardsEndpoint = `glob:*/api/v1/chart/${sliceId}?q=(columns:!(dashboards.id))`;
+test('getSliceDashboards with slice handles success', async () => {
+  fetchMock.reset();
+  fetchMock.get(getSliceDashboardsEndpoint, dashboardSlicesResponsePayload);
+  const dispatch = sinon.spy();
+  const sliceDashboards = await getSliceDashboards(slice)(dispatch);
+  expect(fetchMock.calls(getSliceDashboardsEndpoint)).toHaveLength(1);
+  expect(dispatch.callCount).toBe(0);
+  expect(sliceDashboards).toEqual(getDashboardSlicesReturnValue);
+});
+
+test('getSliceDashboards with slice handles failure', async () => {
+  fetchMock.reset();
+  fetchMock.get(getSliceDashboardsEndpoint, { throws: sampleError });
+  const dispatch = sinon.spy();
+  let caughtError;
+  try {
+    await getSliceDashboards(slice)(dispatch);
+  } catch (error) {
+    caughtError = error;
+  }
+
+  expect(caughtError).toEqual(sampleError);
+  expect(fetchMock.calls(getSliceDashboardsEndpoint)).toHaveLength(4);
+  expect(dispatch.callCount).toBe(1);
+  expect(dispatch.getCall(0).args[0].type).toBe(SAVE_SLICE_FAILED);
+});
+
+test('getSliceDashboards without slice handles success', async () => {
+  fetchMock.reset();
+  fetchMock.get(getSliceDashboardsEndpoint, dashboardSlicesResponsePayload);
+  const dispatch = sinon.spy();
+  const sliceDashboards = await getSliceDashboards()(dispatch);
+  expect(fetchMock.calls(getSliceDashboardsEndpoint)).toHaveLength(0);
+  expect(dispatch.callCount).toBe(0);
+  expect(sliceDashboards).toEqual([]);
 });

--- a/superset-frontend/src/explore/actions/saveModalActions.test.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.test.js
@@ -339,13 +339,3 @@ test('getSliceDashboards with slice handles failure', async () => {
   expect(dispatch.callCount).toBe(1);
   expect(dispatch.getCall(0).args[0].type).toBe(SAVE_SLICE_FAILED);
 });
-
-test('getSliceDashboards without slice handles success', async () => {
-  fetchMock.reset();
-  fetchMock.get(getSliceDashboardsEndpoint, dashboardSlicesResponsePayload);
-  const dispatch = sinon.spy();
-  const sliceDashboards = await getSliceDashboards()(dispatch);
-  expect(fetchMock.calls(getSliceDashboardsEndpoint)).toHaveLength(0);
-  expect(dispatch.callCount).toBe(0);
-  expect(sliceDashboards).toEqual([]);
-});

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -599,7 +599,6 @@ function ExploreViewContainer(props) {
             form_data={props.form_data}
             sliceName={props.sliceName}
             dashboardId={props.dashboardId}
-            sliceDashboards={props.exploreState.sliceDashboards ?? []}
           />
         )}
         <Resizable

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -183,12 +183,14 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
     }
 
     //  Get chart dashboards
-    let sliceDashboards: number[];
-    promise = promise
-      .then(() => this.props.actions.getSliceDashboards(this.props.slice))
-      .then(dashboards => {
-        sliceDashboards = dashboards;
-      });
+    let sliceDashboards: number[] = [];
+    if (this.props.slice && this.state.action === 'overwrite') {
+      promise = promise
+        .then(() => this.props.actions.getSliceDashboards(this.props.slice))
+        .then(dashboards => {
+          sliceDashboards = dashboards;
+        });
+    }
 
     let dashboard: DashboardGetResponse | null = null;
     if (this.state.newDashboardName || this.state.saveToDashboardId) {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As part of moving Explore to the SPA, #20498 replaced the previous single `POST /superset/explore` request that was used to save charts with calls to the v1 API.  The `PUT /api/v1/chart/{id}` endpoint responsible for updating the chart required sending the complete list of IDs of dashboards that the chart should be added to in the request body, and this list was previously sourced from the `form_data.dashboards` array returned by the `GET /api/v1/explore` endpoint.  However, `form_data.dashboards` is not updated when dashboards are deleted from Superset.  As a result, saving a chart that was added to a dashboard when that dashboard was deleted would result in the frontend submitting that dashboard in the `PUT` request, which would cause the request to fail.  This PR fixes this by getting the chart dashboards with a `GET /api/v1/chart/{id}` request during the explore save process, the results of which are correctly updated when dashboards are deleted.

~Additionally, the Save Chart modal was configured to close immediately upon clicking the "Save chart" button, rather than waiting for requests to complete/fail and showing error messages on fail.  This PR also fixes this so errors are displayed correctly.~ **This PR now just fixes the broken saving, as the fix for the Save Chart modal closing before error message shows turned out to trigger other Explore display bugs that couldn't be quickly solved for this PR.**

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

**Saving a chart w/ dashboard deleted before:**

https://user-images.githubusercontent.com/13007381/190811092-42255a80-023b-402b-9caa-78a1572e59d1.mov

**Saving a chart w/ dashboard deleted after:**

https://user-images.githubusercontent.com/13007381/191150662-10359f79-6151-4803-87f8-f9eee0d5eba6.mov

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Create a chart, save it to a dashboard, delete the dashboard, then make a change to the chart and attempt to save again.  The chart should save correctly and opening the chart from the chart list again should show the saved version.  Additionally, verify in the inspector that the `PUT` request was successful, with no `422` error.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
