### PR TITLE
fix(table-chart): don't color empty cells in table chart with color formatters

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/package.json
+++ b/superset-frontend/plugins/plugin-chart-table/package.json
@@ -37,6 +37,9 @@
     "regenerator-runtime": "^0.13.7",
     "xss": "^1.0.10"
   },
+  "devDependencies": {
+    "@testing-library/react": "^11.2.0"
+  },
   "peerDependencies": {
     "@types/react": "*",
     "@superset-ui/chart-controls": "*",

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -393,9 +393,9 @@ export default function TableChart<D extends DataRecord = DataRecord>(
             columnColorFormatters!
               .filter(formatter => formatter.column === column.key)
               .forEach(formatter => {
-                const formatterResult = formatter.getColorFromValue(
-                  value as number,
-                );
+                const formatterResult = value
+                  ? formatter.getColorFromValue(value as number)
+                  : false;
                 if (formatterResult) {
                   backgroundColor = formatterResult;
                 }

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -18,12 +18,12 @@
  */
 import React from 'react';
 import { CommonWrapper } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 import TableChart from '../src/TableChart';
 import transformProps from '../src/transformProps';
 import DateWithFormatter from '../src/utils/DateWithFormatter';
 import testData from './testData';
 import { mount, ProviderWrapper } from './enzyme';
-import { render, screen } from '@testing-library/react';
 
 describe('plugin-chart-table', () => {
   describe('transformProps', () => {
@@ -107,7 +107,7 @@ describe('plugin-chart-table', () => {
       expect(tree.text()).toContain('No records found');
     });
 
-    it('render color with column color formatter', async () => {
+    it('render color with column color formatter', () => {
       render(
         ProviderWrapper({
           children: (
@@ -131,15 +131,13 @@ describe('plugin-chart-table', () => {
         }),
       );
 
-      expect(
-        getComputedStyle(await screen.getByTitle('2467063')).background,
-      ).toBe('rgba(172, 225, 196, 1)');
-      expect(getComputedStyle(await screen.getByTitle('2467')).background).toBe(
-        '',
+      expect(getComputedStyle(screen.getByTitle('2467063')).background).toBe(
+        'rgba(172, 225, 196, 1)',
       );
+      expect(getComputedStyle(screen.getByTitle('2467')).background).toBe('');
     });
 
-    it('render cell without color', async () => {
+    it('render cell without color', () => {
       const dataWithEmptyCell = testData.advanced.queriesData[0];
       dataWithEmptyCell.data.push({
         __timestamp: null,
@@ -172,15 +170,13 @@ describe('plugin-chart-table', () => {
           ),
         }),
       );
-      expect(getComputedStyle(await screen.getByTitle('2467')).background).toBe(
+      expect(getComputedStyle(screen.getByTitle('2467')).background).toBe(
         'rgba(172, 225, 196, 0.812)',
       );
-      expect(
-        getComputedStyle(await screen.getByTitle('2467063')).background,
-      ).toBe('');
-      expect(getComputedStyle(await screen.getByText('N/A')).background).toBe(
+      expect(getComputedStyle(screen.getByTitle('2467063')).background).toBe(
         '',
       );
+      expect(getComputedStyle(screen.getByText('N/A')).background).toBe('');
     });
   });
 });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
If cell value is null don't color it in table chart with conditional formatting, will fix pivot table later if it has similar issue.
fixes: https://github.com/apache/superset/issues/21341

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:

![Screenshot from 2022-09-17 14-47-47](https://user-images.githubusercontent.com/12967587/190849721-8f85cfa4-02fc-448e-8e48-0167486925cb.png)

After:

![Screenshot from 2022-09-17 14-48-23](https://user-images.githubusercontent.com/12967587/190849726-7d16476b-6c4e-4181-a96c-e24e98dafb6e.png)



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. create virtual dataset with following query
`SELECT 34523.323 as gmv, 24523.323 as fm, '1' as shem, '1' as gr
UNION all
SELECT 325323543.323 as gmv, 125323543.323 as fm, '2' as shem, '1' as gr
UNION all
SELECT null as gmv, 4764545.323 as fm, '3' as shem, '2' as gr
UNION all
SELECT -10 as gmv, 35254525.323 as fm, '4' as shem, '2' as gr`

2. create table chart with raw records, and from the customize tab set the conditional color formatter on column`gmv` with condition `< 1`

3. test only colored cell is `-10` in `gmv` column.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/21341
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
