### PR TITLE
perf(word-cloud): reduce render to improve performance

### DIFF
--- a/superset-frontend/plugins/plugin-chart-word-cloud/package.json
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/package.json
@@ -36,6 +36,7 @@
   },
   "peerDependencies": {
     "@types/react": "*",
+    "@types/lodash": "*",
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
     "react": "^16.13.1"

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/chart/WordCloud.tsx
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/chart/WordCloud.tsx
@@ -31,6 +31,7 @@ import {
   seed,
   CategoricalColorScale,
 } from '@superset-ui/core';
+import { isEqual } from 'lodash';
 
 const seedRandom = seed('superset-ui');
 export const ROTATION = {
@@ -134,8 +135,8 @@ class WordCloud extends React.PureComponent<
     const { data, encoding, width, height, rotation } = this.props;
 
     if (
-      prevProps.data !== data ||
-      prevProps.encoding !== encoding ||
+      !isEqual(prevProps.data, data) ||
+      !isEqual(prevProps.encoding, encoding) ||
       prevProps.width !== width ||
       prevProps.height !== height ||
       prevProps.rotation !== rotation


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, the cloud map will re-render multiple times in the dashboard. The reason is that when determining whether to update, the object is judged using the `!==` operator.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### before
<img width="1053" alt="image" src="https://user-images.githubusercontent.com/11830681/190857034-533f37bc-b984-4ef3-9bb4-4f891d3c9d13.png">

#### after
<img width="1050" alt="image" src="https://user-images.githubusercontent.com/11830681/190857039-21343ec2-aa42-4166-8cd7-20bd3b5d12dd.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
