### PR TITLE
feat: new config to filter specific users from dropdown lists

### DIFF
--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -80,7 +80,7 @@ from superset.views.base_api import (
     requires_json,
     statsd_metrics,
 )
-from superset.views.filters import FilterRelatedOwners
+from superset.views.filters import BaseFilterRelatedUsers, FilterRelatedOwners
 
 logger = logging.getLogger(__name__)
 config = app.config
@@ -234,7 +234,10 @@ class ChartRestApi(BaseSupersetModelRestApi):
         "slices": ("slice_name", "asc"),
         "owners": ("first_name", "asc"),
     }
-
+    filter_rel_fields = {
+        "owners": [["id", BaseFilterRelatedUsers, lambda: []]],
+        "created_by": [["id", BaseFilterRelatedUsers, lambda: []]],
+    }
     related_field_filters = {
         "owners": RelatedFieldFilter("first_name", FilterRelatedOwners),
         "created_by": RelatedFieldFilter("first_name", FilterRelatedOwners),

--- a/superset/config.py
+++ b/superset/config.py
@@ -1101,7 +1101,9 @@ def EMAIL_HEADER_MUTATOR(  # pylint: disable=invalid-name,unused-argument
 
 # Define a list of usernames to be excluded from all dropdown lists of users
 # Owners, filters for created_by, etc.
-EXCLUDE_USER_USERNAMES: List[str] = []
+# The users can also be excluded by overriding the get_exclude_users_from_lists method
+# in security manager
+EXCLUDE_USERS_FROM_LISTS: Optional[List[str]] = None
 
 
 # This auth provider is used by background (offline) tasks that need to access

--- a/superset/config.py
+++ b/superset/config.py
@@ -1099,6 +1099,11 @@ def EMAIL_HEADER_MUTATOR(  # pylint: disable=invalid-name,unused-argument
     return msg
 
 
+# Define a list of usernames to be excluded from all dropdown lists of users
+# Owners, filters for created_by, etc.
+EXCLUDE_USER_USERNAMES: List[str] = []
+
+
 # This auth provider is used by background (offline) tasks that need to access
 # protected resources. Can be overridden by end users in order to support
 # custom auth mechanisms

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -94,7 +94,7 @@ from superset.views.base_api import (
     requires_json,
     statsd_metrics,
 )
-from superset.views.filters import FilterRelatedOwners
+from superset.views.filters import BaseFilterRelatedUsers, FilterRelatedOwners
 
 logger = logging.getLogger(__name__)
 
@@ -239,6 +239,10 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         "slices": ("slice_name", "asc"),
         "owners": ("first_name", "asc"),
         "roles": ("name", "asc"),
+    }
+    filter_rel_fields = {
+        "owners": [["id", BaseFilterRelatedUsers, lambda: []]],
+        "created_by": [["id", BaseFilterRelatedUsers, lambda: []]],
     }
     related_field_filters = {
         "owners": RelatedFieldFilter("first_name", FilterRelatedOwners),

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -71,7 +71,7 @@ from superset.views.base_api import (
     requires_json,
     statsd_metrics,
 )
-from superset.views.filters import FilterRelatedOwners
+from superset.views.filters import BaseFilterRelatedUsers, FilterRelatedOwners
 
 logger = logging.getLogger(__name__)
 
@@ -214,6 +214,11 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         "extra",
     ]
     openapi_spec_tag = "Datasets"
+
+    filter_rel_fields = {
+        "owners": [["id", BaseFilterRelatedUsers, lambda: []]],
+        "database": [["id", DatabaseFilter, lambda: []]],
+    }
     related_field_filters = {
         "owners": RelatedFieldFilter("first_name", FilterRelatedOwners),
         "database": "database_name",
@@ -223,7 +228,6 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         "id": [DatasetCertifiedFilter],
     }
     search_columns = ["id", "database", "owners", "schema", "sql", "table_name"]
-    filter_rel_fields = {"database": [["id", DatabaseFilter, lambda: []]]}
     allowed_rel_fields = {"database", "owners"}
     allowed_distinct_fields = {"schema"}
 

--- a/superset/queries/api.py
+++ b/superset/queries/api.py
@@ -24,7 +24,7 @@ from superset.models.sql_lab import Query
 from superset.queries.filters import QueryFilter
 from superset.queries.schemas import openapi_spec_methods_override, QuerySchema
 from superset.views.base_api import BaseSupersetModelRestApi, RelatedFieldFilter
-from superset.views.filters import FilterRelatedOwners
+from superset.views.filters import BaseFilterRelatedUsers, FilterRelatedOwners
 
 logger = logging.getLogger(__name__)
 
@@ -109,7 +109,10 @@ class QueryRestApi(BaseSupersetModelRestApi):
         "tab_name",
         "user.first_name",
     ]
-
+    filter_rel_fields = {
+        "created_by": [["id", BaseFilterRelatedUsers, lambda: []]],
+        "user": [["id", BaseFilterRelatedUsers, lambda: []]],
+    }
     related_field_filters = {
         "created_by": RelatedFieldFilter("first_name", FilterRelatedOwners),
         "user": RelatedFieldFilter("first_name", FilterRelatedOwners),

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -57,7 +57,7 @@ from superset.views.base_api import (
     requires_json,
     statsd_metrics,
 )
-from superset.views.filters import FilterRelatedOwners
+from superset.views.filters import BaseFilterRelatedUsers, FilterRelatedOwners
 
 logger = logging.getLogger(__name__)
 
@@ -204,10 +204,13 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
     ]
     search_filters = {"name": [ReportScheduleAllTextFilter]}
     allowed_rel_fields = {"owners", "chart", "dashboard", "database", "created_by"}
+
     filter_rel_fields = {
         "chart": [["id", ChartFilter, lambda: []]],
         "dashboard": [["id", DashboardAccessFilter, lambda: []]],
         "database": [["id", DatabaseFilter, lambda: []]],
+        "owners": [["id", BaseFilterRelatedUsers, lambda: []]],
+        "created_by": [["id", BaseFilterRelatedUsers, lambda: []]],
     }
     text_field_rel_fields = {
         "dashboard": "dashboard_title",

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1702,6 +1702,22 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         :param target: The mapped instance being persisted
         """
 
+    @staticmethod
+    def get_exclude_users_from_lists() -> List[str]:
+        """
+        Override to dynamically identify a list of usernames to exclude from
+        all UI dropdown lists, owners, created_by filters etc...
+
+        It will exclude all users from the all endpoints of the form
+        ``/api/v1/<modelview>/related/<column>``
+
+        Optionally you can also exclude them using the `EXCLUDE_USERS_FROM_LISTS`
+        config setting.
+
+        :return: A list of usernames
+        """
+        return []
+
     def raise_for_access(
         # pylint: disable=too-many-arguments,too-many-locals
         self,

--- a/superset/views/filters.py
+++ b/superset/views/filters.py
@@ -57,7 +57,7 @@ class FilterRelatedOwners(BaseFilter):  # pylint: disable=too-few-public-methods
 class BaseFilterRelatedUsers(BaseFilter):  # pylint: disable=too-few-public-methods
 
     """
-    Filter to apply on related users. Will exclude users in EXCLUDE_USER_USERNAMES
+    Filter to apply on related users. Will exclude users in EXCLUDE_USERS_FROM_LISTS
 
     Use in the api by adding something like:
     ```
@@ -73,9 +73,10 @@ class BaseFilterRelatedUsers(BaseFilter):  # pylint: disable=too-few-public-meth
 
     def apply(self, query: Query, value: Optional[Any]) -> Query:
         user_model = security_manager.user_model
-        query_ = query.filter(
-            and_(
-                user_model.username.not_in(current_app.config["EXCLUDE_USER_USERNAMES"])
-            )
+        exclude_users = (
+            security_manager.get_exclude_users_from_lists()
+            if current_app.config["EXCLUDE_USERS_FROM_LISTS"] is None
+            else current_app.config["EXCLUDE_USERS_FROM_LISTS"]
         )
+        query_ = query.filter(and_(user_model.username.not_in(exclude_users)))
         return query_

--- a/tests/integration_tests/base_api_tests.py
+++ b/tests/integration_tests/base_api_tests.py
@@ -16,6 +16,8 @@
 # under the License.
 # isort:skip_file
 import json
+from unittest.mock import patch
+
 from tests.integration_tests.fixtures.world_bank_dashboard import (
     load_world_bank_dashboard_with_slices,
     load_world_bank_data,
@@ -32,6 +34,7 @@ from superset.models.dashboard import Dashboard
 from superset.views.base_api import BaseSupersetModelRestApi, requires_json
 
 from .base_tests import SupersetTestCase
+from .conftest import with_config
 
 
 class Model1Api(BaseSupersetModelRestApi):
@@ -288,13 +291,13 @@ class ApiOwnersTestCaseMixin:
         # TODO Check me
         assert expected_results == sorted_results
 
+    @with_config({"EXCLUDE_USERS_FROM_LISTS": ["gamma"]})
     def test_get_base_filter_related_owners(self):
         """
         API: Test get base filter related owners
         """
         self.login(username="admin")
         uri = f"api/v1/{self.resource_name}/related/owners"
-        self.app.config["EXCLUDE_USER_USERNAMES"] = ["gamma"]
         gamma_user = (
             db.session.query(security_manager.user_model)
             .filter(security_manager.user_model.username == "gamma")
@@ -309,8 +312,33 @@ class ApiOwnersTestCaseMixin:
         assert response["count"] == len(users) - 1
         response_users = [result["text"] for result in response["result"]]
         assert "gamma user" not in response_users
-        # revert the config change
-        self.app.config["EXCLUDE_USER_USERNAMES"] = []
+
+    @patch(
+        "superset.security.SupersetSecurityManager.get_exclude_users_from_lists",
+        return_value=["gamma"],
+    )
+    def test_get_base_filter_related_owners_on_sm(
+        self, mock_get_exclude_users_from_list
+    ):
+        """
+        API: Test get base filter related owners using security manager
+        """
+        self.login(username="admin")
+        uri = f"api/v1/{self.resource_name}/related/owners"
+        gamma_user = (
+            db.session.query(security_manager.user_model)
+            .filter(security_manager.user_model.username == "gamma")
+            .one_or_none()
+        )
+        assert gamma_user is not None
+        users = db.session.query(security_manager.user_model).all()
+
+        rv = self.client.get(uri)
+        assert rv.status_code == 200
+        response = json.loads(rv.data.decode("utf-8"))
+        assert response["count"] == len(users) - 1
+        response_users = [result["text"] for result in response["result"]]
+        assert "gamma user" not in response_users
 
     def test_get_ids_related_owners(self):
         """

--- a/tests/integration_tests/base_api_tests.py
+++ b/tests/integration_tests/base_api_tests.py
@@ -288,6 +288,26 @@ class ApiOwnersTestCaseMixin:
         # TODO Check me
         assert expected_results == sorted_results
 
+    def test_get_base_filter_related_owners(self):
+        """
+        API: Test get base filter related owners
+        """
+        self.login(username="admin")
+        uri = f"api/v1/{self.resource_name}/related/owners"
+        users = db.session.query(security_manager.user_model).all()
+        expected_users = [str(user) for user in users]
+
+        rv = self.client.get(uri)
+        assert rv.status_code == 200
+        response = json.loads(rv.data.decode("utf-8"))
+        assert response["count"] == len(users)
+        # This needs to be implemented like this, because ordering varies between
+        # postgres and mysql
+        response_users = [result["text"] for result in response["result"]]
+        raise Exception(expected_users)
+        for expected_user in expected_users:
+            assert expected_user in response_users
+
     def test_get_ids_related_owners(self):
         """
         API: Test get filter related owners


### PR DESCRIPTION
### SUMMARY

Introduces a new config key named `EXCLUDE_USERS_FROM_LISTS` with a list of usernames to exclude from all UI
dropdown user list, owners, created by filters etc.
This is useful for excluding service user's like an initial `admin` and/or the thumbnail user.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
