### PR TITLE
fix: Dataset timeout

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -603,6 +603,7 @@ class Database(
         return self.get_db_engine_spec(url)
 
     @classmethod
+    @memoized
     def get_db_engine_spec(cls, url: URL) -> Type[db_engine_specs.BaseEngineSpec]:
         backend = url.get_backend_name()
         try:


### PR DESCRIPTION
### SUMMARY
Fixes an issue for which the datasets were timing out in certain cases

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N.A.

### TESTING INSTRUCTIONS
1. Open Explore with a large dataset, such as flights
2. The requests should not timeout

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
