### PR TITLE
feat: generate consistent QueryObject whether GenericAxis is enabled or disabled

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/pivotOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/pivotOperator.ts
@@ -21,9 +21,9 @@ import {
   getColumnLabel,
   getMetricLabel,
   PostProcessingPivot,
+  getAxis,
 } from '@superset-ui/core';
 import { PostProcessingFactory } from './types';
-import { getAxis } from './utils';
 
 export const pivotOperator: PostProcessingFactory<PostProcessingPivot> = (
   formData,

--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/pivotOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/pivotOperator.ts
@@ -21,7 +21,7 @@ import {
   getColumnLabel,
   getMetricLabel,
   PostProcessingPivot,
-  getAxis,
+  getXAxis,
 } from '@superset-ui/core';
 import { PostProcessingFactory } from './types';
 
@@ -30,7 +30,7 @@ export const pivotOperator: PostProcessingFactory<PostProcessingPivot> = (
   queryObject,
 ) => {
   const metricLabels = ensureIsArray(queryObject.metrics).map(getMetricLabel);
-  const xAxis = getAxis(formData);
+  const xAxis = getXAxis(formData);
 
   if (xAxis && metricLabels.length) {
     return {

--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/prophetOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/prophetOperator.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitationsxw
  * under the License.
  */
-import { PostProcessingProphet, getAxis } from '@superset-ui/core';
+import { PostProcessingProphet, getXAxis } from '@superset-ui/core';
 import { PostProcessingFactory } from './types';
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -24,7 +24,7 @@ export const prophetOperator: PostProcessingFactory<PostProcessingProphet> = (
   formData,
   queryObject,
 ) => {
-  const xAxis = getAxis(formData);
+  const xAxis = getXAxis(formData);
   if (formData.forecastEnabled && xAxis) {
     return {
       operation: 'prophet',

--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/prophetOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/prophetOperator.ts
@@ -16,9 +16,8 @@
  * specific language governing permissions and limitationsxw
  * under the License.
  */
-import { PostProcessingProphet } from '@superset-ui/core';
+import { PostProcessingProphet, getAxis } from '@superset-ui/core';
 import { PostProcessingFactory } from './types';
-import { getAxis } from './utils';
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 export const prophetOperator: PostProcessingFactory<PostProcessingProphet> = (

--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/renameOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/renameOperator.ts
@@ -22,7 +22,7 @@ import {
   ensureIsArray,
   getMetricLabel,
   ComparisionType,
-  getAxis,
+  getXAxis,
 } from '@superset-ui/core';
 import { PostProcessingFactory } from './types';
 import { getMetricOffsetsMap, isTimeComparison } from './utils';
@@ -34,7 +34,7 @@ export const renameOperator: PostProcessingFactory<PostProcessingRename> = (
   const metrics = ensureIsArray(queryObject.metrics);
   const columns = ensureIsArray(queryObject.columns);
   const { truncate_metric } = formData;
-  const xAxis = getAxis(formData);
+  const xAxis = getXAxis(formData);
   // remove or rename top level of column name(metric name) in the MultiIndex when
   // 1) only 1 metric
   // 2) exist dimentsion

--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/renameOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/renameOperator.ts
@@ -22,6 +22,7 @@ import {
   ensureIsArray,
   getMetricLabel,
   ComparisionType,
+  getAxis,
 } from '@superset-ui/core';
 import { PostProcessingFactory } from './types';
 import { getMetricOffsetsMap, isTimeComparison } from './utils';
@@ -32,7 +33,8 @@ export const renameOperator: PostProcessingFactory<PostProcessingRename> = (
 ) => {
   const metrics = ensureIsArray(queryObject.metrics);
   const columns = ensureIsArray(queryObject.columns);
-  const { x_axis: xAxis, truncate_metric } = formData;
+  const { truncate_metric } = formData;
+  const xAxis = getAxis(formData);
   // remove or rename top level of column name(metric name) in the MultiIndex when
   // 1) only 1 metric
   // 2) exist dimentsion
@@ -42,7 +44,7 @@ export const renameOperator: PostProcessingFactory<PostProcessingRename> = (
   if (
     metrics.length === 1 &&
     columns.length > 0 &&
-    (xAxis || queryObject.is_timeseries) &&
+    xAxis &&
     !(
       // todo: we should provide an approach to handle derived metrics
       (

--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/timeComparePivotOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/timeComparePivotOperator.ts
@@ -22,8 +22,9 @@ import {
   getColumnLabel,
   NumpyFunction,
   PostProcessingPivot,
+  getAxis,
 } from '@superset-ui/core';
-import { getMetricOffsetsMap, isTimeComparison, getAxis } from './utils';
+import { getMetricOffsetsMap, isTimeComparison } from './utils';
 import { PostProcessingFactory } from './types';
 
 export const timeComparePivotOperator: PostProcessingFactory<PostProcessingPivot> =

--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/timeComparePivotOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/timeComparePivotOperator.ts
@@ -22,7 +22,7 @@ import {
   getColumnLabel,
   NumpyFunction,
   PostProcessingPivot,
-  getAxis,
+  getXAxis,
 } from '@superset-ui/core';
 import { getMetricOffsetsMap, isTimeComparison } from './utils';
 import { PostProcessingFactory } from './types';
@@ -30,7 +30,7 @@ import { PostProcessingFactory } from './types';
 export const timeComparePivotOperator: PostProcessingFactory<PostProcessingPivot> =
   (formData, queryObject) => {
     const metricOffsetMap = getMetricOffsetsMap(formData, queryObject);
-    const xAxis = getAxis(formData);
+    const xAxis = getXAxis(formData);
 
     if (isTimeComparison(formData, queryObject) && xAxis) {
       const aggregates = Object.fromEntries(

--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/utils/index.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/utils/index.ts
@@ -21,4 +21,3 @@ export { getMetricOffsetsMap } from './getMetricOffsetsMap';
 export { isTimeComparison } from './isTimeComparison';
 export { isDerivedSeries } from './isDerivedSeries';
 export { TIME_COMPARISON_SEPARATOR } from './constants';
-export { getAxis } from './getAxis';

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/pivotOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/pivotOperator.test.ts
@@ -141,7 +141,7 @@ test('pivot by adhoc x_axis', () => {
         x_axis: {
           label: 'my_case_expr',
           expressionType: 'SQL',
-          expression: 'case when a = 1 then 1 else 0 end',
+          sqlExpression: 'case when a = 1 then 1 else 0 end',
         },
       },
       {

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/prophetOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/prophetOperator.test.ts
@@ -108,7 +108,7 @@ test('should do prophetOperator over adhoc column', () => {
         x_axis: {
           label: 'my_case_expr',
           expressionType: 'SQL',
-          expression: 'case when a = 1 then 1 else 0 end',
+          sqlExpression: 'case when a = 1 then 1 else 0 end',
         },
         forecastEnabled: true,
         forecastPeriods: '3',

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/renameOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/renameOperator.test.ts
@@ -110,7 +110,7 @@ test('should add renameOperator if does not exist x_axis', () => {
     renameOperator(
       {
         ...formData,
-        ...{ x_axis: null },
+        ...{ x_axis: null, granularity_sqla: 'time column' },
       },
       queryObject,
     ),

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/timeComparePivotOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/timeComparePivotOperator.test.ts
@@ -146,7 +146,7 @@ test('should pivot on adhoc x-axis', () => {
         x_axis: {
           label: 'my_case_expr',
           expressionType: 'SQL',
-          expression: 'case when a = 1 then 1 else 0 end',
+          sqlExpression: 'case when a = 1 then 1 else 0 end',
         },
       },
       queryObject,

--- a/superset-frontend/packages/superset-ui-core/src/query/buildQueryContext.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/buildQueryContext.ts
@@ -24,7 +24,7 @@ import { QueryContext, QueryObject } from './types/Query';
 import { SetDataMaskHook } from '../chart';
 import { JsonObject } from '../connection';
 import { normalizeTimeColumn } from './normalizeTimeColumn';
-import { isEnabledAxes } from './getAxis';
+import { isXAxisSet } from './getXAxis';
 
 const WRAP_IN_ARRAY = (baseQueryObject: QueryObject) => [baseQueryObject];
 
@@ -54,7 +54,7 @@ export default function buildQueryContext(
       query.post_processing = query.post_processing.filter(Boolean);
     }
   });
-  if (isEnabledAxes(formData)) {
+  if (isXAxisSet(formData)) {
     queries = queries.map(query => normalizeTimeColumn(formData, query));
   }
   return {

--- a/superset-frontend/packages/superset-ui-core/src/query/buildQueryContext.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/buildQueryContext.ts
@@ -23,8 +23,8 @@ import { QueryFieldAliases, QueryFormData } from './types/QueryFormData';
 import { QueryContext, QueryObject } from './types/Query';
 import { SetDataMaskHook } from '../chart';
 import { JsonObject } from '../connection';
-import { isFeatureEnabled, FeatureFlag } from '../utils';
 import { normalizeTimeColumn } from './normalizeTimeColumn';
+import { isEnabledAxes } from './getAxis';
 
 const WRAP_IN_ARRAY = (baseQueryObject: QueryObject) => [baseQueryObject];
 
@@ -54,7 +54,7 @@ export default function buildQueryContext(
       query.post_processing = query.post_processing.filter(Boolean);
     }
   });
-  if (isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES)) {
+  if (isEnabledAxes(formData)) {
     queries = queries.map(query => normalizeTimeColumn(formData, query));
   }
   return {

--- a/superset-frontend/packages/superset-ui-core/src/query/getAxis.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/getAxis.ts
@@ -28,8 +28,12 @@ export const isEnabledAxes = (formData: QueryFormData) =>
   // return `true` when x_axis in formData but FeatureFlag.GENERIC_CHART_AXES is false
   isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) || formData.x_axis;
 
-export const getAxis = (formData: QueryFormData): string => {
+export const getAxis = (formData: QueryFormData): string | undefined => {
   // The formData should be "raw form_data" -- the snake_case version of formData rather than camelCase.
+  if (!(formData.granularity_sqla || formData.x_axis)) {
+    return undefined;
+  }
+
   if (isEnabledAxes(formData) && formData.x_axis) {
     return getColumnLabel(formData.x_axis);
   }

--- a/superset-frontend/packages/superset-ui-core/src/query/getAxis.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/getAxis.ts
@@ -18,18 +18,20 @@
  */
 import {
   DTTM_ALIAS,
+  FeatureFlag,
   getColumnLabel,
-  isDefined,
+  isFeatureEnabled,
   QueryFormData,
 } from '@superset-ui/core';
 
-export const getAxis = (formData: QueryFormData): string | undefined => {
-  // The formData should be "raw form_data" -- the snake_case version of formData rather than camelCase.
-  if (!(formData.granularity_sqla || formData.x_axis)) {
-    return undefined;
-  }
+export const isEnabledAxes = (formData: QueryFormData) =>
+  // return `true` when x_axis in formData but FeatureFlag.GENERIC_CHART_AXES is false
+  isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) || formData.x_axis;
 
-  return isDefined(formData.x_axis)
-    ? getColumnLabel(formData.x_axis)
-    : DTTM_ALIAS;
+export const getAxis = (formData: QueryFormData): string => {
+  // The formData should be "raw form_data" -- the snake_case version of formData rather than camelCase.
+  if (isEnabledAxes(formData) && formData.x_axis) {
+    return getColumnLabel(formData.x_axis);
+  }
+  return DTTM_ALIAS;
 };

--- a/superset-frontend/packages/superset-ui-core/src/query/getAxis.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/getAxis.ts
@@ -16,17 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  DTTM_ALIAS,
-  FeatureFlag,
-  getColumnLabel,
-  isFeatureEnabled,
-  QueryFormData,
-} from '@superset-ui/core';
+import { DTTM_ALIAS, getColumnLabel, QueryFormData } from '@superset-ui/core';
 
-export const isEnabledAxes = (formData: QueryFormData) =>
-  // return `true` when x_axis in formData but FeatureFlag.GENERIC_CHART_AXES is false
-  isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) || formData.x_axis;
+export const isEnabledAxes = (formData: QueryFormData) => !!formData.x_axis;
 
 export const getAxis = (formData: QueryFormData): string | undefined => {
   // The formData should be "raw form_data" -- the snake_case version of formData rather than camelCase.
@@ -34,7 +26,7 @@ export const getAxis = (formData: QueryFormData): string | undefined => {
     return undefined;
   }
 
-  if (isEnabledAxes(formData) && formData.x_axis) {
+  if (isEnabledAxes(formData)) {
     return getColumnLabel(formData.x_axis);
   }
   return DTTM_ALIAS;

--- a/superset-frontend/packages/superset-ui-core/src/query/getXAxis.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/getXAxis.ts
@@ -16,17 +16,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { DTTM_ALIAS, getColumnLabel, QueryFormData } from '@superset-ui/core';
+import {
+  DTTM_ALIAS,
+  getColumnLabel,
+  isQueryFormColumn,
+  QueryFormData,
+} from '@superset-ui/core';
 
-export const isEnabledAxes = (formData: QueryFormData) => !!formData.x_axis;
+export const isXAxisSet = (formData: QueryFormData) =>
+  isQueryFormColumn(formData.x_axis);
 
-export const getAxis = (formData: QueryFormData): string | undefined => {
+export const getXAxis = (formData: QueryFormData): string | undefined => {
   // The formData should be "raw form_data" -- the snake_case version of formData rather than camelCase.
   if (!(formData.granularity_sqla || formData.x_axis)) {
     return undefined;
   }
 
-  if (isEnabledAxes(formData)) {
+  if (isXAxisSet(formData)) {
     return getColumnLabel(formData.x_axis);
   }
   return DTTM_ALIAS;

--- a/superset-frontend/packages/superset-ui-core/src/query/index.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/index.ts
@@ -29,7 +29,7 @@ export { default as getMetricLabel } from './getMetricLabel';
 export { default as DatasourceKey } from './DatasourceKey';
 export { default as normalizeOrderBy } from './normalizeOrderBy';
 export { normalizeTimeColumn } from './normalizeTimeColumn';
-export { getAxis, isEnabledAxes } from './getAxis';
+export { getXAxis, isXAxisSet } from './getXAxis';
 
 export * from './types/AnnotationLayer';
 export * from './types/QueryFormData';

--- a/superset-frontend/packages/superset-ui-core/src/query/index.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/index.ts
@@ -29,6 +29,7 @@ export { default as getMetricLabel } from './getMetricLabel';
 export { default as DatasourceKey } from './DatasourceKey';
 export { default as normalizeOrderBy } from './normalizeOrderBy';
 export { normalizeTimeColumn } from './normalizeTimeColumn';
+export { getAxis, isEnabledAxes } from './getAxis';
 
 export * from './types/AnnotationLayer';
 export * from './types/QueryFormData';

--- a/superset-frontend/packages/superset-ui-core/src/query/normalizeTimeColumn.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/normalizeTimeColumn.ts
@@ -26,14 +26,14 @@ import {
   QueryFormData,
   QueryObject,
 } from './types';
-import { FeatureFlag, isFeatureEnabled } from '../utils';
+import { isEnabledAxes } from './getAxis';
 
 export function normalizeTimeColumn(
   formData: QueryFormData,
   queryObject: QueryObject,
 ): QueryObject {
   // The formData should be "raw form_data" -- the snake_case version of formData rather than camelCase.
-  if (!(isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) && formData.x_axis)) {
+  if (!isEnabledAxes(formData)) {
     return queryObject;
   }
 

--- a/superset-frontend/packages/superset-ui-core/src/query/normalizeTimeColumn.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/normalizeTimeColumn.ts
@@ -26,14 +26,14 @@ import {
   QueryFormData,
   QueryObject,
 } from './types';
-import { isEnabledAxes } from './getAxis';
+import { isXAxisSet } from './getXAxis';
 
 export function normalizeTimeColumn(
   formData: QueryFormData,
   queryObject: QueryObject,
 ): QueryObject {
   // The formData should be "raw form_data" -- the snake_case version of formData rather than camelCase.
-  if (!isEnabledAxes(formData)) {
+  if (!isXAxisSet(formData)) {
     return queryObject;
   }
 

--- a/superset-frontend/packages/superset-ui-core/test/query/buildQueryContext.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/buildQueryContext.test.ts
@@ -123,7 +123,7 @@ describe('buildQueryContext', () => {
       },
     ]);
   });
-  it('should call normalizeTimeColumn if GENERIC_CHART_AXES is enabled', () => {
+  it('should call normalizeTimeColumn if GENERIC_CHART_AXES is enabled and has x_axis', () => {
     // @ts-ignore
     const spy = jest.spyOn(window, 'window', 'get').mockImplementation(() => ({
       featureFlags: {
@@ -139,6 +139,7 @@ describe('buildQueryContext', () => {
       {
         datasource: '5__table',
         viz_type: 'table',
+        x_axis: 'axis',
       },
       () => [{}],
     );

--- a/superset-frontend/packages/superset-ui-core/test/query/getAxis.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/getAxis.test.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { isEnabledAxes } from '@superset-ui/core';
+import { isXAxisSet } from '@superset-ui/core';
 
 describe('GENERIC_CHART_AXES is enabled', () => {
   let windowSpy: any;
@@ -36,10 +36,10 @@ describe('GENERIC_CHART_AXES is enabled', () => {
 
   it('isEnabledAxies when FF is disabled', () => {
     expect(
-      isEnabledAxes({ datasource: '123', viz_type: 'table' }),
+      isXAxisSet({ datasource: '123', viz_type: 'table' }),
     ).not.toBeTruthy();
     expect(
-      isEnabledAxes({ datasource: '123', viz_type: 'table', x_axis: 'axis' }),
+      isXAxisSet({ datasource: '123', viz_type: 'table', x_axis: 'axis' }),
     ).toBeTruthy();
   });
 });
@@ -62,10 +62,10 @@ describe('GENERIC_CHART_AXES is disabled', () => {
 
   it('isEnabledAxies when FF is disabled', () => {
     expect(
-      isEnabledAxes({ datasource: '123', viz_type: 'table' }),
+      isXAxisSet({ datasource: '123', viz_type: 'table' }),
     ).not.toBeTruthy();
     expect(
-      isEnabledAxes({ datasource: '123', viz_type: 'table', x_axis: 'axis' }),
+      isXAxisSet({ datasource: '123', viz_type: 'table', x_axis: 'axis' }),
     ).toBeTruthy();
   });
 });

--- a/superset-frontend/packages/superset-ui-core/test/query/getAxis.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/getAxis.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { isEnabledAxes } from '@superset-ui/core';
+
+describe('GENERIC_CHART_AXES is enabled', () => {
+  let windowSpy: any;
+
+  beforeAll(() => {
+    // @ts-ignore
+    windowSpy = jest.spyOn(window, 'window', 'get').mockImplementation(() => ({
+      featureFlags: {
+        GENERIC_CHART_AXES: true,
+      },
+    }));
+  });
+
+  afterAll(() => {
+    windowSpy.mockRestore();
+  });
+
+  it('isEnabledAxies when FF is disabled', () => {
+    expect(
+      isEnabledAxes({ datasource: '123', viz_type: 'table' }),
+    ).not.toBeTruthy();
+    expect(
+      isEnabledAxes({ datasource: '123', viz_type: 'table', x_axis: 'axis' }),
+    ).toBeTruthy();
+  });
+});
+
+describe('GENERIC_CHART_AXES is disabled', () => {
+  let windowSpy: any;
+
+  beforeAll(() => {
+    // @ts-ignore
+    windowSpy = jest.spyOn(window, 'window', 'get').mockImplementation(() => ({
+      featureFlags: {
+        GENERIC_CHART_AXES: false,
+      },
+    }));
+  });
+
+  afterAll(() => {
+    windowSpy.mockRestore();
+  });
+
+  it('isEnabledAxies when FF is disabled', () => {
+    expect(
+      isEnabledAxes({ datasource: '123', viz_type: 'table' }),
+    ).not.toBeTruthy();
+    expect(
+      isEnabledAxes({ datasource: '123', viz_type: 'table', x_axis: 'axis' }),
+    ).toBeTruthy();
+  });
+});

--- a/superset-frontend/packages/superset-ui-core/test/query/normalizeTimeColumn.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/normalizeTimeColumn.test.ts
@@ -110,7 +110,7 @@ describe('GENERIC_CHART_AXES is disabled', () => {
   });
 });
 
-describe('GENERIC_CHART_AXES was enabled', () => {
+describe('GENERIC_CHART_AXES is enabled', () => {
   let windowSpy: any;
 
   beforeAll(() => {

--- a/superset-frontend/packages/superset-ui-core/test/query/normalizeTimeColumn.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/normalizeTimeColumn.test.ts
@@ -22,7 +22,7 @@ import {
   SqlaFormData,
 } from '@superset-ui/core';
 
-describe('disabled GENERIC_CHART_AXES', () => {
+describe('GENERIC_CHART_AXES is disabled', () => {
   let windowSpy: any;
 
   beforeAll(() => {
@@ -47,7 +47,6 @@ describe('disabled GENERIC_CHART_AXES', () => {
       time_range: '1 year ago : 2013',
       columns: ['col1'],
       metrics: ['count(*)'],
-      x_axis: 'time_column',
     };
     const query: QueryObject = {
       datasource: '5__table',
@@ -64,9 +63,54 @@ describe('disabled GENERIC_CHART_AXES', () => {
     };
     expect(normalizeTimeColumn(formData, query)).toEqual(query);
   });
+
+  it('should return converted QueryObject even though disabled GENERIC_CHART_AXES (x_axis in formData)', () => {
+    const formData: SqlaFormData = {
+      datasource: '5__table',
+      viz_type: 'table',
+      granularity: 'time_column',
+      time_grain_sqla: 'P1Y',
+      time_range: '1 year ago : 2013',
+      columns: ['col1'],
+      metrics: ['count(*)'],
+      x_axis: 'time_column',
+    };
+    const query: QueryObject = {
+      datasource: '5__table',
+      viz_type: 'table',
+      granularity: 'time_column',
+      extras: {
+        time_grain_sqla: 'P1Y',
+      },
+      time_range: '1 year ago : 2013',
+      orderby: [['count(*)', true]],
+      columns: ['time_column', 'col1'],
+      metrics: ['count(*)'],
+      is_timeseries: true,
+    };
+    expect(normalizeTimeColumn(formData, query)).toEqual({
+      datasource: '5__table',
+      viz_type: 'table',
+      granularity: 'time_column',
+      extras: {},
+      time_range: '1 year ago : 2013',
+      orderby: [['count(*)', true]],
+      columns: [
+        {
+          timeGrain: 'P1Y',
+          columnType: 'BASE_AXIS',
+          sqlExpression: 'time_column',
+          label: 'time_column',
+          expressionType: 'SQL',
+        },
+        'col1',
+      ],
+      metrics: ['count(*)'],
+    });
+  });
 });
 
-describe('enabled GENERIC_CHART_AXES', () => {
+describe('GENERIC_CHART_AXES was enabled', () => {
   let windowSpy: any;
 
   beforeAll(() => {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/buildQuery.ts
@@ -18,12 +18,13 @@
  */
 import {
   buildQueryContext,
-  DTTM_ALIAS,
   ensureIsArray,
   normalizeOrderBy,
   PostProcessingPivot,
   QueryFormData,
   QueryObject,
+  getAxis,
+  isEnabledAxes,
 } from '@superset-ui/core';
 import {
   pivotOperator,
@@ -41,11 +42,8 @@ import {
 } from '../utils/formDataSuffix';
 
 export default function buildQuery(formData: QueryFormData) {
-  const { x_axis: index } = formData;
-  const is_timeseries = index === DTTM_ALIAS || !index;
   const baseFormData = {
     ...formData,
-    is_timeseries,
   };
 
   const formData1 = removeFormDataSuffix(baseFormData, '_b');
@@ -55,9 +53,12 @@ export default function buildQuery(formData: QueryFormData) {
     buildQueryContext(fd, baseQueryObject => {
       const queryObject = {
         ...baseQueryObject,
-        columns: [...ensureIsArray(index), ...ensureIsArray(fd.groupby)],
+        columns: [
+          ...(isEnabledAxes(formData) ? ensureIsArray(getAxis(formData)) : []),
+          ...ensureIsArray(fd.groupby),
+        ],
         series_columns: fd.groupby,
-        is_timeseries,
+        ...(isEnabledAxes(formData) ? {} : { is_timeseries: true }),
       };
 
       const pivotOperatorInRuntime: PostProcessingPivot = isTimeComparison(
@@ -68,8 +69,6 @@ export default function buildQuery(formData: QueryFormData) {
         : pivotOperator(fd, {
             ...queryObject,
             columns: fd.groupby,
-            index,
-            is_timeseries,
           });
 
       const tmpQueryObject = {
@@ -83,7 +82,6 @@ export default function buildQuery(formData: QueryFormData) {
           renameOperator(fd, {
             ...queryObject,
             columns: fd.groupby,
-            is_timeseries,
           }),
           flattenOperator(fd, queryObject),
         ],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/buildQuery.ts
@@ -23,8 +23,8 @@ import {
   PostProcessingPivot,
   QueryFormData,
   QueryObject,
-  getAxis,
-  isEnabledAxes,
+  getXAxis,
+  isXAxisSet,
 } from '@superset-ui/core';
 import {
   pivotOperator,
@@ -54,11 +54,11 @@ export default function buildQuery(formData: QueryFormData) {
       const queryObject = {
         ...baseQueryObject,
         columns: [
-          ...(isEnabledAxes(formData) ? ensureIsArray(getAxis(formData)) : []),
+          ...(isXAxisSet(formData) ? ensureIsArray(getXAxis(formData)) : []),
           ...ensureIsArray(fd.groupby),
         ],
         series_columns: fd.groupby,
-        ...(isEnabledAxes(formData) ? {} : { is_timeseries: true }),
+        ...(isXAxisSet(formData) ? {} : { is_timeseries: true }),
       };
 
       const pivotOperatorInRuntime: PostProcessingPivot = isTimeComparison(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -20,16 +20,16 @@
 import {
   AnnotationLayer,
   CategoricalColorNamespace,
-  DTTM_ALIAS,
   GenericDataType,
-  getColumnLabel,
   getNumberFormatter,
   isEventAnnotationLayer,
   isFormulaAnnotationLayer,
   isIntervalAnnotationLayer,
   isTimeseriesAnnotationLayer,
+  QueryFormData,
   TimeseriesChartDataResponseResult,
   TimeseriesDataRecord,
+  getAxis,
 } from '@superset-ui/core';
 import { EChartsCoreOption, SeriesOption } from 'echarts';
 import {
@@ -152,8 +152,7 @@ export default function transformProps(
 
   const colorScale = CategoricalColorNamespace.getScale(colorScheme as string);
 
-  const xAxisCol =
-    verboseMap[xAxisOrig] || getColumnLabel(xAxisOrig || DTTM_ALIAS);
+  const xAxisCol = getAxis(chartProps.rawFormData as QueryFormData);
 
   const rebasedDataA = rebaseForecastDatum(data1, verboseMap);
   const rawSeriesA = extractSeries(rebasedDataA, {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -29,7 +29,7 @@ import {
   QueryFormData,
   TimeseriesChartDataResponseResult,
   TimeseriesDataRecord,
-  getAxis,
+  getXAxis,
 } from '@superset-ui/core';
 import { EChartsCoreOption, SeriesOption } from 'echarts';
 import {
@@ -152,7 +152,7 @@ export default function transformProps(
 
   const colorScale = CategoricalColorNamespace.getScale(colorScheme as string);
 
-  const xAxisCol = getAxis(chartProps.rawFormData as QueryFormData) as string;
+  const xAxisCol = getXAxis(chartProps.rawFormData as QueryFormData) as string;
 
   const rebasedDataA = rebaseForecastDatum(data1, verboseMap);
   const rawSeriesA = extractSeries(rebasedDataA, {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -152,7 +152,7 @@ export default function transformProps(
 
   const colorScale = CategoricalColorNamespace.getScale(colorScheme as string);
 
-  const xAxisCol = getAxis(chartProps.rawFormData as QueryFormData);
+  const xAxisCol = getAxis(chartProps.rawFormData as QueryFormData) as string;
 
   const rebasedDataA = rebaseForecastDatum(data1, verboseMap);
   const rawSeriesA = extractSeries(rebasedDataA, {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/buildQuery.ts
@@ -18,11 +18,12 @@
  */
 import {
   buildQueryContext,
-  DTTM_ALIAS,
   ensureIsArray,
   normalizeOrderBy,
   PostProcessingPivot,
   QueryFormData,
+  getAxis,
+  isEnabledAxes,
 } from '@superset-ui/core';
 import {
   rollingWindowOperator,
@@ -38,8 +39,7 @@ import {
 } from '@superset-ui/chart-controls';
 
 export default function buildQuery(formData: QueryFormData) {
-  const { x_axis, groupby } = formData;
-  const is_timeseries = x_axis === DTTM_ALIAS || !x_axis;
+  const { groupby } = formData;
   return buildQueryContext(formData, baseQueryObject => {
     /* the `pivotOperatorInRuntime` determines how to pivot the dataframe returned from the raw query.
        1. If it's a time compared query, there will return a pivoted dataframe that append time compared metrics. for instance:
@@ -66,18 +66,17 @@ export default function buildQuery(formData: QueryFormData) {
       baseQueryObject,
     )
       ? timeComparePivotOperator(formData, baseQueryObject)
-      : pivotOperator(formData, {
-          ...baseQueryObject,
-          index: x_axis,
-          is_timeseries,
-        });
+      : pivotOperator(formData, baseQueryObject);
 
     return [
       {
         ...baseQueryObject,
-        columns: [...ensureIsArray(x_axis), ...ensureIsArray(groupby)],
+        columns: [
+          ...(isEnabledAxes(formData) ? ensureIsArray(getAxis(formData)) : []),
+          ...ensureIsArray(groupby),
+        ],
         series_columns: groupby,
-        is_timeseries,
+        ...(isEnabledAxes(formData) ? {} : { is_timeseries: true }),
         // todo: move `normalizeOrderBy to extractQueryFields`
         orderby: normalizeOrderBy(baseQueryObject).orderby,
         time_offsets: isTimeComparison(formData, baseQueryObject)
@@ -92,10 +91,7 @@ export default function buildQuery(formData: QueryFormData) {
           rollingWindowOperator(formData, baseQueryObject),
           timeCompareOperator(formData, baseQueryObject),
           resampleOperator(formData, baseQueryObject),
-          renameOperator(formData, {
-            ...baseQueryObject,
-            is_timeseries,
-          }),
+          renameOperator(formData, baseQueryObject),
           contributionOperator(formData, baseQueryObject),
           flattenOperator(formData, baseQueryObject),
           // todo: move prophet before flatten

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/buildQuery.ts
@@ -22,8 +22,8 @@ import {
   normalizeOrderBy,
   PostProcessingPivot,
   QueryFormData,
-  getAxis,
-  isEnabledAxes,
+  getXAxis,
+  isXAxisSet,
 } from '@superset-ui/core';
 import {
   rollingWindowOperator,
@@ -72,11 +72,11 @@ export default function buildQuery(formData: QueryFormData) {
       {
         ...baseQueryObject,
         columns: [
-          ...(isEnabledAxes(formData) ? ensureIsArray(getAxis(formData)) : []),
+          ...(isXAxisSet(formData) ? ensureIsArray(getXAxis(formData)) : []),
           ...ensureIsArray(groupby),
         ],
         series_columns: groupby,
-        ...(isEnabledAxes(formData) ? {} : { is_timeseries: true }),
+        ...(isXAxisSet(formData) ? {} : { is_timeseries: true }),
         // todo: move `normalizeOrderBy to extractQueryFields`
         orderby: normalizeOrderBy(baseQueryObject).orderby,
         time_offsets: isTimeComparison(formData, baseQueryObject)

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -28,7 +28,7 @@ import {
   isTimeseriesAnnotationLayer,
   TimeseriesChartDataResponseResult,
   t,
-  getAxis,
+  getXAxis,
 } from '@superset-ui/core';
 import { isDerivedSeries } from '@superset-ui/chart-controls';
 import { EChartsCoreOption, SeriesOption } from 'echarts';
@@ -148,7 +148,7 @@ export default function transformProps(
 
   const colorScale = CategoricalColorNamespace.getScale(colorScheme as string);
   const rebasedData = rebaseForecastDatum(data, verboseMap);
-  const xAxisCol = getAxis(chartProps.rawFormData) as string;
+  const xAxisCol = getXAxis(chartProps.rawFormData) as string;
   const isHorizontal = orientation === OrientationType.horizontal;
   const { totalStackedValues, thresholdValues } = extractDataTotalValues(
     rebasedData,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -28,9 +28,9 @@ import {
   isTimeseriesAnnotationLayer,
   TimeseriesChartDataResponseResult,
   t,
-  DTTM_ALIAS,
+  getAxis,
 } from '@superset-ui/core';
-import { getAxis, isDerivedSeries } from '@superset-ui/chart-controls';
+import { isDerivedSeries } from '@superset-ui/chart-controls';
 import { EChartsCoreOption, SeriesOption } from 'echarts';
 import { ZRLineType } from 'echarts/types/src/util/types';
 import {
@@ -148,9 +148,7 @@ export default function transformProps(
 
   const colorScale = CategoricalColorNamespace.getScale(colorScheme as string);
   const rebasedData = rebaseForecastDatum(data, verboseMap);
-  // todo: if the both granularity_sqla and x_axis are `null`, should throw an error
-  const xAxisCol =
-    verboseMap[xAxisOrig] || getAxis(chartProps.rawFormData) || DTTM_ALIAS;
+  const xAxisCol = getAxis(chartProps.rawFormData);
   const isHorizontal = orientation === OrientationType.horizontal;
   const { totalStackedValues, thresholdValues } = extractDataTotalValues(
     rebasedData,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -148,7 +148,7 @@ export default function transformProps(
 
   const colorScale = CategoricalColorNamespace.getScale(colorScheme as string);
   const rebasedData = rebaseForecastDatum(data, verboseMap);
-  const xAxisCol = getAxis(chartProps.rawFormData);
+  const xAxisCol = getAxis(chartProps.rawFormData) as string;
   const isHorizontal = orientation === OrientationType.horizontal;
   const { totalStackedValues, thresholdValues } = extractDataTotalValues(
     rebasedData,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/buildQuery.test.ts
@@ -267,7 +267,22 @@ test('should compile AA in query B', () => {
   });
 });
 
-test('should compile query objects with x-axis', () => {
+test('should convert a queryObject with x-axis although FF is disabled', () => {
+  let windowSpy: any;
+
+  beforeAll(() => {
+    // @ts-ignore
+    windowSpy = jest.spyOn(window, 'window', 'get').mockImplementation(() => ({
+      featureFlags: {
+        GENERIC_CHART_AXES: false,
+      },
+    }));
+  });
+
+  afterAll(() => {
+    windowSpy.mockRestore();
+  });
+
   const { queries } = buildQuery({
     ...formDataMixedChart,
     x_axis: 'my_index',
@@ -280,11 +295,19 @@ test('should compile query objects with x-axis', () => {
     filters: [],
     extras: {
       having: '',
-      time_grain_sqla: 'P1W',
       where: "(foo in ('a', 'b'))",
     },
     applied_time_extras: {},
-    columns: ['my_index', 'foo'],
+    columns: [
+      {
+        columnType: 'BASE_AXIS',
+        expressionType: 'SQL',
+        label: 'my_index',
+        sqlExpression: 'my_index',
+        timeGrain: 'P1W',
+      },
+      'foo',
+    ],
     metrics: ['sum(sales)'],
     annotation_layers: [],
     row_limit: 10,
@@ -296,7 +319,6 @@ test('should compile query objects with x-axis', () => {
     url_params: {},
     custom_params: {},
     custom_form_data: {},
-    is_timeseries: false,
     time_offsets: [],
     post_processing: [
       {
@@ -332,8 +354,16 @@ test('should compile query objects with x-axis', () => {
   // check the main props on the second query
   expect(queries[1]).toEqual(
     expect.objectContaining({
-      is_timeseries: false,
-      columns: ['my_index'],
+      columns: [
+        {
+          columnType: 'BASE_AXIS',
+          expressionType: 'SQL',
+          label: 'my_index',
+          sqlExpression: 'my_index',
+          timeGrain: 'P1W',
+        },
+      ],
+      granularity: 'ds',
       series_columns: [],
       metrics: ['count'],
       post_processing: [
@@ -348,6 +378,93 @@ test('should compile query objects with x-axis', () => {
             columns: [],
             drop_missing_columns: false,
             index: ['my_index'],
+          },
+        },
+        {
+          operation: 'flatten',
+        },
+      ],
+    }),
+  );
+});
+
+test("shouldn't convert a queryObject with axis although FF is enabled", () => {
+  let windowSpy: any;
+
+  beforeAll(() => {
+    // @ts-ignore
+    windowSpy = jest.spyOn(window, 'window', 'get').mockImplementation(() => ({
+      featureFlags: {
+        GENERIC_CHART_AXES: true,
+      },
+    }));
+  });
+
+  afterAll(() => {
+    windowSpy.mockRestore();
+  });
+
+  const { queries } = buildQuery(formDataMixedChart);
+  expect(queries[0]).toEqual(
+    expect.objectContaining({
+      granularity: 'ds',
+      columns: ['foo'],
+      series_columns: ['foo'],
+      metrics: ['sum(sales)'],
+      is_timeseries: true,
+      extras: {
+        time_grain_sqla: 'P1W',
+        having: '',
+        where: "(foo in ('a', 'b'))",
+      },
+      post_processing: [
+        {
+          operation: 'pivot',
+          options: {
+            aggregates: {
+              'sum(sales)': {
+                operator: 'mean',
+              },
+            },
+            columns: ['foo'],
+            drop_missing_columns: false,
+            index: ['__timestamp'],
+          },
+        },
+        {
+          operation: 'rename',
+          options: { columns: { 'sum(sales)': null }, inplace: true, level: 0 },
+        },
+        {
+          operation: 'flatten',
+        },
+      ],
+    }),
+  );
+  expect(queries[1]).toEqual(
+    expect.objectContaining({
+      granularity: 'ds',
+      columns: [],
+      series_columns: [],
+      metrics: ['count'],
+      is_timeseries: true,
+      extras: {
+        time_grain_sqla: 'P1W',
+        having: '',
+        where: "(name in ('c', 'd'))",
+      },
+      post_processing: [
+        {
+          operation: 'pivot',
+          options: {
+            aggregates: {
+              count: {
+                operator: 'mean',
+              },
+            },
+            columns: [],
+            drop_missing_columns: false,
+            index: ['__timestamp'],
           },
         },
         {

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/buildQuery.test.ts
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { SqlaFormData } from '@superset-ui/core';
 import buildQuery from '../../src/Timeseries/buildQuery';
 
 describe('Timeseries buildQuery', () => {
@@ -57,5 +58,183 @@ describe('Timeseries buildQuery', () => {
     expect(query.timeseries_limit_metric).toEqual('bar');
     expect(query.order_desc).toEqual(true);
     expect(query.orderby).toEqual([['foo', true]]);
+  });
+});
+
+describe('GENERIC_CHART_AXES is enabled', () => {
+  let windowSpy: any;
+
+  beforeAll(() => {
+    // @ts-ignore
+    windowSpy = jest.spyOn(window, 'window', 'get').mockImplementation(() => ({
+      featureFlags: {
+        GENERIC_CHART_AXES: true,
+      },
+    }));
+  });
+
+  afterAll(() => {
+    windowSpy.mockRestore();
+  });
+
+  const formData: SqlaFormData = {
+    datasource: '5__table',
+    viz_type: 'table',
+    granularity_sqla: 'time_column',
+    time_grain_sqla: 'P1Y',
+    time_range: '1 year ago : 2013',
+    groupby: ['col1'],
+    metrics: ['count(*)'],
+  };
+
+  it("shouldn't convert queryObject", () => {
+    const { queries } = buildQuery(formData);
+    expect(queries[0]).toEqual(
+      expect.objectContaining({
+        granularity: 'time_column',
+        time_range: '1 year ago : 2013',
+        extras: { time_grain_sqla: 'P1Y', having: '', where: '' },
+        columns: ['col1'],
+        series_columns: ['col1'],
+        metrics: ['count(*)'],
+        is_timeseries: true,
+        post_processing: [
+          {
+            operation: 'pivot',
+            options: {
+              aggregates: { 'count(*)': { operator: 'mean' } },
+              columns: ['col1'],
+              drop_missing_columns: true,
+              index: ['__timestamp'],
+            },
+          },
+          { operation: 'flatten' },
+        ],
+      }),
+    );
+  });
+
+  it('should convert queryObject', () => {
+    const { queries } = buildQuery({ ...formData, x_axis: 'time_column' });
+    expect(queries[0]).toEqual(
+      expect.objectContaining({
+        granularity: 'time_column',
+        time_range: '1 year ago : 2013',
+        extras: { having: '', where: '' },
+        columns: [
+          {
+            columnType: 'BASE_AXIS',
+            expressionType: 'SQL',
+            label: 'time_column',
+            sqlExpression: 'time_column',
+            timeGrain: 'P1Y',
+          },
+          'col1',
+        ],
+        series_columns: ['col1'],
+        metrics: ['count(*)'],
+        post_processing: [
+          {
+            operation: 'pivot',
+            options: {
+              aggregates: { 'count(*)': { operator: 'mean' } },
+              columns: ['col1'],
+              drop_missing_columns: true,
+              index: ['time_column'],
+            },
+          },
+          { operation: 'flatten' },
+        ],
+      }),
+    );
+  });
+});
+
+describe('GENERIC_CHART_AXES is disabled', () => {
+  let windowSpy: any;
+
+  beforeAll(() => {
+    // @ts-ignore
+    windowSpy = jest.spyOn(window, 'window', 'get').mockImplementation(() => ({
+      featureFlags: {
+        GENERIC_CHART_AXES: false,
+      },
+    }));
+  });
+
+  afterAll(() => {
+    windowSpy.mockRestore();
+  });
+
+  const formData: SqlaFormData = {
+    datasource: '5__table',
+    viz_type: 'table',
+    granularity_sqla: 'time_column',
+    time_grain_sqla: 'P1Y',
+    time_range: '1 year ago : 2013',
+    groupby: ['col1'],
+    metrics: ['count(*)'],
+  };
+
+  it("shouldn't convert queryObject", () => {
+    const { queries } = buildQuery(formData);
+    expect(queries[0]).toEqual(
+      expect.objectContaining({
+        granularity: 'time_column',
+        time_range: '1 year ago : 2013',
+        extras: { time_grain_sqla: 'P1Y', having: '', where: '' },
+        columns: ['col1'],
+        series_columns: ['col1'],
+        metrics: ['count(*)'],
+        is_timeseries: true,
+        post_processing: [
+          {
+            operation: 'pivot',
+            options: {
+              aggregates: { 'count(*)': { operator: 'mean' } },
+              columns: ['col1'],
+              drop_missing_columns: true,
+              index: ['__timestamp'],
+            },
+          },
+          { operation: 'flatten' },
+        ],
+      }),
+    );
+  });
+
+  it('should convert queryObject', () => {
+    const { queries } = buildQuery({ ...formData, x_axis: 'time_column' });
+    expect(queries[0]).toEqual(
+      expect.objectContaining({
+        granularity: 'time_column',
+        time_range: '1 year ago : 2013',
+        extras: { having: '', where: '' },
+        columns: [
+          {
+            columnType: 'BASE_AXIS',
+            expressionType: 'SQL',
+            label: 'time_column',
+            sqlExpression: 'time_column',
+            timeGrain: 'P1Y',
+          },
+          'col1',
+        ],
+        series_columns: ['col1'],
+        metrics: ['count(*)'],
+        post_processing: [
+          {
+            operation: 'pivot',
+            options: {
+              aggregates: { 'count(*)': { operator: 'mean' } },
+              columns: ['col1'],
+              drop_missing_columns: true,
+              index: ['time_column'],
+            },
+          },
+          { operation: 'flatten' },
+        ],
+      }),
+    );
   });
 });


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR intends to generate a consistent QueryObject whether GenericAxis FF is enabled or disabled. e.g.: the charts wouldn't change on the Dashboard although Axis FF from `enabled` to `disabled` and vice versa.

1. Make sure that the charts on the Dashboards are consistent whether FF is enabled or disabled, so the FF GenericAxis should be safety enabled by default (will do in separated PR).
2. Add unit test in Echart timeseries charts.
3. Add unit test in Echart MixedTimeseries charts.
4. Move `getXAxis` and `isXAxisSet` into `superset-ui/core`

There are 2 kinds of `queryObject` patterns after this PR:

#### The QueryObjec will be like below when the `x_axis` is not in formData whether `GenericAxis` is enabled or disabled
```
{
        granularity: 'time_column',
        extras: { time_grain_sqla: 'P1Y', having: '', where: '' },
        is_timeseries: true,
        post_processing: [
          {
            operation: 'pivot',
            options: {
              aggregates: { 'count(*)': { operator: 'mean' } },
              columns: ['col1'],
              drop_missing_columns: true,
              index: ['__timestamp'],
            },
          },
          { operation: 'flatten' },
        ],
      }
     ....
     ....
}
```

#### The QueryObjec will be like below when the `x_axis` is in formData whether `GenericAxis` is enabled or disabled.
The `granularity`(axis) and `time_grain` will be converted to `BASE_AXIS`, then remove `time_grain_sqla` and `is_timeseries`

```
{
        extras: { having: '', where: '' },
        columns: [
          {
            columnType: 'BASE_AXIS',
            expressionType: 'SQL',
            label: 'time_column',
            sqlExpression: 'time_column',
            timeGrain: 'P1Y',
          },
          'col1',
        ],
        post_processing: [
          {
            operation: 'pivot',
            options: {
              aggregates: { 'count(*)': { operator: 'mean' } },
              columns: ['col1'],
              drop_missing_columns: true,
              index: ['time_column'],
            },
          },
          { operation: 'flatten' },
        ],
      }
     ....
     ....
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
#### Test Case 1
1. Turn off GenericAxis
2. Make an Echart time-series chart and a Mixed time-series, save to a new Dashboard.
3. Turn on GenericAxis
4. Refresh Dashboard
5. Charts should be as before

#### Test Case 2
1. Turn on GenericAxis
2. Make an Echart time-series chart and a Mixed time-series, save to a new Dashboard.
3. Turn off GenericAxis
4. Refresh Dashboard
5. Charts should be as before



### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces a new feature or API
- [ ] Removes existing feature or API
