### PR TITLE
fix: Reset dataset name after saving a new dataset in SQL Lab

### DIFF
--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { FunctionComponent, useCallback, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Radio } from 'src/components/Radio';
 import { RadioChangeEvent, AsyncSelect } from 'src/components';
 import { Input } from 'src/components/Input';
@@ -140,8 +140,7 @@ const updateDataset = async (
 
 const UNTITLED = t('Untitled Dataset');
 
-// eslint-disable-next-line no-empty-pattern
-export const SaveDatasetModal: FunctionComponent<SaveDatasetModalProps> = ({
+export const SaveDatasetModal = ({
   visible,
   onHide,
   buttonTextOnSave,
@@ -150,7 +149,7 @@ export const SaveDatasetModal: FunctionComponent<SaveDatasetModalProps> = ({
   datasource,
   openWindow = true,
   formData = {},
-}) => {
+}: SaveDatasetModalProps) => {
   const defaultVizType = useSelector<SqlLabRootState, string>(
     state => state.common?.conf?.DEFAULT_VIZ_TYPE || 'table',
   );
@@ -388,7 +387,7 @@ export const SaveDatasetModal: FunctionComponent<SaveDatasetModalProps> = ({
                 {t('Save as new')}
                 <Input
                   className="sdm-input"
-                  defaultValue={datasetName}
+                  value={datasetName}
                   onChange={handleDatasetNameChange}
                   disabled={newOrOverwrite !== 1}
                 />


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Fix #21271 issue when we create a dataset and provide some name and then want to do it again with the same name. In second dataset creation we got Untitled Query 7 08/31/2022 17:58:02 name but input has qwe1 name

### BEFORE SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/29536522/191249384-0f661b49-f744-49b3-8449-5f55e9181f68.mov

### AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/29536522/191249892-583862d2-f641-44c8-8b9a-88b690643a86.mov



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
