### PR TITLE
feat(rightmenu): Add Datasets to + Menu and Hide Databases when one has been connected

### DIFF
--- a/superset-frontend/src/views/CRUD/data/dataset/AddDatasetModal.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDatasetModal.tsx
@@ -17,7 +17,6 @@
  * under the License.
  */
 import React, { FunctionComponent, useState, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
 import { styled, t } from '@superset-ui/core';
 import { useSingleViewResource } from 'src/views/CRUD/hooks';
 import Modal from 'src/components/Modal';
@@ -29,6 +28,7 @@ import {
   LocalStorageKeys,
   setItem,
 } from 'src/utils/localStorageHelpers';
+import { isEmpty } from 'lodash';
 
 type DatasetAddObject = {
   id: number;
@@ -42,6 +42,7 @@ interface DatasetModalProps {
   onDatasetAdd?: (dataset: DatasetAddObject) => void;
   onHide: () => void;
   show: boolean;
+  history?: any; // So we can render the modal when not using SPA
 }
 
 const TableSelectorContainer = styled.div`
@@ -54,8 +55,8 @@ const DatasetModal: FunctionComponent<DatasetModalProps> = ({
   onDatasetAdd,
   onHide,
   show,
+  history,
 }) => {
-  const history = useHistory();
   const [currentDatabase, setCurrentDatabase] = useState<
     DatabaseObject | undefined
   >();
@@ -128,8 +129,16 @@ const DatasetModal: FunctionComponent<DatasetModalProps> = ({
       if (onDatasetAdd) {
         onDatasetAdd({ id: response.id, ...response });
       }
-      history.push(`/chart/add?dataset=${currentTableName}`);
-      cleanup();
+      // We need to be able to work with no SPA routes opening the modal
+      // So useHistory wont be available always thus we check for it
+      if (!isEmpty(history)) {
+        history?.push(`/chart/add?dataset=${currentTableName}`);
+        cleanup();
+      } else {
+        window.location.href = `/chart/add?dataset=${currentTableName}`;
+        cleanup();
+        onHide();
+      }
     });
   };
 

--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
@@ -725,6 +725,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
         show={datasetAddModalOpen}
         onHide={closeDatasetAddModal}
         onDatasetAdd={refreshData}
+        history={history}
       />
       {datasetCurrentlyDeleting && (
         <DeleteModal

--- a/superset-frontend/src/views/components/RightMenu.test.tsx
+++ b/superset-frontend/src/views/components/RightMenu.test.tsx
@@ -18,9 +18,12 @@
  */
 import React from 'react';
 import * as reactRedux from 'react-redux';
+import { Provider } from 'react-redux';
 import fetchMock from 'fetch-mock';
 import waitForComponentToPaint from 'spec/helpers/waitForComponentToPaint';
 import { styledMount as mount } from 'spec/helpers/theming';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
 import RightMenu from './RightMenu';
 import { RightMenuProps } from './types';
 
@@ -28,6 +31,14 @@ jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
   useSelector: jest.fn(),
 }));
+
+jest.mock('src/views/CRUD/data/database/DatabaseModal', () => () => <span />);
+jest.mock('src/views/CRUD/data/dataset/AddDatasetModal.tsx', () => () => (
+  <span />
+));
+
+const mockStore = configureStore([thunk]);
+const store = mockStore({});
 
 const createProps = (): RightMenuProps => ({
   align: 'flex-end',
@@ -82,14 +93,7 @@ const createProps = (): RightMenuProps => ({
   },
 });
 
-const useSelectorMock = jest.spyOn(reactRedux, 'useSelector');
-const useStateMock = jest.spyOn(React, 'useState');
-
-let setShowModal: any;
-let setEngine: any;
-let setAllowUploads: any;
-
-const mockNonGSheetsDBs = [...new Array(2)].map((_, i) => ({
+const mockNonExamplesDB = [...new Array(2)].map((_, i) => ({
   changed_by: {
     first_name: `user`,
     last_name: `${i}`,
@@ -103,29 +107,16 @@ const mockNonGSheetsDBs = [...new Array(2)].map((_, i) => ({
   changed_on_delta_humanized: `${i} day(s) ago`,
   changed_on: new Date().toISOString,
   id: i,
-  engine_information: {
-    supports_file_upload: true,
-  },
 }));
 
-const mockGsheetsDbs = [...new Array(2)].map((_, i) => ({
-  changed_by: {
-    first_name: `user`,
-    last_name: `${i}`,
-  },
-  database_name: `db ${i}`,
-  backend: 'gsheets',
-  allow_run_async: true,
-  allow_dml: false,
-  allow_file_upload: true,
-  expose_in_sqllab: false,
-  changed_on_delta_humanized: `${i} day(s) ago`,
-  changed_on: new Date().toISOString,
-  id: i,
-  engine_information: {
-    supports_file_upload: false,
-  },
-}));
+const useSelectorMock = jest.spyOn(reactRedux, 'useSelector');
+const useStateMock = jest.spyOn(React, 'useState');
+
+let setShowDatabaseModal: any;
+let setShowDatasetModal: any;
+let setEngine: any;
+let setAllowUploads: any;
+let setNonExamplesDBConnected: any;
 
 describe('RightMenu', () => {
   const mockedProps = createProps();
@@ -135,7 +126,11 @@ describe('RightMenu', () => {
     useStateMock.mockReset();
     fetchMock.get(
       'glob:*api/v1/database/?q=(filters:!((col:allow_file_upload,opr:upload_is_enabled,value:!t)))',
-      { result: [], database_count: 0 },
+      { result: [], count: 0 },
+    );
+    fetchMock.get(
+      'glob:*api/v1/database/?q=(filters:!((col:database_name,opr:neq,value:examples)))',
+      { result: [], count: 0 },
     );
     // By default we get file extensions to be uploaded
     useSelectorMock.mockReturnValue({
@@ -144,23 +139,73 @@ describe('RightMenu', () => {
       COLUMNAR_EXTENSIONS: ['parquet', 'zip'],
       ALLOWED_EXTENSIONS: ['parquet', 'zip', 'xls', 'xlsx', 'csv'],
     });
-    setShowModal = jest.fn();
+    setShowDatabaseModal = jest.fn();
+    setShowDatasetModal = jest.fn();
     setEngine = jest.fn();
     setAllowUploads = jest.fn();
-    const mockSetStateModal: any = (x: any) => [x, setShowModal];
+    setNonExamplesDBConnected = jest.fn();
+    const mockSetStateDatabaseModal: any = (x: any) => [
+      x,
+      setShowDatabaseModal,
+    ];
+    const mockSetStateDatasetModal: any = (x: any) => [x, setShowDatasetModal];
     const mockSetStateEngine: any = (x: any) => [x, setEngine];
     const mockSetStateAllow: any = (x: any) => [x, setAllowUploads];
-    useStateMock.mockImplementationOnce(mockSetStateModal);
+    const mockSetNonExamplesDBConnected: any = (x: any) => [
+      x,
+      setNonExamplesDBConnected,
+    ];
+    useStateMock.mockImplementationOnce(mockSetStateDatabaseModal);
+    useStateMock.mockImplementationOnce(mockSetStateDatasetModal);
     useStateMock.mockImplementationOnce(mockSetStateEngine);
     useStateMock.mockImplementationOnce(mockSetStateAllow);
+    useStateMock.mockImplementationOnce(mockSetNonExamplesDBConnected);
   });
   afterEach(fetchMock.restore);
   it('renders', async () => {
-    const wrapper = mount(<RightMenu {...mockedProps} />);
+    const wrapper = mount(
+      <Provider store={store}>
+        <RightMenu {...mockedProps} />
+      </Provider>,
+    );
     await waitForComponentToPaint(wrapper);
     expect(wrapper.find(RightMenu)).toExist();
   });
-  it('If user has permission to upload files we query the existing DBs that has allow_file_upload as True', async () => {
+  it('If user has permission to upload files AND connect DBs we query existing DBs that has allow_file_upload as True and DBs that are not examples', async () => {
+    useSelectorMock.mockReturnValueOnce({
+      createdOn: '2021-04-27T18:12:38.952304',
+      email: 'admin',
+      firstName: 'admin',
+      isActive: true,
+      lastName: 'admin',
+      permissions: {},
+      roles: {
+        Admin: [
+          ['can_this_form_get', 'CsvToDatabaseView'], // So we can upload CSV
+          ['can_write', 'Database'], // So we can write DBs
+        ],
+      },
+      userId: 1,
+      username: 'admin',
+    });
+    // Second call we get the dashboardId
+    useSelectorMock.mockReturnValueOnce('1');
+    const wrapper = mount(
+      <Provider store={store}>
+        <RightMenu {...mockedProps} />
+      </Provider>,
+    );
+    await waitForComponentToPaint(wrapper);
+    const callsD = fetchMock.calls(/database\/\?q/);
+    expect(callsD).toHaveLength(2);
+    expect(callsD[0][0]).toMatchInlineSnapshot(
+      `"http://localhost/api/v1/database/?q=(filters:!((col:allow_file_upload,opr:upload_is_enabled,value:!t)))"`,
+    );
+    expect(callsD[1][0]).toMatchInlineSnapshot(
+      `"http://localhost/api/v1/database/?q=(filters:!((col:database_name,opr:neq,value:examples)))"`,
+    );
+  });
+  it('If user has permission to upload files but NOT to connect DBs we query existing DBs that has allow_file_upload as True only', async () => {
     useSelectorMock.mockReturnValueOnce({
       createdOn: '2021-04-27T18:12:38.952304',
       email: 'admin',
@@ -178,7 +223,11 @@ describe('RightMenu', () => {
     });
     // Second call we get the dashboardId
     useSelectorMock.mockReturnValueOnce('1');
-    const wrapper = mount(<RightMenu {...mockedProps} />);
+    const wrapper = mount(
+      <Provider store={store}>
+        <RightMenu {...mockedProps} />
+      </Provider>,
+    );
     await waitForComponentToPaint(wrapper);
     const callsD = fetchMock.calls(/database\/\?q/);
     expect(callsD).toHaveLength(1);
@@ -186,7 +235,7 @@ describe('RightMenu', () => {
       `"http://localhost/api/v1/database/?q=(filters:!((col:allow_file_upload,opr:upload_is_enabled,value:!t)))"`,
     );
   });
-  it('If user has no permission to upload files the query API should not be called', async () => {
+  it('If user has NO permission to upload files But it DOES have to connect DBs we query DBs that are not examples only', async () => {
     useSelectorMock.mockReturnValueOnce({
       createdOn: '2021-04-27T18:12:38.952304',
       email: 'admin',
@@ -195,22 +244,36 @@ describe('RightMenu', () => {
       lastName: 'admin',
       permissions: {},
       roles: {
-        Admin: [['can_write', 'Chart']], // no file permissions
+        Admin: [
+          ['can_write', 'Database'], // So we can write DBs
+        ],
       },
       userId: 1,
       username: 'admin',
     });
     // Second call we get the dashboardId
     useSelectorMock.mockReturnValueOnce('1');
-    const wrapper = mount(<RightMenu {...mockedProps} />);
+    const wrapper = mount(
+      <Provider store={store}>
+        <RightMenu {...mockedProps} />
+      </Provider>,
+    );
     await waitForComponentToPaint(wrapper);
     const callsD = fetchMock.calls(/database\/\?q/);
-    expect(callsD).toHaveLength(0);
+    expect(callsD).toHaveLength(1);
+    expect(callsD[0][0]).toMatchInlineSnapshot(
+      `"http://localhost/api/v1/database/?q=(filters:!((col:database_name,opr:neq,value:examples)))"`,
+    );
   });
-  it('If user has permission to upload files but there are only gsheets and clickhouse DBs', async () => {
+  it('If only examples DB exist we must show the Connect Database option', async () => {
     fetchMock.get(
       'glob:*api/v1/database/?q=(filters:!((col:allow_file_upload,opr:upload_is_enabled,value:!t)))',
-      { result: [...mockGsheetsDbs], database_count: 2 },
+      { result: [...mockNonExamplesDB], count: 2 },
+      { overwriteRoutes: true },
+    );
+    fetchMock.get(
+      'glob:*api/v1/database/?q=(filters:!((col:database_name,opr:neq,value:examples)))',
+      { result: [], count: 0 },
       { overwriteRoutes: true },
     );
     useSelectorMock.mockReturnValueOnce({
@@ -223,6 +286,8 @@ describe('RightMenu', () => {
       roles: {
         Admin: [
           ['can_this_form_get', 'CsvToDatabaseView'], // So we can upload CSV
+          ['can_write', 'Database'], // So we can write DBs
+          ['can_write', 'Dataset'], // So we can write Datasets
         ],
       },
       userId: 1,
@@ -230,39 +295,56 @@ describe('RightMenu', () => {
     });
     // Second call we get the dashboardId
     useSelectorMock.mockReturnValueOnce('1');
-    const wrapper = mount(<RightMenu {...mockedProps} />);
-    await waitForComponentToPaint(wrapper);
-    const callsD = fetchMock.calls(/database\/\?q/);
-    expect(callsD).toHaveLength(1);
-    expect(setAllowUploads).toHaveBeenCalledWith(false);
-  });
-  it('If user has permission to upload files and some DBs with allow_file_upload are not gsheets nor clickhouse', async () => {
-    fetchMock.get(
-      'glob:*api/v1/database/?q=(filters:!((col:allow_file_upload,opr:upload_is_enabled,value:!t)))',
-      { result: [...mockNonGSheetsDBs, ...mockGsheetsDbs], database_count: 2 },
-      { overwriteRoutes: true },
+    const wrapper = mount(
+      <Provider store={store}>
+        <RightMenu {...mockedProps} />
+      </Provider>,
     );
-    useSelectorMock.mockReturnValueOnce({
-      createdOn: '2021-04-27T18:12:38.952304',
-      email: 'admin',
-      firstName: 'admin',
-      isActive: true,
-      lastName: 'admin',
-      permissions: {},
-      roles: {
-        Admin: [
-          ['can_this_form_get', 'CsvToDatabaseView'], // So we can upload CSV
-        ],
-      },
-      userId: 1,
-      username: 'admin',
-    });
-    // Second call we get the dashboardId
-    useSelectorMock.mockReturnValueOnce('1');
-    const wrapper = mount(<RightMenu {...mockedProps} />);
     await waitForComponentToPaint(wrapper);
     const callsD = fetchMock.calls(/database\/\?q/);
-    expect(callsD).toHaveLength(1);
+    expect(callsD).toHaveLength(2);
     expect(setAllowUploads).toHaveBeenCalledWith(true);
+    expect(setNonExamplesDBConnected).toHaveBeenCalledWith(false);
+  });
+  it('If there is more DBs connected and not just examples we must show the Connect Dataset option', async () => {
+    fetchMock.get(
+      'glob:*api/v1/database/?q=(filters:!((col:allow_file_upload,opr:upload_is_enabled,value:!t)))',
+      { result: [...mockNonExamplesDB], count: 2 },
+      { overwriteRoutes: true },
+    );
+    fetchMock.get(
+      'glob:*api/v1/database/?q=(filters:!((col:database_name,opr:neq,value:examples)))',
+      { result: [...mockNonExamplesDB], count: 2 },
+      { overwriteRoutes: true },
+    );
+    useSelectorMock.mockReturnValueOnce({
+      createdOn: '2021-04-27T18:12:38.952304',
+      email: 'admin',
+      firstName: 'admin',
+      isActive: true,
+      lastName: 'admin',
+      permissions: {},
+      roles: {
+        Admin: [
+          ['can_this_form_get', 'CsvToDatabaseView'], // So we can upload CSV
+          ['can_write', 'Database'], // So we can write DBs
+          ['can_write', 'Dataset'], // So we can write Datasets
+        ],
+      },
+      userId: 1,
+      username: 'admin',
+    });
+    // Second call we get the dashboardId
+    useSelectorMock.mockReturnValueOnce('1');
+    const wrapper = mount(
+      <Provider store={store}>
+        <RightMenu {...mockedProps} />
+      </Provider>,
+    );
+    await waitForComponentToPaint(wrapper);
+    const callsD = fetchMock.calls(/database\/\?q/);
+    expect(callsD).toHaveLength(2);
+    expect(setAllowUploads).toHaveBeenCalledWith(true);
+    expect(setNonExamplesDBConnected).toHaveBeenCalledWith(true);
   });
 });

--- a/superset-frontend/src/views/components/RightMenu.tsx
+++ b/superset-frontend/src/views/components/RightMenu.tsx
@@ -259,10 +259,10 @@ const RightMenu = ({
   }, [canUploadData]);
 
   useEffect(() => {
-    if (canDatabase) {
+    if (canDatabase || canDataset) {
       existsNonExamplesDatabases();
     }
-  }, [canDatabase]);
+  }, [canDatabase, canDataset]);
 
   const menuIconAndLabel = (menu: MenuObjectProps) => (
     <>
@@ -325,7 +325,7 @@ const RightMenu = ({
       )
     ) {
       if (canUploadData) checkAllowUploads();
-      if (canDatabase) existsNonExamplesDatabases();
+      if (canDatabase || canDataset) existsNonExamplesDatabases();
     }
     return null;
   };

--- a/superset-frontend/src/views/components/RightMenu.tsx
+++ b/superset-frontend/src/views/components/RightMenu.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { Fragment, useEffect } from 'react';
+import React, { Fragment, useState, useEffect } from 'react';
 import rison from 'rison';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
@@ -125,11 +125,9 @@ const RightMenu = ({
     ALLOWED_EXTENSIONS,
     HAS_GSHEETS_INSTALLED,
   } = useSelector<any, ExtentionConfigs>(state => state.common.conf);
-  const [showDatabaseModal, setShowDatabaseModal] =
-    React.useState<boolean>(false);
-  const [showDatasetModal, setShowDatasetModal] =
-    React.useState<boolean>(false);
-  const [engine, setEngine] = React.useState<string>('');
+  const [showDatabaseModal, setShowDatabaseModal] = useState<boolean>(false);
+  const [showDatasetModal, setShowDatasetModal] = useState<boolean>(false);
+  const [engine, setEngine] = useState<string>('');
   const canSql = findPermission('can_sqllab', 'Superset', roles);
   const canDashboard = findPermission('can_write', 'Dashboard', roles);
   const canChart = findPermission('can_write', 'Chart', roles);
@@ -146,9 +144,9 @@ const RightMenu = ({
     );
 
   const showActionDropdown = canSql || canChart || canDashboard;
-  const [allowUploads, setAllowUploads] = React.useState<boolean>(false);
+  const [allowUploads, setAllowUploads] = useState<boolean>(false);
   const [nonExamplesDBConnected, setNonExamplesDBConnected] =
-    React.useState<boolean>(false);
+    useState<boolean>(false);
   const isAdmin = isUserAdmin(user);
   const showUploads = allowUploads || isAdmin;
   const dropdownItems: MenuObjectProps[] = [

--- a/superset-frontend/src/views/components/RightMenu.tsx
+++ b/superset-frontend/src/views/components/RightMenu.tsx
@@ -21,6 +21,7 @@ import rison from 'rison';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { useQueryParams, BooleanParam } from 'use-query-params';
+import { isEmpty } from 'lodash';
 
 import {
   t,
@@ -90,6 +91,13 @@ const StyledAnchor = styled.a`
 
 const tagStyles = (theme: SupersetTheme) => css`
   color: ${theme.colors.grayscale.light5};
+`;
+
+const styledChildMenu = (theme: SupersetTheme) => css`
+  &:hover {
+    color: ${theme.colors.primary.base} !important;
+    cursor: pointer !important;
+  }
 `;
 
 const { SubMenu } = Menu;
@@ -298,14 +306,24 @@ const RightMenu = ({
         </Tooltip>
       </Menu.Item>
     ) : (
-      <Menu.Item key={item.name}>
+      <Menu.Item key={item.name} css={styledChildMenu}>
         {item.url ? <a href={item.url}> {item.label} </a> : item.label}
       </Menu.Item>
     );
   };
 
   const onMenuOpen = (openKeys: string[]) => {
-    if (openKeys.length) {
+    // We should query the API only if opening Data submenus
+    // because the rest don't need this information. Not using
+    // "Data" directly since we might change the label later on?
+    if (
+      openKeys.length > 1 &&
+      !isEmpty(
+        openKeys?.filter((key: string) =>
+          key.includes(`sub2_${dropdownItems?.[0]?.label}`),
+        ),
+      )
+    ) {
       if (canUploadData) checkAllowUploads();
       if (canDatabase) existsNonExamplesDatabases();
     }
@@ -379,7 +397,7 @@ const RightMenu = ({
                       {menu?.childs?.map?.((item, idx) =>
                         typeof item !== 'string' && item.name && item.perm ? (
                           <Fragment key={item.name}>
-                            {idx === 2 && <Menu.Divider />}
+                            {idx === 3 && <Menu.Divider />}
                             {buildMenuItem(item)}
                           </Fragment>
                         ) : null,

--- a/superset-frontend/src/views/components/types.ts
+++ b/superset-frontend/src/views/components/types.ts
@@ -40,4 +40,5 @@ export interface RightMenuProps {
 export enum GlobalMenuDataOptions {
   GOOGLE_SHEETS = 'gsheets',
   DB_CONNECTION = 'dbconnection',
+  DATASET_CREATION = 'datasetCreation',
 }


### PR DESCRIPTION
### SUMMARY
We are adding some extra logic to RightMenu so it checks for what databases the user has connected before displaying options in the dropdown.

```
Plus menu logic:

Connect database: shows for users who can create databases, until their first non examples db is connected
Create dataset: shows for users who can create a dataset as soon as at least one non examples db is connected
[no change] Connect Google Sheet: shows for users who can create databases, always
[no change] Upload CSV, columnar, Excel: shows for users who can create databases all the time (tooltip when no csv uploads enabled, active when csv uploads enabled). For users who can upload but can't connect db, only shows once uploads are enabled on at least one db.
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![error](https://user-images.githubusercontent.com/38889534/191266353-16748a9c-fc3c-482a-8fb3-e4adc4ebe323.gif)

After:
![test](https://user-images.githubusercontent.com/38889534/191266421-fd8b2822-efa6-4fe7-8ebf-3a4d9977bfb5.gif)
![test](https://user-images.githubusercontent.com/38889534/191268853-8e3d7ace-13e8-4d25-912b-862d5e410862.gif)


### TESTING INSTRUCTIONS
1. Login into the app
2. Connect a database that is not example and check the logic form above
3. Remove all connected databases and check the logic from above
4. Clicking on the connect database menu should open the Connect Database modal
5. Clicking on the create dataset menu should open the Create Dataset modal

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: https://github.com/apache/superset/issues/21569
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
