### PR TITLE
feat(helm): add annotations on ServiceAccount

### DIFF
--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
   - name: craig-rueda
     email: craig@craigrueda.com
     url: https://github.com/craig-rueda
-version: 0.7.2
+version: 0.7.3
 dependencies:
 - name: postgresql
   version: 11.1.22

--- a/helm/superset/templates/service-account.yaml
+++ b/helm/superset/templates/service-account.yaml
@@ -28,4 +28,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile
+  {{- if .Values.serviceAccount.annotations }}
+  annotations: {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
 {{- end -}}

--- a/helm/superset/values.schema.json
+++ b/helm/superset/values.schema.json
@@ -12,6 +12,9 @@
             "properties": {
                 "create": {
                     "type": "boolean"
+                },
+                "annotations": {
+                    "type": "object"
                 }
             },
             "required": [

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -27,6 +27,7 @@ runAsUser: 0
 # serviceAccountName: superset
 serviceAccount:
   create: false
+  annotations: {}
 
 # Install additional packages and do any other bootstrap configuration in this script
 # For production clusters it's recommended to build own image with this step done in CI


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
We want to add annotations on the Kubernetes ServiceAccount.

### How
- Add the field in `serviceaccount.yaml` template
- Add default empty value in `values.yaml`
- Update JSON schema
- Bump chart version

### TESTING INSTRUCTIONS
```sh
helm lint
helm template . superset-release
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
