### PR TITLE
feat: support multiple time columns with time grain in Pivot Table v2

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
@@ -45,6 +45,7 @@ import {
   ComparisionType,
   isAdhocColumn,
   isPhysicalColumn,
+  ensureIsArray,
 } from '@superset-ui/core';
 
 import {
@@ -57,7 +58,13 @@ import {
   DEFAULT_NUMBER_FORMAT,
 } from '../utils';
 import { TIME_FILTER_LABELS } from '../constants';
-import { SharedControlConfig, Dataset, ColumnMeta } from '../types';
+import {
+  SharedControlConfig,
+  Dataset,
+  ColumnMeta,
+  ControlState,
+  ControlPanelState,
+} from '../types';
 
 import {
   dndAdhocFilterControl,
@@ -340,6 +347,16 @@ const show_empty_columns: SharedControlConfig<'CheckboxControl'> = {
   description: t('Show empty columns'),
 };
 
+const datetime_columns_lookup: SharedControlConfig<'HiddenControl'> = {
+  type: 'HiddenControl',
+  initialValue: (control: ControlState, state: ControlPanelState) =>
+    Object.fromEntries(
+      ensureIsArray<Record<string, any>>(state?.datasource?.columns)
+        .filter(option => option.is_dttm)
+        .map(option => [option.column_name ?? option.name, option.is_dttm]),
+    ),
+};
+
 export default {
   metrics: dndAdhocMetricsControl,
   metric: dndAdhocMetricControl,
@@ -376,4 +393,5 @@ export default {
   truncate_metric,
   x_axis: dndXAxisControl,
   show_empty_columns,
+  datetime_columns_lookup,
 };

--- a/superset-frontend/plugins/plugin-chart-pivot-table/package.json
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/package.json
@@ -25,7 +25,9 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {},
+  "dependencies": {
+    "lodash": "^4.17.11"
+  },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",

--- a/superset-frontend/plugins/plugin-chart-pivot-table/package.json
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/package.json
@@ -25,16 +25,15 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "lodash": "^4.17.11"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
     "@ant-design/icons": "^4.2.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "prop-types": "*"
+    "prop-types": "*",
+    "lodash": "^4.17.11"
   },
   "devDependencies": {
     "@babel/types": "^7.13.12",

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
@@ -43,7 +43,7 @@ export default function buildQuery(formData: PivotTableQueryFormData) {
       isPhysicalColumn(col) &&
       formData.time_grain_sqla &&
       isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) &&
-      formData?.DTTMLookup[col]
+      formData?.datetimeLookup[col]
     ) {
       return {
         timeGrain: formData.time_grain_sqla,

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
@@ -43,7 +43,7 @@ export default function buildQuery(formData: PivotTableQueryFormData) {
       isPhysicalColumn(col) &&
       formData.time_grain_sqla &&
       isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) &&
-      formData?.isDTTMLookup[col]
+      formData?.DTTMLookup[col]
     ) {
       return {
         timeGrain: formData.time_grain_sqla,

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
@@ -17,8 +17,10 @@
  * under the License.
  */
 import {
+  AdhocColumn,
   buildQueryContext,
   ensureIsArray,
+  isPhysicalColumn,
   QueryFormColumn,
   QueryFormOrderBy,
 } from '@superset-ui/core';
@@ -27,10 +29,28 @@ import { PivotTableQueryFormData } from '../types';
 export default function buildQuery(formData: PivotTableQueryFormData) {
   const { groupbyColumns = [], groupbyRows = [] } = formData;
   // TODO: add deduping of AdhocColumns
-  const groupbySet = new Set([
-    ...ensureIsArray<QueryFormColumn>(groupbyColumns),
-    ...ensureIsArray<QueryFormColumn>(groupbyRows),
-  ]);
+  const groupbySet = Array.from(
+    new Set([
+      ...ensureIsArray<QueryFormColumn>(groupbyColumns),
+      ...ensureIsArray<QueryFormColumn>(groupbyRows),
+    ]),
+  ).map(col => {
+    if (
+      isPhysicalColumn(col) &&
+      formData.time_grain_sqla &&
+      formData?.isDTTMLookup[col]
+    ) {
+      return {
+        timeGrain: formData.time_grain_sqla,
+        columnType: 'BASE_AXIS',
+        sqlExpression: col,
+        label: col,
+        expressionType: 'SQL',
+      } as AdhocColumn;
+    }
+    return col;
+  });
+
   return buildQueryContext(formData, baseQueryObject => {
     const { series_limit_metric, metrics, order_desc } = baseQueryObject;
     let orderBy: QueryFormOrderBy[] | undefined;
@@ -43,7 +63,7 @@ export default function buildQuery(formData: PivotTableQueryFormData) {
       {
         ...baseQueryObject,
         orderby: orderBy,
-        columns: [...groupbySet],
+        columns: groupbySet,
       },
     ];
   });

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
@@ -43,7 +43,7 @@ export default function buildQuery(formData: PivotTableQueryFormData) {
       isPhysicalColumn(col) &&
       formData.time_grain_sqla &&
       isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) &&
-      formData?.datetimeColumnLookup[col]
+      formData?.datetimeColumnLookup?.[col]
     ) {
       return {
         timeGrain: formData.time_grain_sqla,

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
@@ -43,7 +43,7 @@ export default function buildQuery(formData: PivotTableQueryFormData) {
       isPhysicalColumn(col) &&
       formData.time_grain_sqla &&
       isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) &&
-      formData?.datetimeColumnLookup?.[col]
+      formData?.datetime_columns_lookup?.[col]
     ) {
       return {
         timeGrain: formData.time_grain_sqla,

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
@@ -33,7 +33,7 @@ import { PivotTableQueryFormData } from '../types';
 export default function buildQuery(formData: PivotTableQueryFormData) {
   const { groupbyColumns = [], groupbyRows = [] } = formData;
   // TODO: add deduping of AdhocColumns
-  const groupbySet = Array.from(
+  const columns = Array.from(
     new Set([
       ...ensureIsArray<QueryFormColumn>(groupbyColumns),
       ...ensureIsArray<QueryFormColumn>(groupbyRows),
@@ -70,7 +70,7 @@ export default function buildQuery(formData: PivotTableQueryFormData) {
           ? omit(baseQueryObject, ['extras.time_grain_sqla'])
           : baseQueryObject),
         orderby: orderBy,
-        columns: groupbySet,
+        columns,
       },
     ];
   });

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
@@ -43,7 +43,7 @@ export default function buildQuery(formData: PivotTableQueryFormData) {
       isPhysicalColumn(col) &&
       formData.time_grain_sqla &&
       isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) &&
-      formData?.datetimeLookup[col]
+      formData?.datetimeColumnLookup[col]
     ) {
       return {
         timeGrain: formData.time_grain_sqla,

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
@@ -16,10 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import omit from 'lodash/omit';
+
 import {
   AdhocColumn,
   buildQueryContext,
   ensureIsArray,
+  FeatureFlag,
+  isFeatureEnabled,
   isPhysicalColumn,
   QueryFormColumn,
   QueryFormOrderBy,
@@ -38,6 +42,7 @@ export default function buildQuery(formData: PivotTableQueryFormData) {
     if (
       isPhysicalColumn(col) &&
       formData.time_grain_sqla &&
+      isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) &&
       formData?.isDTTMLookup[col]
     ) {
       return {
@@ -61,7 +66,9 @@ export default function buildQuery(formData: PivotTableQueryFormData) {
     }
     return [
       {
-        ...baseQueryObject,
+        ...(isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES)
+          ? omit(baseQueryObject, ['extras.time_grain_sqla'])
+          : baseQueryObject),
         orderby: orderBy,
         columns: groupbySet,
       },

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx
@@ -76,7 +76,7 @@ const config: ControlPanelConfig = {
                 config: {
                   ...sharedControls.time_grain_sqla,
                   visibility: ({ controls }) => {
-                    const isDTTMLookup = Object.fromEntries(
+                    const DTTMLookup = Object.fromEntries(
                       ensureIsArray(controls?.groupbyColumns?.options).map(
                         option => [option.column_name, option.is_dttm],
                       ),
@@ -91,7 +91,7 @@ const config: ControlPanelConfig = {
                           return true;
                         }
                         if (isPhysicalColumn(selection)) {
-                          return !!isDTTMLookup[selection];
+                          return !!DTTMLookup[selection];
                         }
                         return false;
                       })
@@ -102,7 +102,7 @@ const config: ControlPanelConfig = {
             : null,
           isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES)
             ? {
-                name: 'isDTTMLookup',
+                name: 'DTTMLookup',
                 config: {
                   type: 'HiddenControl',
                   initialValue: (

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx
@@ -37,8 +37,6 @@ import {
   emitFilterControl,
   Dataset,
   getStandardizedControls,
-  ControlState,
-  ControlPanelState,
 } from '@superset-ui/chart-controls';
 import { MetricsLayoutEnum } from '../types';
 
@@ -81,11 +79,11 @@ const config: ControlPanelConfig = {
                         option => [option.column_name, option.is_dttm],
                       ),
                     );
-                    const selections = [
+
+                    return [
                       ...ensureIsArray(controls?.groupbyColumns.value),
                       ...ensureIsArray(controls?.groupbyRows.value),
-                    ];
-                    return selections
+                    ]
                       .map(selection => {
                         if (isAdhocColumn(selection)) {
                           return true;
@@ -101,23 +99,7 @@ const config: ControlPanelConfig = {
               }
             : null,
           isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES)
-            ? {
-                name: 'datetimeColumnLookup',
-                config: {
-                  type: 'HiddenControl',
-                  default: (control: ControlState, state: ControlPanelState) =>
-                    Object.fromEntries(
-                      ensureIsArray<Record<string, any>>(
-                        state?.datasource?.columns,
-                      )
-                        .filter(option => option.is_dttm)
-                        .map(option => [
-                          option.column_name ?? option.name,
-                          option.is_dttm,
-                        ]),
-                    ),
-                },
-              }
+            ? 'datetime_columns_lookup'
             : null,
         ],
         [

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx
@@ -102,20 +102,19 @@ const config: ControlPanelConfig = {
             : null,
           isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES)
             ? {
-                name: 'DTTMLookup',
+                name: 'datetimeLookup',
                 config: {
                   type: 'HiddenControl',
-                  initialValue: (
-                    control: ControlState,
-                    state: ControlPanelState,
-                  ) =>
+                  default: (control: ControlState, state: ControlPanelState) =>
                     Object.fromEntries(
                       ensureIsArray<Record<string, any>>(
                         state?.datasource?.columns,
-                      ).map(option => [
-                        option.column_name ?? option.name,
-                        option.is_dttm,
-                      ]),
+                      )
+                        .filter(option => option.is_dttm)
+                        .map(option => [
+                          option.column_name ?? option.name,
+                          option.is_dttm,
+                        ]),
                     ),
                 },
               }

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx
@@ -102,7 +102,7 @@ const config: ControlPanelConfig = {
             : null,
           isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES)
             ? {
-                name: 'datetimeLookup',
+                name: 'datetimeColumnLookup',
                 config: {
                   type: 'HiddenControl',
                   default: (control: ControlState, state: ControlPanelState) =>

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx
@@ -76,7 +76,7 @@ const config: ControlPanelConfig = {
                 config: {
                   ...sharedControls.time_grain_sqla,
                   visibility: ({ controls }) => {
-                    const DTTMLookup = Object.fromEntries(
+                    const dttmLookup = Object.fromEntries(
                       ensureIsArray(controls?.groupbyColumns?.options).map(
                         option => [option.column_name, option.is_dttm],
                       ),
@@ -91,7 +91,7 @@ const config: ControlPanelConfig = {
                           return true;
                         }
                         if (isPhysicalColumn(selection)) {
-                          return !!DTTMLookup[selection];
+                          return !!dttmLookup[selection];
                         }
                         return false;
                       })

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx
@@ -76,10 +76,6 @@ const config: ControlPanelConfig = {
                 config: {
                   ...sharedControls.time_grain_sqla,
                   visibility: ({ controls }) => {
-                    if (!isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES)) {
-                      return true;
-                    }
-
                     const isDTTMLookup = Object.fromEntries(
                       ensureIsArray(controls?.groupbyColumns?.options).map(
                         option => [option.column_name, option.is_dttm],
@@ -114,7 +110,9 @@ const config: ControlPanelConfig = {
                     state: ControlPanelState,
                   ) =>
                     Object.fromEntries(
-                      ensureIsArray(state?.datasource?.columns).map(option => [
+                      ensureIsArray<Record<string, any>>(
+                        state?.datasource?.columns,
+                      ).map(option => [
                         option.column_name ?? option.name,
                         option.is_dttm,
                       ]),


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
If the FF Generic Axis is enabled, the Pivot Table v2 will support multiple time columns with time grain. The `TIME GRAIN
` control also moves out from the time section.

There is a limitation in the current design that the Adhoc Column wasn't able to apply the Time Grain, I will open separated PR to support the dynamic detector for the column type.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### After
The time grain is applied on `Order Date` and `Ship Date`
![image](https://user-images.githubusercontent.com/2016594/191489566-e5172f11-8366-4a2e-86cb-892887122e53.png)

The time grain is applied on `Order Date` and `Ship Date` except `Category`

![image](https://user-images.githubusercontent.com/2016594/191489860-3b9c48af-dae5-4147-9d44-ecdca4135b58.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
