### PR TITLE
chore(dashboard): Add filter_scopes warning message for json metadata editor

### DIFF
--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -661,7 +661,7 @@ const PropertiesModal = ({
                     <>
                       {' '}
                       {t(
-                        'Please DO NOT overwrite `filter_scopes` metadata.',
+                        'Please DO NOT overwrite the "filter_scopes" key.',
                       )}{' '}
                       <FilterScopeModal
                         triggerNode={

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -36,6 +36,7 @@ import Modal from 'src/components/Modal';
 import { JsonEditor } from 'src/components/AsyncAceEditor';
 
 import ColorSchemeControlWrapper from 'src/dashboard/components/ColorSchemeControlWrapper';
+import FilterScopeModal from 'src/dashboard/components/filterscope/FilterScopeModal';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
 import withToasts from 'src/components/MessageToasts/withToasts';
 import { FeatureFlag, isFeatureEnabled } from 'src/featureFlags';
@@ -655,6 +656,23 @@ const PropertiesModal = ({
                 <p className="help-block">
                   {t(
                     'This JSON object is generated dynamically when clicking the save or overwrite button in the dashboard view. It is exposed here for reference and for power users who may want to alter specific parameters.',
+                  )}
+                  {onlyApply && (
+                    <>
+                      {' '}
+                      {t(
+                        'Please DO NOT overwrite `filter_scopes` metadata.',
+                      )}{' '}
+                      <FilterScopeModal
+                        triggerNode={
+                          <span className="alert-link">
+                            {t('Use "%(menuName)s" menu instead.', {
+                              menuName: t('Set filter mapping'),
+                            })}
+                          </span>
+                        }
+                      />
+                    </>
                   )}
                 </p>
               </>

--- a/superset-frontend/src/views/routes.test.tsx
+++ b/superset-frontend/src/views/routes.test.tsx
@@ -16,13 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
+import React from 'react';
 import { isFrontendRoute, routes } from './routes';
 
 jest.mock('src/featureFlags', () => ({
   ...jest.requireActual<object>('src/featureFlags'),
   isFeatureEnabled: jest.fn().mockReturnValue(true),
 }));
+jest.mock('src/views/CRUD/welcome/Welcome', () => () => (
+  <div data-test="mock-welcome" />
+));
 
 describe('isFrontendRoute', () => {
   it('returns true if a route matches', () => {


### PR DESCRIPTION
### SUMMARY
Since the existing dashboardState overwrite the `filter_scopes` directly by the UI state from the filter mapping menu, the `filter_scopes` changes made from json metadata editor can be lost.

https://github.com/apache/superset/blob/e438c967c9fd3452d8f5aa811a43bce6ae8ffbd2/superset-frontend/src/dashboard/actions/dashboardState.js#L385-L390

This commit adds the warning message of `filter_scopes` changes and then links to the filter mapping menu for the alternative.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/1392866/191609445-a1756f32-c5a9-44cd-9200-8905f396cb28.mov

### TESTING INSTRUCTIONS
- Go to a dashboard
- Click "edit" and "edit properties"
- Click "advanced" to open json editor
- check the warning message


### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
