### PR TITLE
fix(explore): Fix datasource switch for table chart

### DIFF
--- a/superset-frontend/src/explore/controlUtils/getControlValuesCompatibleWithDatasource.ts
+++ b/superset-frontend/src/explore/controlUtils/getControlValuesCompatibleWithDatasource.ts
@@ -36,11 +36,12 @@ const isControlValueCompatibleWithDatasource = (
 ) => {
   if (controlState.options && typeof value === 'string') {
     if (
-      (Array.isArray(controlState.options) &&
-        controlState.options.some(
-          (option: [string | number, string]) => option[0] === value,
-        )) ||
-      value in controlState.options
+      controlState.options.some(
+        (option: [string | number, string] | { column_name: string }) =>
+          Array.isArray(option)
+            ? option[0] === value
+            : option.column_name === value,
+      )
     ) {
       return datasource.columns.some(column => column.column_name === value);
     }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Another casualty of #21315 was datasource switching for table chart: after that PR, switching between datasources wouldn't preserve any columns.  As a side-effect, saving charts based on SQL queries instead of datasets would fail, as the save process involves switching from the query datasource to the newly-created dataset.  This PR fixes the issue, which was specifically caused by #21315 turning `chartState.options` from an object into an array (see #21484).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

![localhost_9000_explore__form_data_key=O3JVAVF3-mFhHkTJ8F3xoCyHzxNRoottQ-ZJcNMIx1KOzPpJ8ueK6R88J-zJyptf datasource_id=1 datasource_type=query](https://user-images.githubusercontent.com/13007381/191610999-22374190-c71f-4998-b621-d99f9230c939.png)

After:

![localhost_9000_explore__form_data_key=gHVMJ2BnjkTUap0aWTVz-ocYbMr5xFS3xE1sV1c8x1gdIsAPqErF4pzNNsWhFqz3 datasource_id=1 datasource_type=query](https://user-images.githubusercontent.com/13007381/191611053-e01e91f6-f0db-447c-840f-3676feb2bf82.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Create a Table chart from a dataset in Raw mode and try switching datasets.  Ensure that columns that exist on both datasets are preserved.
- Create a Table chart in Raw mode from a query and try saving it.  Ensure that all control values remain unchanged after save.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
