### PR TITLE
fix(dashboard): show correct roles for dashboard access dropdown

### DIFF
--- a/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
@@ -38,7 +38,7 @@ spyColorSchemeControlWrapper.mockImplementation(
 );
 
 fetchMock.get(
-  'http://localhost/api/v1/dashboard/related/roles?q=(filter:%27%27)',
+  'http://localhost/api/v1/dashboard/related/roles?q=(filter:%27%27,page:0,page_size:100)',
   {
     body: {
       count: 6,
@@ -46,26 +46,32 @@ fetchMock.get(
         {
           text: 'Admin',
           value: 1,
+          extra: {},
         },
         {
           text: 'Alpha',
           value: 3,
+          extra: {},
         },
         {
           text: 'Gamma',
           value: 4,
+          extra: {},
         },
         {
           text: 'granter',
           value: 5,
+          extra: {},
         },
         {
           text: 'Public',
           value: 2,
+          extra: {},
         },
         {
           text: 'sql_lab',
           value: 6,
+          extra: {},
         },
       ],
     },
@@ -73,7 +79,7 @@ fetchMock.get(
 );
 
 fetchMock.get(
-  'http://localhost/api/v1/dashboard/related/owners?q=(filter:%27%27)',
+  'http://localhost/api/v1/dashboard/related/owners?q=(filter:%27%27,page:0,page_size:100)',
   {
     body: {
       count: 1,
@@ -81,45 +87,53 @@ fetchMock.get(
         {
           text: 'Superset Admin',
           value: 1,
+          extra: { active: true },
+        },
+        {
+          text: 'Inactive Admin',
+          value: 2,
+          extra: { active: false },
         },
       ],
     },
   },
 );
 
+const dashboardInfo = {
+  certified_by: 'John Doe',
+  certification_details: 'Sample certification',
+  changed_by: null,
+  changed_by_name: '',
+  changed_by_url: '',
+  changed_on: '2021-03-30T19:30:14.020942',
+  charts: [
+    'Vaccine Candidates per Country & Stage',
+    'Vaccine Candidates per Country',
+    'Vaccine Candidates per Country',
+    'Vaccine Candidates per Approach & Stage',
+    'Vaccine Candidates per Phase',
+    'Vaccine Candidates per Phase',
+    'Vaccine Candidates per Country & Stage',
+    'Filtering Vaccines',
+  ],
+  css: '',
+  dashboard_title: 'COVID Vaccine Dashboard',
+  id: 26,
+  metadata: mockedJsonMetadata,
+  owners: [],
+  position_json:
+    '{"CHART-63bEuxjDMJ": {"children": [], "id": "CHART-63bEuxjDMJ", "meta": {"chartId": 369, "height": 76, "sliceName": "Vaccine Candidates per Country", "sliceNameOverride": "Map of Vaccine Candidates", "uuid": "ddc91df6-fb40-4826-bdca-16b85af1c024", "width": 7}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ", "ROW-zvw7luvEL"], "type": "CHART"}, "CHART-F-fkth0Dnv": {"children": [], "id": "CHART-F-fkth0Dnv", "meta": {"chartId": 314, "height": 76, "sliceName": "Vaccine Candidates per Country", "sliceNameOverride": "Treemap of Vaccine Candidates per Country", "uuid": "e2f5a8a7-feb0-4f79-bc6b-01fe55b98b3c", "width": 5}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ", "ROW-zvw7luvEL"], "type": "CHART"}, "CHART-RjD_ygqtwH": {"children": [], "id": "CHART-RjD_ygqtwH", "meta": {"chartId": 351, "height": 59, "sliceName": "Vaccine Candidates per Phase", "sliceNameOverride": "Vaccine Candidates per Phase", "uuid": "30b73c65-85e7-455f-bb24-801bb0cdc670", "width": 2}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ", "ROW-xSeNAspgw"], "type": "CHART"}, "CHART-aGfmWtliqA": {"children": [], "id": "CHART-aGfmWtliqA", "meta": {"chartId": 312, "height": 59, "sliceName": "Vaccine Candidates per Phase", "uuid": "392f293e-0892-4316-bd41-c927b65606a4", "width": 4}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ", "ROW-xSeNAspgw"], "type": "CHART"}, "CHART-dCUpAcPsji": {"children": [], "id": "CHART-dCUpAcPsji", "meta": {"chartId": 325, "height": 82, "sliceName": "Vaccine Candidates per Country & Stage", "sliceNameOverride": "Heatmap of Countries & Clinical Stages", "uuid": "cd111331-d286-4258-9020-c7949a109ed2", "width": 4}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ", "ROW-zhOlQLQnB"], "type": "CHART"}, "CHART-eirDduqb1A": {"children": [], "id": "CHART-eirDduqb1A", "meta": {"chartId": 358, "height": 59, "sliceName": "Filtering Vaccines", "sliceNameOverride": "Filter Box of Vaccines", "uuid": "c29381ce-0e99-4cf3-bf0f-5f55d6b94176", "width": 3}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ", "ROW-xSeNAspgw"], "type": "CHART"}, "CHART-fYo7IyvKZQ": {"children": [], "id": "CHART-fYo7IyvKZQ", "meta": {"chartId": 371, "height": 82, "sliceName": "Vaccine Candidates per Country & Stage", "sliceNameOverride": "Sunburst of Country & Clinical Stages", "uuid": "f69c556f-15fe-4a82-a8bb-69d5b6954123", "width": 5}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ", "ROW-zhOlQLQnB"], "type": "CHART"}, "CHART-j4hUvP5dDD": {"children": [], "id": "CHART-j4hUvP5dDD", "meta": {"chartId": 364, "height": 82, "sliceName": "Vaccine Candidates per Approach & Stage", "sliceNameOverride": "Heatmap of Aproaches & Clinical Stages", "uuid": "0c953c84-0c9a-418d-be9f-2894d2a2cee0", "width": 3}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ", "ROW-zhOlQLQnB"], "type": "CHART"}, "DASHBOARD_VERSION_KEY": "v2", "GRID_ID": {"children": [], "id": "GRID_ID", "parents": ["ROOT_ID"], "type": "GRID"}, "HEADER_ID": {"id": "HEADER_ID", "meta": {"text": "COVID Vaccine Dashboard"}, "type": "HEADER"}, "MARKDOWN-VjQQ5SFj5v": {"children": [], "id": "MARKDOWN-VjQQ5SFj5v", "meta": {"code": "# COVID-19 Vaccine Dashboard\\n\\nEverywhere you look, you see negative news about COVID-19. This is to be expected; it\'s been a brutal year and this disease is no joke. This dashboard hopes to use visualization to inject some optimism about the coming return to normalcy we enjoyed before 2020! There\'s lots to be optimistic about:\\n\\n- the sheer volume of attempts to fund the R&D needed to produce and bring an effective vaccine to market\\n- the large number of countries involved in at least one vaccine candidate (and the diversity of economic status of these countries)\\n- the diversity of vaccine approaches taken\\n- the fact that 2 vaccines have already been approved (and a hundreds of thousands of patients have already been vaccinated)\\n\\n### The Dataset\\n\\nThis dashboard is powered by data maintained by the Millken Institute ([link to dataset](https://airtable.com/shrSAi6t5WFwqo3GM/tblEzPQS5fnc0FHYR/viwDBH7b6FjmIBX5x?blocks=bipZFzhJ7wHPv7x9z)). We researched each vaccine candidate and added our own best guesses for the country responsible for each vaccine effort.\\n\\n_Note that this dataset was last updated on 12/23/2020_.\\n\\n", "height": 59, "width": 3}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ", "ROW-xSeNAspgw"], "type": "MARKDOWN"}, "ROOT_ID": {"children": ["TABS-wUKya7eQ0Z"], "id": "ROOT_ID", "type": "ROOT"}, "ROW-xSeNAspgw": {"children": ["MARKDOWN-VjQQ5SFj5v", "CHART-aGfmWtliqA", "CHART-RjD_ygqtwH", "CHART-eirDduqb1A"], "id": "ROW-xSeNAspgw", "meta": {"0": "ROOT_ID", "background": "BACKGROUND_TRANSPARENT"}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ"], "type": "ROW"}, "ROW-zhOlQLQnB": {"children": ["CHART-j4hUvP5dDD", "CHART-dCUpAcPsji", "CHART-fYo7IyvKZQ"], "id": "ROW-zhOlQLQnB", "meta": {"0": "ROOT_ID", "background": "BACKGROUND_TRANSPARENT"}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ"], "type": "ROW"}, "ROW-zvw7luvEL": {"children": ["CHART-63bEuxjDMJ", "CHART-F-fkth0Dnv"], "id": "ROW-zvw7luvEL", "meta": {"0": "ROOT_ID", "background": "BACKGROUND_TRANSPARENT"}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ"], "type": "ROW"}, "TAB-BCIJF4NvgQ": {"children": ["ROW-xSeNAspgw", "ROW-zvw7luvEL", "ROW-zhOlQLQnB"], "id": "TAB-BCIJF4NvgQ", "meta": {"text": "Overview"}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z"], "type": "TAB"}, "TABS-wUKya7eQ0Z": {"children": ["TAB-BCIJF4NvgQ"], "id": "TABS-wUKya7eQ0Z", "meta": {}, "parents": ["ROOT_ID"], "type": "TABS"}}',
+  published: false,
+  roles: [],
+  slug: null,
+  thumbnail_url:
+    '/api/v1/dashboard/26/thumbnail/b24805e98d90116da8c0974d24f5c533/',
+  url: '/superset/dashboard/26/',
+};
+
 fetchMock.get('glob:*/api/v1/dashboard/26', {
   body: {
-    result: {
-      certified_by: 'John Doe',
-      certification_details: 'Sample certification',
-      changed_by: null,
-      changed_by_name: '',
-      changed_by_url: '',
-      changed_on: '2021-03-30T19:30:14.020942',
-      charts: [
-        'Vaccine Candidates per Country & Stage',
-        'Vaccine Candidates per Country',
-        'Vaccine Candidates per Country',
-        'Vaccine Candidates per Approach & Stage',
-        'Vaccine Candidates per Phase',
-        'Vaccine Candidates per Phase',
-        'Vaccine Candidates per Country & Stage',
-        'Filtering Vaccines',
-      ],
-      css: '',
-      dashboard_title: 'COVID Vaccine Dashboard',
-      id: 26,
-      json_metadata: mockedJsonMetadata,
-      owners: [],
-      position_json:
-        '{"CHART-63bEuxjDMJ": {"children": [], "id": "CHART-63bEuxjDMJ", "meta": {"chartId": 369, "height": 76, "sliceName": "Vaccine Candidates per Country", "sliceNameOverride": "Map of Vaccine Candidates", "uuid": "ddc91df6-fb40-4826-bdca-16b85af1c024", "width": 7}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ", "ROW-zvw7luvEL"], "type": "CHART"}, "CHART-F-fkth0Dnv": {"children": [], "id": "CHART-F-fkth0Dnv", "meta": {"chartId": 314, "height": 76, "sliceName": "Vaccine Candidates per Country", "sliceNameOverride": "Treemap of Vaccine Candidates per Country", "uuid": "e2f5a8a7-feb0-4f79-bc6b-01fe55b98b3c", "width": 5}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ", "ROW-zvw7luvEL"], "type": "CHART"}, "CHART-RjD_ygqtwH": {"children": [], "id": "CHART-RjD_ygqtwH", "meta": {"chartId": 351, "height": 59, "sliceName": "Vaccine Candidates per Phase", "sliceNameOverride": "Vaccine Candidates per Phase", "uuid": "30b73c65-85e7-455f-bb24-801bb0cdc670", "width": 2}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ", "ROW-xSeNAspgw"], "type": "CHART"}, "CHART-aGfmWtliqA": {"children": [], "id": "CHART-aGfmWtliqA", "meta": {"chartId": 312, "height": 59, "sliceName": "Vaccine Candidates per Phase", "uuid": "392f293e-0892-4316-bd41-c927b65606a4", "width": 4}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ", "ROW-xSeNAspgw"], "type": "CHART"}, "CHART-dCUpAcPsji": {"children": [], "id": "CHART-dCUpAcPsji", "meta": {"chartId": 325, "height": 82, "sliceName": "Vaccine Candidates per Country & Stage", "sliceNameOverride": "Heatmap of Countries & Clinical Stages", "uuid": "cd111331-d286-4258-9020-c7949a109ed2", "width": 4}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ", "ROW-zhOlQLQnB"], "type": "CHART"}, "CHART-eirDduqb1A": {"children": [], "id": "CHART-eirDduqb1A", "meta": {"chartId": 358, "height": 59, "sliceName": "Filtering Vaccines", "sliceNameOverride": "Filter Box of Vaccines", "uuid": "c29381ce-0e99-4cf3-bf0f-5f55d6b94176", "width": 3}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ", "ROW-xSeNAspgw"], "type": "CHART"}, "CHART-fYo7IyvKZQ": {"children": [], "id": "CHART-fYo7IyvKZQ", "meta": {"chartId": 371, "height": 82, "sliceName": "Vaccine Candidates per Country & Stage", "sliceNameOverride": "Sunburst of Country & Clinical Stages", "uuid": "f69c556f-15fe-4a82-a8bb-69d5b6954123", "width": 5}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ", "ROW-zhOlQLQnB"], "type": "CHART"}, "CHART-j4hUvP5dDD": {"children": [], "id": "CHART-j4hUvP5dDD", "meta": {"chartId": 364, "height": 82, "sliceName": "Vaccine Candidates per Approach & Stage", "sliceNameOverride": "Heatmap of Aproaches & Clinical Stages", "uuid": "0c953c84-0c9a-418d-be9f-2894d2a2cee0", "width": 3}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ", "ROW-zhOlQLQnB"], "type": "CHART"}, "DASHBOARD_VERSION_KEY": "v2", "GRID_ID": {"children": [], "id": "GRID_ID", "parents": ["ROOT_ID"], "type": "GRID"}, "HEADER_ID": {"id": "HEADER_ID", "meta": {"text": "COVID Vaccine Dashboard"}, "type": "HEADER"}, "MARKDOWN-VjQQ5SFj5v": {"children": [], "id": "MARKDOWN-VjQQ5SFj5v", "meta": {"code": "# COVID-19 Vaccine Dashboard\\n\\nEverywhere you look, you see negative news about COVID-19. This is to be expected; it\'s been a brutal year and this disease is no joke. This dashboard hopes to use visualization to inject some optimism about the coming return to normalcy we enjoyed before 2020! There\'s lots to be optimistic about:\\n\\n- the sheer volume of attempts to fund the R&D needed to produce and bring an effective vaccine to market\\n- the large number of countries involved in at least one vaccine candidate (and the diversity of economic status of these countries)\\n- the diversity of vaccine approaches taken\\n- the fact that 2 vaccines have already been approved (and a hundreds of thousands of patients have already been vaccinated)\\n\\n### The Dataset\\n\\nThis dashboard is powered by data maintained by the Millken Institute ([link to dataset](https://airtable.com/shrSAi6t5WFwqo3GM/tblEzPQS5fnc0FHYR/viwDBH7b6FjmIBX5x?blocks=bipZFzhJ7wHPv7x9z)). We researched each vaccine candidate and added our own best guesses for the country responsible for each vaccine effort.\\n\\n_Note that this dataset was last updated on 12/23/2020_.\\n\\n", "height": 59, "width": 3}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ", "ROW-xSeNAspgw"], "type": "MARKDOWN"}, "ROOT_ID": {"children": ["TABS-wUKya7eQ0Z"], "id": "ROOT_ID", "type": "ROOT"}, "ROW-xSeNAspgw": {"children": ["MARKDOWN-VjQQ5SFj5v", "CHART-aGfmWtliqA", "CHART-RjD_ygqtwH", "CHART-eirDduqb1A"], "id": "ROW-xSeNAspgw", "meta": {"0": "ROOT_ID", "background": "BACKGROUND_TRANSPARENT"}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ"], "type": "ROW"}, "ROW-zhOlQLQnB": {"children": ["CHART-j4hUvP5dDD", "CHART-dCUpAcPsji", "CHART-fYo7IyvKZQ"], "id": "ROW-zhOlQLQnB", "meta": {"0": "ROOT_ID", "background": "BACKGROUND_TRANSPARENT"}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ"], "type": "ROW"}, "ROW-zvw7luvEL": {"children": ["CHART-63bEuxjDMJ", "CHART-F-fkth0Dnv"], "id": "ROW-zvw7luvEL", "meta": {"0": "ROOT_ID", "background": "BACKGROUND_TRANSPARENT"}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ"], "type": "ROW"}, "TAB-BCIJF4NvgQ": {"children": ["ROW-xSeNAspgw", "ROW-zvw7luvEL", "ROW-zhOlQLQnB"], "id": "TAB-BCIJF4NvgQ", "meta": {"text": "Overview"}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z"], "type": "TAB"}, "TABS-wUKya7eQ0Z": {"children": ["TAB-BCIJF4NvgQ"], "id": "TABS-wUKya7eQ0Z", "meta": {}, "parents": ["ROOT_ID"], "type": "TABS"}}',
-      published: false,
-      roles: [],
-      slug: null,
-      thumbnail_url:
-        '/api/v1/dashboard/26/thumbnail/b24805e98d90116da8c0974d24f5c533/',
-      url: '/superset/dashboard/26/',
-    },
+    result: { ...dashboardInfo, json_metadata: mockedJsonMetadata },
   },
 });
 
@@ -346,4 +360,103 @@ test('Empty "Certified by" should clear "Certification details"', async () => {
   expect(
     screen.getByRole('textbox', { name: 'Certification details' }),
   ).toHaveValue('');
+});
+
+test('should show all roles', async () => {
+  spyIsFeatureEnabled.mockReturnValue(true);
+
+  let props = createProps();
+  const propsWithDashboardIndo = { ...props, dashboardInfo };
+
+  const open = () => waitFor(() => userEvent.click(getSelect()));
+  const getSelect = () =>
+    screen.getByRole('combobox', { name: SupersetCore.t('Roles') });
+
+  const getElementsByClassName = (className: string) =>
+    document.querySelectorAll(className)! as NodeListOf<HTMLElement>;
+
+  const findAllSelectOptions = () =>
+    waitFor(() => getElementsByClassName('.ant-select-item-option-content'));
+
+  render(<PropertiesModal {...propsWithDashboardIndo} />, {
+    useRedux: true,
+  });
+
+  expect(screen.getAllByRole('combobox')).toHaveLength(2);
+  expect(
+    screen.getAllByRole('combobox', { name: SupersetCore.t('Roles') }),
+  ).toHaveLength(1);
+
+  await open();
+
+  const options = await findAllSelectOptions();
+
+  expect(options).toHaveLength(6);
+  expect(options[0]).toHaveTextContent('Admin');
+});
+
+test('should show active owners with dashboard rbac', async () => {
+  spyIsFeatureEnabled.mockReturnValue(true);
+
+  let props = createProps();
+  const propsWithDashboardIndo = { ...props, dashboardInfo };
+
+  const open = () => waitFor(() => userEvent.click(getSelect()));
+  const getSelect = () =>
+    screen.getByRole('combobox', { name: SupersetCore.t('Owners') });
+
+  const getElementsByClassName = (className: string) =>
+    document.querySelectorAll(className)! as NodeListOf<HTMLElement>;
+
+  const findAllSelectOptions = () =>
+    waitFor(() => getElementsByClassName('.ant-select-item-option-content'));
+
+  render(<PropertiesModal {...propsWithDashboardIndo} />, {
+    useRedux: true,
+  });
+
+  expect(screen.getAllByRole('combobox')).toHaveLength(2);
+  expect(
+    screen.getAllByRole('combobox', { name: SupersetCore.t('Owners') }),
+  ).toHaveLength(1);
+
+  await open();
+
+  const options = await findAllSelectOptions();
+
+  expect(options).toHaveLength(1);
+  expect(options[0]).toHaveTextContent('Superset Admin');
+});
+
+test('should show active owners without dashboard rbac', async () => {
+  spyIsFeatureEnabled.mockReturnValue(true);
+
+  let props = createProps();
+  const propsWithDashboardIndo = { ...props, dashboardInfo };
+
+  const open = () => waitFor(() => userEvent.click(getSelect()));
+  const getSelect = () =>
+    screen.getByRole('combobox', { name: SupersetCore.t('Owners') });
+
+  const getElementsByClassName = (className: string) =>
+    document.querySelectorAll(className)! as NodeListOf<HTMLElement>;
+
+  const findAllSelectOptions = () =>
+    waitFor(() => getElementsByClassName('.ant-select-item-option-content'));
+
+  render(<PropertiesModal {...propsWithDashboardIndo} />, {
+    useRedux: true,
+  });
+
+  expect(screen.getAllByRole('combobox')).toHaveLength(2);
+  expect(
+    screen.getAllByRole('combobox', { name: SupersetCore.t('Owners') }),
+  ).toHaveLength(1);
+
+  await open();
+
+  const options = await findAllSelectOptions();
+
+  expect(options).toHaveLength(1);
+  expect(options[0]).toHaveTextContent('Superset Admin');
 });

--- a/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
@@ -429,7 +429,7 @@ test('should show active owners with dashboard rbac', async () => {
 });
 
 test('should show active owners without dashboard rbac', async () => {
-  spyIsFeatureEnabled.mockReturnValue(true);
+  spyIsFeatureEnabled.mockReturnValue(false);
 
   let props = createProps();
   const propsWithDashboardIndo = { ...props, dashboardInfo };
@@ -448,7 +448,7 @@ test('should show active owners without dashboard rbac', async () => {
     useRedux: true,
   });
 
-  expect(screen.getAllByRole('combobox')).toHaveLength(2);
+  expect(screen.getAllByRole('combobox')).toHaveLength(1);
   expect(
     screen.getAllByRole('combobox', { name: SupersetCore.t('Owners') }),
   ).toHaveLength(1);

--- a/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
@@ -365,7 +365,7 @@ test('Empty "Certified by" should clear "Certification details"', async () => {
 test('should show all roles', async () => {
   spyIsFeatureEnabled.mockReturnValue(true);
 
-  let props = createProps();
+  const props = createProps();
   const propsWithDashboardIndo = { ...props, dashboardInfo };
 
   const open = () => waitFor(() => userEvent.click(getSelect()));
@@ -384,8 +384,8 @@ test('should show all roles', async () => {
 
   expect(screen.getAllByRole('combobox')).toHaveLength(2);
   expect(
-    screen.getAllByRole('combobox', { name: SupersetCore.t('Roles') }),
-  ).toHaveLength(1);
+    screen.getByRole('combobox', { name: SupersetCore.t('Roles') }),
+  ).toBeInTheDocument();
 
   await open();
 
@@ -398,7 +398,7 @@ test('should show all roles', async () => {
 test('should show active owners with dashboard rbac', async () => {
   spyIsFeatureEnabled.mockReturnValue(true);
 
-  let props = createProps();
+  const props = createProps();
   const propsWithDashboardIndo = { ...props, dashboardInfo };
 
   const open = () => waitFor(() => userEvent.click(getSelect()));
@@ -417,8 +417,8 @@ test('should show active owners with dashboard rbac', async () => {
 
   expect(screen.getAllByRole('combobox')).toHaveLength(2);
   expect(
-    screen.getAllByRole('combobox', { name: SupersetCore.t('Owners') }),
-  ).toHaveLength(1);
+    screen.getByRole('combobox', { name: SupersetCore.t('Owners') }),
+  ).toBeInTheDocument();
 
   await open();
 
@@ -431,7 +431,7 @@ test('should show active owners with dashboard rbac', async () => {
 test('should show active owners without dashboard rbac', async () => {
   spyIsFeatureEnabled.mockReturnValue(false);
 
-  let props = createProps();
+  const props = createProps();
   const propsWithDashboardIndo = { ...props, dashboardInfo };
 
   const open = () => waitFor(() => userEvent.click(getSelect()));
@@ -448,10 +448,10 @@ test('should show active owners without dashboard rbac', async () => {
     useRedux: true,
   });
 
-  expect(screen.getAllByRole('combobox')).toHaveLength(1);
+  expect(screen.getByRole('combobox')).toBeInTheDocument();
   expect(
-    screen.getAllByRole('combobox', { name: SupersetCore.t('Owners') }),
-  ).toHaveLength(1);
+    screen.getByRole('combobox', { name: SupersetCore.t('Owners') }),
+  ).toBeInTheDocument();
 
   await open();
 

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -123,13 +123,7 @@ const PropertiesModal = ({
   };
 
   const loadAccessOptions = useCallback(
-    (
-      accessType = 'owners',
-      input = '',
-      checkActive: boolean = true,
-      page: number,
-      pageSize: number,
-    ) => {
+    (accessType = 'owners', input = '', page: number, pageSize: number) => {
       const query = rison.encode({
         filter: input,
         page,
@@ -137,21 +131,17 @@ const PropertiesModal = ({
       });
       return SupersetClient.get({
         endpoint: `/api/v1/dashboard/related/${accessType}?q=${query}`,
-      }).then(response => {
-        let data = response.json.result;
-        if (checkActive) {
-          data = data.filter(
-            (item: { extra: { active: boolean } }) => item.extra.active,
-          );
-        }
-        return {
-          data: data.map((item: { value: number; text: string }) => ({
+      }).then(response => ({
+        data: response.json.result
+          .filter((item: { extra: { active: boolean } }) =>
+            item.extra.active !== undefined ? item.extra.active : true,
+          )
+          .map((item: { value: number; text: string }) => ({
             value: item.value,
             label: item.text,
           })),
-          totalCount: response.json.count,
-        };
-      });
+        totalCount: response.json.count,
+      }));
     },
     [],
   );
@@ -419,7 +409,7 @@ const PropertiesModal = ({
               mode="multiple"
               onChange={handleOnChangeOwners}
               options={(input, page, pageSize) =>
-                loadAccessOptions('owners', input, true, page, pageSize)
+                loadAccessOptions('owners', input, page, pageSize)
               }
               value={handleOwnersSelectValue()}
             />
@@ -466,7 +456,7 @@ const PropertiesModal = ({
                 mode="multiple"
                 onChange={handleOnChangeOwners}
                 options={(input, page, pageSize) =>
-                  loadAccessOptions('owners', input, true, page, pageSize)
+                  loadAccessOptions('owners', input, page, pageSize)
                 }
                 value={handleOwnersSelectValue()}
               />
@@ -484,10 +474,9 @@ const PropertiesModal = ({
                 ariaLabel={t('Roles')}
                 disabled={isLoading}
                 mode="multiple"
-                labelInValue={true}
                 onChange={handleOnChangeRoles}
                 options={(input, page, pageSize) =>
-                  loadAccessOptions('roles', input, false, page, pageSize)
+                  loadAccessOptions('roles', input, page, pageSize)
                 }
                 value={handleRolesSelectValue()}
               />

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -123,7 +123,13 @@ const PropertiesModal = ({
   };
 
   const loadAccessOptions = useCallback(
-    (accessType = 'owners', input = '', page: number, pageSize: number) => {
+    (
+      accessType = 'owners',
+      input = '',
+      checkActive: boolean = true,
+      page: number,
+      pageSize: number,
+    ) => {
       const query = rison.encode({
         filter: input,
         page,
@@ -131,15 +137,21 @@ const PropertiesModal = ({
       });
       return SupersetClient.get({
         endpoint: `/api/v1/dashboard/related/${accessType}?q=${query}`,
-      }).then(response => ({
-        data: response.json.result
-          .filter((item: { extra: { active: boolean } }) => item.extra.active)
-          .map((item: { value: number; text: string }) => ({
+      }).then(response => {
+        let data = response.json.result;
+        if (checkActive) {
+          data = data.filter(
+            (item: { extra: { active: boolean } }) => item.extra.active,
+          );
+        }
+        return {
+          data: data.map((item: { value: number; text: string }) => ({
             value: item.value,
             label: item.text,
           })),
-        totalCount: response.json.count,
-      }));
+          totalCount: response.json.count,
+        };
+      });
     },
     [],
   );
@@ -407,7 +419,7 @@ const PropertiesModal = ({
               mode="multiple"
               onChange={handleOnChangeOwners}
               options={(input, page, pageSize) =>
-                loadAccessOptions('owners', input, page, pageSize)
+                loadAccessOptions('owners', input, true, page, pageSize)
               }
               value={handleOwnersSelectValue()}
             />
@@ -454,7 +466,7 @@ const PropertiesModal = ({
                 mode="multiple"
                 onChange={handleOnChangeOwners}
                 options={(input, page, pageSize) =>
-                  loadAccessOptions('owners', input, page, pageSize)
+                  loadAccessOptions('owners', input, true, page, pageSize)
                 }
                 value={handleOwnersSelectValue()}
               />
@@ -472,9 +484,10 @@ const PropertiesModal = ({
                 ariaLabel={t('Roles')}
                 disabled={isLoading}
                 mode="multiple"
+                labelInValue={true}
                 onChange={handleOnChangeRoles}
                 options={(input, page, pageSize) =>
-                  loadAccessOptions('roles', input, page, pageSize)
+                  loadAccessOptions('roles', input, false, page, pageSize)
                 }
                 value={handleRolesSelectValue()}
               />


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes: #21538 
regression from https://github.com/apache/superset/pull/20837

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Enable `DASHBOARD_RBAC` feature flag
Add 1 role
Add 1 active and 1 inactive user
Create 1 dashboard
Click on edit dashboard from actions
Check owners dropdown shows only active users
Check roles dropdown shows all roles available


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/21538
- [x] Required feature flags: DASHBOARD_RBAC
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
