### PR TITLE
feat(embedded): +2 fns: getDashboardPermalink, getActiveTabs -> 1.5

### DIFF
--- a/superset-embedded-sdk/src/index.ts
+++ b/superset-embedded-sdk/src/index.ts
@@ -58,6 +58,8 @@ export type Size = {
 export type EmbeddedDashboard = {
   getScrollSize: () => Promise<Size>
   unmount: () => void
+  getDashboardPermalink: (anchor: string) => Promise<string>
+  getActiveTabs: () => Promise<string[]>
 }
 
 /**
@@ -100,12 +102,12 @@ export async function embedDashboard({
       const iframe = document.createElement('iframe');
       const dashboardConfig = dashboardUiConfig ? `?uiConfig=${calculateConfig()}` : ""
 
-      // setup the iframe's sandbox configuration
+      // set up the iframe's sandbox configuration
       iframe.sandbox.add("allow-same-origin"); // needed for postMessage to work
       iframe.sandbox.add("allow-scripts"); // obviously the iframe needs scripts
       iframe.sandbox.add("allow-presentation"); // for fullscreen charts
       iframe.sandbox.add("allow-downloads"); // for downloading charts as image
-      // add these ones if it turns out we need them:
+      // add these if it turns out we need them:
       // iframe.sandbox.add("allow-top-navigation");
       // iframe.sandbox.add("allow-forms");
 
@@ -137,7 +139,7 @@ export async function embedDashboard({
     });
   }
 
-  const [guestToken, ourPort] = await Promise.all([
+  const [guestToken, ourPort]: [string, Switchboard] = await Promise.all([
     fetchGuestToken(),
     mountIframe(),
   ]);
@@ -159,9 +161,14 @@ export async function embedDashboard({
   }
 
   const getScrollSize = () => ourPort.get<Size>('getScrollSize');
+  const getDashboardPermalink = (anchor: string) =>
+    ourPort.get<string>('getDashboardPermalink', { anchor });
+  const getActiveTabs = () => ourPort.get<string[]>('getActiveTabs')
 
   return {
     getScrollSize,
     unmount,
+    getDashboardPermalink,
+    getActiveTabs,
   };
 }

--- a/superset-frontend/src/embedded/api.tsx
+++ b/superset-frontend/src/embedded/api.tsx
@@ -1,0 +1,43 @@
+import { store } from '../views/store';
+import { bootstrapData } from '../preamble';
+import { getDashboardPermalink as getDashboardPermalinkUtil } from "../utils/urlUtils";
+import {RootState} from "../dashboard/types";
+
+type Size = {
+  width: number, height: number
+}
+
+type EmbeddedSupersetApi = {
+  getScrollSize: () => Size;
+  getDashboardPermalink: ({ anchor }: { anchor: string }) => Promise<string>;
+  getActiveTabs: () => string[];
+}
+
+const getScrollSize = (): Size => ({
+  width: document.body.scrollWidth,
+  height: document.body.scrollHeight,
+})
+
+const getDashboardPermalink = async ({anchor}: {anchor: string}): Promise<string> => {
+  const state: RootState = store?.getState();
+  const { dashboardId, dataMask, activeTabs } = {
+    dashboardId: state?.dashboardInfo?.id || bootstrapData?.embedded!.dashboard_id,
+    dataMask: state?.dataMask,
+    activeTabs: state.dashboardState?.activeTabs,
+  }
+
+  return getDashboardPermalinkUtil({
+    dashboardId,
+    dataMask,
+    activeTabs,
+    anchor,
+  });
+}
+
+const getActiveTabs = () => store?.getState()?.dashboardState?.activeTabs || [];
+
+export const embeddedApi: EmbeddedSupersetApi = {
+  getScrollSize,
+  getDashboardPermalink,
+  getActiveTabs
+};

--- a/superset-frontend/src/embedded/api.tsx
+++ b/superset-frontend/src/embedded/api.tsx
@@ -1,30 +1,30 @@
 import { store } from '../views/store';
 import { bootstrapData } from '../preamble';
-import { getDashboardPermalink as getDashboardPermalinkUtil } from "../utils/urlUtils";
-import {RootState} from "../dashboard/types";
+import { getDashboardPermalink as getDashboardPermalinkUtil } from '../utils/urlUtils';
 
 type Size = {
-  width: number, height: number
-}
+  width: number;
+  height: number;
+};
 
 type EmbeddedSupersetApi = {
   getScrollSize: () => Size;
   getDashboardPermalink: ({ anchor }: { anchor: string }) => Promise<string>;
   getActiveTabs: () => string[];
-}
+};
 
 const getScrollSize = (): Size => ({
   width: document.body.scrollWidth,
   height: document.body.scrollHeight,
-})
+});
 
-const getDashboardPermalink = async ({anchor}: {anchor: string}): Promise<string> => {
-  const state: RootState = store?.getState();
+const getDashboardPermalink = async ({ anchor }: { anchor: string }): Promise<string> => {
+  const state = store?.getState();
   const { dashboardId, dataMask, activeTabs } = {
     dashboardId: state?.dashboardInfo?.id || bootstrapData?.embedded!.dashboard_id,
     dataMask: state?.dataMask,
     activeTabs: state.dashboardState?.activeTabs,
-  }
+  };
 
   return getDashboardPermalinkUtil({
     dashboardId,
@@ -32,12 +32,12 @@ const getDashboardPermalink = async ({anchor}: {anchor: string}): Promise<string
     activeTabs,
     anchor,
   });
-}
+};
 
 const getActiveTabs = () => store?.getState()?.dashboardState?.activeTabs || [];
 
 export const embeddedApi: EmbeddedSupersetApi = {
   getScrollSize,
   getDashboardPermalink,
-  getActiveTabs
+  getActiveTabs,
 };

--- a/superset-frontend/src/embedded/api.tsx
+++ b/superset-frontend/src/embedded/api.tsx
@@ -1,6 +1,8 @@
 import { store } from '../views/store';
 import { bootstrapData } from '../preamble';
-import { getDashboardPermalink as getDashboardPermalinkUtil } from '../utils/urlUtils';
+import { URL_PARAMS } from 'src/constants';
+import { getDashboardPermalink as getDashboardPermalinkUtil, getUrlParam } from '../utils/urlUtils';
+import { getFilterValue } from 'src/dashboard/components/nativeFilters/FilterBar/keyValue';
 
 type Size = {
   width: number;
@@ -19,18 +21,18 @@ const getScrollSize = (): Size => ({
 });
 
 const getDashboardPermalink = async ({ anchor }: { anchor: string }): Promise<string> => {
-  const state = store?.getState();
-  const { dashboardId, dataMask, activeTabs } = {
-    dashboardId: state?.dashboardInfo?.id || bootstrapData?.embedded!.dashboard_id,
-    dataMask: state?.dataMask,
-    activeTabs: state.dashboardState?.activeTabs,
-  };
+  const dashboardId = store.getState()?.dashboardInfo?.id || bootstrapData?.embedded!.dashboard_id;
+
+  let filterState = {};
+  const nativeFiltersKey = getUrlParam(URL_PARAMS.nativeFiltersKey);
+  if (nativeFiltersKey && dashboardId) {
+    filterState = await getFilterValue(dashboardId, nativeFiltersKey);
+  }
 
   return getDashboardPermalinkUtil({
     dashboardId,
-    dataMask,
-    activeTabs,
-    anchor,
+    filterState,
+    hash: anchor,
   });
 };
 

--- a/superset-frontend/src/embedded/index.tsx
+++ b/superset-frontend/src/embedded/index.tsx
@@ -29,6 +29,8 @@ import ErrorBoundary from 'src/components/ErrorBoundary';
 import Loading from 'src/components/Loading';
 import { addDangerToast } from 'src/components/MessageToasts/actions';
 import ToastContainer from 'src/components/MessageToasts/ToastContainer';
+import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
+import { embeddedApi } from './api';
 
 const debugMode = process.env.WEBPACK_MODE === 'development';
 
@@ -150,7 +152,7 @@ window.addEventListener('message', function embeddedPageInitializer(event) {
 
     let started = false;
 
-    switchboard.defineMethod('guestToken', ({ guestToken }) => {
+    switchboard.defineMethod('guestToken', ({ guestToken }: { guestToken: string }) => {
       setupGuestClient(guestToken);
       if (!started) {
         ReactDOM.render(<EmbeddedApp />, appMountPoint);
@@ -158,11 +160,9 @@ window.addEventListener('message', function embeddedPageInitializer(event) {
       }
     });
 
-    switchboard.defineMethod('getScrollSize', () => ({
-      width: document.body.scrollWidth,
-      height: document.body.scrollHeight,
-    }));
-
+    switchboard.defineMethod('getScrollSize', embeddedApi.getScrollSize);
+    switchboard.defineMethod('getDashboardPermalink', embeddedApi.getDashboardPermalink);
+    switchboard.defineMethod('getActiveTabs', embeddedApi.getActiveTabs);
     switchboard.start();
   }
 });

--- a/superset-frontend/src/embedded/index.tsx
+++ b/superset-frontend/src/embedded/index.tsx
@@ -29,7 +29,6 @@ import ErrorBoundary from 'src/components/ErrorBoundary';
 import Loading from 'src/components/Loading';
 import { addDangerToast } from 'src/components/MessageToasts/actions';
 import ToastContainer from 'src/components/MessageToasts/ToastContainer';
-import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
 import { embeddedApi } from './api';
 
 const debugMode = process.env.WEBPACK_MODE === 'development';

--- a/superset/security/guest_token.py
+++ b/superset/security/guest_token.py
@@ -78,6 +78,7 @@ class GuestUser(AnonymousUserMixin):
 
     def __init__(self, token: GuestToken, roles: List[Role]):
         user = token["user"]
+        self.id = None
         self.guest_token = token
         self.username = user.get("username", "guest_user")
         self.first_name = user.get("first_name", "Guest")


### PR DESCRIPTION
Added 2 more functions in embedded superset: getDashboardPermalinkForAnchor, getActiveTabs.
This is to merge these changes to 1.5 branch of superset.

This pull request includes cherry-picked changes from https://github.com/apache/superset/pull/21444

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Ability to request the following information from the parent app to embedded superset

Get active tabs
Get dashboard permalink by anchor (example of an anchor - a chart id, for example CHART-a4qv8d)


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
Embed dashboard using embedded sdk
Make calls to get active tabs
Make calls to get a chart permalink

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Required feature flags:  EMBEDDED_SUPERSET = True
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
