### PR TITLE
[DRAFT]chore(deps): Bump Flask-Caching version to ==1.11.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -34,9 +34,7 @@ bleach==3.3.1
 brotli==1.0.9
     # via flask-compress
 cachelib==0.4.1
-    # via
-    #   apache-superset
-    #   flask-caching
+    # via apache-superset
 celery==5.2.2
     # via apache-superset
 cffi==1.14.6
@@ -92,7 +90,7 @@ flask-appbuilder==4.1.4
     # via apache-superset
 flask-babel==1.0.0
     # via flask-appbuilder
-flask-caching==1.11.1
+flask-caching==1.11.0
     # via apache-superset
 flask-compress==1.10.1
     # via apache-superset

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -34,7 +34,9 @@ bleach==3.3.1
 brotli==1.0.9
     # via flask-compress
 cachelib==0.4.1
-    # via apache-superset
+    # via
+    #   apache-superset
+    #   flask-caching
 celery==5.2.2
     # via apache-superset
 cffi==1.14.6
@@ -90,7 +92,7 @@ flask-appbuilder==4.1.4
     # via apache-superset
 flask-babel==1.0.0
     # via flask-appbuilder
-flask-caching==1.10.1
+flask-caching==1.11.1
     # via apache-superset
 flask-compress==1.10.1
     # via apache-superset
@@ -128,6 +130,8 @@ gunicorn==20.1.0
     # via apache-superset
 hashids==1.3.1
     # via apache-superset
+hijri-converter==2.2.4
+    # via holidays
 holidays==0.14.2
     # via apache-superset
 humanize==3.11.0
@@ -232,7 +236,6 @@ pytz==2021.3
     # via
     #   babel
     #   celery
-    #   convertdate
     #   flask-babel
     #   pandas
 pyyaml==5.4.1
@@ -250,14 +253,12 @@ six==1.16.0
     #   bleach
     #   click-repl
     #   flask-talisman
-    #   holidays
     #   isodate
     #   jsonschema
     #   polyline
     #   prison
     #   pyrsistent
     #   python-dateutil
-    #   sqlalchemy-utils
     #   wtforms-json
 slackclient==2.5.0
     # via apache-superset

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -111,6 +111,8 @@ pydata-google-auth==1.2.0
     # via pandas-gbq
 pyfakefs==4.5.6
     # via -r requirements/testing.in
+pyhive[presto]==0.6.5
+    # via apache-superset
 pylint==2.9.6
     # via -r requirements/testing.in
 pytest==6.2.4

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -111,8 +111,6 @@ pydata-google-auth==1.2.0
     # via pandas-gbq
 pyfakefs==4.5.6
     # via -r requirements/testing.in
-pyhive[presto]==0.6.5
-    # via apache-superset
 pylint==2.9.6
     # via -r requirements/testing.in
 pytest==6.2.4

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
         "deprecation>=2.1.0, <2.2.0",
         "flask>=2.0.0, <3.0.0",
         "flask-appbuilder>=4.1.4, <5.0.0",
-        "flask-caching>=1.10.0",
+        "flask-caching==1.11.1",
         "flask-compress",
         "flask-talisman",
         "flask-migrate",

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
         "deprecation>=2.1.0, <2.2.0",
         "flask>=2.0.0, <3.0.0",
         "flask-appbuilder>=4.1.4, <5.0.0",
-        "flask-caching==1.11.1",
+        "flask-caching==1.11.0",
         "flask-compress",
         "flask-talisman",
         "flask-migrate",


### PR DESCRIPTION
### SUMMARY
- pin flask-caching to `1.11.1` to address dependabot issues.

**Note:** 2.0.0 and beyond use a different version of cachelib with breaking changes https://flask-caching.readthedocs.io/en/latest/changelog.html#version-2-0-0

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
