### PR TITLE
fix: Dataset creation header is now uneditable and holds proper default values

### DIFF
--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/AddDataset.test.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/AddDataset.test.tsx
@@ -27,11 +27,7 @@ describe('AddDataset', () => {
     const blankeStateImgs = screen.getAllByRole('img', { name: /empty/i });
 
     // Header
-    expect(
-      await screen.findByRole('textbox', {
-        name: /dataset name/i,
-      }),
-    ).toBeVisible();
+    expect(await screen.findByTestId('editable-title')).toBeVisible();
     // Left panel
     expect(blankeStateImgs[0]).toBeVisible();
     // Footer

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/Header/Header.test.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/Header/Header.test.tsx
@@ -18,7 +18,9 @@
  */
 import React from 'react';
 import { render, screen, waitFor } from 'spec/helpers/testing-library';
-import Header from 'src/views/CRUD/data/dataset/AddDataset/Header';
+import Header, {
+  DEFAULT_TITLE,
+} from 'src/views/CRUD/data/dataset/AddDataset/Header';
 
 describe('Header', () => {
   const mockSetDataset = jest.fn();
@@ -48,7 +50,7 @@ describe('Header', () => {
     await waitForRender();
 
     const datasetName = screen.getByTestId('editable-title');
-    expect(datasetName.innerHTML).toBe('New dataset');
+    expect(datasetName.innerHTML).toBe(DEFAULT_TITLE);
   });
 
   test('displays table name when a table is selected', async () => {

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/Header/Header.test.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/Header/Header.test.tsx
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { render, screen, waitFor } from 'spec/helpers/testing-library';
 import Header from 'src/views/CRUD/data/dataset/AddDataset/Header';
@@ -24,17 +23,13 @@ import Header from 'src/views/CRUD/data/dataset/AddDataset/Header';
 describe('Header', () => {
   const mockSetDataset = jest.fn();
 
-  const waitForRender = (datasetName: string) =>
-    waitFor(() =>
-      render(<Header setDataset={mockSetDataset} datasetName={datasetName} />),
-    );
+  const waitForRender = (props?: any) =>
+    waitFor(() => render(<Header setDataset={mockSetDataset} {...props} />));
 
-  it('renders a blank state Header', async () => {
-    await waitForRender('');
+  test('renders a blank state Header', async () => {
+    await waitForRender();
 
-    const datasetNameTextbox = screen.getByRole('textbox', {
-      name: /dataset name/i,
-    });
+    const datasetName = screen.getByTestId('editable-title');
     const saveButton = screen.getByRole('button', {
       name: /save save/i,
     });
@@ -42,38 +37,26 @@ describe('Header', () => {
       name: /menu actions trigger/i,
     });
 
-    expect(datasetNameTextbox).toBeVisible();
+    expect(datasetName).toBeVisible();
     expect(saveButton).toBeVisible();
     expect(saveButton).toBeDisabled();
     expect(menuButton).toBeVisible();
     expect(menuButton).toBeDisabled();
   });
 
-  it('updates display value of dataset name textbox when Header title is changed', async () => {
-    await waitForRender('');
+  test('displays "New dataset" when a table is not selected', async () => {
+    await waitForRender();
 
-    const datasetNameTextbox = screen.getByRole('textbox', {
-      name: /dataset name/i,
-    });
-
-    // Textbox should start with an empty display value and placeholder text
-    expect(datasetNameTextbox).toHaveDisplayValue('');
-    expect(
-      screen.getByPlaceholderText(/add the name of the dataset/i),
-    ).toBeVisible();
-
-    // Textbox should update its display value when user inputs a new value
-    userEvent.type(datasetNameTextbox, 'Test name');
-    expect(datasetNameTextbox).toHaveDisplayValue('Test name');
+    const datasetName = screen.getByTestId('editable-title');
+    expect(datasetName.innerHTML).toBe('New dataset');
   });
 
-  it('passes an existing dataset title into the dataset name textbox', async () => {
-    await waitForRender('Existing Dataset Name');
+  test('displays table name when a table is selected', async () => {
+    // The schema and table name are passed in through props once selected
+    await waitForRender({ schema: 'testSchema', title: 'testTable' });
 
-    const datasetNameTextbox = screen.getByRole('textbox', {
-      name: /dataset name/i,
-    });
+    const datasetName = screen.getByTestId('editable-title');
 
-    expect(datasetNameTextbox).toHaveDisplayValue('Existing Dataset Name');
+    expect(datasetName.innerHTML).toBe('testTable');
   });
 });

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/Header/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/Header/index.tsx
@@ -59,21 +59,23 @@ const renderOverlay = () => (
 
 export default function Header({
   setDataset,
-  datasetName,
+  title,
+  schema,
 }: {
   setDataset: React.Dispatch<DSReducerActionType>;
-  datasetName: string;
+  title: string;
+  schema?: string;
 }) {
   const editableTitleProps = {
-    title: datasetName,
-    placeholder: t('Add the name of the dataset'),
+    title: schema ? title : t('New dataset'),
+    placeholder: t('New dataset'),
     onSave: (newDatasetName: string) => {
       setDataset({
         type: DatasetActionType.changeDataset,
         payload: { name: 'dataset_name', value: newDatasetName },
       });
     },
-    canEdit: true,
+    canEdit: false,
     label: t('dataset name'),
   };
 

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/Header/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/Header/index.tsx
@@ -64,7 +64,7 @@ export default function Header({
 }: {
   setDataset: React.Dispatch<DSReducerActionType>;
   title: string;
-  schema?: string;
+  schema?: string | null | undefined;
 }) {
   const editableTitleProps = {
     title: schema ? title : t('New dataset'),

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/Header/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/Header/index.tsx
@@ -32,6 +32,8 @@ import {
   DSReducerActionType,
 } from 'src/views/CRUD/data/dataset/AddDataset/types';
 
+export const DEFAULT_TITLE = t('New dataset');
+
 const tooltipProps: { text: string; placement: TooltipPlacement } = {
   text: t('Select a database table and create dataset'),
   placement: 'bottomRight',
@@ -59,16 +61,15 @@ const renderOverlay = () => (
 
 export default function Header({
   setDataset,
-  title,
-  schema,
+  title = DEFAULT_TITLE,
 }: {
   setDataset: React.Dispatch<DSReducerActionType>;
-  title: string;
+  title?: string | null | undefined;
   schema?: string | null | undefined;
 }) {
   const editableTitleProps = {
-    title: schema ? title : t('New dataset'),
-    placeholder: t('New dataset'),
+    title: title ?? DEFAULT_TITLE,
+    placeholder: DEFAULT_TITLE,
     onSave: (newDatasetName: string) => {
       setDataset({
         type: DatasetActionType.changeDataset,

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/index.tsx
@@ -41,7 +41,7 @@ import { DatasetActionType } from '../types';
 
 interface LeftPanelProps {
   setDataset: Dispatch<SetStateAction<object>>;
-  schema?: string | undefined | null;
+  schema?: string;
   dbId?: number;
 }
 

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/index.tsx
@@ -41,7 +41,7 @@ import { DatasetActionType } from '../types';
 
 interface LeftPanelProps {
   setDataset: Dispatch<SetStateAction<object>>;
-  schema?: string;
+  schema?: string | null | undefined;
   dbId?: number;
 }
 

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/index.tsx
@@ -80,6 +80,12 @@ export default function AddDataset() {
       schema={dataset?.schema}
       dbId={dataset?.db?.id}
     />
+  )
+  const prevUrl =
+    '/tablemodelview/list/?pageIndex=0&sortColumn=changed_on_delta_humanized&sortOrder=desc';
+
+  const FooterComponent = () => (
+    <Footer url={prevUrl} datasetObject={dataset} />
   );
   const prevUrl =
     '/tablemodelview/list/?pageIndex=0&sortColumn=changed_on_delta_humanized&sortOrder=desc';

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/index.tsx
@@ -80,7 +80,7 @@ export default function AddDataset() {
       schema={dataset?.schema}
       dbId={dataset?.db?.id}
     />
-  )
+  );
   const prevUrl =
     '/tablemodelview/list/?pageIndex=0&sortColumn=changed_on_delta_humanized&sortOrder=desc';
 

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/index.tsx
@@ -71,13 +71,17 @@ export default function AddDataset() {
   >(datasetReducer, null);
 
   const HeaderComponent = () => (
-    <Header setDataset={setDataset} datasetName={dataset?.dataset_name ?? ''} />
+    <Header
+      setDataset={setDataset}
+      title={dataset?.table_name ?? 'New dataset'}
+      schema={dataset?.schema ?? ''}
+    />
   );
 
   const LeftPanelComponent = () => (
     <LeftPanel
       setDataset={setDataset}
-      schema={dataset?.schema}
+      schema={dataset?.schema ?? ''}
       dbId={dataset?.db?.id}
     />
   );

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/index.tsx
@@ -71,11 +71,7 @@ export default function AddDataset() {
   >(datasetReducer, null);
 
   const HeaderComponent = () => (
-    <Header
-      setDataset={setDataset}
-      title={dataset?.table_name ?? 'New dataset'}
-      schema={dataset?.schema}
-    />
+    <Header setDataset={setDataset} title={dataset?.table_name} />
   );
 
   const LeftPanelComponent = () => (

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/index.tsx
@@ -74,14 +74,14 @@ export default function AddDataset() {
     <Header
       setDataset={setDataset}
       title={dataset?.table_name ?? 'New dataset'}
-      schema={dataset?.schema ?? ''}
+      schema={dataset?.schema}
     />
   );
 
   const LeftPanelComponent = () => (
     <LeftPanel
       setDataset={setDataset}
-      schema={dataset?.schema ?? ''}
+      schema={dataset?.schema}
       dbId={dataset?.db?.id}
     />
   );

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/index.tsx
@@ -91,12 +91,6 @@ export default function AddDataset() {
   const FooterComponent = () => (
     <Footer url={prevUrl} datasetObject={dataset} />
   );
-  const prevUrl =
-    '/tablemodelview/list/?pageIndex=0&sortColumn=changed_on_delta_humanized&sortOrder=desc';
-
-  const FooterComponent = () => (
-    <Footer url={prevUrl} datasetObject={dataset} />
-  );
 
   return (
     <DatasetLayout

--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetLayout/DatasetLayout.test.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetLayout/DatasetLayout.test.tsx
@@ -36,7 +36,7 @@ describe('DatasetLayout', () => {
   const mockSetDataset = jest.fn();
 
   const waitForRender = () =>
-    waitFor(() => render(<Header setDataset={mockSetDataset} title="" />));
+    waitFor(() => render(<Header setDataset={mockSetDataset} />));
 
   it('renders a Header when passed in', async () => {
     await waitForRender();

--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetLayout/DatasetLayout.test.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetLayout/DatasetLayout.test.tsx
@@ -36,18 +36,12 @@ describe('DatasetLayout', () => {
   const mockSetDataset = jest.fn();
 
   const waitForRender = () =>
-    waitFor(() =>
-      render(<Header setDataset={mockSetDataset} datasetName="" />),
-    );
+    waitFor(() => render(<Header setDataset={mockSetDataset} title="" />));
 
   it('renders a Header when passed in', async () => {
     await waitForRender();
 
-    expect(
-      screen.getByRole('textbox', {
-        name: /dataset name/i,
-      }),
-    ).toBeVisible();
+    expect(screen.getByTestId('editable-title')).toBeVisible();
   });
 
   it('renders a LeftPanel when passed in', async () => {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Dataset header name is now uneditable. It displays "New dataset' until a table is selected, then it displays the selected table's name.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### BEFORE:
![dsHeaderBefore](https://user-images.githubusercontent.com/55605634/191843160-6a5d7c6e-f9bf-49b9-aa5d-75010bd8c945.png)

#### AFTER:
![dsHeaderAfter](https://user-images.githubusercontent.com/55605634/191843203-c1365d45-bfe1-474d-aa48-44777a6f60ba.gif)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Go to `http://localhost:9000/dataset/add/?testing`
- Try to click the header and see that it is no longer editable (at any point)
- Select a database, schema, and table name
- Observe that the header now displays the table name

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
