### PR TITLE
feat: Adds the MetadataBar to the Explore header

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,13 +10,15 @@
 .github/workflows/docker-ephemeral-env.yml @robdiciuccio @craig-rueda @rusackas @eschutho @dpgaspar @nytai @mistercrunch
 .github/workflows/ephemeral*.yml @robdiciuccio @craig-rueda @rusackas @eschutho @dpgaspar @nytai @mistercrunch
 
-# Notify some committers of changes in the Select component
+# Notify some committers of changes in the components
 
 /superset-frontend/src/components/Select/ @michael-s-molina @geido @ktmud
+/superset-frontend/src/components/MetadataBar/ @michael-s-molina
 
 # Notify Helm Chart maintainers about changes in it
 
 /helm/superset/ @craig-rueda @dpgaspar @villebro
 
 # Notify E2E test maintainers of changes
+
 /superset-frontend/cypress-base/ @jinghua-qa @geido

--- a/superset-frontend/src/components/MetadataBar/ContentConfig.tsx
+++ b/superset-frontend/src/components/MetadataBar/ContentConfig.tsx
@@ -17,7 +17,6 @@
  * under the License.
  */
 import React from 'react';
-import moment from 'moment';
 import { ensureIsArray, styled, t } from '@superset-ui/core';
 import Icons from 'src/components/Icons';
 import { ContentType, MetadataType } from '.';
@@ -75,13 +74,10 @@ const config = (contentType: ContentType) => {
     case MetadataType.LAST_MODIFIED:
       return {
         icon: Icons.EditOutlined,
-        title: moment.utc(contentType.value).fromNow(),
+        title: contentType.value,
         tooltip: (
           <div>
-            <Info
-              header={t('Last modified')}
-              text={moment.utc(contentType.value).fromNow()}
-            />
+            <Info header={t('Last modified')} text={contentType.value} />
             <Info header={t('Modified by')} text={contentType.modifiedBy} />
           </div>
         ),
@@ -95,10 +91,7 @@ const config = (contentType: ContentType) => {
           <div>
             <Info header={t('Created by')} text={contentType.createdBy} />
             <Info header={t('Owners')} text={contentType.owners} />
-            <Info
-              header={t('Created on')}
-              text={moment.utc(contentType.createdOn).fromNow()}
-            />
+            <Info header={t('Created on')} text={contentType.createdOn} />
           </div>
         ),
       };

--- a/superset-frontend/src/components/MetadataBar/ContentType.ts
+++ b/superset-frontend/src/components/MetadataBar/ContentType.ts
@@ -43,7 +43,7 @@ export type Description = {
 
 export type LastModified = {
   type: MetadataType.LAST_MODIFIED;
-  value: Date;
+  value: string;
   modifiedBy: string;
   onClick?: (type: string) => void;
 };
@@ -52,7 +52,7 @@ export type Owner = {
   type: MetadataType.OWNER;
   createdBy: string;
   owners: string[];
-  createdOn: Date;
+  createdOn: string;
   onClick?: (type: string) => void;
 };
 

--- a/superset-frontend/src/components/MetadataBar/MetadataBar.stories.tsx
+++ b/superset-frontend/src/components/MetadataBar/MetadataBar.stories.tsx
@@ -26,7 +26,7 @@ export default {
   component: MetadataBar,
 };
 
-const A_WEEK_AGO = new Date(Date.now() - 7 * 24 * 3600 * 1000);
+const A_WEEK_AGO = 'a week ago';
 
 export const Component = ({
   items,

--- a/superset-frontend/src/dashboard/components/DrillDetailPane/DrillDetailPane.test.tsx
+++ b/superset-frontend/src/dashboard/components/DrillDetailPane/DrillDetailPane.test.tsx
@@ -22,7 +22,6 @@ import { getMockStoreWithNativeFilters } from 'spec/fixtures/mockStore';
 import chartQueries, { sliceId } from 'spec/fixtures/mockChartQueries';
 import { QueryFormData, SupersetClient } from '@superset-ui/core';
 import fetchMock from 'fetch-mock';
-import moment from 'moment';
 import DrillDetailPane from './DrillDetailPane';
 
 const chart = chartQueries[sliceId];
@@ -48,8 +47,8 @@ const SAMPLES_ENDPOINT =
 const DATASET_ENDPOINT = 'glob:*/api/v1/dataset/*';
 
 const MOCKED_DATASET = {
-  changed_on: new Date(Date.parse('2022-01-01')),
-  created_on: new Date(Date.parse('2022-01-01')),
+  changed_on_humanized: '2 days ago',
+  created_on_humanized: 'a week ago',
   description: 'Simple description',
   table_name: 'test_table',
   changed_by: {
@@ -170,7 +169,7 @@ test('should render the metadata bar', async () => {
     ),
   ).toBeInTheDocument();
   expect(
-    await screen.findByText(moment.utc(MOCKED_DATASET.changed_on).fromNow()),
+    await screen.findByText(MOCKED_DATASET.changed_on_humanized),
   ).toBeInTheDocument();
 });
 

--- a/superset-frontend/src/dashboard/components/DrillDetailPane/DrillDetailPane.tsx
+++ b/superset-frontend/src/dashboard/components/DrillDetailPane/DrillDetailPane.tsx
@@ -249,8 +249,8 @@ export default function DrillDetailPane({
     const items: ContentType[] = [];
     if (result) {
       const {
-        changed_on,
-        created_on,
+        changed_on_humanized,
+        created_on_humanized,
         description,
         table_name,
         changed_by,
@@ -275,14 +275,14 @@ export default function DrillDetailPane({
       });
       items.push({
         type: MetadataType.LAST_MODIFIED,
-        value: changed_on,
+        value: changed_on_humanized,
         modifiedBy,
       });
       items.push({
         type: MetadataType.OWNER,
         createdBy,
         owners: formattedOwners,
-        createdOn: created_on,
+        createdOn: created_on_humanized,
       });
       if (description) {
         items.push({

--- a/superset-frontend/src/dashboard/components/DrillDetailPane/types.ts
+++ b/superset-frontend/src/dashboard/components/DrillDetailPane/types.ts
@@ -34,8 +34,8 @@ export type Dataset = {
     first_name: string;
     last_name: string;
   };
-  changed_on: Date;
-  created_on: Date;
+  changed_on_humanized: string;
+  created_on_humanized: string;
   description: string;
   table_name: string;
   owners: {

--- a/superset-frontend/src/explore/actions/hydrateExplore.ts
+++ b/superset-frontend/src/explore/actions/hydrateExplore.ts
@@ -47,7 +47,7 @@ enum ColorSchemeType {
 
 export const HYDRATE_EXPLORE = 'HYDRATE_EXPLORE';
 export const hydrateExplore =
-  ({ form_data, slice, dataset }: ExplorePageInitialData) =>
+  ({ form_data, slice, dataset, metadata }: ExplorePageInitialData) =>
   (dispatch: Dispatch, getState: () => ExplorePageState) => {
     const { user, datasources, charts, sliceEntities, common, explore } =
       getState();
@@ -123,6 +123,7 @@ export const hydrateExplore =
       controlsTransferred: explore.controlsTransferred,
       standalone: getUrlParam(URL_PARAMS.standalone),
       force: getUrlParam(URL_PARAMS.force),
+      metadata,
     };
 
     // apply initial mapStateToProps for all controls, must execute AFTER

--- a/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
@@ -36,7 +36,7 @@ window.featureFlags = {
   [FeatureFlag.EMBEDDABLE_CHARTS]: true,
 };
 
-const createProps = () => ({
+const createProps = (additionalProps = {}) => ({
   chart: {
     id: 1,
     latestQueryFormData: {
@@ -63,7 +63,7 @@ const createProps = () => ({
     changed_on: '2021-03-19T16:30:56.750230',
     changed_on_humanized: '7 days ago',
     datasource: 'FCC 2018 Survey',
-    description: null,
+    description: 'Simple description',
     description_markeddown: '',
     edit_url: '/chart/edit/318',
     form_data: {
@@ -106,10 +106,19 @@ const createProps = () => ({
   user: {
     userId: 1,
   },
+  metadata: {
+    created_on_humanized: 'a week ago',
+    changed_on_humanized: '2 days ago',
+    owners: ['John Doe'],
+    created_by: 'John Doe',
+    changed_by: 'John Doe',
+    dashboards: [{ id: 1, dashboard_title: 'Test' }],
+  },
   onSaveChart: jest.fn(),
   canOverwrite: false,
   canDownload: false,
   isStarred: false,
+  ...additionalProps,
 });
 
 fetchMock.post(
@@ -145,6 +154,27 @@ test('Cancelling changes to the properties should reset previous properties', as
   userEvent.click(screen.getByText('Edit chart properties'));
 
   expect(await screen.findByDisplayValue(prevChartName)).toBeInTheDocument();
+});
+
+test('renders the metadata bar when saved', async () => {
+  const props = createProps({ showTitlePanelItems: true });
+  render(<ExploreHeader {...props} />, { useRedux: true });
+  expect(
+    await screen.findByText('Added to 1 dashboard(s)'),
+  ).toBeInTheDocument();
+  expect(await screen.findByText('Simple description')).toBeInTheDocument();
+  expect(await screen.findByText('John Doe')).toBeInTheDocument();
+  expect(await screen.findByText('2 days ago')).toBeInTheDocument();
+});
+
+test('does not render the metadata bar when not saved', async () => {
+  const props = createProps({ showTitlePanelItems: true, slice: null });
+  render(<ExploreHeader {...props} />, { useRedux: true });
+  await waitFor(() =>
+    expect(
+      screen.queryByText('Added to 1 dashboard(s)'),
+    ).not.toBeInTheDocument(),
+  );
 });
 
 test('Save chart', async () => {

--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
@@ -62,6 +62,15 @@ const saveButtonStyles = theme => css`
   }
 `;
 
+const additionalItemsStyles = theme => css`
+  display: flex;
+  align-items: center;
+  margin-left: ${theme.gridUnit}px;
+  & > span {
+    margin-right: ${theme.gridUnit * 3}px;
+  }
+`;
+
 export const ExploreChartHeader = ({
   dashboardId,
   slice,
@@ -162,7 +171,7 @@ export const ExploreChartHeader = ({
     items.push({
       type: MetadataType.OWNER,
       createdBy: metadata.created_by || t('Not available'),
-      owners: metadata.owners,
+      owners: metadata.owners.length > 0 ? metadata.owners : t('None'),
       createdOn: metadata.created_on_humanized,
     });
     if (slice?.description) {
@@ -202,7 +211,7 @@ export const ExploreChartHeader = ({
           showTooltip: true,
         }}
         titlePanelAdditionalItems={
-          <>
+          <div css={additionalItemsStyles}>
             {sliceFormData ? (
               <AlteredSliceTag
                 className="altered"
@@ -214,7 +223,7 @@ export const ExploreChartHeader = ({
               />
             ) : null}
             {metadataBar}
-          </>
+          </div>
         }
         rightPanelAdditionalItems={
           <Tooltip

--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
@@ -24,6 +24,7 @@ import { Tooltip } from 'src/components/Tooltip';
 import {
   CategoricalColorNamespace,
   css,
+  logging,
   SupersetClient,
   t,
 } from '@superset-ui/core';
@@ -35,6 +36,7 @@ import Icons from 'src/components/Icons';
 import PropertiesModal from 'src/explore/components/PropertiesModal';
 import { sliceUpdated } from 'src/explore/actions/exploreActions';
 import { PageHeaderWithActions } from 'src/components/PageHeaderWithActions';
+import MetadataBar, { MetadataType } from 'src/components/MetadataBar';
 import { useExploreAdditionalActionsMenu } from '../useExploreAdditionalActionsMenu';
 
 const propTypes = {
@@ -75,51 +77,51 @@ export const ExploreChartHeader = ({
   sliceName,
   onSaveChart,
   saveDisabled,
+  metadata,
 }) => {
   const { latestQueryFormData, sliceFormData } = chart;
   const [isPropertiesModalOpen, setIsPropertiesModalOpen] = useState(false);
 
-  const fetchChartDashboardData = async () => {
-    await SupersetClient.get({
-      endpoint: `/api/v1/chart/${slice.slice_id}`,
-    })
-      .then(res => {
-        const response = res?.json?.result;
-        if (response && response.dashboards && response.dashboards.length) {
-          const { dashboards } = response;
-          const dashboard =
-            dashboardId &&
-            dashboards.length &&
-            dashboards.find(d => d.id === dashboardId);
+  const updateCategoricalNamespace = async () => {
+    const { dashboards } = metadata || {};
+    const dashboard =
+      dashboardId && dashboards && dashboards.find(d => d.id === dashboardId);
 
-          if (dashboard && dashboard.json_metadata) {
-            // setting the chart to use the dashboard custom label colors if any
-            const metadata = JSON.parse(dashboard.json_metadata);
-            const sharedLabelColors = metadata.shared_label_colors || {};
-            const customLabelColors = metadata.label_colors || {};
-            const mergedLabelColors = {
-              ...sharedLabelColors,
-              ...customLabelColors,
-            };
+    if (dashboard) {
+      try {
+        // Dashboards from metadata don't contain the json_metadata field
+        // to avoid unnecessary payload. Here we query for the dashboard json_metadata.
+        const response = await SupersetClient.get({
+          endpoint: `/api/v1/dashboard/${dashboard.id}`,
+        });
+        const result = response?.json?.result;
 
-            const categoricalNamespace =
-              CategoricalColorNamespace.getNamespace();
+        // setting the chart to use the dashboard custom label colors if any
+        const metadata = JSON.parse(result.json_metadata);
+        const sharedLabelColors = metadata.shared_label_colors || {};
+        const customLabelColors = metadata.label_colors || {};
+        const mergedLabelColors = {
+          ...sharedLabelColors,
+          ...customLabelColors,
+        };
 
-            Object.keys(mergedLabelColors).forEach(label => {
-              categoricalNamespace.setColor(
-                label,
-                mergedLabelColors[label],
-                metadata.color_scheme,
-              );
-            });
-          }
-        }
-      })
-      .catch(() => {});
+        const categoricalNamespace = CategoricalColorNamespace.getNamespace();
+
+        Object.keys(mergedLabelColors).forEach(label => {
+          categoricalNamespace.setColor(
+            label,
+            mergedLabelColors[label],
+            metadata.color_scheme,
+          );
+        });
+      } catch (error) {
+        logging.info(t('Unable to retrieve dashboard colors'));
+      }
+    }
   };
 
   useEffect(() => {
-    if (dashboardId) fetchChartDashboardData();
+    if (dashboardId) updateCategoricalNamespace();
   }, []);
 
   const openPropertiesModal = () => {
@@ -139,6 +141,38 @@ export const ExploreChartHeader = ({
       openPropertiesModal,
       ownState,
     );
+
+  const metadataBar = useMemo(() => {
+    if (!metadata) {
+      return null;
+    }
+    const items = [];
+    items.push({
+      type: MetadataType.DASHBOARDS,
+      title:
+        metadata.dashboards.length > 0
+          ? t('Added to %s dashboard(s)', metadata.dashboards.length)
+          : t('Not added to any dashboard'),
+    });
+    items.push({
+      type: MetadataType.LAST_MODIFIED,
+      value: metadata.changed_on_humanized,
+      modifiedBy: metadata.changed_by || t('Not available'),
+    });
+    items.push({
+      type: MetadataType.OWNER,
+      createdBy: metadata.created_by || t('Not available'),
+      owners: metadata.owners,
+      createdOn: metadata.created_on_humanized,
+    });
+    if (slice?.description) {
+      items.push({
+        type: MetadataType.DESCRIPTION,
+        value: slice?.description,
+      });
+    }
+    return <MetadataBar items={items} />;
+  }, [metadata, slice?.description]);
 
   const oldSliceName = slice?.slice_name;
   return (
@@ -168,16 +202,19 @@ export const ExploreChartHeader = ({
           showTooltip: true,
         }}
         titlePanelAdditionalItems={
-          sliceFormData ? (
-            <AlteredSliceTag
-              className="altered"
-              origFormData={{
-                ...sliceFormData,
-                chartTitle: oldSliceName,
-              }}
-              currentFormData={{ ...formData, chartTitle: sliceName }}
-            />
-          ) : null
+          <>
+            {sliceFormData ? (
+              <AlteredSliceTag
+                className="altered"
+                origFormData={{
+                  ...sliceFormData,
+                  chartTitle: oldSliceName,
+                }}
+                currentFormData={{ ...formData, chartTitle: sliceName }}
+              />
+            ) : null}
+            {metadataBar}
+          </>
         }
         rightPanelAdditionalItems={
           <Tooltip

--- a/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
@@ -44,6 +44,14 @@ const reduxState = {
     slice: {
       slice_id: 1,
     },
+    metadata: {
+      created_on_humanized: 'a week ago',
+      changed_on_humanized: '2 days ago',
+      owners: ['John Doe'],
+      created_by: 'John Doe',
+      changed_by: 'John Doe',
+      dashboards: [{ id: 1, dashboard_title: 'Test' }],
+    },
   },
   charts: {
     1: {

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -565,6 +565,7 @@ function ExploreViewContainer(props) {
         reports={props.reports}
         onSaveChart={toggleModal}
         saveDisabled={errorMessage || props.chart.chartStatus === 'loading'}
+        metadata={props.metadata}
       />
       <ExplorePanelContainer id="explore-container">
         <Global
@@ -706,7 +707,7 @@ ExploreViewContainer.propTypes = propTypes;
 function mapStateToProps(state) {
   const { explore, charts, common, impressionId, dataMask, reports, user } =
     state;
-  const { controls, slice, datasource } = explore;
+  const { controls, slice, datasource, metadata } = explore;
   const form_data = getFormDataFromControls(controls);
   const slice_id = form_data.slice_id ?? slice?.slice_id ?? 0; // 0 - unsaved chart
   form_data.extra_form_data = mergeExtraFormData(
@@ -752,6 +753,7 @@ function mapStateToProps(state) {
     user,
     exploreState: explore,
     reports,
+    metadata,
   };
 }
 

--- a/superset-frontend/src/explore/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal/index.tsx
@@ -159,6 +159,7 @@ function PropertiesModal({
         ...payload,
         ...res.json.result,
         id: slice.slice_id,
+        owners: selectedOwners,
       };
       onSave(updatedChart);
       addSuccessToast(t('Chart properties updated'));

--- a/superset-frontend/src/explore/reducers/exploreReducer.js
+++ b/superset-frontend/src/explore/reducers/exploreReducer.js
@@ -245,9 +245,17 @@ export default function exploreReducer(state = {}, action) {
         slice: {
           ...state.slice,
           ...action.slice,
-          owners: action.slice.owners ?? null,
+          owners: action.slice.owners
+            ? action.slice.owners.map(owner => owner.value)
+            : null,
         },
         sliceName: action.slice.slice_name ?? state.sliceName,
+        metadata: {
+          ...state.metadata,
+          owners: action.slice.owners
+            ? action.slice.owners.map(owner => owner.label)
+            : null,
+        },
       };
     },
     [actions.SET_FORCE_QUERY]() {

--- a/superset-frontend/src/explore/types.ts
+++ b/superset-frontend/src/explore/types.ts
@@ -72,6 +72,13 @@ export interface ExplorePageInitialData {
   dataset: Dataset;
   form_data: QueryFormData;
   slice: Slice | null;
+  metadata?: {
+    created_on_humanized: string;
+    changed_on_humanized: string;
+    owners: string[];
+    created_by?: string;
+    changed_by?: string;
+  };
 }
 
 export interface ExploreResponsePayload {

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -179,9 +179,11 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         "extra",
         "kind",
         "created_on",
+        "created_on_humanized",
         "created_by.first_name",
         "created_by.last_name",
         "changed_on",
+        "changed_on_humanized",
         "changed_by.first_name",
         "changed_by.last_name",
     ]

--- a/superset/explore/commands/get.py
+++ b/superset/explore/commands/get.py
@@ -153,11 +153,29 @@ class GetExploreCommand(BaseCommand, ABC):
         except (SupersetException, SQLAlchemyError):
             dataset_data = dummy_dataset_data
 
+        metadata = None
+
+        if slc:
+            metadata = {
+                "created_on_humanized": slc.created_on_humanized,
+                "changed_on_humanized": slc.changed_on_humanized,
+                "owners": [owner.get_full_name() for owner in slc.owners],
+                "dashboards": [
+                    {"id": dashboard.id, "dashboard_title": dashboard.dashboard_title}
+                    for dashboard in slc.dashboards
+                ],
+            }
+            if slc.created_by:
+                metadata["created_by"] = slc.created_by.get_full_name()
+            if slc.changed_by:
+                metadata["changed_by"] = slc.changed_by.get_full_name()
+
         return {
             "dataset": sanitize_datasource_data(dataset_data),
             "form_data": form_data,
             "slice": slc.data if slc else None,
             "message": message,
+            "metadata": metadata,
         }
 
     def validate(self) -> None:


### PR DESCRIPTION
### SUMMARY
- Adds the `MetadataBar` to the Explore header
- Improves the `MetadataBar` resize capabilities and changes the component to work with server-side timestamps
- Changes the logic to get slice-related dashboards to use them in the metadata bar
- Adds and adjusts tests

@kasiazjc I didn't add a tooltip for the number of dashboards because it requires a future PR that will increment the 3 dots menu with the list of related dashboards. This will be made in a follow-up.

@codyml @rusackas 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/191856911-45de56e6-a020-4178-b600-705bb1bf6538.mov

### TESTING INSTRUCTIONS
- Check the video for instructions on the general behavior
- Make sure that the previous logic of inheriting dashboard color schemes is not affected

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
