### PR TITLE
fix(report): Fix permission check for set up email report on charts/dashboards. Fixes #21559

### DIFF
--- a/superset-frontend/src/components/ReportModal/HeaderReportDropdown/index.test.tsx
+++ b/superset-frontend/src/components/ReportModal/HeaderReportDropdown/index.test.tsx
@@ -50,21 +50,34 @@ const stateWithOnlyUser = {
 };
 
 const stateWithNonAdminUser = {
-  explore: {
-    user: {
-      email: 'nonadmin@test.com',
-      firstName: 'nonadmin',
-      isActive: true,
-      lastName: 'nonadmin',
-      permissions: {},
-      createdOn: '2022-01-12T10:17:37.801361',
-      roles: {
-        Gamma: [['no_menu_access', 'Manage']],
-        OtherRole: [['menu_access', 'Manage']],
-      },
-      userId: 1,
-      username: 'nonadmin',
+  user: {
+    email: 'nonadmin@test.com',
+    firstName: 'nonadmin',
+    isActive: true,
+    lastName: 'nonadmin',
+    permissions: {},
+    createdOn: '2022-01-12T10:17:37.801361',
+    roles: {
+      Gamme: [['no_menu_access', 'Manage']],
+      OtherRole: [['menu_access', 'Manage']],
     },
+    userId: 1,
+    username: 'nonadmin',
+  },
+  reports: {},
+};
+
+const stateWithNonMenuAccessOnManage = {
+  user: {
+    email: 'nonaccess@test.com',
+    firstName: 'nonaccess',
+    isActive: true,
+    lastName: 'nonaccess',
+    permissions: {},
+    createdOn: '2022-01-12T10:17:37.801361',
+    roles: { Gamma: [['no_menu_access', 'Manage']] },
+    userId: 1,
+    username: 'nonaccess',
   },
   reports: {},
 };
@@ -225,5 +238,20 @@ describe('Header Report Dropdown', () => {
       setup(mockedProps, stateWithNonAdminUser);
     });
     expect(screen.getByText('Set up an email report')).toBeInTheDocument();
+  });
+
+  it('do not render Schedule Email Reports if user no permission', () => {
+    let mockedProps = createProps();
+    mockedProps = {
+      ...mockedProps,
+      useTextMenu: true,
+      isDropdownVisible: true,
+    };
+    act(() => {
+      setup(mockedProps, stateWithNonMenuAccessOnManage);
+    });
+    expect(
+      screen.queryByText('Set up an email report'),
+    ).not.toBeInTheDocument();
   });
 });

--- a/superset-frontend/src/components/ReportModal/HeaderReportDropdown/index.test.tsx
+++ b/superset-frontend/src/components/ReportModal/HeaderReportDropdown/index.test.tsx
@@ -49,6 +49,26 @@ const stateWithOnlyUser = {
   reports: {},
 };
 
+const stateWithNonAdminUser = {
+  explore: {
+    user: {
+      email: 'nonadmin@test.com',
+      firstName: 'nonadmin',
+      isActive: true,
+      lastName: 'nonadmin',
+      permissions: {},
+      createdOn: '2022-01-12T10:17:37.801361',
+      roles: {
+        Gamma: [['no_menu_access', 'Manage']],
+        OtherRole: [['menu_access', 'Manage']],
+      },
+      userId: 1,
+      username: 'nonadmin',
+    },
+  },
+  reports: {},
+};
+
 const stateWithUserAndReport = {
   user: {
     email: 'admin@test.com',
@@ -190,6 +210,19 @@ describe('Header Report Dropdown', () => {
     };
     act(() => {
       setup(mockedProps, stateWithOnlyUser);
+    });
+    expect(screen.getByText('Set up an email report')).toBeInTheDocument();
+  });
+
+  it('renders Schedule Email Reports as long as user has permission through any role', () => {
+    let mockedProps = createProps();
+    mockedProps = {
+      ...mockedProps,
+      useTextMenu: true,
+      isDropdownVisible: true,
+    };
+    act(() => {
+      setup(mockedProps, stateWithNonAdminUser);
     });
     expect(screen.getByText('Set up an email report')).toBeInTheDocument();
   });

--- a/superset-frontend/src/components/ReportModal/HeaderReportDropdown/index.tsx
+++ b/superset-frontend/src/components/ReportModal/HeaderReportDropdown/index.tsx
@@ -120,7 +120,7 @@ export default function HeaderReportDropDown({
         perms => perms[0] === 'menu_access' && perms[1] === 'Manage',
       ),
     );
-    return permissions[0].length > 0;
+    return permissions.some(permission => permission.length > 0);
   };
 
   const [currentReportDeleting, setCurrentReportDeleting] =


### PR DESCRIPTION
### SUMMARY
set up email report button should be enabled for users who have "menu_access on Manage" permission. However, the previous implementation only checks if the first role associated with the user has the required permission, not the others. For those who were granted with the permission through other roles, they won't be able to see the button.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before
<img width="285" alt="Screen Shot 2022-09-22 at 3 57 51 PM" src="https://user-images.githubusercontent.com/105950525/191872445-00ef1295-e539-4b88-8d29-22785bbea7bf.png">

After
![Screen Shot 2022-09-21 at 10 59 51 AM](https://user-images.githubusercontent.com/105950525/191872460-2b726509-fc1a-4ebc-9ab4-c7a747171420.png)


### TESTING INSTRUCTIONS
I have tested with our own superset stack. With the same set of permissions, before the change, the user couldn't see the button. But after the change, the button shows up.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: https://github.com/apache/superset/issues/21559
- [X] Required feature flags: ALERT_REPORTS needs to be enabled
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
