### PR TITLE
fix: catch error when masking encrypted extra is none

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1614,9 +1614,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         return user.username if user else None
 
     @classmethod
-    def mask_encrypted_extra(
-        cls, encrypted_extra: Union[str, None]
-    ) -> Union[str, None]:
+    def mask_encrypted_extra(cls, encrypted_extra: Optional[str]) -> Optional[str]:
         """
         Mask ``encrypted_extra``.
 
@@ -1630,8 +1628,8 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     # pylint: disable=unused-argument
     @classmethod
     def unmask_encrypted_extra(
-        cls, old: Union[str, None], new: Union[str, None]
-    ) -> Union[str, None]:
+        cls, old: Optional[str], new: Optional[str]
+    ) -> Optional[str]:
         """
         Remove masks from ``encrypted_extra``.
 

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1614,7 +1614,9 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         return user.username if user else None
 
     @classmethod
-    def mask_encrypted_extra(cls, encrypted_extra: str) -> str:
+    def mask_encrypted_extra(
+        cls, encrypted_extra: Union[str, None]
+    ) -> Union[str, None]:
         """
         Mask ``encrypted_extra``.
 
@@ -1627,7 +1629,9 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
 
     # pylint: disable=unused-argument
     @classmethod
-    def unmask_encrypted_extra(cls, old: str, new: str) -> str:
+    def unmask_encrypted_extra(
+        cls, old: Union[str, None], new: Union[str, None]
+    ) -> Union[str, None]:
         """
         Remove masks from ``encrypted_extra``.
 

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -397,8 +397,11 @@ class BigQueryEngineSpec(BaseEngineSpec):
 
     @classmethod
     def mask_encrypted_extra(cls, encrypted_extra: Optional[str]) -> Optional[str]:
+        if encrypted_extra is None:
+            return encrypted_extra
+
         try:
-            config = json.loads(encrypted_extra)  # type:ignore
+            config = json.loads(encrypted_extra)
         except (json.JSONDecodeError, TypeError):
             return encrypted_extra
 
@@ -416,9 +419,12 @@ class BigQueryEngineSpec(BaseEngineSpec):
         """
         Reuse ``private_key`` if available and unchanged.
         """
+        if old is None or new is None:
+            return new
+
         try:
-            old_config = json.loads(old)  # type:ignore
-            new_config = json.loads(new)  # type:ignore
+            old_config = json.loads(old)
+            new_config = json.loads(new)
         except (TypeError, json.JSONDecodeError):
             return new
 

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -18,7 +18,7 @@ import json
 import re
 import urllib
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Pattern, Tuple, Type, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Pattern, Tuple, Type, TYPE_CHECKING, Union
 
 import pandas as pd
 from apispec import APISpec
@@ -396,10 +396,12 @@ class BigQueryEngineSpec(BaseEngineSpec):
         raise ValidationError("Invalid service credentials")
 
     @classmethod
-    def mask_encrypted_extra(cls, encrypted_extra: str) -> str:
+    def mask_encrypted_extra(
+        cls, encrypted_extra: Union[str, None]
+    ) -> Union[str, None]:
         try:
-            config = json.loads(encrypted_extra)
-        except json.JSONDecodeError:
+            config = json.loads(encrypted_extra)  # type:ignore
+        except (json.JSONDecodeError, TypeError):
             return encrypted_extra
 
         try:
@@ -410,14 +412,16 @@ class BigQueryEngineSpec(BaseEngineSpec):
         return json.dumps(config)
 
     @classmethod
-    def unmask_encrypted_extra(cls, old: str, new: str) -> str:
+    def unmask_encrypted_extra(
+        cls, old: Union[str, None], new: Union[str, None]
+    ) -> Union[str, None]:
         """
         Reuse ``private_key`` if available and unchanged.
         """
         try:
-            old_config = json.loads(old)
-            new_config = json.loads(new)
-        except json.JSONDecodeError:
+            old_config = json.loads(old)  # type:ignore
+            new_config = json.loads(new)  # type:ignore
+        except (TypeError, json.JSONDecodeError):
             return new
 
         if "credentials_info" not in new_config:

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -18,7 +18,7 @@ import json
 import re
 import urllib
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Pattern, Tuple, Type, TYPE_CHECKING, Union
+from typing import Any, Dict, List, Optional, Pattern, Tuple, Type, TYPE_CHECKING
 
 import pandas as pd
 from apispec import APISpec
@@ -396,9 +396,7 @@ class BigQueryEngineSpec(BaseEngineSpec):
         raise ValidationError("Invalid service credentials")
 
     @classmethod
-    def mask_encrypted_extra(
-        cls, encrypted_extra: Union[str, None]
-    ) -> Union[str, None]:
+    def mask_encrypted_extra(cls, encrypted_extra: Optional[str]) -> Optional[str]:
         try:
             config = json.loads(encrypted_extra)  # type:ignore
         except (json.JSONDecodeError, TypeError):
@@ -413,8 +411,8 @@ class BigQueryEngineSpec(BaseEngineSpec):
 
     @classmethod
     def unmask_encrypted_extra(
-        cls, old: Union[str, None], new: Union[str, None]
-    ) -> Union[str, None]:
+        cls, old: Optional[str], new: Optional[str]
+    ) -> Optional[str]:
         """
         Reuse ``private_key`` if available and unchanged.
         """

--- a/superset/db_engine_specs/gsheets.py
+++ b/superset/db_engine_specs/gsheets.py
@@ -17,7 +17,7 @@
 import json
 import re
 from contextlib import closing
-from typing import Any, Dict, List, Optional, Pattern, Tuple, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Pattern, Tuple, TYPE_CHECKING, Union
 
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
@@ -138,10 +138,12 @@ class GSheetsEngineSpec(SqliteEngineSpec):
         raise ValidationError("Invalid service credentials")
 
     @classmethod
-    def mask_encrypted_extra(cls, encrypted_extra: str) -> str:
+    def mask_encrypted_extra(
+        cls, encrypted_extra: Union[str, None]
+    ) -> Union[str, None]:
         try:
-            config = json.loads(encrypted_extra)
-        except json.JSONDecodeError:
+            config = json.loads(encrypted_extra)  # type:ignore
+        except (TypeError, json.JSONDecodeError):
             return encrypted_extra
 
         try:
@@ -152,14 +154,16 @@ class GSheetsEngineSpec(SqliteEngineSpec):
         return json.dumps(config)
 
     @classmethod
-    def unmask_encrypted_extra(cls, old: str, new: str) -> str:
+    def unmask_encrypted_extra(
+        cls, old: Union[str, None], new: Union[str, None]
+    ) -> Union[str, None]:
         """
         Reuse ``private_key`` if available and unchanged.
         """
         try:
-            old_config = json.loads(old)
-            new_config = json.loads(new)
-        except json.JSONDecodeError:
+            old_config = json.loads(old)  # type:ignore
+            new_config = json.loads(new)  # type:ignore
+        except (TypeError, json.JSONDecodeError):
             return new
 
         if "service_account_info" not in new_config:

--- a/superset/db_engine_specs/gsheets.py
+++ b/superset/db_engine_specs/gsheets.py
@@ -139,8 +139,11 @@ class GSheetsEngineSpec(SqliteEngineSpec):
 
     @classmethod
     def mask_encrypted_extra(cls, encrypted_extra: Optional[str]) -> Optional[str]:
+        if encrypted_extra is None:
+            return encrypted_extra
+
         try:
-            config = json.loads(encrypted_extra)  # type:ignore
+            config = json.loads(encrypted_extra)
         except (TypeError, json.JSONDecodeError):
             return encrypted_extra
 
@@ -158,9 +161,12 @@ class GSheetsEngineSpec(SqliteEngineSpec):
         """
         Reuse ``private_key`` if available and unchanged.
         """
+        if old is None or new is None:
+            return new
+
         try:
-            old_config = json.loads(old)  # type:ignore
-            new_config = json.loads(new)  # type:ignore
+            old_config = json.loads(old)
+            new_config = json.loads(new)
         except (TypeError, json.JSONDecodeError):
             return new
 

--- a/superset/db_engine_specs/gsheets.py
+++ b/superset/db_engine_specs/gsheets.py
@@ -17,7 +17,7 @@
 import json
 import re
 from contextlib import closing
-from typing import Any, Dict, List, Optional, Pattern, Tuple, TYPE_CHECKING, Union
+from typing import Any, Dict, List, Optional, Pattern, Tuple, TYPE_CHECKING
 
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
@@ -138,9 +138,7 @@ class GSheetsEngineSpec(SqliteEngineSpec):
         raise ValidationError("Invalid service credentials")
 
     @classmethod
-    def mask_encrypted_extra(
-        cls, encrypted_extra: Union[str, None]
-    ) -> Union[str, None]:
+    def mask_encrypted_extra(cls, encrypted_extra: Optional[str]) -> Optional[str]:
         try:
             config = json.loads(encrypted_extra)  # type:ignore
         except (TypeError, json.JSONDecodeError):
@@ -155,8 +153,8 @@ class GSheetsEngineSpec(SqliteEngineSpec):
 
     @classmethod
     def unmask_encrypted_extra(
-        cls, old: Union[str, None], new: Union[str, None]
-    ) -> Union[str, None]:
+        cls, old: Optional[str], new: Optional[str]
+    ) -> Optional[str]:
         """
         Reuse ``private_key`` if available and unchanged.
         """

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -24,7 +24,7 @@ from ast import literal_eval
 from contextlib import closing
 from copy import deepcopy
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union
 
 import numpy
 import pandas as pd
@@ -248,7 +248,7 @@ class Database(
         return sqlalchemy_url.get_backend_name()
 
     @property
-    def masked_encrypted_extra(self) -> str:
+    def masked_encrypted_extra(self) -> Union[str, None]:
         return self.db_engine_spec.mask_encrypted_extra(self.encrypted_extra)
 
     @property
@@ -262,7 +262,7 @@ class Database(
             self.encrypted_extra
         )
         try:
-            encrypted_config = json.loads(masked_encrypted_extra)
+            encrypted_config = json.loads(masked_encrypted_extra)  # type: ignore
         except (TypeError, json.JSONDecodeError):
             encrypted_config = {}
 

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -24,7 +24,7 @@ from ast import literal_eval
 from contextlib import closing
 from copy import deepcopy
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type
 
 import numpy
 import pandas as pd
@@ -248,7 +248,7 @@ class Database(
         return sqlalchemy_url.get_backend_name()
 
     @property
-    def masked_encrypted_extra(self) -> Union[str, None]:
+    def masked_encrypted_extra(self) -> Optional[str]:
         return self.db_engine_spec.mask_encrypted_extra(self.encrypted_extra)
 
     @property

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -261,10 +261,12 @@ class Database(
         masked_encrypted_extra = db_engine_spec.mask_encrypted_extra(
             self.encrypted_extra
         )
-        try:
-            encrypted_config = json.loads(masked_encrypted_extra)  # type: ignore
-        except (TypeError, json.JSONDecodeError):
-            encrypted_config = {}
+        encrypted_config = {}
+        if masked_encrypted_extra is not None:
+            try:
+                encrypted_config = json.loads(masked_encrypted_extra)
+            except (TypeError, json.JSONDecodeError):
+                pass
 
         try:
             # pylint: disable=useless-suppression

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -186,7 +186,7 @@ def test_unmask_encrypted_extra() -> None:
         }
     )
 
-    assert json.loads(BigQueryEngineSpec.unmask_encrypted_extra(old, new)) == {  # type: ignore
+    assert json.loads(str(BigQueryEngineSpec.unmask_encrypted_extra(old, new))) == {
         "credentials_info": {
             "project_id": "yellow-unicorn-314419",
             "private_key": "SECRET",
@@ -210,7 +210,7 @@ def test_unmask_encrypted_extra_when_empty() -> None:
         }
     )
 
-    assert json.loads(BigQueryEngineSpec.unmask_encrypted_extra(old, new)) == {  # type: ignore
+    assert json.loads(str(BigQueryEngineSpec.unmask_encrypted_extra(old, new))) == {
         "credentials_info": {
             "project_id": "yellow-unicorn-314419",
             "private_key": "XXXXXXXXXX",

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -186,9 +186,61 @@ def test_unmask_encrypted_extra() -> None:
         }
     )
 
-    assert json.loads(BigQueryEngineSpec.unmask_encrypted_extra(old, new)) == {
+    assert json.loads(BigQueryEngineSpec.unmask_encrypted_extra(old, new)) == {  # type: ignore
         "credentials_info": {
             "project_id": "yellow-unicorn-314419",
             "private_key": "SECRET",
         },
     }
+
+
+def test_unmask_encrypted_extra_when_empty() -> None:
+    """
+    Test that a None value works for ``encrypted_extra``.
+    """
+    from superset.db_engine_specs.bigquery import BigQueryEngineSpec
+
+    old = None
+    new = json.dumps(
+        {
+            "credentials_info": {
+                "project_id": "yellow-unicorn-314419",
+                "private_key": "XXXXXXXXXX",
+            },
+        }
+    )
+
+    assert json.loads(BigQueryEngineSpec.unmask_encrypted_extra(old, new)) == {  # type: ignore
+        "credentials_info": {
+            "project_id": "yellow-unicorn-314419",
+            "private_key": "XXXXXXXXXX",
+        },
+    }
+
+
+def test_unmask_encrypted_extra_when_new_is_empty() -> None:
+    """
+    Test that a None value works for ``encrypted_extra``.
+    """
+    from superset.db_engine_specs.bigquery import BigQueryEngineSpec
+
+    old = json.dumps(
+        {
+            "credentials_info": {
+                "project_id": "black-sanctum-314419",
+                "private_key": "SECRET",
+            },
+        }
+    )
+    new = None
+
+    assert BigQueryEngineSpec.unmask_encrypted_extra(old, new) == None
+
+
+def test_mask_encrypted_extra_when_empty() -> None:
+    """
+    Test that the encrypted extra will return a none value if the field is empty.
+    """
+    from superset.db_engine_specs.bigquery import BigQueryEngineSpec
+
+    assert BigQueryEngineSpec.mask_encrypted_extra(None) == None

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -234,7 +234,7 @@ def test_unmask_encrypted_extra_when_new_is_empty() -> None:
     )
     new = None
 
-    assert BigQueryEngineSpec.unmask_encrypted_extra(old, new) == None
+    assert BigQueryEngineSpec.unmask_encrypted_extra(old, new) is None
 
 
 def test_mask_encrypted_extra_when_empty() -> None:
@@ -243,4 +243,4 @@ def test_mask_encrypted_extra_when_empty() -> None:
     """
     from superset.db_engine_specs.bigquery import BigQueryEngineSpec
 
-    assert BigQueryEngineSpec.mask_encrypted_extra(None) == None
+    assert BigQueryEngineSpec.mask_encrypted_extra(None) is None

--- a/tests/unit_tests/db_engine_specs/test_gsheets.py
+++ b/tests/unit_tests/db_engine_specs/test_gsheets.py
@@ -280,4 +280,4 @@ def test_unmask_encrypted_extra_when_new_is_none() -> None:
     )
     new = None
 
-    assert GSheetsEngineSpec.unmask_encrypted_extra(old, new) == None
+    assert GSheetsEngineSpec.unmask_encrypted_extra(old, new) is None

--- a/tests/unit_tests/db_engine_specs/test_gsheets.py
+++ b/tests/unit_tests/db_engine_specs/test_gsheets.py
@@ -228,9 +228,56 @@ def test_unmask_encrypted_extra() -> None:
         }
     )
 
-    assert json.loads(GSheetsEngineSpec.unmask_encrypted_extra(old, new)) == {
+    assert json.loads(
+        GSheetsEngineSpec.unmask_encrypted_extra(old, new)  # type:ignore
+    ) == {
         "service_account_info": {
             "project_id": "yellow-unicorn-314419",
             "private_key": "SECRET",
         },
     }
+
+
+def test_unmask_encrypted_extra_when_old_is_none() -> None:
+    """
+    Test that a None value works for ``encrypted_extra``.
+    """
+    from superset.db_engine_specs.gsheets import GSheetsEngineSpec
+
+    old = None
+    new = json.dumps(
+        {
+            "service_account_info": {
+                "project_id": "yellow-unicorn-314419",
+                "private_key": "XXXXXXXXXX",
+            },
+        }
+    )
+
+    assert json.loads(
+        GSheetsEngineSpec.unmask_encrypted_extra(old, new)  # type:ignore
+    ) == {
+        "service_account_info": {
+            "project_id": "yellow-unicorn-314419",
+            "private_key": "XXXXXXXXXX",
+        },
+    }
+
+
+def test_unmask_encrypted_extra_when_new_is_none() -> None:
+    """
+    Test that a None value works for ``encrypted_extra``.
+    """
+    from superset.db_engine_specs.gsheets import GSheetsEngineSpec
+
+    old = json.dumps(
+        {
+            "service_account_info": {
+                "project_id": "yellow-unicorn-314419",
+                "private_key": "XXXXXXXXXX",
+            },
+        }
+    )
+    new = None
+
+    assert GSheetsEngineSpec.unmask_encrypted_extra(old, new) == None

--- a/tests/unit_tests/db_engine_specs/test_gsheets.py
+++ b/tests/unit_tests/db_engine_specs/test_gsheets.py
@@ -228,9 +228,7 @@ def test_unmask_encrypted_extra() -> None:
         }
     )
 
-    assert json.loads(
-        GSheetsEngineSpec.unmask_encrypted_extra(old, new)  # type:ignore
-    ) == {
+    assert json.loads(str(GSheetsEngineSpec.unmask_encrypted_extra(old, new))) == {
         "service_account_info": {
             "project_id": "yellow-unicorn-314419",
             "private_key": "SECRET",
@@ -254,9 +252,7 @@ def test_unmask_encrypted_extra_when_old_is_none() -> None:
         }
     )
 
-    assert json.loads(
-        GSheetsEngineSpec.unmask_encrypted_extra(old, new)  # type:ignore
-    ) == {
+    assert json.loads(str(GSheetsEngineSpec.unmask_encrypted_extra(old, new))) == {
         "service_account_info": {
             "project_id": "yellow-unicorn-314419",
             "private_key": "XXXXXXXXXX",


### PR DESCRIPTION
### SUMMARY
When masking/unmasking the encrypted extra field, this change allows imported dbs to have a blank encrypted extra field, because they are not imported. 


### TESTING INSTRUCTIONS
Import a database and try to edit it in the database connection modal. 


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
