### PR TITLE
fix(dashboard): dashboard doesn't load properly if it has tabs

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -114,22 +114,7 @@ const StyledTabsContainer = styled.div`
 export class Tabs extends React.PureComponent {
   constructor(props) {
     super(props);
-    let tabIndex = Math.max(
-      0,
-      findTabIndexByComponentId({
-        currentComponent: props.component,
-        directPathToChild: props.directPathToChild,
-      }),
-    );
-    if (tabIndex === 0 && props.activeTabs?.length) {
-      props.component.children.forEach((tabId, index) => {
-        if (tabIndex === 0 && props.activeTabs.includes(tabId)) {
-          tabIndex = index;
-        }
-      });
-    }
-    const { children: tabIds } = props.component;
-    const activeKey = tabIds[tabIndex];
+    const { tabIndex, activeKey } = this.getTabInfo(props);
 
     this.state = {
       tabIndex,
@@ -164,6 +149,15 @@ export class Tabs extends React.PureComponent {
       this.setState(() => ({ tabIndex: maxIndex }));
     }
 
+    // reset tab index if dashboard was changed
+    if (nextProps.dashboardId !== this.props.dashboardId) {
+      const { tabIndex, activeKey } = this.getTabInfo(nextProps);
+      this.setState(() => ({
+        tabIndex,
+        activeKey,
+      }));
+    }
+
     if (nextProps.isComponentVisible) {
       const nextFocusComponent = getLeafComponentIdFromPath(
         nextProps.directPathToChild,
@@ -195,6 +189,30 @@ export class Tabs extends React.PureComponent {
       }
     }
   }
+
+  getTabInfo = props => {
+    let tabIndex = Math.max(
+      0,
+      findTabIndexByComponentId({
+        currentComponent: props.component,
+        directPathToChild: props.directPathToChild,
+      }),
+    );
+    if (tabIndex === 0 && props.activeTabs?.length) {
+      props.component.children.forEach((tabId, index) => {
+        if (tabIndex === 0 && props.activeTabs.includes(tabId)) {
+          tabIndex = index;
+        }
+      });
+    }
+    const { children: tabIds } = props.component;
+    const activeKey = tabIds[tabIndex];
+
+    return {
+      tabIndex,
+      activeKey,
+    };
+  };
 
   showDeleteConfirmModal = key => {
     const { component, deleteComponent } = this.props;

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.test.jsx
@@ -204,17 +204,14 @@ describe('Tabs', () => {
     expect(deleteComponent.callCount).toBe(0);
   });
 
-  if (
-    ('should set new tab key if dashboardId was changed',
-    () => {
-      const wrapper = shallow(<Tabs {...props} />);
-      expect(wrapper.state('activeKey')).toBe('TABS_ID');
-      wrapper.setProps({
-        ...props,
-        dashboardId: 2,
-        component: dashboardLayoutWithTabs.present.TAB_ID,
-      });
-      expect(wrapper.state('activeKey')).toBe('TAB_ID');
-    })
-  );
+  it('should set new tab key if dashboardId was changed', () => {
+    const wrapper = shallow(<Tabs {...props} />);
+    expect(wrapper.state('activeKey')).toBe('TABS_ID');
+    wrapper.setProps({
+      ...props,
+      dashboardId: 2,
+      component: dashboardLayoutWithTabs.present.TAB_ID,
+    });
+    expect(wrapper.state('activeKey')).toBe('TAB_ID');
+  });
 });

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.test.jsx
@@ -204,17 +204,14 @@ describe('Tabs', () => {
     expect(deleteComponent.callCount).toBe(0);
   });
 
-  if (
-    ('should set new tab key if dashboardId was changed',
-    () => {
-      const wrapper = shallow(<Tabs {...props} />);
-      expect(wrapper.state('activeKey')).toBe('TABS_ID');
-      wrapper.setProps({
-        ...props,
-        dashboardId: 2,
-        component: dashboardLayoutWithTabs.present.TAB_ID,
-      });
-      expect(wrapper.state('activeKey')).toBe('TAB_ID');
-    })
-  );
+  it('should set new tab key if dashboardId was changed', () => {
+    const wrapper = shallow(<Tabs {...props} />);
+    expect(wrapper.state('activeKey')).toBe('TAB_ID');
+    wrapper.setProps({
+      ...props,
+      dashboardId: 2,
+      component: dashboardLayoutWithTabs.present.TAB_ID,
+    });
+    expect(wrapper.state('activeKey')).toBe('ROW_ID');
+  });
 });

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.test.jsx
@@ -53,6 +53,7 @@ describe('Tabs', () => {
     editMode: false,
     availableColumnCount: 12,
     columnWidth: 50,
+    dashboardId: 1,
     onResizeStart() {},
     onResize() {},
     onResizeStop() {},
@@ -202,4 +203,18 @@ describe('Tabs', () => {
     expect(modalMock.mock.calls).toHaveLength(1);
     expect(deleteComponent.callCount).toBe(0);
   });
+
+  if (
+    ('should set new tab key if dashboardId was changed',
+    () => {
+      let wrapper = shallow(<Tabs {...props} />);
+      expect(wrapper.state('activeKey')).toBe('TABS_ID');
+      wrapper.setProps({
+        ...props,
+        dashboardId: 2,
+        component: dashboardLayoutWithTabs.present.TAB_ID,
+      });
+      expect(wrapper.state('activeKey')).toBe('TAB_ID');
+    })
+  );
 });

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.test.jsx
@@ -207,7 +207,7 @@ describe('Tabs', () => {
   if (
     ('should set new tab key if dashboardId was changed',
     () => {
-      let wrapper = shallow(<Tabs {...props} />);
+      const wrapper = shallow(<Tabs {...props} />);
       expect(wrapper.state('activeKey')).toBe('TABS_ID');
       wrapper.setProps({
         ...props,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes the problem that dashboard does not load properly after switching dashboard when there are tabs and native filters. The reason is that the dashboard is loading the tab component with incorrect timing.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### before

https://user-images.githubusercontent.com/11830681/192158153-15686b05-60de-4a32-bb80-79e86ab87fea.mov



#### after

https://user-images.githubusercontent.com/11830681/192158119-ab5d5fcd-c1ae-4efc-b950-21d2bbdc4d49.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: 
- fixes https://github.com/apache/superset/issues/20797
- fixes https://github.com/apache/superset/issues/20748
- fixes https://github.com/apache/superset/issues/20930
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
