### PR TITLE
feat: adding XAxis to BigNumberTrend

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/index.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/index.ts
@@ -37,4 +37,4 @@ export { legacySortBy } from './shared-controls/legacySortBy';
 export * from './shared-controls/emitFilterControl';
 export * from './shared-controls/components';
 export * from './types';
-export { xAxisMixin, temporalXAxisMixin } from './shared-controls/constants';
+export { xAxisMixin, temporalColumnMixin } from './shared-controls/constants';

--- a/superset-frontend/packages/superset-ui-chart-controls/src/index.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/index.ts
@@ -37,3 +37,4 @@ export { legacySortBy } from './shared-controls/legacySortBy';
 export * from './shared-controls/emitFilterControl';
 export * from './shared-controls/components';
 export * from './types';
+export { xAxisMixin, temporalXAxisMixin } from './shared-controls/constants';

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/constants.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/constants.tsx
@@ -24,7 +24,12 @@ import {
   t,
   validateNonEmpty,
 } from '@superset-ui/core';
-import { ControlPanelState, ControlState, Dataset } from '../types';
+import {
+  BaseControlConfig,
+  ControlPanelState,
+  ControlState,
+  Dataset,
+} from '../types';
 
 const getAxisLabel = (
   formData: QueryFormData,
@@ -53,8 +58,8 @@ export const xAxisMixin = {
   default: undefined,
 };
 
-export const temporalColumnMixin = {
-  mapStateToProps: ({ datasource }: ControlPanelState) => {
+export const temporalColumnMixin: Pick<BaseControlConfig, 'mapStateToProps'> = {
+  mapStateToProps: ({ datasource }) => {
     if (datasource?.columns[0]?.hasOwnProperty('column_name')) {
       const temporalColumns =
         (datasource as Dataset)?.columns?.filter(c => c.is_dttm) ?? [];

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/constants.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/constants.tsx
@@ -53,8 +53,7 @@ export const xAxisMixin = {
   default: undefined,
 };
 
-export const temporalXAxisMixin = {
-  label: t('TEMPORAL X-AXIS'),
+export const temporalColumnMixin = {
   mapStateToProps: ({ datasource }: ControlPanelState) => {
     if (datasource?.columns[0]?.hasOwnProperty('column_name')) {
       const temporalColumns =

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/constants.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/constants.tsx
@@ -20,10 +20,11 @@ import {
   FeatureFlag,
   isFeatureEnabled,
   QueryFormData,
+  QueryResponse,
   t,
   validateNonEmpty,
 } from '@superset-ui/core';
-import { ControlPanelState, ControlState } from '../types';
+import { ControlPanelState, ControlState, Dataset } from '../types';
 
 const getAxisLabel = (
   formData: QueryFormData,
@@ -32,7 +33,7 @@ const getAxisLabel = (
     ? { label: t('Y-axis'), description: t('Dimension to use on y-axis.') }
     : { label: t('X-axis'), description: t('Dimension to use on x-axis.') };
 
-export const xAxisControlConfig = {
+export const xAxisMixin = {
   label: (state: ControlPanelState) => getAxisLabel(state?.form_data).label,
   multi: false,
   description: (state: ControlPanelState) =>
@@ -50,4 +51,30 @@ export const xAxisControlConfig = {
     return undefined;
   },
   default: undefined,
+};
+
+export const temporalXAxisMixin = {
+  label: t('TEMPORAL X-AXIS'),
+  mapStateToProps: ({ datasource }: ControlPanelState) => {
+    if (datasource?.columns[0]?.hasOwnProperty('column_name')) {
+      const temporalColumns =
+        (datasource as Dataset)?.columns?.filter(c => c.is_dttm) ?? [];
+      return {
+        options: temporalColumns,
+        default:
+          (datasource as Dataset)?.main_dttm_col ||
+          temporalColumns[0]?.column_name ||
+          null,
+        isTemporal: true,
+      };
+    }
+    const sortedQueryColumns = (datasource as QueryResponse)?.columns?.sort(
+      query => (query?.is_dttm ? -1 : 1),
+    );
+    return {
+      options: sortedQueryColumns,
+      default: sortedQueryColumns[0]?.name || null,
+      isTemporal: true,
+    };
+  },
 };

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx
@@ -22,7 +22,6 @@ import {
   FeatureFlag,
   isFeatureEnabled,
   QueryColumn,
-  QueryResponse,
   t,
   validateNonEmpty,
 } from '@superset-ui/core';
@@ -39,6 +38,7 @@ import {
   ColumnOption,
   ColumnMeta,
   FilterOption,
+  temporalColumnMixin,
 } from '..';
 import { xAxisMixin } from './constants';
 
@@ -231,6 +231,7 @@ export const dndSecondaryMetricControl: typeof dndAdhocMetricControl = {
 
 export const dndGranularitySqlaControl: typeof dndSeriesControl = {
   ...dndSeriesControl,
+  ...temporalColumnMixin,
   label: TIME_FILTER_LABELS.granularity_sqla,
   description: t(
     'The time column for the visualization. Note that you ' +
@@ -247,28 +248,6 @@ export const dndGranularitySqlaControl: typeof dndSeriesControl = {
   optionRenderer: (c: ColumnMeta) => <ColumnOption showType column={c} />,
   valueRenderer: (c: ColumnMeta) => <ColumnOption column={c} />,
   valueKey: 'column_name',
-  mapStateToProps: ({ datasource }) => {
-    if (datasource?.columns[0]?.hasOwnProperty('column_name')) {
-      const temporalColumns =
-        (datasource as Dataset)?.columns?.filter(c => c.is_dttm) ?? [];
-      return {
-        options: temporalColumns,
-        default:
-          (datasource as Dataset)?.main_dttm_col ||
-          temporalColumns[0]?.column_name ||
-          null,
-        isTemporal: true,
-      };
-    }
-    const sortedQueryColumns = (datasource as QueryResponse)?.columns?.sort(
-      query => (query?.is_dttm ? -1 : 1),
-    );
-    return {
-      options: sortedQueryColumns,
-      default: sortedQueryColumns[0]?.name || null,
-      isTemporal: true,
-    };
-  },
 };
 
 export const dndXAxisControl: typeof dndGroupByControl = {

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx
@@ -40,7 +40,7 @@ import {
   ColumnMeta,
   FilterOption,
 } from '..';
-import { xAxisControlConfig } from './constants';
+import { xAxisMixin } from './constants';
 
 type Control = {
   savedMetrics?: Metric[] | null;
@@ -273,7 +273,7 @@ export const dndGranularitySqlaControl: typeof dndSeriesControl = {
 
 export const dndXAxisControl: typeof dndGroupByControl = {
   ...dndGroupByControl,
-  ...xAxisControlConfig,
+  ...xAxisMixin,
 };
 
 export function withDndFallback(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/controlPanel.tsx
@@ -29,6 +29,7 @@ import {
   formatSelectOptions,
   getStandardizedControls,
   sections,
+  temporalXAxisMixin,
 } from '@superset-ui/chart-controls';
 import React from 'react';
 import { headerFontSize, subheaderFontSize } from '../sharedControls';
@@ -284,6 +285,7 @@ const config: ControlPanelConfig = {
     y_axis_format: {
       label: t('Number format'),
     },
+    x_axis: temporalXAxisMixin,
   },
   formDataOverrides: formData => ({
     ...formData,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/controlPanel.tsx
@@ -29,7 +29,7 @@ import {
   formatSelectOptions,
   getStandardizedControls,
   sections,
-  temporalXAxisMixin,
+  temporalColumnMixin,
 } from '@superset-ui/chart-controls';
 import React from 'react';
 import { headerFontSize, subheaderFontSize } from '../sharedControls';
@@ -285,7 +285,10 @@ const config: ControlPanelConfig = {
     y_axis_format: {
       label: t('Number format'),
     },
-    x_axis: temporalXAxisMixin,
+    x_axis: {
+      label: t('TEMPORAL X-AXIS'),
+      ...temporalColumnMixin,
+    },
   },
   formDataOverrides: formData => ({
     ...formData,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/controlPanel.tsx
@@ -16,7 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { smartDateFormatter, t } from '@superset-ui/core';
+import {
+  FeatureFlag,
+  isFeatureEnabled,
+  smartDateFormatter,
+  t,
+} from '@superset-ui/core';
 import {
   ControlPanelConfig,
   D3_FORMAT_DOCS,
@@ -30,11 +35,20 @@ import { headerFontSize, subheaderFontSize } from '../sharedControls';
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
-    sections.legacyTimeseriesTime,
+    sections.genericTime,
     {
       label: t('Query'),
       expanded: true,
-      controlSetRows: [['metric'], ['adhoc_filters']],
+      controlSetRows: [
+        [isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) ? 'x_axis' : null],
+        [
+          isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES)
+            ? 'time_grain_sqla'
+            : null,
+        ],
+        ['metric'],
+        ['adhoc_filters'],
+      ],
     },
     {
       label: t('Options'),

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.ts
@@ -17,17 +17,16 @@
  * under the License.
  */
 import {
-  DTTM_ALIAS,
   extractTimegrain,
   getNumberFormatter,
   NumberFormats,
-  QueryFormData,
   GenericDataType,
   getMetricLabel,
   t,
   smartDateVerboseFormatter,
   NumberFormatter,
   TimeFormatter,
+  getXAxis,
 } from '@superset-ui/core';
 import { EChartsCoreOption, graphic } from 'echarts';
 import {
@@ -88,7 +87,7 @@ export default function transformProps(
     yAxisFormat,
     timeRangeFixed,
   } = formData;
-  const granularity = extractTimegrain(rawFormData as QueryFormData);
+  const granularity = extractTimegrain(rawFormData);
   const {
     data = [],
     colnames = [],
@@ -103,10 +102,11 @@ export default function transformProps(
   const { r, g, b } = colorPicker;
   const mainColor = `rgb(${r}, ${g}, ${b})`;
 
+  const timeColumn = getXAxis(rawFormData) as string;
   let trendLineData;
   let percentChange = 0;
   let bigNumber = data.length === 0 ? null : data[0][metricName];
-  let timestamp = data.length === 0 ? null : data[0][DTTM_ALIAS];
+  let timestamp = data.length === 0 ? null : data[0][timeColumn];
   let bigNumberFallback;
 
   const metricColtypeIndex = colnames.findIndex(name => name === metricName);
@@ -115,7 +115,7 @@ export default function transformProps(
 
   if (data.length > 0) {
     const sortedData = (data as BigNumberDatum[])
-      .map(d => [d[DTTM_ALIAS], parseMetricValue(d[metricName])])
+      .map(d => [d[timeColumn], parseMetricValue(d[metricName])])
       // sort in time descending order
       .sort((a, b) => (a[0] !== null && b[0] !== null ? b[0] - a[0] : 0));
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/types.ts
@@ -43,7 +43,7 @@ export type BigNumberWithTrendlineFormData = BigNumberTotalFormData & {
   compareLag?: string | number;
 };
 
-export type BigNumberTotalChartProps = ChartProps & {
+export type BigNumberTotalChartProps = ChartProps<QueryFormData> & {
   formData: BigNumberTotalFormData;
   queriesData: (ChartDataResponseResult & {
     data?: BigNumberDatum[];

--- a/superset-frontend/plugins/plugin-chart-echarts/test/BigNumber/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/BigNumber/transformProps.test.ts
@@ -36,7 +36,8 @@ const formData = {
     a: 1,
   },
   compareLag: 1,
-  timeGrainSqla: 'P3M' as TimeGranularity,
+  timeGrainSqla: TimeGranularity.QUARTER,
+  granularitySqla: 'ds',
   compareSuffix: 'over last quarter',
   viz_type: 'big_number',
   yAxisFormat: '.3s',
@@ -44,6 +45,7 @@ const formData = {
 };
 
 const rawFormData = {
+  datasource: '1__table',
   metric: 'value',
   color_picker: {
     r: 0,
@@ -52,7 +54,8 @@ const rawFormData = {
     a: 1,
   },
   compare_lag: 1,
-  time_grain_sqla: 'P3M' as TimeGranularity,
+  time_grain_sqla: TimeGranularity.QUARTER,
+  granularity_sqla: 'ds',
   compare_suffix: 'over last quarter',
   viz_type: 'big_number',
   y_axis_format: '.3s',


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Apply temporal XAxis to BigNumber with Trendline

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### After
![image](https://user-images.githubusercontent.com/2016594/192184089-6157391a-968e-4cf7-9bb1-32f385ed27d4.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
