### PR TITLE
build: optimize docker build by better utilizing build cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN /frontend-mem-nag.sh
 
 WORKDIR /app/superset-frontend/
 
-COPY superset-frontend/package*.json .
+COPY superset-frontend/package*.json ./
 RUN npm ci
 
 COPY ./superset-frontend .

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,35 +16,9 @@
 #
 
 ######################################################################
-# PY stage that simply does a pip install on our requirements
-######################################################################
-ARG PY_VER=3.8.13-slim
-FROM python:${PY_VER} AS superset-py
-
-RUN mkdir /app \
-        && apt-get update -y \
-        && apt-get install -y --no-install-recommends \
-            build-essential \
-            default-libmysqlclient-dev \
-            libpq-dev \
-            libsasl2-dev \
-            libecpg-dev \
-        && rm -rf /var/lib/apt/lists/*
-
-# First, we just wanna install requirements, which will allow us to utilize the cache
-# in order to only build if and only if requirements change
-COPY ./requirements/*.txt  /app/requirements/
-COPY setup.py MANIFEST.in README.md /app/
-COPY superset-frontend/package.json /app/superset-frontend/
-RUN cd /app \
-    && mkdir -p superset/static \
-    && touch superset/static/version_info.json \
-    && pip install --no-cache -r requirements/local.txt
-
-
-######################################################################
 # Node stage to deal with static asset construction
 ######################################################################
+ARG PY_VER=3.8.13-slim
 FROM node:16-slim AS superset-node
 
 ARG NPM_BUILD_CMD="build"
@@ -52,23 +26,23 @@ ENV BUILD_CMD=${NPM_BUILD_CMD}
 
 # NPM ci first, as to NOT invalidate previous steps except for when package.json changes
 RUN mkdir -p /app/superset-frontend
-RUN mkdir -p /app/superset/assets
+
 COPY ./docker/frontend-mem-nag.sh /
-COPY ./superset-frontend /app/superset-frontend
-RUN /frontend-mem-nag.sh \
-        && cd /app/superset-frontend \
-        && npm ci
+RUN /frontend-mem-nag.sh
+
+WORKDIR /app/superset-frontend/
+
+COPY superset-frontend/package*.json .
+RUN npm ci
+
+COPY ./superset-frontend .
 
 # This seems to be the most expensive step
-RUN cd /app/superset-frontend \
-        && npm run ${BUILD_CMD} \
-        && rm -rf node_modules
-
+RUN npm run ${BUILD_CMD}
 
 ######################################################################
 # Final lean image...
 ######################################################################
-ARG PY_VER=3.8.13-slim
 FROM python:${PY_VER} AS lean
 
 ENV LANG=C.UTF-8 \
@@ -85,16 +59,24 @@ RUN mkdir -p ${PYTHONPATH} \
         && apt-get install -y --no-install-recommends \
             build-essential \
             default-libmysqlclient-dev \
+            libsasl2-dev \
             libsasl2-modules-gssapi-mit \
             libpq-dev \
             libecpg-dev \
         && rm -rf /var/lib/apt/lists/*
 
-COPY --from=superset-py /usr/local/lib/python3.8/site-packages/ /usr/local/lib/python3.8/site-packages/
-# Copying site-packages doesn't move the CLIs, so let's copy them one by one
-COPY --from=superset-py /usr/local/bin/gunicorn /usr/local/bin/celery /usr/local/bin/flask /usr/bin/
+COPY ./requirements/*.txt  /app/requirements/
+COPY setup.py MANIFEST.in README.md /app/
+
+# setup.py uses the version information in package.json
+COPY superset-frontend/package.json /app/superset-frontend/
+
+RUN cd /app \
+    && mkdir -p superset/static \
+    && touch superset/static/version_info.json \
+    && pip install --no-cache -r requirements/local.txt
+
 COPY --from=superset-node /app/superset/static/assets /app/superset/static/assets
-COPY --from=superset-node /app/superset-frontend /app/superset-frontend
 
 ## Lastly, let's install superset itself
 COPY superset /app/superset


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Using common docker build practice to use docker build cache better.  
New docker image build
1. 394.79 MB -> 348.48 MB
2. 3-5 minutes saving for initial build by not copying/deleting unneeded file, especial node_modules.
3. merged the first stage to the lean image. still being able to cache the pip requirements installation. 
4. fix the random error when delete node_modules folder.
<img width="1351" alt="image" src="https://user-images.githubusercontent.com/1592014/194344191-814dc4d2-85a7-4bf9-832c-8b94344c09cc.png">


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
```bash
podman build -t superset  --no-cache --target lean -f ./Dockerfile
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
