### PR TITLE
chore(dep): Unpin slackclient dependency

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,21 +7,14 @@
 #
 -e file:.
     # via -r requirements/base.in
-aiohttp==3.8.1
-    # via slackclient
-aiosignal==1.2.0
-    # via aiohttp
 alembic==1.6.5
     # via flask-migrate
 amqp==5.1.0
     # via kombu
 apispec[yaml]==3.3.2
     # via flask-appbuilder
-async-timeout==4.0.2
-    # via aiohttp
 attrs==21.2.0
     # via
-    #   aiohttp
     #   jsonschema
 babel==2.9.1
     # via flask-babel
@@ -39,8 +32,6 @@ celery==5.2.2
     # via apache-superset
 cffi==1.14.6
     # via cryptography
-charset-normalizer==2.0.4
-    # via aiohttp
 click==8.0.4
     # via
     #   apache-superset
@@ -110,10 +101,6 @@ flask-wtf==0.14.3
     # via
     #   apache-superset
     #   flask-appbuilder
-frozenlist==1.3.0
-    # via
-    #   aiohttp
-    #   aiosignal
 func-timeout==4.3.5
     # via apache-superset
 geographiclib==1.52
@@ -135,7 +122,6 @@ humanize==3.11.0
 idna==3.2
     # via
     #   email-validator
-    #   yarl
 isodate==0.6.0
     # via apache-superset
 itsdangerous==2.1.1
@@ -172,10 +158,6 @@ marshmallow-sqlalchemy==0.23.1
     # via flask-appbuilder
 msgpack==1.0.2
     # via apache-superset
-multidict==5.1.0
-    # via
-    #   aiohttp
-    #   yarl
 numpy==1.22.1
     # via
     #   apache-superset
@@ -259,7 +241,7 @@ six==1.16.0
     #   python-dateutil
     #   sqlalchemy-utils
     #   wtforms-json
-slackclient==2.5.0
+slack_sdk==3.18.3
     # via apache-superset
 sqlalchemy==1.4.36
     # via
@@ -301,8 +283,6 @@ wtforms==2.3.3
     #   wtforms-json
 wtforms-json==0.3.3
     # via apache-superset
-yarl==1.6.3
-    # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -115,7 +115,7 @@ gunicorn==20.1.0
     # via apache-superset
 hashids==1.3.1
     # via apache-superset
-holidays==0.14.2
+holidays==0.16.0
     # via apache-superset
 humanize==3.11.0
     # via apache-superset

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ setup(
         "redis",
         "selenium>=3.141.0",
         "simplejson>=3.15.0",
-        "slack_sdk>=3.1.1",
+        "slack_sdk>=3.1.1, <4",
         "sqlalchemy>=1.4, <2",
         "sqlalchemy-utils>=0.38.3, <0.39",
         "sqlparse==0.3.0",  # PINNED! see https://github.com/andialbrecht/sqlparse/issues/562

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ setup(
         "sqlalchemy>=1.4, <2",
         "sqlalchemy-utils>=0.38.3, <0.39",
         "sqlparse==0.3.0",  # PINNED! see https://github.com/andialbrecht/sqlparse/issues/562
-        "tabulate>=0.8.9",
+        "tabulate>=0.8.9, <0.9",
         # needed to support Literal (3.8) and TypeGuard (3.10)
         "typing-extensions>=3.10, <4",
         "wtforms-json",

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ setup(
         "redis",
         "selenium>=3.141.0",
         "simplejson>=3.15.0",
-        "slackclient==2.5.0",  # PINNED! slack changes file upload api in the future versions
+        "slack_sdk>=3.1.1",
         "sqlalchemy>=1.4, <2",
         "sqlalchemy-utils>=0.38.3, <0.39",
         "sqlparse==0.3.0",  # PINNED! see https://github.com/andialbrecht/sqlparse/issues/562

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
         "graphlib-backport",
         "gunicorn>=20.1.0",
         "hashids>=1.3.1, <2",
-        "holidays==0.14.2",
+        "holidays>=0.14.2",
         "humanize",
         "isodate",
         "markdown>=3.0",
@@ -118,7 +118,7 @@ setup(
         "sqlalchemy>=1.4, <2",
         "sqlalchemy-utils>=0.38.3, <0.39",
         "sqlparse==0.3.0",  # PINNED! see https://github.com/andialbrecht/sqlparse/issues/562
-        "tabulate==0.8.9",
+        "tabulate>=0.8.9",
         # needed to support Literal (3.8) and TypeGuard (3.10)
         "typing-extensions>=3.10, <4",
         "wtforms-json",

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
         "graphlib-backport",
         "gunicorn>=20.1.0",
         "hashids>=1.3.1, <2",
-        "holidays>=0.14.2",
+        "holidays>=0.16.0, <0.17",
         "humanize",
         "isodate",
         "markdown>=3.0",

--- a/superset/reports/notifications/slack.py
+++ b/superset/reports/notifications/slack.py
@@ -22,8 +22,8 @@ from typing import Sequence, Union
 
 import backoff
 from flask_babel import gettext as __
-from slack import WebClient
-from slack.errors import SlackApiError, SlackClientError
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError, SlackClientError
 
 from superset import app
 from superset.reports.models import ReportRecipientType

--- a/superset/tasks/slack_util.py
+++ b/superset/tasks/slack_util.py
@@ -23,9 +23,9 @@ from typing import cast, Optional, Union
 
 import backoff
 from flask import current_app
-from slack import WebClient
-from slack.errors import SlackApiError
-from slack.web.slack_response import SlackResponse
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+from slack_sdk.web.slack_response import SlackResponse
 
 # Globals
 logger = logging.getLogger("tasks.slack_util")


### PR DESCRIPTION
SUMMARY

This is the last of three PRs, attempting to unpin Superset dependencies. See also https://github.com/apache/superset/pull/21581 and https://github.com/apache/superset/pull/21091

`slackclient` was originally pinned in https://github.com/apache/superset/pull/10345 due to https://github.com/slackapi/python-slack-sdk/issues/728 which was fixed in a series of PRs concluding with https://github.com/slackapi/python-slack-sdk/issues/901 which was released in `slack_sdk` version 3.1.1.

`slack_sdk` no longer depends on `aiohttp`, which removes a handful of dependencies.

While here, make `tabulate` and `holidays` dependency versions open-ended. This leaves only `numpy` pinned in `install_requires` in setup.py.