### PR TITLE
refactor: remove `time_series` from QueryObject

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/buildQuery.ts
@@ -33,7 +33,6 @@ export default function buildQuery(formData: BoxPlotQueryFormData) {
       {
         ...baseQueryObject,
         columns: [...distributionColumns, ...columns, ...groupby],
-        series_columns: groupby,
         post_processing: [boxplotOperator(formData, baseQueryObject)],
       },
     ];

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Gauge/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Gauge/buildQuery.ts
@@ -23,7 +23,6 @@ export default function buildQuery(formData: QueryFormData) {
   return buildQueryContext(formData, baseQueryObject => [
     {
       ...baseQueryObject,
-      groupby: formData.groupby || [],
       ...(sort_by_metric && { orderby: [[metric, false]] }),
     },
   ]);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/buildQuery.ts
@@ -39,7 +39,6 @@ import {
 } from '@superset-ui/chart-controls';
 
 export default function buildQuery(formData: QueryFormData) {
-  const { groupby } = formData;
   return buildQueryContext(formData, baseQueryObject => {
     /* the `pivotOperatorInRuntime` determines how to pivot the dataframe returned from the raw query.
        1. If it's a time compared query, there will return a pivoted dataframe that append time compared metrics. for instance:
@@ -73,9 +72,8 @@ export default function buildQuery(formData: QueryFormData) {
         ...baseQueryObject,
         columns: [
           ...(isXAxisSet(formData) ? ensureIsArray(getXAxis(formData)) : []),
-          ...ensureIsArray(groupby),
+          ...ensureIsArray(baseQueryObject.columns),
         ],
-        series_columns: groupby,
         ...(isXAxisSet(formData) ? {} : { is_timeseries: true }),
         // todo: move `normalizeOrderBy to extractQueryFields`
         orderby: normalizeOrderBy(baseQueryObject).orderby,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/BoxPlot/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/BoxPlot/buildQuery.test.ts
@@ -44,7 +44,6 @@ describe('BoxPlot buildQuery', () => {
     const [query] = queryContext.queries;
     expect(query.metrics).toEqual(['foo']);
     expect(query.columns).toEqual(['ds', 'bar']);
-    expect(query.series_columns).toEqual(['bar']);
     const [rule] = query.post_processing || [];
     expect(isPostProcessingBoxplot(rule)).toEqual(true);
     expect((rule as PostProcessingBoxplot)?.options?.groupby).toEqual(['bar']);
@@ -55,7 +54,6 @@ describe('BoxPlot buildQuery', () => {
     const [query] = queryContext.queries;
     expect(query.metrics).toEqual(['foo']);
     expect(query.columns).toEqual(['qwerty', 'bar']);
-    expect(query.series_columns).toEqual(['bar']);
     const [rule] = query.post_processing || [];
     expect(isPostProcessingBoxplot(rule)).toEqual(true);
     expect((rule as PostProcessingBoxplot)?.options?.groupby).toEqual(['bar']);

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Gauge/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Gauge/buildQuery.test.ts
@@ -29,20 +29,20 @@ describe('Gauge buildQuery', () => {
     const formData = { ...baseFormData, groupby: undefined };
     const queryContext = buildQuery(formData);
     const [query] = queryContext.queries;
-    expect(query.groupby).toEqual([]);
+    expect(query.columns).toEqual([]);
   });
 
   it('should build query fields with single group by column', () => {
     const formData = { ...baseFormData, groupby: ['foo'] };
     const queryContext = buildQuery(formData);
     const [query] = queryContext.queries;
-    expect(query.groupby).toEqual(['foo']);
+    expect(query.columns).toEqual(['foo']);
   });
 
   it('should build query fields with multiple group by columns', () => {
     const formData = { ...baseFormData, groupby: ['foo', 'bar'] };
     const queryContext = buildQuery(formData);
     const [query] = queryContext.queries;
-    expect(query.groupby).toEqual(['foo', 'bar']);
+    expect(query.columns).toEqual(['foo', 'bar']);
   });
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/buildQuery.test.ts
@@ -106,7 +106,7 @@ test('should compile query object A', () => {
     annotation_layers: [],
     row_limit: 10,
     row_offset: undefined,
-    series_columns: ['foo'],
+    series_columns: undefined,
     series_limit: undefined,
     series_limit_metric: undefined,
     timeseries_limit: 5,
@@ -144,6 +144,8 @@ test('should compile query object A', () => {
       },
     ],
     orderby: [['count', false]],
+    timeseries_limit_metric: 'count',
+    order_desc: true,
   });
 });
 
@@ -166,7 +168,7 @@ test('should compile query object B', () => {
     annotation_layers: [],
     row_limit: 100,
     row_offset: undefined,
-    series_columns: [],
+    series_columns: undefined,
     series_limit: undefined,
     series_limit_metric: undefined,
     timeseries_limit: 0,
@@ -194,6 +196,8 @@ test('should compile query object B', () => {
       },
     ],
     orderby: [['count', true]],
+    timeseries_limit_metric: undefined,
+    order_desc: false,
   });
 });
 
@@ -312,7 +316,7 @@ test('should convert a queryObject with x-axis although FF is disabled', () => {
     annotation_layers: [],
     row_limit: 10,
     row_offset: undefined,
-    series_columns: ['foo'],
+    series_columns: undefined,
     series_limit: undefined,
     series_limit_metric: undefined,
     timeseries_limit: 5,
@@ -349,6 +353,8 @@ test('should convert a queryObject with x-axis although FF is disabled', () => {
       },
     ],
     orderby: [['count', false]],
+    timeseries_limit_metric: 'count',
+    order_desc: true,
   });
 
   // check the main props on the second query
@@ -364,7 +370,6 @@ test('should convert a queryObject with x-axis although FF is disabled', () => {
         },
       ],
       granularity: 'ds',
-      series_columns: [],
       metrics: ['count'],
       post_processing: [
         {
@@ -409,7 +414,6 @@ test("shouldn't convert a queryObject with axis although FF is enabled", () => {
     expect.objectContaining({
       granularity: 'ds',
       columns: ['foo'],
-      series_columns: ['foo'],
       metrics: ['sum(sales)'],
       is_timeseries: true,
       extras: {
@@ -445,7 +449,6 @@ test("shouldn't convert a queryObject with axis although FF is enabled", () => {
     expect.objectContaining({
       granularity: 'ds',
       columns: [],
-      series_columns: [],
       metrics: ['count'],
       is_timeseries: true,
       extras: {

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/buildQuery.test.ts
@@ -95,7 +95,6 @@ describe('GENERIC_CHART_AXES is enabled', () => {
         time_range: '1 year ago : 2013',
         extras: { time_grain_sqla: 'P1Y', having: '', where: '' },
         columns: ['col1'],
-        series_columns: ['col1'],
         metrics: ['count(*)'],
         is_timeseries: true,
         post_processing: [
@@ -131,7 +130,6 @@ describe('GENERIC_CHART_AXES is enabled', () => {
           },
           'col1',
         ],
-        series_columns: ['col1'],
         metrics: ['count(*)'],
         post_processing: [
           {
@@ -184,7 +182,6 @@ describe('GENERIC_CHART_AXES is disabled', () => {
         time_range: '1 year ago : 2013',
         extras: { time_grain_sqla: 'P1Y', having: '', where: '' },
         columns: ['col1'],
-        series_columns: ['col1'],
         metrics: ['count(*)'],
         is_timeseries: true,
         post_processing: [
@@ -220,7 +217,6 @@ describe('GENERIC_CHART_AXES is disabled', () => {
           },
           'col1',
         ],
-        series_columns: ['col1'],
         metrics: ['count(*)'],
         post_processing: [
           {

--- a/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/buildQuery.ts
@@ -23,13 +23,10 @@ import {
 } from '@superset-ui/core';
 
 export default function buildQuery(formData: QueryFormData) {
-  const { groupby } = formData;
-
   return buildQueryContext(formData, baseQueryObject => [
     {
       ...baseQueryObject,
       orderby: normalizeOrderBy(baseQueryObject).orderby,
-      ...(groupby && { groupby }),
     },
   ]);
 }

--- a/superset-frontend/plugins/plugin-chart-handlebars/test/plugin/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-handlebars/test/plugin/buildQuery.test.ts
@@ -32,6 +32,6 @@ describe('Handlebars buildQuery', () => {
   it('should build groupby with series in form data', () => {
     const queryContext = buildQuery(formData);
     const [query] = queryContext.queries;
-    expect(query.groupby).toEqual(['foo']);
+    expect(query.columns).toEqual(['foo']);
   });
 });


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
TBD

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
