### PR TITLE
chore: removing '.git' from web url references in Yeoman generator's package.json

### DIFF
--- a/superset-frontend/packages/generator-superset/package.json
+++ b/superset-frontend/packages/generator-superset/package.json
@@ -8,9 +8,9 @@
     "superset",
     "yeoman-generator"
   ],
-  "homepage": "https://github.com/apache/superset.git#readme",
+  "homepage": "https://github.com/apache/superset#readme",
   "bugs": {
-    "url": "https://github.com/apache/superset.git/issues"
+    "url": "https://github.com/apache/superset/issues"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Just a couple of quick fixes to urls in the Yeoman Generator's package.json file

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Copy/paste the URLs into your browser and make sure they're correct.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
