### PR TITLE
fix(sqllab): SqlEditorLeftBar listening to database changes

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
@@ -138,7 +138,7 @@ export default function SqlEditorLeftBar({
       setUserSelected(userSelected);
       setItem(LocalStorageKeys.db, null);
     } else setUserSelected(database);
-  }, []);
+  }, [database]);
 
   useEffect(() => {
     queryEditorRef.current = queryEditor;


### PR DESCRIPTION
### SUMMARY
We stopped listening to database prop changes at some point to only take into account the initial component render. That however, caused the component to always work with the initial database passed as prop and never take into account new user selections. Which you might evidence for example with empty table dropdown after changing DB.

We're bringing that feature back with this fix. Also we're using the right props in our tests and adding a new one to consider the re-renders with new database.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![error](https://user-images.githubusercontent.com/38889534/192873161-7c688e1c-e74c-4233-8f9a-905fb34ade8e.gif)

After:
![test](https://user-images.githubusercontent.com/38889534/192873391-7666bcfd-a1b0-4d3e-9efe-2c5951bce29a.gif)

### TESTING INSTRUCTIONS
Go to sql lab and do a query on your default data base
In the same query tab, switch databases
Select your table
Try to select a table

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
