### PR TITLE
fix: Selected tab after save and go to dashboard

### DIFF
--- a/superset-frontend/src/dashboard/actions/hydrate.js
+++ b/superset-frontend/src/dashboard/actions/hydrate.js
@@ -293,7 +293,7 @@ export const hydrateDashboard =
 
     // find direct link component and path from root
     const directLinkComponentId = getLocationHash();
-    let directPathToChild = [];
+    let directPathToChild = dashboardState.directPathToChild || [];
     if (layout[directLinkComponentId]) {
       directPathToChild = (layout[directLinkComponentId].parents || []).slice();
       directPathToChild.push(directLinkComponentId);


### PR DESCRIPTION
### SUMMARY
Fixes a bug with the selected tab after saving a chart and navigating to the dashboard. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/192880032-da6d437e-18ee-4b2f-9e5f-942db2b9e60d.mov

https://user-images.githubusercontent.com/70410625/192880102-25cfff7d-32a7-46ab-b11c-ee727bac3194.mov

### TESTING INSTRUCTIONS
Check the videos for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
