### PR TITLE
chore: avoid undefined property on `Global` type

### DIFF
--- a/superset-frontend/packages/superset-ui-switchboard/src/switchboard.test.ts
+++ b/superset-frontend/packages/superset-ui-switchboard/src/switchboard.test.ts
@@ -105,7 +105,9 @@ describe('comms', () => {
   let originalConsoleError: any = null;
 
   beforeAll(() => {
-    global.MessageChannel = FakeMessageChannel; // yolo
+    Object.defineProperty(global, 'MessageChannel', {
+      value: FakeMessageChannel,
+    });
     originalConsoleDebug = console.debug;
     originalConsoleError = console.error;
   });

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -283,7 +283,7 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
     setBarTopOffset(headerRef.current?.getBoundingClientRect()?.height || 0);
 
     let observer: ResizeObserver;
-    if (typeof global.ResizeObserver !== 'undefined' && headerRef.current) {
+    if (global.hasOwnProperty('ResizeObserver') && headerRef.current) {
       observer = new ResizeObserver(entries => {
         setBarTopOffset(
           current => entries?.[0]?.contentRect?.height || current,


### PR DESCRIPTION
### SUMMARY
This commit avoids the following potential typescript error due to directly access `global` properties.

```
TS2339: Property 'MessageChannel' does not exist on type 'Global'.

108     global.MessageChannel = FakeMessageChannel; // yolo

TS2339: Property 'ResizeObserver' does not exist on type 'Global'.

307     if (typeof global.ResizeObserver !== 'undefined' && headerRef.current) {
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
npm run type

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @ktmud 