### PR TITLE
chore: standardize ExploreMixin column object to use new Sip-69 Columns model

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1643,19 +1643,18 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                 if sqla_col is not None:
                     pass
                 elif col_obj and filter_grain:
-                    if isinstance(col_obj, dict):
-                        sqla_col = self.get_timestamp_expression(
-                            col_obj, time_grain, template_processor=template_processor
-                        )
-                    else:
-                        sqla_col = col_obj.get_timestamp_expression(
-                            time_grain=filter_grain,
-                            template_processor=template_processor,
-                        )
-                elif col_obj and isinstance(col_obj, dict):
-                    sqla_col = sa.column(col_obj.get("column_name"))
+                    sqla_col = self.get_timestamp_expression(
+                        col_obj, time_grain, template_processor=template_processor
+                    )
+                    # else:
+                    #     sqla_col = col_obj.get_timestamp_expression(
+                    #         time_grain=filter_grain,
+                    #         template_processor=template_processor,
+                    #     )
                 elif col_obj:
-                    sqla_col = col_obj.get_sqla_col()
+                    sqla_col = sa.column(col_obj.name)
+                # elif col_obj:
+                #     sqla_col = col_obj.get_sqla_col()
 
                 if col_obj and isinstance(col_obj, dict):
                     col_type = col_obj.get("type")

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# pylint: disable=import-outside-toplevel
+
+
+def test_explore_mixin_get_timestamp():
+    from superset.columns.models import Column as SLColumn
+    from superset.models.core import Database
+    from superset.models.sql_lab import Query
+
+    db = Database(database_name="my_database", sqlalchemy_uri="sqlite://")
+    query = Query(
+        client_id="foo",
+        database=db,
+        tab_name="test_tab",
+        sql_editor_id="test_editor_id",
+        sql="select * from bar",
+        select_sql="select * from bar",
+        executed_sql="select * from bar",
+        limit=100,
+        select_as_cta=False,
+        rows=100,
+        error_message="none",
+        results_key="abc",
+    )
+
+    col = SLColumn(name="foo", type="TIMESTAMP")
+    query.get_timestamp_expression(col, time_grain=None)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Before generating sqlalchemy query, we want standardized how the column objects are annotated. Right now `Query` stores  columns as a `dict` and as we incorporate `Datasets` it will get confusing because the column object won't have the same schema. To fix this I'm refactoring the ExploreMixin to have `self.columns` to be converted into a `List[SLColumn]` to make easier to generate the sqlaquery query downstream.

Also i'm incorporating some unit test around the column conversion logic

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
