### PR TITLE
fix: respect chart cache timeout setting

### DIFF
--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -47,7 +47,7 @@ class QueryContext:
     enforce_numerical_metrics: ClassVar[bool] = True
 
     datasource: BaseDatasource
-    slice_id: Optional[int] = None
+    slice: Optional[Slice] = None
     queries: List[QueryObject]
     form_data: Optional[Dict[str, Any]]
     result_type: ChartDataResultType
@@ -102,7 +102,7 @@ class QueryContext:
     def get_cache_timeout(self) -> Optional[int]:
         if self.custom_cache_timeout is not None:
             return self.custom_cache_timeout
-        if self.slice and self.slice.cache_timeout:
+        if self.slice and self.slice.cache_timeout is not None:
             return self.slice.cache_timeout
         if self.datasource.cache_timeout is not None:
             return self.datasource.cache_timeout

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -27,6 +27,7 @@ from superset.common.query_context_processor import (
     QueryContextProcessor,
 )
 from superset.common.query_object import QueryObject
+from superset.models.slice import Slice
 
 if TYPE_CHECKING:
     from superset.connectors.base.models import BaseDatasource
@@ -46,6 +47,7 @@ class QueryContext:
     enforce_numerical_metrics: ClassVar[bool] = True
 
     datasource: BaseDatasource
+    slice_id: Optional[int] = None
     queries: List[QueryObject]
     form_data: Optional[Dict[str, Any]]
     result_type: ChartDataResultType
@@ -64,6 +66,7 @@ class QueryContext:
         *,
         datasource: BaseDatasource,
         queries: List[QueryObject],
+        slice: Optional[Slice],
         form_data: Optional[Dict[str, Any]],
         result_type: ChartDataResultType,
         result_format: ChartDataResultFormat,
@@ -72,6 +75,7 @@ class QueryContext:
         cache_values: Dict[str, Any],
     ) -> None:
         self.datasource = datasource
+        self.slice = slice
         self.result_type = result_type
         self.result_format = result_format
         self.queries = queries
@@ -98,6 +102,8 @@ class QueryContext:
     def get_cache_timeout(self) -> Optional[int]:
         if self.custom_cache_timeout is not None:
             return self.custom_cache_timeout
+        if self.slice and self.slice.cache_timeout:
+            return self.slice.cache_timeout
         if self.datasource.cache_timeout is not None:
             return self.datasource.cache_timeout
         if hasattr(self.datasource, "database"):

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -47,7 +47,7 @@ class QueryContext:
     enforce_numerical_metrics: ClassVar[bool] = True
 
     datasource: BaseDatasource
-    slice: Optional[Slice] = None
+    slice_: Optional[Slice] = None
     queries: List[QueryObject]
     form_data: Optional[Dict[str, Any]]
     result_type: ChartDataResultType
@@ -66,7 +66,7 @@ class QueryContext:
         *,
         datasource: BaseDatasource,
         queries: List[QueryObject],
-        slice: Optional[Slice],
+        slice_: Optional[Slice],
         form_data: Optional[Dict[str, Any]],
         result_type: ChartDataResultType,
         result_format: ChartDataResultFormat,
@@ -75,7 +75,7 @@ class QueryContext:
         cache_values: Dict[str, Any],
     ) -> None:
         self.datasource = datasource
-        self.slice = slice
+        self.slice_ = slice_
         self.result_type = result_type
         self.result_format = result_format
         self.queries = queries
@@ -102,8 +102,8 @@ class QueryContext:
     def get_cache_timeout(self) -> Optional[int]:
         if self.custom_cache_timeout is not None:
             return self.custom_cache_timeout
-        if self.slice and self.slice.cache_timeout is not None:
-            return self.slice.cache_timeout
+        if self.slice_ and self.slice_.cache_timeout is not None:
+            return self.slice_.cache_timeout
         if self.datasource.cache_timeout is not None:
             return self.datasource.cache_timeout
         if hasattr(self.datasource, "database"):

--- a/superset/common/query_context_factory.py
+++ b/superset/common/query_context_factory.py
@@ -60,8 +60,7 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
 
         slice = None
         if form_data and form_data.get("slice_id") is not None:
-            slice_id = form_data.get("slice_id")
-            slice = self._get_slice(slice_id)
+            slice = self._get_slice(form_data.get("slice_id"))
 
         result_type = result_type or ChartDataResultType.FULL
         result_format = result_format or ChartDataResultFormat.JSON

--- a/superset/common/query_context_factory.py
+++ b/superset/common/query_context_factory.py
@@ -58,9 +58,9 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
         if datasource:
             datasource_model_instance = self._convert_to_model(datasource)
 
-        slice = None
+        slice_ = None
         if form_data and form_data.get("slice_id") is not None:
-            slice = self._get_slice(form_data.get("slice_id"))
+            slice_ = self._get_slice(form_data.get("slice_id"))
 
         result_type = result_type or ChartDataResultType.FULL
         result_format = result_format or ChartDataResultFormat.JSON
@@ -79,7 +79,7 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
         return QueryContext(
             datasource=datasource_model_instance,
             queries=queries_,
-            slice=slice,
+            slice_=slice_,
             form_data=form_data,
             result_type=result_type,
             result_format=result_format,

--- a/superset/common/query_context_factory.py
+++ b/superset/common/query_context_factory.py
@@ -19,10 +19,12 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 from superset import app, db
+from superset.charts.dao import ChartDAO
 from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
 from superset.common.query_context import QueryContext
 from superset.common.query_object_factory import QueryObjectFactory
 from superset.datasource.dao import DatasourceDAO
+from superset.models.slice import Slice
 from superset.utils.core import DatasourceDict, DatasourceType
 
 if TYPE_CHECKING:
@@ -55,6 +57,12 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
         datasource_model_instance = None
         if datasource:
             datasource_model_instance = self._convert_to_model(datasource)
+
+        slice = None
+        if form_data and form_data.get("slice_id") is not None:
+            slice_id = form_data.get("slice_id")
+            slice = self._get_slice(slice_id)
+
         result_type = result_type or ChartDataResultType.FULL
         result_format = result_format or ChartDataResultFormat.JSON
         queries_ = [
@@ -72,6 +80,7 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
         return QueryContext(
             datasource=datasource_model_instance,
             queries=queries_,
+            slice=slice,
             form_data=form_data,
             result_type=result_type,
             result_format=result_format,
@@ -88,3 +97,6 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
             datasource_type=DatasourceType(datasource["type"]),
             datasource_id=int(datasource["id"]),
         )
+
+    def _get_slice(self, slice_id: Any) -> Optional[Slice]:
+        return ChartDAO.find_by_id(slice_id)

--- a/tests/integration_tests/fixtures/energy_dashboard.py
+++ b/tests/integration_tests/fixtures/energy_dashboard.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import random
-from typing import Dict, Set
+from typing import Dict, List, Set
 
 import pandas as pd
 import pytest
@@ -59,8 +59,8 @@ def load_energy_table_data():
 @pytest.fixture()
 def load_energy_table_with_slice(load_energy_table_data):
     with app.app_context():
-        _create_energy_table()
-        yield
+        slices = _create_energy_table()
+        yield slices
         _cleanup()
 
 
@@ -69,7 +69,7 @@ def _get_dataframe():
     return pd.DataFrame.from_dict(data)
 
 
-def _create_energy_table():
+def _create_energy_table() -> List[Slice]:
     table = create_table_metadata(
         table_name=ENERGY_USAGE_TBL_NAME,
         database=get_example_database(),
@@ -86,13 +86,17 @@ def _create_energy_table():
     db.session.commit()
     table.fetch_metadata()
 
+    slices = []
     for slice_data in _get_energy_slices():
-        _create_and_commit_energy_slice(
+
+        slice = _create_and_commit_energy_slice(
             table,
             slice_data["slice_title"],
             slice_data["viz_type"],
             slice_data["params"],
         )
+        slices.append(slice)
+    return slices
 
 
 def _create_and_commit_energy_slice(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fixes: #21635

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
start redis locally, and setup redis cache in config for data
create any chart on 1 dataset
set dataset cache timeout to 120 seconds
set chart cache timeout to 20 seconds (from properties modal).
open chart, and click on update chart
use redis cli, to check the expiry set on the cache key using ttl {cache_key} -> ishould be around 20 seconds.
after 20 seconds, click on update chart -> should not show `cached` tag on top right corner.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #21635 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
