### PR TITLE
fix: disable __REACT_DEVTOOLS_GLOBAL_HOOK__ in production mode

### DIFF
--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -170,7 +170,7 @@ if (!isDevMode) {
   plugins.push(
     // disable __REACT_DEVTOOLS_GLOBAL_HOOK__
     new webpack.DefinePlugin({
-      '__REACT_DEVTOOLS_GLOBAL_HOOK__': '({ isDisabled: true })'
+      '__REACT_DEVTOOLS_GLOBAL_HOOK__': '({ isDisabled: true })',
     }),
   );
 }

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -170,7 +170,7 @@ if (!isDevMode) {
   plugins.push(
     // disable __REACT_DEVTOOLS_GLOBAL_HOOK__
     new webpack.DefinePlugin({
-      '__REACT_DEVTOOLS_GLOBAL_HOOK__': '({ isDisabled: true })',
+      __REACT_DEVTOOLS_GLOBAL_HOOK__: '({ isDisabled: true })',
     }),
   );
 }

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -166,6 +166,13 @@ if (!isDevMode) {
       },
     }),
   );
+
+  plugins.push(
+    // disable __REACT_DEVTOOLS_GLOBAL_HOOK__
+    new webpack.DefinePlugin({
+      '__REACT_DEVTOOLS_GLOBAL_HOOK__': '({ isDisabled: true })'
+    }),
+  );
 }
 
 const PREAMBLE = [path.join(APP_DIR, '/src/preamble.ts')];


### PR DESCRIPTION
### SUMMARY
try to fix https://github.com/apache/superset/issues/20815
refer: https://stackoverflow.com/questions/42196819/disable-hide-download-the-react-devtools
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
#### BEFORE
![image](https://user-images.githubusercontent.com/10289162/192948667-9606a801-f799-4f62-aee7-43ab96719d72.png)

#### AFTER
![image](https://user-images.githubusercontent.com/10289162/192947035-b7c78c5f-0a07-480d-953e-63e4f613f99a.png)



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #20815
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
