### PR TITLE
fix(superset-embedded-sdk): Buffer is not defined

### DIFF
--- a/superset-embedded-sdk/package-lock.json
+++ b/superset-embedded-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@superset-ui/embedded-sdk",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@superset-ui/embedded-sdk",
-      "version": "0.1.0-alpha.8",
+      "version": "0.1.0-alpha.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@superset-ui/switchboard": "^0.18.26-0",

--- a/superset-embedded-sdk/package-lock.json
+++ b/superset-embedded-sdk/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@superset-ui/embedded-sdk",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@superset-ui/embedded-sdk",
-      "version": "0.1.0-alpha.7",
+      "version": "0.1.0-alpha.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@superset-ui/switchboard": "^0.18.26-0"
+        "@superset-ui/switchboard": "^0.18.26-0",
+        "jwt-decode": "^3.1.2"
       },
       "devDependencies": {
         "@babel/cli": "^7.16.8",
@@ -6494,6 +6495,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -13041,6 +13047,11 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "kind-of": {
       "version": "6.0.3",

--- a/superset-embedded-sdk/package.json
+++ b/superset-embedded-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/embedded-sdk",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "SDK for embedding resources from Superset into your own application",
   "access": "public",
   "keywords": [
@@ -33,7 +33,8 @@
     "last 3 edge versions"
   ],
   "dependencies": {
-    "@superset-ui/switchboard": "^0.18.26-0"
+    "@superset-ui/switchboard": "^0.18.26-0",
+    "jwt-decode": "^3.1.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.16.8",

--- a/superset-embedded-sdk/package.json
+++ b/superset-embedded-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/embedded-sdk",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.7",
   "description": "SDK for embedding resources from Superset into your own application",
   "access": "public",
   "keywords": [

--- a/superset-embedded-sdk/src/guestTokenRefresh.ts
+++ b/superset-embedded-sdk/src/guestTokenRefresh.ts
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import jwt_decode from "jwt-decode";
 
 export const REFRESH_TIMING_BUFFER_MS = 5000 // refresh guest token early to avoid failed superset requests
 export const MIN_REFRESH_WAIT_MS = 10000 // avoid blasting requests as fast as the cpu can handle
@@ -23,7 +24,7 @@ export const DEFAULT_TOKEN_EXP_MS = 300000 // (5 min) used only when parsing gue
 
 // when do we refresh the guest token?
 export function getGuestTokenRefreshTiming(currentGuestToken: string) {
-  const parsedJwt = JSON.parse(Buffer.from(currentGuestToken.split('.')[1], 'base64').toString());
+  const parsedJwt = jwt_decode<Record<string, any>>(currentGuestToken);
   // if exp is int, it is in seconds, but Date() takes milliseconds
   const exp = new Date(/[^0-9\.]/g.test(parsedJwt.exp) ? parsedJwt.exp : parseFloat(parsedJwt.exp) * 1000);
   const isValidDate = exp.toString() !== 'Invalid Date';


### PR DESCRIPTION
`Buffer` is a Nodejs api, doesn't support in the browser environment. Replace `Buffer` with [jwt-decode](https://www.npmjs.com/package/jwt-decode) to parse Jwt.

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
