### PR TITLE
feat: support xaxis on Power Query when Generic Axis is enabled

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1172,6 +1172,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
             )
         return ob
 
+    # pylint: disable=import-outside-toplevel, too-many-locals
     def adhoc_column_to_sqla(
         self,
         col: AdhocColumn,
@@ -1195,7 +1196,8 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
             schema=self.schema,
             template_processor=template_processor,
         )
-        # note that: the column name is "name" instead of "column_name" in SQLLab query metadata
+        # note that: the column name is "name" instead of "column_name"
+        # in SQLLab query metadata
         col_in_metadata = (
             [col for col in self.columns if col.get("name") == expression] or [None]
         )[0]


### PR DESCRIPTION
### SUMMARY
This is a quick fix that should apply time grain when Generic Axis is enabled. The Power Query should get more consideration and code design in the future so that share the same unit test and codebase with `connections.model.sqla` and logic.


The column in the `X-Axis` control is designed as a time column when `Generic Axis` is enabled. The `Time Grain` control should apply a time truncation function to the `X-Axis` column. This feature has been implemented in the **virtual dataset** and the **physical dataset** but can't use in Power Query mode.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
#### Before


https://user-images.githubusercontent.com/2016594/192987619-c7f948eb-1051-44f6-a180-8fd70c19cd4b.mov

#### After


https://user-images.githubusercontent.com/2016594/192988248-23318254-14ec-4244-9279-669ed17c2aa6.mov






### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
