### PR TITLE
refactor: remove useless groupby from QueryObject

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Gauge/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Gauge/buildQuery.ts
@@ -23,7 +23,6 @@ export default function buildQuery(formData: QueryFormData) {
   return buildQueryContext(formData, baseQueryObject => [
     {
       ...baseQueryObject,
-      groupby: formData.groupby || [],
       ...(sort_by_metric && { orderby: [[metric, false]] }),
     },
   ]);

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Gauge/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Gauge/buildQuery.test.ts
@@ -29,20 +29,20 @@ describe('Gauge buildQuery', () => {
     const formData = { ...baseFormData, groupby: undefined };
     const queryContext = buildQuery(formData);
     const [query] = queryContext.queries;
-    expect(query.groupby).toEqual([]);
+    expect(query.columns).toEqual([]);
   });
 
   it('should build query fields with single group by column', () => {
     const formData = { ...baseFormData, groupby: ['foo'] };
     const queryContext = buildQuery(formData);
     const [query] = queryContext.queries;
-    expect(query.groupby).toEqual(['foo']);
+    expect(query.columns).toEqual(['foo']);
   });
 
   it('should build query fields with multiple group by columns', () => {
     const formData = { ...baseFormData, groupby: ['foo', 'bar'] };
     const queryContext = buildQuery(formData);
     const [query] = queryContext.queries;
-    expect(query.groupby).toEqual(['foo', 'bar']);
+    expect(query.columns).toEqual(['foo', 'bar']);
   });
 });

--- a/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/buildQuery.ts
@@ -23,13 +23,10 @@ import {
 } from '@superset-ui/core';
 
 export default function buildQuery(formData: QueryFormData) {
-  const { groupby } = formData;
-
   return buildQueryContext(formData, baseQueryObject => [
     {
       ...baseQueryObject,
       orderby: normalizeOrderBy(baseQueryObject).orderby,
-      ...(groupby && { groupby }),
     },
   ]);
 }

--- a/superset-frontend/plugins/plugin-chart-handlebars/test/plugin/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-handlebars/test/plugin/buildQuery.test.ts
@@ -32,6 +32,6 @@ describe('Handlebars buildQuery', () => {
   it('should build groupby with series in form data', () => {
     const queryContext = buildQuery(formData);
     const [query] = queryContext.queries;
-    expect(query.groupby).toEqual(['foo']);
+    expect(query.columns).toEqual(['foo']);
   });
 });


### PR DESCRIPTION
### SUMMARY
The `groupby` isn't a valid QueryObject field so remove this field from 1) `Gauge Chart` 2) `Handlebars Chart`. The original chart can work is because the [extractQueryFields](https://github.com/apache/superset/blob/b787c3fef4655c1142da3d827fe6766c853ffe72/superset-frontend/packages/superset-ui-core/src/query/extractQueryFields.ts#L93) has converted it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Gauge Chart and Handlebars Chart should work as before.


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
