### PR TITLE
fix: time grain can't be removed in explore

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
@@ -189,7 +189,7 @@ const time_grain_sqla: SharedControlConfig<'SelectControl'> = {
       // If a chart is in a Dashboard, the ControlPanelState is empty.
       return control.value;
     }
-    // if a chart is a new one that isn't saved, the 'time_grain_sqla' isn't in the form_data.
+    // If a chart is a new one that isn't saved, the 'time_grain_sqla' isn't in the form_data.
     return 'time_grain_sqla' in (state?.form_data ?? {})
       ? state.form_data?.time_grain_sqla
       : 'P1D';

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
@@ -186,11 +186,13 @@ const time_grain_sqla: SharedControlConfig<'SelectControl'> = {
   label: TIME_FILTER_LABELS.time_grain_sqla,
   initialValue: (control: ControlState, state: ControlPanelState) => {
     if (!isDefined(state)) {
-      // should return control value if the chart is from Dashboard
+      // If a chart is in a Dashboard, the ControlPanelState is empty.
       return control.value;
     }
-    // use default value 'P1D' for a new chart only.
-    return isDefined(state.slice) ? control.value : 'P1D';
+    // if a chart is a new one that isn't saved, the 'time_grain_sqla' isn't in the form_data.
+    return 'time_grain_sqla' in (state?.form_data ?? {})
+      ? state.form_data?.time_grain_sqla
+      : 'P1D';
   },
   description: t(
     'The time granularity for the visualization. This ' +

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
@@ -46,6 +46,7 @@ import {
   isAdhocColumn,
   isPhysicalColumn,
   ensureIsArray,
+  isDefined,
 } from '@superset-ui/core';
 
 import {
@@ -183,7 +184,14 @@ const granularity: SharedControlConfig<'SelectControl'> = {
 const time_grain_sqla: SharedControlConfig<'SelectControl'> = {
   type: 'SelectControl',
   label: TIME_FILTER_LABELS.time_grain_sqla,
-  default: 'P1D',
+  initialValue: (control: ControlState, state: ControlPanelState) => {
+    if (!isDefined(state)) {
+      // should return control value if the chart is from Dashboard
+      return control.value;
+    }
+    // use default value 'P1D' for a new chart only.
+    return isDefined(state.slice) ? control.value : 'P1D';
+  },
   description: t(
     'The time granularity for the visualization. This ' +
       'applies a date transformation to alter ' +
@@ -192,7 +200,7 @@ const time_grain_sqla: SharedControlConfig<'SelectControl'> = {
       'engine basis in the Superset source code.',
   ),
   mapStateToProps: ({ datasource }) => ({
-    choices: (datasource as Dataset)?.time_grain_sqla || null,
+    choices: (datasource as Dataset)?.time_grain_sqla || [],
   }),
   visibility: ({ controls }) => {
     if (!isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES)) {

--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -86,6 +86,7 @@ export interface ControlPanelState {
   form_data: QueryFormData;
   datasource: Dataset | QueryResponse | null;
   controls: ControlStateMapping;
+  slice?: AnyDict;
 }
 
 /**

--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -86,7 +86,6 @@ export interface ControlPanelState {
   form_data: QueryFormData;
   datasource: Dataset | QueryResponse | null;
   controls: ControlStateMapping;
-  slice?: AnyDict;
 }
 
 /**


### PR DESCRIPTION
### SUMMARY
There is a long-term issue in the `Time Grain` control that it can't be cleared time grain value even though remove it or select `Original value`.

This PR intends to fix it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### Before
https://user-images.githubusercontent.com/2016594/192993267-adee1b93-7c16-428f-9021-ca54612e7a7d.mov

### After


https://user-images.githubusercontent.com/2016594/192994143-994a3eb3-9c23-4d9f-947a-340962fa0692.mov





### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
