### PR TITLE
fix: Switch tab on drag hover

### DIFF
--- a/superset-frontend/src/dashboard/components/dnd/DragDroppable.jsx
+++ b/superset-frontend/src/dashboard/components/dnd/DragDroppable.jsx
@@ -42,6 +42,7 @@ const propTypes = {
   index: PropTypes.number.isRequired,
   style: PropTypes.object,
   onDrop: PropTypes.func,
+  onHover: PropTypes.func,
   editMode: PropTypes.bool.isRequired,
   useEmptyDragPreview: PropTypes.bool,
 
@@ -61,6 +62,7 @@ const defaultProps = {
   disableDragDrop: false,
   children() {},
   onDrop() {},
+  onHover() {},
   orientation: 'row',
   useEmptyDragPreview: false,
   isDragging: false,

--- a/superset-frontend/src/dashboard/components/dnd/handleHover.js
+++ b/superset-frontend/src/dashboard/components/dnd/handleHover.js
@@ -40,6 +40,8 @@ function handleHover(props, monitor, Component) {
     return;
   }
 
+  Component?.props?.onHover();
+
   Component.setState(() => ({
     dropIndicator: dropPosition,
   }));

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
@@ -43,6 +43,7 @@ const propTypes = {
   depth: PropTypes.number.isRequired,
   renderType: PropTypes.oneOf([RENDER_TAB, RENDER_TAB_CONTENT]).isRequired,
   onDropOnTab: PropTypes.func,
+  onHoverTab: PropTypes.func,
   editMode: PropTypes.bool.isRequired,
   canEdit: PropTypes.bool.isRequired,
 
@@ -64,6 +65,7 @@ const defaultProps = {
   availableColumnCount: 0,
   columnWidth: 0,
   onDropOnTab() {},
+  onHoverTab() {},
   onResizeStart() {},
   onResize() {},
   onResizeStop() {},
@@ -95,6 +97,7 @@ class Tab extends React.PureComponent {
     super(props);
     this.handleChangeText = this.handleChangeText.bind(this);
     this.handleDrop = this.handleDrop.bind(this);
+    this.handleOnHover = this.handleOnHover.bind(this);
     this.handleTopDropTargetDrop = this.handleTopDropTargetDrop.bind(this);
     this.handleChangeTab = this.handleChangeTab.bind(this);
   }
@@ -121,6 +124,10 @@ class Tab extends React.PureComponent {
   handleDrop(dropResult) {
     this.props.handleComponentDrop(dropResult);
     this.props.onDropOnTab(dropResult);
+  }
+
+  handleOnHover() {
+    this.props.onHoverTab();
   }
 
   handleTopDropTargetDrop(dropResult) {
@@ -216,6 +223,7 @@ class Tab extends React.PureComponent {
             depth={depth} // see isValidChild.js for why tabs don't increment child depth
             index={componentIndex}
             onDrop={this.handleDrop}
+            onHover={this.handleOnHover}
             availableColumnCount={availableColumnCount}
             columnWidth={columnWidth}
             onResizeStart={onResizeStart}
@@ -234,6 +242,7 @@ class Tab extends React.PureComponent {
             index={tabComponent.children.length}
             depth={depth}
             onDrop={this.handleDrop}
+            onHover={this.handleOnHover}
             editMode
             className="empty-droptarget"
           >
@@ -263,6 +272,7 @@ class Tab extends React.PureComponent {
         index={index}
         depth={depth}
         onDrop={this.handleDrop}
+        onHover={this.handleOnHover}
         editMode={editMode}
       >
         {({ dropIndicatorProps, dragSourceRef }) => (

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -388,6 +388,7 @@ export class Tabs extends React.PureComponent {
                       availableColumnCount={availableColumnCount}
                       columnWidth={columnWidth}
                       onDropOnTab={this.handleDropOnTab}
+                      onHoverTab={() => this.handleClickTab(tabIndex)}
                       isFocused={activeKey === tabId}
                       isHighlighted={
                         activeKey !== tabId && tabsToHighlight?.includes(tabId)


### PR DESCRIPTION
### SUMMARY
When dragging a chart to a tab, the dashboard should switch to the target tab instead of scrolling upward.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/193051650-9352e810-c582-4ab6-be07-1e688cffedab.mov

https://user-images.githubusercontent.com/70410625/193050486-29c1e985-7d1c-4deb-ae28-cf4c35f7d877.mov

### TESTING INSTRUCTIONS
Check the videos for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
