### PR TITLE
docs: add organization that uses superset

### DIFF
--- a/RESOURCES/INTHEWILD.md
+++ b/RESOURCES/INTHEWILD.md
@@ -147,6 +147,9 @@ Join our growing community!
 ### HR / Staffing
 - [Symmetrics](https://www.symmetrics.fyi)
 
+## News
+- [Prensa Iberica](https://www.prensaiberica.es/) [@zamar-roura]
+
 ### Others
 - [Dropbox](https://www.dropbox.com/) [@bkyryliuk]
 - [Grassroot](https://www.grassrootinstitute.org/)

--- a/RESOURCES/INTHEWILD.md
+++ b/RESOURCES/INTHEWILD.md
@@ -147,7 +147,7 @@ Join our growing community!
 ### HR / Staffing
 - [Symmetrics](https://www.symmetrics.fyi)
 
-## News
+### News
 - [Prensa Iberica](https://www.prensaiberica.es/) [@zamar-roura]
 
 ### Others


### PR DESCRIPTION
### SUMMARY
In our company, (the second biggest news organization in spain, aiming for the first!) we've been using Superset since version 1.1 and we've done some tweaks and functionalities for our company use, but we think that it's time to also contribute to open source. 

I'm trying to push a bigquery estimation cost PR and having the permission to run github actions also would be useful..