### PR TITLE
fix(plugin-chart-echarts): boxplot throw error in the dashboard

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/index.tsx
@@ -349,7 +349,7 @@ const show_empty_columns: SharedControlConfig<'CheckboxControl'> = {
 
 const datetime_columns_lookup: SharedControlConfig<'HiddenControl'> = {
   type: 'HiddenControl',
-  initialValue: (control: ControlState, state: ControlPanelState) =>
+  initialValue: (control: ControlState, state: ControlPanelState | null) =>
     Object.fromEntries(
       ensureIsArray<Record<string, any>>(state?.datasource?.columns)
         .filter(option => option.is_dttm)

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/mixins.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/mixins.tsx
@@ -39,7 +39,7 @@ export const xAxisMixin = {
   description: (state: ControlPanelState) =>
     getAxisLabel(state?.form_data).description,
   validators: [validateNonEmpty],
-  initialValue: (control: ControlState, state: ControlPanelState) => {
+  initialValue: (control: ControlState, state: ControlPanelState | null) => {
     if (
       isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) &&
       state?.form_data?.granularity_sqla &&

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts
@@ -172,10 +172,14 @@ const config: ControlPanelConfig = {
       label: t('Distribute across'),
       multi: true,
       description: t('Columns to calculate distribution across.'),
-      initialValue: (control: ControlState, state: ControlPanelState) => {
+      initialValue: (
+        control: ControlState,
+        state: ControlPanelState | null,
+      ) => {
         if (
-          (state && !control?.value) ||
-          (Array.isArray(control?.value) && control.value.length === 0)
+          state &&
+          (!control?.value ||
+            (Array.isArray(control?.value) && control.value.length === 0))
         ) {
           return [getTemporalColumns(state.datasource).defaultTemporalColumn];
         }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The reason is the `controlPanelState` may be `null` in the dashboard.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
<img width="1790" alt="image" src="https://user-images.githubusercontent.com/11830681/193225162-b20add9f-94af-4e8b-a675-ed3b464b054a.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
