### PR TITLE
fix(sqllab): async query broken due to #21320

### DIFF
--- a/superset-frontend/src/SqlLab/components/RunQueryActionButton/index.tsx
+++ b/superset-frontend/src/SqlLab/components/RunQueryActionButton/index.tsx
@@ -130,6 +130,7 @@ const RunQueryActionButton = ({
   return (
     <StyledButton>
       <ButtonComponent
+        data-test="run-query-action"
         onClick={() =>
           onClick(shouldShowStopBtn, allowAsync, runQuery, stopQuery)
         }

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -235,8 +235,7 @@ const SqlEditor = ({
     }
   };
 
-  // hack the useMemo hook to imitate componentWillMount
-  useMemo(() => {
+  useEffect(() => {
     if (autorun) {
       setAutorun(false);
       dispatch(queryEditorSetAutorun(queryEditor, false));

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -229,6 +229,12 @@ const SqlEditor = ({
     }
   };
 
+  const runQuery = () => {
+    if (database) {
+      startQuery();
+    }
+  };
+
   useState(() => {
     if (autorun) {
       setAutorun(false);
@@ -542,7 +548,7 @@ const SqlEditor = ({
               allowAsync={database ? database.allow_run_async : false}
               queryEditor={queryEditor}
               queryState={latestQuery?.state}
-              runQuery={startQuery}
+              runQuery={runQuery}
               stopQuery={stopQuery}
               overlayCreateAsMenu={showMenu ? runMenuBtn : null}
             />

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -235,13 +235,14 @@ const SqlEditor = ({
     }
   };
 
-  useState(() => {
+  // hack the useMemo hook to imitate componentWillMount
+  useMemo(() => {
     if (autorun) {
       setAutorun(false);
       dispatch(queryEditorSetAutorun(queryEditor, false));
       startQuery();
     }
-  });
+  }, []);
 
   // One layer of abstraction for easy spying in unit tests
   const getSqlEditorHeight = () =>


### PR DESCRIPTION
### SUMMARY
This commit fixes the async query broken issue on #21656

In #21320, it updated the following code 

```diff
---624      runQuery={this.runQuery}
+++540      runQuery={startQuery}
```
which skips the following `startQuery` with empty args operation.
```
/// 422
  runQuery() {
    if (this.props.database) {
      this.startQuery();
    }
  }
```
This different payload broke the async query request.
This commit reverts back this origin logic.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

- Before

<img width="762" alt="Screen Shot 2022-09-30 at 2 00 34 PM" src="https://user-images.githubusercontent.com/1392866/193357024-750e5c58-487f-4060-850f-2069c84baf1a.png">

- After

<img width="780" alt="Screen Shot 2022-09-30 at 2 00 59 PM" src="https://user-images.githubusercontent.com/1392866/193357014-e2f0f888-5712-4ac1-bbc6-2f4f94defbc7.png">

### TESTING INSTRUCTIONS
enable database option to async query execution
run the query

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
