### PR TITLE
fix: sc-56694: Fixes issue where Metrics with custom SQL were being removed

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.test.tsx
@@ -18,7 +18,7 @@
  */
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { FeatureFlag } from '@superset-ui/core';
+import { DatasourceType, FeatureFlag } from '@superset-ui/core';
 import {
   render,
   screen,
@@ -26,7 +26,11 @@ import {
   fireEvent,
   waitFor,
 } from 'spec/helpers/testing-library';
-import { DndMetricSelect } from 'src/explore/components/controls/DndColumnSelectControl/DndMetricSelect';
+import {
+  DndMetricSelect,
+  retainCustomSQLMetric,
+  MetricExpression,
+} from 'src/explore/components/controls/DndColumnSelectControl/DndMetricSelect';
 import { AGGREGATES } from 'src/explore/constants';
 import { EXPRESSION_TYPES } from '../MetricControl/AdhocMetric';
 
@@ -405,4 +409,67 @@ test('title changes on custom SQL text change', async () => {
   expect(screen.getByTestId('AdhocMetricEditTitle#trigger')).toHaveTextContent(
     'New metric',
   );
+});
+
+test('retainCustomSQLMetric', () => {
+  const metric: MetricExpression = {
+    expressionType: EXPRESSION_TYPES.SQL,
+  };
+
+  expect(
+    retainCustomSQLMetric(
+      metric,
+      { type: DatasourceType.Query },
+      { type: DatasourceType.Table },
+    ),
+  ).toBeTruthy();
+
+  expect(
+    retainCustomSQLMetric(
+      metric,
+      { type: DatasourceType.Query },
+      { type: DatasourceType.Dataset },
+    ),
+  ).toBeTruthy();
+
+  expect(
+    retainCustomSQLMetric(
+      // @ts-ignore
+      null,
+      { type: DatasourceType.Dataset },
+      { type: DatasourceType.Query },
+    ),
+  ).toBeFalsy();
+
+  expect(
+    retainCustomSQLMetric(
+      metric,
+      // @ts-ignore
+      { typeWrongName: DatasourceType.Dataset },
+      { type: DatasourceType.Query },
+    ),
+  ).toBeFalsy();
+
+  expect(
+    retainCustomSQLMetric(
+      metric,
+      // @ts-ignore
+      null,
+      { type: DatasourceType.Query },
+    ),
+  ).toBeFalsy();
+
+  expect(
+    retainCustomSQLMetric(
+      metric,
+      { type: DatasourceType.Query },
+      // @ts-ignore
+      null,
+    ),
+  ).toBeFalsy();
+
+  expect(
+    // @ts-ignore
+    retainCustomSQLMetric(),
+  ).toBeFalsy();
 });


### PR DESCRIPTION
Fixes issue where Metrics with custom SQL were being removed when Transitioning from Query to Dataset in Explore Save

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Repro steps
Go to SQL lab
Run a query (e.g. Select * from "Vehicle Sales" )
Create chart
Switch to AGGREGATE query mode
Add product_line as dimensions
MAX(sales) as metric using the Custom SQL tab
Update chart and Save it
Pay attention to the "Metrics" control
Expected results
Metrics control remains filled in
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
