### PR TITLE
fix(native-filters): Range filter max/min default display value

### DIFF
--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.test.tsx
@@ -18,7 +18,7 @@
  */
 import { AppSection, GenericDataType } from '@superset-ui/core';
 import React from 'react';
-import { render } from 'spec/helpers/testing-library';
+import { render, screen } from 'spec/helpers/testing-library';
 import RangeFilterPlugin from './RangeFilterPlugin';
 import { SingleValueType } from './SingleValueType';
 import transformProps from './transformProps';
@@ -121,41 +121,49 @@ describe('RangeFilterPlugin', () => {
   });
 
   it('should call setDataMask with correct greater than filter', () => {
-    getWrapper({ enableSingleValue: SingleValueType.Minimum });
+    getWrapper({
+      enableSingleValue: SingleValueType.Minimum,
+      defaultValue: [20, 60],
+    });
     expect(setDataMask).toHaveBeenCalledWith({
       extraFormData: {
         filters: [
           {
             col: 'SP_POP_TOTL',
             op: '>=',
-            val: 70,
+            val: 20,
           },
         ],
       },
       filterState: {
-        label: 'x ≥ 70',
-        value: [70, 100],
+        label: 'x ≥ 20',
+        value: [20, 100],
       },
     });
+    expect(screen.getByRole('slider')).toHaveAttribute('aria-valuenow', '20');
   });
 
   it('should call setDataMask with correct less than filter', () => {
-    getWrapper({ enableSingleValue: SingleValueType.Maximum });
+    getWrapper({
+      enableSingleValue: SingleValueType.Maximum,
+      defaultValue: [20, 60],
+    });
     expect(setDataMask).toHaveBeenCalledWith({
       extraFormData: {
         filters: [
           {
             col: 'SP_POP_TOTL',
             op: '<=',
-            val: 70,
+            val: 60,
           },
         ],
       },
       filterState: {
-        label: 'x ≤ 70',
-        value: [10, 70],
+        label: 'x ≤ 60',
+        value: [10, 60],
       },
     });
+    expect(screen.getByRole('slider')).toHaveAttribute('aria-valuenow', '60');
   });
 
   it('should call setDataMask with correct exact filter', () => {

--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
@@ -261,13 +261,13 @@ export default function RangeFilterPlugin(props: PluginFilterRangeProps) {
 
   useEffect(() => {
     if (enableSingleMaxValue) {
-      handleAfterChange([min, minMax[minIndex]]);
+      handleAfterChange([min, minMax[maxIndex]]);
     }
   }, [enableSingleMaxValue]);
 
   useEffect(() => {
     if (enableSingleMinValue) {
-      handleAfterChange([minMax[maxIndex], max]);
+      handleAfterChange([minMax[minIndex], max]);
     }
   }, [enableSingleMinValue]);
 


### PR DESCRIPTION
### SUMMARY
When user added a range native filter with single value option (minimum or maximum) and a default value, the default value would be displayed incorrectly (even though the filter applied correct values). This PR fixes that behaviour

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/15073128/193591149-6719bb6e-e44a-419f-b42d-4ca28ef4aeba.mov

After:

https://user-images.githubusercontent.com/15073128/193590816-d63a7d98-0198-4c97-954c-21945d1a1c56.mov


### TESTING INSTRUCTIONS
1. Create a range native filter, select single value minimum or maximum and a default value
2. Verify that the filter in the filter bar displays with correct default range
3. Verify that filter is applied correctly to charts

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
