### PR TITLE
fix: Pass slice_id in Explore get

### DIFF
--- a/superset/explore/commands/get.py
+++ b/superset/explore/commands/get.py
@@ -97,7 +97,9 @@ class GetExploreCommand(BaseCommand, ABC):
                     )
 
         form_data, slc = get_form_data(
-            use_slice_data=True, initial_form_data=initial_form_data
+            slice_id=self._slice_id,
+            use_slice_data=True,
+            initial_form_data=initial_form_data,
         )
         try:
             self._dataset_id, self._dataset_type = get_datasource_info(


### PR DESCRIPTION
### SUMMARY
Pass `slice_id` to `get_form_data` if one is provided in the URL.

### TESTING INSTRUCTIONS
Check that if a slice_id is provided in the URL, it will be passed to `get_form_data`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
