### PR TITLE
fix: Right-click on misconfigured World Map

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
@@ -24,6 +24,8 @@ import {
   getNumberFormatter,
   getSequentialSchemeRegistry,
   CategoricalColorNamespace,
+  logging,
+  t,
 } from '@superset-ui/core';
 import Datamap from 'datamaps/dist/datamaps.world.min';
 import { ColorBy } from './utils';
@@ -108,16 +110,26 @@ function WorldMap(element, props) {
   const handleContextMenu = source => {
     const pointerEvent = d3.event;
     pointerEvent.preventDefault();
-    const val = mapData[source.id || source.country].name;
-    const filters = [
-      {
-        col: entity,
-        op: '==',
-        val,
-        formattedVal: val,
-      },
-    ];
-    onContextMenu(filters, pointerEvent.clientX, pointerEvent.clientY);
+    const key = source.id || source.country;
+    const val = mapData[key]?.name;
+    if (val) {
+      const filters = [
+        {
+          col: entity,
+          op: '==',
+          val,
+          formattedVal: val,
+        },
+      ];
+      onContextMenu(filters, pointerEvent.clientX, pointerEvent.clientY);
+    } else {
+      logging.warn(
+        t(
+          `Unable to process right-click on %s. Check you chart configuration.`,
+        ),
+        key,
+      );
+    }
   };
 
   const map = new Datamap({


### PR DESCRIPTION
### SUMMARY
Fixes a bug that happens when a user right-clicks on a World Map chart that has an invalid configuration in the Country Column or Country Field Type. Examples of invalid configuration would be assigning a region/number/etc to the Country Column or choosing the wrong Country Field Type formatting.

@codyml 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="630" alt="Screen Shot 2022-10-03 at 6 48 24 PM" src="https://user-images.githubusercontent.com/70410625/193880551-761b7453-0a13-48e6-b2ce-d011a33a4ae6.png">

<img width="602" alt="Screen Shot 2022-10-04 at 1 56 21 PM" src="https://user-images.githubusercontent.com/70410625/193880491-38ac5b06-eac7-4575-8d7a-d6bae87d4fa1.png">

### TESTING INSTRUCTIONS
Check that instead of throwing an error, the application shows a warning for invalid World Map configurations.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
