### PR TITLE
chore(key-value): remove redundant exception logging

### DIFF
--- a/superset/key_value/commands/create.py
+++ b/superset/key_value/commands/create.py
@@ -64,7 +64,6 @@ class CreateKeyValueCommand(BaseCommand):
             return self.create()
         except SQLAlchemyError as ex:
             db.session.rollback()
-            logger.exception("Error running create command")
             raise KeyValueCreateFailedError() from ex
 
     def validate(self) -> None:

--- a/superset/key_value/commands/delete.py
+++ b/superset/key_value/commands/delete.py
@@ -50,7 +50,6 @@ class DeleteKeyValueCommand(BaseCommand):
             return self.delete()
         except SQLAlchemyError as ex:
             db.session.rollback()
-            logger.exception("Error running delete command")
             raise KeyValueDeleteFailedError() from ex
 
     def validate(self) -> None:

--- a/superset/key_value/commands/delete_expired.py
+++ b/superset/key_value/commands/delete_expired.py
@@ -46,7 +46,6 @@ class DeleteExpiredKeyValueCommand(BaseCommand):
             self.delete_expired()
         except SQLAlchemyError as ex:
             db.session.rollback()
-            logger.exception("Error running delete command")
             raise KeyValueDeleteFailedError() from ex
 
     def validate(self) -> None:

--- a/superset/key_value/commands/get.py
+++ b/superset/key_value/commands/get.py
@@ -52,7 +52,6 @@ class GetKeyValueCommand(BaseCommand):
         try:
             return self.get()
         except SQLAlchemyError as ex:
-            logger.exception("Error running get command")
             raise KeyValueGetFailedError() from ex
 
     def validate(self) -> None:

--- a/superset/key_value/commands/update.py
+++ b/superset/key_value/commands/update.py
@@ -66,7 +66,6 @@ class UpdateKeyValueCommand(BaseCommand):
             return self.update()
         except SQLAlchemyError as ex:
             db.session.rollback()
-            logger.exception("Error running update command")
             raise KeyValueUpdateFailedError() from ex
 
     def validate(self) -> None:

--- a/superset/key_value/exceptions.py
+++ b/superset/key_value/exceptions.py
@@ -46,5 +46,9 @@ class KeyValueUpdateFailedError(UpdateFailedError):
     message = _("An error occurred while updating the value.")
 
 
+class KeyValueUpsertFailedError(UpdateFailedError):
+    message = _("An error occurred while upserting the value.")
+
+
 class KeyValueAccessDeniedError(ForbiddenError):
     message = _("You don't have permission to modify the value.")


### PR DESCRIPTION
### SUMMARY
Currently the `key-value` commands are logging exceptions despite reraising the exception. This causes unnecessary noise on logs if the caller is anticipating a failure, which can be caught by the reraised `KeyValue(Get|Create|Delete|Update)FailedError` if needed. In addition, the Upsert command didn't have an exception of its own, and was not catching the `KeyValueCreateFailedError` exception, causing an expected `ValueError` to go unnoticed: https://github.com/apache/superset/blob/de444d4de6a917af8f8efe2335fb1a26ac86e6d8/superset/key_value/commands/create.py#L82-L88

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
