### PR TITLE
fix: Right-click on a chart's null values

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/EchartsMixedTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/EchartsMixedTimeseries.tsx
@@ -22,6 +22,7 @@ import { EchartsMixedTimeseriesChartTransformedProps } from './types';
 import Echart from '../components/Echart';
 import { EventHandlers } from '../types';
 import { currentSeries } from '../utils/series';
+import { NULL_STRING } from '../constants';
 
 export default function EchartsMixedTimeseries({
   height,
@@ -123,16 +124,16 @@ export default function EchartsMixedTimeseries({
           filters.push({
             col: formData.granularitySqla,
             grain: formData.timeGrainSqla,
-            op: '==',
-            val: data[0],
             formattedVal: xValueFormatter(data[0]),
+            ...(data[0] ? { op: '==', val: data[0] } : { op: 'IS NULL' }),
           });
           groupby.forEach((dimension, i) =>
             filters.push({
               col: dimension,
-              op: '==',
-              val: values[i],
               formattedVal: String(values[i]),
+              ...(eventParams.seriesName === NULL_STRING
+                ? { op: 'IS NULL' }
+                : { op: '==', val: values[i] }),
             }),
           );
           onContextMenu(filters, pointerEvent.clientX, pointerEvent.clientY);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -26,6 +26,7 @@ import Echart from '../components/Echart';
 import { TimeseriesChartTransformedProps } from './types';
 import { currentSeries } from '../utils/series';
 import { ExtraControls } from '../components/ExtraControls';
+import { NULL_STRING } from '../constants';
 
 const TIMER_DURATION = 300;
 
@@ -187,16 +188,16 @@ export default function EchartsTimeseries({
           filters.push({
             col: formData.granularitySqla,
             grain: formData.timeGrainSqla,
-            op: '==',
-            val: data[0],
             formattedVal: xValueFormatter(data[0]),
+            ...(data[0] ? { op: '==', val: data[0] } : { op: 'IS NULL' }),
           });
           formData.groupby.forEach((dimension, i) =>
             filters.push({
               col: dimension,
-              op: '==',
-              val: values[i],
               formattedVal: String(values[i]),
+              ...(eventParams.seriesName === NULL_STRING
+                ? { op: 'IS NULL' }
+                : { op: '==', val: values[i] }),
             }),
           );
           onContextMenu(filters, pointerEvent.clientX, pointerEvent.clientY);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/EchartsTreemap.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/EchartsTreemap.tsx
@@ -96,9 +96,10 @@ export default function EchartsTreemap({
           treePath.forEach((path, i) =>
             filters.push({
               col: groupby[i],
-              op: '==',
-              val: path,
               formattedVal: path,
+              ...(path === 'null'
+                ? { op: 'IS NULL' }
+                : { op: '==', val: path }),
             }),
           );
           onContextMenu(filters, pointerEvent.clientX, pointerEvent.clientY);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/eventHandlers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/eventHandlers.ts
@@ -54,9 +54,8 @@ export const contextMenuEventHandler =
         groupby.forEach((dimension, i) =>
           filters.push({
             col: dimension,
-            op: '==',
-            val: values[i],
             formattedVal: String(values[i]),
+            ...(values[i] ? { op: '==', val: values[i] } : { op: 'IS NULL' }),
           }),
         );
       }

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -379,9 +379,8 @@ export default function PivotTableChart(props: PivotTableProps) {
             if (i > 0) {
               filters.push({
                 col,
-                op: '==',
-                val,
                 formattedVal,
+                ...(val ? { val, op: '==' } : { op: 'IS NULL' }),
               });
             }
           });
@@ -393,9 +392,8 @@ export default function PivotTableChart(props: PivotTableProps) {
               dateFormatters[col]?.(val as number) || String(val);
             filters.push({
               col,
-              op: '==',
-              val,
               formattedVal,
+              ...(val ? { val, op: '==' } : { op: 'IS NULL' }),
             });
           });
         }

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -633,11 +633,18 @@ export default function TableChart<D extends DataRecord = DataRecord>(
           const filters: QueryObjectFilterClause[] = [];
           columnsMeta.forEach(col => {
             if (!col.isMetric) {
+              const dataRecordValue = value[col.key];
               filters.push({
                 col: col.key,
-                op: '==',
-                val: value[col.key] as string | number | boolean,
-                formattedVal: String(value[col.key]),
+                formattedVal: formatColumnValue(col, dataRecordValue)[1],
+                ...(dataRecordValue
+                  ? {
+                      op: '==',
+                      val: dataRecordValue as string | number | boolean,
+                    }
+                  : {
+                      op: 'IS NULL',
+                    }),
               });
             }
           });

--- a/superset-frontend/src/dashboard/components/DrillDetailPane/utils.ts
+++ b/superset-frontend/src/dashboard/components/DrillDetailPane/utils.ts
@@ -22,11 +22,15 @@ import {
   QueryFormData,
   BinaryQueryObjectFilterClause,
   buildQueryObject,
+  UnaryQueryObjectFilterClause,
 } from '@superset-ui/core';
 
 export function getDrillPayload(
   queryFormData?: QueryFormData,
-  drillFilters?: BinaryQueryObjectFilterClause[],
+  drillFilters?: (
+    | BinaryQueryObjectFilterClause
+    | UnaryQueryObjectFilterClause
+  )[],
 ) {
   if (!queryFormData) {
     return undefined;


### PR DESCRIPTION
### SUMMARY
Fixes a bug when right-clicking on a chart's `null` values.

@codyml 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/194123238-f9f622dc-ac4d-4df1-8243-bcd7849d7f3b.mov

https://user-images.githubusercontent.com/70410625/194123328-9fb476f1-2b33-44d5-9ddc-b7883a7ebfe8.mov

### TESTING INSTRUCTIONS
Check the videos for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
