### PR TITLE
fix(explore): chart link is broken without localStorage

### DIFF
--- a/superset-frontend/src/explore/ExplorePage.tsx
+++ b/superset-frontend/src/explore/ExplorePage.tsx
@@ -101,7 +101,7 @@ const getDashboardContextFormData = () => {
     Object.assign(dashboardContextWithFilters, { dashboardId });
     return dashboardContextWithFilters;
   }
-  return {};
+  return null;
 };
 
 export default function ExplorePage() {
@@ -117,10 +117,12 @@ export default function ExplorePage() {
     if (!isExploreInitialized.current || isSaveAction) {
       fetchExploreData(exploreUrlParams)
         .then(({ result }) => {
-          const formData = getFormDataWithDashboardContext(
-            result.form_data,
-            dashboardContextFormData,
-          );
+          const formData = dashboardContextFormData
+            ? getFormDataWithDashboardContext(
+                result.form_data,
+                dashboardContextFormData,
+              )
+            : result.form_data;
           dispatch(
             hydrateExplore({
               ...result,


### PR DESCRIPTION
### SUMMARY
Addition to #21422 issue

"Edit chart" from dashboard may not work if the dashboard context is not found in localStorage.
It's specially missing `filterBox` metadata due to the lack of exploreFormData mapping in [mergeFilterBoxToFormData](https://github.com/apache/superset/blob/7b66e0bb3461ba05afddda3e8cd127456b4f3691/superset-frontend/src/explore/controlUtils/getFormDataWithDashboardContext.ts#L87).

<img width="623" alt="Screen Shot 2022-10-05 at 10 36 53 AM" src="https://user-images.githubusercontent.com/1392866/194125559-0b13581a-45e9-4a35-a473-3beb0343b27e.png">

This could happen when users either don't have localStorage enabled in there browser (unlikely) or copied the link in the different browser.

This commit fixes this issue by using the original explore formData if dashboardContextFormData is empty.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

- Before

<img width="1121" alt="Notification_Center" src="https://user-images.githubusercontent.com/1392866/194123785-3355d3be-f5f7-4462-91fe-01b29f7e1ca4.png">

- After

<img width="1315" alt="Notification_Center" src="https://user-images.githubusercontent.com/1392866/194124106-f1eba25f-d295-41b5-ae8f-4a6a42ac5226.png">

### TESTING INSTRUCTIONS

- Go to a Dashboard page
- Delete localStorage item dashboard__explore_context
- Go edit chart having time granularity in the dashboard

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @ktmud 