### PR TITLE
fix(database): Handle String errors in DatabaseModal

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.test.jsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.test.jsx
@@ -26,6 +26,7 @@ import {
   cleanup,
   act,
 } from 'spec/helpers/testing-library';
+import * as hooks from 'src/views/CRUD/hooks';
 import DatabaseModal from './index';
 
 const dbProps = {
@@ -1267,6 +1268,96 @@ describe('DatabaseModal', () => {
       });
       expect(allowFileUploadText).not.toBeInTheDocument();
       expect(schemasForFileUploadText).not.toBeInTheDocument();
+    });
+  });
+
+  describe('DatabaseModal w errors as objects', () => {
+    jest.mock('src/views/CRUD/hooks', () => ({
+      ...jest.requireActual('src/views/CRUD/hooks'),
+      useSingleViewResource: jest.fn(),
+    }));
+    const useSingleViewResourceMock = jest.spyOn(
+      hooks,
+      'useSingleViewResource',
+    );
+
+    useSingleViewResourceMock.mockReturnValue({
+      state: {
+        loading: false,
+        resource: null,
+        error: { _schema: 'Test Error With Object' },
+      },
+      fetchResource: jest.fn(),
+      createResource: jest.fn(),
+      updateResource: jest.fn(),
+      clearError: jest.fn(),
+    });
+
+    const renderAndWait = async () => {
+      const mounted = act(async () => {
+        render(<DatabaseModal {...dbProps} dbEngine="PostgreSQL" />, {
+          useRedux: true,
+        });
+      });
+
+      return mounted;
+    };
+
+    beforeEach(async () => {
+      await renderAndWait();
+    });
+
+    test('Error displays when it is an object', async () => {
+      const step2of3text = screen.getByText(/step 2 of 3/i);
+      const errorSection = screen.getByText(/Database Creation Error/i);
+      expect(step2of3text).toBeVisible();
+      expect(errorSection).toBeVisible();
+    });
+  });
+
+  describe('DatabaseModal w errors as strings', () => {
+    jest.mock('src/views/CRUD/hooks', () => ({
+      ...jest.requireActual('src/views/CRUD/hooks'),
+      useSingleViewResource: jest.fn(),
+    }));
+    const useSingleViewResourceMock = jest.spyOn(
+      hooks,
+      'useSingleViewResource',
+    );
+
+    useSingleViewResourceMock.mockReturnValue({
+      state: {
+        loading: false,
+        resource: null,
+        error: 'Test Error With String',
+      },
+      fetchResource: jest.fn(),
+      createResource: jest.fn(),
+      updateResource: jest.fn(),
+      clearError: jest.fn(),
+    });
+
+    const renderAndWait = async () => {
+      const mounted = act(async () => {
+        render(<DatabaseModal {...dbProps} dbEngine="PostgreSQL" />, {
+          useRedux: true,
+        });
+      });
+
+      return mounted;
+    };
+
+    beforeEach(async () => {
+      await renderAndWait();
+    });
+
+    test('Error displays when it is a string', async () => {
+      const step2of3text = screen.getByText(/step 2 of 3/i);
+      const errorTitleMessage = screen.getByText(/Database Creation Error/i);
+      const errorMessage = screen.getByText(/Test Error With String/i);
+      expect(step2of3text).toBeVisible();
+      expect(errorTitleMessage).toBeVisible();
+      expect(errorMessage).toBeVisible();
     });
   });
 });

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -1144,7 +1144,12 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
   const errorAlert = () => {
     let alertErrors: string[] = [];
     if (!isEmpty(dbErrors)) {
-      alertErrors = typeof dbErrors === 'object' ? Object.values(dbErrors) : [];
+      alertErrors =
+        typeof dbErrors === 'object'
+          ? Object.values(dbErrors)
+          : typeof dbErrors === 'string'
+          ? [dbErrors]
+          : [];
     } else if (!isEmpty(validationErrors)) {
       alertErrors =
         validationErrors?.error_type === 'GENERIC_DB_ENGINE_ERROR'


### PR DESCRIPTION
### SUMMARY
At some point we stopped handling and displaying API errors coming as raw strings in the DatabaseModal. We are bringing that back, so for example, if someone tries to connect a BigQuery DB using credential JSON files with no roles in it, an error gets displayed vs no indication at all.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![error](https://user-images.githubusercontent.com/38889534/194174126-697cfc81-2e8e-41d8-940d-52dbf0243089.gif)

After:
![test](https://user-images.githubusercontent.com/38889534/194174150-879db5fb-0d3f-429f-9212-82f2b9e7a4bc.gif)


### TESTING INSTRUCTIONS
Create a new Service Account on Google Console. Doesn’t grant any Role to it.
Download the Service Account key via jSON.
Access your Workspace.
Hover over the + on the top right corner, then navigate to Data > Connect database.
Select Google BigQuery.
Click on Choose File to upload the JSON.
Click on CONNECT.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
