### PR TITLE
chore(sqllab): refactor addQueryEditor for new tab

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -32,6 +32,7 @@ import {
 } from 'src/components/MessageToasts/actions';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
 import COMMON_ERR_MESSAGES from 'src/utils/errorMessages';
+import { newQueryTabName } from '../utils/newQueryTabName';
 
 export const RESET_STATE = 'RESET_STATE';
 export const ADD_QUERY_EDITOR = 'ADD_QUERY_EDITOR';
@@ -587,6 +588,22 @@ export function addQueryEditor(queryEditor) {
           ),
         ),
       );
+  };
+}
+
+export function addNewQueryEditor(queryEditor) {
+  return function (dispatch, getState) {
+    const {
+      sqlLab: { queryEditors },
+    } = getState();
+    const name = newQueryTabName(queryEditors || []);
+
+    return dispatch(
+      addQueryEditor({
+        ...queryEditor,
+        name,
+      }),
+    );
   };
 }
 

--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.js
@@ -410,6 +410,28 @@ describe('async actions', () => {
         expect(store.getActions()).toEqual(expectedActions);
       });
     });
+
+    describe('addNewQueryEditor', () => {
+      it('creates new query editor with new tab name', () => {
+        const store = mockStore(initialState);
+        const expectedActions = [
+          {
+            type: actions.ADD_QUERY_EDITOR,
+            queryEditor: {
+              ...defaultQueryEditor,
+              id: 'abcd',
+              name: `Untitled Query ${
+                store.getState().sqlLab.queryEditors.length + 1
+              }`,
+            },
+          },
+        ];
+        const request = actions.addNewQueryEditor(defaultQueryEditor);
+        return request(store.dispatch, store.getState).then(() => {
+          expect(store.getActions()).toEqual(expectedActions);
+        });
+      });
+    });
   });
 
   describe('backend sync', () => {

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -37,7 +37,7 @@ import { Menu } from 'src/components/Menu';
 import Icons from 'src/components/Icons';
 import { detectOS } from 'src/utils/common';
 import {
-  addQueryEditor,
+  addNewQueryEditor,
   CtasEnum,
   estimateQueryCost,
   persistEditorHeight,
@@ -84,7 +84,6 @@ import ShareSqlLabQuery from '../ShareSqlLabQuery';
 import SqlEditorLeftBar from '../SqlEditorLeftBar';
 import AceEditorWrapper from '../AceEditorWrapper';
 import RunQueryActionButton from '../RunQueryActionButton';
-import { newQueryTabName } from '../../utils/newQueryTabName';
 import QueryLimitSelect from '../QueryLimitSelect';
 
 const appContainer = document.getElementById('app');
@@ -179,8 +178,6 @@ const SqlEditor = ({
     },
   );
 
-  const queryEditors = useSelector(({ sqlLab }) => sqlLab.queryEditors);
-
   const [height, setHeight] = useState(0);
   const [autorun, setAutorun] = useState(queryEditor.autorun);
   const [ctas, setCtas] = useState('');
@@ -274,13 +271,7 @@ const SqlEditor = ({
         key: userOS === 'Windows' ? 'ctrl+q' : 'ctrl+t',
         descr: t('New tab'),
         func: () => {
-          const name = newQueryTabName(queryEditors || []);
-          dispatch(
-            addQueryEditor({
-              ...queryEditor,
-              name,
-            }),
-          );
+          dispatch(addNewQueryEditor(queryEditor));
         },
       },
       {

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.jsx
@@ -29,7 +29,6 @@ import { Tooltip } from 'src/components/Tooltip';
 import { detectOS } from 'src/utils/common';
 import * as Actions from 'src/SqlLab/actions/sqlLab';
 import { EmptyStateBig } from 'src/components/EmptyState';
-import { newQueryTabName } from '../../utils/newQueryTabName';
 import SqlEditor from '../SqlEditor';
 import SqlEditorTabHeader from '../SqlEditorTabHeader';
 
@@ -242,10 +241,7 @@ class TabbedSqlEditors extends React.PureComponent {
           '-- Note: Unless you save your query, these tabs will NOT persist if you clear your cookies or change browsers.\n\n',
         );
 
-    const newTitle = newQueryTabName(this.props.queryEditors || []);
-
     const qe = {
-      name: newTitle,
       dbId:
         activeQueryEditor && activeQueryEditor.dbId
           ? activeQueryEditor.dbId
@@ -255,7 +251,7 @@ class TabbedSqlEditors extends React.PureComponent {
       sql: `${warning}SELECT ...`,
       queryLimit: this.props.defaultQueryLimit,
     };
-    this.props.actions.addQueryEditor(qe);
+    this.props.actions.addNewQueryEditor(qe);
   }
 
   handleSelect(key) {


### PR DESCRIPTION
### SUMMARY
In order to get `newQueryTabName`, the root component must retrieve the `queryEditors` list.
This value is unnecessary during the rendering time but it only needs when the action is invoked.
This commit refactors this part that uses `queryEditors` in the action to remove this unnecessary prop in the rendering component.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
go to sqllab
create new tab and check the untitled name incremental by tab numbers

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @ktmud @EugeneTorap 