### PR TITLE
feat: support None operand in EQUAL operator

### DIFF
--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -819,7 +819,8 @@ class ChartDataFilterSchema(Schema):
     )
     val = fields.Raw(
         description="The value or values to compare against. Can be a string, "
-        "integer, decimal or list, depending on the operator.",
+        "integer, decimal, None or list, depending on the operator.",
+        allow_none=True,
         example=["China", "France", "Japan"],
     )
     grain = fields.String(

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1615,7 +1615,14 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
                 elif op == utils.FilterOperator.IS_FALSE.value:
                     where_clause_and.append(sqla_col.is_(False))
                 else:
-                    if eq is None:
+                    if (
+                        op
+                        not in {
+                            utils.FilterOperator.EQUALS.value,
+                            utils.FilterOperator.NOT_EQUALS.value,
+                        }
+                        and eq is None
+                    ):
                         raise QueryObjectValidationError(
                             _(
                                 "Must specify a value for filters "

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -51,6 +51,7 @@ from tests.integration_tests.fixtures.birth_names_dashboard import (
 from tests.integration_tests.test_app import app
 
 from .base_tests import SupersetTestCase
+from .conftest import only_postgresql
 
 VIRTUAL_TABLE_INT_TYPES: Dict[str, Pattern[str]] = {
     "hive": re.compile(r"^INT_TYPE$"),
@@ -659,51 +660,48 @@ def test_filter_on_text_column(text_column_table):
     assert result_object.df["count"][0] == 1
 
 
-def test_should_generate_closed_and_open_time_filter_range():
-    with app.app_context():
-        if backend() != "postgresql":
-            pytest.skip(f"{backend()} has different dialect for datetime column")
-
-        table = SqlaTable(
-            table_name="temporal_column_table",
-            sql=(
-                "SELECT '2021-12-31'::timestamp as datetime_col "
-                "UNION SELECT '2022-01-01'::timestamp "
-                "UNION SELECT '2022-03-10'::timestamp "
-                "UNION SELECT '2023-01-01'::timestamp "
-                "UNION SELECT '2023-03-10'::timestamp "
-            ),
-            database=get_example_database(),
-        )
-        TableColumn(
-            column_name="datetime_col",
-            type="TIMESTAMP",
-            table=table,
-            is_dttm=True,
-        )
-        SqlMetric(metric_name="count", expression="count(*)", table=table)
-        result_object = table.query(
-            {
-                "metrics": ["count"],
-                "is_timeseries": False,
-                "filter": [],
-                "from_dttm": datetime(2022, 1, 1),
-                "to_dttm": datetime(2023, 1, 1),
-                "granularity": "datetime_col",
-            }
-        )
-        """ >>> result_object.query
-                SELECT count(*) AS count
-                FROM
-                  (SELECT '2021-12-31'::timestamp as datetime_col
-                   UNION SELECT '2022-01-01'::timestamp
-                   UNION SELECT '2022-03-10'::timestamp
-                   UNION SELECT '2023-01-01'::timestamp
-                   UNION SELECT '2023-03-10'::timestamp) AS virtual_table
-                WHERE datetime_col >= TO_TIMESTAMP('2022-01-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
-                  AND datetime_col < TO_TIMESTAMP('2023-01-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
-        """
-        assert result_object.df.iloc[0]["count"] == 2
+@only_postgresql
+def test_should_generate_closed_and_open_time_filter_range(login_as_admin):
+    table = SqlaTable(
+        table_name="temporal_column_table",
+        sql=(
+            "SELECT '2021-12-31'::timestamp as datetime_col "
+            "UNION SELECT '2022-01-01'::timestamp "
+            "UNION SELECT '2022-03-10'::timestamp "
+            "UNION SELECT '2023-01-01'::timestamp "
+            "UNION SELECT '2023-03-10'::timestamp "
+        ),
+        database=get_example_database(),
+    )
+    TableColumn(
+        column_name="datetime_col",
+        type="TIMESTAMP",
+        table=table,
+        is_dttm=True,
+    )
+    SqlMetric(metric_name="count", expression="count(*)", table=table)
+    result_object = table.query(
+        {
+            "metrics": ["count"],
+            "is_timeseries": False,
+            "filter": [],
+            "from_dttm": datetime(2022, 1, 1),
+            "to_dttm": datetime(2023, 1, 1),
+            "granularity": "datetime_col",
+        }
+    )
+    """ >>> result_object.query
+            SELECT count(*) AS count
+            FROM
+              (SELECT '2021-12-31'::timestamp as datetime_col
+               UNION SELECT '2022-01-01'::timestamp
+               UNION SELECT '2022-03-10'::timestamp
+               UNION SELECT '2023-01-01'::timestamp
+               UNION SELECT '2023-03-10'::timestamp) AS virtual_table
+            WHERE datetime_col >= TO_TIMESTAMP('2022-01-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
+              AND datetime_col < TO_TIMESTAMP('2023-01-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
+    """
+    assert result_object.df.iloc[0]["count"] == 2
 
 
 def test_none_operand_in_filter(login_as_admin, physical_dataset):


### PR DESCRIPTION
### SUMMARY
This PR intends to support the `None` operand with `Equal` and `Not-Equal` operators in Filters in QueryObject. Currently, the `In` operator has supported `None` operand calculation, in order to align that the `Equal` and` Not-Equal` should support as well.
 
After the PR, there are 4 approaches to generate `is null` or `is not null` filter in SQL.

1. `EQUAL` / `NOT EQUAL` operator
```Python
>>> result = mock_dataset.query({
    "metrics": ["count"],
    "filter": [{"col": "col", "val": None, "op": "=="}],
    "is_timeseries": False,
})
>>> result.query
SELECT count(*) AS count
FROM mock_dataset
WHERE col IS NULL
```

2. `IS NULL` / `IS NOT NULL` operator
```Python
>>> result = mock_dataset.query({
    "metrics": ["count"],
    "filter": [{"col": "col", "op": "IS NULL"}],
    "is_timeseries": False,
})
>>> result.query
SELECT count(*) AS count
FROM mock_dataset
WHERE col IS NULL
```

3. `IN` operator
```Python
>>> result = mock_dataset.query({
    "metrics": ["count"],
    "filter": [{"col": "col", val: ["a", None], "op": "IN"}],
    "is_timeseries": False,
})
>>> result.query
SELECT count(*) AS count
FROM mock_dataset
WHERE col IS NULL
  OR col IN ('a')
```

4. There is an additional case that `<NULL>` as filter operand literal constant in the EQ or IN operators
```Python
>>> result = mock_dataset.query({
    "metrics": ["count"],
    "filter": [{"col": "col", "val": '<NULL>', "op": "=="}],
    "is_timeseries": False,
})
>>> result.query
SELECT count(*) AS count
FROM mock_dataset
WHERE col IS NULL
```


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
