### PR TITLE
fix: Drill to detail formatted val on TableChart

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -633,11 +633,12 @@ export default function TableChart<D extends DataRecord = DataRecord>(
           const filters: QueryObjectFilterClause[] = [];
           columnsMeta.forEach(col => {
             if (!col.isMetric) {
+              const dataRecordValue = value[col.key];
               filters.push({
                 col: col.key,
                 op: '==',
-                val: value[col.key] as string | number | boolean,
-                formattedVal: String(value[col.key]),
+                val: dataRecordValue as string | number | boolean,
+                formattedVal: formatColumnValue(col, dataRecordValue)[1],
               });
             }
           });


### PR DESCRIPTION
### SUMMARY
Fixes the formatted value of a TableChart when interacting with the Drill to Detail context menu.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="576" alt="Screen Shot 2022-10-06 at 11 45 04 AM" src="https://user-images.githubusercontent.com/70410625/194343961-9eed908f-6add-4850-ba55-3718d039ee35.png">

<img width="575" alt="Screen Shot 2022-10-06 at 11 41 46 AM" src="https://user-images.githubusercontent.com/70410625/194343512-acbede08-3554-4d64-8ca5-23f3f28ef9f7.png">

### TESTING INSTRUCTIONS
Check that N/A values are displayed as such in the Drill to Detail context menu. 

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
