### PR TITLE
fix(dashboard): Stop updating chart owners for charts removed from dashboard

### DIFF
--- a/superset/dashboards/commands/update.py
+++ b/superset/dashboards/commands/update.py
@@ -50,13 +50,13 @@ class UpdateDashboardCommand(UpdateMixin, BaseCommand):
         self.validate()
         try:
             dashboard = DashboardDAO.update(self._model, self._properties, commit=False)
-            dashboard = DashboardDAO.update_charts_owners(dashboard, commit=False)
             if self._properties.get("json_metadata"):
                 dashboard = DashboardDAO.set_dash_metadata(
                     dashboard,
                     data=json.loads(self._properties.get("json_metadata", "{}")),
                     commit=False,
                 )
+            dashboard = DashboardDAO.update_charts_owners(dashboard, commit=False)
             db.session.commit()
         except DAOUpdateFailedError as ex:
             logger.exception(ex.exception)

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -1347,6 +1347,65 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
         db.session.delete(user_alpha2)
         db.session.commit()
 
+    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+    def test_update_dashboard_chart_owners_propagation(self):
+        """
+        Dashboard API: Test update chart owners propagation
+        """
+        user_alpha1 = self.create_user(
+            "alpha1",
+            "password",
+            "Alpha",
+            email="alpha1@superset.org",
+            first_name="alpha1",
+        )
+        admin = self.get_user("admin")
+        slices = []
+        slices.append(db.session.query(Slice).filter_by(slice_name="Trends").one())
+        slices.append(db.session.query(Slice).filter_by(slice_name="Boys").one())
+
+        # Insert dashboard with admin as owner
+        dashboard = self.insert_dashboard(
+            "title1",
+            "slug1",
+            [admin.id],
+            slices=slices,
+        )
+
+        # Updates dashboard without Boys in json_metadata positions
+        # and user_alpha1 as owner
+        dashboard_data = {
+            "owners": [user_alpha1.id],
+            "json_metadata": json.dumps(
+                {
+                    "positions": {
+                        f"{slices[0].id}": {
+                            "type": "CHART",
+                            "meta": {"chartId": slices[0].id},
+                        },
+                    }
+                }
+            ),
+        }
+        self.login(username="admin")
+        uri = f"api/v1/dashboard/{dashboard.id}"
+        rv = self.client.put(uri, json=dashboard_data)
+        self.assertEqual(rv.status_code, 200)
+
+        # Check that chart named Boys does not contain alpha 1 in its owners
+        boys = db.session.query(Slice).filter_by(slice_name="Boys").one()
+        self.assertNotIn(user_alpha1, boys.owners)
+
+        # Revert owners on slice
+        for slice in slices:
+            slice.owners = []
+            db.session.commit()
+
+        # Rollback changes
+        db.session.delete(dashboard)
+        db.session.delete(user_alpha1)
+        db.session.commit()
+
     def test_update_partial_dashboard(self):
         """
         Dashboard API: Test update partial


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
https://github.com/apache/superset/pull/9484 made it so any chart saved to a dashboard has its owners updated to include all owners of the parent dashboard.  However, during the handling of the `PUT /api/v1/dashboard/{pk}` endpoint, `update_chart_owners` is called on all charts present in `dashboard.slices` before `dashboard.slices` is updated based on the charts preset in the parsed `json_metadata` contained in the request.  As a result, when deleting charts from a dashboard, those charts have the dashboard owners added as owners.  This PR changes execution order so `dashboard.slices` is updated before `update_chart_owners` is called, preventing owners from being updated on charts being deleted from dashboards.

NOTE: This does raise the question of how charts ended up on the dashboard in the first place without having the dashboard owners added as chart owners, as `update_chart_owners` is called on every create/update dashboard command.  It looks like saving a chart to a dashboard from Explore doesn't have an analogous subroutine, so if you have overwrite privileges on a chart and save it to a dashboard that has other owners, those owners won't be added as owners of the chart.  If we really need all charts to have dashboard owners as chart owners, we should probably look into this further.  Either way, I think this fix is still relevant, because even if we do want dashboard owners to also be owners of all their charts, this shouldn't be applied when a chart is deleted from the dashboard.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

**Before:**

https://user-images.githubusercontent.com/13007381/194379164-1b221bca-4ddc-44e7-a2aa-f03d0fca780c.mov

**After:**

https://user-images.githubusercontent.com/13007381/194379238-7f1761dd-49e3-47c7-872a-46df031f0dc7.mov

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

- Create a dashboard.
- Add a chart that is owned by someone else to the dashboard.
  - **Adding the chart to the dashboard may add yourself to the chart's owners (this is expected behavior).  If it does, edit the chart's properties to remove yourself as an owner once the chart is added to the dashboard.**
- Edit the dashboard and remove the chart.
- Check the chart's properties to ensure that you have not been added as an owner of the dashboard.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
