### PR TITLE
fix: Null values on Treemap right-click

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/EchartsTreemap.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/EchartsTreemap.tsx
@@ -19,6 +19,7 @@
 import { DataRecordValue, QueryObjectFilterClause } from '@superset-ui/core';
 import React, { useCallback } from 'react';
 import Echart from '../components/Echart';
+import { NULL_STRING } from '../constants';
 import { EventHandlers } from '../types';
 import { extractTreePathInfo } from './constants';
 import { TreemapTransformedProps } from './types';
@@ -97,7 +98,7 @@ export default function EchartsTreemap({
             filters.push({
               col: groupby[i],
               op: '==',
-              val: path,
+              val: path === 'null' ? NULL_STRING : path,
               formattedVal: path,
             }),
           );


### PR DESCRIPTION
### SUMMARY
Fixes a bug when right-clicking on TreeMap null values. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/194386222-9100b7de-8b43-4197-892b-c7d79925d643.mov

### TESTING INSTRUCTIONS
Make sure the right-click works with `null` values.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
