### PR TITLE
fix(report): Capture unexpected errors in report screenshots. Fixes #21653

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -595,6 +595,12 @@ SCREENSHOT_SELENIUM_RETRIES = 5
 SCREENSHOT_SELENIUM_HEADSTART = 3
 # Wait for the chart animation, in seconds
 SCREENSHOT_SELENIUM_ANIMATION_WAIT = 5
+# Replace unexpected errors in screenshots with real error messages
+SCREENSHOT_REPLACE_UNEXPECTED_ERRORS = False
+# Max time to wait for error message modal to show up, in seconds
+SCREENSHOT_WAIT_FOR_ERROR_MODAL_VISIBLE = 5
+# Max time to wait for error message modal to close, in seconds
+SCREENSHOT_WAIT_FOR_ERROR_MODAL_INVISIBLE = 5
 
 # ---------------------------------------------------
 # Image and file configuration

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import logging
 from enum import Enum
 from time import sleep
-from typing import Any, Dict, Optional, Tuple, TYPE_CHECKING, List
+from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 
 from flask import current_app
 from selenium.common.exceptions import (
@@ -57,8 +57,7 @@ def find_unexpected_errors(driver: WebDriver) -> List[str]:
     try:
         alert_divs = driver.find_elements(By.XPATH, "//div[@role = 'alert']")
         logger.debug(
-            "%i alert elements have been found in the screenshot",
-            len(alert_divs)
+            "%i alert elements have been found in the screenshot", len(alert_divs)
         )
 
         for alert_div in alert_divs:
@@ -66,12 +65,15 @@ def find_unexpected_errors(driver: WebDriver) -> List[str]:
             alert_div.find_element(By.XPATH, ".//*[@role = 'button']").click()
 
             # wait for modal to show up
-            modal = WebDriverWait(driver, current_app.config[
-                "SCREENSHOT_WAIT_FOR_ERROR_MODAL_VISIBLE"]).until(
+            modal = WebDriverWait(
+                driver, current_app.config["SCREENSHOT_WAIT_FOR_ERROR_MODAL_VISIBLE"]
+            ).until(
                 EC.visibility_of_any_elements_located(
                     (By.CLASS_NAME, "ant-modal-content")
                 )
-            )[0]
+            )[
+                0
+            ]
 
             err_msg_div = modal.find_element(By.CLASS_NAME, "ant-modal-body")
 
@@ -82,25 +84,23 @@ def find_unexpected_errors(driver: WebDriver) -> List[str]:
             modal.find_element(By.CLASS_NAME, "ant-modal-close").click()
 
             # wait until the modal becomes invisible
-            WebDriverWait(driver, current_app.config[
-                "SCREENSHOT_WAIT_FOR_ERROR_MODAL_INVISIBLE"]).until(
-                EC.invisibility_of_element(modal)
-            )
+            WebDriverWait(
+                driver, current_app.config["SCREENSHOT_WAIT_FOR_ERROR_MODAL_INVISIBLE"]
+            ).until(EC.invisibility_of_element(modal))
 
             # Use HTML so that error messages are shown in the same style (color)
-            error_as_html = err_msg_div.get_attribute("innerHTML") \
-                .replace("'", "\\'")
+            error_as_html = err_msg_div.get_attribute("innerHTML").replace("'", "\\'")
 
             try:
                 # Even if some errors can't be updated in the screenshot,
                 # keep all the errors in the server log and do not fail the loop
                 driver.execute_script(
-                    f"arguments[0].innerHTML = '{error_as_html}'",
-                    alert_div
+                    f"arguments[0].innerHTML = '{error_as_html}'", alert_div
                 )
             except WebDriverException:
-                logger.warning("Failed to update error messages using alert_div",
-                               exc_info=True)
+                logger.warning(
+                    "Failed to update error messages using alert_div", exc_info=True
+                )
     except WebDriverException:
         logger.warning("Failed to capture unexpected errors", exc_info=True)
 
@@ -203,7 +203,10 @@ class WebDriverProxy:
                 if unexpected_errors:
                     logger.warning(
                         "%i errors found in the screenshot. URL: %s. Errors are: %s",
-                        len(unexpected_errors), url, unexpected_errors)
+                        len(unexpected_errors),
+                        url,
+                        unexpected_errors,
+                    )
 
             img = element.screenshot_as_png
 

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import logging
 from enum import Enum
 from time import sleep
-from typing import Any, Dict, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Dict, Optional, Tuple, TYPE_CHECKING, List
 
 from flask import current_app
 from selenium.common.exceptions import (
@@ -141,7 +141,17 @@ class WebDriverProxy:
                 url,
                 user.username,
             )
+
+            if current_app.config["SCREENSHOT_REPLACE_UNEXPECTED_ERRORS"]:
+                unexpected_errors = self.find_unexpected_errors(driver)
+                if unexpected_errors:
+                    logger.warning(
+                        f"{len(unexpected_errors)} errors found in the screenshot. "
+                        f"URL: {url} "
+                        f"Errors are: {unexpected_errors}")
+
             img = element.screenshot_as_png
+
         except TimeoutException:
             logger.warning("Selenium timed out requesting url %s", url, exc_info=True)
         except StaleElementReferenceException:
@@ -155,3 +165,56 @@ class WebDriverProxy:
         finally:
             self.destroy(driver, current_app.config["SCREENSHOT_SELENIUM_RETRIES"])
         return img
+
+    def find_unexpected_errors(self, driver: WebDriver) -> List[str]:
+        error_messages = []
+
+        try:
+            alert_divs = driver.find_elements(By.XPATH, "//div[@role = 'alert']")
+            logger.debug(
+                f"{len(alert_divs)} alert elements have been found in the screenshot")
+
+            for alert_div in alert_divs:
+                # See More button
+                alert_div.find_element(By.XPATH, ".//*[@role = 'button']").click()
+
+                # wait for modal to show up
+                modal = WebDriverWait(driver, current_app.config[
+                    "SCREENSHOT_WAIT_FOR_ERROR_MODAL_VISIBLE"]).until(
+                    EC.visibility_of_any_elements_located(
+                        (By.CLASS_NAME, "ant-modal-content")
+                    )
+                )[0]
+
+                err_msg_div = modal.find_element(By.CLASS_NAME, "ant-modal-body")
+
+                # collect error message
+                error_messages.append(err_msg_div.text)
+
+                # close modal after collecting error messages
+                modal.find_element(By.CLASS_NAME, "ant-modal-close").click()
+
+                # wait until the modal becomes invisible
+                WebDriverWait(driver, current_app.config[
+                    "SCREENSHOT_WAIT_FOR_ERROR_MODAL_INVISIBLE"]).until(
+                    EC.invisibility_of_element(modal)
+                )
+
+                # Use HTML so that error messages are shown in the same style (color)
+                error_as_html = err_msg_div.get_attribute("innerHTML") \
+                    .replace("'", "\\'")
+
+                try:
+                    # Even if some errors can't be updated in the screenshot,
+                    # keep all the errors in the server log and do not fail the loop
+                    driver.execute_script(
+                        f"arguments[0].innerHTML = '{error_as_html}'",
+                        alert_div
+                    )
+                except WebDriverException:
+                    logger.warning("Failed to update error messages using alert_div",
+                                   exc_info=True)
+        except WebDriverException:
+            logger.warning("Failed to capture unexpected errors", exc_info=True)
+
+        return error_messages

--- a/tests/integration_tests/thumbnails_tests.py
+++ b/tests/integration_tests/thumbnails_tests.py
@@ -30,7 +30,7 @@ from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.utils.screenshots import ChartScreenshot, DashboardScreenshot
 from superset.utils.urls import get_url_host, get_url_path
-from superset.utils.webdriver import WebDriverProxy
+from superset.utils.webdriver import WebDriverProxy, find_unexpected_errors
 from tests.integration_tests.conftest import with_feature_flags
 from tests.integration_tests.test_app import app
 
@@ -112,7 +112,7 @@ class TestWebDriverScreenshotErrorDetector(SupersetTestCase):
 
         # there is no error in example dashboards, unexpected_errors should return 0
         # and no error should be raised
-        unexpected_errors = webdriver_proxy.find_unexpected_errors(driver=webdriver)
+        unexpected_errors = find_unexpected_errors(driver=webdriver)
         assert len(unexpected_errors) == 0
 
 

--- a/tests/integration_tests/thumbnails_tests.py
+++ b/tests/integration_tests/thumbnails_tests.py
@@ -30,7 +30,7 @@ from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.utils.screenshots import ChartScreenshot, DashboardScreenshot
 from superset.utils.urls import get_url_host, get_url_path
-from superset.utils.webdriver import WebDriverProxy, find_unexpected_errors
+from superset.utils.webdriver import find_unexpected_errors, WebDriverProxy
 from tests.integration_tests.conftest import with_feature_flags
 from tests.integration_tests.test_app import app
 
@@ -63,7 +63,6 @@ class TestThumbnailsSeleniumLive(LiveServerTestCase):
 
 
 class TestWebDriverScreenshotErrorDetector(SupersetTestCase):
-
     @patch("superset.utils.webdriver.WebDriverWait")
     @patch("superset.utils.webdriver.firefox")
     @patch("superset.utils.webdriver.find_unexpected_errors")

--- a/tests/integration_tests/thumbnails_tests.py
+++ b/tests/integration_tests/thumbnails_tests.py
@@ -66,7 +66,7 @@ class TestWebDriverScreenshotErrorDetector(SupersetTestCase):
 
     @patch("superset.utils.webdriver.WebDriverWait")
     @patch("superset.utils.webdriver.firefox")
-    @patch("superset.utils.webdriver.WebDriverProxy.find_unexpected_errors")
+    @patch("superset.utils.webdriver.find_unexpected_errors")
     def test_not_call_find_unexpected_errors_if_feature_disabled(
         self, mock_find_unexpected_errors, mock_firefox, mock_webdriver_wait
     ):
@@ -81,7 +81,7 @@ class TestWebDriverScreenshotErrorDetector(SupersetTestCase):
 
     @patch("superset.utils.webdriver.WebDriverWait")
     @patch("superset.utils.webdriver.firefox")
-    @patch("superset.utils.webdriver.WebDriverProxy.find_unexpected_errors")
+    @patch("superset.utils.webdriver.find_unexpected_errors")
     def test_call_find_unexpected_errors_if_feature_enabled(
         self, mock_find_unexpected_errors, mock_firefox, mock_webdriver_wait
     ):


### PR DESCRIPTION
### SUMMARY
As mentioned in https://github.com/apache/superset/issues/21653, there are cases that users receive a screenshot with "Unexpected errors" and "See More" links and there is no error on the server side. It might be caused by transient errors and the error is already gone after opening the dashboard again. In this case, there is no way to know what exactly happened and why we got the errors. Adding an option to log those errors to help debug issues and improve systems, and also reveal the errors to users to understand what happens.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
#### Case 1
##### Before
![screenshot_before_1](https://user-images.githubusercontent.com/105950525/194399027-5805c1fb-84e4-4b01-a785-4091b532dc7e.png)
##### After 
![screenshot_after_1](https://user-images.githubusercontent.com/105950525/194399084-b76f25b0-0a5b-412a-80ac-5c0e69f9f1a3.png)
#### Case 2
##### Before
![screenshot_before_2](https://user-images.githubusercontent.com/105950525/194399166-64c7a2d3-3f02-472e-a660-0c87bfd8c58f.png)
##### After
![screenshot_after_2](https://user-images.githubusercontent.com/105950525/194399196-073083b8-29ca-4327-bf58-5e63b4cab0b2.png)


### TESTING INSTRUCTIONS
Tested locally with some broken dashboards. Screenshots attached.

### ADDITIONAL INFORMATION
- [x] Has associated issue: #21653
- [x] Required feature flags: SCREENSHOT_REPLACE_UNEXPECTED_ERRORS

