### PR TITLE
fix(sqllab): resultset disappeared on switching tabs

### DIFF
--- a/superset-frontend/src/components/FilterableTable/index.tsx
+++ b/superset-frontend/src/components/FilterableTable/index.tsx
@@ -332,7 +332,6 @@ const FilterableTable = ({
       .map(key => widthsForColumnsByKey[key])
       .reduce((curr, next) => curr + next),
   );
-  const totalTableHeight = useRef(height);
   const container = useRef<HTMLDivElement>(null);
 
   const fitTableToWidthIfNeeded = () => {
@@ -347,10 +346,6 @@ const FilterableTable = ({
   useEffect(() => {
     fitTableToWidthIfNeeded();
   }, []);
-
-  useEffect(() => {
-    totalTableHeight.current = height;
-  }, [height]);
 
   const hasMatch = (text: string, row: Datum) => {
     const values: string[] = [];
@@ -567,15 +562,13 @@ const FilterableTable = ({
   };
 
   const renderGrid = () => {
-    totalTableHeight.current = height;
-    if (
+    // exclude the height of the horizontal scroll bar from the height of the table
+    // and the height of the table container if the content overflows
+    const totalTableHeight =
       container.current &&
       totalTableWidth.current > container.current.clientWidth
-    ) {
-      // exclude the height of the horizontal scroll bar from the height of the table
-      // and the height of the table container if the content overflows
-      totalTableHeight.current -= SCROLL_BAR_HEIGHT;
-    }
+        ? height - SCROLL_BAR_HEIGHT
+        : height;
 
     const getColumnWidth = ({ index }: { index: number }) =>
       widthsForColumnsByKey[orderedColumnKeys[index]];
@@ -604,7 +597,7 @@ const FilterableTable = ({
                       cellRenderer={renderGridCell}
                       columnCount={orderedColumnKeys.length}
                       columnWidth={getColumnWidth}
-                      height={totalTableHeight.current - rowHeight}
+                      height={totalTableHeight - rowHeight}
                       onScroll={onScroll}
                       overscanColumnCount={overscanColumnCount}
                       overscanRowCount={overscanRowCount}
@@ -648,15 +641,13 @@ const FilterableTable = ({
       );
     }
 
-    totalTableHeight.current = height;
-    if (
+    // exclude the height of the horizontal scroll bar from the height of the table
+    // and the height of the table container if the content overflows
+    const totalTableHeight =
       container.current &&
       totalTableWidth.current > container.current.clientWidth
-    ) {
-      // exclude the height of the horizontal scroll bar from the height of the table
-      // and the height of the table container if the content overflows
-      totalTableHeight.current -= SCROLL_BAR_HEIGHT;
-    }
+        ? height - SCROLL_BAR_HEIGHT
+        : height;
 
     const rowGetter = ({ index }: { index: number }) =>
       getDatum(sortedAndFilteredList, index);
@@ -669,7 +660,7 @@ const FilterableTable = ({
         {fitted && (
           <Table
             headerHeight={headerHeight}
-            height={totalTableHeight.current}
+            height={totalTableHeight}
             overscanRowCount={overscanRowCount}
             rowClassName={rowClassName}
             rowHeight={rowHeight}

--- a/superset-frontend/src/components/FilterableTable/index.tsx
+++ b/superset-frontend/src/components/FilterableTable/index.tsx
@@ -348,6 +348,10 @@ const FilterableTable = ({
     fitTableToWidthIfNeeded();
   }, []);
 
+  useEffect(() => {
+    totalTableHeight.current = height;
+  }, [height]);
+
   const hasMatch = (text: string, row: Datum) => {
     const values: string[] = [];
     Object.keys(row).forEach(key => {


### PR DESCRIPTION
### SUMMARY
Since the rendering refactoring by #20877, the number of redundant rendering reduced.
The FilterableTable re-rendering reduced related to the unnecessary property update but it wasn't reloaded when height is updated. It's mainly caused by functional component refactoring at #21136 which uses `useRef` to capture the height so it won't refreshed with the updated `height` prop properly.

https://github.com/EugeneTorap/superset/blob/66b704c13ae5b3840109c584989b1248cafb86e1/superset-frontend/src/components/FilterableTable/index.tsx#L335-L336

This occurs the empty result-set problem due to react-virtualized rendering issue with `NaN` height value.

This commit fixes the rendering issue with the updated height value.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
- Before

https://user-images.githubusercontent.com/1392866/194672139-106af5f1-718f-44a4-a3a4-f70433f53642.mov

- After

https://user-images.githubusercontent.com/1392866/194672137-58aa31ed-6b9d-4aac-b123-a26eb81df189.mov

### TESTING INSTRUCTIONS
- Go to SqlLab
- Open 2 tabs in UI
- Run query in 1 and wait for results to show
- Switch to other tab, then back to original tab

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
cc: @EugeneTorap 