### PR TITLE
fix: Fix regression introduced in #20893

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1198,7 +1198,10 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         extra_dict_by_name = {
             table.name: table.extra_dict
             for table in (
-                db.session.query(SqlaTable).filter(SqlaTable.schema == schema_parsed)
+                db.session.query(SqlaTable).filter(
+                    SqlaTable.database_id == database.id,
+                    SqlaTable.schema == schema_parsed,
+                )
             ).all()
         }
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR fixes a regression introduced in https://github.com/apache/superset/pull/20893 where when fetching the extra table metadata the query should be restricted to the database in question given that schema/table names aren't unique across databases.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI, i.e., [existing integration tests](https://github.com/apache/superset/blob/master/tests/integration_tests/core_tests.py#L155-L232).

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
