### PR TITLE
chore(explore): Add tests for getControlValuesCompatibleWithDatasource

### DIFF
--- a/superset-frontend/src/explore/controlUtils/getControlValuesCompatibleWithDatasource.test.ts
+++ b/superset-frontend/src/explore/controlUtils/getControlValuesCompatibleWithDatasource.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  ControlState,
+  Dataset,
+  sharedControls,
+} from '@superset-ui/chart-controls';
+import { DatasourceType, JsonValue } from '@superset-ui/core';
+import { getControlValuesCompatibleWithDatasource } from './getControlValuesCompatibleWithDatasource';
+
+const sampleDatasource: Dataset = {
+  id: 1,
+  type: DatasourceType.Table,
+  columns: [
+    { column_name: 'sample_column_1' },
+    { column_name: 'sample_column_3' },
+    { column_name: 'sample_column_4' },
+  ],
+  metrics: [{ metric_name: 'saved_metric_2' }],
+  column_format: {},
+  verbose_map: {},
+  main_dttm_col: '',
+  datasource_name: 'Sample Dataset',
+  description: 'A sample dataset',
+};
+
+const getValues = (controlState: ControlState) => {
+  const { value } = controlState;
+  return getControlValuesCompatibleWithDatasource(
+    sampleDatasource,
+    controlState,
+    value as JsonValue,
+  );
+};
+
+test('empty values', () => {
+  const controlState = sharedControls.groupby;
+  expect(
+    getValues({
+      ...controlState,
+      value: undefined,
+    }),
+  ).toEqual(undefined);
+
+  expect(
+    getValues({
+      ...controlState,
+      value: null,
+    }),
+  ).toEqual(undefined);
+
+  expect(
+    getValues({
+      ...controlState,
+      value: [],
+    }),
+  ).toEqual(controlState.default);
+});
+
+test('column values', () => {
+  const controlState = {
+    ...sharedControls.columns,
+    options: [
+      { column_name: 'sample_column_1' },
+      { column_name: 'sample_column_2' },
+      { column_name: 'sample_column_3' },
+    ],
+  };
+
+  expect(
+    getValues({
+      ...controlState,
+      value: 'sample_column_1',
+    }),
+  ).toEqual('sample_column_1');
+
+  expect(
+    getValues({
+      ...controlState,
+      value: 'sample_column_2',
+    }),
+  ).toEqual(controlState.default);
+
+  expect(
+    getValues({
+      ...controlState,
+      value: 'sample_column_3',
+    }),
+  ).toEqual('sample_column_3');
+
+  expect(
+    getValues({
+      ...controlState,
+      value: ['sample_column_1', 'sample_column_2', 'sample_column_3'],
+    }),
+  ).toEqual(['sample_column_1', 'sample_column_3']);
+});
+
+test('saved metric values', () => {
+  const controlState = {
+    ...sharedControls.metrics,
+    savedMetrics: [
+      { metric_name: 'saved_metric_1' },
+      { metric_name: 'saved_metric_2' },
+    ],
+  };
+
+  expect(
+    getValues({
+      ...controlState,
+      value: 'saved_metric_1',
+    }),
+  ).toEqual(controlState.default);
+
+  expect(
+    getValues({
+      ...controlState,
+      value: 'saved_metric_2',
+    }),
+  ).toEqual('saved_metric_2');
+
+  expect(
+    getValues({
+      ...controlState,
+      value: ['saved_metric_1', 'saved_metric_2'],
+    }),
+  ).toEqual(['saved_metric_2']);
+});
+
+test('simple ad-hoc metric values', () => {
+  const controlState = {
+    ...sharedControls.metrics,
+    columns: [
+      { column_name: 'sample_column_1' },
+      { column_name: 'sample_column_2' },
+      { column_name: 'sample_column_3' },
+    ],
+  };
+
+  expect(
+    getValues({
+      ...controlState,
+      value: {
+        expressionType: 'SIMPLE',
+        column: { column_name: 'sample_column_1' },
+      },
+    }),
+  ).toEqual({
+    expressionType: 'SIMPLE',
+    column: { column_name: 'sample_column_1' },
+  });
+
+  expect(
+    getValues({
+      ...controlState,
+      value: {
+        expressionType: 'SIMPLE',
+        column: { column_name: 'sample_column_2' },
+      },
+    }),
+  ).toEqual(controlState.default);
+
+  expect(
+    getValues({
+      ...controlState,
+      value: [
+        {
+          expressionType: 'SIMPLE',
+          column: { column_name: 'sample_column_1' },
+        },
+        {
+          expressionType: 'SIMPLE',
+          column: { column_name: 'sample_column_2' },
+        },
+      ],
+    }),
+  ).toEqual([
+    { expressionType: 'SIMPLE', column: { column_name: 'sample_column_1' } },
+  ]);
+});
+
+test('SQL ad-hoc metric values', () => {
+  const controlState = {
+    ...sharedControls.metrics,
+  };
+
+  expect(
+    getValues({
+      ...controlState,
+      value: {
+        expressionType: 'SQL',
+        sqlExpression: 'select * from sample_column_1;',
+      },
+    }),
+  ).toEqual({
+    expressionType: 'SQL',
+    sqlExpression: 'select * from sample_column_1;',
+  });
+});
+
+test('simple ad-hoc filter values', () => {
+  const controlState = {
+    ...sharedControls.adhoc_filters,
+    columns: [
+      { column_name: 'sample_column_1' },
+      { column_name: 'sample_column_2' },
+      { column_name: 'sample_column_3' },
+    ],
+  };
+
+  expect(
+    getValues({
+      ...controlState,
+      value: {
+        expressionType: 'SIMPLE',
+        subject: 'sample_column_1',
+      },
+    }),
+  ).toEqual({
+    expressionType: 'SIMPLE',
+    subject: 'sample_column_1',
+  });
+
+  expect(
+    getValues({
+      ...controlState,
+      value: {
+        expressionType: 'SIMPLE',
+        subject: 'sample_column_2',
+      },
+    }),
+  ).toEqual(controlState.default);
+
+  expect(
+    getValues({
+      ...controlState,
+      value: [
+        {
+          expressionType: 'SIMPLE',
+          subject: 'sample_column_1',
+        },
+        {
+          expressionType: 'SIMPLE',
+          subject: 'sample_column_2',
+        },
+      ],
+    }),
+  ).toEqual([{ expressionType: 'SIMPLE', subject: 'sample_column_1' }]);
+});
+
+test('SQL ad-hoc filter values', () => {
+  const controlState = {
+    ...sharedControls.adhoc_filters,
+  };
+
+  expect(
+    getValues({
+      ...controlState,
+      value: {
+        expressionType: 'SQL',
+        sqlExpression: 'select * from sample_column_1;',
+      },
+    }),
+  ).toEqual({
+    expressionType: 'SQL',
+    sqlExpression: 'select * from sample_column_1;',
+  });
+});


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
PR #21544 was a fix for something I broke in #21315.  This PR adds unit tests for the `getControlValuesCompatibleWithDatasource` module, used when the datasource is switched in Explore to keep valid control values, that would have caught this bug.


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- All tests should pass.
- Cherry-picking this commit onto b36bd3f083d0b2c125f472c23caa39b035ee5f27, the commit before #21544 was merged, and run tests again.  One should fail.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
