### PR TITLE
fix: Fixed Embedded Dashboards Bulk Delete Error

### DIFF
--- a/superset/dashboards/dao.py
+++ b/superset/dashboards/dao.py
@@ -160,6 +160,7 @@ class DashboardDAO(BaseDAO):
             for model in models:
                 model.slices = []
                 model.owners = []
+                model.embedded = []
                 db.session.merge(model)
         # bulk delete itself
         try:


### PR DESCRIPTION
### SUMMARY
Delete embedded relationship when deleting multiple dashboards with bulk operation. So now when you try to delete more than one embedded dashboard in a row using the bulk delete function you will not get an error.

Fixes #21746 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #21746
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
