### PR TITLE
chore(deps): bump react-map-gl from 4.0.10 to 6.1.19

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -84,6 +84,7 @@
         "json-stringify-pretty-compact": "^2.0.0",
         "lodash": "^4.17.21",
         "lodash-es": "^4.17.21",
+        "mapbox-gl": "^2.10.0",
         "match-sorter": "^6.1.0",
         "memoize-one": "^5.1.1",
         "moment": "^2.26.0",
@@ -9613,14 +9614,6 @@
       "resolved": "https://registry.npmjs.org/@mapbox/extent/-/extent-0.4.0.tgz",
       "integrity": "sha1-PlkfMuHww5gchkI597CsBuYQ+Kk="
     },
-    "node_modules/@mapbox/geojson-area": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz",
-      "integrity": "sha1-GNeBSqNr8j+7zDefjiaiKSfevxA=",
-      "dependencies": {
-        "wgs84": "0.0.0"
-      }
-    },
     "node_modules/@mapbox/geojson-coords": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/geojson-coords/-/geojson-coords-0.0.2.tgz",
@@ -9658,17 +9651,26 @@
       }
     },
     "node_modules/@mapbox/geojson-rewind": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.4.1.tgz",
-      "integrity": "sha512-mxo2MEr7izA1uOXcDsw99Kgg6xW3P4H2j4n1lmldsgviIelpssvP+jQDivFKOHrOVJDpTTi5oZJvRcHtU9Uufw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
+      "integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
       "dependencies": {
-        "@mapbox/geojson-area": "0.2.2",
-        "concat-stream": "~1.6.0",
-        "minimist": "^1.2.5",
-        "sharkdown": "^0.1.0"
+        "get-stream": "^6.0.1",
+        "minimist": "^1.2.6"
       },
       "bin": {
         "geojson-rewind": "geojson-rewind"
+      }
+    },
+    "node_modules/@mapbox/geojson-rewind/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@mapbox/geojson-types": {
@@ -9685,12 +9687,9 @@
       }
     },
     "node_modules/@mapbox/mapbox-gl-supported": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
-      "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
-      "peerDependencies": {
-        "mapbox-gl": ">=0.32.1 <2.0.0"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-2.0.1.tgz",
+      "integrity": "sha512-HP6XvfNIzfoMVfyGjBckjiAOQK9WfX0ywdLubuPMPv+Vqf5fj0uCbgBQYpiqcWZT6cbyyRnTSXDheT1ugvF6UQ=="
     },
     "node_modules/@mapbox/martini": {
       "version": "0.2.0",
@@ -18232,6 +18231,14 @@
         "@types/lodash": "*"
       }
     },
+    "node_modules/@types/mapbox-gl": {
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-2.7.6.tgz",
+      "integrity": "sha512-EPIfNO7WApXaFM7DuJBj+kpXmqffqJHMJ3Q9gbV/nNL23XHR0PC5CCDYbAFa4tKErm0xJd9C5kPLF6KvA/cRcA==",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@types/math-expression-evaluator": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/math-expression-evaluator/-/math-expression-evaluator-1.2.1.tgz",
@@ -20365,11 +20372,6 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
-    },
-    "node_modules/ansicolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
-      "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
     },
     "node_modules/antd": {
       "version": "4.9.4",
@@ -22878,18 +22880,6 @@
       },
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/cardinal": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
-      "integrity": "sha1-ylu2iltRG5D+k7ms6km97lwyv+I=",
-      "dependencies": {
-        "ansicolors": "~0.2.1",
-        "redeyed": "~0.4.0"
-      },
-      "bin": {
-        "cdl": "bin/cdl.js"
       }
     },
     "node_modules/cartocolor": {
@@ -27416,9 +27406,9 @@
       }
     },
     "node_modules/earcut": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
-      "integrity": "sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug=="
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
@@ -29195,6 +29185,7 @@
       "version": "3.2.25",
       "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
       "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -39117,51 +39108,48 @@
       }
     },
     "node_modules/mapbox-gl": {
-      "version": "0.53.1",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-0.53.1.tgz",
-      "integrity": "sha512-dTtW/qlkUowKGlqOhE8fqII2Tj4lcokvlZwUDLnkjy4uQ9zMFnVBULGeSzzTVkj9HtQZ3Zbey10/jmoVPV9t5w==",
-      "peer": true,
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-2.10.0.tgz",
+      "integrity": "sha512-ZAlCe55LXlbg60l15okSBs70NQAPLw3yRO3SSJMTB1uU7uj2QQbLCQPy1Ds+3B4wlaa5W3ewv8FNOZPQOoSSPA==",
       "dependencies": {
-        "@mapbox/geojson-rewind": "^0.4.0",
+        "@mapbox/geojson-rewind": "^0.5.1",
         "@mapbox/geojson-types": "^1.0.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/mapbox-gl-supported": "^1.4.0",
+        "@mapbox/mapbox-gl-supported": "^2.0.1",
         "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/tiny-sdf": "^1.1.0",
+        "@mapbox/tiny-sdf": "^2.0.5",
         "@mapbox/unitbezier": "^0.0.0",
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
-        "csscolorparser": "~1.0.2",
-        "earcut": "^2.1.5",
-        "esm": "^3.0.84",
+        "csscolorparser": "~1.0.3",
+        "earcut": "^2.2.4",
         "geojson-vt": "^3.2.1",
-        "gl-matrix": "^3.0.0",
+        "gl-matrix": "^3.4.3",
         "grid-index": "^1.1.0",
-        "minimist": "0.0.8",
         "murmurhash-js": "^1.0.0",
-        "pbf": "^3.0.5",
-        "potpack": "^1.0.1",
+        "pbf": "^3.2.1",
+        "potpack": "^1.0.2",
         "quickselect": "^2.0.0",
         "rw": "^1.3.3",
-        "supercluster": "^6.0.1",
-        "tinyqueue": "^2.0.0",
-        "vt-pbf": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6.4.0"
+        "supercluster": "^7.1.4",
+        "tinyqueue": "^2.0.3",
+        "vt-pbf": "^3.1.3"
       }
     },
-    "node_modules/mapbox-gl/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==",
-      "peer": true
+    "node_modules/mapbox-gl/node_modules/@mapbox/tiny-sdf": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.5.tgz",
+      "integrity": "sha512-OhXt2lS//WpLdkqrzo/KwB7SRD8AiNTFFzuo9n14IBupzIMa67yGItcK7I2W9D8Ghpa4T04Sw9FWsKCJG50Bxw=="
+    },
+    "node_modules/mapbox-gl/node_modules/gl-matrix": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
+      "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA=="
     },
     "node_modules/mapbox-gl/node_modules/supercluster": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-6.0.2.tgz",
-      "integrity": "sha512-aa0v2HURjBTOpbcknilcfxGDuArM8khklKSmZ/T8ZXL0BuRwb5aRw95lz+2bmWpFvCXDX/+FzqHxmg0TIaJErw==",
-      "peer": true,
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.5.tgz",
+      "integrity": "sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==",
       "dependencies": {
         "kdbush": "^3.0.0"
       }
@@ -43056,9 +43044,9 @@
       }
     },
     "node_modules/potpack": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.1.tgz",
-      "integrity": "sha512-15vItUAbViaYrmaB/Pbw7z6qX2xENbFSTA7Ii4tgbPtasxm5v6ryKhKtL91tpWovDJzTiZqdwzhcFBCwiMVdVw=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ=="
     },
     "node_modules/preferred-pm": {
       "version": "3.0.3",
@@ -45172,16 +45160,18 @@
       }
     },
     "node_modules/react-map-gl": {
-      "version": "4.1.16",
-      "resolved": "https://registry.npmjs.org/react-map-gl/-/react-map-gl-4.1.16.tgz",
-      "integrity": "sha512-EtiHCeqM69wKR9RDyLvtk6pTPS5+OFeAPIsYw6afnlGTauFAq3iD40SHuAOElgoJmm7J+cjPfHqu7m7tB4/FfA==",
+      "version": "6.1.19",
+      "resolved": "https://registry.npmjs.org/react-map-gl/-/react-map-gl-6.1.19.tgz",
+      "integrity": "sha512-rrDoRyEIGzVLUB5QfgsZ5xCw7jeUtmmYzHUv86xDx8oGp90VTV2KTQJ4RPQiSAmpfIFh6/pPqI28Pguf1u/mOg==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
-        "mapbox-gl": "~0.54.0",
-        "mjolnir.js": "^2.2.0",
+        "@types/geojson": "^7946.0.7",
+        "@types/mapbox-gl": "^2.0.3",
+        "mapbox-gl": "^2.3.0",
+        "mjolnir.js": "^2.5.0",
         "prop-types": "^15.7.2",
-        "react-virtualized-auto-sizer": "^1.0.2",
-        "viewport-mercator-project": "^6.2.1"
+        "resize-observer-polyfill": "^1.5.1",
+        "viewport-mercator-project": "^7.0.4"
       },
       "engines": {
         "node": ">= 4",
@@ -45191,59 +45181,12 @@
         "react": ">=16.3.0"
       }
     },
-    "node_modules/react-map-gl/node_modules/esm": {
-      "version": "3.0.84",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.0.84.tgz",
-      "integrity": "sha512-SzSGoZc17S7P+12R9cg21Bdb7eybX25RnIeRZ80xZs+VZ3kdQKzqTp2k4hZJjR7p9l0186TTXSgrxzlMDBktlw==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/react-map-gl/node_modules/mapbox-gl": {
-      "version": "0.54.1",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-0.54.1.tgz",
-      "integrity": "sha512-HtY+HobYTHTsFOJ3buTHtNvZv/Tjfp0vararhEWCjI7wQq8XxK16sEpsXucokrAhuu94js4KJylo13bKJx6l0Q==",
+    "node_modules/react-map-gl/node_modules/viewport-mercator-project": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/viewport-mercator-project/-/viewport-mercator-project-7.0.4.tgz",
+      "integrity": "sha512-0jzpL6pIMocCKWg1C3mqi/N4UPgZC3FzwghEm1H+XsUo8hNZAyJc3QR7YqC816ibOR8aWT5pCsV+gCu8/BMJgg==",
       "dependencies": {
-        "@mapbox/geojson-rewind": "^0.4.0",
-        "@mapbox/geojson-types": "^1.0.2",
-        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/mapbox-gl-supported": "^1.4.0",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/tiny-sdf": "^1.1.0",
-        "@mapbox/unitbezier": "^0.0.0",
-        "@mapbox/vector-tile": "^1.3.1",
-        "@mapbox/whoots-js": "^3.1.0",
-        "csscolorparser": "~1.0.2",
-        "earcut": "^2.1.5",
-        "esm": "~3.0.84",
-        "geojson-vt": "^3.2.1",
-        "gl-matrix": "^3.0.0",
-        "grid-index": "^1.1.0",
-        "minimist": "0.0.8",
-        "murmurhash-js": "^1.0.0",
-        "pbf": "^3.0.5",
-        "potpack": "^1.0.1",
-        "quickselect": "^2.0.0",
-        "rw": "^1.3.3",
-        "supercluster": "^6.0.1",
-        "tinyqueue": "^2.0.0",
-        "vt-pbf": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6.4.0"
-      }
-    },
-    "node_modules/react-map-gl/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q=="
-    },
-    "node_modules/react-map-gl/node_modules/supercluster": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-6.0.2.tgz",
-      "integrity": "sha512-aa0v2HURjBTOpbcknilcfxGDuArM8khklKSmZ/T8ZXL0BuRwb5aRw95lz+2bmWpFvCXDX/+FzqHxmg0TIaJErw==",
-      "dependencies": {
-        "kdbush": "^3.0.0"
+        "@math.gl/web-mercator": "^3.5.5"
       }
     },
     "node_modules/react-markdown": {
@@ -46203,26 +46146,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/redeyed": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
-      "integrity": "sha1-N+mQpvKyGyoRwuakj9QTVpjLqX8=",
-      "dependencies": {
-        "esprima": "~1.0.4"
-      }
-    },
-    "node_modules/redeyed/node_modules/esprima": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-      "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/reduce-css-calc": {
@@ -47756,24 +47679,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/sharkdown": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/sharkdown/-/sharkdown-0.1.1.tgz",
-      "integrity": "sha512-exwooSpmo5s45lrexgz6Q0rFQM574wYIX3iDZ7RLLqOb7IAoQZu9nxlZODU972g19sR69OIpKP2cpHTzU+PHIg==",
-      "dependencies": {
-        "cardinal": "~0.4.2",
-        "minimist": "0.0.5",
-        "split": "~0.2.10"
-      },
-      "bin": {
-        "sharkdown": "sharkdown"
-      }
-    },
-    "node_modules/sharkdown/node_modules/minimist": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
-      "integrity": "sha512-rSJ0cdmCj3qmKdObcnMcWgPVOyaOWlazLhZAJW0s6G6lx1ZEuFkraWmEH5LTvX90btkfHPclQBjvjU7A/kYRFg=="
-    },
     "node_modules/shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -48504,17 +48409,6 @@
       "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-1.0.0.tgz",
       "integrity": "sha512-lgxErLl/7A5+vgIIXsh9MbeukOaCb2axgQ+bKCdIE+ibNT4XNYGNCR1qFEGq6F+YDASXK3Fh/c5FgtZchFolxw==",
       "dev": true
-    },
-    "node_modules/split": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
-      "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
-      "dependencies": {
-        "through": "2"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/split-on-first": {
       "version": "1.1.0",
@@ -50154,7 +50048,8 @@
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "devOptional": true
     },
     "node_modules/through2": {
       "version": "2.0.5",
@@ -53068,11 +52963,6 @@
       "engines": {
         "node": ">=0.8.0"
       }
-    },
-    "node_modules/wgs84": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/wgs84/-/wgs84-0.0.0.tgz",
-      "integrity": "sha1-NP3FVZF7blfPKigu0ENxDASc3HY="
     },
     "node_modules/whatwg-encoding": {
       "version": "1.0.5",
@@ -56066,7 +55956,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "prop-types": "^15.6.2",
-        "react-map-gl": "^4.0.10",
+        "react-map-gl": "^6.1.19",
         "supercluster": "^4.1.1",
         "viewport-mercator-project": "^6.1.1"
       },
@@ -56299,7 +56189,7 @@
         "mapbox-gl": "*",
         "react": "^16.13.1",
         "react-dom": "^16.13.1",
-        "react-map-gl": "^4.0.10"
+        "react-map-gl": "^6.1.19"
       }
     },
     "plugins/legacy-preset-chart-deckgl/node_modules/d3-scale": {
@@ -63860,14 +63750,6 @@
       "resolved": "https://registry.npmjs.org/@mapbox/extent/-/extent-0.4.0.tgz",
       "integrity": "sha1-PlkfMuHww5gchkI597CsBuYQ+Kk="
     },
-    "@mapbox/geojson-area": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz",
-      "integrity": "sha1-GNeBSqNr8j+7zDefjiaiKSfevxA=",
-      "requires": {
-        "wgs84": "0.0.0"
-      }
-    },
     "@mapbox/geojson-coords": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/geojson-coords/-/geojson-coords-0.0.2.tgz",
@@ -63901,14 +63783,19 @@
       "integrity": "sha1-HaHms6et060pkJsw9Dj2BYG3zYA="
     },
     "@mapbox/geojson-rewind": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.4.1.tgz",
-      "integrity": "sha512-mxo2MEr7izA1uOXcDsw99Kgg6xW3P4H2j4n1lmldsgviIelpssvP+jQDivFKOHrOVJDpTTi5oZJvRcHtU9Uufw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
+      "integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
       "requires": {
-        "@mapbox/geojson-area": "0.2.2",
-        "concat-stream": "~1.6.0",
-        "minimist": "^1.2.5",
-        "sharkdown": "^0.1.0"
+        "get-stream": "^6.0.1",
+        "minimist": "^1.2.6"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
+        }
       }
     },
     "@mapbox/geojson-types": {
@@ -63922,10 +63809,9 @@
       "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ="
     },
     "@mapbox/mapbox-gl-supported": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
-      "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
-      "requires": {}
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-2.0.1.tgz",
+      "integrity": "sha512-HP6XvfNIzfoMVfyGjBckjiAOQK9WfX0ywdLubuPMPv+Vqf5fj0uCbgBQYpiqcWZT6cbyyRnTSXDheT1ugvF6UQ=="
     },
     "@mapbox/martini": {
       "version": "0.2.0",
@@ -70180,7 +70066,7 @@
       "version": "file:plugins/legacy-plugin-chart-map-box",
       "requires": {
         "prop-types": "^15.6.2",
-        "react-map-gl": "^4.0.10",
+        "react-map-gl": "^6.1.19",
         "supercluster": "^4.1.1",
         "viewport-mercator-project": "^6.1.1"
       }
@@ -71258,6 +71144,14 @@
       "integrity": "sha512-E6zzjR3GtNig8UJG/yodBeJeIOtgPkMgsLjDU3CbgCAPC++vJ0eCMnJhVpRZb/ENqEFlov1+3K9TKtY4UdWKtQ==",
       "requires": {
         "@types/lodash": "*"
+      }
+    },
+    "@types/mapbox-gl": {
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-2.7.6.tgz",
+      "integrity": "sha512-EPIfNO7WApXaFM7DuJBj+kpXmqffqJHMJ3Q9gbV/nNL23XHR0PC5CCDYbAFa4tKErm0xJd9C5kPLF6KvA/cRcA==",
+      "requires": {
+        "@types/geojson": "*"
       }
     },
     "@types/math-expression-evaluator": {
@@ -73007,11 +72901,6 @@
           "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
         }
       }
-    },
-    "ansicolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
-      "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
     },
     "antd": {
       "version": "4.9.4",
@@ -74962,15 +74851,6 @@
       "dev": true,
       "requires": {
         "rsvp": "^4.8.4"
-      }
-    },
-    "cardinal": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
-      "integrity": "sha1-ylu2iltRG5D+k7ms6km97lwyv+I=",
-      "requires": {
-        "ansicolors": "~0.2.1",
-        "redeyed": "~0.4.0"
       }
     },
     "cartocolor": {
@@ -78525,9 +78405,9 @@
       }
     },
     "earcut": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
-      "integrity": "sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug=="
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -79899,7 +79779,8 @@
     "esm": {
       "version": "3.2.25",
       "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "dev": true
     },
     "espree": {
       "version": "7.3.1",
@@ -87544,48 +87425,48 @@
       }
     },
     "mapbox-gl": {
-      "version": "0.53.1",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-0.53.1.tgz",
-      "integrity": "sha512-dTtW/qlkUowKGlqOhE8fqII2Tj4lcokvlZwUDLnkjy4uQ9zMFnVBULGeSzzTVkj9HtQZ3Zbey10/jmoVPV9t5w==",
-      "peer": true,
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-2.10.0.tgz",
+      "integrity": "sha512-ZAlCe55LXlbg60l15okSBs70NQAPLw3yRO3SSJMTB1uU7uj2QQbLCQPy1Ds+3B4wlaa5W3ewv8FNOZPQOoSSPA==",
       "requires": {
-        "@mapbox/geojson-rewind": "^0.4.0",
+        "@mapbox/geojson-rewind": "^0.5.1",
         "@mapbox/geojson-types": "^1.0.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/mapbox-gl-supported": "^1.4.0",
+        "@mapbox/mapbox-gl-supported": "^2.0.1",
         "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/tiny-sdf": "^1.1.0",
+        "@mapbox/tiny-sdf": "^2.0.5",
         "@mapbox/unitbezier": "^0.0.0",
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
-        "csscolorparser": "~1.0.2",
-        "earcut": "^2.1.5",
-        "esm": "^3.0.84",
+        "csscolorparser": "~1.0.3",
+        "earcut": "^2.2.4",
         "geojson-vt": "^3.2.1",
-        "gl-matrix": "^3.0.0",
+        "gl-matrix": "^3.4.3",
         "grid-index": "^1.1.0",
-        "minimist": "0.0.8",
         "murmurhash-js": "^1.0.0",
-        "pbf": "^3.0.5",
-        "potpack": "^1.0.1",
+        "pbf": "^3.2.1",
+        "potpack": "^1.0.2",
         "quickselect": "^2.0.0",
         "rw": "^1.3.3",
-        "supercluster": "^6.0.1",
-        "tinyqueue": "^2.0.0",
-        "vt-pbf": "^3.1.1"
+        "supercluster": "^7.1.4",
+        "tinyqueue": "^2.0.3",
+        "vt-pbf": "^3.1.3"
       },
       "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==",
-          "peer": true
+        "@mapbox/tiny-sdf": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.5.tgz",
+          "integrity": "sha512-OhXt2lS//WpLdkqrzo/KwB7SRD8AiNTFFzuo9n14IBupzIMa67yGItcK7I2W9D8Ghpa4T04Sw9FWsKCJG50Bxw=="
+        },
+        "gl-matrix": {
+          "version": "3.4.3",
+          "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
+          "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA=="
         },
         "supercluster": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-6.0.2.tgz",
-          "integrity": "sha512-aa0v2HURjBTOpbcknilcfxGDuArM8khklKSmZ/T8ZXL0BuRwb5aRw95lz+2bmWpFvCXDX/+FzqHxmg0TIaJErw==",
-          "peer": true,
+          "version": "7.1.5",
+          "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.5.tgz",
+          "integrity": "sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==",
           "requires": {
             "kdbush": "^3.0.0"
           }
@@ -90639,9 +90520,9 @@
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
     },
     "potpack": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.1.tgz",
-      "integrity": "sha512-15vItUAbViaYrmaB/Pbw7z6qX2xENbFSTA7Ii4tgbPtasxm5v6ryKhKtL91tpWovDJzTiZqdwzhcFBCwiMVdVw=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ=="
     },
     "preferred-pm": {
       "version": "3.0.3",
@@ -92274,65 +92155,26 @@
       }
     },
     "react-map-gl": {
-      "version": "4.1.16",
-      "resolved": "https://registry.npmjs.org/react-map-gl/-/react-map-gl-4.1.16.tgz",
-      "integrity": "sha512-EtiHCeqM69wKR9RDyLvtk6pTPS5+OFeAPIsYw6afnlGTauFAq3iD40SHuAOElgoJmm7J+cjPfHqu7m7tB4/FfA==",
+      "version": "6.1.19",
+      "resolved": "https://registry.npmjs.org/react-map-gl/-/react-map-gl-6.1.19.tgz",
+      "integrity": "sha512-rrDoRyEIGzVLUB5QfgsZ5xCw7jeUtmmYzHUv86xDx8oGp90VTV2KTQJ4RPQiSAmpfIFh6/pPqI28Pguf1u/mOg==",
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "mapbox-gl": "~0.54.0",
-        "mjolnir.js": "^2.2.0",
+        "@types/geojson": "^7946.0.7",
+        "@types/mapbox-gl": "^2.0.3",
+        "mapbox-gl": "^2.3.0",
+        "mjolnir.js": "^2.5.0",
         "prop-types": "^15.7.2",
-        "react-virtualized-auto-sizer": "^1.0.2",
-        "viewport-mercator-project": "^6.2.1"
+        "resize-observer-polyfill": "^1.5.1",
+        "viewport-mercator-project": "^7.0.4"
       },
       "dependencies": {
-        "esm": {
-          "version": "3.0.84",
-          "resolved": "https://registry.npmjs.org/esm/-/esm-3.0.84.tgz",
-          "integrity": "sha512-SzSGoZc17S7P+12R9cg21Bdb7eybX25RnIeRZ80xZs+VZ3kdQKzqTp2k4hZJjR7p9l0186TTXSgrxzlMDBktlw=="
-        },
-        "mapbox-gl": {
-          "version": "0.54.1",
-          "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-0.54.1.tgz",
-          "integrity": "sha512-HtY+HobYTHTsFOJ3buTHtNvZv/Tjfp0vararhEWCjI7wQq8XxK16sEpsXucokrAhuu94js4KJylo13bKJx6l0Q==",
+        "viewport-mercator-project": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/viewport-mercator-project/-/viewport-mercator-project-7.0.4.tgz",
+          "integrity": "sha512-0jzpL6pIMocCKWg1C3mqi/N4UPgZC3FzwghEm1H+XsUo8hNZAyJc3QR7YqC816ibOR8aWT5pCsV+gCu8/BMJgg==",
           "requires": {
-            "@mapbox/geojson-rewind": "^0.4.0",
-            "@mapbox/geojson-types": "^1.0.2",
-            "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-            "@mapbox/mapbox-gl-supported": "^1.4.0",
-            "@mapbox/point-geometry": "^0.1.0",
-            "@mapbox/tiny-sdf": "^1.1.0",
-            "@mapbox/unitbezier": "^0.0.0",
-            "@mapbox/vector-tile": "^1.3.1",
-            "@mapbox/whoots-js": "^3.1.0",
-            "csscolorparser": "~1.0.2",
-            "earcut": "^2.1.5",
-            "esm": "~3.0.84",
-            "geojson-vt": "^3.2.1",
-            "gl-matrix": "^3.0.0",
-            "grid-index": "^1.1.0",
-            "minimist": "0.0.8",
-            "murmurhash-js": "^1.0.0",
-            "pbf": "^3.0.5",
-            "potpack": "^1.0.1",
-            "quickselect": "^2.0.0",
-            "rw": "^1.3.3",
-            "supercluster": "^6.0.1",
-            "tinyqueue": "^2.0.0",
-            "vt-pbf": "^3.1.1"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q=="
-        },
-        "supercluster": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-6.0.2.tgz",
-          "integrity": "sha512-aa0v2HURjBTOpbcknilcfxGDuArM8khklKSmZ/T8ZXL0BuRwb5aRw95lz+2bmWpFvCXDX/+FzqHxmg0TIaJErw==",
-          "requires": {
-            "kdbush": "^3.0.0"
+            "@math.gl/web-mercator": "^3.5.5"
           }
         }
       }
@@ -93096,21 +92938,6 @@
       "requires": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
-      }
-    },
-    "redeyed": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
-      "integrity": "sha1-N+mQpvKyGyoRwuakj9QTVpjLqX8=",
-      "requires": {
-        "esprima": "~1.0.4"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-          "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
-        }
       }
     },
     "reduce-css-calc": {
@@ -94306,23 +94133,6 @@
         }
       }
     },
-    "sharkdown": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/sharkdown/-/sharkdown-0.1.1.tgz",
-      "integrity": "sha512-exwooSpmo5s45lrexgz6Q0rFQM574wYIX3iDZ7RLLqOb7IAoQZu9nxlZODU972g19sR69OIpKP2cpHTzU+PHIg==",
-      "requires": {
-        "cardinal": "~0.4.2",
-        "minimist": "0.0.5",
-        "split": "~0.2.10"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
-          "integrity": "sha512-rSJ0cdmCj3qmKdObcnMcWgPVOyaOWlazLhZAJW0s6G6lx1ZEuFkraWmEH5LTvX90btkfHPclQBjvjU7A/kYRFg=="
-        }
-      }
-    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -94914,14 +94724,6 @@
       "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-1.0.0.tgz",
       "integrity": "sha512-lgxErLl/7A5+vgIIXsh9MbeukOaCb2axgQ+bKCdIE+ibNT4XNYGNCR1qFEGq6F+YDASXK3Fh/c5FgtZchFolxw==",
       "dev": true
-    },
-    "split": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
-      "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
-      "requires": {
-        "through": "2"
-      }
     },
     "split-on-first": {
       "version": "1.1.0",
@@ -96166,7 +95968,8 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "devOptional": true
     },
     "through2": {
       "version": "2.0.5",
@@ -98373,11 +98176,6 @@
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
       "devOptional": true
-    },
-    "wgs84": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/wgs84/-/wgs84-0.0.0.tgz",
-      "integrity": "sha1-NP3FVZF7blfPKigu0ENxDASc3HY="
     },
     "whatwg-encoding": {
       "version": "1.0.5",

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -127,8 +127,6 @@
         "react-transition-group": "^2.5.3",
         "react-ultimate-pagination": "^1.2.0",
         "react-virtualized": "9.19.1",
-        "react-virtualized-auto-sizer": "^1.0.2",
-        "react-virtualized-select": "^3.1.3",
         "react-window": "^1.8.5",
         "redux": "^4.0.5",
         "redux-localstorage": "^0.4.1",
@@ -45690,47 +45688,6 @@
       "peerDependencies": {
         "react": "^15.3.0 || ^16.0.0-alpha",
         "react-dom": "^15.3.0 || ^16.0.0-alpha"
-      }
-    },
-    "node_modules/react-virtualized-auto-sizer": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.6.tgz",
-      "integrity": "sha512-7tQ0BmZqfVF6YYEWcIGuoR3OdYe8I/ZFbNclFlGOC3pMqunkYF/oL30NCjSGl9sMEb17AnzixDz98Kqc3N76HQ==",
-      "engines": {
-        "node": ">8.0.0"
-      },
-      "peerDependencies": {
-        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0",
-        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0"
-      }
-    },
-    "node_modules/react-virtualized-select": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/react-virtualized-select/-/react-virtualized-select-3.1.3.tgz",
-      "integrity": "sha512-u6j/EfynCB9s4Lz5GGZhNUCZHvFQdtLZws7W/Tcd/v03l19OjpQs3eYjK82iYS0FgD2+lDIBpqS8LpD/hjqDRQ==",
-      "dependencies": {
-        "babel-runtime": "^6.11.6",
-        "prop-types": "^15.5.8",
-        "react-select": "^1.0.0-rc.2",
-        "react-virtualized": "^9.0.0"
-      },
-      "peerDependencies": {
-        "react": "^15.3.0 || ^16.0.0-alpha",
-        "react-dom": "^15.3.0 || ^16.0.0-alpha"
-      }
-    },
-    "node_modules/react-virtualized-select/node_modules/react-select": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.3.0.tgz",
-      "integrity": "sha512-g/QAU1HZrzSfxkwMAo/wzi6/ezdWye302RGZevsATec07hI/iSxcpB1hejFIp7V63DJ8mwuign6KmB3VjdlinQ==",
-      "dependencies": {
-        "classnames": "^2.2.4",
-        "prop-types": "^15.5.8",
-        "react-input-autosize": "^2.1.2"
-      },
-      "peerDependencies": {
-        "react": "^0.14.9 || ^15.3.0 || ^16.0.0-rc || ^16.0",
-        "react-dom": "^0.14.9 || ^15.3.0 || ^16.0.0-rc || ^16.0"
       }
     },
     "node_modules/react-window": {
@@ -92578,35 +92535,6 @@
         "loose-envify": "^1.3.0",
         "prop-types": "^15.6.0",
         "react-lifecycles-compat": "^3.0.4"
-      }
-    },
-    "react-virtualized-auto-sizer": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.6.tgz",
-      "integrity": "sha512-7tQ0BmZqfVF6YYEWcIGuoR3OdYe8I/ZFbNclFlGOC3pMqunkYF/oL30NCjSGl9sMEb17AnzixDz98Kqc3N76HQ==",
-      "requires": {}
-    },
-    "react-virtualized-select": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/react-virtualized-select/-/react-virtualized-select-3.1.3.tgz",
-      "integrity": "sha512-u6j/EfynCB9s4Lz5GGZhNUCZHvFQdtLZws7W/Tcd/v03l19OjpQs3eYjK82iYS0FgD2+lDIBpqS8LpD/hjqDRQ==",
-      "requires": {
-        "babel-runtime": "^6.11.6",
-        "prop-types": "^15.5.8",
-        "react-select": "^1.0.0-rc.2",
-        "react-virtualized": "^9.0.0"
-      },
-      "dependencies": {
-        "react-select": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.3.0.tgz",
-          "integrity": "sha512-g/QAU1HZrzSfxkwMAo/wzi6/ezdWye302RGZevsATec07hI/iSxcpB1hejFIp7V63DJ8mwuign6KmB3VjdlinQ==",
-          "requires": {
-            "classnames": "^2.2.4",
-            "prop-types": "^15.5.8",
-            "react-input-autosize": "^2.1.2"
-          }
-        }
       }
     },
     "react-window": {

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -148,6 +148,7 @@
     "json-stringify-pretty-compact": "^2.0.0",
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",
+    "mapbox-gl": "^2.10.0",
     "match-sorter": "^6.1.0",
     "memoize-one": "^5.1.1",
     "moment": "^2.26.0",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -191,8 +191,6 @@
     "react-transition-group": "^2.5.3",
     "react-ultimate-pagination": "^1.2.0",
     "react-virtualized": "9.19.1",
-    "react-virtualized-auto-sizer": "^1.0.2",
-    "react-virtualized-select": "^3.1.3",
     "react-window": "^1.8.5",
     "redux": "^4.0.5",
     "redux-localstorage": "^0.4.1",

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/package.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/package.json
@@ -2,6 +2,19 @@
   "name": "@superset-ui/legacy-plugin-chart-map-box",
   "version": "0.18.25",
   "description": "Superset Legacy Chart - MapBox",
+  "keywords": [
+    "superset"
+  ],
+  "homepage": "https://superset.apache.org/",
+  "bugs": {
+    "url": "https://github.com/apache/superset/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/apache/superset.git"
+  },
+  "license": "Apache-2.0",
+  "author": "Superset",
   "sideEffects": [
     "*.css"
   ],
@@ -11,32 +24,19 @@
     "esm",
     "lib"
   ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/apache-superset/superset-ui.git"
-  },
-  "keywords": [
-    "superset"
-  ],
-  "author": "Superset",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/apache-superset/superset-ui/issues"
-  },
-  "homepage": "https://github.com/apache-superset/superset-ui#readme",
-  "publishConfig": {
-    "access": "public"
-  },
   "dependencies": {
     "prop-types": "^15.6.2",
-    "react-map-gl": "^4.0.10",
+    "react-map-gl": "^6.1.19",
     "supercluster": "^4.1.1",
     "viewport-mercator-project": "^6.1.1"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
-    "react": "^15 || ^16",
-    "mapbox-gl": "*"
+    "mapbox-gl": "*",
+    "react": "^15 || ^16"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/package.json
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/package.json
@@ -5,13 +5,13 @@
   "keywords": [
     "superset"
   ],
-  "homepage": "https://github.com/apache-superset/superset-ui-plugins-deckgl#readme",
+  "homepage": "https://superset.apache.org/",
   "bugs": {
-    "url": "https://github.com/apache-superset/superset-ui-plugins-deckgl/issues"
+    "url": "https://github.com/apache/superset/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/apache-superset/superset-ui-plugins-deckgl.git"
+    "url": "git+https://github.com/apache/superset.git"
   },
   "license": "Apache-2.0",
   "author": "Superset",
@@ -44,10 +44,10 @@
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
+    "mapbox-gl": "*",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-map-gl": "^4.0.10",
-    "mapbox-gl": "*"
+    "react-map-gl": "^6.1.19"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Since there is "Prototype Pollution" in minimist(< 1.2.6), we need to upgrade to 1.2.6. Currently we have two dependecy chains: 
- minimist (0.0.5) -> sharkdown -> @mapbox/geojson-rewind -> mapbox-gl(0.53.1)
- minimist (0.0.8) -> react-map-gl (4.1.16) -> mapbox-gl(0.54.1)

So just upgrading react-map-gl  and mapbox-gl can resolve the issue. However, react-map-gl has break change in version 7 (https://visgl.github.io/react-map-gl/docs/upgrade-guide), we upgrade to version 6 to avoid major changes。
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
