### PR TITLE
fix(alerts): restrict list view and gamma perms

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -32,7 +32,7 @@ assists people when migrating to a new version.
 
 ### Breaking Changes
 
-- [21765](https://github.com/apache/superset/pull/21765): Gamma users will no longer have read and write access to Alerts & Reports. To give Gamma users the ability to schedule alerts and reports like before, create an additional role with "can read on ReportSchedule", "can write on ReportSchedule", "menu access on Manage" and "menu access on Alerts & Report".
+- [21765](https://github.com/apache/superset/pull/21765): For deployments that have enabled the "ALERT_REPORTS" feature flag, Gamma users will no longer have read and write access to Alerts & Reports by default. To give Gamma users the ability to schedule reports from the Dashboard and Explore view like before, create an additional role with "can read on ReportSchedule" and "can write on ReportSchedule" permissions. To further give Gamma users access to the "Alerts & Reports" menu and CRUD view, add "menu access on Manage" and "menu access on Alerts & Report" permissions to the role.
 
 ### Potential Downtime
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -32,6 +32,8 @@ assists people when migrating to a new version.
 
 ### Breaking Changes
 
+- [21765](https://github.com/apache/superset/pull/21765): Gamma users will no longer have read and write access to Alerts & Reports. To give Gamma users the ability to schedule alerts and reports like before, create an additional role with "can read on ReportSchedule", "can write on ReportSchedule", "menu access on Manage" and "menu access on Alerts & Report".
+
 ### Potential Downtime
 
 ### Other

--- a/superset-frontend/src/views/CRUD/alert/AlertList.test.jsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertList.test.jsx
@@ -55,7 +55,7 @@ const mockalerts = [...new Array(3)].map((_, i) => ({
   last_eval_dttm: Date.now(),
   last_state: 'ok',
   name: `alert ${i}  `,
-  owners: [],
+  owners: [{ id: 1 }],
   recipients: [
     {
       id: `${i}`,
@@ -67,6 +67,8 @@ const mockalerts = [...new Array(3)].map((_, i) => ({
 
 const mockUser = {
   userId: 1,
+  firstName: 'user 1',
+  lastName: 'lastname',
 };
 
 fetchMock.get(alertsEndpoint, {

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -43,7 +43,7 @@ from superset.reports.commands.exceptions import (
     ReportScheduleUpdateFailedError,
 )
 from superset.reports.commands.update import UpdateReportScheduleCommand
-from superset.reports.filters import ReportScheduleAllTextFilter
+from superset.reports.filters import ReportScheduleAllTextFilter, ReportScheduleFilter
 from superset.reports.models import ReportSchedule
 from superset.reports.schemas import (
     get_delete_ids_schema,
@@ -79,6 +79,10 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
     method_permission_name = MODEL_API_RW_METHOD_PERMISSION_MAP
     resource_name = "report"
     allow_browser_login = True
+
+    base_filters = [
+        ["id", ReportScheduleFilter, lambda: []],
+    ]
 
     show_columns = [
         "id",

--- a/superset/reports/dao.py
+++ b/superset/reports/dao.py
@@ -26,6 +26,7 @@ from sqlalchemy.orm import Session
 from superset.dao.base import BaseDAO
 from superset.dao.exceptions import DAOCreateFailedError, DAODeleteFailedError
 from superset.extensions import db
+from superset.reports.filters import ReportScheduleFilter
 from superset.reports.models import (
     ReportExecutionLog,
     ReportRecipients,
@@ -43,6 +44,7 @@ REPORT_SCHEDULE_ERROR_NOTIFICATION_MARKER = "Notification sent with error"
 
 class ReportScheduleDAO(BaseDAO):
     model_cls = ReportSchedule
+    base_filter = ReportScheduleFilter
 
     @staticmethod
     def find_by_chart_id(chart_id: int) -> List[ReportSchedule]:

--- a/superset/reports/filters.py
+++ b/superset/reports/filters.py
@@ -27,7 +27,7 @@ from superset.views.base import BaseFilter
 
 class ReportScheduleFilter(BaseFilter):  # pylint: disable=too-few-public-methods
     def apply(self, query: Query, value: Any) -> Query:
-        if security_manager.is_admin():
+        if security_manager.can_access_all_datasources():
             return query
         owner_ids_query = (
             db.session.query(ReportSchedule.id)

--- a/superset/reports/filters.py
+++ b/superset/reports/filters.py
@@ -17,7 +17,7 @@
 from typing import Any
 
 from flask_babel import lazy_gettext as _
-from sqlalchemy import and_, or_
+from sqlalchemy import or_
 from sqlalchemy.orm.query import Query
 
 from superset import db, security_manager

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -186,7 +186,6 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         "Upload a CSV",
         "ReportSchedule",
         "Alerts & Report",
-        "Annotation Layers",
     }
 
     ADMIN_ONLY_PERMISSIONS = {

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -184,6 +184,9 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         "Queries",
         "Import dashboards",
         "Upload a CSV",
+        "ReportSchedule",
+        "Alerts & Report",
+        "Annotation Layers",
     }
 
     ADMIN_ONLY_PERMISSIONS = {

--- a/tests/integration_tests/reports/api_tests.py
+++ b/tests/integration_tests/reports/api_tests.py
@@ -1316,7 +1316,7 @@ class TestReportSchedulesApi(SupersetTestCase):
         }
         uri = f"api/v1/report/{report_schedule.id}"
         rv = self.put_assert_metric(uri, report_schedule_data, "put")
-        self.assertEqual(rv.status_code, 403)
+        self.assertEqual(rv.status_code, 404)
 
     @pytest.mark.usefixtures("create_report_schedules")
     def test_delete_report_schedule(self):
@@ -1375,7 +1375,7 @@ class TestReportSchedulesApi(SupersetTestCase):
         self.login(username="alpha2", password="password")
         uri = f"api/v1/report/{report_schedule.id}"
         rv = self.delete_assert_metric(uri, "delete")
-        self.assertEqual(rv.status_code, 403)
+        self.assertEqual(rv.status_code, 404)
 
     @pytest.mark.usefixtures("create_report_schedules")
     def test_bulk_delete_report_schedule(self):
@@ -1432,7 +1432,7 @@ class TestReportSchedulesApi(SupersetTestCase):
         self.login(username="alpha2", password="password")
         uri = f"api/v1/report/?q={prison.dumps(report_schedules_ids)}"
         rv = self.delete_assert_metric(uri, "bulk_delete")
-        self.assertEqual(rv.status_code, 403)
+        self.assertEqual(rv.status_code, 404)
 
     @pytest.mark.usefixtures("create_report_schedules")
     def test_get_list_report_schedule_logs(self):

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -17,7 +17,7 @@
 import json
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 from unittest.mock import Mock, patch
 from uuid import uuid4
 


### PR DESCRIPTION
### SUMMARY
Currently Gamma users have read and write permissions for Alerts & Reports and menu access for "Alerts & Reports". However, since they don't have access to the "Manage" menu, they can't see the menu item. This means that they can actually access the list view if the URL is provided to them. In addition, the list view shows all entries in the report schedule, although users are only able to edit entries they own.

This PR does the following:
- Removes "can read on ReportSchedule", "can write on ReportSchedule" and "Alerts & Report" permissions from Gamma users
- Adds a new base filter to only show owned entries for users without the `all_datasource_access` perm
- Adds tests to assert that admin, alpha and gamma users see the all entries in the list view (admin sees all, alpha sees all, gamma with extra perms only sees owned entries)
- If the user doesn't have edit rights (=isn't owner or isn't Admin) do the following:
  - disable the toggle
  - remove trashcan
  - replace "Edit" + Pen icon with "View" + Binoculars icon
- Adds an entry to `UPDATING.md` with instructions on how to give perms to Gamma users

### AFTER
When an Alpha user enters the list view, non-owned objects will appear with the toggle disabled, no trashcan and the "Edit" + Pen replaced with "View" + Binoculars (note that I didn't change the modal by dsabling fields etc, as changing that is a slightly bigger effort):
<img width="1668" alt="image" src="https://user-images.githubusercontent.com/33317356/195788432-9a1560fe-b7ad-4f4e-b2f7-7bdd1e66cb13.png">

When a regular Gamma user tries to access the Alerts & Reports list view with the direct URL, they get an "Access denied" error:
![image](https://user-images.githubusercontent.com/33317356/195040780-a5a5c65a-ded8-4c3e-bbc0-65253ce7d1eb.png)

When a Gamma user with the `read on ReportSchedule` perm accesses the list view, they can only see their own entries in the list view, despite there being four entries in the report schedule (see the Before screenshot):
![image](https://user-images.githubusercontent.com/33317356/195040724-e98542af-37ab-4fdd-9907-ae075eae2270.png)

### BEFORE
Previously the Gamma and Alpha user saw and were able to edit all users' entries, despite not being able to change them (here I'm trying to enable another user's alert as a Gamma user, which fails due to missing perms).
![image](https://user-images.githubusercontent.com/33317356/195040833-0b535e16-483a-4d18-85b3-18ca2e3ab5b5.png)

Previously Gamma users were able to access the list view if they knew the URL, despite not having menu access:
![image](https://user-images.githubusercontent.com/33317356/195040879-23e75e09-7aa8-4712-bd24-90cb22cef4ba.png)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
