### PR TITLE
fix: Dataset left panel now uses client side search

### DIFF
--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/LeftPanel.test.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/LeftPanel.test.tsx
@@ -17,215 +17,224 @@
  * under the License.
  */
 import React from 'react';
-import { SupersetClient } from '@superset-ui/core';
-// import fetchMock from 'fetch-mock';
+import fetchMock from 'fetch-mock';
 import userEvent from '@testing-library/user-event';
 import { render, screen, waitFor } from 'spec/helpers/testing-library';
 import LeftPanel from 'src/views/CRUD/data/dataset/AddDataset/LeftPanel';
 
-// const tablesEndpoint = 'glob:*/superset/tables*';
+const databasesEndpoint = 'glob:*/api/v1/database/?q*';
+const schemasEndpoint = 'glob:*/api/v1/database/*/schemas*';
+const tablesEndpoint = 'glob:*/superset/tables*';
 
-// fetchMock.get(tablesEndpoint, {
-//   tableLength: 1,
-//   options: [{ value: 'Sheet1', type: 'table', extra: null }],
-// });
+fetchMock.get(databasesEndpoint, {
+  count: 2,
+  description_columns: {},
+  ids: [1, 2],
+  label_columns: {
+    allow_file_upload: 'Allow Csv Upload',
+    allow_ctas: 'Allow Ctas',
+    allow_cvas: 'Allow Cvas',
+    allow_dml: 'Allow Dml',
+    allow_multi_schema_metadata_fetch: 'Allow Multi Schema Metadata Fetch',
+    allow_run_async: 'Allow Run Async',
+    allows_cost_estimate: 'Allows Cost Estimate',
+    allows_subquery: 'Allows Subquery',
+    allows_virtual_table_explore: 'Allows Virtual Table Explore',
+    disable_data_preview: 'Disables SQL Lab Data Preview',
+    backend: 'Backend',
+    changed_on: 'Changed On',
+    changed_on_delta_humanized: 'Changed On Delta Humanized',
+    'created_by.first_name': 'Created By First Name',
+    'created_by.last_name': 'Created By Last Name',
+    database_name: 'Database Name',
+    explore_database_id: 'Explore Database Id',
+    expose_in_sqllab: 'Expose In Sqllab',
+    force_ctas_schema: 'Force Ctas Schema',
+    id: 'Id',
+  },
+  list_columns: [
+    'allow_file_upload',
+    'allow_ctas',
+    'allow_cvas',
+    'allow_dml',
+    'allow_multi_schema_metadata_fetch',
+    'allow_run_async',
+    'allows_cost_estimate',
+    'allows_subquery',
+    'allows_virtual_table_explore',
+    'disable_data_preview',
+    'backend',
+    'changed_on',
+    'changed_on_delta_humanized',
+    'created_by.first_name',
+    'created_by.last_name',
+    'database_name',
+    'explore_database_id',
+    'expose_in_sqllab',
+    'force_ctas_schema',
+    'id',
+  ],
+  list_title: 'List Database',
+  order_columns: [
+    'allow_file_upload',
+    'allow_dml',
+    'allow_run_async',
+    'changed_on',
+    'changed_on_delta_humanized',
+    'created_by.first_name',
+    'database_name',
+    'expose_in_sqllab',
+  ],
+  result: [
+    {
+      allow_file_upload: false,
+      allow_ctas: false,
+      allow_cvas: false,
+      allow_dml: false,
+      allow_multi_schema_metadata_fetch: false,
+      allow_run_async: false,
+      allows_cost_estimate: null,
+      allows_subquery: true,
+      allows_virtual_table_explore: true,
+      disable_data_preview: false,
+      backend: 'postgresql',
+      changed_on: '2021-03-09T19:02:07.141095',
+      changed_on_delta_humanized: 'a day ago',
+      created_by: null,
+      database_name: 'test-postgres',
+      explore_database_id: 1,
+      expose_in_sqllab: true,
+      force_ctas_schema: null,
+      id: 1,
+    },
+    {
+      allow_csv_upload: false,
+      allow_ctas: false,
+      allow_cvas: false,
+      allow_dml: false,
+      allow_multi_schema_metadata_fetch: false,
+      allow_run_async: false,
+      allows_cost_estimate: null,
+      allows_subquery: true,
+      allows_virtual_table_explore: true,
+      disable_data_preview: false,
+      backend: 'mysql',
+      changed_on: '2021-03-09T19:02:07.141095',
+      changed_on_delta_humanized: 'a day ago',
+      created_by: null,
+      database_name: 'test-mysql',
+      explore_database_id: 1,
+      expose_in_sqllab: true,
+      force_ctas_schema: null,
+      id: 2,
+    },
+  ],
+});
 
-describe('LeftPanel', () => {
-  const mockFun = jest.fn();
+fetchMock.get(schemasEndpoint, {
+  result: ['information_schema', 'public'],
+});
 
-  const SupersetClientGet = jest.spyOn(SupersetClient, 'get');
+fetchMock.get(tablesEndpoint, {
+  tableLength: 3,
+  options: [
+    { value: 'Sheet1', type: 'table', extra: null },
+    { value: 'Sheet2', type: 'table', extra: null },
+    { value: 'Sheet3', type: 'table', extra: null },
+  ],
+});
 
-  beforeEach(() => {
-    jest.resetAllMocks();
-    SupersetClientGet.mockImplementation(
-      async ({ endpoint }: { endpoint: string }) => {
-        console.log('FINDME TEST', endpoint);
-        if (endpoint.includes('schemas')) {
-          return {
-            json: { result: ['information_schema', 'public'] },
-          } as any;
-        }
-        if (endpoint.includes('tables')) {
-          return {
-            tableLength: 1,
-            options: [{ value: 'Sheet1', type: 'table', extra: null }],
-          };
-        }
-        return {
-          json: {
-            count: 2,
-            description_columns: {},
-            ids: [1, 2],
-            label_columns: {
-              allow_file_upload: 'Allow Csv Upload',
-              allow_ctas: 'Allow Ctas',
-              allow_cvas: 'Allow Cvas',
-              allow_dml: 'Allow Dml',
-              allow_multi_schema_metadata_fetch:
-                'Allow Multi Schema Metadata Fetch',
-              allow_run_async: 'Allow Run Async',
-              allows_cost_estimate: 'Allows Cost Estimate',
-              allows_subquery: 'Allows Subquery',
-              allows_virtual_table_explore: 'Allows Virtual Table Explore',
-              disable_data_preview: 'Disables SQL Lab Data Preview',
-              backend: 'Backend',
-              changed_on: 'Changed On',
-              changed_on_delta_humanized: 'Changed On Delta Humanized',
-              'created_by.first_name': 'Created By First Name',
-              'created_by.last_name': 'Created By Last Name',
-              database_name: 'Database Name',
-              explore_database_id: 'Explore Database Id',
-              expose_in_sqllab: 'Expose In Sqllab',
-              force_ctas_schema: 'Force Ctas Schema',
-              id: 'Id',
-            },
-            list_columns: [
-              'allow_file_upload',
-              'allow_ctas',
-              'allow_cvas',
-              'allow_dml',
-              'allow_multi_schema_metadata_fetch',
-              'allow_run_async',
-              'allows_cost_estimate',
-              'allows_subquery',
-              'allows_virtual_table_explore',
-              'disable_data_preview',
-              'backend',
-              'changed_on',
-              'changed_on_delta_humanized',
-              'created_by.first_name',
-              'created_by.last_name',
-              'database_name',
-              'explore_database_id',
-              'expose_in_sqllab',
-              'force_ctas_schema',
-              'id',
-            ],
-            list_title: 'List Database',
-            order_columns: [
-              'allow_file_upload',
-              'allow_dml',
-              'allow_run_async',
-              'changed_on',
-              'changed_on_delta_humanized',
-              'created_by.first_name',
-              'database_name',
-              'expose_in_sqllab',
-            ],
-            result: [
-              {
-                allow_file_upload: false,
-                allow_ctas: false,
-                allow_cvas: false,
-                allow_dml: false,
-                allow_multi_schema_metadata_fetch: false,
-                allow_run_async: false,
-                allows_cost_estimate: null,
-                allows_subquery: true,
-                allows_virtual_table_explore: true,
-                disable_data_preview: false,
-                backend: 'postgresql',
-                changed_on: '2021-03-09T19:02:07.141095',
-                changed_on_delta_humanized: 'a day ago',
-                created_by: null,
-                database_name: 'test-postgres',
-                explore_database_id: 1,
-                expose_in_sqllab: true,
-                force_ctas_schema: null,
-                id: 1,
-              },
-              {
-                allow_csv_upload: false,
-                allow_ctas: false,
-                allow_cvas: false,
-                allow_dml: false,
-                allow_multi_schema_metadata_fetch: false,
-                allow_run_async: false,
-                allows_cost_estimate: null,
-                allows_subquery: true,
-                allows_virtual_table_explore: true,
-                disable_data_preview: false,
-                backend: 'mysql',
-                changed_on: '2021-03-09T19:02:07.141095',
-                changed_on_delta_humanized: 'a day ago',
-                created_by: null,
-                database_name: 'test-mysql',
-                explore_database_id: 1,
-                expose_in_sqllab: true,
-                force_ctas_schema: null,
-                id: 2,
-              },
-            ],
-          },
-        } as any;
-      },
-    );
+const mockFun = jest.fn();
+
+test('should render', async () => {
+  render(<LeftPanel setDataset={mockFun} />, {
+    useRedux: true,
+  });
+  expect(
+    await screen.findByText(/select database & schema/i),
+  ).toBeInTheDocument();
+});
+
+test('should render schema selector, database selector container, and selects', async () => {
+  render(<LeftPanel setDataset={mockFun} />, { useRedux: true });
+
+  expect(await screen.findByText(/select database & schema/i)).toBeVisible();
+
+  const databaseSelect = screen.getByRole('combobox', {
+    name: 'Select database or type database name',
+  });
+  const schemaSelect = screen.getByRole('combobox', {
+    name: 'Select schema or type schema name',
+  });
+  expect(databaseSelect).toBeInTheDocument();
+  expect(schemaSelect).toBeInTheDocument();
+});
+
+test('does not render blank state if there is nothing selected', async () => {
+  render(<LeftPanel setDataset={mockFun} />, { useRedux: true });
+
+  expect(
+    await screen.findByText(/select database & schema/i),
+  ).toBeInTheDocument();
+  const emptyState = screen.queryByRole('img', { name: /empty/i });
+  expect(emptyState).not.toBeInTheDocument();
+});
+
+test('renders list of options when user clicks on schema', async () => {
+  render(<LeftPanel setDataset={mockFun} schema="schema_a" dbId={1} />, {
+    useRedux: true,
   });
 
-  const getTableMockFunction = async () =>
-    ({
-      tableLength: 1,
-      options: [{ value: 'Sheet1', type: 'table', extra: null }],
-    } as any);
+  // Click 'test-postgres' database to access schemas
+  const databaseSelect = screen.getByRole('combobox', {
+    name: 'Select database or type database name',
+  });
+  // Schema select should be disabled until database is selected
+  const schemaSelect = screen.getByRole('combobox', {
+    name: /select schema or type schema name/i,
+  });
+  userEvent.click(databaseSelect);
+  expect(await screen.findByText('test-postgres')).toBeInTheDocument();
+  expect(schemaSelect).toBeDisabled();
+  userEvent.click(screen.getByText('test-postgres'));
 
-  test('should render', async () => {
-    render(<LeftPanel setDataset={mockFun} />, {
-      useRedux: true,
-    });
-    expect(
-      await screen.findByText(/select database & schema/i),
-    ).toBeInTheDocument();
+  // Wait for schema field to be enabled
+  await waitFor(() => {
+    expect(schemaSelect).toBeEnabled();
+  });
+});
+
+test('searches for a table name', async () => {
+  render(<LeftPanel setDataset={mockFun} schema="schema_a" dbId={1} />, {
+    useRedux: true,
   });
 
-  test('should render schema selector, databa selector container, and selects', async () => {
-    render(<LeftPanel setDataset={mockFun} />, { useRedux: true });
+  const databaseSelect = screen.getByRole('combobox', {
+    name: /select database or type database name/i,
+  });
+  userEvent.click(databaseSelect);
+  userEvent.click(await screen.findByText('test-postgres'));
 
-    expect(await screen.findByText(/select database & schema/i)).toBeVisible();
-
-    const databaseSelect = screen.getByRole('combobox', {
-      name: 'Select database or type database name',
-    });
-    const schemaSelect = screen.getByRole('combobox', {
-      name: 'Select schema or type schema name',
-    });
-    expect(databaseSelect).toBeInTheDocument();
-    expect(schemaSelect).toBeInTheDocument();
+  const schemaSelect = screen.getByRole('combobox', {
+    name: /select schema or type schema name/i,
   });
 
-  test('does not render blank state if there is nothing selected', async () => {
-    render(<LeftPanel setDataset={mockFun} />, { useRedux: true });
+  await waitFor(() => expect(schemaSelect).toBeEnabled());
 
-    expect(
-      await screen.findByText(/select database & schema/i),
-    ).toBeInTheDocument();
-    const emptyState = screen.queryByRole('img', { name: /empty/i });
-    expect(emptyState).not.toBeInTheDocument();
+  userEvent.click(schemaSelect);
+  userEvent.click(screen.getAllByText('public')[1]);
+
+  await waitFor(() => {
+    expect(screen.getByText('Sheet1')).toBeInTheDocument();
+    expect(screen.getByText('Sheet2')).toBeInTheDocument();
+    expect(screen.getByText('Sheet3')).toBeInTheDocument();
   });
 
-  test('renders list of options when user clicks on schema', async () => {
-    render(<LeftPanel setDataset={mockFun} schema="schema_a" dbId={1} />, {
-      useRedux: true,
-    });
+  userEvent.type(screen.getByRole('textbox'), 'Sheet2');
 
-    // Click 'test-postgres' database to access schemas
-    const databaseSelect = screen.getByRole('combobox', {
-      name: 'Select database or type database name',
-    });
-    // Schema select should be disabled until database is selected
-    const schemaSelect = screen.getByRole('combobox', {
-      name: /select schema or type schema name/i,
-    });
-    userEvent.click(databaseSelect);
-    expect(await screen.findByText('test-postgres')).toBeInTheDocument();
-    expect(schemaSelect).toBeDisabled();
-    userEvent.click(screen.getByText('test-postgres'));
-
-    // Wait for schema field to be enabled
-    await waitFor(() => {
-      expect(schemaSelect).toBeEnabled();
-    });
-
-    // // Todo: (Phillip) finish testing for showing list of options once table is implemented
-    // // screen.debug(screen.getByText('table_a'));
+  await waitFor(() => {
+    expect(screen.queryByText('Sheet1')).not.toBeInTheDocument();
+    expect(screen.getByText('Sheet2')).toBeInTheDocument();
+    expect(screen.queryByText('Sheet3')).not.toBeInTheDocument();
   });
 });

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/LeftPanel.test.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/LeftPanel.test.tsx
@@ -20,7 +20,7 @@ import React from 'react';
 import { SupersetClient } from '@superset-ui/core';
 // import fetchMock from 'fetch-mock';
 import userEvent from '@testing-library/user-event';
-import { render, screen, waitFor, within } from 'spec/helpers/testing-library';
+import { render, screen, waitFor } from 'spec/helpers/testing-library';
 import LeftPanel from 'src/views/CRUD/data/dataset/AddDataset/LeftPanel';
 
 // const tablesEndpoint = 'glob:*/superset/tables*';
@@ -219,44 +219,13 @@ describe('LeftPanel', () => {
     expect(await screen.findByText('test-postgres')).toBeInTheDocument();
     expect(schemaSelect).toBeDisabled();
     userEvent.click(screen.getByText('test-postgres'));
-    // screen.debug(databaseSelect);
-    // userEvent.selectOptions(databaseSelect, 'test-postgres');
 
     // Wait for schema field to be enabled
     await waitFor(() => {
       expect(schemaSelect).toBeEnabled();
     });
-    const lbs = screen.getAllByRole('listbox');
-    const cbs = screen.getAllByRole('combobox');
-    const options = screen.getAllByRole('option');
-
-    // userEvent.selectOptions(schemaSelect, '');
-    screen.debug(within(lbs[0]).getAllByRole('option')[1]);
-    userEvent.click(within(lbs[0]).getAllByRole('option')[1]);
-    // await waitFor(() =>
-    //   expect(screen.getByRole('option', { name: 'public' })).toBeVisible(),
-    // );
-    // // screen.debug(screen.getByRole('option', { name: 'information_schema' }));
-    // expect(
-    //   await screen.findByRole('option', { name: 'information_schema' }),
-    // ).toBeVisible();
-    // expect(await screen.findByRole('option', { name: 'public' })).toBeVisible();
-
-    // SupersetClientGet.mockImplementation(await getTableMockFunction());
-    // screen.logTestingPlaygroundURL();
-
-    // userEvent.click(screen.getByRole('option', { name: '2' }));
-    // screen.logTestingPlaygroundURL();
 
     // // Todo: (Phillip) finish testing for showing list of options once table is implemented
     // // screen.debug(screen.getByText('table_a'));
-    // screen.debug(screen.getAllByRole('option'));
-    // userEvent.selectOptions(
-    //   schemaSelect,
-    //   screen.getByRole('option', { name: 'public' }),
-    // );
-    // screen.logTestingPlaygroundURL();
-    // screen.debug(screen.getByTestId('options-list'));
-    // expect(screen.getByTestId('options-list')).toBeInTheDocument();
   });
 });

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/index.tsx
@@ -219,10 +219,14 @@ export default function LeftPanel({
     [dbId, encodedSchema],
   );
 
+  const filteredOptions = tableOptions.filter(option =>
+    option?.value?.toLowerCase().includes(searchVal.toLowerCase()),
+  );
+
   const Loader = (inline: string) => (
     <div className="loading-container">
       <Loading position="inline" />
-      <p>{inline} </p>
+      <p>{inline}</p>
     </div>
   );
 
@@ -273,7 +277,7 @@ export default function LeftPanel({
           </Form>
           <div className="options-list" data-test="options-list">
             {!refresh &&
-              tableOptions.map((option, i) => (
+              filteredOptions.map((option, i) => (
                 <div
                   className={
                     selectedTable === i ? 'options-highlighted' : 'options'


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR changed the left panel's search functionality from server side searching to client side searching.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### BEFORE:
![unsuccessfulTableSearch](https://user-images.githubusercontent.com/55605634/195189825-ff332aa1-bbe4-4fc4-a8a2-424aba1bbd30.gif)

#### AFTER:
![successfulTableSearch](https://user-images.githubusercontent.com/55605634/195189856-022c2f7e-e0fc-4d24-83f3-1b3f8c636911.gif)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Go to `http://localhost:9000/dataset/add/?testing`
- Select a database and schema
- Search for a table name
- Observe that the search functions correctly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
