### PR TITLE
fix(sqllab): remove set state on component update lifecycle

### DIFF
--- a/superset-frontend/src/SqlLab/components/SouthPane/SouthPane.test.jsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/SouthPane.test.jsx
@@ -25,60 +25,25 @@ import SouthPaneContainer from 'src/SqlLab/components/SouthPane/state';
 import ResultSet from 'src/SqlLab/components/ResultSet';
 import '@testing-library/jest-dom/extend-expect';
 import { STATUS_OPTIONS } from 'src/SqlLab/constants';
-import { initialState } from 'src/SqlLab/fixtures';
+import { initialState, table, defaultQueryEditor } from 'src/SqlLab/fixtures';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
 
 const NOOP = () => {};
 
 const mockedProps = {
-  editorQueries: [
-    {
-      cached: false,
-      changedOn: Date.now(),
-      db: 'main',
-      dbId: 1,
-      id: 'LCly_kkIN',
-      startDttm: Date.now(),
-    },
-    {
-      cached: false,
-      changedOn: 1559238500401,
-      db: 'main',
-      dbId: 1,
-      id: 'lXJa7F9_r',
-      startDttm: 1559238500401,
-    },
-    {
-      cached: false,
-      changedOn: 1559238506925,
-      db: 'main',
-      dbId: 1,
-      id: '2g2_iRFMl',
-      startDttm: 1559238506925,
-    },
-    {
-      cached: false,
-      changedOn: 1559238516395,
-      db: 'main',
-      dbId: 1,
-      id: 'erWdqEWPm',
-      startDttm: 1559238516395,
-    },
-  ],
+  queryEditorId: defaultQueryEditor.id,
   latestQueryId: 'LCly_kkIN',
-  dataPreviewQueries: [],
   actions: {},
   activeSouthPaneTab: '',
   height: 1,
   displayLimit: 1,
   databases: {},
-  offline: false,
+  defaultQueryLimit: 100,
 };
 
 const mockedEmptyProps = {
-  editorQueries: [],
+  queryEditorId: 'random_id',
   latestQueryId: '',
-  dataPreviewQueries: [],
   actions: {
     queryEditorSetAndSaveSql: NOOP,
     cloneQueryToNewTab: NOOP,
@@ -90,15 +55,75 @@ const mockedEmptyProps = {
   activeSouthPaneTab: '',
   height: 100,
   databases: '',
-  offline: false,
   displayLimit: 100,
   user: UserWithPermissionsAndRoles,
   defaultQueryLimit: 100,
 };
 
+// const tabHistory = ['dfsadfs', 'newEditorId'];
+
+// const tables = [
+//   { ...table, dataPreviewQueryId: 'B1-VQU1zW', queryEditorId: 'newEditorId' },
+// ];
+
+// const queries = {
+//   'B1-VQU1zW': {
+//     id: 'B1-VQU1zW',
+//     sqlEditorId: 'newEditorId',
+//     tableName: 'ab_user',
+//     state: 'success',
+//   },
+// };
+
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
-const store = mockStore(initialState);
+const store = mockStore({
+  ...initialState,
+  sqlLab: {
+    ...initialState,
+    offline: false,
+    tables: [],
+    databases: {},
+    queries: {
+      LCly_kkIN: {
+        cached: false,
+        changedOn: Date.now(),
+        db: 'main',
+        dbId: 1,
+        id: 'LCly_kkIN',
+        startDttm: Date.now(),
+        sqlEditorId: defaultQueryEditor.id,
+      },
+      lXJa7F9_r: {
+        cached: false,
+        changedOn: 1559238500401,
+        db: 'main',
+        dbId: 1,
+        id: 'lXJa7F9_r',
+        startDttm: 1559238500401,
+        sqlEditorId: defaultQueryEditor.id,
+      },
+      '2g2_iRFMl': {
+        cached: false,
+        changedOn: 1559238506925,
+        db: 'main',
+        dbId: 1,
+        id: '2g2_iRFMl',
+        startDttm: 1559238506925,
+        sqlEditorId: defaultQueryEditor.id,
+      },
+      erWdqEWPm: {
+        cached: false,
+        changedOn: 1559238516395,
+        db: 'main',
+        dbId: 1,
+        id: 'erWdqEWPm',
+        startDttm: 1559238516395,
+        sqlEditorId: defaultQueryEditor.id,
+      },
+    },
+  },
+});
 const setup = (overrides = {}) => (
   <SouthPaneContainer store={store} {...mockedProps} {...overrides} />
 );

--- a/superset-frontend/src/SqlLab/components/SouthPane/SouthPane.test.jsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/SouthPane.test.jsx
@@ -60,21 +60,6 @@ const mockedEmptyProps = {
   defaultQueryLimit: 100,
 };
 
-// const tabHistory = ['dfsadfs', 'newEditorId'];
-
-// const tables = [
-//   { ...table, dataPreviewQueryId: 'B1-VQU1zW', queryEditorId: 'newEditorId' },
-// ];
-
-// const queries = {
-//   'B1-VQU1zW': {
-//     id: 'B1-VQU1zW',
-//     sqlEditorId: 'newEditorId',
-//     tableName: 'ab_user',
-//     state: 'success',
-//   },
-// };
-
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
 const store = mockStore({
@@ -82,7 +67,13 @@ const store = mockStore({
   sqlLab: {
     ...initialState,
     offline: false,
-    tables: [],
+    tables: [
+      {
+        ...table,
+        dataPreviewQueryId: '2g2_iRFMl',
+        queryEditorId: defaultQueryEditor.id,
+      },
+    ],
     databases: {},
     queries: {
       LCly_kkIN: {
@@ -142,8 +133,13 @@ describe('SouthPane - Enzyme', () => {
   it('should pass latest query down to ResultSet component', () => {
     wrapper = getWrapper().dive();
     expect(wrapper.find(ResultSet)).toExist();
-    expect(wrapper.find(ResultSet).props().query.id).toEqual(
+    // for editorQueries
+    expect(wrapper.find(ResultSet).first().props().query.id).toEqual(
       mockedProps.latestQueryId,
+    );
+    // for dataPreviewQueries
+    expect(wrapper.find(ResultSet).last().props().query.id).toEqual(
+      '2g2_iRFMl',
     );
   });
 });

--- a/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
@@ -41,7 +41,8 @@ const TAB_HEIGHT = 140;
     editorQueries are queries executed by users passed from SqlEditor component
     dataPrebiewQueries are all queries executed for preview of table data (from SqlEditorLeft)
 */
-interface SouthPanePropTypes {
+export interface SouthPanePropTypes {
+  queryEditorId: string;
   editorQueries: any[];
   latestQueryId?: string;
   dataPreviewQueries: any[];

--- a/superset-frontend/src/SqlLab/components/SouthPane/state.ts
+++ b/superset-frontend/src/SqlLab/components/SouthPane/state.ts
@@ -19,14 +19,36 @@
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 import * as Actions from 'src/SqlLab/actions/sqlLab';
-import SouthPane from '.';
+import { SqlLabRootState } from 'src/SqlLab/types';
+import SouthPane, { SouthPanePropTypes } from '.';
 
-function mapStateToProps({ sqlLab }: Record<string, any>) {
+function mapStateToProps(
+  { sqlLab }: SqlLabRootState,
+  { queryEditorId }: SouthPanePropTypes,
+) {
+  const { databases, activeSouthPaneTab, offline, user, queries, tables } =
+    sqlLab;
+  const dataPreviewQueries = tables
+    .filter(
+      ({ dataPreviewQueryId, queryEditorId: qeId }) =>
+        dataPreviewQueryId &&
+        queryEditorId === qeId &&
+        queries[dataPreviewQueryId],
+    )
+    .map(({ name, dataPreviewQueryId }) => ({
+      ...queries[dataPreviewQueryId],
+      tableName: name,
+    }));
+  const editorQueries = Object.values(queries).filter(
+    ({ sqlEditorId }) => sqlEditorId === queryEditorId,
+  );
   return {
-    activeSouthPaneTab: sqlLab.activeSouthPaneTab,
-    databases: sqlLab.databases,
-    offline: sqlLab.offline,
-    user: sqlLab.user,
+    editorQueries,
+    dataPreviewQueries,
+    activeSouthPaneTab,
+    databases,
+    offline,
+    user,
   };
 }
 

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -615,6 +615,7 @@ const SqlEditor = ({
           {renderEditorBottomBar(hotkeys)}
         </div>
         <ConnectedSouthPane
+          queryEditorId={queryEditor.id}
           latestQueryId={latestQuery?.id}
           actions={actions}
           height={southPaneHeight}

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -137,8 +137,6 @@ const StyledSidebar = styled.div`
 const propTypes = {
   actions: PropTypes.object.isRequired,
   tables: PropTypes.array.isRequired,
-  editorQueries: PropTypes.array.isRequired,
-  dataPreviewQueries: PropTypes.array.isRequired,
   queryEditor: PropTypes.object.isRequired,
   defaultQueryLimit: PropTypes.number.isRequired,
   maxRow: PropTypes.number.isRequired,
@@ -150,8 +148,6 @@ const propTypes = {
 const SqlEditor = ({
   actions,
   tables,
-  editorQueries,
-  dataPreviewQueries,
   queryEditor,
   defaultQueryLimit,
   maxRow,
@@ -619,9 +615,7 @@ const SqlEditor = ({
           {renderEditorBottomBar(hotkeys)}
         </div>
         <ConnectedSouthPane
-          editorQueries={editorQueries}
           latestQueryId={latestQuery?.id}
-          dataPreviewQueries={dataPreviewQueries}
           actions={actions}
           height={southPaneHeight}
           displayLimit={displayLimit}

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors/TabbedSqlEditors.test.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors/TabbedSqlEditors.test.jsx
@@ -30,7 +30,7 @@ import { supersetTheme, ThemeProvider } from '@superset-ui/core';
 import { EditableTabs } from 'src/components/Tabs';
 import TabbedSqlEditors from 'src/SqlLab/components/TabbedSqlEditors';
 import SqlEditor from 'src/SqlLab/components/SqlEditor';
-import { table, initialState } from 'src/SqlLab/fixtures';
+import { initialState } from 'src/SqlLab/fixtures';
 import { newQueryTabName } from 'src/SqlLab/utils/newQueryTabName';
 import QueryProvider from 'src/views/QueryProvider';
 
@@ -42,12 +42,6 @@ describe('TabbedSqlEditors', () => {
   const middlewares = [thunk];
   const mockStore = configureStore(middlewares);
   const store = mockStore(initialState);
-
-  const tabHistory = ['dfsadfs', 'newEditorId'];
-
-  const tables = [
-    { ...table, dataPreviewQueryId: 'B1-VQU1zW', queryEditorId: 'newEditorId' },
-  ];
 
   const queryEditors = [
     {
@@ -61,14 +55,6 @@ describe('TabbedSqlEditors', () => {
       name: 'Untitled Query',
     },
   ];
-  const queries = {
-    'B1-VQU1zW': {
-      id: 'B1-VQU1zW',
-      sqlEditorId: 'newEditorId',
-      tableName: 'ab_user',
-      state: 'success',
-    },
-  };
   const mockedProps = {
     actions: {},
     databases: {},
@@ -143,20 +129,6 @@ describe('TabbedSqlEditors', () => {
       await mountWithAct();
       expect(window.history.replaceState.getCall(0).args[2]).toBe(
         '/superset/sqllab',
-      );
-    });
-  });
-  describe('UNSAFE_componentWillReceiveProps', () => {
-    beforeEach(() => {
-      wrapper = getWrapper();
-      wrapper.setProps({ queryEditors, queries, tabHistory, tables });
-    });
-    it('should update queriesArray and dataPreviewQueries', () => {
-      expect(wrapper.state().queriesArray.slice(-1)[0]).toBe(
-        queries['B1-VQU1zW'],
-      );
-      expect(wrapper.state().dataPreviewQueries.slice(-1)[0]).toEqual(
-        queries['B1-VQU1zW'],
       );
     });
   });

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.jsx
@@ -24,7 +24,6 @@ import { bindActionCreators } from 'redux';
 import URI from 'urijs';
 import { styled, t } from '@superset-ui/core';
 import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
-import { areArraysShallowEqual } from 'src/reduxUtils';
 import { Tooltip } from 'src/components/Tooltip';
 import { detectOS } from 'src/utils/common';
 import * as Actions from 'src/SqlLab/actions/sqlLab';

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.jsx
@@ -72,8 +72,6 @@ class TabbedSqlEditors extends React.PureComponent {
     const sqlLabUrl = '/superset/sqllab';
     this.state = {
       sqlLabUrl,
-      queriesArray: [],
-      dataPreviewQueries: [],
     };
     this.removeQueryEditor = this.removeQueryEditor.bind(this);
     this.duplicateQueryEditor = this.duplicateQueryEditor.bind(this);
@@ -186,37 +184,6 @@ class TabbedSqlEditors extends React.PureComponent {
     }
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    const nextActiveQeId =
-      nextProps.tabHistory[nextProps.tabHistory.length - 1];
-    const queriesArray = Object.values(nextProps.queries).filter(
-      query => query.sqlEditorId === nextActiveQeId,
-    );
-    if (!areArraysShallowEqual(queriesArray, this.state.queriesArray)) {
-      this.setState({ queriesArray });
-    }
-
-    const dataPreviewQueries = [];
-    nextProps.tables.forEach(table => {
-      const queryId = table.dataPreviewQueryId;
-      if (
-        queryId &&
-        nextProps.queries[queryId] &&
-        table.queryEditorId === nextActiveQeId
-      ) {
-        dataPreviewQueries.push({
-          ...nextProps.queries[queryId],
-          tableName: table.name,
-        });
-      }
-    });
-    if (
-      !areArraysShallowEqual(dataPreviewQueries, this.state.dataPreviewQueries)
-    ) {
-      this.setState({ dataPreviewQueries });
-    }
-  }
-
   popNewTab() {
     // Clean the url in browser history
     window.history.replaceState({}, document.title, this.state.sqlLabUrl);
@@ -298,8 +265,6 @@ class TabbedSqlEditors extends React.PureComponent {
         <SqlEditor
           tables={this.props.tables.filter(xt => xt.queryEditorId === qe.id)}
           queryEditor={qe}
-          editorQueries={this.state.queriesArray}
-          dataPreviewQueries={this.state.dataPreviewQueries}
           actions={this.props.actions}
           defaultQueryLimit={this.props.defaultQueryLimit}
           maxRow={this.props.maxRow}


### PR DESCRIPTION
### SUMMARY
Since the legacy TabbedSqlEditor component uses `UNSAFE_componentWillReceiveProps` lifecycle method to update the state for `editorQueries` and `dataPreviewQueries`, which **only** consumes in the result panel.
This can also violate the maximum update depth exceeded in some point. 

This commit deprecates `UNSAFE_componentWillReceiveProps` implementation and moves to the SouthPane connector where it actually needs.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="715" alt="Screen Shot 2022-10-11 at 11 00 46 AM" src="https://user-images.githubusercontent.com/1392866/195172412-44f5ee8a-5fc7-4515-9e3e-0bdf84155c8f.png">

<img width="874" alt="Screen Shot 2022-10-10 at 4 34 19 PM" src="https://user-images.githubusercontent.com/1392866/195174797-a630d588-087c-4e66-a885-c364169d8a2b.png">

After:
No errors

### TESTING INSTRUCTIONS
- Turn off `SQLLAB_BACKEND_PERSISTENCE`
- Go to SqlLab and open a tab
- Modify the localState of `redux.sqlLab.tables` (remove the table data associated to the current queryEditor id) from the array) in order to trigger the following setState update during lifecycle period.
 
https://github.com/apache/superset/blob/52d33b05fdb93b4e7a897641ae4e167528756829/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.jsx#L213-L216

- Refresh the page and check the console

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
cc: @ktmud 