### PR TITLE
fix: remove deprecated ETagResponseMixin

### DIFF
--- a/superset/utils/cache.py
+++ b/superset/utils/cache.py
@@ -25,7 +25,7 @@ from typing import Any, Callable, Dict, Optional, TYPE_CHECKING, Union
 from flask import current_app as app, request
 from flask_caching import Cache
 from flask_caching.backends import NullCache
-from werkzeug.wrappers.etag import ETagResponseMixin
+from werkzeug.wrappers import Response
 
 from superset import db
 from superset.extensions import cache_manager
@@ -175,7 +175,7 @@ def etag_cache(
 
     def decorator(f: Callable[..., Any]) -> Callable[..., Any]:
         @wraps(f)
-        def wrapper(*args: Any, **kwargs: Any) -> ETagResponseMixin:
+        def wrapper(*args: Any, **kwargs: Any) -> Response:
             # Check if the user can access the resource
             if raise_for_access:
                 try:


### PR DESCRIPTION
### SUMMARY
The Werkzeug 2.1 release removed some deprecated code and merged the ETagResponseMixin into the Response class. Instead of pinning superset to any flask or werkzeug version, I'm returning the Response object here instead of the mixin so that we can continue to support later versions. This seems to be an issue commonly found in Ubuntu systems.



### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes https://github.com/apache/superset/issues/20723
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
