### PR TITLE
fix(CustomFrame): Resolves issue #21731 where date range in explore throws runtime error

### DIFF
--- a/superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.test.tsx
@@ -40,12 +40,10 @@ const store = mockStore({
 });
 
 // case when common.locale is not populated
-const mockEmptyStore = configureStore([thunk]);
-const emptyStore = mockEmptyStore({});
+const emptyStore = mockStore({});
 
 // case when common.locale is populated with invalid locale
-const mockInvalidStore = configureStore([thunk]);
-const invalidStore = mockInvalidStore({ common: { locale: 'invalid_locale' } });
+const invalidStore = mockStore({ common: { locale: 'invalid_locale' } });
 
 test('renders with default props', () => {
   render(

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.test.tsx
@@ -39,6 +39,14 @@ const store = mockStore({
   common: { locale: 'en' },
 });
 
+// case when common.locale is not populated
+const mockEmptyStore = configureStore([thunk]);
+const emptyStore = mockEmptyStore({});
+
+// case when common.locale is populated with invalid locale
+const mockInvalidStore = configureStore([thunk]);
+const invalidStore = mockInvalidStore({ common: { locale: 'invalid_locale' } });
+
 test('renders with default props', () => {
   render(
     <Provider store={store}>
@@ -51,6 +59,54 @@ test('renders with default props', () => {
   expect(screen.getByText('Days Before')).toBeInTheDocument();
   expect(screen.getByText('Specific Date/Time')).toBeInTheDocument();
   expect(screen.getByRole('img', { name: 'calendar' })).toBeInTheDocument();
+});
+
+test('renders with empty store', () => {
+  render(
+    <Provider store={emptyStore}>
+      <CustomFrame onChange={jest.fn()} value={emptyValue} />
+    </Provider>,
+  );
+  expect(screen.getByText('Configure custom time range')).toBeInTheDocument();
+  expect(screen.getByText('Relative Date/Time')).toBeInTheDocument();
+  expect(screen.getByRole('spinbutton')).toBeInTheDocument();
+  expect(screen.getByText('Days Before')).toBeInTheDocument();
+  expect(screen.getByText('Specific Date/Time')).toBeInTheDocument();
+  expect(screen.getByRole('img', { name: 'calendar' })).toBeInTheDocument();
+});
+
+test('renders since and until with specific date/time with default locale', () => {
+  render(
+    <Provider store={emptyStore}>
+      <CustomFrame onChange={jest.fn()} value={specificValue} />
+    </Provider>,
+  );
+  expect(screen.getAllByText('Specific Date/Time').length).toBe(2);
+  expect(screen.getAllByRole('img', { name: 'calendar' }).length).toBe(2);
+});
+
+test('renders with invalid locale', () => {
+  render(
+    <Provider store={invalidStore}>
+      <CustomFrame onChange={jest.fn()} value={emptyValue} />
+    </Provider>,
+  );
+  expect(screen.getByText('Configure custom time range')).toBeInTheDocument();
+  expect(screen.getByText('Relative Date/Time')).toBeInTheDocument();
+  expect(screen.getByRole('spinbutton')).toBeInTheDocument();
+  expect(screen.getByText('Days Before')).toBeInTheDocument();
+  expect(screen.getByText('Specific Date/Time')).toBeInTheDocument();
+  expect(screen.getByRole('img', { name: 'calendar' })).toBeInTheDocument();
+});
+
+test('renders since and until with specific date/time with invalid locale', () => {
+  render(
+    <Provider store={invalidStore}>
+      <CustomFrame onChange={jest.fn()} value={specificValue} />
+    </Provider>,
+  );
+  expect(screen.getAllByText('Specific Date/Time').length).toBe(2);
+  expect(screen.getAllByRole('img', { name: 'calendar' }).length).toBe(2);
 });
 
 test('renders since and until with specific date/time', () => {

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.tsx
@@ -110,9 +110,15 @@ export function CustomFrame(props: FrameComponentProps) {
     }
   }
 
-  const localFromFlaskBabel =
-    useSelector((state: ExplorePageState) => state.common.locale) || 'en';
-  const currentLocale = locales[LOCALE_MAPPING[localFromFlaskBabel]].DatePicker;
+  // check if there is a locale defined for explore
+  const localFromFlaskBabel = useSelector(
+    (state: ExplorePageState) => state?.common?.locale,
+  );
+  // An undefined datePickerLocale is acceptable if no match is found in the LOCALE_MAPPING[localFromFlaskBabel] lookup
+  // and will fall back to antd's default locale when the antd DataPicker's prop locale === undefined
+  // This also protects us from the case where state is populated with a locale that antd locales does not recognize
+  const datePickerLocale =
+    locales[LOCALE_MAPPING[localFromFlaskBabel]]?.DatePicker;
 
   return (
     <div data-test="custom-frame">
@@ -141,7 +147,7 @@ export function CustomFrame(props: FrameComponentProps) {
                   onChange('sinceDatetime', datetime.format(MOMENT_FORMAT))
                 }
                 allowClear={false}
-                locale={currentLocale}
+                locale={datePickerLocale}
               />
             </Row>
           )}
@@ -194,7 +200,7 @@ export function CustomFrame(props: FrameComponentProps) {
                   onChange('untilDatetime', datetime.format(MOMENT_FORMAT))
                 }
                 allowClear={false}
-                locale={currentLocale}
+                locale={datePickerLocale}
               />
             </Row>
           )}
@@ -252,7 +258,7 @@ export function CustomFrame(props: FrameComponentProps) {
                   }
                   allowClear={false}
                   className="control-anchor-to-datetime"
-                  locale={currentLocale}
+                  locale={datePickerLocale}
                 />
               </Col>
             )}


### PR DESCRIPTION


<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Resolves issue #21731 where date range in explore throws runtime error when explore.common is undefined in Redux state.  
See associated issue: https://github.com/apache/superset/issues/21731

This issue is reproducible from the 2.0.0 and 2.0.1 RC1 releases but the change also improves runtime resilience of master.  PR is targeting master, but intended to be cherry picked into the 2.0.1 RC1 as well.

Changes made in superset/superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.tsx 

in PR https://github.com/apache/superset/pull/20063/files#diff-ac08ce133d14a8a92607bf02bc368b6b52b8314ddef1b872e42746ba8d6038d0

introduced a bug that expects redux state to contain a path that may be undefined, and assume that a provided locale is valid and known by antd.  This fix ensures safety checks are made and that antd DatePicker can fall back to internal default is a compatible locale is not identified.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
See associated issue: https://github.com/apache/superset/issues/21731

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
See associated issue: https://github.com/apache/superset/issues/21731

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: #21731 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
