### PR TITLE
fix(plugin-chart-handlebars): Update webpack/babel config to fix build/runtime warnings/errors

### DIFF
--- a/superset-frontend/babel.config.js
+++ b/superset-frontend/babel.config.js
@@ -20,7 +20,7 @@ const packageConfig = require('./package');
 
 module.exports = {
   sourceMaps: true,
-  sourceType: 'module',
+  sourceType: 'unambiguous',
   retainLines: true,
   presets: [
     [

--- a/superset-frontend/babel.config.js
+++ b/superset-frontend/babel.config.js
@@ -20,7 +20,7 @@ const packageConfig = require('./package');
 
 module.exports = {
   sourceMaps: true,
-  sourceType: 'unambiguous',
+  sourceType: 'module',
   retainLines: true,
   presets: [
     [
@@ -103,4 +103,10 @@ module.exports = {
       plugins: [],
     },
   },
+  overrides: [
+    {
+      test: './plugins/plugin-chart-handlebars/node_modules/just-handlebars-helpers/*',
+      sourceType: 'unambiguous',
+    },
+  ],
 };

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -289,6 +289,7 @@ const config = {
       //  AntD version conflict has been resolved
       antd: path.resolve(path.join(APP_DIR, './node_modules/antd')),
       react: path.resolve(path.join(APP_DIR, './node_modules/react')),
+      handlebars: 'handlebars/dist/handlebars.js',
     },
     extensions: ['.ts', '.tsx', '.js', '.jsx', '.yml'],
     fallback: {

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -289,6 +289,8 @@ const config = {
       //  AntD version conflict has been resolved
       antd: path.resolve(path.join(APP_DIR, './node_modules/antd')),
       react: path.resolve(path.join(APP_DIR, './node_modules/react')),
+      // TODO: remove Handlebars alias once Handlebars NPM package has been updated to
+      // correctly support webpack import (https://github.com/handlebars-lang/handlebars.js/issues/953)
       handlebars: 'handlebars/dist/handlebars.js',
     },
     extensions: ['.ts', '.tsx', '.js', '.jsx', '.yml'],


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR is an attempt to fix the Handlebars viz plugin, which currently raises both build and runtime errors, by updating Webpack and Babel config.

#### Build warning
Webpack would emit the following warning several times during build: `require.extensions is not supported by webpack. Use a loader instead.`.  The source listed was various lines in `./node_modules/handlebars/lib/index.js`.  According to the Handlebars GH project, this is due to the package not correctly indicating which build is client-side-compatible.  A [fix](https://github.com/handlebars-lang/handlebars.js/pull/1862) was merged, but it hasn't made it into an NPM-published release.  A workaround was recommended by [this comment](https://github.com/handlebars-lang/handlebars.js/issues/953#issuecomment-239874313) and is included in this PR.  This issue doesn't seem to be related to the runtime error and this fix just clears the build warning.

#### Runtime error
When rendering a Handlebars chart in Explore, the following error appears: `ReferenceError: exports is not defined`.  An inspection of the console shows that the culprit is the `just-handlebars-helpers` package's references to `exports`, as is standard in the CJS module system.  After some digging, I found [this comment](https://github.com/webpack/webpack/issues/4039#issuecomment-419284940) that makes me think the problem is a CJS/ESM incompatibility: our Babel setup assumes all JS is ESM-style modules and therefore doesn't transpile CJS-style `require` and `module.exports` statements into `import`/`export` statements, and Webpack assumes Babel output is ESM-style modules and doesn't provide global `require`/`module.exports` that you'd find in a CJS environment, causing this error (`just-handlebars-helpers` seems to be CJS-only).  As suggested by the comment, I changed `sourceType` to `unambiguous` so it stops assuming modules are ESM-style and instead makes a guess based on the presence of `require`/`module.exports`.  This seems to fix the issue, though I don't have a great sense of what else this might affect.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

<img width="638" alt="Screen Shot 2022-10-11 at 8 59 13 PM" src="https://user-images.githubusercontent.com/13007381/195239857-bcf58122-033f-4ef2-aeaf-78cee419efb1.png">

<img width="897" alt="Screen Shot 2022-10-11 at 8 59 24 PM" src="https://user-images.githubusercontent.com/13007381/195239878-7803d2ef-80ca-4a5a-9226-8a1d1ecf848c.png">

After:

<img width="638" alt="Screen Shot 2022-10-11 at 9 00 27 PM" src="https://user-images.githubusercontent.com/13007381/195239925-9b694af4-9e52-468d-867b-32a070a9a370.png">

<img width="895" alt="Screen Shot 2022-10-11 at 9 00 35 PM" src="https://user-images.githubusercontent.com/13007381/195239937-e19fb700-19fe-4ec3-84dc-1934aac3bed5.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Run webpack and ensure the aforementioned build warnings are gone.
- Try creating a Handlebars chart and ensure the runtime error doesn't show up.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
