### PR TITLE
perf(native-filters): reduce the re-rendering of native filter modal

### DIFF
--- a/superset-frontend/cypress-base/cypress/support/directories.ts
+++ b/superset-frontend/cypress-base/cypress/support/directories.ts
@@ -360,8 +360,7 @@ export const nativeFilters = {
   silentLoading: '.loading inline-centered css-101mkpk',
   filterConfigurationSections: {
     sectionHeader: '.ant-collapse-header',
-    displayedSection:
-      'div[style="height: 100%; overflow-y: auto; display: block;"]',
+    displayedSection: 'div[style="height: 100%; overflow-y: auto;"]',
     collapseExpandButton: '.ant-collapse-arrow',
     checkedCheckbox: '.ant-checkbox-wrapper-checked',
     infoTooltip: '[aria-label="Show info tooltip"]',

--- a/superset-frontend/cypress-base/cypress/support/directories.ts
+++ b/superset-frontend/cypress-base/cypress/support/directories.ts
@@ -360,7 +360,8 @@ export const nativeFilters = {
   silentLoading: '.loading inline-centered css-101mkpk',
   filterConfigurationSections: {
     sectionHeader: '.ant-collapse-header',
-    displayedSection: 'div[style="height: 100%; overflow-y: auto;"]',
+    displayedSection:
+      'div[style="height: 100%; overflow-y: auto; display: block;"]',
     collapseExpandButton: '.ant-collapse-arrow',
     checkedCheckbox: '.ant-checkbox-wrapper-checked',
     infoTooltip: '[aria-label="Show info tooltip"]',

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterConfigurationLink/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterConfigurationLink/index.tsx
@@ -54,7 +54,7 @@ export const FilterConfigurationLink: React.FC<FCBProps> = ({
     [dispatch, close],
   );
 
-  const onClick = useCallback(() => {
+  const handleClick = useCallback(() => {
     setOpen(true);
   }, [setOpen]);
 
@@ -65,7 +65,7 @@ export const FilterConfigurationLink: React.FC<FCBProps> = ({
         {...getFilterBarTestId('create-filter')}
         buttonStyle="link"
         buttonSize="xsmall"
-        onClick={onClick}
+        onClick={handleClick}
       >
         {children}
       </HeaderButton>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterConfigurationLink/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterConfigurationLink/index.tsx
@@ -16,17 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { setFilterConfiguration } from 'src/dashboard/actions/nativeFilters';
 import Button from 'src/components/Button';
 import { FilterConfiguration, styled } from '@superset-ui/core';
-import { FiltersConfigModal } from 'src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal';
+import FiltersConfigModal from 'src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal';
 import { getFilterBarTestId } from '..';
 
 export interface FCBProps {
   createNewOnOpen?: boolean;
   dashboardId?: number;
+  children?: React.ReactNode;
 }
 
 const HeaderButton = styled(Button)`
@@ -41,14 +42,21 @@ export const FilterConfigurationLink: React.FC<FCBProps> = ({
   const dispatch = useDispatch();
   const [isOpen, setOpen] = useState(false);
 
-  function close() {
+  const close = useCallback(() => {
     setOpen(false);
-  }
+  }, [setOpen]);
 
-  async function submit(filterConfig: FilterConfiguration) {
-    dispatch(await setFilterConfiguration(filterConfig));
-    close();
-  }
+  const submit = useCallback(
+    async (filterConfig: FilterConfiguration) => {
+      dispatch(await setFilterConfiguration(filterConfig));
+      close();
+    },
+    [dispatch, close],
+  );
+
+  const onClick = useCallback(() => {
+    setOpen(true);
+  }, [setOpen]);
 
   return (
     <>
@@ -57,7 +65,7 @@ export const FilterConfigurationLink: React.FC<FCBProps> = ({
         {...getFilterBarTestId('create-filter')}
         buttonStyle="link"
         buttonSize="xsmall"
-        onClick={() => setOpen(true)}
+        onClick={onClick}
       >
         {children}
       </HeaderButton>
@@ -72,4 +80,4 @@ export const FilterConfigurationLink: React.FC<FCBProps> = ({
   );
 };
 
-export default FilterConfigurationLink;
+export default React.memo(FilterConfigurationLink);

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/index.tsx
@@ -18,7 +18,7 @@
  */
 /* eslint-disable no-param-reassign */
 import { css, styled, t, useTheme } from '@superset-ui/core';
-import React, { FC } from 'react';
+import React, { FC, useMemo } from 'react';
 import Icons from 'src/components/Icons';
 import Button from 'src/components/Button';
 import { useSelector } from 'react-redux';
@@ -74,7 +74,7 @@ const AddFiltersButtonContainer = styled.div`
 const Header: FC<HeaderProps> = ({ toggleFiltersBar }) => {
   const theme = useTheme();
   const filters = useFilters();
-  const filterValues = Object.values(filters);
+  const filterValues = useMemo(() => Object.values(filters), [filters]);
   const canEdit = useSelector<RootState, boolean>(
     ({ dashboardInfo }) => dashboardInfo.dash_edit_perm,
   );
@@ -109,4 +109,4 @@ const Header: FC<HeaderProps> = ({ toggleFiltersBar }) => {
   );
 };
 
-export default Header;
+export default React.memo(Header);

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
@@ -32,8 +32,7 @@ import {
   TimeFilterPlugin,
   TimeGrainFilterPlugin,
 } from 'src/filters/components';
-import {
-  FiltersConfigModal,
+import FiltersConfigModal, {
   FiltersConfigModalProps,
 } from './FiltersConfigModal';
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/NativeFiltersModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/NativeFiltersModal.test.tsx
@@ -28,7 +28,7 @@ import waitForComponentToPaint from 'spec/helpers/waitForComponentToPaint';
 import { AntdDropdown } from 'src/components';
 import { Menu } from 'src/components/Menu';
 import Alert from 'src/components/Alert';
-import { FiltersConfigModal } from 'src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal';
+import FiltersConfigModal from 'src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal';
 
 Object.defineProperty(window, 'matchMedia', {
   writable: true,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We use `why-did-you-render` tool to measure the re-rendering of the native filter modal. This PR improves native filter modal in two scenarios (which has more than 20 native filters):

- Enter the dashboard for the first time:
  - before: 1000+ re-rendering <img width="218" alt="image" src="https://user-images.githubusercontent.com/11830681/195267652-db977c48-86e0-4e03-bd51-68e72d69d5a3.png">

  - after: 0 re-rendering <img width="227" alt="image" src="https://user-images.githubusercontent.com/11830681/195266152-15d2d90d-5795-4984-a568-41eeea7c5a84.png">

- Close the native filter model:
  - before: 28 re-rendering <img width="200" alt="image" src="https://user-images.githubusercontent.com/11830681/195268195-8f38d6eb-b3ba-4fa5-b909-2fa7019b5310.png">
  - after: 8 re-rendering <img width="198" alt="image" src="https://user-images.githubusercontent.com/11830681/195268867-b4484165-5a2e-413e-b07b-7ba2f2717686.png">

In next PR I will improve the filter configure form in the modal.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/21147
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
