### PR TITLE
chore: stop logging "SyntaxError" as exceptions

### DIFF
--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -313,8 +313,6 @@ def execute_sql_statement(  # pylint: disable=too-many-arguments,too-many-statem
         if query.status == QueryStatus.STOPPED:
             raise SqlLabQueryStoppedException() from ex
 
-        logger.error("Query %d: %s", query.id, type(ex), exc_info=True)
-        logger.debug("Query %d: %s", query.id, ex)
         raise SqlLabException(db_engine_spec.extract_error_message(ex)) from ex
 
     logger.debug("Query %d: Fetching cursor description", query.id)

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -313,6 +313,7 @@ def execute_sql_statement(  # pylint: disable=too-many-arguments,too-many-statem
         if query.status == QueryStatus.STOPPED:
             raise SqlLabQueryStoppedException() from ex
 
+        logger.debug("Query %d: %s", query.id, ex)
         raise SqlLabException(db_engine_spec.extract_error_message(ex)) from ex
 
     logger.debug("Query %d: Fetching cursor description", query.id)

--- a/superset/sqllab/command.py
+++ b/superset/sqllab/command.py
@@ -132,7 +132,8 @@ class ExecuteSqlCommand(BaseCommand):
                 ) from ex
             raise ex
         except Exception as ex:
-            logger.exception("Query %d: %s", query.id, type(ex))
+            query_id = query.id if query else None
+            logger.exception("Query %d: %s", query_id, type(ex))
             raise SqlLabException(self._execution_context, exception=ex) from ex
 
     def _try_get_existing_query(self) -> Optional[Query]:

--- a/superset/sqllab/command.py
+++ b/superset/sqllab/command.py
@@ -132,6 +132,8 @@ class ExecuteSqlCommand(BaseCommand):
                 ) from ex
             raise ex
         except Exception as ex:
+            logger.error("Query %d: %s", query.id, type(ex), exc_info=True)
+            logger.debug("Query %d: %s", query.id, ex)
             raise SqlLabException(self._execution_context, exception=ex) from ex
 
     def _try_get_existing_query(self) -> Optional[Query]:

--- a/superset/sqllab/command.py
+++ b/superset/sqllab/command.py
@@ -133,7 +133,6 @@ class ExecuteSqlCommand(BaseCommand):
             raise ex
         except Exception as ex:
             logger.error("Query %d: %s", query.id, type(ex), exc_info=True)
-            logger.debug("Query %d: %s", query.id, ex)
             raise SqlLabException(self._execution_context, exception=ex) from ex
 
     def _try_get_existing_query(self) -> Optional[Query]:

--- a/superset/sqllab/command.py
+++ b/superset/sqllab/command.py
@@ -132,7 +132,7 @@ class ExecuteSqlCommand(BaseCommand):
                 ) from ex
             raise ex
         except Exception as ex:
-            logger.error("Query %d: %s", query.id, type(ex), exc_info=True)
+            logger.exception("Query %d: %s", query.id, type(ex))
             raise SqlLabException(self._execution_context, exception=ex) from ex
 
     def _try_get_existing_query(self) -> Optional[Query]:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Moving exception logs to upper level `command.py` file since we are doing filtering of Syntax errors there. The goals is not to log users errors on our end. This PR will be an example for other errors that we might not want to log as exceptions.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
