### PR TITLE
fix(dashboard): Fix filter_scopes override on json editor

### DIFF
--- a/superset-frontend/src/SqlLab/components/TableElement/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TableElement/index.tsx
@@ -72,6 +72,10 @@ const Fade = styled.div`
   opacity: ${(props: { hovered: boolean }) => (props.hovered ? 1 : 0)};
 `;
 
+const WrappedBox = styled.small`
+  word-break: break-all;
+`;
+
 const TableElement = ({ table, ...props }: TableElementProps) => {
   const dispatch = useDispatch();
 
@@ -116,9 +120,9 @@ const TableElement = ({ table, ...props }: TableElementProps) => {
 
       partitions = (
         <div>
-          <small>
+          <WrappedBox>
             {t('latest partition:')} {latest}
-          </small>{' '}
+          </WrappedBox>{' '}
           {partitionClipBoard}
         </div>
       );
@@ -127,9 +131,9 @@ const TableElement = ({ table, ...props }: TableElementProps) => {
     if (table.metadata) {
       metadata = Object.entries(table.metadata).map(([key, value]) => (
         <div>
-          <small>
+          <WrappedBox>
             <strong>{key}:</strong> {value}
-          </small>
+          </WrappedBox>
         </div>
       ));
     }

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -46,7 +46,6 @@ import UndoRedoKeyListeners from 'src/dashboard/components/UndoRedoKeyListeners'
 import PropertiesModal from 'src/dashboard/components/PropertiesModal';
 import { chartPropShape } from 'src/dashboard/util/propShapes';
 import { getDashboardFilterKey } from 'src/dashboard/util/getDashboardFilterKey';
-import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
 import {
   UNDO_LIMIT,
   SAVE_TYPE_OVERWRITE,

--- a/superset-frontend/src/dashboard/containers/DashboardHeader.jsx
+++ b/superset-frontend/src/dashboard/containers/DashboardHeader.jsx
@@ -42,6 +42,7 @@ import {
   setRefreshFrequency,
   onRefresh,
 } from 'src/dashboard/actions/dashboardState';
+import { updateDashboardFiltersScope } from 'src/dashboard/actions/dashboardFilters';
 
 import {
   undoLayoutAction,
@@ -132,6 +133,7 @@ function mapDispatchToProps(dispatch) {
       dashboardTitleChanged,
       updateDataMask,
       fetchUISpecificReport,
+      updateDashboardFiltersScope,
     },
     dispatch,
   );


### PR DESCRIPTION
### SUMMARY
Since `filter_scopes` key overrides by the redux state, hard-coded `filter_scopes` value from json editor ignored.

https://github.com/apache/superset/blob/75e6a04269bf73c0c7160290333ded4e63421a4b/superset-frontend/src/dashboard/actions/dashboardState.js#L356-L362

This commit adds the redux updateDashboardFiltersScope logic from the json editor.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

- Before


https://user-images.githubusercontent.com/1392866/195411595-776d3c4a-209e-4b3d-96dc-ff1b1cd1f92d.mov

- After

https://user-images.githubusercontent.com/1392866/195411604-333489b7-94db-43a7-9c7f-928e37f2be14.mov

### TESTING INSTRUCTIONS
Go to a dashboard has a filter box
Open "Edit Properties" and then change the `filter_scopes` value from JSON editor
Check the updates from "set filter mapping" modal

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @ktmud 