### PR TITLE
fix(explore): Persist URL params to form-data

### DIFF
--- a/superset/explore/commands/get.py
+++ b/superset/explore/commands/get.py
@@ -19,7 +19,7 @@ from abc import ABC
 from typing import Any, cast, Dict, Optional
 
 import simplejson as json
-from flask import current_app as app
+from flask import current_app, request
 from flask_babel import gettext as __, lazy_gettext as _
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -121,7 +121,7 @@ class GetExploreCommand(BaseCommand, ABC):
         dataset_name = dataset.name if dataset else _("[Missing Dataset]")
 
         if dataset:
-            if app.config["ENABLE_ACCESS_REQUEST"] and (
+            if current_app.config["ENABLE_ACCESS_REQUEST"] and (
                 not security_manager.can_access_datasource(dataset)
             ):
                 message = __(security_manager.get_datasource_access_error_msg(dataset))
@@ -139,9 +139,10 @@ class GetExploreCommand(BaseCommand, ABC):
             str(self._dataset_id) + "__" + cast(str, self._dataset_type)
         )
 
-        # On explore, merge legacy and extra filters into the form data
+        # On explore, merge legacy/extra filters and URL params into the form data
         utils.convert_legacy_filters_into_adhoc(form_data)
         utils.merge_extra_filters(form_data)
+        utils.merge_request_params(form_data, request.args)
 
         dummy_dataset_data: Dict[str, Any] = {
             "type": self._dataset_type,

--- a/tests/integration_tests/explore/api_tests.py
+++ b/tests/integration_tests/explore/api_tests.py
@@ -226,3 +226,15 @@ def test_wrong_endpoint(mock_get_datasource, test_client, login_as_admin, datase
     data = json.loads(resp.data.decode("utf-8"))
     assert resp.status_code == 302
     assert data["redirect"] == dataset.default_endpoint
+
+
+def test_get_url_params(test_client, login_as_admin, chart_id):
+    resp = test_client.get(f"api/v1/explore/?slice_id={chart_id}&foo=bar")
+    assert resp.status_code == 200
+    data = json.loads(resp.data.decode("utf-8"))
+    result = data.get("result")
+
+    assert result["form_data"]["url_params"] == {
+        "foo": "bar",
+        "slice_id": str(chart_id),
+    }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR fixes a regression introduced in https://github.com/apache/superset/pull/20399 where the URL parameters—which are defined in the request arguments—were not persisted to the form-data, i.e., the code did not adhere the the existing logic defined in the soon to be deprecated legacy endpoint [here](https://github.com/apache/superset/blob/master/superset/views/core.py#L905-L907).

<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Added unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
