### PR TITLE
fix: Allow comma in Number Format

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx
@@ -125,6 +125,7 @@ const config: ControlPanelConfig = {
               description: `${t(
                 'D3 format syntax: https://github.com/d3/d3-format',
               )} ${t('Only applies when "Label Type" is set to show values.')}`,
+              tokenSeparators: ['\n', '\t', ';'],
             },
           },
         ],


### PR DESCRIPTION
### SUMMARY
This PR removes the comma from the token separators for the Number Format control so that it would be possible to create values that include commas.

### AFTER

https://user-images.githubusercontent.com/60598000/195866494-ebb7ce81-61a8-401a-a751-39bfa0c7cc08.mp4

### TESTING INSTRUCTIONS
1. Open a Pie Chart
2. Open the Customize tab
3. Enter a value that includes commas in the Number Format control
4. It should be possible to add commas

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
