### PR TITLE
fix(sqllab): Fix spacing on Schedule option in SqlEditor dropdown

### DIFF
--- a/superset-frontend/src/SqlLab/components/ScheduleQueryButton/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ScheduleQueryButton/index.tsx
@@ -101,7 +101,9 @@ export const StyledButtonComponent = styled(Button)`
     color: ${theme.colors.grayscale.dark2};
     font-size: 14px;
     font-weight: ${theme.typography.weights.normal};
+    margin-left: 0;
     &:disabled {
+      margin-left: 0;
       background: none;
       color: ${theme.colors.grayscale.dark2};
       &:hover {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes the spacing on the Schedule option in the SqlEditor dropdown.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### BEFORE:
<img width="212" alt="scheduleBefore" src="https://user-images.githubusercontent.com/55605634/196193445-8e820234-7f0e-4322-9ce6-6f987e050e48.png">

#### AFTER:
<img width="212" alt="scheduleAfter" src="https://user-images.githubusercontent.com/55605634/196192909-dba458ec-97f8-45bb-b3c8-13dbd5158f7d.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Go to SQL Lab
- Click the SQL Editor dropdown
- Observe that the spacing for Schedule is consistent with the other options

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
