### PR TITLE
feat(bigquery): Custom message when Service Account doesnt have the correct Roles and Permissions

### DIFF
--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -41,6 +41,7 @@ from superset.databases.commands.exceptions import (
     DatabaseDeleteFailedError,
     DatabaseInvalidError,
     DatabaseNotFoundError,
+    DatabaseTestConnectionFailedError,
     DatabaseUpdateFailedError,
     InvalidParametersError,
 )
@@ -278,6 +279,8 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
             return self.response_422(message=ex.normalized_messages())
         except DatabaseConnectionFailedError as ex:
             return self.response_422(message=str(ex))
+        except DatabaseTestConnectionFailedError as ex:
+            return self.response_422(message=ex.normalized_messages())
         except DatabaseCreateFailedError as ex:
             logger.error(
                 "Error creating model %s: %s",

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -41,7 +41,6 @@ from superset.databases.commands.exceptions import (
     DatabaseDeleteFailedError,
     DatabaseInvalidError,
     DatabaseNotFoundError,
-    DatabaseTestConnectionFailedError,
     DatabaseUpdateFailedError,
     InvalidParametersError,
 )
@@ -279,8 +278,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
             return self.response_422(message=ex.normalized_messages())
         except DatabaseConnectionFailedError as ex:
             return self.response_422(message=str(ex))
-        except DatabaseTestConnectionFailedError as ex:
-            return self.response_422(message=ex.normalized_messages())
         except DatabaseCreateFailedError as ex:
             logger.error(
                 "Error creating model %s: %s",

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -72,10 +72,12 @@ from superset.databases.schemas import (
 from superset.databases.utils import get_table_metadata
 from superset.db_engine_specs import get_available_engine_specs
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
+from superset.exceptions import SupersetErrorsException
 from superset.extensions import security_manager
 from superset.models.core import Database
 from superset.superset_typing import FlaskResponse
 from superset.utils.core import error_msg_from_exception, parse_js_uri_path_item
+from superset.views.base import json_errors_response
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
     requires_form_data,
@@ -221,7 +223,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         log_to_statsd=False,
     )
     @requires_json
-    def post(self) -> Response:
+    def post(self) -> FlaskResponse:
         """Creates a new Database
         ---
         post:
@@ -278,6 +280,8 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
             return self.response_422(message=ex.normalized_messages())
         except DatabaseConnectionFailedError as ex:
             return self.response_422(message=str(ex))
+        except SupersetErrorsException as ex:
+            return json_errors_response(errors=ex.errors, status=ex.status)
         except DatabaseCreateFailedError as ex:
             logger.error(
                 "Error creating model %s: %s",

--- a/superset/databases/commands/create.py
+++ b/superset/databases/commands/create.py
@@ -31,6 +31,7 @@ from superset.databases.commands.exceptions import (
 )
 from superset.databases.commands.test_connection import TestConnectionDatabaseCommand
 from superset.databases.dao import DatabaseDAO
+from superset.exceptions import SupersetErrorsException
 from superset.extensions import db, event_logger, security_manager
 
 logger = logging.getLogger(__name__)
@@ -46,7 +47,7 @@ class CreateDatabaseCommand(BaseCommand):
         try:
             # Test connection before starting create transaction
             TestConnectionDatabaseCommand(self._properties).run()
-        except DatabaseConnectionFailedError as ex:
+        except SupersetErrorsException as ex:
             event_logger.log_with_context(
                 action=f"db_creation_failed.{ex.__class__.__name__}",
                 engine=self._properties.get("sqlalchemy_uri", "").split(":")[0],

--- a/superset/databases/commands/create.py
+++ b/superset/databases/commands/create.py
@@ -72,9 +72,8 @@ class CreateDatabaseCommand(BaseCommand):
                     error.error_type
                     == SupersetErrorType.CONNECTION_DATABASE_PERMISSIONS_ERROR
                 ):
-                    raise DatabaseConnectionFailedError(
-                        message=str(error.message)
-                    ) from ex
+                    # Raise original DatabaseTestConnectionFailedError
+                    raise ex
                 raise DatabaseConnectionFailedError() from ex
         except Exception as ex:
             event_logger.log_with_context(

--- a/superset/databases/commands/test_connection.py
+++ b/superset/databases/commands/test_connection.py
@@ -117,8 +117,11 @@ class TestConnectionDatabaseCommand(BaseCommand):
                     level=ErrorLevel.ERROR,
                     extra={"sqlalchemy_uri": database.sqlalchemy_uri},
                 ) from ex
-            except Exception:  # pylint: disable=broad-except
+            except Exception as ex:
                 alive = False
+                # So we stop losing the original message if any
+                raise DBAPIError(str(ex), None, None) from ex
+
             if not alive:
                 raise DBAPIError(None, None, None)
 

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -46,8 +46,8 @@ if TYPE_CHECKING:
 
 
 CONNECTION_DATABASE_PERMISSIONS_REGEX = re.compile(
-    "Access Denied: Project User does not have bigquery.jobs.create "
-    + "permission in project (?P<project>.+?)"
+    "Access Denied: Project (?P<project_name>.+?): User does not have "
+    + "bigquery.jobs.create permission in project (?P<project>.+?)"
 )
 
 TABLE_DOES_NOT_EXIST_REGEX = re.compile(
@@ -154,9 +154,12 @@ class BigQueryEngineSpec(BaseEngineSpec):
     custom_errors: Dict[Pattern[str], Tuple[str, SupersetErrorType, Dict[str, Any]]] = {
         CONNECTION_DATABASE_PERMISSIONS_REGEX: (
             __(
-                "We were unable to connect to your database. Please "
-                "confirm that your service account has the Viewer "
-                "and Job User roles on the project."
+                "Unable to connect. Verify that the following roles are set "
+                'on the service account: "BigQuery Data Viewer", '
+                '"BigQuery Metadata Viewer", "BigQuery Job User" '
+                "and the following permissions are set "
+                '"bigquery.readsessions.create", '
+                '"bigquery.readsessions.getData"'
             ),
             SupersetErrorType.CONNECTION_DATABASE_PERMISSIONS_ERROR,
             {},

--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -114,6 +114,12 @@ class SupersetErrorsException(SupersetException):
         if status is not None:
             self.status = status
 
+    def normalized_messages(self) -> Dict[Any, Any]:
+        errors: Dict[Any, Any] = {}
+        for error in self.errors:
+            errors.update({error.error_type: error.message})
+        return errors
+
 
 class SupersetSyntaxErrorException(SupersetErrorsException):
     status = 422

--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -114,12 +114,6 @@ class SupersetErrorsException(SupersetException):
         if status is not None:
             self.status = status
 
-    def normalized_messages(self) -> Dict[Any, Any]:
-        errors: Dict[Any, Any] = {}
-        for error in self.errors:
-            errors.update({error.error_type: error.message})
-        return errors
-
 
 class SupersetSyntaxErrorException(SupersetErrorsException):
     status = 422

--- a/tests/integration_tests/databases/commands_tests.py
+++ b/tests/integration_tests/databases/commands_tests.py
@@ -32,7 +32,6 @@ from superset.databases.commands.exceptions import (
     DatabaseNotFoundError,
     DatabaseSecurityUnsafeError,
     DatabaseTestConnectionDriverError,
-    DatabaseTestConnectionFailedError,
     DatabaseTestConnectionUnexpectedError,
 )
 from superset.databases.commands.export import ExportDatabasesCommand
@@ -683,7 +682,7 @@ class TestTestConnectionDatabaseCommand(SupersetTestCase):
         json_payload = {"sqlalchemy_uri": db_uri}
         command_without_db_name = TestConnectionDatabaseCommand(json_payload)
 
-        with pytest.raises(DatabaseTestConnectionFailedError) as excinfo:
+        with pytest.raises(SupersetErrorsException) as excinfo:
             command_without_db_name.run()
         assert (
             excinfo.value.errors[0].error_type
@@ -757,7 +756,7 @@ class TestTestConnectionDatabaseCommand(SupersetTestCase):
         json_payload = {"sqlalchemy_uri": db_uri}
         command_without_db_name = TestConnectionDatabaseCommand(json_payload)
 
-        with pytest.raises(DatabaseTestConnectionFailedError) as excinfo:
+        with pytest.raises(SupersetErrorsException) as excinfo:
             command_without_db_name.run()
             assert str(excinfo.value) == (
                 "Connection failed, please check your connection settings"

--- a/tests/integration_tests/db_engine_specs/bigquery_tests.py
+++ b/tests/integration_tests/db_engine_specs/bigquery_tests.py
@@ -246,11 +246,11 @@ class TestBigQueryDbEngineSpec(TestDbEngineSpec):
         )
 
     def test_extract_errors(self):
-        msg = "403 POST https://bigquery.googleapis.com/bigquery/v2/projects/test-keel-310804/jobs?prettyPrint=false: Access Denied: Project User does not have bigquery.jobs.create permission in project profound-keel-310804"
+        msg = "403 POST https://bigquery.googleapis.com/bigquery/v2/projects/test-keel-310804/jobs?prettyPrint=false: Access Denied: Project profound-keel-310804: User does not have bigquery.jobs.create permission in project profound-keel-310804"
         result = BigQueryEngineSpec.extract_errors(Exception(msg))
         assert result == [
             SupersetError(
-                message="We were unable to connect to your database. Please confirm that your service account has the Viewer and Job User roles on the project.",
+                message='Unable to connect. Verify that the following roles are set on the service account: "BigQuery Data Viewer", "BigQuery Metadata Viewer", "BigQuery Job User" and the following permissions are set "bigquery.readsessions.create", "bigquery.readsessions.getData"',
                 error_type=SupersetErrorType.CONNECTION_DATABASE_PERMISSIONS_ERROR,
                 level=ErrorLevel.ERROR,
                 extra={


### PR DESCRIPTION
### SUMMARY
`BigQuery` is now returning the project name twice in the error message when connecting, which breaks the Regex in the `custom_errors` dictionary, so we need to adjust it in order to stop displaying the general connection failed message. Also, we are updating the message displayed to users and the tests.

Additionally, in order to actually being able to catch the right error, we are raising the exceptions with their original message instead of the default one, otherwise the exception handler will ignore it and display the default message.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![error](https://user-images.githubusercontent.com/38889534/196283269-38a6f706-fadc-4282-837d-be0d2371b5ce.gif)

After:
![test](https://user-images.githubusercontent.com/38889534/196283298-900b4552-3690-4dba-a9f1-fc245e14ec1f.gif)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
