### PR TITLE
feat(datasets): Change in API to create virtual datasets

### DIFF
--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -196,7 +196,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     add_model_schema = DatasetPostSchema()
     edit_model_schema = DatasetPutSchema()
     duplicate_model_schema = DatasetDuplicateSchema()
-    add_columns = ["database", "schema", "table_name", "owners"]
+    add_columns = ["database", "schema", "table_name", "sql", "owners"]
     edit_columns = [
         "table_name",
         "sql",

--- a/superset/datasets/commands/create.py
+++ b/superset/datasets/commands/create.py
@@ -59,6 +59,7 @@ class CreateDatasetCommand(CreateMixin, BaseCommand):
         database_id = self._properties["database"]
         table_name = self._properties["table_name"]
         schema = self._properties.get("schema", None)
+        sql = self._properties.get("sql", None)
         owner_ids: Optional[List[int]] = self._properties.get("owners")
 
         # Validate uniqueness
@@ -71,9 +72,11 @@ class CreateDatasetCommand(CreateMixin, BaseCommand):
             exceptions.append(DatabaseNotFoundValidationError())
         self._properties["database"] = database
 
-        # Validate table exists on dataset
-        if database and not DatasetDAO.validate_table_exists(
-            database, table_name, schema
+        # Validate table exists on dataset if sql is not provided
+        if (
+            database
+            and not sql
+            and not DatasetDAO.validate_table_exists(database, table_name, schema)
         ):
             exceptions.append(TableNotFoundValidationError(table_name))
 

--- a/superset/datasets/commands/create.py
+++ b/superset/datasets/commands/create.py
@@ -73,6 +73,7 @@ class CreateDatasetCommand(CreateMixin, BaseCommand):
         self._properties["database"] = database
 
         # Validate table exists on dataset if sql is not provided
+        # This should be validated when the dataset is physical
         if (
             database
             and not sql

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -80,6 +80,7 @@ class DatasetPostSchema(Schema):
     database = fields.Integer(required=True)
     schema = fields.String(validate=Length(0, 250))
     table_name = fields.String(required=True, allow_none=False, validate=Length(1, 250))
+    sql = fields.String(allow_none=True)
     owners = fields.List(fields.Integer())
     is_managed_externally = fields.Boolean(allow_none=True, default=False)
     external_url = fields.String(allow_none=True)


### PR DESCRIPTION
### SUMMARY
The create API for datasets only allows the creation of physical datasets. This makes the ability to directly create virtual datasets not possible. This adds a support for the same. This is a non-breaking change, adding a non-mandatory parameter in the request body.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
NA

### TESTING INSTRUCTIONS
`curl --location --request POST 'http://localhost:8088/api/v1/dataset/' \
--header 'Content-Type: application/json' \
--header 'Cookie: ${COOKIE}' \
--header 'Origin: http://localhost:8088' \
--header 'Referer: http://localhost:8088/swagger/v1' \
--header 'accept: application/json' \
--header 'X-csrftoken: ${CSRF_TOKEN}' \
--data-raw '{
  "database": 1,
  "external_url": "",
  "is_managed_externally": false,
  "owners": [
    1
  ],
  "sql": "select a.*,b.name from ab_permission_view a join ab_permission b on a.permission_id = b.id",
  "schema": "public",
  "table_name": "test1234"
}'`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
