### PR TITLE
fix: drilling on the categorical xaxis on the stacked barchart v2

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/chart/types/Base.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/types/Base.ts
@@ -73,4 +73,11 @@ export const chartLabelWeight: Record<ChartLabel, { weight: number }> = {
   },
 };
 
+export enum AxisType {
+  category = 'category',
+  value = 'value',
+  time = 'time',
+  log = 'log',
+}
+
 export default {};

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -17,11 +17,15 @@
  * under the License.
  */
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { DTTM_ALIAS, QueryObjectFilterClause } from '@superset-ui/core';
+import {
+  DTTM_ALIAS,
+  QueryObjectFilterClause,
+  AxisType,
+} from '@superset-ui/core';
 import { ViewRootGroup } from 'echarts/types/src/util/types';
 import GlobalModel from 'echarts/types/src/model/Global';
 import ComponentModel from 'echarts/types/src/model/Component';
-import { AxisType, EchartsHandler, EventHandlers } from '../types';
+import { EchartsHandler, EventHandlers } from '../types';
 import Echart from '../components/Echart';
 import { TimeseriesChartTransformedProps } from './types';
 import { currentSeries } from '../utils/series';

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -17,11 +17,11 @@
  * under the License.
  */
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { QueryObjectFilterClause } from '@superset-ui/core';
+import { DTTM_ALIAS, QueryObjectFilterClause } from '@superset-ui/core';
 import { ViewRootGroup } from 'echarts/types/src/util/types';
 import GlobalModel from 'echarts/types/src/model/Global';
 import ComponentModel from 'echarts/types/src/model/Component';
-import { EchartsHandler, EventHandlers } from '../types';
+import { AxisType, EchartsHandler, EventHandlers } from '../types';
 import Echart from '../components/Echart';
 import { TimeseriesChartTransformedProps } from './types';
 import { currentSeries } from '../utils/series';
@@ -43,6 +43,7 @@ export default function EchartsTimeseries({
   legendData = [],
   onContextMenu,
   xValueFormatter,
+  xAxis,
 }: TimeseriesChartTransformedProps) {
   const { emitFilter, stack } = formData;
   const echartRef = useRef<EchartsHandler | null>(null);
@@ -182,16 +183,28 @@ export default function EchartsTimeseries({
         const { data } = eventParams;
         if (data) {
           const pointerEvent = eventParams.event.event;
-          const values = labelMap[eventParams.seriesName];
+          const values = [
+            ...(eventParams.name ? [eventParams.name] : []),
+            ...labelMap[eventParams.seriesName],
+          ];
           const filters: QueryObjectFilterClause[] = [];
-          filters.push({
-            col: formData.granularitySqla,
-            grain: formData.timeGrainSqla,
-            op: '==',
-            val: data[0],
-            formattedVal: xValueFormatter(data[0]),
-          });
-          formData.groupby.forEach((dimension, i) =>
+          if (xAxis.type === AxisType.time) {
+            filters.push({
+              col:
+                // if the xAxis is '__timestamp', granularity_sqla will be the column of filter
+                xAxis.label === DTTM_ALIAS
+                  ? formData.granularitySqla
+                  : xAxis.label,
+              grain: formData.timeGrainSqla,
+              op: '==',
+              val: data[0],
+              formattedVal: xValueFormatter(data[0]),
+            });
+          }
+          [
+            ...(xAxis.type === AxisType.category ? [xAxis.label] : []),
+            ...formData.groupby,
+          ].forEach((dimension, i) =>
             filters.push({
               col: dimension,
               op: '==',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -29,6 +29,7 @@ import {
   TimeseriesChartDataResponseResult,
   t,
   getXAxis,
+  AxisType,
 } from '@superset-ui/core';
 import { isDerivedSeries } from '@superset-ui/chart-controls';
 import { EChartsCoreOption, SeriesOption } from 'echarts';
@@ -39,7 +40,6 @@ import {
   EchartsTimeseriesSeriesType,
   TimeseriesChartTransformedProps,
   OrientationType,
-  AxisType,
 } from './types';
 import { DEFAULT_FORM_DATA } from './constants';
 import { ForecastSeriesEnum, ForecastValue } from '../types';

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -451,5 +451,9 @@ export default function transformProps(
     legendData,
     onContextMenu,
     xValueFormatter: tooltipFormatter,
+    xAxis: {
+      label: xAxisCol,
+      type: xAxisType,
+    },
   };
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -33,6 +33,7 @@ import {
   TimeFormatter,
   TimeseriesAnnotationLayer,
   TimeseriesDataRecord,
+  AxisType,
 } from '@superset-ui/core';
 import { SeriesOption } from 'echarts';
 import {
@@ -52,12 +53,7 @@ import {
 import { MarkLine1DDataItemOption } from 'echarts/types/src/component/marker/MarkLineModel';
 
 import { extractForecastSeriesContext } from '../utils/forecast';
-import {
-  AxisType,
-  ForecastSeriesEnum,
-  LegendOrientation,
-  StackType,
-} from '../types';
+import { ForecastSeriesEnum, LegendOrientation, StackType } from '../types';
 import { EchartsTimeseriesSeriesType } from './types';
 
 import {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
@@ -96,6 +96,10 @@ export interface EchartsTimeseriesChartProps
 export type TimeseriesChartTransformedProps =
   EChartTransformedProps<EchartsTimeseriesFormData> & {
     xValueFormatter: TimeFormatter | StringConstructor;
+    xAxis: {
+      label: string;
+      type: AxisType;
+    };
   };
 
 export enum AxisType {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
@@ -25,6 +25,7 @@ import {
   TimeGranularity,
   ContributionType,
   TimeFormatter,
+  AxisType,
 } from '@superset-ui/core';
 import {
   EchartsLegendFormData,
@@ -101,10 +102,3 @@ export type TimeseriesChartTransformedProps =
       type: AxisType;
     };
   };
-
-export enum AxisType {
-  category = 'category',
-  value = 'value',
-  time = 'time',
-  log = 'log',
-}

--- a/superset-frontend/plugins/plugin-chart-echarts/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/types.ts
@@ -132,6 +132,4 @@ export interface EchartsTitleFormData {
 
 export type StackType = boolean | null | Partial<AreaChartExtraControlsValue>;
 
-export type AxisType = 'time' | 'value' | 'category';
-
 export * from './Timeseries/types';

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/annotation.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/annotation.ts
@@ -31,8 +31,9 @@ import {
   isRecordAnnotationResult,
   isTableAnnotationLayer,
   isTimeseriesAnnotationResult,
+  AxisType,
 } from '@superset-ui/core';
-import { AxisType, EchartsTimeseriesChartProps } from '../types';
+import { EchartsTimeseriesChartProps } from '../types';
 import { EchartsMixedTimeseriesProps } from '../MixedTimeseries/types';
 
 export function evalFormula(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -323,9 +323,9 @@ export const currentSeries = {
 
 export function getAxisType(dataType?: GenericDataType): AxisType {
   if (dataType === GenericDataType.TEMPORAL) {
-    return 'time';
+    return AxisType.time;
   }
-  return 'category';
+  return AxisType.category;
 }
 
 export function getOverMaxHiddenFormatter(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -27,6 +27,7 @@ import {
   NumberFormats,
   NumberFormatter,
   TimeFormatter,
+  AxisType,
 } from '@superset-ui/core';
 import { format, LegendComponentOption, SeriesOption } from 'echarts';
 import {
@@ -34,7 +35,7 @@ import {
   NULL_STRING,
   TIMESERIES_CONSTANTS,
 } from '../constants';
-import { AxisType, LegendOrientation, LegendType, StackType } from '../types';
+import { LegendOrientation, LegendType, StackType } from '../types';
 import { defaultLegendPadding } from '../defaults';
 
 function isDefined<T>(value: T | undefined | null): boolean {

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/annotation.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/annotation.test.ts
@@ -17,15 +17,16 @@
  * under the License.
  */
 import {
-  AnnotationLayer,
   AnnotationData,
+  AnnotationLayer,
   AnnotationOpacity,
   AnnotationSourceType,
   AnnotationStyle,
   AnnotationType,
+  AxisType,
+  DataRecord,
   FormulaAnnotationLayer,
   TimeseriesDataRecord,
-  DataRecord,
 } from '@superset-ui/core';
 import {
   evalFormula,
@@ -161,7 +162,7 @@ describe('evalFormula', () => {
       { __timestamp: 10 },
     ];
 
-    expect(evalFormula(layer, data, '__timestamp', 'time')).toEqual([
+    expect(evalFormula(layer, data, '__timestamp', AxisType.time)).toEqual([
       [0, 1],
       [10, 11],
     ]);
@@ -178,7 +179,7 @@ describe('evalFormula', () => {
         { ...layer, value: 'y  = x* 2   -1' },
         data,
         '__timestamp',
-        'time',
+        AxisType.time,
       ),
     ).toEqual([
       [0, -1],
@@ -190,7 +191,12 @@ describe('evalFormula', () => {
     const data: DataRecord[] = [{ gender: 'boy' }, { gender: 'girl' }];
 
     expect(
-      evalFormula({ ...layer, value: 'y = 1000' }, data, 'gender', 'category'),
+      evalFormula(
+        { ...layer, value: 'y = 1000' },
+        data,
+        'gender',
+        AxisType.category,
+      ),
     ).toEqual([
       ['boy', 1000],
       ['girl', 1000],


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, if the `GENERIC_CHART_AXES` FF is enabled, the drill-to-detail on the dashboard will not generate correct filters. it because of using a temporal column logic to generate filters rather than a categorical column to do that.

...and take a little bit refactoring is that move `AxisType` into `@superset-ui/core`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### After


https://user-images.githubusercontent.com/2016594/196340484-56ec8b6d-3baf-4e92-8e38-9779deb9cae2.mov




#### Before
![image](https://user-images.githubusercontent.com/2016594/196339876-09594a5d-1945-48a0-8164-0be9d8935010.png)



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
