### PR TITLE
feat(db_engine_specs): Allow uploaded columns of dtype datetime to be stored as TIMESTAMP in the Hive schema

### DIFF
--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -213,6 +213,7 @@ class HiveEngineSpec(PrestoEngineSpec):
                 np.dtype("float64"): "DOUBLE",
                 np.dtype("int64"): "BIGINT",
                 np.dtype("object"): "STRING",
+                np.dtype("datetime64[ns]"): "TIMESTAMP",
             }
 
             return hive_type_by_dtype.get(dtype, "STRING")

--- a/tests/integration_tests/db_engine_specs/hive_tests.py
+++ b/tests/integration_tests/db_engine_specs/hive_tests.py
@@ -270,7 +270,6 @@ def test_df_to_sql_schema_definition(mock_upload_to_s3, mock_g):
         "datetime": pd.Series(dtype="datetime64[ns]")
     })
     expected_schema_definition = "`bool` BOOLEAN, `float64` DOUBLE, `int64` BIGINT, `object` STRING, `datetime` TIMESTAMP"
-
     with app.app_context():
         HiveEngineSpec.df_to_sql(
             mock_database,
@@ -279,13 +278,8 @@ def test_df_to_sql_schema_definition(mock_upload_to_s3, mock_g):
             {"if_exists": "replace"},
         )
 
-    mock_execute.assert_any_call(
-        f"""
-        CREATE TABLE {table_name} ({expected_schema_definition})
-        STORED AS PARQUET
-        LOCATION :{mock_location}
-        """
-    )
+    _, call_args, _ = mock_execute.mock_calls[1]
+    assert expected_schema_definition in str(call_args[0])
     app.config = config
     
     


### PR DESCRIPTION
### SUMMARY
The views for uploading data files (csv, excel etc.) to a database have form options to pass and/or infer `datetime` columns. However, the hive `df_to_sql` method does not support storing `datetime` columns as TIMESTAMPs in the Hive schema. It would be a nice for the `_get_hive_type` functionality to at least support the basic `datetime64[ns]` dtype.

### TESTING INSTRUCTIONS
The following steps require you to be able to upload files to a schema on Superset  (`allow_file_upload`) + use Hive as DB engine.
Steps:
1. Upload a csv with an inferable timestamp:
```
test_column,timestamp
something,2022-01-01T01:01:01.000000
```
2. Make sure `parse_dates` is set to the timestamp column in your csv file and `infer_datetime_format` is set to true within the form.
3. Submit the CSV and confirm that the new table has a column with type TIMESTAMP.


### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
