### PR TITLE
feat: Disables HTML rendering in Toast by default

### DIFF
--- a/superset-frontend/src/components/MessageToasts/Toast.tsx
+++ b/superset-frontend/src/components/MessageToasts/Toast.tsx
@@ -97,7 +97,7 @@ export default function Toast({ toast, onCloseToast }: ToastPresenterProps) {
       role="alert"
     >
       {icon}
-      <Interweave content={toast.text} />
+      <Interweave content={toast.text} noHtml={!toast.allowHtml} />
       <i
         className="fa fa-close pull-right pointer"
         role="button"

--- a/superset-frontend/src/components/MessageToasts/types.ts
+++ b/superset-frontend/src/components/MessageToasts/types.ts
@@ -31,4 +31,8 @@ export interface ToastMeta {
   /** Whether to skip displaying this message if there are another toast
    * with the same message. */
   noDuplicate?: boolean;
+  /** For security reasons, HTML rendering is disabled. Use this property to enable
+   * HTML rendering and make sure any required sanitization is applied.
+   */
+  allowHtml?: boolean;
 }

--- a/superset-frontend/src/components/MessageToasts/types.ts
+++ b/superset-frontend/src/components/MessageToasts/types.ts
@@ -31,8 +31,6 @@ export interface ToastMeta {
   /** Whether to skip displaying this message if there are another toast
    * with the same message. */
   noDuplicate?: boolean;
-  /** For security reasons, HTML rendering is disabled. Use this property to enable
-   * HTML rendering and make sure any required sanitization is applied.
-   */
+  /** For security reasons, HTML rendering is disabled by default. Use this property to enable it. */
   allowHtml?: boolean;
 }


### PR DESCRIPTION
### SUMMARY
This PR disables HTML rendering in toast messages by default. I couldn't find any instances of toast messages with HTML content but it is a valid use case, so I created an `allowHtml` property for this scenario.

### TESTING INSTRUCTIONS
1 - Make sure toast messages don't render HTML by default
2 - Make sure toast messages render HTML if `allowHtml` is enabled

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
