### PR TITLE
fix: Default temporal column in Datasource

### DIFF
--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
@@ -315,7 +315,7 @@ test('should set the first available temporal column', async () => {
   });
 });
 
-test('should set the temporal column at null', async () => {
+test('should not set the temporal column', async () => {
   const props = createProps();
   const overrideProps = {
     ...props,
@@ -345,7 +345,7 @@ test('should set the temporal column at null', async () => {
   await waitFor(() => {
     expect(props.actions.setControlValue).toHaveBeenCalledWith(
       'granularity_sqla',
-      null,
+      undefined,
     );
   });
 });

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
@@ -66,11 +66,10 @@ const createProps = () => ({
   onDatasourceSave: jest.fn(),
 });
 
-fetchMock.post('glob:*/datasource/save/', {
-  ...createProps().datasource,
-});
-
-async function openAndSaveChanges() {
+async function openAndSaveChanges(datasource: any) {
+  fetchMock.post('glob:*/datasource/save/', datasource, {
+    overwriteRoutes: true,
+  });
   userEvent.click(screen.getByTestId('datasource-menu-trigger'));
   userEvent.click(await screen.findByTestId('edit-dataset'));
   userEvent.click(await screen.findByTestId('datasource-modal-save'));
@@ -271,7 +270,7 @@ test('should set the default temporal column', async () => {
     useRedux: true,
   });
 
-  await openAndSaveChanges();
+  await openAndSaveChanges(overrideProps.datasource);
   await waitFor(() => {
     expect(props.actions.setControlValue).toHaveBeenCalledWith(
       'granularity_sqla',
@@ -306,7 +305,7 @@ test('should set the first available temporal column', async () => {
     useRedux: true,
   });
 
-  await openAndSaveChanges();
+  await openAndSaveChanges(overrideProps.datasource);
   await waitFor(() => {
     expect(props.actions.setControlValue).toHaveBeenCalledWith(
       'granularity_sqla',
@@ -341,11 +340,11 @@ test('should not set the temporal column', async () => {
     useRedux: true,
   });
 
-  await openAndSaveChanges();
+  await openAndSaveChanges(overrideProps.datasource);
   await waitFor(() => {
     expect(props.actions.setControlValue).toHaveBeenCalledWith(
       'granularity_sqla',
-      undefined,
+      null,
     );
   });
 });

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
@@ -18,9 +18,10 @@
  */
 
 import React from 'react';
-import { render, screen, act } from 'spec/helpers/testing-library';
+import { render, screen, act, waitFor } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
 import { SupersetClient, DatasourceType } from '@superset-ui/core';
+import fetchMock from 'fetch-mock';
 import DatasourceControl from '.';
 
 const SupersetClientGet = jest.spyOn(SupersetClient, 'get');
@@ -45,7 +46,10 @@ const createProps = () => ({
   },
   validationErrors: [],
   name: 'datasource',
-  actions: {},
+  actions: {
+    changeDatasource: jest.fn(),
+    setControlValue: jest.fn(),
+  },
   isEditable: true,
   user: {
     createdOn: '2021-04-27T18:12:38.952304',
@@ -61,6 +65,17 @@ const createProps = () => ({
   onChange: jest.fn(),
   onDatasourceSave: jest.fn(),
 });
+
+fetchMock.post('glob:*/datasource/save/', {
+  ...createProps().datasource,
+});
+
+async function openAndSaveChanges() {
+  userEvent.click(screen.getByTestId('datasource-menu-trigger'));
+  userEvent.click(await screen.findByTestId('edit-dataset'));
+  userEvent.click(await screen.findByTestId('datasource-modal-save'));
+  userEvent.click(await screen.findByText('OK'));
+}
 
 test('Should render', async () => {
   const props = createProps();
@@ -228,4 +243,109 @@ test('Click on Save as dataset', async () => {
   expect(screen.getByRole('button', { name: /save/i })).toBeVisible();
   expect(screen.getByRole('button', { name: /close/i })).toBeVisible();
   expect(dropdownField).toBeVisible();
+});
+
+test('should set the default temporal column', async () => {
+  const props = createProps();
+  const overrideProps = {
+    ...props,
+    form_data: {
+      granularity_sqla: 'test-col',
+    },
+    datasource: {
+      ...props.datasource,
+      main_dttm_col: 'test-default',
+      columns: [
+        {
+          column_name: 'test-col',
+          is_dttm: false,
+        },
+        {
+          column_name: 'test-default',
+          is_dttm: true,
+        },
+      ],
+    },
+  };
+  render(<DatasourceControl {...props} {...overrideProps} />, {
+    useRedux: true,
+  });
+
+  await openAndSaveChanges();
+  await waitFor(() => {
+    expect(props.actions.setControlValue).toHaveBeenCalledWith(
+      'granularity_sqla',
+      'test-default',
+    );
+  });
+});
+
+test('should set the first available temporal column', async () => {
+  const props = createProps();
+  const overrideProps = {
+    ...props,
+    form_data: {
+      granularity_sqla: 'test-col',
+    },
+    datasource: {
+      ...props.datasource,
+      main_dttm_col: null,
+      columns: [
+        {
+          column_name: 'test-col',
+          is_dttm: false,
+        },
+        {
+          column_name: 'test-first',
+          is_dttm: true,
+        },
+      ],
+    },
+  };
+  render(<DatasourceControl {...props} {...overrideProps} />, {
+    useRedux: true,
+  });
+
+  await openAndSaveChanges();
+  await waitFor(() => {
+    expect(props.actions.setControlValue).toHaveBeenCalledWith(
+      'granularity_sqla',
+      'test-first',
+    );
+  });
+});
+
+test('should set the temporal column at null', async () => {
+  const props = createProps();
+  const overrideProps = {
+    ...props,
+    form_data: {
+      granularity_sqla: null,
+    },
+    datasource: {
+      ...props.datasource,
+      main_dttm_col: null,
+      columns: [
+        {
+          column_name: 'test-col',
+          is_dttm: false,
+        },
+        {
+          column_name: 'test-col-2',
+          is_dttm: false,
+        },
+      ],
+    },
+  };
+  render(<DatasourceControl {...props} {...overrideProps} />, {
+    useRedux: true,
+  });
+
+  await openAndSaveChanges();
+  await waitFor(() => {
+    expect(props.actions.setControlValue).toHaveBeenCalledWith(
+      'granularity_sqla',
+      null,
+    );
+  });
 });

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -27,7 +27,7 @@ import {
   t,
   withTheme,
 } from '@superset-ui/core';
-
+import { getTemporalColumns } from '@superset-ui/chart-controls';
 import { getUrlParam } from 'src/utils/urlUtils';
 import { AntdDropdown } from 'src/components';
 import { Menu } from 'src/components/Menu';
@@ -176,18 +176,14 @@ class DatasourceControl extends React.PureComponent {
     const timeColConf = columns.find(
       ({ column_name }) => column_name === timeCol,
     );
-    const firstDttmCol =
-      columns.find(column => column.is_dttm)?.column_name || null;
-    const currentMainDttmCol = columns.find(
-      c => c.column_name === datasource.main_dttm_col,
-    );
-    const setDttmCol = currentMainDttmCol?.is_dttm
-      ? currentMainDttmCol.column_name
-      : firstDttmCol;
     if (datasource.type === 'table') {
       // resets new default time col or picks the first available one
       if (!timeColConf?.is_dttm) {
-        this.props.actions.setControlValue('granularity_sqla', setDttmCol);
+        const setDttmCol = getTemporalColumns(this.props.datasource);
+        this.props.actions.setControlValue(
+          'granularity_sqla',
+          setDttmCol.defaultTemporalColumn,
+        );
       }
     }
 

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -169,28 +169,25 @@ class DatasourceControl extends React.PureComponent {
     };
   }
 
-  onDatasourceSave = (datasource) => {
+  onDatasourceSave = datasource => {
     this.props.actions.changeDatasource(datasource);
     const { columns } = this.props.datasource;
     const timeCol = this.props.form_data?.granularity_sqla;
-    const timeColConf = columns.find(({ column_name }) => column_name === timeCol);
-    const firstDttmCol = columns.find(column => column.is_dttm)?.column_name || null;
-    const currentMainDttmCol = columns.find(c => c.column_name === datasource.main_dttm_col);
-    const setDttmCol = currentMainDttmCol?.is_dttm ? currentMainDttmCol.column_name : firstDttmCol;
-    console.log("firstDttmCol", firstDttmCol);
-    console.log("currentMainDttmCol", currentMainDttmCol);
-
-
+    const timeColConf = columns.find(
+      ({ column_name }) => column_name === timeCol,
+    );
+    const firstDttmCol =
+      columns.find(column => column.is_dttm)?.column_name || null;
+    const currentMainDttmCol = columns.find(
+      c => c.column_name === datasource.main_dttm_col,
+    );
+    const setDttmCol = currentMainDttmCol?.is_dttm
+      ? currentMainDttmCol.column_name
+      : firstDttmCol;
     if (datasource.type === 'table') {
       // resets new default time col or picks the first available one
-      if (
-        datasource.main_dttm_col !== timeCol || !timeColConf?.is_dttm
-      ) {
-          console.log("setDttmCol", setDttmCol);
-          this.props.actions.setControlValue(
-            'granularity_sqla',
-            setDttmCol,
-          );
+      if (!timeColConf?.is_dttm) {
+        this.props.actions.setControlValue('granularity_sqla', setDttmCol);
       }
     }
 

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -169,21 +169,31 @@ class DatasourceControl extends React.PureComponent {
     };
   }
 
-  onDatasourceSave = datasource => {
+  onDatasourceSave = (datasource) => {
     this.props.actions.changeDatasource(datasource);
-    const timeCol = this.props.form_data?.granularity_sqla;
     const { columns } = this.props.datasource;
-    const firstDttmCol = columns.find(column => column.is_dttm);
-    if (
-      datasource.type === 'table' &&
-      !columns.find(({ column_name }) => column_name === timeCol)?.is_dttm
-    ) {
-      // set `granularity_sqla` to first datatime column name or null
-      this.props.actions.setControlValue(
-        'granularity_sqla',
-        firstDttmCol ? firstDttmCol.column_name : null,
-      );
+    const timeCol = this.props.form_data?.granularity_sqla;
+    const timeColConf = columns.find(({ column_name }) => column_name === timeCol);
+    const firstDttmCol = columns.find(column => column.is_dttm)?.column_name || null;
+    const currentMainDttmCol = columns.find(c => c.column_name === datasource.main_dttm_col);
+    const setDttmCol = currentMainDttmCol?.is_dttm ? currentMainDttmCol.column_name : firstDttmCol;
+    console.log("firstDttmCol", firstDttmCol);
+    console.log("currentMainDttmCol", currentMainDttmCol);
+
+
+    if (datasource.type === 'table') {
+      // resets new default time col or picks the first available one
+      if (
+        datasource.main_dttm_col !== timeCol || !timeColConf?.is_dttm
+      ) {
+          console.log("setDttmCol", setDttmCol);
+          this.props.actions.setControlValue(
+            'granularity_sqla',
+            setDttmCol,
+          );
+      }
     }
+
     if (this.props.onDatasourceSave) {
       this.props.onDatasourceSave(datasource);
     }


### PR DESCRIPTION
### SUMMARY
Fixes an issue for which the default temporal column wasn't picked up correctly

### BEFORE

https://user-images.githubusercontent.com/60598000/196451738-e7f3f3b6-53a1-48fe-b5e8-4ad57f6a39a8.mov

### AFTER

https://user-images.githubusercontent.com/60598000/196451906-047ecee0-f85d-4b12-abef-6dc9535bf085.mp4

### TESTING INSTRUCTIONS

1. Edit a dataset with multiple temporal columns
2. Disable all temporal columns and save
3. Make sure the control is now empty
4. Edit the dataset again and add two temporal columns and make one the default and save
5. Make sure the default is picked in the control after saving
6. Edit the dataset again and remove the default from temporal columns and save
7. The control should have picked the first available temporal column

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
