### PR TITLE
feat(select filter): add CRLF separator for Windows

### DIFF
--- a/superset-frontend/src/components/Select/constants.ts
+++ b/superset-frontend/src/components/Select/constants.ts
@@ -21,7 +21,7 @@ import { rankedSearchCompare } from 'src/utils/rankedSearchCompare';
 
 export const MAX_TAG_COUNT = 4;
 
-export const TOKEN_SEPARATORS = [',', '\n', '\t', ';'];
+export const TOKEN_SEPARATORS = [',', '\r\n', '\n', '\t', ';'];
 
 export const EMPTY_OPTIONS = [];
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The token separators without the CRLF.
In Windows environment, when copy the multiple line text and paste to Select Filters, there is the carriage return behind the result value.
The query filter contain "\r", affecting the query result is incorrect.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Environment: Windows OS
1. Copy the multiple line text.
2. Paste to the Select Filter.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
