### PR TITLE
fix: categorical x-axis can't apply the label of column

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -30,6 +30,8 @@ import {
   TimeseriesChartDataResponseResult,
   TimeseriesDataRecord,
   getXAxisLabel,
+  isPhysicalColumn,
+  isDefined,
 } from '@superset-ui/core';
 import { EChartsCoreOption, SeriesOption } from 'echarts';
 import {
@@ -152,23 +154,29 @@ export default function transformProps(
 
   const colorScale = CategoricalColorNamespace.getScale(colorScheme as string);
 
-  const xAxisCol = getXAxisLabel(
+  let xAxisLabel = getXAxisLabel(
     chartProps.rawFormData as QueryFormData,
   ) as string;
+  if (
+    isPhysicalColumn(chartProps.rawFormData?.x_axis) &&
+    isDefined(verboseMap[xAxisLabel])
+  ) {
+    xAxisLabel = verboseMap[xAxisLabel];
+  }
 
   const rebasedDataA = rebaseForecastDatum(data1, verboseMap);
   const rawSeriesA = extractSeries(rebasedDataA, {
     fillNeighborValue: stack ? 0 : undefined,
-    xAxis: xAxisCol,
+    xAxis: xAxisLabel,
   });
   const rebasedDataB = rebaseForecastDatum(data2, verboseMap);
   const rawSeriesB = extractSeries(rebasedDataB, {
     fillNeighborValue: stackB ? 0 : undefined,
-    xAxis: xAxisCol,
+    xAxis: xAxisLabel,
   });
 
   const dataTypes = getColtypesMapping(queriesData[0]);
-  const xAxisDataType = dataTypes?.[xAxisCol] ?? dataTypes?.[xAxisOrig];
+  const xAxisDataType = dataTypes?.[xAxisLabel] ?? dataTypes?.[xAxisOrig];
   const xAxisType = getAxisType(xAxisDataType);
   const series: SeriesOption[] = [];
   const formatter = getNumberFormatter(contributionMode ? ',.0%' : yAxisFormat);
@@ -205,7 +213,7 @@ export default function transformProps(
     {
       stack,
       percentageThreshold,
-      xAxisCol,
+      xAxisCol: xAxisLabel,
     },
   );
   const {
@@ -214,7 +222,7 @@ export default function transformProps(
   } = extractDataTotalValues(rebasedDataB, {
     stack: Boolean(stackB),
     percentageThreshold,
-    xAxisCol,
+    xAxisCol: xAxisLabel,
   });
 
   annotationLayers
@@ -225,7 +233,7 @@ export default function transformProps(
           transformFormulaAnnotation(
             layer,
             data1,
-            xAxisCol,
+            xAxisLabel,
             xAxisType,
             colorScale,
             sliceId,
@@ -502,7 +510,7 @@ export default function transformProps(
     onContextMenu,
     xValueFormatter: tooltipFormatter,
     xAxis: {
-      label: xAxisCol,
+      label: xAxisLabel,
       type: xAxisType,
     },
   };


### PR DESCRIPTION
### SUMMARY
This PR intends to fix that the categorical x-axis can't correct to render. This issue is caused by not getting the the label of column.

When I fix this issue, I found another issue in the Adhoc Column control is that the query result can't apply the label of column (alias in the SQL) as well, but this issue requires extensive refactoring, which is beyond the scope of this PR. 

![image](https://user-images.githubusercontent.com/2016594/196658801-8b46c9d0-b7c6-4754-9862-af7b72997826.png)





### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

#### After

![image](https://user-images.githubusercontent.com/2016594/196657223-f1c57c71-54ef-4aa8-a140-e3088bafdd65.png)



#### Before
![image](https://user-images.githubusercontent.com/2016594/196657365-d5fd8800-13e8-44db-b843-3d163ac8c047.png)




### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
