### PR TITLE
feat(python): add task celery to prune events logs

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -73,6 +73,7 @@ if TYPE_CHECKING:
 # Realtime stats logger, a StatsD implementation exists
 STATS_LOGGER = DummyStatsLogger()
 EVENT_LOGGER = DBEventLogger()
+EVENT_LOG_PRUNE = 90
 
 SUPERSET_LOG_VIEW = True
 
@@ -763,7 +764,11 @@ class CeleryConfig:  # pylint: disable=too-few-public-methods
         },
         "reports.prune_log": {
             "task": "reports.prune_log",
-            "schedule": crontab(minute=0, hour=0),
+            "schedule": crontab(minute="0", hour="0"),
+        },
+        "events.prune_log": {
+            "task": "events.prune_log",
+            "schedule": crontab(minute="0", hour="0"),
         },
     }
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -764,11 +764,11 @@ class CeleryConfig:  # pylint: disable=too-few-public-methods
         },
         "reports.prune_log": {
             "task": "reports.prune_log",
-            "schedule": crontab(minute="0", hour="0"),
+            "schedule": crontab(minute=0, hour=0),
         },
         "events.prune_log": {
             "task": "events.prune_log",
-            "schedule": crontab(minute="0", hour="0"),
+            "schedule": crontab(minute=0, hour=0),
         },
     }
 

--- a/superset/tasks/scheduler.py
+++ b/superset/tasks/scheduler.py
@@ -25,6 +25,7 @@ from superset.extensions import celery_app
 from superset.reports.commands.exceptions import ReportScheduleUnexpectedError
 from superset.reports.commands.execute import AsyncExecuteReportScheduleCommand
 from superset.reports.commands.log_prune import AsyncPruneReportScheduleLogCommand
+from superset.utils.log import AsyncPruneEventScheduleLogCommand
 from superset.reports.dao import ReportScheduleDAO
 from superset.tasks.cron_util import cron_schedule_window
 from superset.utils.celery import session_scope
@@ -99,3 +100,13 @@ def prune_log() -> None:
         logger.warning("A timeout occurred while pruning report schedule logs: %s", ex)
     except CommandException as ex:
         logger.exception("An exception occurred while pruning report schedule logs")
+
+
+@celery_app.task(name="events.prune_log")
+def prune_event_log() -> None:
+    try:
+        AsyncPruneEventScheduleLogCommand().run()
+    except SoftTimeLimitExceeded as ex:
+        logger.warning("A timeout occurred while pruning event logs: %s", ex)
+    except CommandException as ex:
+        logger.exception("An exception occurred while event logs")

--- a/superset/utils/log.py
+++ b/superset/utils/log.py
@@ -43,7 +43,6 @@ from typing_extensions import Literal
 
 from superset.utils.core import get_user_id
 
-from superset.models.core import Log
 from superset.utils.celery import session_scope
 from superset.dao.exceptions import DAODeleteFailedError
 from sqlalchemy.orm import Session
@@ -369,6 +368,7 @@ class AsyncPruneEventScheduleLogCommand(AbstractEventLogger):
         self._worker_context = worker_context
 
     def run(self) -> None:
+
         log_retention = current_app.config["EVENT_LOG_PRUNE"]
 
         with session_scope(nullpool=True) as session:
@@ -399,6 +399,10 @@ def bulk_delete_logs(
     session: Optional[Session] = None,
     commit: bool = True,
 ) -> Optional[int]:
+
+    # pylint: disable=import-outside-toplevel
+    from superset.models.core import Log
+
     session = session or db.session
     try:
         row_count = (

--- a/superset/utils/log.py
+++ b/superset/utils/log.py
@@ -43,10 +43,8 @@ from typing_extensions import Literal
 
 from superset.utils.core import get_user_id
 
-from superset.utils.celery import session_scope
-from superset.dao.exceptions import DAODeleteFailedError
 from sqlalchemy.orm import Session
-from superset.extensions import db
+        from superset.dao.exceptions import DAODeleteFailedError
 
 if TYPE_CHECKING:
     from superset.stats_logger import BaseStatsLogger
@@ -369,8 +367,11 @@ class AsyncPruneEventScheduleLogCommand(AbstractEventLogger):
 
     def run(self) -> None:
 
-        log_retention = current_app.config["EVENT_LOG_PRUNE"]
+        # pylint: disable=import-outside-toplevel
+        from superset.utils.celery import session_scope
 
+        log_retention = current_app.config["EVENT_LOG_PRUNE"]
+        
         with session_scope(nullpool=True) as session:
             self.validate()
             prune_errors = []
@@ -402,6 +403,7 @@ def bulk_delete_logs(
 
     # pylint: disable=import-outside-toplevel
     from superset.models.core import Log
+    from superset.extensions import db
 
     session = session or db.session
     try:
@@ -419,3 +421,5 @@ def bulk_delete_logs(
         if commit:
             session.rollback()
         raise DAODeleteFailedError(str(ex)) from ex
+
+

--- a/superset/utils/log.py
+++ b/superset/utils/log.py
@@ -44,7 +44,7 @@ from typing_extensions import Literal
 from superset.utils.core import get_user_id
 
 from sqlalchemy.orm import Session
-        from superset.dao.exceptions import DAODeleteFailedError
+from superset.dao.exceptions import DAODeleteFailedError
 
 if TYPE_CHECKING:
     from superset.stats_logger import BaseStatsLogger


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
After exchange with superset contributor we find add a celery task a good idea to not impact users.

Add a task celery schedul one time per day to prune events log in tables logs. 

This PR is a reponse of this exchange : https://github.com/apache/superset/pull/20636 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://user-images.githubusercontent.com/78090694/196707909-a55900f7-7950-490c-a0e5-d7684bfa489e.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/16528
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
