### PR TITLE
feat: Adds a Content Security Policy (CSP) check for production environments

### DIFF
--- a/docs/docs/security.mdx
+++ b/docs/docs/security.mdx
@@ -131,6 +131,28 @@ For example, the filters `client_id=4` and `client_id=5`, applied to a role,
 will result in users of that role having `client_id=4` AND `client_id=5`
 added to their query, which can never be true.
 
+### Content Security Policiy (CSP)
+
+[Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) is an added
+layer of security that helps to detect and mitigate certain types of attacks, including
+Cross-Site Scripting (XSS) and data injection attacks.
+
+CSP makes it possible for server administrators to reduce or eliminate the vectors by which XSS can
+occur by specifying the domains that the browser should consider to be valid sources of executable scripts.
+A CSP compatible browser will then only execute scripts loaded in source files received from those allowed domains,
+ignoring all other scripts (including inline scripts and event-handling HTML attributes).
+
+A policy is described using a series of policy directives, each of which describes the policy for
+a certain resource type or policy area. You can check possible directives
+[here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy).
+
+It's extremely important to correclty configure a Content Security Policy when deploying Superset to
+prevent many types of attacks. For that matter, Superset provides the ` TALISMAN_CONFIG` key in `config.py`
+where admnistrators can define the policy. When running in production mode, Superset will check for the presence
+of a policy and if it's not able to find one, it will issue a warning with the security risks. For environments
+where CSP policies are defined outside of Superset using other software, administrators can disable
+the warning using the `CONTENT_SECURITY_POLICY_WARNING` key in `config.py`.
+
 ### Reporting Security Vulnerabilities
 
 Apache Software Foundation takes a rigorous standpoint in annihilating the security issues in its

--- a/superset/config.py
+++ b/superset/config.py
@@ -1223,11 +1223,14 @@ PREFERRED_DATABASES: List[str] = [
 # one here.
 TEST_DATABASE_CONNECTION_TIMEOUT = timedelta(seconds=30)
 
+# Enable/disable CSP warning
+CONTENT_SECURITY_POLICY_WARNING = True
+
 # Do you want Talisman enabled?
-TALISMAN_ENABLED = False
+TALISMAN_ENABLED = True
 # If you want Talisman, how do you want it configured??
 TALISMAN_CONFIG = {
-    "content_security_policy": None,
+    "content_security_policy": "default-src 'self'",
     "force_https": True,
     "force_https_permanent": False,
 }

--- a/superset/config.py
+++ b/superset/config.py
@@ -1227,10 +1227,10 @@ TEST_DATABASE_CONNECTION_TIMEOUT = timedelta(seconds=30)
 CONTENT_SECURITY_POLICY_WARNING = True
 
 # Do you want Talisman enabled?
-TALISMAN_ENABLED = True
+TALISMAN_ENABLED = False
 # If you want Talisman, how do you want it configured??
 TALISMAN_CONFIG = {
-    "content_security_policy": "default-src 'self'",
+    "content_security_policy": None,
     "force_https": True,
     "force_https_permanent": False,
 }

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -589,11 +589,13 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
 
         if show_csp_warning:
             logger.warning(
-                "We haven't found any Content Security Policy (CSP) defined in the configurations. "
-                "Please make sure to configure CSP using the TALISMAN_CONFIG key or any other external software. "
-                "Failing to configure CSP have serious security implications. "
-                "Check https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP for more information. "
-                "You can disable this warning using the CONTENT_SECURITY_POLICY_WARNING key."
+                "We haven't found any Content Security Policy (CSP) defined in "
+                "the configurations. Please make sure to configure CSP using the "
+                "TALISMAN_CONFIG key or any other external software. Failing to "
+                "configure CSP have serious security implications. Check "
+                "https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP for more "
+                "information. You can disable this warning using the "
+                "CONTENT_SECURITY_POLICY_WARNING key."
             )
 
     def configure_logging(self) -> None:

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -575,8 +575,26 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         # Flask-Compress
         Compress(self.superset_app)
 
-        if self.config["TALISMAN_ENABLED"]:
-            talisman.init_app(self.superset_app, **self.config["TALISMAN_CONFIG"])
+        show_csp_warning = False
+        if (
+            self.config["CONTENT_SECURITY_POLICY_WARNING"]
+            and not self.superset_app.debug
+        ):
+            if self.config["TALISMAN_ENABLED"]:
+                talisman.init_app(self.superset_app, **self.config["TALISMAN_CONFIG"])
+                if not self.config["TALISMAN_CONFIG"]["content_security_policy"]:
+                    show_csp_warning = True
+            else:
+                show_csp_warning = True
+
+        if show_csp_warning:
+            logger.warning(
+                "We haven't found any Content Security Policy (CSP) defined in the configurations. "
+                "Please make sure to configure CSP using the TALISMAN_CONFIG key or any other external software. "
+                "Failing to configure CSP have serious security implications. "
+                "Check https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP for more information. "
+                "You can disable this warning using the CONTENT_SECURITY_POLICY_WARNING key."
+            )
 
     def configure_logging(self) -> None:
         self.config["LOGGING_CONFIGURATOR"].configure_logging(

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -582,7 +582,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         ):
             if self.config["TALISMAN_ENABLED"]:
                 talisman.init_app(self.superset_app, **self.config["TALISMAN_CONFIG"])
-                if not self.config["TALISMAN_CONFIG"]["content_security_policy"]:
+                if not self.config["TALISMAN_CONFIG"].get("content_security_policy"):
                     show_csp_warning = True
             else:
                 show_csp_warning = True


### PR DESCRIPTION
### SUMMARY
Adds a [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) check for production environments that verifies if a policy is defined or otherwise issues a warning. For deployments that manage CSP with other software, this check can be disabled using the `CONTENT_SECURITY_POLICY_WARNING` configuration.

### TESTING INSTRUCTIONS
Check if the warning is correctly emitted or skipped.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
