### PR TITLE
fix: Change timer font to monospace

### DIFF
--- a/superset-frontend/src/components/Timer/index.tsx
+++ b/superset-frontend/src/components/Timer/index.tsx
@@ -31,6 +31,7 @@ export interface TimerProps {
 
 const TimerLabel = styled(Label)`
   text-align: left;
+  font-family: ${({ theme }) => theme.typography.families.monospace};
 `;
 
 export default function Timer({


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR changes the timer to use a monospace font so its width doesn't change.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### BEFORE:
![timerBefore](https://user-images.githubusercontent.com/55605634/196760218-485913b6-6f5c-4108-877d-2928ca1734e7.gif)

#### AFTER:
![timerAfter](https://user-images.githubusercontent.com/55605634/196760257-13f9a290-f55b-400c-8c7e-36ffee053bcf.gif)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Go to SQL Lab
- Run a query
- Observe that the width of the timer does not change with the monospace font
- Note: This timer also exists in Explore when fetching data for a chart

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
