### PR TITLE
fix: type of AnnotationLayer

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/query/types/AnnotationLayer.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/AnnotationLayer.ts
@@ -125,7 +125,8 @@ export type AnnotationLayer =
   | EventAnnotationLayer
   | IntervalAnnotationLayer
   | FormulaAnnotationLayer
-  | TimeseriesAnnotationLayer;
+  | TimeseriesAnnotationLayer
+  | TableAnnotationLayer;
 
 export function isFormulaAnnotationLayer(
   layer: AnnotationLayer,


### PR DESCRIPTION
### SUMMARY
This commit fixes the type of AnnotationLayer to be compatible with TableAnnotationLayer
This will be thrown an error in next typescript version.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<img width="818" alt="Screen Shot 2022-10-19 at 2 31 09 PM" src="https://user-images.githubusercontent.com/1392866/196809128-b2423d24-5f55-4e61-b640-e5edbc04d883.png">


### TESTING INSTRUCTIONS
bump up typescript to 4.6.4 and then `npm run type`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
