### PR TITLE
feat(explore): add config for default time filter

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/query/constants.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/constants.ts
@@ -25,7 +25,6 @@ import {
 } from './types';
 
 export const DTTM_ALIAS = '__timestamp';
-export const DEFAULT_TIME_RANGE = 'No filter'; // TODO: make this configurable per Superset installation
 export const NO_TIME_RANGE = 'No filter';
 
 export const EXTRA_FORM_DATA_OVERRIDE_EXTRA_KEYS: (keyof ExtraFormDataOverrideExtras)[] =

--- a/superset-frontend/src/explore/actions/hydrateExplore.test.ts
+++ b/superset-frontend/src/explore/actions/hydrateExplore.test.ts
@@ -160,3 +160,49 @@ test('creates hydrate action with existing state', () => {
     }),
   );
 });
+
+test('uses configured default time range if not set', () => {
+  const dispatch = jest.fn();
+  const getState = jest.fn(() => ({
+    user: {},
+    charts: {},
+    datasources: {},
+    common: {
+      conf: {
+        DEFAULT_TIME_FILTER: 'Last year',
+      },
+    },
+    explore: {},
+  }));
+  // @ts-ignore
+  hydrateExplore({ form_data: {}, slice: {}, dataset: {} })(dispatch, getState);
+  expect(dispatch).toHaveBeenCalledWith(
+    expect.objectContaining({
+      data: expect.objectContaining({
+        explore: expect.objectContaining({
+          form_data: expect.objectContaining({
+            time_range: 'Last year',
+          }),
+        }),
+      }),
+    }),
+  );
+  const withTimeRangeSet = {
+    form_data: { time_range: 'Last day' },
+    slice: {},
+    dataset: {},
+  };
+  // @ts-ignore
+  hydrateExplore(withTimeRangeSet)(dispatch, getState);
+  expect(dispatch).toHaveBeenCalledWith(
+    expect.objectContaining({
+      data: expect.objectContaining({
+        explore: expect.objectContaining({
+          form_data: expect.objectContaining({
+            time_range: 'Last day',
+          }),
+        }),
+      }),
+    }),
+  );
+});

--- a/superset-frontend/src/explore/actions/hydrateExplore.ts
+++ b/superset-frontend/src/explore/actions/hydrateExplore.ts
@@ -30,6 +30,7 @@ import {
   ensureIsArray,
   getCategoricalSchemeRegistry,
   getSequentialSchemeRegistry,
+  NO_TIME_RANGE,
 } from '@superset-ui/core';
 import {
   getFormDataFromControls,
@@ -61,6 +62,10 @@ export const hydrateExplore =
       const defaultVizType = common?.conf.DEFAULT_VIZ_TYPE || 'table';
       initialFormData.viz_type =
         getUrlParam(URL_PARAMS.vizType) || defaultVizType;
+    }
+    if (!initialFormData.time_range) {
+      initialFormData.time_range =
+        common?.conf?.DEFAULT_TIME_FILTER || NO_TIME_RANGE;
     }
     if (dashboardId) {
       initialFormData.dashboardId = dashboardId;

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -17,14 +17,7 @@
  * under the License.
  */
 import React, { useState, useEffect, useMemo } from 'react';
-import {
-  css,
-  styled,
-  t,
-  useTheme,
-  DEFAULT_TIME_RANGE,
-  NO_TIME_RANGE,
-} from '@superset-ui/core';
+import { css, styled, t, useTheme, NO_TIME_RANGE } from '@superset-ui/core';
 import Button from 'src/components/Button';
 import ControlHeader from 'src/explore/components/ControlHeader';
 import Label, { Type } from 'src/components/Label';
@@ -128,7 +121,7 @@ const IconWrapper = styled.span`
 
 export default function DateFilterLabel(props: DateFilterControlProps) {
   const {
-    value = DEFAULT_TIME_RANGE,
+    value = NO_TIME_RANGE,
     onChange,
     type,
     onOpenPopover = noOp,

--- a/superset-frontend/src/explore/fixtures.tsx
+++ b/superset-frontend/src/explore/fixtures.tsx
@@ -115,7 +115,6 @@ export const exploreInitialData: ExplorePageInitialData = {
     datasource: '8__table',
     metric: 'count',
     slice_id: 371,
-    time_range: 'No filter',
     viz_type: 'table',
   },
   slice: {
@@ -128,7 +127,6 @@ export const exploreInitialData: ExplorePageInitialData = {
       datasource: '8__table',
       metric: 'count',
       slice_id: 371,
-      time_range: 'No filter',
       viz_type: 'table',
     },
   },

--- a/superset-frontend/src/explore/reducers/exploreReducer.js
+++ b/superset-frontend/src/explore/reducers/exploreReducer.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 /* eslint camelcase: 0 */
-import { ensureIsArray, DEFAULT_TIME_RANGE } from '@superset-ui/core';
+import { ensureIsArray } from '@superset-ui/core';
 import { DYNAMIC_PLUGIN_CONTROLS_READY } from 'src/components/Chart/chartAction';
 import { getControlsState } from 'src/explore/store';
 import {
@@ -59,11 +59,8 @@ export default function exploreReducer(state = {}, action) {
         prevDatasource.id !== newDatasource.id ||
         prevDatasource.type !== newDatasource.type
       ) {
-        // reset time range filter to default
-        newFormData.time_range = DEFAULT_TIME_RANGE;
         newFormData.datasource = newDatasource.uid;
       }
-
       // reset control values for column/metric related controls
       Object.entries(controls).forEach(([controlName, controlState]) => {
         if (

--- a/superset/config.py
+++ b/superset/config.py
@@ -59,7 +59,7 @@ from superset.constants import CHANGE_ME_SECRET_KEY
 from superset.jinja_context import BaseTemplateProcessor
 from superset.stats_logger import DummyStatsLogger
 from superset.superset_typing import CacheConfig
-from superset.utils.core import is_test, parse_boolean_string
+from superset.utils.core import is_test, NO_TIME_RANGE, parse_boolean_string
 from superset.utils.encrypt import SQLAlchemyUtilsAdapter
 from superset.utils.log import DBEventLogger
 from superset.utils.logging_configurator import DefaultLoggingConfigurator
@@ -155,7 +155,7 @@ SAMPLES_ROW_LIMIT = 1000
 FILTER_SELECT_ROW_LIMIT = 10000
 # default time filter in explore
 # values may be "Last day", "Last week", "<ISO date> : now", etc.
-DEFAULT_TIME_FILTER = None
+DEFAULT_TIME_FILTER = NO_TIME_RANGE
 
 SUPERSET_WEBSERVER_PROTOCOL = "http"
 SUPERSET_WEBSERVER_ADDRESS = "0.0.0.0"

--- a/superset/config.py
+++ b/superset/config.py
@@ -153,6 +153,9 @@ ROW_LIMIT = 50000
 SAMPLES_ROW_LIMIT = 1000
 # max rows retrieved by filter select auto complete
 FILTER_SELECT_ROW_LIMIT = 10000
+# default time filter in explore
+# values may be "Last day", "Last week", "<ISO date> : now", etc.
+DEFAULT_TIME_FILTER = None
 
 SUPERSET_WEBSERVER_PROTOCOL = "http"
 SUPERSET_WEBSERVER_ADDRESS = "0.0.0.0"

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -110,6 +110,7 @@ FRONTEND_CONF_KEYS = (
     "COLUMNAR_EXTENSIONS",
     "ALLOWED_EXTENSIONS",
     "SAMPLES_ROW_LIMIT",
+    "DEFAULT_TIME_FILTER",
 )
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

First change to complete https://github.com/apache/superset/issues/13125: We add a new configuration `DEFAULT_TIME_FILTER` to allow admins to set a global default time filter for any new explore charts. By default this is set to `None`, which replicates the previous behavior (`"No filter"`). To get a default filter of -1w the configuration can be set to `'Last week'` or any other value understood by Superset.

There is a minor change in behavior `UPDATE_FORM_DATA_BY_DATASOURCE` (when switching dataset in explore), the time filter is not reset anymore. This is similar to the behavior of other globally configured filters such as the row limit for explore, which also do not reset.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
New explore chart with `DEFAULT_TIME_FILTER = None`:
<img src="https://user-images.githubusercontent.com/1842905/196846013-317773cd-21e7-4ee3-889c-a16803874426.png" width="200">
New explore chart with `DEFAULT_TIME_FILTER = "Last week"`:
<img src="https://user-images.githubusercontent.com/1842905/196845999-d4838206-18d8-4ba3-bbdc-a9d93bed3957.png" width="200">

### TESTING INSTRUCTIONS

#### Test default behavior
1. Go to datasets and click on users (example dataset)
2. Add `updated` (time) as a dimension (helps to verify)

**Expected**: No time filter is applied when running the chart

#### Test with new configuration
1. Set `DEFAULT_TIME_FILTER = "2020-06-01T00:00:00 : now"` in `config.py`
2. Go to datasets and click on users (example dataset)
4. Add `updated` (time) as dimension (helps to verify)

**Expected**: Default time filter is applied

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/13125
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
