### PR TITLE
fix(dashboard): Ensure correct positioning of "Drill to detail by" submenu

### DIFF
--- a/superset-frontend/src/components/Chart/ChartContextMenu.tsx
+++ b/superset-frontend/src/components/Chart/ChartContextMenu.tsx
@@ -36,9 +36,7 @@ import { findPermission } from 'src/utils/findPermission';
 import { Menu } from 'src/components/Menu';
 import { AntdDropdown as Dropdown } from 'src/components';
 import { DrillDetailMenuItems } from './DrillDetail';
-
-const MENU_ITEM_HEIGHT = 32;
-const MENU_VERTICAL_SPACING = 32;
+import { getMenuAdjustedY } from './utils';
 
 export interface ChartContextMenuProps {
   id: number;
@@ -78,8 +76,9 @@ const ChartContextMenu = (
       <DrillDetailMenuItems
         chartId={id}
         formData={formData}
-        isContextMenu
         filters={filters}
+        isContextMenu
+        contextMenuY={clientY}
         onSelection={onSelection}
       />,
     );
@@ -91,21 +90,12 @@ const ChartContextMenu = (
       clientY: number,
       filters?: BinaryQueryObjectFilterClause[],
     ) => {
-      // Viewport height
-      const vh = Math.max(
-        document.documentElement.clientHeight || 0,
-        window.innerHeight || 0,
-      );
-
       const itemsCount =
         [
           showDrillToDetail ? 2 : 0, // Drill to detail always has 2 top-level menu items
         ].reduce((a, b) => a + b, 0) || 1; // "No actions" appears if no actions in menu
 
-      const menuHeight = MENU_ITEM_HEIGHT * itemsCount + MENU_VERTICAL_SPACING;
-      // Always show the context menu inside the viewport
-      const adjustedY = vh - clientY < menuHeight ? vh - menuHeight : clientY;
-
+      const adjustedY = getMenuAdjustedY(clientY, itemsCount);
       setState({
         clientX,
         clientY: adjustedY,

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailMenuItems.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailMenuItems.tsx
@@ -34,6 +34,9 @@ import { Menu } from 'src/components/Menu';
 import Icons from 'src/components/Icons';
 import { Tooltip } from 'src/components/Tooltip';
 import DrillDetailModal from './DrillDetailModal';
+import { getMenuAdjustedY, MENU_ITEM_HEIGHT } from '../utils';
+
+const MENU_PADDING = 4;
 
 const DisabledMenuItemTooltip = ({ title }: { title: ReactNode }) => (
   <Tooltip title={title} placement="top">
@@ -79,6 +82,7 @@ export type DrillDetailMenuItemsProps = {
   formData: QueryFormData;
   filters?: BinaryQueryObjectFilterClause[];
   isContextMenu?: boolean;
+  contextMenuY?: number;
   onSelection?: () => void;
   onClick?: (event: MouseEvent) => void;
 };
@@ -88,6 +92,7 @@ const DrillDetailMenuItems = ({
   formData,
   filters = [],
   isContextMenu = false,
+  contextMenuY = 0,
   onSelection = () => null,
   onClick = () => null,
   ...props
@@ -176,9 +181,22 @@ const DrillDetailMenuItems = ({
     );
   }
 
+  // Ensure submenu doesn't appear offscreen
+  const submenuYOffset = useMemo(() => {
+    const itemsCount = filters.length > 1 ? filters.length + 1 : filters.length;
+    const submenuY =
+      contextMenuY + MENU_PADDING + MENU_ITEM_HEIGHT + MENU_PADDING;
+
+    return getMenuAdjustedY(submenuY, itemsCount) - submenuY;
+  }, [contextMenuY, filters.length]);
+
   if (handlesDimensionContextMenu && !noAggregations && filters?.length) {
     drillToDetailByMenuItem = (
-      <Menu.SubMenu {...props} title={t('Drill to detail by')}>
+      <Menu.SubMenu
+        {...props}
+        popupOffset={[0, submenuYOffset]}
+        title={t('Drill to detail by')}
+      >
         <div data-test="drill-to-detail-by-submenu">
           {filters.map((filter, i) => (
             <Menu.Item

--- a/superset-frontend/src/components/Chart/utils.test.ts
+++ b/superset-frontend/src/components/Chart/utils.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { getMenuAdjustedY } from './utils';
+
+const originalInnerHeight = window.innerHeight;
+
+beforeEach(() => {
+  window.innerHeight = 500;
+});
+
+afterEach(() => {
+  window.innerHeight = originalInnerHeight;
+});
+
+test('correctly positions at upper edge of screen', () => {
+  expect(getMenuAdjustedY(75, 1)).toEqual(75); // No adjustment
+  expect(getMenuAdjustedY(75, 2)).toEqual(75); // No adjustment
+  expect(getMenuAdjustedY(75, 3)).toEqual(75); // No adjustment
+});
+
+test('correctly positions at lower edge of screen', () => {
+  expect(getMenuAdjustedY(425, 1)).toEqual(425); // No adjustment
+  expect(getMenuAdjustedY(425, 2)).toEqual(404); // Adjustment
+  expect(getMenuAdjustedY(425, 3)).toEqual(372); // Adjustment
+});

--- a/superset-frontend/src/components/Chart/utils.ts
+++ b/superset-frontend/src/components/Chart/utils.ts
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export const MENU_ITEM_HEIGHT = 32;
+const MENU_VERTICAL_SPACING = 32;
+
+/**
+ * Calculates an adjusted Y-offset for a menu or submenu to prevent that
+ * menu from appearing offscreen
+ *
+ * @param clientY The original Y-offset
+ * @param itemsCount The number of menu items
+ */
+export function getMenuAdjustedY(clientY: number, itemsCount: number) {
+  // Viewport height
+  const vh = Math.max(
+    document.documentElement.clientHeight || 0,
+    window.innerHeight || 0,
+  );
+
+  const menuHeight = MENU_ITEM_HEIGHT * itemsCount + MENU_VERTICAL_SPACING;
+  // Always show the context menu inside the viewport
+  return vh - clientY < menuHeight ? vh - menuHeight : clientY;
+}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The "Drill to detail by" context menu submenu introduced in #21351 can end up offscreen, if there are enough menu items and you right-click close to the bottom of the viewport.  This PR uses the logic that currently handles that issue with the top-level context menu to also handle the issue for the submenu.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
<img width="947" alt="Screen Shot 2022-10-20 at 3 12 59 PM" src="https://user-images.githubusercontent.com/13007381/197059380-b8198c3a-ef33-4d38-9697-06a3008f02a7.png">

After:
<img width="955" alt="Screen Shot 2022-10-20 at 3 13 27 PM" src="https://user-images.githubusercontent.com/13007381/197059420-85b573d9-c9ee-4559-8586-ef41127f4272.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Run Superset with `DRILL_TO_DETAIL` set to `True`.
2. Create a dashboard full of time-series bar charts with > 1 dimension.
3. Try opening the drill to detail context menu all over the chart.  Submenu placement should be the default Y-position (slightly lower than the parent item) everywhere except near the bottom edge.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Required feature flags: `DRILL_TO_DETAIL`
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
