### PR TITLE
chore: Updating SIP issue template to boost the link, and (hopefully) reduce duplicate-numbered SIP issues.

### DIFF
--- a/.github/ISSUE_TEMPLATE/sip.md
+++ b/.github/ISSUE_TEMPLATE/sip.md
@@ -1,14 +1,14 @@
 ---
 name: SIP
-about: Superset Improvement Proposal
+about: Superset Improvement Proposal [See SIP-0](https://github.com/apache/superset/issues/5602)
 labels: "#SIP"
 
 ---
 
 *Please make sure you are familiar with the SIP process documented*
-(here)[https://github.com/apache/superset/issues/5602]. The SIP number should be the next number after the latest SIP listed [here](https://github.com/apache/superset/issues?q=is%3Aissue+label%3Asip).
+(here)[https://github.com/apache/superset/issues/5602]. The SIP will be numbered by a committer upon acceptance.
 
-## [SIP-\<number>] Proposal for <title>
+## [SIP] Proposal for ...<title>
 
 ### Motivation
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR does a few things:
1) Moves the link to SIP-0 to the template list page (not sure if this will work!)
2) Removes instructions for people to number their own sip. A committer should do this, per SIP-0
3) Adjusts the PR title accordingly to item 2.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Open a new issue when merged, make sure the link works!

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
