### PR TITLE
fix(sqllab): fix control x to stop query

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -174,7 +174,7 @@ const SqlEditor = ({
         database: databases[dbId],
         latestQuery: queries[latestQueryId],
         hideLeftBar,
-      }
+      };
     },
   );
 
@@ -332,14 +332,13 @@ const SqlEditor = ({
     };
   }, []);
 
-  useEffect(()=> {
+  useEffect(() => {
     // setup hotkeys
     Mousetrap.reset();
     const hotkeys = getHotkeyConfig();
     hotkeys.forEach(keyConfig => {
       Mousetrap.bind([keyConfig.key], keyConfig.func);
     });
-
   }, [latestQuery])
 
   const onResizeStart = () => {

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -339,7 +339,7 @@ const SqlEditor = ({
     hotkeys.forEach(keyConfig => {
       Mousetrap.bind([keyConfig.key], keyConfig.func);
     });
-  }, [latestQuery])
+  }, [latestQuery]);
 
   const onResizeStart = () => {
     // Set the heights on the ace editor and the ace content area after drag starts

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -174,7 +174,7 @@ const SqlEditor = ({
         database: databases[dbId],
         latestQuery: queries[latestQueryId],
         hideLeftBar,
-      };
+      }
     },
   );
 
@@ -219,6 +219,7 @@ const SqlEditor = ({
     if (latestQuery && ['running', 'pending'].indexOf(latestQuery.state) >= 0) {
       dispatch(postStopQuery(latestQuery));
     }
+    return false;
   };
 
   const runQuery = () => {
@@ -244,7 +245,6 @@ const SqlEditor = ({
   const getHotkeyConfig = () => {
     // Get the user's OS
     const userOS = detectOS();
-
     const base = [
       {
         name: 'runQuery1',
@@ -326,17 +326,21 @@ const SqlEditor = ({
     window.addEventListener('resize', handleWindowResizeWithThrottle);
     window.addEventListener('beforeunload', onBeforeUnload);
 
-    // setup hotkeys
-    const hotkeys = getHotkeyConfig();
-    hotkeys.forEach(keyConfig => {
-      Mousetrap.bind([keyConfig.key], keyConfig.func);
-    });
-
     return () => {
       window.removeEventListener('resize', handleWindowResizeWithThrottle);
       window.removeEventListener('beforeunload', onBeforeUnload);
     };
   }, []);
+
+  useEffect(()=> {
+    // setup hotkeys
+    Mousetrap.reset();
+    const hotkeys = getHotkeyConfig();
+    hotkeys.forEach(keyConfig => {
+      Mousetrap.bind([keyConfig.key], keyConfig.func);
+    });
+
+  }, [latestQuery])
 
   const onResizeStart = () => {
     // Set the heights on the ace editor and the ace content area after drag starts


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
After the refactor of the sqleditor component users weren't able to to stop query by control + x. This pr ensures that the component rebinds the mouestrap keys when latesquery is updated. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
after 


https://user-images.githubusercontent.com/17326228/197295606-1ca27619-e690-4726-972d-4842d71939fd.mov



### TESTING INSTRUCTIONS
Go to sqllab and run a query and use the control + x key to stop the query.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
