### PR TITLE
fix: eslint error in VSCode

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -37,9 +37,6 @@ if (process.env.NODE_ENV === 'production') {
 }
 
 module.exports = {
-  workingDirectories: [
-    {"mode": "auto"}
-  ],
   extends: [
     'airbnb',
     'prettier',

--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -37,6 +37,9 @@ if (process.env.NODE_ENV === 'production') {
 }
 
 module.exports = {
+  workingDirectories: [
+    {"mode": "auto"}
+  ],
   extends: [
     'airbnb',
     'prettier',
@@ -150,7 +153,9 @@ module.exports = {
       },
       settings: {
         'import/resolver': {
-          typescript: {},
+          typescript: {
+            moduleDirectory: ['node_modules', '.'],
+          },
         },
         react: {
           version: 'detect',


### PR DESCRIPTION
Fix eslint error in VSCode

1. Import error: Unable to resolve path to module 'src/utils/urlUtils'

2. Parsing error: No Babel config file detected for /superset/superset-frontend/.eslintrc.js. Either disable config file checking with requireConfigFile:false, or configure Babel so that it can find the config files. 

  Update `settings.json` of VSCode:
  ```json
  "eslint.workingDirectories": [
     {"mode": "auto"}
  ],
  ```

![11](https://user-images.githubusercontent.com/10323102/197149801-325f5db7-e1bf-4e78-b299-504954eaa37a.png)

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
