### PR TITLE
chore: Improves D2D loading indicator

### DIFF
--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.test.tsx
@@ -122,11 +122,11 @@ test('should render', async () => {
   expect(container).toBeInTheDocument();
 });
 
-test('should render metadata and table loading indicators', async () => {
+test('should render loading indicator', async () => {
   fetchWithData();
   setup();
   await waitFor(() =>
-    expect(screen.getAllByLabelText('Loading').length).toBe(2),
+    expect(screen.getByLabelText('Loading')).toBeInTheDocument(),
   );
 });
 

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
@@ -194,6 +194,12 @@ export default function DrillDetailPane({
     resultsPages,
   ]);
 
+  // Get datasource metadata
+  const response = useApiV1Resource<Dataset>(`/api/v1/dataset/${datasourceId}`);
+
+  const bootstrapping =
+    (!responseError && !resultsPages.size) || response.status === 'loading';
+
   let tableContent = null;
   if (responseError) {
     // Render error if page download failed
@@ -206,7 +212,7 @@ export default function DrillDetailPane({
         {responseError}
       </pre>
     );
-  } else if (!resultsPages.size) {
+  } else if (bootstrapping) {
     // Render loading if first page hasn't loaded
     tableContent = <Loading />;
   } else if (resultsPage?.total === 0) {
@@ -240,9 +246,6 @@ export default function DrillDetailPane({
       />
     );
   }
-
-  // Get datasource metadata
-  const response = useApiV1Resource<Dataset>(`/api/v1/dataset/${datasourceId}`);
 
   const metadata = useMemo(() => {
     const { status, result } = response;
@@ -298,7 +301,6 @@ export default function DrillDetailPane({
           margin-bottom: ${theme.gridUnit * 4}px;
         `}
       >
-        {status === 'loading' && <Loading position="inline-centered" />}
         {status === 'complete' && <MetadataBar items={items} />}
         {status === 'error' && (
           <Alert
@@ -312,14 +314,16 @@ export default function DrillDetailPane({
 
   return (
     <>
-      {metadata}
-      <TableControls
-        filters={filters}
-        setFilters={setFilters}
-        totalCount={resultsPage?.total}
-        loading={isLoading}
-        onReload={handleReload}
-      />
+      {!bootstrapping && metadata}
+      {!bootstrapping && (
+        <TableControls
+          filters={filters}
+          setFilters={setFilters}
+          totalCount={resultsPage?.total}
+          loading={isLoading}
+          onReload={handleReload}
+        />
+      )}
       {tableContent}
     </>
   );


### PR DESCRIPTION
### SUMMARY
Improves Drill to Detail loading indicator to show only one spinner when bootstrapping.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/197198336-97ecdf3b-265a-4fdf-89d4-cc0dce855a3b.mov

https://user-images.githubusercontent.com/70410625/197198392-4aac720d-ddba-40d6-8d7f-3ae89a41b1ad.mov

### TESTING INSTRUCTIONS
Check the videos for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
