### PR TITLE
fix(superset): Fixed API for bulk delete of embedded dashboards

### DIFF
--- a/superset/dashboards/dao.py
+++ b/superset/dashboards/dao.py
@@ -160,6 +160,7 @@ class DashboardDAO(BaseDAO):
             for model in models:
                 model.slices = []
                 model.owners = []
+                model.embedded = []
                 db.session.merge(model)
         # bulk delete itself
         try:

--- a/superset/dashboards/dao.py
+++ b/superset/dashboards/dao.py
@@ -160,7 +160,6 @@ class DashboardDAO(BaseDAO):
             for model in models:
                 model.slices = []
                 model.owners = []
-                model.embedded = []
                 db.session.merge(model)
         # bulk delete itself
         try:

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -814,16 +814,16 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
             dashboard_ids.append(
                 self.insert_dashboard(
                     f"title{dashboard_name_index}",
-                    f"slug{dashboard_name_index}",
+                    None,
                     [user.id],
                 ).id
             )
         self.login(username=user.username)
-        for dashboard_name_index in range(dashboard_count):
+        for dashboard_id in dashboard_ids:
             # post succeeds and returns value
             allowed_domains = ["test.example", "embedded.example"]
             resp = self.post_assert_metric(
-                f"api/v1/dashboard/slug{dashboard_name_index}/embedded",
+                f"api/v1/dashboard/{dashboard_id}/embedded",
                 {"allowed_domains": allowed_domains},
                 "set_embedded",
             )

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -807,7 +807,7 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
         """
         Dashboard API: Test delete bulk embedded
         """
-        admin_id = self.get_user("admin").id
+        user = self.get_user("admin")
         dashboard_count = 4
         dashboard_ids = list()
         for dashboard_name_index in range(dashboard_count):
@@ -815,10 +815,10 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
                 self.insert_dashboard(
                     f"title{dashboard_name_index}",
                     f"slug{dashboard_name_index}",
-                    [admin_id],
+                    [user.id],
                 ).id
             )
-        self.login(username="admin")
+        self.login(username=user.username)
         for dashboard_name_index in range(dashboard_count):
             # post succeeds and returns value
             allowed_domains = ["test.example", "embedded.example"]
@@ -832,7 +832,6 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
             self.assertIsNotNone(result["uuid"])
             self.assertNotEqual(result["uuid"], "")
             self.assertEqual(result["allowed_domains"], allowed_domains)
-        self.login(username="admin")
         argument = dashboard_ids
         uri = f"api/v1/dashboard/?q={prison.dumps(argument)}"
         rv = self.delete_assert_metric(uri, "bulk_delete")

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -819,11 +819,11 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
                 ).id
             )
         self.login(username="admin")
-        for dashboard_id in range(dashboard_ids):
+        for dashboard_name_index in range(dashboard_count):
             # post succeeds and returns value
             allowed_domains = ["test.example", "embedded.example"]
             resp = self.post_assert_metric(
-                f"api/v1/dashboard/{dashboard_id}/embedded",
+                f"api/v1/dashboard/slug{dashboard_name_index}/embedded",
                 {"allowed_domains": allowed_domains},
                 "set_embedded",
             )


### PR DESCRIPTION
### SUMMARY
This change fixes bulk delete of dashboards which have embedding enabled.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
NA

### TESTING INSTRUCTIONS
`curl $'http://localhost:8088/api/v1/dashboard/?q=\u0021(id1,id2)' \
  -X 'DELETE' \
  -H 'Accept: application/json' \
  -H 'Cookie: session=some-session' \
  -H 'Origin: http://localhost:8088' \
  -H 'X-CSRFToken: some-token' \
  --compressed`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
