### PR TITLE
fix: Fix Cypress test broken by extra dashboards

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/chart_list/list.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/chart_list/list.test.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { CHART_LIST } from 'cypress/utils/urls';
+import { CHART_LIST, DASHBOARD_LIST } from 'cypress/utils/urls';
 import { setGridMode, toggleBulkSelect } from 'cypress/utils';
 import {
   setFilter,
@@ -68,6 +68,20 @@ describe('Charts list', () => {
       cy.createSampleCharts([0]);
     });
 
+    after(() => {
+      cy.visit(DASHBOARD_LIST);
+      cy.wait(1000);
+      toggleBulkSelect();
+      cy.wait(1000);
+      cy.getBySel('table-row').each($row => {
+        if ($row.text().indexOf('Sample dashboard') > -1) {
+          cy.wrap($row).find('input[type="checkbox"]').click();
+        }
+      });
+      cy.getBySel('bulk-select-action').eq(0).contains('Delete').click();
+      confirmDelete();
+    });
+
     it('should show the cross-referenced dashboards in the table cell', () => {
       interceptDashboardGet();
       cy.getBySel('table-row')
@@ -92,6 +106,7 @@ describe('Charts list', () => {
       saveChartToDashboard('2 - Sample dashboard');
       saveChartToDashboard('3 - Sample dashboard');
       saveChartToDashboard('4 - Sample dashboard');
+      cy.wait(500);
       visitChartList();
       cy.getBySel('count-crosslinks').should('be.visible');
       cy.getBySel('crosslinks')


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The Cypress test **`chart_list/list.test.ts` > Charts list > Cross-referenced dashboards** adds new dashboards but doesn't remove them, causing `dashboard_list/list.test.ts` to fail when testing sort order if the two test files end up run on the same worker/machine.  This PR adds an `after` clause that removes those dashboards, and also adds a `wait` that I think should help with making `chart_list/list.test.ts` less flaky.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
<img width="737" alt="Screen Shot 2022-10-21 at 7 25 06 PM" src="https://user-images.githubusercontent.com/13007381/197310756-63187681-23ec-48e9-bd22-7d135270e3b0.png">

After:
<img width="748" alt="Screen Shot 2022-10-21 at 7 24 56 PM" src="https://user-images.githubusercontent.com/13007381/197310761-df2b3433-2e09-42cb-a79e-b29401fc8504.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- In Cypress, try running `chart_list/list.test.ts` followed by `dashboard_list/list.test.ts`.  There shouldn't be any errors.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
