### PR TITLE
fix(explore): Chart save modal displays error instead of failing silently

### DIFF
--- a/superset-frontend/src/explore/ExplorePage.tsx
+++ b/superset-frontend/src/explore/ExplorePage.tsx
@@ -124,7 +124,6 @@ export default function ExplorePage() {
     ) as SaveActionType | null;
     const dashboardContextFormData = getDashboardContextFormData();
     if (!isExploreInitialized.current || !!saveAction) {
-      exploreUrlParams.delete(URL_PARAMS.saveAction.name);
       fetchExploreData(exploreUrlParams)
         .then(({ result }) => {
           const formData = dashboardContextFormData

--- a/superset-frontend/src/explore/ExplorePage.tsx
+++ b/superset-frontend/src/explore/ExplorePage.tsx
@@ -37,7 +37,7 @@ import { getAppliedFilterValues } from 'src/dashboard/util/activeDashboardFilter
 import { getParsedExploreURLParams } from './exploreUtils/getParsedExploreURLParams';
 import { hydrateExplore } from './actions/hydrateExplore';
 import ExploreViewContainer from './components/ExploreViewContainer';
-import { ExploreResponsePayload } from './types';
+import { ExploreResponsePayload, SaveActionType } from './types';
 import { fallbackExploreInitialData } from './fixtures';
 import { getItem, LocalStorageKeys } from '../utils/localStorageHelpers';
 import { getFormDataWithDashboardContext } from './controlUtils/getFormDataWithDashboardContext';
@@ -119,9 +119,12 @@ export default function ExplorePage() {
 
   useEffect(() => {
     const exploreUrlParams = getParsedExploreURLParams(location);
-    const isSaveAction = !!getUrlParam(URL_PARAMS.saveAction);
+    const saveAction = getUrlParam(
+      URL_PARAMS.saveAction,
+    ) as SaveActionType | null;
     const dashboardContextFormData = getDashboardContextFormData();
-    if (!isExploreInitialized.current || isSaveAction) {
+    if (!isExploreInitialized.current || !!saveAction) {
+      exploreUrlParams.delete(URL_PARAMS.saveAction.name);
       fetchExploreData(exploreUrlParams)
         .then(({ result }) => {
           const formData = dashboardContextFormData
@@ -134,6 +137,7 @@ export default function ExplorePage() {
             hydrateExplore({
               ...result,
               form_data: formData,
+              saveAction,
             }),
           );
         })

--- a/superset-frontend/src/explore/actions/exploreActions.ts
+++ b/superset-frontend/src/explore/actions/exploreActions.ts
@@ -25,7 +25,7 @@ import {
   toastActions,
 } from 'src/components/MessageToasts/actions';
 import { Slice } from 'src/types/Chart';
-import { SaveActionType } from '../types';
+import { SaveActionType } from 'src/explore/types';
 
 const FAVESTAR_BASE_URL = '/superset/favstar/slice';
 

--- a/superset-frontend/src/explore/actions/exploreActions.ts
+++ b/superset-frontend/src/explore/actions/exploreActions.ts
@@ -25,6 +25,7 @@ import {
   toastActions,
 } from 'src/components/MessageToasts/actions';
 import { Slice } from 'src/types/Chart';
+import { SaveActionType } from '../types';
 
 const FAVESTAR_BASE_URL = '/superset/favstar/slice';
 
@@ -112,6 +113,11 @@ export function setFormData(formData: QueryFormData) {
 export const UPDATE_CHART_TITLE = 'UPDATE_CHART_TITLE';
 export function updateChartTitle(sliceName: string) {
   return { type: UPDATE_CHART_TITLE, sliceName };
+}
+
+export const SET_SAVE_ACTION = 'SET_SAVE_ACTION';
+export function setSaveAction(saveAction: SaveActionType | null) {
+  return { type: SET_SAVE_ACTION, saveAction };
 }
 
 export const CREATE_NEW_SLICE = 'CREATE_NEW_SLICE';

--- a/superset-frontend/src/explore/actions/hydrateExplore.test.ts
+++ b/superset-frontend/src/explore/actions/hydrateExplore.test.ts
@@ -70,6 +70,7 @@ test('creates hydrate action from initial data', () => {
         saveModal: {
           dashboards: [],
           saveModalAlert: null,
+          isVisible: false,
         },
         explore: {
           can_add: false,
@@ -84,6 +85,7 @@ test('creates hydrate action from initial data', () => {
           slice: exploreInitialData.slice,
           standalone: null,
           force: null,
+          saveAction: null,
         },
       },
     }),
@@ -140,6 +142,7 @@ test('creates hydrate action with existing state', () => {
         saveModal: {
           dashboards: [],
           saveModalAlert: null,
+          isVisible: false,
         },
         explore: {
           can_add: false,
@@ -155,6 +158,7 @@ test('creates hydrate action with existing state', () => {
           slice: exploreInitialData.slice,
           standalone: null,
           force: null,
+          saveAction: null,
         },
       },
     }),

--- a/superset-frontend/src/explore/actions/hydrateExplore.ts
+++ b/superset-frontend/src/explore/actions/hydrateExplore.ts
@@ -48,7 +48,13 @@ enum ColorSchemeType {
 
 export const HYDRATE_EXPLORE = 'HYDRATE_EXPLORE';
 export const hydrateExplore =
-  ({ form_data, slice, dataset, metadata }: ExplorePageInitialData) =>
+  ({
+    form_data,
+    slice,
+    dataset,
+    metadata,
+    saveAction = null,
+  }: ExplorePageInitialData) =>
   (dispatch: Dispatch, getState: () => ExplorePageState) => {
     const { user, datasources, charts, sliceEntities, common, explore } =
       getState();
@@ -129,6 +135,7 @@ export const hydrateExplore =
       standalone: getUrlParam(URL_PARAMS.standalone),
       force: getUrlParam(URL_PARAMS.force),
       metadata,
+      saveAction,
     };
 
     // apply initial mapStateToProps for all controls, must execute AFTER
@@ -174,6 +181,7 @@ export const hydrateExplore =
         saveModal: {
           dashboards: [],
           saveModalAlert: null,
+          isVisible: false,
         },
         explore: exploreState,
       },

--- a/superset-frontend/src/explore/actions/saveModalActions.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.js
@@ -33,6 +33,12 @@ export function fetchDashboardsFailed(userId) {
   return { type: FETCH_DASHBOARDS_FAILED, userId };
 }
 
+export const SET_SAVE_CHART_MODAL_VISIBILITY =
+  'SET_SAVE_CHART_MODAL_VISIBILITY';
+export function setSaveChartModalVisibility(isVisible) {
+  return { type: SET_SAVE_CHART_MODAL_VISIBILITY, isVisible };
+}
+
 export function fetchDashboards(userId) {
   return function fetchDashboardsThunk(dispatch) {
     return SupersetClient.get({

--- a/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
@@ -23,6 +23,7 @@ import { render, screen, waitFor } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import * as chartAction from 'src/components/Chart/chartAction';
+import * as saveModalActions from 'src/explore/actions/saveModalActions';
 import * as downloadAsImage from 'src/utils/downloadAsImage';
 import * as exploreUtils from 'src/explore/exploreUtils';
 import { FeatureFlag } from '@superset-ui/core';
@@ -114,7 +115,6 @@ const createProps = (additionalProps = {}) => ({
     changed_by: 'John Doe',
     dashboards: [{ id: 1, dashboard_title: 'Test' }],
   },
-  onSaveChart: jest.fn(),
   canOverwrite: false,
   canDownload: false,
   isStarred: false,
@@ -178,19 +178,29 @@ test('does not render the metadata bar when not saved', async () => {
 });
 
 test('Save chart', async () => {
+  const setSaveChartModalVisibility = jest.spyOn(
+    saveModalActions,
+    'setSaveChartModalVisibility',
+  );
   const props = createProps();
   render(<ExploreHeader {...props} />, { useRedux: true });
   expect(await screen.findByText('Save')).toBeInTheDocument();
   userEvent.click(screen.getByText('Save'));
-  expect(props.onSaveChart).toHaveBeenCalled();
+  expect(setSaveChartModalVisibility).toHaveBeenCalledWith(true);
+  setSaveChartModalVisibility.mockClear();
 });
 
 test('Save disabled', async () => {
+  const setSaveChartModalVisibility = jest.spyOn(
+    saveModalActions,
+    'setSaveChartModalVisibility',
+  );
   const props = createProps();
   render(<ExploreHeader {...props} saveDisabled />, { useRedux: true });
   expect(await screen.findByText('Save')).toBeInTheDocument();
   userEvent.click(screen.getByText('Save'));
-  expect(props.onSaveChart).not.toHaveBeenCalled();
+  expect(setSaveChartModalVisibility).not.toHaveBeenCalled();
+  setSaveChartModalVisibility.mockClear();
 });
 
 describe('Additional actions tests', () => {

--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
@@ -16,9 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useEffect, useMemo, useState } from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Tooltip } from 'src/components/Tooltip';
 import {
@@ -28,16 +27,15 @@ import {
   SupersetClient,
   t,
 } from '@superset-ui/core';
-import { toggleActive, deleteActiveReport } from 'src/reports/actions/reports';
 import { chartPropShape } from 'src/dashboard/util/propShapes';
 import AlteredSliceTag from 'src/components/AlteredSliceTag';
 import Button from 'src/components/Button';
 import Icons from 'src/components/Icons';
 import PropertiesModal from 'src/explore/components/PropertiesModal';
 import { sliceUpdated } from 'src/explore/actions/exploreActions';
-import { setSaveChartModalVisibility } from 'src/explore/actions/saveModalActions';
 import { PageHeaderWithActions } from 'src/components/PageHeaderWithActions';
 import MetadataBar, { MetadataType } from 'src/components/MetadataBar';
+import { setSaveChartModalVisibility } from 'src/explore/actions/saveModalActions';
 import { useExploreAdditionalActionsMenu } from '../useExploreAdditionalActionsMenu';
 
 const propTypes = {
@@ -83,12 +81,11 @@ export const ExploreChartHeader = ({
   canOverwrite,
   canDownload,
   isStarred,
-  sliceUpdated,
-  setSaveChartModalVisibility,
   sliceName,
   saveDisabled,
   metadata,
 }) => {
+  const dispatch = useDispatch();
   const { latestQueryFormData, sliceFormData } = chart;
   const [isPropertiesModalOpen, setIsPropertiesModalOpen] = useState(false);
 
@@ -141,6 +138,17 @@ export const ExploreChartHeader = ({
   const closePropertiesModal = () => {
     setIsPropertiesModalOpen(false);
   };
+
+  const showModal = useCallback(() => {
+    dispatch(setSaveChartModalVisibility(true));
+  }, [dispatch]);
+
+  const updateSlice = useCallback(
+    slice => {
+      dispatch(sliceUpdated(slice));
+    },
+    [dispatch],
+  );
 
   const [menu, isDropdownVisible, setIsDropdownVisible] =
     useExploreAdditionalActionsMenu(
@@ -245,7 +253,7 @@ export const ExploreChartHeader = ({
             <div>
               <Button
                 buttonStyle="secondary"
-                onClick={() => setSaveChartModalVisibility(true)}
+                onClick={showModal}
                 disabled={saveDisabled}
                 data-test="query-save-button"
                 css={saveButtonStyles}
@@ -266,7 +274,7 @@ export const ExploreChartHeader = ({
         <PropertiesModal
           show={isPropertiesModalOpen}
           onHide={closePropertiesModal}
-          onSave={sliceUpdated}
+          onSave={updateSlice}
           slice={slice}
         />
       )}
@@ -276,16 +284,4 @@ export const ExploreChartHeader = ({
 
 ExploreChartHeader.propTypes = propTypes;
 
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators(
-    {
-      sliceUpdated,
-      toggleActive,
-      deleteActiveReport,
-      setSaveChartModalVisibility,
-    },
-    dispatch,
-  );
-}
-
-export default connect(null, mapDispatchToProps)(ExploreChartHeader);
+export default ExploreChartHeader;

--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
@@ -35,6 +35,7 @@ import Button from 'src/components/Button';
 import Icons from 'src/components/Icons';
 import PropertiesModal from 'src/explore/components/PropertiesModal';
 import { sliceUpdated } from 'src/explore/actions/exploreActions';
+import { setSaveChartModalVisibility } from 'src/explore/actions/saveModalActions';
 import { PageHeaderWithActions } from 'src/components/PageHeaderWithActions';
 import MetadataBar, { MetadataType } from 'src/components/MetadataBar';
 import { useExploreAdditionalActionsMenu } from '../useExploreAdditionalActionsMenu';
@@ -83,8 +84,8 @@ export const ExploreChartHeader = ({
   canDownload,
   isStarred,
   sliceUpdated,
+  setSaveChartModalVisibility,
   sliceName,
-  onSaveChart,
   saveDisabled,
   metadata,
 }) => {
@@ -244,7 +245,7 @@ export const ExploreChartHeader = ({
             <div>
               <Button
                 buttonStyle="secondary"
-                onClick={onSaveChart}
+                onClick={() => setSaveChartModalVisibility(true)}
                 disabled={saveDisabled}
                 data-test="query-save-button"
                 css={saveButtonStyles}
@@ -277,7 +278,12 @@ ExploreChartHeader.propTypes = propTypes;
 
 function mapDispatchToProps(dispatch) {
   return bindActionCreators(
-    { sliceUpdated, toggleActive, deleteActiveReport },
+    {
+      sliceUpdated,
+      toggleActive,
+      deleteActiveReport,
+      setSaveChartModalVisibility,
+    },
     dispatch,
   );
 }

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -80,6 +80,7 @@ const propTypes = {
   timeout: PropTypes.number,
   impressionId: PropTypes.string,
   vizType: PropTypes.string,
+  saveAction: PropTypes.string,
 };
 
 const ExploreContainer = styled.div`
@@ -240,7 +241,6 @@ function ExploreViewContainer(props) {
     props.controls,
   );
 
-  const [showingModal, setShowingModal] = useState(false);
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [shouldForceUpdate, setShouldForceUpdate] = useState(-1);
   const tabId = useTabId();
@@ -336,10 +336,6 @@ function ExploreViewContainer(props) {
     if (props.chart && props.chart.queryController) {
       props.chart.queryController.abort();
     }
-  }
-
-  function toggleModal() {
-    setShowingModal(!showingModal);
   }
 
   function toggleCollapse() {
@@ -471,11 +467,11 @@ function ExploreViewContainer(props) {
     return false;
   }, [lastQueriedControls, props.controls]);
 
-  const saveAction = getUrlParam(URL_PARAMS.saveAction);
-  useChangeEffect(saveAction, () => {
-    if (['saveas', 'overwrite'].includes(saveAction)) {
+  useChangeEffect(props.saveAction, () => {
+    if (['saveas', 'overwrite'].includes(props.saveAction)) {
       onQuery();
       addHistory({ isReplace: true });
+      props.actions.setSaveAction(null);
     }
   });
 
@@ -566,7 +562,6 @@ function ExploreViewContainer(props) {
         ownState={props.ownState}
         user={props.user}
         reports={props.reports}
-        onSaveChart={toggleModal}
         saveDisabled={errorMessage || props.chart.chartStatus === 'loading'}
         metadata={props.metadata}
       />
@@ -595,16 +590,6 @@ function ExploreViewContainer(props) {
             }
           `}
         />
-        {showingModal && (
-          <SaveModal
-            addDangerToast={props.addDangerToast}
-            onHide={toggleModal}
-            actions={props.actions}
-            form_data={props.form_data}
-            sliceName={props.sliceName}
-            dashboardId={props.dashboardId}
-          />
-        )}
         <Resizable
           onResizeStop={(evt, direction, ref, d) => {
             setShouldForceUpdate(d?.width);
@@ -701,6 +686,13 @@ function ExploreViewContainer(props) {
           {renderChartContainer()}
         </div>
       </ExplorePanelContainer>
+      <SaveModal
+        addDangerToast={props.addDangerToast}
+        actions={props.actions}
+        form_data={props.form_data}
+        sliceName={props.sliceName}
+        dashboardId={props.dashboardId}
+      />
     </ExploreContainer>
   );
 }
@@ -757,6 +749,7 @@ function mapStateToProps(state) {
     exploreState: explore,
     reports,
     metadata,
+    saveAction: explore.saveAction,
   };
 }
 
@@ -776,4 +769,4 @@ function mapDispatchToProps(dispatch) {
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-)(withToasts(ExploreViewContainer));
+)(withToasts(React.memo(ExploreViewContainer)));

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -81,6 +81,7 @@ const propTypes = {
   impressionId: PropTypes.string,
   vizType: PropTypes.string,
   saveAction: PropTypes.string,
+  isSaveModalVisible: PropTypes.bool,
 };
 
 const ExploreContainer = styled.div`
@@ -686,13 +687,15 @@ function ExploreViewContainer(props) {
           {renderChartContainer()}
         </div>
       </ExplorePanelContainer>
-      <SaveModal
-        addDangerToast={props.addDangerToast}
-        actions={props.actions}
-        form_data={props.form_data}
-        sliceName={props.sliceName}
-        dashboardId={props.dashboardId}
-      />
+      {props.isSaveModalVisible && (
+        <SaveModal
+          addDangerToast={props.addDangerToast}
+          actions={props.actions}
+          form_data={props.form_data}
+          sliceName={props.sliceName}
+          dashboardId={props.dashboardId}
+        />
+      )}
     </ExploreContainer>
   );
 }
@@ -700,8 +703,16 @@ function ExploreViewContainer(props) {
 ExploreViewContainer.propTypes = propTypes;
 
 function mapStateToProps(state) {
-  const { explore, charts, common, impressionId, dataMask, reports, user } =
-    state;
+  const {
+    explore,
+    charts,
+    common,
+    impressionId,
+    dataMask,
+    reports,
+    user,
+    saveModal,
+  } = state;
   const { controls, slice, datasource, metadata } = explore;
   const form_data = getFormDataFromControls(controls);
   const slice_id = form_data.slice_id ?? slice?.slice_id ?? 0; // 0 - unsaved chart
@@ -750,6 +761,7 @@ function mapStateToProps(state) {
     reports,
     metadata,
     saveAction: explore.saveAction,
+    isSaveModalVisible: saveModal.isVisible,
   };
 }
 

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -420,7 +420,14 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
         footer={this.renderFooter()}
       >
         {this.state.isLoading ? (
-          <Loading position="normal" />
+          <div
+            css={css`
+              display: flex;
+              justify-content: center;
+            `}
+          >
+            <Loading position="normal" />
+          </div>
         ) : (
           this.renderSaveChartModal()
         )}

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -33,8 +33,8 @@ import { Radio } from 'src/components/Radio';
 import Button from 'src/components/Button';
 import { Select } from 'src/components';
 import Loading from 'src/components/Loading';
-import { setSaveChartModalVisibility } from '../actions/saveModalActions';
-import { SaveActionType } from '../types';
+import { setSaveChartModalVisibility } from 'src/explore/actions/saveModalActions';
+import { SaveActionType } from 'src/explore/types';
 
 // Session storage key for recent dashboard
 const SK_DASHBOARD_ID = 'save_chart_recent_dashboard';

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -24,7 +24,13 @@ import { connect } from 'react-redux';
 import ReactMarkdown from 'react-markdown';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
-import { t, styled, DatasourceType, isDefined } from '@superset-ui/core';
+import {
+  t,
+  styled,
+  DatasourceType,
+  isDefined,
+  ensureIsArray,
+} from '@superset-ui/core';
 import { Input } from 'src/components/Input';
 import { Form, FormItem } from 'src/components/Form';
 import Alert from 'src/components/Alert';
@@ -110,7 +116,10 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
 
   componentDidMount() {
     this.props.actions.fetchDashboards(this.props.userId).then(() => {
-      const dashboardIds = this.props.dashboards.map(
+      if (ensureIsArray(this.props.dashboards).length === 0) {
+        return;
+      }
+      const dashboardIds = this.props.dashboards?.map(
         dashboard => dashboard.value,
       );
       const lastDashboard = sessionStorage.getItem(SK_DASHBOARD_ID);

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -25,6 +25,7 @@ import ReactMarkdown from 'react-markdown';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
 import {
+  css,
   t,
   styled,
   DatasourceType,

--- a/superset-frontend/src/explore/reducers/exploreReducer.js
+++ b/superset-frontend/src/explore/reducers/exploreReducer.js
@@ -222,6 +222,12 @@ export default function exploreReducer(state = {}, action) {
         sliceName: action.sliceName,
       };
     },
+    [actions.SET_SAVE_ACTION]() {
+      return {
+        ...state,
+        saveAction: action.saveAction,
+      };
+    },
     [actions.CREATE_NEW_SLICE]() {
       return {
         ...state,

--- a/superset-frontend/src/explore/reducers/saveModalReducer.js
+++ b/superset-frontend/src/explore/reducers/saveModalReducer.js
@@ -22,6 +22,9 @@ import { HYDRATE_EXPLORE } from '../actions/hydrateExplore';
 
 export default function saveModalReducer(state = {}, action) {
   const actionHandlers = {
+    [actions.SET_SAVE_CHART_MODAL_VISIBILITY]() {
+      return { ...state, isVisible: action.isVisible };
+    },
     [actions.FETCH_DASHBOARDS_SUCCEEDED]() {
       return { ...state, dashboards: action.choices };
     },

--- a/superset-frontend/src/explore/types.ts
+++ b/superset-frontend/src/explore/types.ts
@@ -79,6 +79,7 @@ export interface ExplorePageInitialData {
     created_by?: string;
     changed_by?: string;
   };
+  saveAction?: SaveActionType | null;
 }
 
 export interface ExploreResponsePayload {
@@ -112,3 +113,5 @@ export interface ExplorePageState {
   };
   sliceEntities?: JsonObject; // propagated from Dashboard view
 }
+
+export type SaveActionType = 'overwrite' | 'saveas';

--- a/superset-frontend/src/explore/types.ts
+++ b/superset-frontend/src/explore/types.ts
@@ -32,6 +32,8 @@ import { DatabaseObject } from 'src/views/CRUD/types';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
 import { Slice } from 'src/types/Chart';
 
+export type SaveActionType = 'overwrite' | 'saveas';
+
 export type ChartStatus =
   | 'loading'
   | 'rendered'
@@ -113,5 +115,3 @@ export interface ExplorePageState {
   };
   sliceEntities?: JsonObject; // propagated from Dashboard view
 }
-
-export type SaveActionType = 'overwrite' | 'saveas';


### PR DESCRIPTION

### SUMMARY
When user tried to save a chart and a request executed by SaveModal chart failed, the modal would just close and there would be no indication that an error occurred. That might lead the user to think that their chart was successfully saved even though it wasn't.
This PR fixes that behaviour by not closing the modal and displaying an alert with error message within it. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/15073128/197514948-a996021b-bd5d-4939-aee5-c9f23c34b2d6.mov

After:

https://user-images.githubusercontent.com/15073128/197514625-2667b4fe-519b-4313-be65-58e00a31c66f.mov

### TESTING INSTRUCTIONS
1. Open the chart save modal
2. Turn off the Internet (to trigger an error)
3. Click save button 
4. See that the error is displayed and the modal doesn't close

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @codyml