### PR TITLE
fix: Ensure data cleanup in Cypress

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/chart_list/list.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/chart_list/list.test.ts
@@ -60,12 +60,9 @@ describe('Charts list', () => {
 
   describe('Cross-referenced dashboards', () => {
     beforeEach(() => {
-      visitChartList();
-    });
-
-    before(() => {
       cy.createSampleDashboards([0, 1, 2, 3]);
       cy.createSampleCharts([0]);
+      visitChartList();
     });
 
     it('should show the cross-referenced dashboards in the table cell', () => {

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/editmode.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/editmode.test.ts
@@ -75,6 +75,10 @@ function visitEdit(sampleDashboard = SAMPLE_DASHBOARD_1) {
   interceptCharts();
   interceptGet();
 
+  if (sampleDashboard === SAMPLE_DASHBOARD_1) {
+    cy.createSampleDashboards([0]);
+  }
+
   cy.visit(sampleDashboard);
   cy.wait('@get');
   editDashboard();
@@ -648,11 +652,11 @@ describe('Dashboard edit', () => {
 
   describe('Edit properties', () => {
     before(() => {
-      cy.createSampleDashboards([0]);
       visitEdit();
     });
 
     beforeEach(() => {
+      cy.createSampleDashboards([0]);
       openProperties();
     });
 
@@ -700,11 +704,11 @@ describe('Dashboard edit', () => {
 
   describe('Edit mode', () => {
     before(() => {
-      cy.createSampleDashboards([0]);
       visitEdit();
     });
 
     beforeEach(() => {
+      cy.createSampleDashboards([0]);
       discardChanges();
     });
 
@@ -736,10 +740,6 @@ describe('Dashboard edit', () => {
   });
 
   describe('Components', () => {
-    before(() => {
-      cy.createSampleDashboards([0]);
-    });
-
     beforeEach(() => {
       visitEdit();
     });
@@ -787,7 +787,6 @@ describe('Dashboard edit', () => {
 
   describe('Save', () => {
     beforeEach(() => {
-      cy.createSampleDashboards();
       visitEdit();
     });
 

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
@@ -55,10 +55,14 @@ import {
 
 const SAMPLE_CHART = { name: 'Most Populated Countries', viz: 'table' };
 
-function visitDashboard() {
+function visitDashboard(createSample = true) {
   interceptCharts();
   interceptGet();
   interceptDatasets();
+
+  if (createSample) {
+    cy.createSampleDashboards([0]);
+  }
 
   cy.visit(SAMPLE_DASHBOARD_1);
   cy.wait('@get');
@@ -70,6 +74,7 @@ function visitDashboard() {
 function prepareDashboardFilters(
   filters: { name: string; column: string; datasetId: number }[],
 ) {
+  cy.createSampleDashboards([0]);
   cy.request({
     method: 'GET',
     url: `api/v1/dashboard/1-sample-dashboard`,
@@ -169,7 +174,7 @@ function prepareDashboardFilters(
             json_metadata: JSON.stringify(jsonMetadata),
           },
         })
-        .then(() => visitDashboard());
+        .then(() => visitDashboard(false));
     }
     return cy;
   });
@@ -379,11 +384,11 @@ describe('Native filters', () => {
 
   describe('Nativefilters basic interactions', () => {
     before(() => {
-      cy.createSampleDashboards([0]);
       visitDashboard();
     });
 
     beforeEach(() => {
+      cy.createSampleDashboards([0]);
       closeFilterModal();
     });
 
@@ -436,10 +441,6 @@ describe('Native filters', () => {
   });
 
   describe('Nativefilters initial state not required', () => {
-    beforeEach(() => {
-      cy.createSampleDashboards([0]);
-    });
-
     it("User can check 'Filter has default value'", () => {
       prepareDashboardFilters([
         { name: 'country_name', column: 'country_name', datasetId: 2 },

--- a/superset-frontend/cypress-base/cypress/integration/explore/chart.test.js
+++ b/superset-frontend/cypress-base/cypress/integration/explore/chart.test.js
@@ -91,13 +91,10 @@ describe('Cross-referenced dashboards', () => {
     interceptFiltering();
 
     cy.preserveLogin();
-    cy.visit(CHART_LIST);
-    cy.wait('@filtering');
-  });
-
-  before(() => {
     cy.createSampleDashboards(SAMPLE_DASHBOARDS_INDEXES);
     cy.createSampleCharts([0]);
+    cy.visit(CHART_LIST);
+    cy.wait('@filtering');
   });
 
   it('should show the cross-referenced dashboards', () => {

--- a/superset-frontend/cypress-base/cypress/support/index.ts
+++ b/superset-frontend/cypress-base/cypress/support/index.ts
@@ -42,11 +42,15 @@ before(() => {
   cy.login();
   cy.loadChartFixtures();
   cy.loadDashboardFixtures();
+});
+
+beforeEach(() => {
   cy.cleanDashboards();
   cy.cleanCharts();
 });
 
-Cypress.Commands.add('cleanDashboards', () =>
+Cypress.Commands.add('cleanDashboards', () => {
+  cy.login();
   cy.getDashboards().then((sampleDashboards?: Record<string, any>[]) => {
     const deletableDashboards = [];
     for (let i = 0; i < DASHBOARD_FIXTURES.length; i += 1) {
@@ -74,10 +78,11 @@ Cypress.Commands.add('cleanDashboards', () =>
         },
       }).then(resp => resp);
     }
-  }),
-);
+  });
+});
 
-Cypress.Commands.add('cleanCharts', () =>
+Cypress.Commands.add('cleanCharts', () => {
+  cy.login();
   cy.getCharts().then((sampleCharts?: Record<string, any>[]) => {
     const deletableCharts = [];
     for (let i = 0; i < CHART_FIXTURES.length; i += 1) {
@@ -89,7 +94,7 @@ Cypress.Commands.add('cleanCharts', () =>
         deletableCharts.push(isInDb.id);
       }
     }
-    if (deletableCharts) {
+    if (deletableCharts.length) {
       cy.request({
         failOnStatusCode: false,
         method: 'DELETE',
@@ -105,8 +110,8 @@ Cypress.Commands.add('cleanCharts', () =>
         },
       }).then(resp => resp);
     }
-  }),
-);
+  });
+});
 
 Cypress.Commands.add('getBySel', (selector, ...args) =>
   cy.get(`[data-test=${selector}]`, ...args),


### PR DESCRIPTION
### SUMMARY
As reported in [this PR ](https://github.com/apache/superset/pull/21915) sample data could be hanging between parallel Cypress runs. These changes ensure that all sample data is cleaned up before every test.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N.A.

### TESTING INSTRUCTIONS
All tests should pass

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
