### PR TITLE
fix: accept old database payload

### DIFF
--- a/tests/unit_tests/databases/schema_tests.py
+++ b/tests/unit_tests/databases/schema_tests.py
@@ -190,3 +190,38 @@ def test_database_parameters_schema_mixin_invalid_type(
         dummy_schema.load(payload)
     except ValidationError as err:
         assert err.messages == {"port": ["Not a valid integer."]}
+
+
+def test_rename_encrypted_extra() -> None:
+    """
+    Test that ``encrypted_extra`` gets renamed to ``masked_encrypted_extra``.
+    """
+    from superset.databases.schemas import ConfigurationMethod, DatabasePostSchema
+
+    schema = DatabasePostSchema()
+
+    # current schema
+    payload = schema.load(
+        {
+            "database_name": "My database",
+            "masked_encrypted_extra": "{}",
+        }
+    )
+    assert payload == {
+        "database_name": "My database",
+        "configuration_method": ConfigurationMethod.SQLALCHEMY_FORM,
+        "masked_encrypted_extra": "{}",
+    }
+
+    # previous schema
+    payload = schema.load(
+        {
+            "database_name": "My database",
+            "encrypted_extra": "{}",
+        }
+    )
+    assert payload == {
+        "database_name": "My database",
+        "configuration_method": ConfigurationMethod.SQLALCHEMY_FORM,
+        "masked_encrypted_extra": "{}",
+    }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

https://github.com/apache/superset/pull/21248/ fixed a vulnerability issue where credentials stored in `encrypted_extra` were being displayed to all users who could see the database. Unfortunately the PR changed the schema used for databases CRUD (create, update, validate parameters, etc.) since one of the fields was renamed from `encrypted_extra` to `masked_encrypted_extra`. This is a breaking change that affected clients talking to Superset APIs.

This PR adds some pre-load validation to the schema, so that the old payload with `encrypted_extra` is still supported.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

I added a unit test.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
