### PR TITLE
fix: Crash caused by numpy.vectorize

### DIFF
--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -63,8 +63,13 @@ def stringify(obj: Any) -> str:
 
 
 def stringify_values(array: np.ndarray) -> np.ndarray:
-    vstringify = np.vectorize(stringify)
-    return vstringify(array)
+    result = np.copy(array)
+
+    with np.nditer(result, flags=["refs_ok"], op_flags=["readwrite"]) as it:
+        for obj in it:
+            obj[...] = stringify(obj)
+
+    return result
 
 
 def destringify(obj: str) -> Any:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

We (Airbnb) has a user report an error where in SQL Lab an aysnc query would run for infinitum when the row limit was increased. The issue was the Celery worker crashed with the following error:

```
WorkerLostError: Worker exited prematurely: signal 9 (SIGKILL).
```

It turns out the root cause was a call to `numpy.vectorize` function which per [here](https://stackoverflow.com/questions/7078371/how-to-avoid-enormous-additional-memory-consumption-when-using-numpy-vectorize) can consume copious amounts of memory. The fix was merely to un-vectorize the logic using a iterator per the Numpy [documentation](https://numpy.org/doc/stable/reference/arrays.nditer.html#modifying-array-values), acknowledging that there may be a performance hit.

Note this is the only place in the code base which uses the `numpy.vectorize` function.

```
$ git grep "vectorize"
superset/result_set.py:    vstringify = np.vectorize(stringify)
```

<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
