### PR TITLE
fix: add form data for empty state control to save dataset

### DIFF
--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
@@ -51,7 +51,6 @@ import { postFormData } from 'src/explore/exploreUtils/formData';
 import { URL_PARAMS } from 'src/constants';
 import { SelectValue } from 'antd/lib/select';
 import { isEmpty, isString } from 'lodash';
-import { NumberTypeKnob } from '@storybook/addon-knobs/dist/components/types';
 
 interface QueryDatabase {
   id?: number;
@@ -71,7 +70,7 @@ export type Database = {
   backend: string;
   id: number;
   parameter: object;
-}
+};
 
 export interface ISaveableDatasource {
   columns: ISimpleColumn[];

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
@@ -51,6 +51,7 @@ import { postFormData } from 'src/explore/exploreUtils/formData';
 import { URL_PARAMS } from 'src/constants';
 import { SelectValue } from 'antd/lib/select';
 import { isEmpty, isString } from 'lodash';
+import { NumberTypeKnob } from '@storybook/addon-knobs/dist/components/types';
 
 interface QueryDatabase {
   id?: number;
@@ -66,6 +67,12 @@ export interface ISimpleColumn {
   is_dttm?: boolean | null;
 }
 
+export type Database = {
+  backend: string;
+  id: number;
+  parameter: object;
+}
+
 export interface ISaveableDatasource {
   columns: ISimpleColumn[];
   name: string;
@@ -73,6 +80,7 @@ export interface ISaveableDatasource {
   sql: string;
   templateParams?: string | object | null;
   schema?: string | null;
+  database?: Database;
 }
 
 interface SaveDatasetModalProps {
@@ -283,7 +291,7 @@ export const SaveDatasetModal = ({
       createDatasource({
         schema: datasource.schema,
         sql: datasource.sql,
-        dbId: datasource.dbId,
+        dbId: datasource.dbId || datasource?.database?.id,
         templateParams,
         datasourceName: datasetName,
         columns: selectedColumns,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
There is an issue where if a user tries to save the dataset from the time control, when user power charts from query, user will be shown an error of missing params. This was because of the potential for the database info to be structured different from the original object structure.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

before

https://user-images.githubusercontent.com/17326228/198397197-a2149a45-5df6-4a95-98bc-a63f48ec9b23.mov



### TESTING INSTRUCTIONS
Run a sql query in sql lab that has no temporal columns
Create a chart with the query powering the chart
In the Time section, click the blank state button to create a dataset

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
