### PR TITLE
chore: bump pyathena and related packages

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,8 +14,7 @@ amqp==5.1.0
 apispec[yaml]==3.3.2
     # via flask-appbuilder
 attrs==21.2.0
-    # via
-    #   jsonschema
+    # via jsonschema
 babel==2.9.1
     # via flask-babel
 backoff==1.11.1
@@ -115,13 +114,14 @@ gunicorn==20.1.0
     # via apache-superset
 hashids==1.3.1
     # via apache-superset
+hijri-converter==2.2.4
+    # via holidays
 holidays==0.16.0
     # via apache-superset
 humanize==3.11.0
     # via apache-superset
 idna==3.2
-    # via
-    #   email-validator
+    # via email-validator
 isodate==0.6.0
     # via apache-superset
 itsdangerous==2.1.1
@@ -214,7 +214,6 @@ pytz==2021.3
     # via
     #   babel
     #   celery
-    #   convertdate
     #   flask-babel
     #   pandas
 pyyaml==5.4.1
@@ -232,16 +231,14 @@ six==1.16.0
     #   bleach
     #   click-repl
     #   flask-talisman
-    #   holidays
     #   isodate
     #   jsonschema
     #   polyline
     #   prison
     #   pyrsistent
     #   python-dateutil
-    #   sqlalchemy-utils
     #   wtforms-json
-slack_sdk==3.18.3
+slack-sdk==3.18.3
     # via apache-superset
 sqlalchemy==1.4.36
     # via
@@ -259,7 +256,7 @@ sqlparse==0.4.3
     # via apache-superset
 tabulate==0.8.9
     # via apache-superset
-typing-extensions==3.10.0.0
+typing-extensions==4.4.0
     # via apache-superset
 urllib3==1.26.6
     # via selenium

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -28,6 +28,8 @@ certifi==2021.10.8
     # via requests
 chardet==4.0.0
     # via tabulator
+charset-normalizer==2.0.12
+    # via requests
 decorator==5.1.1
     # via ipython
 et-xmlfile==1.1.0

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -111,6 +111,8 @@ pydata-google-auth==1.2.0
     # via pandas-gbq
 pyfakefs==4.5.6
     # via -r requirements/testing.in
+pyhive[presto]==0.6.5
+    # via apache-superset
 pylint==2.9.6
     # via -r requirements/testing.in
 pytest==6.2.4

--- a/setup.py
+++ b/setup.py
@@ -120,11 +120,11 @@ setup(
         "sqlparse>=0.4.3, <0.5",
         "tabulate>=0.8.9, <0.9",
         # needed to support Literal (3.8) and TypeGuard (3.10)
-        "typing-extensions>=3.10, <4",
+        "typing-extensions>=4, <5",
         "wtforms-json",
     ],
     extras_require={
-        "athena": ["pyathena>=1.10.8, <1.11"],
+        "athena": ["pyathena[pandas]>=2, <3"],
         "aurora-data-api": ["preset-sqlalchemy-aurora-data-api>=0.2.8,<0.3"],
         "bigquery": [
             "pandas_gbq>=0.10.0",

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,6 @@ setup(
         "sqlalchemy-utils>=0.38.3, <0.39",
         "sqlparse>=0.4.3, <0.5",
         "tabulate>=0.8.9, <0.9",
-        # needed to support Literal (3.8) and TypeGuard (3.10)
         "typing-extensions>=4, <5",
         "wtforms-json",
     ],


### PR DESCRIPTION
### SUMMARY
Bumping pyathena and adding in the relevant pandas requirements for that package in order to use the schema `pyathena+pandas` which was introduced in 2.0. Typing-extensions was also bumped to 4.x for compatibility with other packages. 

### TESTING INSTRUCTIONS
Creating and running dbs with both rest and pandas drivers for pyathena should now work


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
