### PR TITLE
fix: dashboard api cache decorator

### DIFF
--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -276,6 +276,8 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             self.appbuilder.app.config["VERSION_SHA"],
         )
 
+    @expose("/<id_or_slug>", methods=["GET"])
+    @protect()
     @etag_cache(
         get_last_modified=lambda _self, id_or_slug: DashboardDAO.get_dashboard_changed_on(  # pylint: disable=line-too-long,useless-suppression
             id_or_slug
@@ -286,8 +288,6 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         ),
         skip=lambda _self, id_or_slug: not is_feature_enabled("DASHBOARD_CACHE"),
     )
-    @expose("/<id_or_slug>", methods=["GET"])
-    @protect()
     @safe
     @statsd_metrics
     @with_dashboard
@@ -334,6 +334,8 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         )
         return self.response(200, result=result)
 
+    @expose("/<id_or_slug>/datasets", methods=["GET"])
+    @protect()
     @etag_cache(
         get_last_modified=lambda _self, id_or_slug: DashboardDAO.get_dashboard_and_datasets_changed_on(  # pylint: disable=line-too-long,useless-suppression
             id_or_slug
@@ -344,8 +346,6 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         ),
         skip=lambda _self, id_or_slug: not is_feature_enabled("DASHBOARD_CACHE"),
     )
-    @expose("/<id_or_slug>/datasets", methods=["GET"])
-    @protect()
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
@@ -403,6 +403,8 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         except DashboardNotFoundError:
             return self.response_404()
 
+    @expose("/<id_or_slug>/charts", methods=["GET"])
+    @protect()
     @etag_cache(
         get_last_modified=lambda _self, id_or_slug: DashboardDAO.get_dashboard_and_slices_changed_on(  # pylint: disable=line-too-long,useless-suppression
             id_or_slug
@@ -413,8 +415,6 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         ),
         skip=lambda _self, id_or_slug: not is_feature_enabled("DASHBOARD_CACHE"),
     )
-    @expose("/<id_or_slug>/charts", methods=["GET"])
-    @protect()
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(


### PR DESCRIPTION
### SUMMARY

Small refactor, `@etag_cache` needs to be on a different position on the decorators

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
