### PR TITLE
fix(sqllab): Remove invalid hotkey config

### DIFF
--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/AceEditorWrapper.test.tsx
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/AceEditorWrapper.test.tsx
@@ -54,6 +54,7 @@ const setup = (queryEditor: QueryEditor, store?: Store) =>
       onChange={jest.fn()}
       onBlur={jest.fn()}
       autocomplete
+      hotkeys={[]}
     />,
     {
       useRedux: true,

--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/AceEditorWrapper.test.tsx
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/AceEditorWrapper.test.tsx
@@ -50,7 +50,6 @@ const setup = (queryEditor: QueryEditor, store?: Store) =>
     <AceEditorWrapper
       queryEditorId={queryEditor.id}
       height="100px"
-      hotkeys={[]}
       database={{}}
       onChange={jest.fn()}
       onBlur={jest.fn()}

--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/index.tsx
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/index.tsx
@@ -20,6 +20,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { usePrevious } from 'src/hooks/usePrevious';
 import { areArraysShallowEqual } from 'src/reduxUtils';
+import { detectOS } from 'src/utils/common';
 import sqlKeywords from 'src/SqlLab/utils/sqlKeywords';
 import {
   queryEditorSetSelectedText,
@@ -132,6 +133,7 @@ const AceEditorWrapper = ({
   };
 
   const onEditorLoad = (editor: any) => {
+    const userOS = detectOS();
     editor.commands.addCommand({
       name: 'runQuery',
       bindKey: { win: 'Alt-enter', mac: 'Alt-enter' },
@@ -139,6 +141,16 @@ const AceEditorWrapper = ({
         onAltEnter();
       },
     });
+
+    if (userOS === 'MacOS') {
+      editor.commands.addCommand({
+        name: 'previousLine',
+        bindKey: { mac: 'ctrl+p' },
+        exec: (e: { navigateUp: (line: number) => void }) => {
+          e.navigateUp(1);
+        },
+      });
+    }
 
     hotkeys.forEach(keyConfig => {
       editor.commands.addCommand({

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -241,7 +241,7 @@ const SqlEditor = ({
   const getHotkeyConfig = () => {
     // Get the user's OS
     const userOS = detectOS();
-    const base = [
+    return [
       {
         name: 'runQuery1',
         key: 'ctrl+r',
@@ -277,19 +277,6 @@ const SqlEditor = ({
         func: stopQuery,
       },
     ];
-
-    if (userOS === 'MacOS') {
-      base.push({
-        name: 'previousLine',
-        key: 'ctrl+p',
-        descr: t('Previous Line'),
-        func: editor => {
-          editor.navigateUp(1);
-        },
-      });
-    }
-
-    return base;
   };
 
   const handleWindowResize = () => {
@@ -615,7 +602,7 @@ const SqlEditor = ({
             height={`${aceEditorHeight}px`}
             hotkeys={hotkeys}
           />
-          {renderEditorBottomBar(hotkeys)}
+          {renderEditorBottomBar()}
         </div>
         <ConnectedSouthPane
           queryEditorId={queryEditor.id}


### PR DESCRIPTION
### SUMMARY
There's a bug that throws an error when hit `ctrl + p` shortcut out of the editor textbox because it contains the editor specific command is included in the global keyboard shortcut handlers.

This commit removes the editor specific command from the global shortcut list.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://user-images.githubusercontent.com/1392866/198749083-07a809f2-31ae-4fde-9a56-dce338d8cf98.mov

After:

No errors thrown


### TESTING INSTRUCTIONS
1. Go to sqllab
2. Focus out of the sql editor input
3. Hit `Ctrl + p` and then check console log

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
