### PR TITLE
refactor: use exception status for logging

### DIFF
--- a/superset/errors.py
+++ b/superset/errors.py
@@ -90,6 +90,9 @@ class SupersetErrorType(str, Enum):
     INVALID_PAYLOAD_FORMAT_ERROR = "INVALID_PAYLOAD_FORMAT_ERROR"
     INVALID_PAYLOAD_SCHEMA_ERROR = "INVALID_PAYLOAD_SCHEMA_ERROR"
 
+    # Report errors
+    REPORT_NOTIFICATION_ERROR = "REPORT_NOTIFICATION_ERROR"
+
 
 ISSUE_CODES = {
     1000: _("The datasource is too large to query."),

--- a/superset/reports/commands/exceptions.py
+++ b/superset/reports/commands/exceptions.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import List
+
 from flask_babel import lazy_gettext as _
 
 from superset.commands.exceptions import (
@@ -24,6 +26,7 @@ from superset.commands.exceptions import (
     ForbiddenError,
     ValidationError,
 )
+from superset.exceptions import SupersetError, SupersetErrorsException
 from superset.reports.models import ReportScheduleType
 
 
@@ -256,6 +259,17 @@ class ReportScheduleUserNotFoundError(CommandException):
 
 class ReportScheduleStateNotFoundError(CommandException):
     message = _("Report Schedule state not found")
+
+
+class ReportScheduleSystemErrorsException(CommandException, SupersetErrorsException):
+    errors: List[SupersetError] = []
+    message = _("Report schedule system error")
+
+
+class ReportScheduleClientErrorsException(CommandException, SupersetErrorsException):
+    status = 400
+    errors: List[SupersetError] = []
+    message = _("Report schedule client error")
 
 
 class ReportScheduleUnexpectedError(CommandException):

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -26,6 +26,7 @@ import bleach
 from flask_babel import gettext as __
 
 from superset import app
+from superset.exceptions import SupersetErrorsException
 from superset.reports.models import ReportRecipientType
 from superset.reports.notifications.base import BaseNotification
 from superset.reports.notifications.exceptions import NotificationError
@@ -210,5 +211,9 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
             logger.info(
                 "Report sent to email, notification content is %s", content.header_data
             )
+        except SupersetErrorsException as ex:
+            raise NotificationError(
+                ";".join([error.message for error in ex.errors])
+            ) from ex
         except Exception as ex:
             raise NotificationError(str(ex)) from ex

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -211,4 +211,4 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
                 "Report sent to email, notification content is %s", content.header_data
             )
         except Exception as ex:
-            raise NotificationError(ex) from ex
+            raise NotificationError(str(ex)) from ex

--- a/superset/tasks/scheduler.py
+++ b/superset/tasks/scheduler.py
@@ -29,6 +29,7 @@ from superset.reports.commands.log_prune import AsyncPruneReportScheduleLogComma
 from superset.reports.dao import ReportScheduleDAO
 from superset.tasks.cron_util import cron_schedule_window
 from superset.utils.celery import session_scope
+from superset.utils.core import LoggerLevel
 from superset.utils.log import get_logger_from_status
 
 logger = logging.getLogger(__name__)
@@ -98,7 +99,7 @@ def execute(self: Celery.task, report_schedule_id: int, scheduled_dttm: str) -> 
         logger_func(
             "A downstream %s occurred while generating a report: %s", level, task_id
         )
-        if level == "exception":
+        if level == LoggerLevel.EXCEPTION:
             self.update_state(state="FAILURE")
 
 

--- a/superset/tasks/scheduler.py
+++ b/superset/tasks/scheduler.py
@@ -29,6 +29,7 @@ from superset.reports.commands.log_prune import AsyncPruneReportScheduleLogComma
 from superset.reports.dao import ReportScheduleDAO
 from superset.tasks.cron_util import cron_schedule_window
 from superset.utils.celery import session_scope
+from superset.utils.log import get_logger_from_status
 
 logger = logging.getLogger(__name__)
 
@@ -92,11 +93,13 @@ def execute(self: Celery.task, report_schedule_id: int, scheduled_dttm: str) -> 
             "An unexpected occurred while executing the report: %s", task_id
         )
         self.update_state(state="FAILURE")
-    except CommandException:
-        logger.exception(
-            "A downstream exception occurred while generating" " a report: %s", task_id
+    except CommandException as ex:
+        logger_func, level = get_logger_from_status(ex.status)
+        logger_func(
+            "A downstream %s occurred while generating a report: %s", level, task_id
         )
-        self.update_state(state="FAILURE")
+        if level == "exception":
+            self.update_state(state="FAILURE")
 
 
 @celery_app.task(name="reports.prune_log")

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -190,6 +190,12 @@ class DatasourceType(str, Enum):
     VIEW = "view"
 
 
+class LoggerLevel(str, Enum):
+    INFO = "info"
+    WARNING = "warning"
+    EXCEPTION = "exception"
+
+
 class HeaderDataType(TypedDict):
     notification_format: str
     owners: List[int]

--- a/superset/utils/log.py
+++ b/superset/utils/log.py
@@ -42,7 +42,7 @@ from flask_appbuilder.const import API_URI_RIS_KEY
 from sqlalchemy.exc import SQLAlchemyError
 from typing_extensions import Literal
 
-from superset.utils.core import get_user_id
+from superset.utils.core import get_user_id, LoggerLevel
 
 if TYPE_CHECKING:
     from superset.stats_logger import BaseStatsLogger
@@ -85,7 +85,12 @@ def get_logger_from_status(
     Return logger method by status of exception.
     Maps logger level to status code level
     """
-    log_map = {"2": "info", "3": "info", "4": "warning", "5": "exception"}
+    log_map = {
+        "2": LoggerLevel.INFO,
+        "3": LoggerLevel.INFO,
+        "4": LoggerLevel.WARNING,
+        "5": LoggerLevel.EXCEPTION,
+    }
     log_level = log_map[str(status)[0]]
 
     return (getattr(logger, log_level), log_level)

--- a/superset/utils/log.py
+++ b/superset/utils/log.py
@@ -31,6 +31,7 @@ from typing import (
     Dict,
     Iterator,
     Optional,
+    Tuple,
     Type,
     TYPE_CHECKING,
     Union,
@@ -45,6 +46,8 @@ from superset.utils.core import get_user_id
 
 if TYPE_CHECKING:
     from superset.stats_logger import BaseStatsLogger
+
+logger = logging.getLogger(__name__)
 
 
 def collect_request_payload() -> Dict[str, Any]:
@@ -73,6 +76,19 @@ def collect_request_payload() -> Dict[str, Any]:
         del payload["rison"]
 
     return payload
+
+
+def get_logger_from_status(
+    status: int,
+) -> Tuple[Callable[..., None], str]:
+    """
+    Return logger method by status of exception.
+    Maps logger level to status code level
+    """
+    log_map = {"2": "info", "3": "info", "4": "warning", "5": "exception"}
+    log_level = log_map[str(status)[0]]
+
+    return (getattr(logger, log_level), log_level)
 
 
 class AbstractEventLogger(ABC):

--- a/tests/integration_tests/event_logger_tests.py
+++ b/tests/integration_tests/event_logger_tests.py
@@ -29,7 +29,6 @@ from superset.utils.log import (
     AbstractEventLogger,
     DBEventLogger,
     get_event_logger_from_cfg_value,
-    get_logger_from_status,
 )
 from tests.integration_tests.test_app import app
 

--- a/tests/integration_tests/event_logger_tests.py
+++ b/tests/integration_tests/event_logger_tests.py
@@ -29,6 +29,7 @@ from superset.utils.log import (
     AbstractEventLogger,
     DBEventLogger,
     get_event_logger_from_cfg_value,
+    get_logger_from_status,
 )
 from tests.integration_tests.test_app import app
 

--- a/tests/unit_tests/utils/log_tests.py
+++ b/tests/unit_tests/utils/log_tests.py
@@ -14,33 +14,24 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from superset.exceptions import SupersetException
 
 
-class NotificationError(SupersetException):
-    """
-    Generic unknown exception - only used when
-    bubbling up unknown exceptions from lower levels
-    """
+from superset.utils.log import get_logger_from_status
 
 
-class NotificationParamException(SupersetException):
-    status = 422
+def test_log_from_status_exception() -> None:
+    (func, log_level) = get_logger_from_status(500)
+    assert func.__name__ == "exception"
+    assert log_level == "exception"
 
 
-class NotificationAuthorizationException(SupersetException):
-    status = 401
+def test_log_from_status_warning() -> None:
+    (func, log_level) = get_logger_from_status(422)
+    assert func.__name__ == "warning"
+    assert log_level == "warning"
 
 
-class NotificationUnprocessableException(SupersetException):
-    """
-    When a third party client service is down.
-    The request should be retried. There is no further
-    action required on our part or the user's other than to retry
-    """
-
-    status = 400
-
-
-class NotificationMalformedException(SupersetException):
-    status = 400
+def test_log_from_status_info() -> None:
+    (func, log_level) = get_logger_from_status(300)
+    assert func.__name__ == "info"
+    assert log_level == "info"


### PR DESCRIPTION
### SUMMARY
Followup to https://github.com/apache/superset/pull/21627
In order to be able to log celery errors and warnings separately, I am focusing on report errors for both slack and email and raising either a ReportScheduleClientErrorsException or ReportScheduleSystemErrorsException and then logging according to the status code of each (4xx or 500). 
For slack errors, I am also catching each error from the slack api and raising an appropriate http status code, which then helps to inform the logging level for celery.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
