### PR TITLE
chore: bubble up more db error messages

### DIFF
--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -24,6 +24,10 @@ import Label from 'src/components/Label';
 import { FormLabel } from 'src/components/Form';
 import RefreshLabel from 'src/components/RefreshLabel';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
+import {
+  getClientErrorMessage,
+  getClientErrorObject,
+} from 'src/utils/getClientErrorObject';
 
 const DatabaseSelectorWrapper = styled.div`
   ${({ theme }) => `
@@ -238,9 +242,16 @@ export default function DatabaseSelector({
           setLoadingSchemas(false);
           if (refresh > 0) addSuccessToast('List refreshed');
         })
-        .catch(() => {
+        .catch(err => {
           setLoadingSchemas(false);
-          handleError(t('There was an error loading the schemas'));
+          getClientErrorObject(err).then(clientError => {
+            handleError(
+              getClientErrorMessage(
+                t('There was an error loading the schemas'),
+                clientError,
+              ),
+            );
+          });
         });
     }
   }, [currentDb, onSchemasLoad, refresh]);

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -38,6 +38,10 @@ import WarningIconWithTooltip from 'src/components/WarningIconWithTooltip';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
 import { SchemaOption } from 'src/SqlLab/types';
 import { useTables, Table } from 'src/hooks/apiResources';
+import {
+  getClientErrorMessage,
+  getClientErrorObject,
+} from 'src/utils/getClientErrorObject';
 
 const REFRESH_WIDTH = 30;
 
@@ -187,7 +191,16 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
         addSuccessToast(t('List updated'));
       }
     },
-    onError: () => handleError(t('There was an error loading the tables')),
+    onError: (err: Response) => {
+      getClientErrorObject(err).then(clientError => {
+        handleError(
+          getClientErrorMessage(
+            t('There was an error loading the tables'),
+            clientError,
+          ),
+        );
+      });
+    },
   });
 
   const tableOptions = useMemo<TableOption[]>(

--- a/superset-frontend/src/explore/ExplorePage.tsx
+++ b/superset-frontend/src/explore/ExplorePage.tsx
@@ -42,10 +42,8 @@ import { fallbackExploreInitialData } from './fixtures';
 import { getItem, LocalStorageKeys } from '../utils/localStorageHelpers';
 import { getFormDataWithDashboardContext } from './controlUtils/getFormDataWithDashboardContext';
 
-const isResult = (rv: JsonObject): rv is ExploreResponsePayload =>
-  rv?.result?.form_data &&
-  rv?.result?.dataset &&
-  isDefined(rv?.result?.dataset?.id);
+const isValidResult = (rv: JsonObject): boolean =>
+  rv?.result?.form_data && isDefined(rv?.result?.dataset?.id);
 
 const fetchExploreData = async (exploreUrlParams: URLSearchParams) => {
   try {
@@ -53,10 +51,15 @@ const fetchExploreData = async (exploreUrlParams: URLSearchParams) => {
       method: 'GET',
       endpoint: 'api/v1/explore/',
     })(exploreUrlParams);
-    if (isResult(rv)) {
+    if (isValidResult(rv)) {
       return rv;
     }
-    throw new Error(t('Failed to load chart data.'));
+    let message = t('Failed to load chart data');
+    const responseError = rv?.result?.message;
+    if (responseError) {
+      message = `${message}:\n${responseError}`;
+    }
+    throw new Error(message);
   } catch (err) {
     // todo: encapsulate the error handler
     const clientError = await getClientErrorObject(err);

--- a/superset-frontend/src/utils/getClientErrorObject.ts
+++ b/superset-frontend/src/utils/getClientErrorObject.ts
@@ -171,3 +171,15 @@ export function getClientErrorObject(
     });
   });
 }
+
+export function getClientErrorMessage(
+  message: string,
+  clientError?: ClientErrorObject,
+) {
+  let finalMessage = message;
+  const errorMessage = clientError?.message || clientError?.error;
+  if (errorMessage) {
+    finalMessage = `${finalMessage}:\n${errorMessage}`;
+  }
+  return finalMessage;
+}

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -75,7 +75,7 @@ from superset.databases.schemas import (
 from superset.databases.utils import get_table_metadata
 from superset.db_engine_specs import get_available_engine_specs
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
-from superset.exceptions import SupersetErrorsException
+from superset.exceptions import SupersetErrorsException, SupersetException
 from superset.extensions import security_manager
 from superset.models.core import Database
 from superset.superset_typing import FlaskResponse
@@ -293,6 +293,8 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
                 exc_info=True,
             )
             return self.response_422(message=str(ex))
+        except SupersetException as ex:
+            return self.response(ex.status, message=ex.message)
 
     @expose("/<int:pk>", methods=["PUT"])
     @protect()
@@ -486,6 +488,8 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
             return self.response(
                 500, message="There was an error connecting to the database"
             )
+        except SupersetException as ex:
+            return self.response(ex.status, message=ex.message)
 
     @expose("/<int:pk>/table/<table_name>/<schema_name>/", methods=["GET"])
     @protect()
@@ -544,6 +548,9 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         except SQLAlchemyError as ex:
             self.incr_stats("error", self.table_metadata.__name__)
             return self.response_422(error_msg_from_exception(ex))
+        except SupersetException as ex:
+            return self.response(ex.status, message=ex.message)
+
         self.incr_stats("success", self.table_metadata.__name__)
         return self.response(200, **table_info)
 

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -639,7 +639,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
                 return cursor.fetchmany(limit)
             return cursor.fetchall()
         except Exception as ex:
-            raise cls.get_dbapi_mapped_exception(ex)
+            raise cls.get_dbapi_mapped_exception(ex) from ex
 
     @classmethod
     def expand_data(
@@ -1025,7 +1025,11 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         :param schema: Schema to inspect. If omitted, uses default schema for database
         :return: All tables in schema
         """
-        tables = inspector.get_table_names(schema)
+        try:
+            tables = inspector.get_table_names(schema)
+        except Exception as ex:
+            raise cls.get_dbapi_mapped_exception(ex) from ex
+
         if schema and cls.try_remove_schema_from_table_name:
             tables = [re.sub(f"^{schema}\\.", "", table) for table in tables]
         return sorted(tables)
@@ -1045,7 +1049,11 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         :param schema: Schema name. If omitted, uses default schema for database
         :return: All views in schema
         """
-        views = inspector.get_view_names(schema)
+        try:
+            views = inspector.get_view_names(schema)
+        except Exception as ex:
+            raise cls.get_dbapi_mapped_exception(ex) from ex
+
         if schema and cls.try_remove_schema_from_table_name:
             views = [re.sub(f"^{schema}\\.", "", view) for view in views]
         return sorted(views)
@@ -1326,7 +1334,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         try:
             cursor.execute(query)
         except Exception as ex:
-            raise cls.get_dbapi_mapped_exception(ex)
+            raise cls.get_dbapi_mapped_exception(ex) from ex
 
     @classmethod
     def make_label_compatible(cls, label: str) -> Union[str, quoted_name]:

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -35,7 +35,7 @@ from superset.constants import PASSWORD_MASK
 from superset.databases.schemas import encrypted_field_properties, EncryptedString
 from superset.databases.utils import make_url_safe
 from superset.db_engine_specs.base import BaseEngineSpec, BasicPropertiesType
-from superset.db_engine_specs.exceptions import SupersetDBAPIDisconnectionError
+from superset.db_engine_specs.exceptions import SupersetDBAPIConnectionError
 from superset.errors import SupersetError, SupersetErrorType
 from superset.sql_parse import Table
 from superset.utils import core as utils
@@ -449,7 +449,7 @@ class BigQueryEngineSpec(BaseEngineSpec):
         # pylint: disable=import-outside-toplevel
         from google.auth.exceptions import DefaultCredentialsError
 
-        return {DefaultCredentialsError: SupersetDBAPIDisconnectionError}
+        return {DefaultCredentialsError: SupersetDBAPIConnectionError}
 
     @classmethod
     def validate_parameters(

--- a/superset/db_engine_specs/druid.py
+++ b/superset/db_engine_specs/druid.py
@@ -17,13 +17,14 @@
 import json
 import logging
 from datetime import datetime
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Type, TYPE_CHECKING
 
 from sqlalchemy import types
 from sqlalchemy.engine.reflection import Inspector
 
 from superset import is_feature_enabled
 from superset.db_engine_specs.base import BaseEngineSpec
+from superset.db_engine_specs.exceptions import SupersetDBAPIDisconnectionError
 from superset.exceptions import SupersetException
 from superset.utils import core as utils
 
@@ -136,3 +137,12 @@ class DruidEngineSpec(BaseEngineSpec):
         type_map["complex<hllsketch>"] = types.BLOB
 
         return super().get_columns(inspector, table_name, schema)
+
+    @classmethod
+    def get_dbapi_exception_mapping(cls) -> Dict[Type[Exception], Type[Exception]]:
+        # pylint: disable=import-error,import-outside-toplevel
+        from requests import exceptions as requests_exceptions
+
+        return {
+            requests_exceptions.ConnectionError: SupersetDBAPIDisconnectionError,
+        }

--- a/superset/db_engine_specs/druid.py
+++ b/superset/db_engine_specs/druid.py
@@ -24,7 +24,7 @@ from sqlalchemy.engine.reflection import Inspector
 
 from superset import is_feature_enabled
 from superset.db_engine_specs.base import BaseEngineSpec
-from superset.db_engine_specs.exceptions import SupersetDBAPIDisconnectionError
+from superset.db_engine_specs.exceptions import SupersetDBAPIConnectionError
 from superset.exceptions import SupersetException
 from superset.utils import core as utils
 
@@ -144,5 +144,5 @@ class DruidEngineSpec(BaseEngineSpec):
         from requests import exceptions as requests_exceptions
 
         return {
-            requests_exceptions.ConnectionError: SupersetDBAPIDisconnectionError,
+            requests_exceptions.ConnectionError: SupersetDBAPIConnectionError,
         }

--- a/superset/db_engine_specs/exceptions.py
+++ b/superset/db_engine_specs/exceptions.py
@@ -29,7 +29,7 @@ class SupersetDBAPIDatabaseError(SupersetDBAPIError):
     pass
 
 
-class SupersetDBAPIDisconnectionError(SupersetDBAPIError):
+class SupersetDBAPIConnectionError(SupersetDBAPIError):
     pass
 
 

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Optional, TYPE_CHECKING
+from typing import Any, Dict, Optional, Type, TYPE_CHECKING
 
 import simplejson as json
 from flask import current_app
@@ -27,6 +27,7 @@ from sqlalchemy.orm import Session
 from superset.constants import USER_AGENT
 from superset.databases.utils import make_url_safe
 from superset.db_engine_specs.base import BaseEngineSpec
+from superset.db_engine_specs.exceptions import SupersetDBAPIDisconnectionError
 from superset.db_engine_specs.presto import PrestoBaseEngineSpec
 from superset.models.sql_lab import Query
 from superset.utils import core as utils
@@ -220,3 +221,12 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
         except json.JSONDecodeError as ex:
             logger.error(ex, exc_info=True)
             raise ex
+
+    @classmethod
+    def get_dbapi_exception_mapping(cls) -> Dict[Type[Exception], Type[Exception]]:
+        # pylint: disable=import-error,import-outside-toplevel
+        from requests import exceptions as requests_exceptions
+
+        return {
+            requests_exceptions.ConnectionError: SupersetDBAPIDisconnectionError,
+        }

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -27,7 +27,7 @@ from sqlalchemy.orm import Session
 from superset.constants import USER_AGENT
 from superset.databases.utils import make_url_safe
 from superset.db_engine_specs.base import BaseEngineSpec
-from superset.db_engine_specs.exceptions import SupersetDBAPIDisconnectionError
+from superset.db_engine_specs.exceptions import SupersetDBAPIConnectionError
 from superset.db_engine_specs.presto import PrestoBaseEngineSpec
 from superset.models.sql_lab import Query
 from superset.utils import core as utils
@@ -228,5 +228,5 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
         from requests import exceptions as requests_exceptions
 
         return {
-            requests_exceptions.ConnectionError: SupersetDBAPIDisconnectionError,
+            requests_exceptions.ConnectionError: SupersetDBAPIConnectionError,
         }

--- a/superset/explore/commands/get.py
+++ b/superset/explore/commands/get.py
@@ -144,7 +144,8 @@ class GetExploreCommand(BaseCommand, ABC):
         utils.merge_extra_filters(form_data)
         utils.merge_request_params(form_data, request.args)
 
-        dummy_dataset_data: Dict[str, Any] = {
+        # TODO: this is a dummy placeholder - should be refactored to being just `None`
+        dataset_data: Dict[str, Any] = {
             "type": self._dataset_type,
             "name": dataset_name,
             "columns": [],
@@ -152,9 +153,12 @@ class GetExploreCommand(BaseCommand, ABC):
             "database": {"id": 0, "backend": ""},
         }
         try:
-            dataset_data = dataset.data if dataset else dummy_dataset_data
-        except (SupersetException, SQLAlchemyError):
-            dataset_data = dummy_dataset_data
+            if dataset:
+                dataset_data = dataset.data
+        except SupersetException as ex:
+            message = ex.message
+        except SQLAlchemyError:
+            message = "SQLAlchemy error"
 
         metadata = None
 

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -563,9 +563,8 @@ class Database(
                 database=self, inspector=self.inspector, schema=schema
             )
             return [(table, schema) for table in tables]
-        except Exception:  # pylint: disable=broad-except
-            logger.warning("Get all table names in schema failed", exc_info=True)
-            return []
+        except Exception as ex:  # pylint: disable=broad-except
+            raise self.db_engine_spec.get_dbapi_mapped_exception(ex)
 
     @cache_util.memoized_func(
         key="db:{self.id}:schema:{schema}:view_list",
@@ -594,9 +593,8 @@ class Database(
                 database=self, inspector=self.inspector, schema=schema
             )
             return [(view, schema) for view in views]
-        except Exception:  # pylint: disable=broad-except
-            logger.warning("Get all view names failed", exc_info=True)
-            return []
+        except Exception as ex:  # pylint: disable=broad-except
+            raise self.db_engine_spec.get_dbapi_mapped_exception(ex)
 
     @cache_util.memoized_func(
         key="db:{self.id}:schema_list",
@@ -618,7 +616,10 @@ class Database(
         :param force: whether to force refresh the cache
         :return: schema list
         """
-        return self.db_engine_spec.get_schema_names(self.inspector)
+        try:
+            return self.db_engine_spec.get_schema_names(self.inspector)
+        except Exception as ex:
+            raise self.db_engine_spec.get_dbapi_mapped_exception(ex) from ex
 
     @property
     def db_engine_spec(self) -> Type[db_engine_specs.BaseEngineSpec]:

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1165,35 +1165,40 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         )
 
         if not database:
-            return json_error_response("Database not found", status=404)
+            return json_error_response(
+                __("Database not found: %(id)s", id=db_id), status=404
+            )
 
-        tables = security_manager.get_datasources_accessible_by_user(
-            database=database,
-            schema=schema_parsed,
-            datasource_names=[
-                utils.DatasourceName(*datasource_name)
-                for datasource_name in database.get_all_table_names_in_schema(
-                    schema=schema_parsed,
-                    force=force_refresh_parsed,
-                    cache=database.table_cache_enabled,
-                    cache_timeout=database.table_cache_timeout,
-                )
-            ],
-        )
+        try:
+            tables = security_manager.get_datasources_accessible_by_user(
+                database=database,
+                schema=schema_parsed,
+                datasource_names=[
+                    utils.DatasourceName(*datasource_name)
+                    for datasource_name in database.get_all_table_names_in_schema(
+                        schema=schema_parsed,
+                        force=force_refresh_parsed,
+                        cache=database.table_cache_enabled,
+                        cache_timeout=database.table_cache_timeout,
+                    )
+                ],
+            )
 
-        views = security_manager.get_datasources_accessible_by_user(
-            database=database,
-            schema=schema_parsed,
-            datasource_names=[
-                utils.DatasourceName(*datasource_name)
-                for datasource_name in database.get_all_view_names_in_schema(
-                    schema=schema_parsed,
-                    force=force_refresh_parsed,
-                    cache=database.table_cache_enabled,
-                    cache_timeout=database.table_cache_timeout,
-                )
-            ],
-        )
+            views = security_manager.get_datasources_accessible_by_user(
+                database=database,
+                schema=schema_parsed,
+                datasource_names=[
+                    utils.DatasourceName(*datasource_name)
+                    for datasource_name in database.get_all_view_names_in_schema(
+                        schema=schema_parsed,
+                        force=force_refresh_parsed,
+                        cache=database.table_cache_enabled,
+                        cache_timeout=database.table_cache_timeout,
+                    )
+                ],
+            )
+        except SupersetException as ex:
+            return json_error_response(ex.message, ex.status)
 
         extra_dict_by_name = {
             table.name: table.extra_dict


### PR DESCRIPTION
### SUMMARY
Many small improvements to error handling:
- Map exceptions from the `requests` library to Superset exceptions for both Trino and Druid (both use `requests` for communication, and has "clean" error messages that shouldn't contain sensitive info)
- In SQL Lab, both table and schema metadata requests only show a generic error message on failure; this adds the error message to provide additional context on what the error was.
- In Explore, unexpected exceptions are not shown in the error toast. Similar to SQL Lab table and schema errors, this adds the sanitized error message to the Explore error toast if available.
- `BaseEngineSpec` was missing `get_dbapi_mapped_exception` in many methods that potentially raised database-specific exceptions - these are added here + exception chaining as recommended [here](https://docs.python.org/3/tutorial/errors.html#exception-chaining).

### AFTER
When trying to Explore a dataset that has an error, the toast now shows the error message:
![image](https://user-images.githubusercontent.com/33317356/198996047-cac67b7d-6c47-4a97-b40a-64f1b64f4398.png)

Error messages are also surfaced in SQL Lab when fetching schemas/tables:
![image](https://user-images.githubusercontent.com/33317356/198996100-c4ae72c9-ec14-4832-a115-c53b6948b8f5.png)

### BEFORE
On Explore, a generic uninformative error was toasted:
![image](https://user-images.githubusercontent.com/33317356/198996145-8d9db079-1892-4c7e-9e50-b5c1bc6f71d8.png)

In SQL Lab, previously the table error message wasn't always raised, and no error context was available for either schema or table error toasts:
![image](https://user-images.githubusercontent.com/33317356/198996180-48d97dbd-1ea8-4a5c-bbc7-171abfb25191.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
