### PR TITLE
feat(dashboard): Add edit button to filter fashboard cards

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterConfigurationLink/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterConfigurationLink/index.tsx
@@ -27,6 +27,8 @@ import { getFilterBarTestId } from '..';
 export interface FCBProps {
   createNewOnOpen?: boolean;
   dashboardId?: number;
+  initialFilterId?: string;
+  onClick?: () => void;
   children?: React.ReactNode;
 }
 
@@ -37,6 +39,8 @@ const HeaderButton = styled(Button)`
 export const FilterConfigurationLink: React.FC<FCBProps> = ({
   createNewOnOpen,
   dashboardId,
+  initialFilterId,
+  onClick,
   children,
 }) => {
   const dispatch = useDispatch();
@@ -56,7 +60,10 @@ export const FilterConfigurationLink: React.FC<FCBProps> = ({
 
   const handleClick = useCallback(() => {
     setOpen(true);
-  }, [setOpen]);
+    if (onClick) {
+      onClick();
+    }
+  }, [setOpen, onClick]);
 
   return (
     <>
@@ -73,6 +80,7 @@ export const FilterConfigurationLink: React.FC<FCBProps> = ({
         isOpen={isOpen}
         onSave={submit}
         onCancel={close}
+        initialFilterId={initialFilterId}
         createNewOnOpen={createNewOnOpen}
         key={`filters-for-${dashboardId}`}
       />

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/FilterCard.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/FilterCard.test.tsx
@@ -218,7 +218,7 @@ const getTextInHTMLTags =
   };
 
 const renderContent = (filter = baseFilter, initialState = baseInitialState) =>
-  render(<FilterCardContent filter={filter} />, {
+  render(<FilterCardContent filter={filter} hidePopover={() => {}} />, {
     useRedux: true,
     initialState,
   });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/FilterCardContent.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/FilterCardContent.tsx
@@ -24,9 +24,17 @@ import { DependenciesRow } from './DependenciesRow';
 import { NameRow } from './NameRow';
 import { TypeRow } from './TypeRow';
 
-export const FilterCardContent = ({ filter }: { filter: Filter }) => (
+interface FilterCardContentProps {
+  filter: Filter;
+  hidePopover: () => void;
+}
+
+export const FilterCardContent = ({
+  filter,
+  hidePopover,
+}: FilterCardContentProps) => (
   <div>
-    <NameRow filter={filter} />
+    <NameRow filter={filter} hidePopover={hidePopover} />
     <TypeRow filter={filter} />
     <ScopeRow filter={filter} />
     <DependenciesRow filter={filter} />

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/NameRow.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/NameRow.tsx
@@ -17,34 +17,53 @@
  * under the License.
  */
 import React, { useRef } from 'react';
+import { useSelector } from 'react-redux';
 import { css, SupersetTheme } from '@superset-ui/core';
 import Icons from 'src/components/Icons';
 import { useTruncation } from 'src/hooks/useTruncation';
-import { Row, FilterName } from './Styles';
+import { RootState } from 'src/dashboard/types';
+import { Row, FilterName, StyledEdit, InternalRow } from './Styles';
 import { FilterCardRowProps } from './types';
+import { FilterConfigurationLink } from '../FilterBar/FilterConfigurationLink';
 import { TooltipWithTruncation } from './TooltipWithTruncation';
 
-export const NameRow = ({ filter }: FilterCardRowProps) => {
+export const NameRow = ({
+  filter,
+  hidePopover,
+}: FilterCardRowProps & { hidePopover: () => void }) => {
   const filterNameRef = useRef<HTMLElement>(null);
   const [elementsTruncated] = useTruncation(filterNameRef);
+  const dashboardId = useSelector<RootState, number>(
+    ({ dashboardInfo }) => dashboardInfo.id,
+  );
   return (
     <Row
       css={(theme: SupersetTheme) =>
         css`
           margin-bottom: ${theme.gridUnit * 3}px;
+          justify-content: space-between;
         `
       }
     >
-      <Icons.FilterSmall
-        css={(theme: SupersetTheme) =>
-          css`
-            margin-right: ${theme.gridUnit}px;
-          `
-        }
-      />
-      <TooltipWithTruncation title={elementsTruncated ? filter.name : null}>
-        <FilterName ref={filterNameRef}>{filter.name}</FilterName>
-      </TooltipWithTruncation>
+      <InternalRow>
+        <Icons.FilterSmall
+          css={(theme: SupersetTheme) =>
+            css`
+              margin-right: ${theme.gridUnit}px;
+            `
+          }
+        />
+        <TooltipWithTruncation title={elementsTruncated ? filter.name : null}>
+          <FilterName ref={filterNameRef}>{filter.name}</FilterName>
+        </TooltipWithTruncation>
+      </InternalRow>
+      <FilterConfigurationLink
+        dashboardId={dashboardId}
+        onClick={() => hidePopover()}
+        initialFilterId={filter.id}
+      >
+        <StyledEdit />
+      </FilterConfigurationLink>
     </Row>
   );
 };

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/Styles.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/Styles.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { css, styled } from '@superset-ui/core';
-import Icons from '../../../../components/Icons';
+import Icons from 'src/components/Icons';
 
 export const Row = styled.div`
   ${({ theme }) => css`

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/Styles.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/Styles.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { css, styled } from '@superset-ui/core';
+import Icons from '../../../../components/Icons';
 
 export const Row = styled.div`
   ${({ theme }) => css`
@@ -91,4 +92,16 @@ export const TooltipTrigger = styled.div`
   min-width: 0;
   display: inline-flex;
   white-space: nowrap;
+`;
+
+export const InternalRow = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+export const StyledEdit = styled(Icons.Edit)`
+  svg {
+    width: 14px;
+    height: 14px;
+  }
 `;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/index.tsx
@@ -30,6 +30,10 @@ export const FilterCard = ({
 }: FilterCardProps) => {
   const [internalIsVisible, setInternalIsVisible] = useState(false);
 
+  const hidePopover = () => {
+    setInternalIsVisible(false);
+  };
+
   useEffect(() => {
     if (!externalIsVisible) {
       setInternalIsVisible(false);
@@ -45,9 +49,8 @@ export const FilterCard = ({
         setInternalIsVisible(externalIsVisible && visible);
       }}
       visible={externalIsVisible && internalIsVisible}
-      content={<FilterCardContent filter={filter} />}
+      content={<FilterCardContent filter={filter} hidePopover={hidePopover} />}
       getPopupContainer={getPopupContainer ?? (() => document.body)}
-      destroyTooltipOnHide
     >
       {children}
     </Popover>


### PR DESCRIPTION
Add an option to jump directly to editing the selected filter in the dashboard view

### SUMMARY
Add an edit button in the form of an icon to quickly edit the selected filter.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![Add filter edit button](https://user-images.githubusercontent.com/1985940/199123896-657896b8-006c-47ed-8224-672394c59d08.png)


### TESTING INSTRUCTIONS
- It should only appear for admin user
- Clicking opens filters config modal and selects current filter for editing


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
