### PR TITLE
chore: Verify edit permission for Horizontal filter bar

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/index.tsx
@@ -93,9 +93,8 @@ const Header: FC<HeaderProps> = ({ toggleFiltersBar }) => {
   const dashboardId = useSelector<RootState, number>(
     ({ dashboardInfo }) => dashboardInfo.id,
   );
-  const canSetHorizontalFilterBar = isFeatureEnabled(
-    FeatureFlag.HORIZONTAL_FILTER_BAR,
-  );
+  const canSetHorizontalFilterBar =
+    canEdit && isFeatureEnabled(FeatureFlag.HORIZONTAL_FILTER_BAR);
 
   return (
     <Wrapper>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Verifies wether the user can edit in order to show the horizontal/vertical filter bar display options

### FILTER BAR DISPLAY OPTIONS

![Screenshot 2022-11-01 at 15 32 44](https://user-images.githubusercontent.com/60598000/199245559-0dba0f10-28e4-46fb-9e91-1e3f27169f1f.png)


### TESTING INSTRUCTIONS
1. Open a Dashboard for which you don't have permissions, the gear icon should not appear
2. Open a Dashboard for which yo have permissions, the gear icon should appear

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
