### PR TITLE
fix: allow error message to carry over to expandable modal

### DIFF
--- a/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
@@ -104,9 +104,7 @@ export default function ErrorAlert({
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isBodyExpanded, setIsBodyExpanded] = useState(false);
 
-  const isExpandable = ['explore', 'sqllab', 'dbConnectionModal'].includes(
-    source,
-  );
+  const isExpandable = ['explore', 'sqllab'].includes(source);
   const iconColor = theme.colors[level].base;
 
   return (

--- a/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
@@ -104,7 +104,9 @@ export default function ErrorAlert({
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isBodyExpanded, setIsBodyExpanded] = useState(false);
 
-  const isExpandable = ['explore', 'sqllab'].includes(source);
+  const isExpandable = ['explore', 'sqllab', 'dbConnectionModal'].includes(
+    source,
+  );
   const iconColor = theme.colors[level].base;
 
   return (

--- a/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
@@ -88,6 +88,7 @@ interface ErrorAlertProps {
   subtitle: ReactNode;
   title: ReactNode;
   description?: string;
+  nonExpand?: boolean;
 }
 
 export default function ErrorAlert({
@@ -98,6 +99,7 @@ export default function ErrorAlert({
   subtitle,
   title,
   description,
+  nonExpand,
 }: ErrorAlertProps) {
   const theme = useTheme();
 
@@ -129,7 +131,7 @@ export default function ErrorAlert({
           </span>
         )}
       </div>
-      {description && (
+      {description && !nonExpand && (
         <div className="error-body">
           <p>{description}</p>
           {!isExpandable && (
@@ -142,6 +144,11 @@ export default function ErrorAlert({
               {t('See more')}
             </span>
           )}
+        </div>
+      )}
+      {description && nonExpand && (
+        <div className="error-body">
+          <p>{description}</p>
         </div>
       )}
       {isExpandable ? (

--- a/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.tsx
@@ -34,6 +34,7 @@ type Props = {
   source?: ErrorSource;
   description?: string;
   errorMitigationFunction?: () => void;
+  nonExpand?: boolean;
 };
 
 export default function ErrorMessageWithStackTrace({
@@ -45,6 +46,7 @@ export default function ErrorMessageWithStackTrace({
   stackTrace,
   source,
   description,
+  nonExpand,
 }: Props) {
   // Check if a custom error message component was registered for this message
   if (error) {
@@ -69,6 +71,7 @@ export default function ErrorMessageWithStackTrace({
       subtitle={subtitle}
       copyText={copyText}
       description={description}
+      nonExpand={nonExpand}
       source={source}
       body={
         link || stackTrace ? (

--- a/superset-frontend/src/components/ErrorMessage/types.ts
+++ b/superset-frontend/src/components/ErrorMessage/types.ts
@@ -87,7 +87,11 @@ export type ErrorType = ValueOf<typeof ErrorTypeEnum>;
 // Keep in sync with superset/views/errors.py
 export type ErrorLevel = 'info' | 'warning' | 'error';
 
-export type ErrorSource = 'dashboard' | 'explore' | 'sqllab';
+export type ErrorSource =
+  | 'dashboard'
+  | 'explore'
+  | 'sqllab'
+  | 'dbConnectionModal';
 
 export type SupersetError<ExtraType = Record<string, any> | null> = {
   error_type: ErrorType;

--- a/superset-frontend/src/components/ErrorMessage/types.ts
+++ b/superset-frontend/src/components/ErrorMessage/types.ts
@@ -87,11 +87,7 @@ export type ErrorType = ValueOf<typeof ErrorTypeEnum>;
 // Keep in sync with superset/views/errors.py
 export type ErrorLevel = 'info' | 'warning' | 'error';
 
-export type ErrorSource =
-  | 'dashboard'
-  | 'explore'
-  | 'sqllab'
-  | 'dbConnectionModal';
+export type ErrorSource = 'dashboard' | 'explore' | 'sqllab';
 
 export type SupersetError<ExtraType = Record<string, any> | null> = {
   error_type: ErrorType;

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -1172,7 +1172,6 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
           description={alertErrors[0]}
           subtitle={validationErrors?.description || alertErrors[0]}
           copyText={validationErrors?.description || alertErrors[0]}
-          source="dbConnectionModal"
         />
       );
     }

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -458,6 +458,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
   const [importingErrorMessage, setImportingErrorMessage] = useState<string>();
   const [passwordFields, setPasswordFields] = useState<string[]>([]);
 
+  const MAX_CHARS = 180;
   const conf = useCommonConf();
   const dbImages = getDatabaseImages();
   const connectionAlert = getConnectionAlert();
@@ -1165,6 +1166,12 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
           : [];
     }
 
+    const showMore = (error: string) => {
+      // Maximum amount of chars before to allow enable modal
+      if (error.length > MAX_CHARS) return true;
+      return false;
+    };
+
     if (alertErrors.length) {
       return (
         <ErrorMessageWithStackTrace
@@ -1172,6 +1179,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
           description={alertErrors[0]}
           subtitle={validationErrors?.description || alertErrors[0]}
           copyText={validationErrors?.description || alertErrors[0]}
+          nonExpand={showMore(alertErrors[0])}
         />
       );
     }

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -1170,8 +1170,9 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
         <ErrorMessageWithStackTrace
           title={t('Database Creation Error')}
           description={alertErrors[0]}
-          subtitle={validationErrors?.description}
-          copyText={validationErrors?.description}
+          subtitle={validationErrors?.description || alertErrors[0]}
+          copyText={validationErrors?.description || alertErrors[0]}
+          source="dbConnectionModal"
         />
       );
     }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
There is an issue in the db connection modal where the error text is not carried over to expandable error modal. This pr updates the prev refactor to allow user to see and copy db connection errors.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

befo
<img width="451" alt="Screen Shot 2022-11-02 at 4 10 58 PM" src="https://user-images.githubusercontent.com/17326228/199619369-9e7d3423-71c7-4cf2-ae7f-f87c2c958940.png">
re 

after
<img width="1154" alt="Screen Shot 2022-11-02 at 4 04 47 PM" src="https://user-images.githubusercontent.com/17326228/199618827-3a1fa464-4118-41bd-907a-7350aac7f15d.png">


### TESTING INSTRUCTIONS
Try to connect a database with a potential error to connect and check to see if the error text shows up in the see more modal.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
