### PR TITLE
fix(sqllab): inconsistent addNewQueryEditor behavior

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/sqllab/tabs.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/sqllab/tabs.test.ts
@@ -22,9 +22,10 @@ describe('SqlLab query tabs', () => {
     cy.visit('/superset/sqllab');
   });
 
+  const tablistSelector = '[data-test="sql-editor-tabs"] > [role="tablist"]';
+  const tabSelector = `${tablistSelector} [role="tab"]`;
+
   it('allows you to create and close a tab', () => {
-    const tablistSelector = '[data-test="sql-editor-tabs"] > [role="tablist"]';
-    const tabSelector = `${tablistSelector} [role="tab"]`;
     cy.get(tabSelector).then(tabs => {
       const initialTabCount = tabs.length;
       const initialUntitledCount = Math.max(
@@ -57,6 +58,57 @@ describe('SqlLab query tabs', () => {
 
       cy.get(`${tablistSelector} [aria-label="remove"]:last`).click();
       cy.get(tabSelector).should('have.length', initialTabCount);
+    });
+  });
+
+  it('opens a new tab by a button and a shortcut', () => {
+    const editorContent = '#ace-editor .ace_content';
+    const editorInput = '#ace-editor textarea';
+    const queryLimitSelector = '#js-sql-toolbar .limitDropdown';
+    cy.get(tabSelector).then(tabs => {
+      const initialTabCount = tabs.length;
+      const initialUntitledCount = Math.max(
+        0,
+        ...tabs
+          .map(
+            (i, tabItem) =>
+              Number(tabItem.textContent?.match(/Untitled Query (\d+)/)?.[1]) ||
+              0,
+          )
+          .toArray(),
+      );
+
+      // configure some editor settings
+      cy.get(editorInput).type('some random query string', { force: true });
+      cy.get(queryLimitSelector).parent().click({ force: true });
+      cy.get('.ant-dropdown-menu')
+        .last()
+        .find('.ant-dropdown-menu-item')
+        .first()
+        .click({ force: true });
+
+      // open a new tab by a button
+      cy.get('[data-test="add-tab-icon"]:visible:last').click({ force: true });
+      cy.contains('[role="tab"]', `Untitled Query ${initialUntitledCount + 1}`);
+      cy.get(tabSelector).should('have.length', initialTabCount + 1);
+      cy.get(editorContent).contains('SELECT ...');
+      cy.get(queryLimitSelector).contains('10');
+
+      // close the tab
+      cy.get(`${tabSelector}:last [data-test="dropdown-trigger"]`).click({
+        force: true,
+      });
+      cy.get(`${tablistSelector} [aria-label="remove"]:last`).click({
+        force: true,
+      });
+      cy.get(tabSelector).should('have.length', initialTabCount);
+
+      // open a new tab by a shortcut
+      cy.get('body').type('{ctrl}t');
+      cy.get(tabSelector).should('have.length', initialTabCount + 1);
+      cy.contains('[role="tab"]', `Untitled Query ${initialUntitledCount + 1}`);
+      cy.get(editorContent).contains('SELECT ...');
+      cy.get(queryLimitSelector).contains('10');
     });
   });
 });

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -615,10 +615,11 @@ export function addNewQueryEditor() {
     const activeQueryEditor = queryEditors.find(
       qe => qe.id === tabHistory[tabHistory.length - 1],
     );
-    const firstDbId = Math.min(
-      ...Object.values(databases).map(database => database.id),
-    );
-    const queryEditor = {
+    const firstDbId =
+      databases.length > 0
+        ? Math.min(...Object.values(databases).map(database => database.id))
+        : undefined;
+    const { dbId, schema, queryLimit } = {
       ...queryEditors[0],
       ...activeQueryEditor,
       ...(unsavedQueryEditor.id === activeQueryEditor?.id &&
@@ -634,11 +635,11 @@ export function addNewQueryEditor() {
 
     return dispatch(
       addQueryEditor({
-        dbId: queryEditor.dbId || defaultDbId || firstDbId,
-        schema: queryEditor.schema,
+        dbId: dbId || defaultDbId || firstDbId,
+        schema,
         autorun: false,
         sql: `${warning}SELECT ...`,
-        queryLimit: queryEditor.queryLimit || common.conf.DEFAULT_SQLLAB_LIMIT,
+        queryLimit: queryLimit || common.conf.DEFAULT_SQLLAB_LIMIT,
         name,
       }),
     );

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -612,7 +612,7 @@ export function addNewQueryEditor() {
       },
       common,
     } = getState();
-    const sourceQueryEditor = queryEditors.find(
+    const activeQueryEditor = queryEditors.find(
       qe => qe.id === tabHistory[tabHistory.length - 1],
     );
     const firstDbId = Math.min(
@@ -620,8 +620,8 @@ export function addNewQueryEditor() {
     );
     const queryEditor = {
       ...queryEditors[0],
-      ...sourceQueryEditor,
-      ...(unsavedQueryEditor.id === sourceQueryEditor?.id &&
+      ...activeQueryEditor,
+      ...(unsavedQueryEditor.id === activeQueryEditor?.id &&
         unsavedQueryEditor),
     };
     const warning = isFeatureEnabled(FeatureFlag.SQLLAB_BACKEND_PERSISTENCE)

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -619,7 +619,7 @@ export function addNewQueryEditor() {
       databases.length > 0
         ? Math.min(...Object.values(databases).map(database => database.id))
         : undefined;
-    const { dbId, schema, queryLimit } = {
+    const { dbId, schema, queryLimit, autorun } = {
       ...queryEditors[0],
       ...activeQueryEditor,
       ...(unsavedQueryEditor.id === activeQueryEditor?.id &&
@@ -636,8 +636,8 @@ export function addNewQueryEditor() {
     return dispatch(
       addQueryEditor({
         dbId: dbId || defaultDbId || firstDbId,
-        schema,
-        autorun: false,
+        schema: schema ?? null,
+        autorun: autorun ?? false,
         sql: `${warning}SELECT ...`,
         queryLimit: queryLimit || common.conf.DEFAULT_SQLLAB_LIMIT,
         name,

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -615,10 +615,8 @@ export function addNewQueryEditor() {
     const activeQueryEditor = queryEditors.find(
       qe => qe.id === tabHistory[tabHistory.length - 1],
     );
-    const firstDbId =
-      databases.length > 0
-        ? Math.min(...Object.values(databases).map(database => database.id))
-        : undefined;
+    const dbIds = Object.values(databases).map(database => database.id);
+    const firstDbId = dbIds.length > 0 ? Math.min(...dbIds) : undefined;
     const { dbId, schema, queryLimit, autorun } = {
       ...queryEditors[0],
       ...activeQueryEditor,

--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.js
@@ -480,15 +480,21 @@ describe('async actions', () => {
           {
             type: actions.ADD_QUERY_EDITOR,
             queryEditor: {
-              ...defaultQueryEditor,
               id: 'abcd',
+              sql: expect.stringContaining('SELECT ...'),
               name: `Untitled Query ${
                 store.getState().sqlLab.queryEditors.length + 1
               }`,
+              dbId: defaultQueryEditor.dbId,
+              schema: defaultQueryEditor.schema,
+              autorun: false,
+              queryLimit:
+                defaultQueryEditor.queryLimit ||
+                initialState.common.conf.DEFAULT_SQLLAB_LIMIT,
             },
           },
         ];
-        const request = actions.addNewQueryEditor(defaultQueryEditor);
+        const request = actions.addNewQueryEditor();
         return request(store.dispatch, store.getState).then(() => {
           expect(store.getActions()).toEqual(expectedActions);
         });

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -319,7 +319,7 @@ const SqlEditor = ({
         key: userOS === 'Windows' ? 'ctrl+q' : 'ctrl+t',
         descr: t('New tab'),
         func: () => {
-          dispatch(addNewQueryEditor(queryEditor));
+          dispatch(addNewQueryEditor());
         },
       },
       {

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.jsx
@@ -201,27 +201,7 @@ class TabbedSqlEditors extends React.PureComponent {
   }
 
   newQueryEditor() {
-    const activeQueryEditor = this.activeQueryEditor();
-    const firstDbId = Math.min(
-      ...Object.values(this.props.databases).map(database => database.id),
-    );
-    const warning = isFeatureEnabled(FeatureFlag.SQLLAB_BACKEND_PERSISTENCE)
-      ? ''
-      : t(
-          '-- Note: Unless you save your query, these tabs will NOT persist if you clear your cookies or change browsers.\n\n',
-        );
-
-    const qe = {
-      dbId:
-        activeQueryEditor && activeQueryEditor.dbId
-          ? activeQueryEditor.dbId
-          : this.props.defaultDbId || firstDbId,
-      schema: activeQueryEditor ? activeQueryEditor.schema : null,
-      autorun: false,
-      sql: `${warning}SELECT ...`,
-      queryLimit: this.props.defaultQueryLimit,
-    };
-    this.props.actions.addNewQueryEditor(qe);
+    this.props.actions.addNewQueryEditor();
   }
 
   handleSelect(key) {


### PR DESCRIPTION
### SUMMARY
Since `addNewQueryEditor` action handled differently between shortkey and the tab button, it pops up the new tab in a different configuration. This commit consolidates the `addNewQueryEditor` action to configure the new tab setting consistently.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

- Before

https://user-images.githubusercontent.com/1392866/199376112-538577e5-03fd-437e-b861-a098adfb5fa6.mov

- After

https://user-images.githubusercontent.com/1392866/199376105-d52fa2cf-54a6-42cc-ba6f-f755a91f2d94.mov

### TESTING INSTRUCTIONS
- Go to SqlLab
- Click "+" button to open a new tab
- Switch to the previous tab
- Hit Ctrl + t (mac) / Ctrl + q (windows) to open a new tab
- Compare the content with the previous step

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
