### PR TITLE
feat(dashboard): Support changing filter bar location

### DIFF
--- a/superset-frontend/src/dashboard/actions/dashboardInfo.ts
+++ b/superset-frontend/src/dashboard/actions/dashboardInfo.ts
@@ -17,9 +17,17 @@
  * under the License.
  */
 import { Dispatch } from 'redux';
-import { makeApi, CategoricalColorNamespace } from '@superset-ui/core';
+import { makeApi, CategoricalColorNamespace, t } from '@superset-ui/core';
 import { isString } from 'lodash';
-import { ChartConfiguration, DashboardInfo } from '../reducers/types';
+import { getClientErrorObject } from 'src/utils/getClientErrorObject';
+import { addDangerToast } from 'src/components/MessageToasts/actions';
+import {
+  DashboardInfo,
+  FilterBarLocation,
+  RootState,
+} from 'src/dashboard/types';
+import { ChartConfiguration } from 'src/dashboard/reducers/types';
+import { onSave } from './dashboardState';
 
 export const DASHBOARD_INFO_UPDATED = 'DASHBOARD_INFO_UPDATED';
 
@@ -111,3 +119,60 @@ export const setChartConfiguration =
       dispatch({ type: SET_CHART_CONFIG_FAIL, chartConfiguration });
     }
   };
+
+export const SET_FILTER_BAR_LOCATION = 'SET_FILTER_BAR_LOCATION';
+export interface SetFilterBarLocation {
+  type: typeof SET_FILTER_BAR_LOCATION;
+  filterBarLocation: FilterBarLocation;
+}
+export function setFilterBarLocation(filterBarLocation: FilterBarLocation) {
+  return { type: SET_FILTER_BAR_LOCATION, filterBarLocation };
+}
+
+export function saveFilterBarLocation(location: FilterBarLocation) {
+  return (dispatch: Dispatch, getState: () => RootState) => {
+    const { id, metadata } = getState().dashboardInfo;
+    const updateDashboard = makeApi<
+      Partial<DashboardInfo>,
+      { result: Partial<DashboardInfo>; last_modified_time: number }
+    >({
+      method: 'PUT',
+      endpoint: `/api/v1/dashboard/${id}`,
+    });
+    return updateDashboard({
+      json_metadata: JSON.stringify({
+        ...metadata,
+        filter_bar_location: location,
+      }),
+    })
+      .then(response => {
+        const updatedDashboard = response.result;
+        const lastModifiedTime = response.last_modified_time;
+        if (updatedDashboard.json_metadata) {
+          const metadata = JSON.parse(updatedDashboard.json_metadata);
+          if (metadata.filter_bar_location) {
+            dispatch(setFilterBarLocation(metadata.filter_bar_location));
+          }
+        }
+        if (lastModifiedTime) {
+          dispatch(onSave(lastModifiedTime));
+        }
+      })
+      .catch(async errorObject => {
+        const { error, message } = await getClientErrorObject(errorObject);
+        let errorText = t('Sorry, an unknown error occurred.');
+
+        if (error) {
+          errorText = t(
+            'Sorry, there was an error saving this dashboard: %s',
+            error,
+          );
+        }
+        if (typeof message === 'string' && message === 'Forbidden') {
+          errorText = t('You do not have permission to edit this dashboard');
+        }
+        dispatch(addDangerToast(errorText));
+        throw errorObject;
+      });
+  };
+}

--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -284,7 +284,7 @@ export function saveDashboardRequest(data, id, saveType) {
     const onUpdateSuccess = response => {
       const updatedDashboard = response.json.result;
       const lastModifiedTime = response.json.last_modified_time;
-      // synching with the backend transformations of the metadata
+      // syncing with the backend transformations of the metadata
       if (updatedDashboard.json_metadata) {
         const metadata = JSON.parse(updatedDashboard.json_metadata);
         dispatch(

--- a/superset-frontend/src/dashboard/actions/hydrate.js
+++ b/superset-frontend/src/dashboard/actions/hydrate.js
@@ -57,6 +57,7 @@ import getNativeFilterConfig from '../util/filterboxMigrationHelper';
 import { updateColorSchema } from './dashboardInfo';
 import { getChartIdsInFilterScope } from '../util/getChartIdsInFilterScope';
 import updateComponentParentsList from '../util/updateComponentParentsList';
+import { FilterBarLocation } from '../types';
 
 export const HYDRATE_DASHBOARD = 'HYDRATE_DASHBOARD';
 
@@ -428,6 +429,8 @@ export const hydrateDashboard =
             flash_messages: common?.flash_messages,
             conf: common?.conf,
           },
+          filterBarLocation:
+            metadata.filter_bar_location ?? FilterBarLocation.VERTICAL,
         },
         dataMask,
         dashboardFilters,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBarLocationSelect/FilterBarLocationSelect.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBarLocationSelect/FilterBarLocationSelect.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import { render, screen } from 'spec/helpers/testing-library';
+import { FilterBarLocation } from 'src/dashboard/types';
+import { RootState } from 'src/dashboard/types';
+import { FilterBarLocationSelect } from './index';
+
+const initialState: Partial<RootState> = {
+  dashboardInfo: {
+    id: 1,
+    userId: '1',
+    metadata: {
+      native_filter_configuration: {},
+      show_native_filters: true,
+      chart_configuration: {},
+      color_scheme: '',
+      color_namespace: '',
+      color_scheme_domain: [],
+      label_colors: {},
+      shared_label_colors: {},
+    },
+    json_metadata: '',
+    dash_edit_perm: true,
+    filterBarLocation: FilterBarLocation.VERTICAL,
+    common: {
+      conf: {},
+      flash_messages: [],
+    },
+  },
+};
+
+const setup = (initialStateOverride: Partial<RootState> = {}) => {
+  return render(<FilterBarLocationSelect />, {
+    useRedux: true,
+    initialState: { ...initialState, ...initialStateOverride },
+  });
+};
+
+test('Dropdown trigger renders', () => {
+  setup();
+  expect(screen.getByLabelText('gear')).toBeVisible();
+});

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBarLocationSelect/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBarLocationSelect/index.tsx
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useCallback, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { t, useTheme } from '@superset-ui/core';
+import { MenuProps } from 'src/components/Menu';
+import { FilterBarLocation, RootState } from 'src/dashboard/types';
+import { saveFilterBarLocation } from 'src/dashboard/actions/dashboardInfo';
+import Icons from 'src/components/Icons';
+import DropdownSelectableIcon from 'src/components/DropdownSelectableIcon';
+
+export const FilterBarLocationSelect = () => {
+  const dispatch = useDispatch();
+  const theme = useTheme();
+  const filterBarLocation = useSelector<RootState, FilterBarLocation>(
+    ({ dashboardInfo }) => dashboardInfo.filterBarLocation,
+  );
+  const [selectedFilterBarLocation, setSelectedFilterBarLocation] =
+    useState(filterBarLocation);
+
+  const toggleFilterBarLocation = useCallback(
+    (
+      selection: Parameters<
+        Required<Pick<MenuProps, 'onSelect'>>['onSelect']
+      >[0],
+    ) => {
+      const selectedKey = selection.key as FilterBarLocation;
+      if (selectedKey !== filterBarLocation) {
+        // set displayed selection in local state for immediate visual response after clicking
+        setSelectedFilterBarLocation(selectedKey);
+        try {
+          // save selection in Redux and backend
+          dispatch(saveFilterBarLocation(selection.key as FilterBarLocation));
+        } catch {
+          // revert local state in case of error when saving
+          setSelectedFilterBarLocation(filterBarLocation);
+        }
+      }
+    },
+    [dispatch, filterBarLocation],
+  );
+
+  return (
+    <DropdownSelectableIcon
+      onSelect={toggleFilterBarLocation}
+      info={t('Placement of filter bar')}
+      icon={<Icons.Gear name="gear" iconColor={theme.colors.grayscale.base} />}
+      menuItems={[
+        {
+          key: FilterBarLocation.VERTICAL,
+          label: t('Vertical (Left)'),
+        },
+        {
+          key: FilterBarLocation.HORIZONTAL,
+          label: t('Horizontal (Top)'),
+        },
+      ]}
+      selectedKeys={[selectedFilterBarLocation]}
+    />
+  );
+};

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBarLocationSelect/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBarLocationSelect/index.tsx
@@ -36,7 +36,7 @@ export const FilterBarLocationSelect = () => {
     useState(filterBarLocation);
 
   const toggleFilterBarLocation = useCallback(
-    (
+    async (
       selection: Parameters<
         Required<Pick<MenuProps, 'onSelect'>>['onSelect']
       >[0],
@@ -47,7 +47,9 @@ export const FilterBarLocationSelect = () => {
         setSelectedFilterBarLocation(selectedKey);
         try {
           // save selection in Redux and backend
-          dispatch(saveFilterBarLocation(selection.key as FilterBarLocation));
+          await dispatch(
+            saveFilterBarLocation(selection.key as FilterBarLocation),
+          );
         } catch {
           // revert local state in case of error when saving
           setSelectedFilterBarLocation(filterBarLocation);

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/index.tsx
@@ -32,8 +32,8 @@ import { useSelector } from 'react-redux';
 import FilterConfigurationLink from 'src/dashboard/components/nativeFilters/FilterBar/FilterConfigurationLink';
 import { useFilters } from 'src/dashboard/components/nativeFilters/FilterBar/state';
 import { RootState } from 'src/dashboard/types';
-import DropdownSelectableIcon from 'src/components/DropdownSelectableIcon';
 import { getFilterBarTestId } from '..';
+import { FilterBarLocationSelect } from '../FilterBarLocationSelect';
 
 const TitleArea = styled.h4`
   display: flex;
@@ -93,34 +93,14 @@ const Header: FC<HeaderProps> = ({ toggleFiltersBar }) => {
   const dashboardId = useSelector<RootState, number>(
     ({ dashboardInfo }) => dashboardInfo.id,
   );
-  const canSetHorizontalFilterBar = isFeatureEnabled(
-    FeatureFlag.HORIZONTAL_FILTER_BAR,
-  );
+  const canSetHorizontalFilterBar =
+    canEdit && isFeatureEnabled(FeatureFlag.HORIZONTAL_FILTER_BAR);
 
   return (
     <Wrapper>
       <TitleArea>
         <span>{t('Filters')}</span>
-        {canSetHorizontalFilterBar && (
-          <DropdownSelectableIcon
-            onSelect={item => console.log('Selected item', item)}
-            info={t('Placement of filter bar')}
-            icon={
-              <Icons.Gear name="gear" iconColor={theme.colors.grayscale.base} />
-            }
-            menuItems={[
-              {
-                key: 'vertical',
-                label: t('Vertical (Left)'),
-              },
-              {
-                key: 'horizontal',
-                label: t('Horizontal (Top)'),
-              },
-            ]}
-            selectedKeys={['vertical']}
-          />
-        )}
+        {canSetHorizontalFilterBar && <FilterBarLocationSelect />}
         <HeaderButton
           {...getFilterBarTestId('collapse-button')}
           buttonStyle="link"

--- a/superset-frontend/src/dashboard/reducers/dashboardInfo.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardInfo.js
@@ -17,7 +17,10 @@
  * under the License.
  */
 
-import { DASHBOARD_INFO_UPDATED } from '../actions/dashboardInfo';
+import {
+  DASHBOARD_INFO_UPDATED,
+  SET_FILTER_BAR_LOCATION,
+} from '../actions/dashboardInfo';
 import { HYDRATE_DASHBOARD } from '../actions/hydrate';
 
 export default function dashboardStateReducer(state = {}, action) {
@@ -34,6 +37,11 @@ export default function dashboardStateReducer(state = {}, action) {
         ...state,
         ...action.data.dashboardInfo,
         // set async api call data
+      };
+    case SET_FILTER_BAR_LOCATION:
+      return {
+        ...state,
+        filterBarLocation: action.filterBarLocation,
       };
     default:
       return state;

--- a/superset-frontend/src/dashboard/types.ts
+++ b/superset-frontend/src/dashboard/types.ts
@@ -92,6 +92,7 @@ export type DashboardInfo = {
     label_colors: JsonObject;
     shared_label_colors: JsonObject;
   };
+  filterBarLocation: FilterBarLocation;
 };
 
 export type ChartsState = { [key: string]: Chart };
@@ -174,3 +175,8 @@ export type EmbeddedDashboard = {
   dashboard_id: string;
   allowed_domains: string[];
 };
+
+export enum FilterBarLocation {
+  VERTICAL = 'VERTICAL',
+  HORIZONTAL = 'HORIZONTAL',
+}

--- a/superset-frontend/src/dashboard/types.ts
+++ b/superset-frontend/src/dashboard/types.ts
@@ -52,6 +52,11 @@ export type Chart = ChartState & {
   };
 };
 
+export enum FilterBarLocation {
+  VERTICAL = 'VERTICAL',
+  HORIZONTAL = 'HORIZONTAL',
+}
+
 export type ActiveTabs = string[];
 export type DashboardLayout = { [key: string]: LayoutItem };
 export type DashboardLayoutState = { present: DashboardLayout };
@@ -175,8 +180,3 @@ export type EmbeddedDashboard = {
   dashboard_id: string;
   allowed_domains: string[];
 };
-
-export enum FilterBarLocation {
-  VERTICAL = 'VERTICAL',
-  HORIZONTAL = 'HORIZONTAL',
-}

--- a/superset-frontend/src/dashboard/util/permissionUtils.test.ts
+++ b/superset-frontend/src/dashboard/util/permissionUtils.test.ts
@@ -20,7 +20,7 @@ import {
   UndefinedUser,
   UserWithPermissionsAndRoles,
 } from 'src/types/bootstrapTypes';
-import Dashboard from 'src/types/Dashboard';
+import { Dashboard } from 'src/types/Dashboard';
 import Owner from 'src/types/Owner';
 import { canUserEditDashboard, isUserAdmin } from './permissionUtils';
 

--- a/superset-frontend/src/dashboard/util/permissionUtils.ts
+++ b/superset-frontend/src/dashboard/util/permissionUtils.ts
@@ -21,7 +21,7 @@ import {
   UndefinedUser,
   UserWithPermissionsAndRoles,
 } from 'src/types/bootstrapTypes';
-import Dashboard from 'src/types/Dashboard';
+import { Dashboard } from 'src/types/Dashboard';
 import { findPermission } from 'src/utils/findPermission';
 
 // this should really be a config value,

--- a/superset-frontend/src/types/Dashboard.ts
+++ b/superset-frontend/src/types/Dashboard.ts
@@ -36,5 +36,3 @@ export interface Dashboard {
   owners: Owner[];
   roles: Role[];
 }
-
-export default Dashboard;

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -133,6 +133,7 @@ class DashboardJSONMetadataSchema(Schema):
     # used for v0 import/export
     import_time = fields.Integer()
     remote_id = fields.Integer()
+    filter_bar_location = fields.Str(allow_none=True)
 
 
 class UserSchema(Schema):


### PR DESCRIPTION
### SUMMARY
This PR implements support for changing the native filters bar location.

1. Clicking on menu items updates Redux state (`dashboardInfo.filterBarLocation`) and sends a PUT request to `api/v1/dashboard/{id}` endpoint with updated `json_metadata`.
2. Initial Redux state of `dashboardInfo.filterBarLocation` is populated in dashboard's `hydrate` function
3. Clicking on menu item applies checkmark next to selected item immediately, without waiting for backend response (for better user experience). If backend returns an error, the selection is reverted. The actual position of the filter bar depends on backend response.
4. If there's an error, a toast message appears

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/15073128/199560452-ad5b52dc-5505-479f-9475-1d8ce964fb72.mov

### TESTING INSTRUCTIONS
1. Enable `HORIZONTAL_FILTER_BAR` ff
2. Go to dashboard and click on a gear icon in native filters bar
3. Verify that clicking on menu items dispatches Redux actions and API requests with the new `filter_bar_location` in the body
4. Verify that if an error occurs (by for example disconnecting your internet), then a toast message appears, selection in gear icon menu is reverted and no Redux action related to filter bar is dispatched

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
