### PR TITLE
fix(dashboard): chart doesn't resize when tab switch

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/tabs.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/tabs.test.ts
@@ -22,6 +22,7 @@ import {
   getChartAliasBySpec,
 } from 'cypress/utils';
 import { TABBED_DASHBOARD } from 'cypress/utils/urls';
+import { expandFilterOnLeftPanel } from './utils';
 
 const TREEMAP = { name: 'Treemap', viz: 'treemap' };
 const FILTER_BOX = { name: 'Region Filter', viz: 'filter_box' };
@@ -165,5 +166,34 @@ describe('Dashboard tabs', () => {
         throw new Error('Unexpected API call.');
       });
     });
+  });
+
+  it('should update size when switch tab', () => {
+    topLevelTabs();
+    waitForChartLoad(TREEMAP);
+
+    cy.get('@top-level-tabs')
+      .last()
+      .click()
+      .should('have.class', 'ant-tabs-tab-active');
+
+    expandFilterOnLeftPanel();
+
+    cy.wait(1000);
+
+    cy.get('@top-level-tabs')
+      .first()
+      .click()
+      .should('have.class', 'ant-tabs-tab-active');
+
+    cy.wait(1000);
+
+    cy.get("[data-test-viz-type='treemap'] .chart-container").then(
+      $chartContainer => {
+        expect($chartContainer.get(0).scrollWidth).eq(
+          $chartContainer.get(0).offsetWidth,
+        );
+      },
+    );
   });
 });

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/tabs.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/tabs.test.ts
@@ -92,6 +92,7 @@ describe('Dashboard tabs', () => {
     cy.get('@row-level-tabs').last().click();
     waitForChartLoad(LINE_CHART);
     cy.getBySel('grid-container').find('.line').should('be.visible');
+    cy.get('@row-level-tabs').first().click();
   });
 
   it.skip('should send new queries when tab becomes visible', () => {
@@ -169,9 +170,6 @@ describe('Dashboard tabs', () => {
   });
 
   it('should update size when switch tab', () => {
-    topLevelTabs();
-    waitForChartLoad(TREEMAP);
-
     cy.get('@top-level-tabs')
       .last()
       .click()

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -190,7 +190,9 @@ class Chart extends React.Component {
 
       if (
         nextProps.width !== this.props.width ||
-        nextProps.height !== this.props.height
+        nextProps.height !== this.props.height ||
+        nextProps.width !== this.state.width ||
+        nextProps.height !== this.state.height
       ) {
         clearTimeout(this.resizeTimeout);
         this.resizeTimeout = setTimeout(this.resize, RESIZE_TIMEOUT);


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently the chart doesn't resize when tab switch.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### before
You can see the charts have been cut off: 

https://user-images.githubusercontent.com/11830681/199552052-1f68738f-524c-4845-9022-79710d1b6619.mov


### after

https://user-images.githubusercontent.com/11830681/199551845-041b294f-011e-4237-874d-99fd617ae7e5.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: https://github.com/apache/superset/issues/21852
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
