### PR TITLE
fix: Apply border radius and fix height for MetadataBar

### DIFF
--- a/superset-frontend/src/components/MetadataBar/MetadataBar.tsx
+++ b/superset-frontend/src/components/MetadataBar/MetadataBar.tsx
@@ -58,6 +58,8 @@ const Bar = styled.div<{ count: number }>`
       (ICON_WIDTH + SPACE_BETWEEN_ITEMS) * count -
       SPACE_BETWEEN_ITEMS
     }px;
+    border-radius: ${theme.borderRadius}px;
+    line-height: 1;
   `}
 `;
 
@@ -68,6 +70,7 @@ const StyledItem = styled.div<{
 }>`
   ${({ theme, collapsed, last, onClick }) => `
     display: flex;
+    align-items: center;
     max-width: ${
       ICON_WIDTH +
       ICON_PADDING +
@@ -91,6 +94,9 @@ const StyledItem = styled.div<{
           : theme.colors.grayscale.base
       };
       padding-right: ${collapsed ? 0 : ICON_PADDING}px;
+      & .anticon {
+        line-height: 0;
+      }
     }
     & .metadata-text {
       min-width: ${TEXT_MIN_WIDTH}px;


### PR DESCRIPTION

### SUMMARY
Apply minor CSS changes to make MetadataBar consistent with designs.

1. Add `border-radius: 4px`
2. MetadataBar had height 34.5px instead of 32px. Adding `line-height: 1` to the container and `line-height: 0` to the icons fixed it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="995" alt="image" src="https://user-images.githubusercontent.com/15073128/199558090-a6db479b-6e9c-4033-a36b-3a27b1dc2544.png">

After:

<img width="890" alt="image" src="https://user-images.githubusercontent.com/15073128/199558026-5d72c0c5-e45f-4c7c-b58a-3db979754d7c.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @kasiazjc 