### PR TITLE
fix: Change downloadAsImage to use Superset theme

### DIFF
--- a/superset-frontend/src/utils/downloadAsImage.ts
+++ b/superset-frontend/src/utils/downloadAsImage.ts
@@ -71,7 +71,7 @@ export default function downloadAsImage(
     return domToImage
       .toJpeg(elementToPrint, {
         quality: 0.95,
-        bgcolor: supersetTheme.colors.primary.light3,
+        bgcolor: supersetTheme.colors.grayscale.light4,
         filter,
       })
       .then(dataUrl => {

--- a/superset-frontend/src/utils/downloadAsImage.ts
+++ b/superset-frontend/src/utils/downloadAsImage.ts
@@ -19,14 +19,8 @@
 import { SyntheticEvent } from 'react';
 import domToImage from 'dom-to-image-more';
 import kebabCase from 'lodash/kebabCase';
-import { t } from '@superset-ui/core';
+import { t, supersetTheme } from '@superset-ui/core';
 import { addWarningToast } from 'src/components/MessageToasts/actions';
-
-/**
- * @remark
- * same as https://github.com/apache/superset/blob/c53bc4ddf9808a8bb6916bbe3cb31935d33a2420/superset-frontend/src/assets/stylesheets/less/variables.less#L34
- */
-const GRAY_BACKGROUND_COLOR = '#F5F5F5';
 
 /**
  * generate a consistent file stem from a description and date
@@ -77,7 +71,7 @@ export default function downloadAsImage(
     return domToImage
       .toJpeg(elementToPrint, {
         quality: 0.95,
-        bgcolor: GRAY_BACKGROUND_COLOR,
+        bgcolor: supersetTheme.colors.primary.light3,
         filter,
       })
       .then(dataUrl => {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR changes the background color of downloadAsImage to use the Superset theme. Originally, the value for this color was held in a local variable that referenced [this line from our LESS variables file](https://github.com/apache/superset/blob/master/superset-frontend/src/assets/stylesheets/less/variables.less#L34), but was assigned to the color `#F5F5F5`. Since that referenced color is now `#d2edf4` in our LESS variables file, I referenced the matching color in our Superset theme instead (`supersetTheme.colors.primary.light3`).

### BEFORE/AFTER SCREENSHOTS
<!--- Skip this if not applicable -->
I downloaded a chart as an image for both of these screenshots
#### BEFORE:
![dlAsImgBefore](https://user-images.githubusercontent.com/55605634/199593272-d5bb62fc-9e68-4fa9-9281-08c3eb80fdd3.jpg)

#### AFTER:
![dlAsImgAfter](https://user-images.githubusercontent.com/55605634/199593307-f1a82452-17fb-4dce-b882-b7cb1455e5d4.jpg)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Open a chart and click the dropdown menu in the header next to the save button
- Hover over the Download option and click "Download as Image" in the resulting menu
- Observe the background color

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
