### PR TITLE
fix(sqllab): Add templateParams on kv store

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -1365,6 +1365,7 @@ export function popStoredQuery(urlId) {
             schema: json.schema ? json.schema : null,
             autorun: json.autorun ? json.autorun : false,
             sql: json.sql ? json.sql : 'SELECT ...',
+            templateParams: json.templateParams,
           }),
         ),
       )

--- a/superset-frontend/src/SqlLab/components/ShareSqlLabQuery/ShareSqlLabQuery.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ShareSqlLabQuery/ShareSqlLabQuery.test.tsx
@@ -72,6 +72,7 @@ const unsavedQueryEditor = {
   schema: 'query_schema_updated',
   sql: 'SELECT * FROM Updated Limit 100',
   autorun: true,
+  templateParams: '{ "my_value": "foo" }',
 };
 
 const standardProviderWithUnsaved: React.FC = ({ children }) => (

--- a/superset-frontend/src/SqlLab/components/ShareSqlLabQuery/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ShareSqlLabQuery/index.tsx
@@ -48,13 +48,19 @@ function ShareSqlLabQuery({
 }: ShareSqlLabQueryPropTypes) {
   const theme = useTheme();
 
-  const { dbId, name, schema, autorun, sql, remoteId } = useQueryEditor(
-    queryEditorId,
-    ['dbId', 'name', 'schema', 'autorun', 'sql', 'remoteId'],
-  );
+  const { dbId, name, schema, autorun, sql, remoteId, templateParams } =
+    useQueryEditor(queryEditorId, [
+      'dbId',
+      'name',
+      'schema',
+      'autorun',
+      'sql',
+      'remoteId',
+      'templateParams',
+    ]);
 
   const getCopyUrlForKvStore = (callback: Function) => {
-    const sharedQuery = { dbId, name, schema, autorun, sql };
+    const sharedQuery = { dbId, name, schema, autorun, sql, templateParams };
 
     return storeQuery(sharedQuery)
       .then(shortUrl => {


### PR DESCRIPTION
### SUMMARY
When "copy link" on SqlLab, it ignores the template parameters. Therefore, it's difficult to share a query with the template variables.
This commit adds the template parameters in kv store.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://user-images.githubusercontent.com/1392866/199621087-c4982f9e-66db-406a-8106-8da3663ccf13.mov

After:

https://user-images.githubusercontent.com/1392866/199621083-2dda64db-db79-43b3-9273-5d4c1392cef5.mov

### TESTING INSTRUCTIONS

enable `SHARE_QUERIES_VIA_KV_STORE` feature
go to SqlLab and add template parameters
click "copy link" and then paste the link in the new tab
check the template parameters in new tab

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @ktmud @john-bodley 