### PR TITLE
fix: Revert shared controls typing change.

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -239,7 +239,7 @@ export interface BaseControlConfig<
   ) => boolean;
   mapStateToProps?: (
     state: ControlPanelState,
-    controlState?: ControlState,
+    controlState: ControlState,
     // TODO: add strict `chartState` typing (see superset-frontend/src/explore/types)
     chartState?: AnyDict,
   ) => ExtraControlProps;

--- a/superset-frontend/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-histogram/src/controlPanel.ts
@@ -25,14 +25,15 @@ import {
   sections,
   getStandardizedControls,
   sharedControls,
+  ControlState,
 } from '@superset-ui/chart-controls';
 
 const columnsConfig = {
   ...sharedControls.columns,
   label: t('Columns'),
   description: t('Select the numeric columns to draw the histogram'),
-  mapStateToProps: (state: ControlPanelState) => ({
-    ...(sharedControls.columns.mapStateToProps?.(state) || {}),
+  mapStateToProps: (state: ControlPanelState, controlState: ControlState) => ({
+    ...(sharedControls.columns.mapStateToProps?.(state, controlState) || {}),
     choices: columnChoices(state.datasource),
   }),
   validators: [validateNonEmpty],


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As part of unifying drag-and-drop and non-drag-and-drop controls in #21315, I unnecessarily changed a type to optional.  This PR reverts that change and instead updates the viz plugin that was causing TypeScript to complain to match the previous function signature.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Confirm that Histogram charts don't look any different than they did before.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
