### PR TITLE
chore(bigquery): Add extra logging for BigQuery exceptions so we can have better insight on exceptions

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -64,7 +64,7 @@ from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.sql_parse import ParsedQuery, Table
 from superset.superset_typing import ResultSetColumnType
 from superset.utils import core as utils
-from superset.utils.core import ColumnSpec, GenericDataType, get_username
+from superset.utils.core import ColumnSpec, EngineType, GenericDataType, get_username
 from superset.utils.hashing import md5_sha_from_str
 from superset.utils.network import is_hostname_valid, is_port_open
 
@@ -453,7 +453,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         new_exception = cls.get_dbapi_exception_mapping().get(type(exception))
         if not new_exception:
             # We are interested in just BigQuery exceptions
-            if cls.engine == "bigquery":
+            if cls.engine == EngineType.BIGQUERY:
                 logger.error(cls.parse_error_exception(str(exception)), exc_info=True)
             return exception
         return new_exception(str(exception))

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -431,6 +431,15 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         return {}
 
     @classmethod
+    def parse_error_exception(cls, exception_message: str) -> str:
+        """
+        Each engine can implement and converge its own specific parser method
+
+        :return: A parsed string off the original exception
+        """
+        return exception_message
+
+    @classmethod
     def get_dbapi_mapped_exception(cls, exception: Exception) -> Exception:
         """
         Get a superset custom DBAPI exception from the driver specific exception.
@@ -443,6 +452,9 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         """
         new_exception = cls.get_dbapi_exception_mapping().get(type(exception))
         if not new_exception:
+            # We are interested in just BigQuery exceptions
+            if cls.engine == "bigquery":
+                logger.error(cls.parse_error_exception(str(exception)), exc_info=True)
             return exception
         return new_exception(str(exception))
 

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -64,7 +64,7 @@ from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.sql_parse import ParsedQuery, Table
 from superset.superset_typing import ResultSetColumnType
 from superset.utils import core as utils
-from superset.utils.core import ColumnSpec, EngineType, GenericDataType, get_username
+from superset.utils.core import ColumnSpec, GenericDataType, get_username
 from superset.utils.hashing import md5_sha_from_str
 from superset.utils.network import is_hostname_valid, is_port_open
 
@@ -431,13 +431,13 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         return {}
 
     @classmethod
-    def parse_error_exception(cls, exception_message: str) -> str:
+    def parse_error_exception(cls, exception: Exception) -> Exception:
         """
         Each engine can implement and converge its own specific parser method
 
-        :return: A parsed string off the original exception
+        :return: An Exception with a parsed string off the original exception
         """
-        return exception_message
+        return exception
 
     @classmethod
     def get_dbapi_mapped_exception(cls, exception: Exception) -> Exception:
@@ -452,10 +452,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         """
         new_exception = cls.get_dbapi_exception_mapping().get(type(exception))
         if not new_exception:
-            # We are interested in just BigQuery exceptions
-            if cls.engine == EngineType.BIGQUERY:
-                logger.error(cls.parse_error_exception(str(exception)), exc_info=True)
-            return exception
+            return cls.parse_error_exception(exception)
         return new_exception(str(exception))
 
     @classmethod

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -581,4 +581,9 @@ class BigQueryEngineSpec(BaseEngineSpec):
 
     @classmethod
     def parse_error_exception(cls, exception_message: str) -> str:
-        return exception_message.rsplit("\n")[0]
+        try:
+            return exception_message.rsplit("\n")[0]
+        except Exception:  # pylint: disable=broad-except
+            # If for some reason we get an exception, for example, no new line
+            # We will return the original exception_message
+            return exception_message

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -583,7 +583,10 @@ class BigQueryEngineSpec(BaseEngineSpec):
     def parse_error_exception(cls, exception: Exception) -> Exception:
         try:
             return Exception(
-                str(exception).rsplit("\n")[0]  # pylint: disable=use-maxsplit-arg
+                str(exception)  # pylint: disable=use-maxsplit-arg
+                .rsplit("\n")[0]
+                .rsplit(":")[1]
+                .strip()
             )
         except Exception:  # pylint: disable=broad-except
             # If for some reason we get an exception, for example, no new line

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -580,10 +580,12 @@ class BigQueryEngineSpec(BaseEngineSpec):
         return [column(c["name"]).label(c["name"].replace(".", "__")) for c in cols]
 
     @classmethod
-    def parse_error_exception(cls, exception_message: str) -> str:
+    def parse_error_exception(cls, exception: Exception) -> Exception:
         try:
-            return exception_message.rsplit("\n")[0]
+            return Exception(
+                str(exception).rsplit("\n")[0]  # pylint: disable=use-maxsplit-arg
+            )
         except Exception:  # pylint: disable=broad-except
             # If for some reason we get an exception, for example, no new line
-            # We will return the original exception_message
-            return exception_message
+            # We will return the original exception
+            return exception

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -578,3 +578,7 @@ class BigQueryEngineSpec(BaseEngineSpec):
         "author__name" and "author__email", respectively.
         """
         return [column(c["name"]).label(c["name"].replace(".", "__")) for c in cols]
+
+    @classmethod
+    def parse_error_exception(cls, exception_message: str) -> str:
+        return exception_message.rsplit("\n")[0]

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -582,12 +582,7 @@ class BigQueryEngineSpec(BaseEngineSpec):
     @classmethod
     def parse_error_exception(cls, exception: Exception) -> Exception:
         try:
-            return Exception(
-                str(exception)  # pylint: disable=use-maxsplit-arg
-                .rsplit("\n")[0]
-                .rsplit(":")[1]
-                .strip()
-            )
+            return Exception(str(exception).splitlines()[0].rsplit(":")[1].strip())
         except Exception:  # pylint: disable=broad-except
             # If for some reason we get an exception, for example, no new line
             # We will return the original exception

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -190,10 +190,6 @@ class DatasourceType(str, Enum):
     VIEW = "view"
 
 
-class EngineType(str, Enum):
-    BIGQUERY = "bigquery"
-
-
 class HeaderDataType(TypedDict):
     notification_format: str
     owners: List[int]

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -190,6 +190,10 @@ class DatasourceType(str, Enum):
     VIEW = "view"
 
 
+class EngineType(str, Enum):
+    BIGQUERY = "bigquery"
+
+
 class HeaderDataType(TypedDict):
     notification_format: str
     owners: List[int]

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -279,8 +279,14 @@ def test_parse_error_message() -> None:
     expected_result_2 = (
         '400 Syntax error: Expected "(" or keyword UNNEST but got "@" at [4:80]'
     )
-    assert BigQueryEngineSpec.parse_error_exception(message) == expected_result
-    assert BigQueryEngineSpec.parse_error_exception(message_2) == expected_result_2
+    assert (
+        str(BigQueryEngineSpec.parse_error_exception(Exception(message)))
+        == expected_result
+    )
+    assert (
+        str(BigQueryEngineSpec.parse_error_exception(Exception(message_2)))
+        == expected_result_2
+    )
 
 
 def test_parse_error_raises_exception() -> None:
@@ -300,6 +306,12 @@ def test_parse_error_raises_exception() -> None:
     expected_result_2 = (
         '400 Syntax error: Expected "(" or keyword UNNEST but got "@" at [4:80]'
     )
-    assert BigQueryEngineSpec.parse_error_exception(message) == expected_result
-    assert BigQueryEngineSpec.parse_error_exception(message_2) == expected_result_2
-    assert BigQueryEngineSpec.parse_error_exception(message_3) == "6"
+    assert (
+        str(BigQueryEngineSpec.parse_error_exception(Exception(message)))
+        == expected_result
+    )
+    assert (
+        str(BigQueryEngineSpec.parse_error_exception(Exception(message_2)))
+        == expected_result_2
+    )
+    assert str(BigQueryEngineSpec.parse_error_exception(Exception(message_3))) == "6"

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -281,3 +281,25 @@ def test_parse_error_message() -> None:
     )
     assert BigQueryEngineSpec.parse_error_exception(message) == expected_result
     assert BigQueryEngineSpec.parse_error_exception(message_2) == expected_result_2
+
+
+def test_parse_error_raises_exception() -> None:
+    """
+    Test that we handle any exception we might get from calling the parse_error_exception method.
+
+    Example errors:
+    400 Syntax error: Expected "(" or keyword UNNEST but got "@" at [4:80]
+    bigquery error: 400 Table \"case_detail_all_suites\" must be qualified with a dataset (e.g. dataset.table).
+    """
+    from superset.db_engine_specs.bigquery import BigQueryEngineSpec
+
+    message = 'bigquery error: 400 Table "case_detail_all_suites" must be qualified with a dataset (e.g. dataset.table).'
+    message_2 = '400 Syntax error: Expected "(" or keyword UNNEST but got "@" at [4:80]'
+    message_3 = "6"
+    expected_result = 'bigquery error: 400 Table "case_detail_all_suites" must be qualified with a dataset (e.g. dataset.table).'
+    expected_result_2 = (
+        '400 Syntax error: Expected "(" or keyword UNNEST but got "@" at [4:80]'
+    )
+    assert BigQueryEngineSpec.parse_error_exception(message) == expected_result
+    assert BigQueryEngineSpec.parse_error_exception(message_2) == expected_result_2
+    assert BigQueryEngineSpec.parse_error_exception(message_3) == "6"

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -244,3 +244,40 @@ def test_mask_encrypted_extra_when_empty() -> None:
     from superset.db_engine_specs.bigquery import BigQueryEngineSpec
 
     assert BigQueryEngineSpec.mask_encrypted_extra(None) is None
+
+
+def test_parse_error_message() -> None:
+    """
+    Test that we parse a received message and just extract the useful information.
+
+    Example errors:
+    400 Syntax error: Expected "(" or keyword UNNEST but got "@" at [4:80]
+
+    (job ID: 60c732c3-4b4e-4da6-9988-18ba20d389ee)
+
+                                                -----Query Job SQL Follows-----
+
+    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |
+    1:SELECT count(*) AS `count_1`
+    2:FROM (SELECT `bigquery-public-data.census_bureau_acs.blockgroup_2010_5yr`.`geo_id` AS `bigquery_public_data_census_bureau_acs_blockgroup_2010_5yr_geo_id`
+    3:FROM `bigquery-public-data.census_bureau_acs.blockgroup_2010_5yr`
+    4:WHERE `bigquery-public-data.census_bureau_acs.blockgroup_2010_5yr`.`geo_id` IN @`geo_id_1`) AS `anon_1`
+    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |
+
+
+    bigquery error: 400 Table \"case_detail_all_suites\" must be qualified with a dataset (e.g. dataset.table).
+
+    (job ID: ddf30b05-44e8-4fbf-aa29-40bfccaed886)
+                                                -----Query Job SQL Follows-----
+    |    .    |    .    |    .    |\n   1:select * from case_detail_all_suites\n   2:LIMIT 1001\n    |    .    |    .    |    .    |
+    """
+    from superset.db_engine_specs.bigquery import BigQueryEngineSpec
+
+    message = 'bigquery error: 400 Table "case_detail_all_suites" must be qualified with a dataset (e.g. dataset.table).\n\n(job ID: ddf30b05-44e8-4fbf-aa29-40bfccaed886)\n\n     -----Query Job SQL Follows-----     \n\n    |    .    |    .    |    .    |\n   1:select * from case_detail_all_suites\n   2:LIMIT 1001\n    |    .    |    .    |    .    |'
+    message_2 = '400 Syntax error: Expected "(" or keyword UNNEST but got "@" at [4:80]\n\n(job ID: 60c732c3-4b4e-4da6-9988-18ba20d389ee)\n\n                                                -----Query Job SQL Follows-----                                                                \n\n    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |\n\n    1:SELECT count(*) AS `count_1` \n\n    2:FROM (SELECT `bigquery-public-data.census_bureau_acs.blockgroup_2010_5yr`.`geo_id` AS `bigquery_public_data_census_bureau_acs_blockgroup_2010_5yr_geo_id` \n\n    3:FROM `bigquery-public-data.census_bureau_acs.blockgroup_2010_5yr` \n\n    4:WHERE `bigquery-public-data.census_bureau_acs.blockgroup_2010_5yr`.`geo_id` IN @`geo_id_1`) AS `anon_1`'
+    expected_result = 'bigquery error: 400 Table "case_detail_all_suites" must be qualified with a dataset (e.g. dataset.table).'
+    expected_result_2 = (
+        '400 Syntax error: Expected "(" or keyword UNNEST but got "@" at [4:80]'
+    )
+    assert BigQueryEngineSpec.parse_error_exception(message) == expected_result
+    assert BigQueryEngineSpec.parse_error_exception(message_2) == expected_result_2

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -251,20 +251,6 @@ def test_parse_error_message() -> None:
     Test that we parse a received message and just extract the useful information.
 
     Example errors:
-    400 Syntax error: Expected "(" or keyword UNNEST but got "@" at [4:80]
-
-    (job ID: 60c732c3-4b4e-4da6-9988-18ba20d389ee)
-
-                                                -----Query Job SQL Follows-----
-
-    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |
-    1:SELECT count(*) AS `count_1`
-    2:FROM (SELECT `bigquery-public-data.census_bureau_acs.blockgroup_2010_5yr`.`geo_id` AS `bigquery_public_data_census_bureau_acs_blockgroup_2010_5yr_geo_id`
-    3:FROM `bigquery-public-data.census_bureau_acs.blockgroup_2010_5yr`
-    4:WHERE `bigquery-public-data.census_bureau_acs.blockgroup_2010_5yr`.`geo_id` IN @`geo_id_1`) AS `anon_1`
-    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |
-
-
     bigquery error: 400 Table \"case_detail_all_suites\" must be qualified with a dataset (e.g. dataset.table).
 
     (job ID: ddf30b05-44e8-4fbf-aa29-40bfccaed886)
@@ -274,18 +260,10 @@ def test_parse_error_message() -> None:
     from superset.db_engine_specs.bigquery import BigQueryEngineSpec
 
     message = 'bigquery error: 400 Table "case_detail_all_suites" must be qualified with a dataset (e.g. dataset.table).\n\n(job ID: ddf30b05-44e8-4fbf-aa29-40bfccaed886)\n\n     -----Query Job SQL Follows-----     \n\n    |    .    |    .    |    .    |\n   1:select * from case_detail_all_suites\n   2:LIMIT 1001\n    |    .    |    .    |    .    |'
-    message_2 = '400 Syntax error: Expected "(" or keyword UNNEST but got "@" at [4:80]\n\n(job ID: 60c732c3-4b4e-4da6-9988-18ba20d389ee)\n\n                                                -----Query Job SQL Follows-----                                                                \n\n    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |\n\n    1:SELECT count(*) AS `count_1` \n\n    2:FROM (SELECT `bigquery-public-data.census_bureau_acs.blockgroup_2010_5yr`.`geo_id` AS `bigquery_public_data_census_bureau_acs_blockgroup_2010_5yr_geo_id` \n\n    3:FROM `bigquery-public-data.census_bureau_acs.blockgroup_2010_5yr` \n\n    4:WHERE `bigquery-public-data.census_bureau_acs.blockgroup_2010_5yr`.`geo_id` IN @`geo_id_1`) AS `anon_1`'
-    expected_result = 'bigquery error: 400 Table "case_detail_all_suites" must be qualified with a dataset (e.g. dataset.table).'
-    expected_result_2 = (
-        '400 Syntax error: Expected "(" or keyword UNNEST but got "@" at [4:80]'
-    )
+    expected_result = '400 Table "case_detail_all_suites" must be qualified with a dataset (e.g. dataset.table).'
     assert (
         str(BigQueryEngineSpec.parse_error_exception(Exception(message)))
         == expected_result
-    )
-    assert (
-        str(BigQueryEngineSpec.parse_error_exception(Exception(message_2)))
-        == expected_result_2
     )
 
 
@@ -300,18 +278,10 @@ def test_parse_error_raises_exception() -> None:
     from superset.db_engine_specs.bigquery import BigQueryEngineSpec
 
     message = 'bigquery error: 400 Table "case_detail_all_suites" must be qualified with a dataset (e.g. dataset.table).'
-    message_2 = '400 Syntax error: Expected "(" or keyword UNNEST but got "@" at [4:80]'
-    message_3 = "6"
-    expected_result = 'bigquery error: 400 Table "case_detail_all_suites" must be qualified with a dataset (e.g. dataset.table).'
-    expected_result_2 = (
-        '400 Syntax error: Expected "(" or keyword UNNEST but got "@" at [4:80]'
-    )
+    message_2 = "6"
+    expected_result = '400 Table "case_detail_all_suites" must be qualified with a dataset (e.g. dataset.table).'
     assert (
         str(BigQueryEngineSpec.parse_error_exception(Exception(message)))
         == expected_result
     )
-    assert (
-        str(BigQueryEngineSpec.parse_error_exception(Exception(message_2)))
-        == expected_result_2
-    )
-    assert str(BigQueryEngineSpec.parse_error_exception(Exception(message_3))) == "6"
+    assert str(BigQueryEngineSpec.parse_error_exception(Exception(message_2))) == "6"


### PR DESCRIPTION
### SUMMARY
Some BigQuery exceptions are not being logged with enough information, so we need to add some extra method that parses the original exception and logs the correct message. We also add some unit tests to the new method.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After:
![test](https://user-images.githubusercontent.com/38889534/199721944-5717e9b9-698c-406b-90c6-0b4a4bd4c2a3.png)


### TESTING INSTRUCTIONS
1. Connect Locally to a BigQuery DB
2. Run an invalid SQL statement so you get a BigQuery exception
3. Check you are logging the correct message out of the original exception

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
