### PR TITLE
feat: Add 3 new extension points for inserting custom icons

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/ui-overrides/ExtensionsRegistry.ts
+++ b/superset-frontend/packages/superset-ui-core/src/ui-overrides/ExtensionsRegistry.ts
@@ -18,7 +18,6 @@
  */
 
 import React from 'react';
-import { MenuObjectChildProps } from 'src/views/components/Menu';
 import { TypedRegistry } from '../models';
 import { makeSingleton } from '../utils';
 
@@ -36,6 +35,20 @@ type ReturningDisplayable<P = void> = (props: P) => string | React.ReactElement;
  * When defining a new option here, take care to keep any parameters to functions (or components) minimal.
  * Any removal or alteration to a parameter will be considered a breaking change.
  */
+
+// from src/views/components/Menu, not imported since this is a separate package
+interface MenuObjectChildProps {
+  label: string;
+  name?: string;
+  icon?: string;
+  index?: number;
+  url?: string;
+  isFrontendRoute?: boolean;
+  perm?: string | boolean;
+  view?: string;
+  disable?: boolean;
+};
+
 type ConfigDetailsProps = {
   embeddedId: string;
 };

--- a/superset-frontend/packages/superset-ui-core/src/ui-overrides/ExtensionsRegistry.ts
+++ b/superset-frontend/packages/superset-ui-core/src/ui-overrides/ExtensionsRegistry.ts
@@ -18,6 +18,7 @@
  */
 
 import React from 'react';
+import { MenuObjectChildProps } from 'src/views/components/Menu';
 import { TypedRegistry } from '../models';
 import { makeSingleton } from '../utils';
 
@@ -38,13 +39,19 @@ type ReturningDisplayable<P = void> = (props: P) => string | React.ReactElement;
 type ConfigDetailsProps = {
   embeddedId: string;
 };
+type RightMenuItemIconProps = {
+  menuChild: MenuObjectChildProps;
+};
 
 export type Extensions = Partial<{
+  'alertsreports.header.icon': React.ComponentType;
   'embedded.documentation.configuration_details': React.ComponentType<ConfigDetailsProps>;
   'embedded.documentation.description': ReturningDisplayable;
   'embedded.documentation.url': string;
   'dashboard.nav.right': React.ComponentType;
+  'navbar.right-menu.item.icon': React.ComponentType<RightMenuItemIconProps>;
   'navbar.right': React.ComponentType;
+  'report-modal.dropdown.item.icon': React.ComponentType;
   'welcome.message': React.ComponentType;
   'welcome.banner': React.ComponentType;
   'welcome.main.replacement': React.ComponentType;

--- a/superset-frontend/packages/superset-ui-core/src/ui-overrides/ExtensionsRegistry.ts
+++ b/superset-frontend/packages/superset-ui-core/src/ui-overrides/ExtensionsRegistry.ts
@@ -47,7 +47,7 @@ interface MenuObjectChildProps {
   perm?: string | boolean;
   view?: string;
   disable?: boolean;
-};
+}
 
 type ConfigDetailsProps = {
   embeddedId: string;

--- a/superset-frontend/src/components/ReportModal/HeaderReportDropdown/index.tsx
+++ b/superset-frontend/src/components/ReportModal/HeaderReportDropdown/index.tsx
@@ -23,9 +23,11 @@ import {
   t,
   SupersetTheme,
   css,
+  styled,
   useTheme,
   FeatureFlag,
   isFeatureEnabled,
+  getExtensionsRegistry,
 } from '@superset-ui/core';
 import Icons from 'src/components/Icons';
 import { Switch } from 'src/components/Switch';
@@ -45,6 +47,8 @@ import {
 } from 'src/reports/actions/reports';
 import { reportSelector } from 'src/views/CRUD/hooks';
 import { MenuItemWithCheckboxContainer } from 'src/explore/components/useExploreAdditionalActionsMenu/index';
+
+const extensionsRegistry = getExtensionsRegistry();
 
 const deleteColor = (theme: SupersetTheme) => css`
   color: ${theme.colors.error.base};
@@ -70,6 +74,21 @@ const onMenuItemHover = (theme: SupersetTheme) => css`
     background-color: ${theme.colors.secondary.light5};
   }
 `;
+
+const StyledDropdownItemWithIcon = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  > *:first-child {
+    margin-right: ${({ theme }) => theme.gridUnit}px;
+  }
+`;
+
+const DropdownItemExtension = extensionsRegistry.get(
+  'report-modal.dropdown.item.icon',
+);
+
 export enum CreationMethod {
   CHARTS = 'charts',
   DASHBOARDS = 'dashboards',
@@ -204,7 +223,14 @@ export default function HeaderReportDropDown({
     ) : (
       <Menu selectable={false} css={onMenuHover}>
         <Menu.Item onClick={handleShowMenu}>
-          {t('Set up an email report')}
+          {DropdownItemExtension ? (
+            <StyledDropdownItemWithIcon>
+              <div>{t('Set up an email report')}</div>
+              <DropdownItemExtension />
+            </StyledDropdownItemWithIcon>
+          ) : (
+            t('Set up an email report')
+          )}
         </Menu.Item>
         <Menu.Divider />
       </Menu>

--- a/superset-frontend/src/views/CRUD/alert/AlertList.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertList.tsx
@@ -19,7 +19,13 @@
 
 import React, { useState, useMemo, useEffect, useCallback } from 'react';
 import { useHistory } from 'react-router-dom';
-import { t, SupersetClient, makeApi, styled } from '@superset-ui/core';
+import {
+  t,
+  SupersetClient,
+  makeApi,
+  styled,
+  getExtensionsRegistry,
+} from '@superset-ui/core';
 import moment from 'moment';
 import ActionsBar, { ActionProps } from 'src/components/ListView/ActionsBar';
 import FacePile from 'src/components/FacePile';
@@ -48,6 +54,8 @@ import { isUserAdmin } from 'src/dashboard/util/permissionUtils';
 import Owner from 'src/types/Owner';
 import AlertReportModal from './AlertReportModal';
 import { AlertObject, AlertState } from './types';
+
+const extensionsRegistry = getExtensionsRegistry();
 
 const PAGE_SIZE = 25;
 
@@ -81,6 +89,18 @@ const RefreshContainer = styled.div`
     ${({ theme }) => theme.gridUnit * 3}px;
   background-color: ${({ theme }) => theme.colors.grayscale.light5};
 `;
+
+const StyledHeaderWithIcon = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  > *:first-child {
+    margin-right: ${({ theme }) => theme.gridUnit}px;
+  }
+`;
+
+const HeaderExtension = extensionsRegistry.get('alertsreports.header.icon');
 
 function AlertList({
   addDangerToast,
@@ -491,11 +511,20 @@ function AlertList({
     [],
   );
 
+  const header = HeaderExtension ? (
+    <StyledHeaderWithIcon>
+      <div>{t('Alerts & reports')}</div>
+      <HeaderExtension />
+    </StyledHeaderWithIcon>
+  ) : (
+    t('Alerts & reports')
+  );
+
   return (
     <>
       <SubMenu
         activeChild={pathName}
-        name={t('Alerts & reports')}
+        name={header}
         tabs={[
           {
             name: 'Alerts',

--- a/superset-frontend/src/views/components/RightMenu.tsx
+++ b/superset-frontend/src/views/components/RightMenu.tsx
@@ -84,6 +84,13 @@ const StyledDiv = styled.div<{ align: string }>`
   }
 `;
 
+const StyledMenuItemWithIcon = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+`;
+
 const StyledAnchor = styled.a`
   padding-right: ${({ theme }) => theme.gridUnit}px;
   padding-left: ${({ theme }) => theme.gridUnit}px;
@@ -330,6 +337,9 @@ const RightMenu = ({
     return null;
   };
   const RightMenuExtension = extensionsRegistry.get('navbar.right');
+  const RightMenuItemIconExtension = extensionsRegistry.get(
+    'navbar.right-menu.item.icon',
+  );
 
   const handleDatabaseAdd = () => setQuery({ databaseAdded: true });
   const handleDatasetAdd = () => setQuery({ datasetAdded: true });
@@ -372,6 +382,7 @@ const RightMenu = ({
         mode="horizontal"
         onClick={handleMenuSelection}
         onOpenChange={onMenuOpen}
+        subMenuCloseDelay={60}
       >
         {RightMenuExtension && <RightMenuExtension />}
         {!navbarRight.user_is_anonymous && showActionDropdown && (
@@ -447,12 +458,20 @@ const RightMenu = ({
             <Menu.ItemGroup key={`${section.label}`} title={section.label}>
               {section?.childs?.map?.(child => {
                 if (typeof child !== 'string') {
+                  const menuItemDisplay = RightMenuItemIconExtension ? (
+                    <StyledMenuItemWithIcon>
+                      {child.label}
+                      <RightMenuItemIconExtension menuChild={child} />
+                    </StyledMenuItemWithIcon>
+                  ) : (
+                    child.label
+                  );
                   return (
                     <Menu.Item key={`${child.label}`}>
                       {isFrontendRoute(child.url) ? (
-                        <Link to={child.url || ''}>{child.label}</Link>
+                        <Link to={child.url || ''}>{menuItemDisplay}</Link>
                       ) : (
-                        <a href={child.url}>{child.label}</a>
+                        <a href={child.url}>{menuItemDisplay}</a>
                       )}
                     </Menu.Item>
                   );

--- a/superset-frontend/src/views/components/RightMenu.tsx
+++ b/superset-frontend/src/views/components/RightMenu.tsx
@@ -382,7 +382,6 @@ const RightMenu = ({
         mode="horizontal"
         onClick={handleMenuSelection}
         onOpenChange={onMenuOpen}
-        subMenuCloseDelay={60}
       >
         {RightMenuExtension && <RightMenuExtension />}
         {!navbarRight.user_is_anonymous && showActionDropdown && (


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Preset would like to include custom icons in these three components. This PR introduces three new keys to the extensions registry to support this.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
<img width="206" alt="Screen Shot 2022-11-03 at 8 38 17 AM" src="https://user-images.githubusercontent.com/47196419/199766512-5908c027-71e0-4390-ae18-bd3acf1b9253.png">

<img width="434" alt="Screen Shot 2022-11-03 at 8 38 35 AM" src="https://user-images.githubusercontent.com/47196419/199766528-d1ba0996-96c0-4afc-8c14-4575abeb3bdb.png">

<img width="224" alt="Screen Shot 2022-11-03 at 8 39 22 AM" src="https://user-images.githubusercontent.com/47196419/199766546-ba315de3-ac27-4c54-8887-cfa935c19661.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
