### PR TITLE
fix: JSON serializers

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -703,9 +703,14 @@ class Database(
         self, table_name: str, schema: Optional[str] = None
     ) -> Dict[str, Any]:
         pk_constraint = self.inspector.get_pk_constraint(table_name, schema) or {}
-        return {
-            key: utils.base_json_conv(value) for key, value in pk_constraint.items()
-        }
+
+        def _convert(value: Any) -> Any:
+            try:
+                return utils.base_json_conv(value)
+            except TypeError:
+                return None
+
+        return {key: _convert(value) for key, value in pk_constraint.items()}
 
     def get_foreign_keys(
         self, table_name: str, schema: Optional[str] = None


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

I'm not exactly sure why this issue didn't surface prior to https://github.com/apache/superset/pull/21936 when `np.vectorize` was being leveraged, but the JSON serialization failed when an `np.array` was undefined, i.e., `np.array(None)`, i.e., in SQL Lab one would see the following,

```
Unserializable object None of type <class 'numpy.ndarray'>
```

if the column was an array but the array was null.

The issue was that the `base_json_conv` treated a return value of `None` as representing an object which wasn't able to be converted however some converted types can have a return value of `None`, i.e., `np.array(None).tolist()` is `None`. 

The fix is to make `base_json_conv` raise a `TypeError` if the type is unknown and to reorganize the logic for the JSON serializers. See the inline comments for more details.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Added unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
