### PR TITLE
chore(dataset): enable reload for schema and table

### DIFF
--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -306,7 +306,7 @@ export default function DatabaseSelector({
   }
 
   function renderSchemaSelect() {
-    const refreshIcon = !formMode && !readOnly && (
+    const refreshIcon = !readOnly && (
       <RefreshLabel
         onClick={() => setRefresh(refresh + 1)}
         tooltipContent={t('Force refresh schema list')}

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -327,7 +327,7 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
       />
     );
 
-    const refreshLabel = !formMode && !readOnly && (
+    const refreshLabel = !readOnly && (
       <RefreshLabel
         onClick={() => refetch()}
         tooltipContent={t('Force refresh table list')}


### PR DESCRIPTION
### SUMMARY

long history but schema and table selector isn't enabled the reload feature when [Dataset creation modal implemented](https://github.com/apache/superset/pull/10104/files#diff-8c9115b0992f26d4cd78ff12e49f36832c9c0478e660c9e80c233b6f7366aabfR370).

Due to the cached dataset, user cannot create a new dataset using "Add dataset" modal when a new table recently added. In order to do so, user must hit the refresh request on sqllab page and then reload the modal again.

This commit enables the refresh button for formMode (which is only used on DatasetModal) in order to reduce the UX inconvenience. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:
<img width="660" alt="Screen Shot 2022-11-03 at 3 28 48 PM" src="https://user-images.githubusercontent.com/1392866/199847691-5f0c8221-dbd8-4cf0-b93d-6a2a1377e5cc.png">

After:
<img width="633" alt="Screen Shot 2022-11-03 at 3 35 11 PM" src="https://user-images.githubusercontent.com/1392866/199847714-a109416a-2f4d-4444-bd60-0f21a916fcd8.png">

### TESTING INSTRUCTIONS

- create a new table
- go to datasets
- click add new dataset
- search the table just created

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

@ktmud @etr2460 cc: @john-bodley 
