### PR TITLE
chore(sqllab): Change icon color for running sql

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/style/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/style/index.tsx
@@ -22,6 +22,7 @@ import createCache from '@emotion/cache';
 
 export {
   css,
+  keyframes,
   jsx,
   ThemeProvider,
   CacheProvider as EmotionCacheProvider,

--- a/superset-frontend/src/SqlLab/components/TabStatusIcon/TabStatusIcon.test.tsx
+++ b/superset-frontend/src/SqlLab/components/TabStatusIcon/TabStatusIcon.test.tsx
@@ -16,24 +16,22 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { QueryState } from '@superset-ui/core';
 import React from 'react';
-import sinon from 'sinon';
-import { shallow } from 'enzyme';
 
+import { render } from 'spec/helpers/testing-library';
 import TabStatusIcon from 'src/SqlLab/components/TabStatusIcon';
 
 function setup() {
-  const onClose = sinon.spy();
-  const wrapper = shallow(
-    <TabStatusIcon onClose={onClose} tabState="running" />,
-  );
-  return { wrapper, onClose };
+  return render(<TabStatusIcon tabState={'running' as QueryState} />);
 }
 
 describe('TabStatusIcon', () => {
   it('renders a circle without an x when hovered', () => {
-    const { wrapper } = setup();
-    expect(wrapper.find('div.circle')).toExist();
-    expect(wrapper.text()).toBe('');
+    const { container } = setup();
+    expect(container.getElementsByClassName('circle')[0]).toBeInTheDocument();
+    expect(
+      container.getElementsByClassName('circle')[0]?.textContent ?? 'undefined',
+    ).toBe('');
   });
 });

--- a/superset-frontend/src/SqlLab/components/TabStatusIcon/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TabStatusIcon/index.tsx
@@ -17,21 +17,13 @@
  * under the License.
  */
 import React from 'react';
-import { QueryState, styled, keyframes } from '@superset-ui/core';
+import { QueryState, styled } from '@superset-ui/core';
+import Icons from 'src/components/Icons';
 
-const dimmingFrames = keyframes`
-  40% {
-    opacity: 0.5;
-  }
-
-  100% {
-    opacity: 1;
-  }
-`;
-
-const DimmingIcon = styled.div<{ isDimming: boolean }>`
-  animation: ${({ isDimming }) => (isDimming ? dimmingFrames : 'none')} 1s ease
-    infinite;
+const IconContainer = styled.span`
+  position: absolute;
+  top: -7px;
+  left: 0px;
 `;
 
 interface TabStatusIconProps {
@@ -40,9 +32,13 @@ interface TabStatusIconProps {
 
 export default function TabStatusIcon({ tabState }: TabStatusIconProps) {
   return (
-    <DimmingIcon
-      className={`circle ${tabState}`}
-      isDimming={tabState === 'running'}
-    />
+    <div className={`circle ${tabState}`}>
+      {['success', 'failed'].includes(tabState) && (
+        <IconContainer>
+          {tabState === 'success' && <Icons.Check iconSize="xs" />}
+          {tabState === 'failed' && <Icons.CancelX iconSize="xs" />}
+        </IconContainer>
+      )}
+    </div>
   );
 }

--- a/superset-frontend/src/SqlLab/components/TabStatusIcon/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TabStatusIcon/index.tsx
@@ -17,12 +17,32 @@
  * under the License.
  */
 import React from 'react';
-import { QueryState } from '@superset-ui/core';
+import { QueryState, styled, keyframes } from '@superset-ui/core';
+
+const dimmingFrames = keyframes`
+  40% {
+    opacity: 0.5;
+  }
+
+  100% {
+    opacity: 1;
+  }
+`;
+
+const DimmingIcon = styled.div<{ isDimming: boolean }>`
+  animation: ${({ isDimming }) => (isDimming ? dimmingFrames : 'none')} 1s ease
+    infinite;
+`;
 
 interface TabStatusIconProps {
   tabState: QueryState;
 }
 
 export default function TabStatusIcon({ tabState }: TabStatusIconProps) {
-  return <div className={`circle ${tabState}`} />;
+  return (
+    <DimmingIcon
+      className={`circle ${tabState}`}
+      isDimming={tabState === 'running'}
+    />
+  );
 }

--- a/superset-frontend/src/SqlLab/components/TabStatusIcon/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TabStatusIcon/index.tsx
@@ -18,7 +18,7 @@
  */
 import React from 'react';
 import { QueryState, styled } from '@superset-ui/core';
-import Icons from 'src/components/Icons';
+import Icons, { IconType } from 'src/components/Icons';
 
 const IconContainer = styled.span`
   position: absolute;
@@ -30,13 +30,18 @@ interface TabStatusIconProps {
   tabState: QueryState;
 }
 
+const STATE_ICONS: Record<string, React.FC<IconType>> = {
+  success: Icons.Check,
+  failed: Icons.CancelX,
+};
+
 export default function TabStatusIcon({ tabState }: TabStatusIconProps) {
+  const StatusIcon = STATE_ICONS[tabState];
   return (
     <div className={`circle ${tabState}`}>
-      {['success', 'failed'].includes(tabState) && (
+      {StatusIcon && (
         <IconContainer>
-          {tabState === 'success' && <Icons.Check iconSize="xs" />}
-          {tabState === 'failed' && <Icons.CancelX iconSize="xs" />}
+          <StatusIcon iconSize="xs" />
         </IconContainer>
       )}
     </div>

--- a/superset-frontend/src/SqlLab/main.less
+++ b/superset-frontend/src/SqlLab/main.less
@@ -161,11 +161,12 @@ div.Workspace {
   vertical-align: middle;
   font-size: @font-size-m;
   font-weight: @font-weight-bold;
+  color: @lightest;
+  position: relative;
 }
 
 .running {
-  background-color: fade(@success, @opacity-heavy);
-  color: @darkest;
+  background-color: @info;
 }
 
 .success {


### PR DESCRIPTION
### SUMMARY
There's [an open issue](https://github.com/apache/superset/issues/11123) that is hard to distinguish icons between running and successful query state in sqllab.
~This commit adds the animated dimming translation for running statue to be distinguishing the running state easily.~
This commit updates the icon color for running state to be distinguishing the running and finish states. It also adds the icons for success and fail status to help red/green colorblind to distinguish the color status.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

- Before:

<img width="436" alt="Screen_Shot_2022-11-07_at_2_49_13_PM" src="https://user-images.githubusercontent.com/1392866/200432585-f763df31-a3e2-49ec-927b-e9ae26c64cde.png">

- After:

<img width="587" alt="Screen Shot 2022-11-08 at 11 09 38 AM" src="https://user-images.githubusercontent.com/1392866/200653955-d32be97e-1586-43f2-918b-7e3e23927c9a.png">

```
Grey: Not yet started
Blue: In progress*
Green: Success
Red: Failed
Note people are red/green colorblind so maybe having a check-mark/x-mark inside the circle would help to distinguish between (3) and (4).
```

### TESTING INSTRUCTIONS
Go to sqllab
Run a query

### ADDITIONAL INFORMATION
- [x] Has associated issue: [issues#11123](https://github.com/apache/superset/issues/11123) [issues#13648](https://github.com/apache/superset/issues/13648) [discussion#18402](https://github.com/apache/superset/discussions/18402)
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
