### PR TITLE
feat(dashboard): Add superset_can_share permission to Tab component

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
@@ -46,6 +46,7 @@ const propTypes = {
   onHoverTab: PropTypes.func,
   editMode: PropTypes.bool.isRequired,
   canEdit: PropTypes.bool.isRequired,
+  supersetCanShare: PropTypes.bool.isRequired,
 
   // grid related
   availableColumnCount: PropTypes.number,
@@ -262,6 +263,7 @@ class Tab extends React.PureComponent {
       editMode,
       isFocused,
       isHighlighted,
+      supersetCanShare,
     } = this.props;
 
     return (
@@ -290,7 +292,7 @@ class Tab extends React.PureComponent {
               showTooltip={false}
               editing={editMode && isFocused}
             />
-            {!editMode && (
+            {supersetCanShare && !editMode && (
               <AnchorLink
                 id={component.id}
                 dashboardId={this.props.dashboardId}

--- a/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
+++ b/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
@@ -76,6 +76,7 @@ function mapStateToProps(
     getComponentById: id => dashboardLayout[id],
     parentComponent: dashboardLayout[parentId],
     editMode: dashboardState.editMode,
+    supersetCanShare: !!dashboardInfo.superset_can_share,
     filters: getActiveFilters(),
     dashboardId: dashboardInfo.id,
     fullSizeChartId: dashboardState.fullSizeChartId,


### PR DESCRIPTION
### SUMMARY
add permission: superset_can_share to TAB component

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE

https://user-images.githubusercontent.com/10289162/200526015-e904dcb4-74ba-4799-8125-53ead8f118af.mov

AFTER

https://user-images.githubusercontent.com/10289162/200522032-7f6298ed-1618-4a56-97d9-e35babd92c45.mov


### TESTING INSTRUCTIONS
remove permissions in roles
![image](https://user-images.githubusercontent.com/10289162/200523714-fe5524a1-cc58-4216-b0de-a706ce20a572.png)
![image](https://user-images.githubusercontent.com/10289162/200526236-9c42e6e3-c4bb-4b0e-9c5e-683d7bbe849b.png)



### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
