### PR TITLE
revert: feat: support None operand in EQUAL operator (#21713)"

### DIFF
--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -819,8 +819,7 @@ class ChartDataFilterSchema(Schema):
     )
     val = fields.Raw(
         description="The value or values to compare against. Can be a string, "
-        "integer, decimal, None or list, depending on the operator.",
-        allow_none=True,
+        "integer, decimal or list, depending on the operator.",
         example=["China", "France", "Japan"],
     )
     grain = fields.String(

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -129,6 +129,7 @@ from superset.superset_typing import (
 from superset.tables.models import Table as NewTable
 from superset.utils import core as utils
 from superset.utils.core import (
+    backend,
     GenericDataType,
     get_column_name,
     get_username,

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1629,14 +1629,7 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
                 elif op == utils.FilterOperator.IS_FALSE.value:
                     where_clause_and.append(sqla_col.is_(False))
                 else:
-                    if (
-                        op
-                        not in {
-                            utils.FilterOperator.EQUALS.value,
-                            utils.FilterOperator.NOT_EQUALS.value,
-                        }
-                        and eq is None
-                    ):
+                    if eq is None:
                         raise QueryObjectValidationError(
                             _(
                                 "Must specify a value for filters "

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -49,7 +49,6 @@ from tests.integration_tests.fixtures.birth_names_dashboard import (
 from tests.integration_tests.test_app import app
 
 from .base_tests import SupersetTestCase
-from .conftest import only_postgresql
 
 VIRTUAL_TABLE_INT_TYPES: Dict[str, Pattern[str]] = {
     "hive": re.compile(r"^INT_TYPE$"),
@@ -666,90 +665,51 @@ def test_filter_on_text_column(text_column_table):
     assert result_object.df["count"][0] == 1
 
 
-@only_postgresql
-def test_should_generate_closed_and_open_time_filter_range(login_as_admin):
-    table = SqlaTable(
-        table_name="temporal_column_table",
-        sql=(
-            "SELECT '2021-12-31'::timestamp as datetime_col "
-            "UNION SELECT '2022-01-01'::timestamp "
-            "UNION SELECT '2022-03-10'::timestamp "
-            "UNION SELECT '2023-01-01'::timestamp "
-            "UNION SELECT '2023-03-10'::timestamp "
-        ),
-        database=get_example_database(),
-    )
-    TableColumn(
-        column_name="datetime_col",
-        type="TIMESTAMP",
-        table=table,
-        is_dttm=True,
-    )
-    SqlMetric(metric_name="count", expression="count(*)", table=table)
-    result_object = table.query(
-        {
-            "metrics": ["count"],
-            "is_timeseries": False,
-            "filter": [],
-            "from_dttm": datetime(2022, 1, 1),
-            "to_dttm": datetime(2023, 1, 1),
-            "granularity": "datetime_col",
-        }
-    )
-    """ >>> result_object.query
-            SELECT count(*) AS count
-            FROM
-              (SELECT '2021-12-31'::timestamp as datetime_col
-               UNION SELECT '2022-01-01'::timestamp
-               UNION SELECT '2022-03-10'::timestamp
-               UNION SELECT '2023-01-01'::timestamp
-               UNION SELECT '2023-03-10'::timestamp) AS virtual_table
-            WHERE datetime_col >= TO_TIMESTAMP('2022-01-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
-              AND datetime_col < TO_TIMESTAMP('2023-01-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
-    """
-    assert result_object.df.iloc[0]["count"] == 2
+def test_should_generate_closed_and_open_time_filter_range():
+    with app.app_context():
+        if backend() != "postgresql":
+            pytest.skip(f"{backend()} has different dialect for datetime column")
 
-
-def test_none_operand_in_filter(login_as_admin, physical_dataset):
-    expected_results = [
-        {
-            "operator": FilterOperator.EQUALS.value,
-            "count": 10,
-            "sql_should_contain": "COL4 IS NULL",
-        },
-        {
-            "operator": FilterOperator.NOT_EQUALS.value,
-            "count": 0,
-            "sql_should_contain": "COL4 IS NOT NULL",
-        },
-    ]
-    for expected in expected_results:
-        result = physical_dataset.query(
+        table = SqlaTable(
+            table_name="temporal_column_table",
+            sql=(
+                "SELECT '2021-12-31'::timestamp as datetime_col "
+                "UNION SELECT '2022-01-01'::timestamp "
+                "UNION SELECT '2022-03-10'::timestamp "
+                "UNION SELECT '2023-01-01'::timestamp "
+                "UNION SELECT '2023-03-10'::timestamp "
+            ),
+            database=get_example_database(),
+        )
+        TableColumn(
+            column_name="datetime_col",
+            type="TIMESTAMP",
+            table=table,
+            is_dttm=True,
+        )
+        SqlMetric(metric_name="count", expression="count(*)", table=table)
+        result_object = table.query(
             {
                 "metrics": ["count"],
-                "filter": [{"col": "col4", "val": None, "op": expected["operator"]}],
                 "is_timeseries": False,
+                "filter": [],
+                "from_dttm": datetime(2022, 1, 1),
+                "to_dttm": datetime(2023, 1, 1),
+                "granularity": "datetime_col",
             }
         )
-        assert result.df["count"][0] == expected["count"]
-        assert expected["sql_should_contain"] in result.query.upper()
-
-    with pytest.raises(QueryObjectValidationError):
-        for flt in [
-            FilterOperator.GREATER_THAN,
-            FilterOperator.LESS_THAN,
-            FilterOperator.GREATER_THAN_OR_EQUALS,
-            FilterOperator.LESS_THAN_OR_EQUALS,
-            FilterOperator.LIKE,
-            FilterOperator.ILIKE,
-        ]:
-            physical_dataset.query(
-                {
-                    "metrics": ["count"],
-                    "filter": [{"col": "col4", "val": None, "op": flt.value}],
-                    "is_timeseries": False,
-                }
-            )
+        """ >>> result_object.query
+                SELECT count(*) AS count
+                FROM
+                  (SELECT '2021-12-31'::timestamp as datetime_col
+                   UNION SELECT '2022-01-01'::timestamp
+                   UNION SELECT '2022-03-10'::timestamp
+                   UNION SELECT '2023-01-01'::timestamp
+                   UNION SELECT '2023-03-10'::timestamp) AS virtual_table
+                WHERE datetime_col >= TO_TIMESTAMP('2022-01-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
+                  AND datetime_col < TO_TIMESTAMP('2023-01-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')
+        """
+        assert result_object.df.iloc[0]["count"] == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR reverts https://github.com/apache/superset/pull/21713 —via `git revert`. @zhaoyongjie and @villebro though I love the essence of this PR—which is somewhat akin to what Tableau does; making SQL more attainable especially as it relates to handling `NULL`—sadly I don't believe the change is ready for primetime. Specifically:

1. Aspects of https://github.com/apache/superset/pull/21713#pullrequestreview-1132542047 haven't been addressed.
2. The `None` use case never materializes as far as I'm concerned (see attached screenshots) given that this is interpreted as the string `'None'`. 
3. The `CUSTOM SQL` tab in the ad-hoc filter modal doesn't reflect the `SIMPLE` tab logic and thus there's a disconnect between the SQL rendered in the modal and the executed SQL (see attached screenshots). 
4. We already have the `IS NULL` and `IS NOT NULL` options which this functionality is replacing. Collectively as a community we need to decide whether the filters map one-to-one with SQL—which is currently how the ad-hoc filter model is defined given the symbiotic relationship between the `SIMPLE` and `CUSTOM SQL` tabs—or should depart from SQL and represent what is commonly perceived user intent, especially if users aren't well versed with the nuances when handling NULLs. 
 
I think for consistency it first makes sense to revert said logic before the issues/inconsistencies have been addressed. Furthermore such a change could actually break existing charts—if the author was unaware of the nuances around `NULL`—and thus a line item in UPDATING.md is likely required so various installations can send out the appropriate PSA to their users. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### Handling of None

##### SIMPLE

<img width="349" alt="Screen Shot 2022-11-08 at 10 09 56 AM" src="https://user-images.githubusercontent.com/4567245/200644540-e6531d07-0abb-4dc4-8dcf-fd9ba8b95fd0.png">

##### Executed SQL

<img width="229" alt="Screen Shot 2022-11-08 at 10 10 43 AM" src="https://user-images.githubusercontent.com/4567245/200644537-ddad0a54-c3a9-4678-bd4f-e7db8cc073cf.png">

### SIMPLE vs CUSTOM SQL

##### SIMPLE

<img width="345" alt="Screen Shot 2022-11-08 at 10 06 02 AM" src="https://user-images.githubusercontent.com/4567245/200644616-61aa15c4-db1f-4700-9b6d-e7fb9b416d30.png">

##### CUSTOM SQL

<img width="348" alt="Screen Shot 2022-11-08 at 10 06 09 AM" src="https://user-images.githubusercontent.com/4567245/200644606-b01e59b1-8698-49f4-9042-dc9d99cb04fb.png">

##### Executed SQL

<img width="299" alt="Screen Shot 2022-11-08 at 10 06 55 AM" src="https://user-images.githubusercontent.com/4567245/200644599-03b3b332-e39c-4147-af02-44cc6d595a83.png">

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
