### PR TITLE
test: Fix act errors in DndColumnSelectControl tests

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/Option.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/Option.test.tsx
@@ -21,47 +21,53 @@ import { render, screen } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
 import Option from 'src/explore/components/controls/DndColumnSelectControl/Option';
 
-test('renders with default props', () => {
+test('renders with default props', async () => {
   const { container } = render(
     <Option index={1} clickClose={jest.fn()}>
       Option
     </Option>,
   );
   expect(container).toBeInTheDocument();
-  expect(screen.getByRole('img', { name: 'x-small' })).toBeInTheDocument();
+  expect(
+    await screen.findByRole('img', { name: 'x-small' }),
+  ).toBeInTheDocument();
   expect(
     screen.queryByRole('img', { name: 'caret-right' }),
   ).not.toBeInTheDocument();
 });
 
-test('renders with caret', () => {
+test('renders with caret', async () => {
   render(
     <Option index={1} clickClose={jest.fn()} withCaret>
       Option
     </Option>,
   );
-  expect(screen.getByRole('img', { name: 'x-small' })).toBeInTheDocument();
-  expect(screen.getByRole('img', { name: 'caret-right' })).toBeInTheDocument();
+  expect(
+    await screen.findByRole('img', { name: 'x-small' }),
+  ).toBeInTheDocument();
+  expect(
+    await screen.findByRole('img', { name: 'caret-right' }),
+  ).toBeInTheDocument();
 });
 
-test('renders with extra triangle', () => {
+test('renders with extra triangle', async () => {
   render(
     <Option index={1} clickClose={jest.fn()} isExtra>
       Option
     </Option>,
   );
   expect(
-    screen.getByRole('button', { name: 'Show info tooltip' }),
+    await screen.findByRole('button', { name: 'Show info tooltip' }),
   ).toBeInTheDocument();
 });
 
-test('triggers onClose', () => {
+test('triggers onClose', async () => {
   const clickClose = jest.fn();
   render(
     <Option index={1} clickClose={clickClose}>
       Option
     </Option>,
   );
-  userEvent.click(screen.getByRole('img', { name: 'x-small' }));
+  userEvent.click(await screen.findByRole('img', { name: 'x-small' }));
   expect(clickClose).toHaveBeenCalled();
 });

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/OptionWrapper.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/OptionWrapper.test.tsx
@@ -21,7 +21,7 @@ import { render, screen, fireEvent } from 'spec/helpers/testing-library';
 import { DndItemType } from 'src/explore/components/DndItemType';
 import OptionWrapper from 'src/explore/components/controls/DndColumnSelectControl/OptionWrapper';
 
-test('renders with default props', () => {
+test('renders with default props', async () => {
   const { container } = render(
     <OptionWrapper
       index={1}
@@ -33,10 +33,12 @@ test('renders with default props', () => {
     { useDnd: true },
   );
   expect(container).toBeInTheDocument();
-  expect(screen.getByRole('img', { name: 'x-small' })).toBeInTheDocument();
+  expect(
+    await screen.findByRole('img', { name: 'x-small' }),
+  ).toBeInTheDocument();
 });
 
-test('triggers onShiftOptions on drop', () => {
+test('triggers onShiftOptions on drop', async () => {
   const onShiftOptions = jest.fn();
   render(
     <>
@@ -58,7 +60,7 @@ test('triggers onShiftOptions on drop', () => {
     { useDnd: true },
   );
 
-  fireEvent.dragStart(screen.getByText('Option 1'));
-  fireEvent.drop(screen.getByText('Option 2'));
+  fireEvent.dragStart(await screen.findByText('Option 1'));
+  fireEvent.drop(await screen.findByText('Option 2'));
   expect(onShiftOptions).toHaveBeenCalled();
 });


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Cleans up a few act errors in 
- superset-frontend/src/explore/components/controls/DndColumnSelectControl/OptionWrapper.test.tsx
- superset-frontend/src/explore/components/controls/DndColumnSelectControl/Option.test.tsx

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- cd into `/superset-frontend`
- `npm run test -- src/explore/components/controls/DndColumnSelectControl/Option.test.tsx`
- `npm run test -- src/explore/components/controls/DndColumnSelectControl/OptionWrapper.test.tsx`
- Check for act errors

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
