### PR TITLE
fix: Right click on country map with code filter

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/drilltodetail.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/drilltodetail.test.ts
@@ -415,8 +415,8 @@ describe('Drill to detail modal', () => {
         });
         cy.get("[data-test-viz-type='world_map'] svg").then($canvas => {
           cy.wrap($canvas).scrollIntoView().rightclick(200, 140);
-          openModalFromChartContext('Drill to detail by SLV');
-          cy.getBySel('filter-val').should('contain', 'SLV');
+          openModalFromChartContext('Drill to detail by SVK');
+          cy.getBySel('filter-val').should('contain', 'SVK');
         });
       });
     });

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/drilltodetail.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/drilltodetail.test.ts
@@ -409,14 +409,14 @@ describe('Drill to detail modal', () => {
 
         cy.get("[data-test-viz-type='world_map'] svg").then($canvas => {
           cy.wrap($canvas).scrollIntoView().rightclick(70, 150);
-          openModalFromChartContext('Drill to detail by United States');
-          cy.getBySel('filter-val').should('contain', 'United States');
+          openModalFromChartContext('Drill to detail by USA');
+          cy.getBySel('filter-val').should('contain', 'USA');
           closeModal();
         });
         cy.get("[data-test-viz-type='world_map'] svg").then($canvas => {
           cy.wrap($canvas).scrollIntoView().rightclick(200, 140);
-          openModalFromChartContext('Drill to detail by Slovakia');
-          cy.getBySel('filter-val').should('contain', 'Slovakia');
+          openModalFromChartContext('Drill to detail by SLV');
+          cy.getBySel('filter-val').should('contain', 'SLV');
         });
       });
     });

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
@@ -52,6 +52,7 @@ const formatter = getNumberFormatter();
 
 function WorldMap(element, props) {
   const {
+    countryFieldtype,
     entity,
     data,
     width,
@@ -111,7 +112,7 @@ function WorldMap(element, props) {
     const pointerEvent = d3.event;
     pointerEvent.preventDefault();
     const key = source.id || source.country;
-    const val = mapData[key]?.name;
+    const val = countryFieldtype === 'name' ? mapData[key]?.name : key;
     if (val) {
       const filters = [
         {

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/transformProps.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/transformProps.js
@@ -23,6 +23,7 @@ export default function transformProps(chartProps) {
     chartProps;
   const { onContextMenu } = hooks;
   const {
+    countryFieldtype,
     entity,
     maxBubbleSize,
     showBubbles,
@@ -35,6 +36,7 @@ export default function transformProps(chartProps) {
   const { r, g, b } = colorPicker;
 
   return {
+    countryFieldtype,
     entity,
     data: queriesData[0].data,
     width,


### PR DESCRIPTION
### SUMMARY
Fix a bug that happens on right-clicking a World Map country that uses codes as the Country Column.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/200861843-e5371bb8-2372-4856-8601-7f7d830d90d6.mov

https://user-images.githubusercontent.com/70410625/200861900-bc0f15d2-5f03-47b0-ac69-d2bfb679f3e3.mov

### TESTING INSTRUCTIONS
Make sure the right click works on World Map charts configured to use names or codes as the Country Column.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
