### PR TITLE
chore: improve performance on bootstrap permissions

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -76,7 +76,7 @@ flask==2.0.3
     #   flask-migrate
     #   flask-sqlalchemy
     #   flask-wtf
-flask-appbuilder==4.1.6rc1
+flask-appbuilder==4.1.6
     # via apache-superset
 flask-babel==1.0.0
     # via flask-appbuilder

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -76,7 +76,7 @@ flask==2.0.3
     #   flask-migrate
     #   flask-sqlalchemy
     #   flask-wtf
-flask-appbuilder==4.1.4
+flask-appbuilder==4.1.6rc1
     # via apache-superset
 flask-babel==1.0.0
     # via flask-appbuilder

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
         "cryptography>=3.3.2",
         "deprecation>=2.1.0, <2.2.0",
         "flask>=2.0.0, <3.0.0",
-        "flask-appbuilder>=4.1.4, <5.0.0",
+        "flask-appbuilder==4.1.6rc1, <5.0.0",
         "flask-caching>=1.10.0",
         "flask-compress",
         "flask-talisman",

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
         "cryptography>=3.3.2",
         "deprecation>=2.1.0, <2.2.0",
         "flask>=2.0.0, <3.0.0",
-        "flask-appbuilder==4.1.6rc1, <5.0.0",
+        "flask-appbuilder>=4.1.6, <5.0.0",
         "flask-caching>=1.10.0",
         "flask-compress",
         "flask-talisman",

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -101,10 +101,6 @@ def bootstrap_user_data(user: User, include_perms: bool = False) -> Dict[str, An
     return payload
 
 
-# 019353721141815185
-# 00747002124786377
-
-
 def get_permissions(
     user: User,
 ) -> Tuple[Dict[str, List[Tuple[str]]], DefaultDict[str, List[str]]]:

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -113,7 +113,7 @@ def get_permissions(
 
     data_permissions = defaultdict(set)
     roles_permissions = security_manager.get_user_roles_permissions(user)
-    for role_name, permissions in roles_permissions.items():
+    for _, permissions in roles_permissions.items():
         for permission in permissions:
             if permission[0] in ("datasource_access", "database_access"):
                 data_permissions[permission[0]].add(permission[1])

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -101,25 +101,26 @@ def bootstrap_user_data(user: User, include_perms: bool = False) -> Dict[str, An
     return payload
 
 
+# 019353721141815185
+# 00747002124786377
+
+
 def get_permissions(
     user: User,
-) -> Tuple[Dict[str, List[List[str]]], DefaultDict[str, List[str]]]:
+) -> Tuple[Dict[str, List[Tuple[str]]], DefaultDict[str, List[str]]]:
     if not user.roles:
         raise AttributeError("User object does not have roles")
 
-    roles = defaultdict(list)
-    permissions = defaultdict(set)
-
-    for role in user.roles:
-        permissions_ = security_manager.get_role_permissions(role)
-        for permission in permissions_:
+    data_permissions = defaultdict(set)
+    roles_permissions = security_manager.get_user_roles_permissions(user)
+    for role_name, permissions in roles_permissions.items():
+        for permission in permissions:
             if permission[0] in ("datasource_access", "database_access"):
-                permissions[permission[0]].add(permission[1])
-            roles[role.name].append([permission[0], permission[1]])
+                data_permissions[permission[0]].add(permission[1])
     transformed_permissions = defaultdict(list)
-    for perm in permissions:
-        transformed_permissions[perm] = list(permissions[perm])
-    return roles, transformed_permissions
+    for perm in data_permissions:
+        transformed_permissions[perm] = list(data_permissions[perm])
+    return roles_permissions, transformed_permissions
 
 
 def get_viz(


### PR DESCRIPTION
### SUMMARY

Improves performance when fetching user permissions for bootstrap data. Previously we were doing 1 query per user role, now it will just do 1 query no matter how many roles a user has.

Measured `get_permissions` execution time, on 100 executions the avg time was:
```
0.019353721141815185 <- previous call
0.00747002124786377 <- new call
```
~60% speed improvement

Performance improvement on FAB: https://github.com/dpgaspar/Flask-AppBuilder/blob/master/flask_appbuilder/security/sqla/manager.py#L398

Followup PR from this: https://github.com/apache/superset/pull/21313

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
