### PR TITLE
chore: Change get_table_names/get_view_names return type

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1016,7 +1016,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         database: "Database",
         inspector: Inspector,
         schema: Optional[str],
-    ) -> List[str]:
+    ) -> Set[str]:
         """
         Get all the real table names within the specified schema.
 
@@ -1030,13 +1030,13 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         """
 
         try:
-            tables = inspector.get_table_names(schema)
+            tables = set(inspector.get_table_names(schema))
         except Exception as ex:
             raise cls.get_dbapi_mapped_exception(ex) from ex
 
         if schema and cls.try_remove_schema_from_table_name:
-            tables = [re.sub(f"^{schema}\\.", "", table) for table in tables]
-        return sorted(tables)
+            tables = {re.sub(f"^{schema}\\.", "", table) for table in tables}
+        return tables
 
     @classmethod
     def get_view_names(  # pylint: disable=unused-argument
@@ -1044,7 +1044,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         database: "Database",
         inspector: Inspector,
         schema: Optional[str],
-    ) -> List[str]:
+    ) -> Set[str]:
         """
         Get all the view names within the specified schema.
 
@@ -1058,13 +1058,13 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         """
 
         try:
-            views = inspector.get_view_names(schema)
+            views = set(inspector.get_view_names(schema))
         except Exception as ex:
             raise cls.get_dbapi_mapped_exception(ex) from ex
 
         if schema and cls.try_remove_schema_from_table_name:
-            views = [re.sub(f"^{schema}\\.", "", view) for view in views]
-        return sorted(views)
+            views = {re.sub(f"^{schema}\\.", "", view) for view in views}
+        return views
 
     @classmethod
     def get_table_comment(

--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -16,7 +16,7 @@
 # under the License.
 
 from datetime import datetime
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, Dict, Optional, Set, TYPE_CHECKING
 
 from sqlalchemy.engine.reflection import Inspector
 
@@ -103,9 +103,7 @@ class DatabricksNativeEngineSpec(DatabricksODBCEngineSpec):
         database: "Database",
         inspector: Inspector,
         schema: Optional[str],
-    ) -> List[str]:
-        tables = set(super().get_table_names(database, inspector, schema))
-        views = set(cls.get_view_names(database, inspector, schema))
-        actual_tables = tables - views
-
-        return list(actual_tables)
+    ) -> Set[str]:
+        return super().get_table_names(
+            database, inspector, schema
+        ) - cls.get_view_names(database, inspector, schema)

--- a/superset/db_engine_specs/duckdb.py
+++ b/superset/db_engine_specs/duckdb.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import re
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Pattern, Tuple, TYPE_CHECKING
+from typing import Any, Dict, Optional, Pattern, Set, Tuple, TYPE_CHECKING
 
 from flask_babel import gettext as __
 from sqlalchemy.engine.reflection import Inspector
@@ -75,5 +75,5 @@ class DuckDBEngineSpec(BaseEngineSpec):
     @classmethod
     def get_table_names(
         cls, database: Database, inspector: Inspector, schema: Optional[str]
-    ) -> List[str]:
-        return sorted(inspector.get_table_names(schema))
+    ) -> Set[str]:
+        return set(inspector.get_table_names(schema))

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -18,7 +18,7 @@ import json
 import logging
 import re
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Pattern, Tuple, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Pattern, Set, Tuple, TYPE_CHECKING
 
 from flask_babel import gettext as __
 from sqlalchemy.dialects.postgresql import ARRAY, DOUBLE_PRECISION, ENUM, JSON
@@ -228,11 +228,11 @@ class PostgresEngineSpec(PostgresBaseEngineSpec, BasicParametersMixin):
     @classmethod
     def get_table_names(
         cls, database: "Database", inspector: PGInspector, schema: Optional[str]
-    ) -> List[str]:
+    ) -> Set[str]:
         """Need to consider foreign tables for PostgreSQL"""
-        tables = inspector.get_table_names(schema)
-        tables.extend(inspector.get_foreign_table_names(schema))
-        return sorted(tables)
+        return set(inspector.get_table_names(schema)) | set(
+            inspector.get_foreign_table_names(schema)
+        )
 
     @classmethod
     def convert_dttm(

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -26,7 +26,18 @@ from contextlib import closing
 from datetime import datetime
 from distutils.version import StrictVersion
 from textwrap import dedent
-from typing import Any, cast, Dict, List, Optional, Pattern, Tuple, TYPE_CHECKING, Union
+from typing import (
+    Any,
+    cast,
+    Dict,
+    List,
+    Optional,
+    Pattern,
+    Set,
+    Tuple,
+    TYPE_CHECKING,
+    Union,
+)
 from urllib import parse
 
 import pandas as pd
@@ -396,7 +407,7 @@ class PrestoEngineSpec(PrestoBaseEngineSpec):
         database: Database,
         inspector: Inspector,
         schema: Optional[str],
-    ) -> List[str]:
+    ) -> Set[str]:
         """
         Get all the real table names within the specified schema.
 
@@ -414,12 +425,9 @@ class PrestoEngineSpec(PrestoBaseEngineSpec):
         :returns: The physical table names
         """
 
-        return sorted(
-            list(
-                set(super().get_table_names(database, inspector, schema))
-                - set(cls.get_view_names(database, inspector, schema))
-            )
-        )
+        return super().get_table_names(
+            database, inspector, schema
+        ) - cls.get_view_names(database, inspector, schema)
 
     @classmethod
     def get_view_names(
@@ -427,7 +435,7 @@ class PrestoEngineSpec(PrestoBaseEngineSpec):
         database: Database,
         inspector: Inspector,
         schema: Optional[str],
-    ) -> List[str]:
+    ) -> Set[str]:
         """
         Get all the view names within the specified schema.
 
@@ -469,7 +477,7 @@ class PrestoEngineSpec(PrestoBaseEngineSpec):
             cursor.execute(sql, params)
             results = cursor.fetchall()
 
-        return sorted([row[0] for row in results])
+        return {row[0] for row in results}
 
     @classmethod
     def _create_column_info(

--- a/superset/db_engine_specs/sqlite.py
+++ b/superset/db_engine_specs/sqlite.py
@@ -16,7 +16,7 @@
 # under the License.
 import re
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Pattern, Tuple, TYPE_CHECKING
+from typing import Any, Dict, Optional, Pattern, Set, Tuple, TYPE_CHECKING
 
 from flask_babel import gettext as __
 from sqlalchemy.engine.reflection import Inspector
@@ -88,6 +88,6 @@ class SqliteEngineSpec(BaseEngineSpec):
     @classmethod
     def get_table_names(
         cls, database: "Database", inspector: Inspector, schema: Optional[str]
-    ) -> List[str]:
+    ) -> Set[str]:
         """Need to disregard the schema for Sqlite"""
-        return sorted(inspector.get_table_names())
+        return set(inspector.get_table_names())

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -546,7 +546,7 @@ class Database(
         cache: bool = False,
         cache_timeout: Optional[int] = None,
         force: bool = False,
-    ) -> List[Tuple[str, str]]:
+    ) -> Set[Tuple[str, str]]:
         """Parameters need to be passed as keyword arguments.
 
         For unused parameters, they are referenced in
@@ -556,13 +556,17 @@ class Database(
         :param cache: whether cache is enabled for the function
         :param cache_timeout: timeout in seconds for the cache
         :param force: whether to force refresh the cache
-        :return: list of tables
+        :return: set of tables
         """
         try:
-            tables = self.db_engine_spec.get_table_names(
-                database=self, inspector=self.inspector, schema=schema
-            )
-            return [(table, schema) for table in tables]
+            return {
+                (table, schema)
+                for table in self.db_engine_spec.get_table_names(
+                    database=self,
+                    inspector=self.inspector,
+                    schema=schema,
+                )
+            }
         except Exception as ex:
             raise self.db_engine_spec.get_dbapi_mapped_exception(ex)
 
@@ -576,7 +580,7 @@ class Database(
         cache: bool = False,
         cache_timeout: Optional[int] = None,
         force: bool = False,
-    ) -> List[Tuple[str, str]]:
+    ) -> Set[Tuple[str, str]]:
         """Parameters need to be passed as keyword arguments.
 
         For unused parameters, they are referenced in
@@ -586,13 +590,17 @@ class Database(
         :param cache: whether cache is enabled for the function
         :param cache_timeout: timeout in seconds for the cache
         :param force: whether to force refresh the cache
-        :return: list of views
+        :return: set of views
         """
         try:
-            views = self.db_engine_spec.get_view_names(
-                database=self, inspector=self.inspector, schema=schema
-            )
-            return [(view, schema) for view in views]
+            return {
+                (view, schema)
+                for view in self.db_engine_spec.get_view_names(
+                    database=self,
+                    inspector=self.inspector,
+                    schema=schema,
+                )
+            }
         except Exception as ex:
             raise self.db_engine_spec.get_dbapi_mapped_exception(ex)
 

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -556,7 +556,7 @@ class Database(
         :param cache: whether cache is enabled for the function
         :param cache_timeout: timeout in seconds for the cache
         :param force: whether to force refresh the cache
-        :return: set of tables
+        :return: The table/schema pairs
         """
         try:
             return {

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1185,7 +1185,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             tables = security_manager.get_datasources_accessible_by_user(
                 database=database,
                 schema=schema_parsed,
-                datasource_names=[
+                datasource_names=sorted(
                     utils.DatasourceName(*datasource_name)
                     for datasource_name in database.get_all_table_names_in_schema(
                         schema=schema_parsed,
@@ -1193,13 +1193,13 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
                         cache=database.table_cache_enabled,
                         cache_timeout=database.table_cache_timeout,
                     )
-                ],
+                ),
             )
 
             views = security_manager.get_datasources_accessible_by_user(
                 database=database,
                 schema=schema_parsed,
-                datasource_names=[
+                datasource_names=sorted(
                     utils.DatasourceName(*datasource_name)
                     for datasource_name in database.get_all_view_names_in_schema(
                         schema=schema_parsed,
@@ -1207,7 +1207,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
                         cache=database.table_cache_enabled,
                         cache_timeout=database.table_cache_timeout,
                     )
-                ],
+                ),
             )
         except SupersetException as ex:
             return json_error_response(ex.message, ex.status)

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -765,7 +765,7 @@ class TestDatasetApi(SupersetTestCase):
             with patch.object(
                 dialect, "get_view_names", wraps=dialect.get_view_names
             ) as patch_get_view_names:
-                patch_get_view_names.return_value = ["test_case_view"]
+                patch_get_view_names.return_value = {"test_case_view"}
 
             self.login(username="admin")
             table_data = {

--- a/tests/integration_tests/db_engine_specs/base_engine_spec_tests.py
+++ b/tests/integration_tests/db_engine_specs/base_engine_spec_tests.py
@@ -233,7 +233,7 @@ class TestDbEngineSpecs(TestDbEngineSpec):
         base_result = BaseEngineSpec.get_table_names(
             database=mock.ANY, schema="schema", inspector=inspector
         )
-        self.assertSetEqual(base_result_expected, base_result)
+        assert base_result_expected == base_result
 
     @pytest.mark.usefixtures("load_energy_table_with_slice")
     def test_column_datatype_to_string(self):

--- a/tests/integration_tests/db_engine_specs/base_engine_spec_tests.py
+++ b/tests/integration_tests/db_engine_specs/base_engine_spec_tests.py
@@ -229,11 +229,11 @@ class TestDbEngineSpecs(TestDbEngineSpec):
 
         """ Make sure base engine spec removes schema name from table name
         ie. when try_remove_schema_from_table_name == True. """
-        base_result_expected = ["table", "table_2"]
+        base_result_expected = {"table", "table_2"}
         base_result = BaseEngineSpec.get_table_names(
             database=mock.ANY, schema="schema", inspector=inspector
         )
-        self.assertListEqual(base_result_expected, base_result)
+        self.assertSetEqual(base_result_expected, base_result)
 
     @pytest.mark.usefixtures("load_energy_table_with_slice")
     def test_column_datatype_to_string(self):

--- a/tests/integration_tests/db_engine_specs/postgres_tests.py
+++ b/tests/integration_tests/db_engine_specs/postgres_tests.py
@@ -45,11 +45,11 @@ class TestPostgresDbEngineSpec(TestDbEngineSpec):
         inspector.get_table_names = mock.Mock(return_value=["schema.table", "table_2"])
         inspector.get_foreign_table_names = mock.Mock(return_value=["table_3"])
 
-        pg_result_expected = ["schema.table", "table_2", "table_3"]
+        pg_result_expected = {"schema.table", "table_2", "table_3"}
         pg_result = PostgresEngineSpec.get_table_names(
             database=mock.ANY, schema="schema", inspector=inspector
         )
-        self.assertListEqual(pg_result_expected, pg_result)
+        self.assertSetEqual(pg_result_expected, pg_result)
 
     def test_time_exp_literal_no_grain(self):
         """

--- a/tests/integration_tests/db_engine_specs/postgres_tests.py
+++ b/tests/integration_tests/db_engine_specs/postgres_tests.py
@@ -49,7 +49,7 @@ class TestPostgresDbEngineSpec(TestDbEngineSpec):
         pg_result = PostgresEngineSpec.get_table_names(
             database=mock.ANY, schema="schema", inspector=inspector
         )
-        self.assertSetEqual(pg_result_expected, pg_result)
+        assert pg_result_expected == pg_result
 
     def test_time_exp_literal_no_grain(self):
         """

--- a/tests/integration_tests/db_engine_specs/presto_tests.py
+++ b/tests/integration_tests/db_engine_specs/presto_tests.py
@@ -55,7 +55,7 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
             ).strip(),
             {"schema": schema},
         )
-        assert result == ["a", "d"]
+        assert result == {"a", "d"}
 
     def test_get_view_names_without_schema(self):
         database = mock.MagicMock()
@@ -76,7 +76,7 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
             ).strip(),
             {},
         )
-        assert result == ["a", "d"]
+        assert result == {"a", "d"}
 
     def verify_presto_column(self, column, expected_results):
         inspector = mock.Mock()
@@ -669,10 +669,10 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
         mock_get_view_names,
         mock_get_table_names,
     ):
-        mock_get_view_names.return_value = ["view1", "view2"]
-        mock_get_table_names.return_value = ["table1", "table2", "view1", "view2"]
+        mock_get_view_names.return_value = {"view1", "view2"}
+        mock_get_table_names.return_value = {"table1", "table2", "view1", "view2"}
         tables = PrestoEngineSpec.get_table_names(mock.Mock(), mock.Mock(), None)
-        assert tables == ["table1", "table2"]
+        assert tables == {"table1", "table2"}
 
     def test_get_full_name(self):
         names = [


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

After working on https://github.com/apache/superset/pull/21794 I realized that the `get_table_names` and `get_view_names` methods should really return a set of names rather than an ordered list. The results can then be sorted—if needed—within the API response. Hopefully this refactor simplifies the code logic.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
