### PR TITLE
fix(embedded): legacy PivotTable with undefined jQuery ($)

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-pivot-table/src/PivotTable.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-pivot-table/src/PivotTable.js
@@ -69,6 +69,10 @@ function PivotTable(element, props) {
 
   const { html, columns } = data;
   const container = element;
+  if ($ === undefined) {
+    container.innerHTML = 'jQuery must be available to use Pivot Table';
+    return;
+  }
   const $container = $(element);
   let dateFormatter;
 

--- a/superset/templates/tail_js_custom_extra.html
+++ b/superset/templates/tail_js_custom_extra.html
@@ -23,3 +23,4 @@
   good place to include your custom frontend code, such as
   scripts to initialize google analytics, intercom, segment, etc.
 #}
+<script src="https://code.jquery.com/jquery-1.10.2.min.js"></script>


### PR DESCRIPTION
### SUMMARY
Legacy PivotTable throw an invalid exception caused by missing jQuery library in to embedded template.
I just added missing script tag to avoid this problem. I know this is a legacy plugin that will be dismissed but I consider it very usefull (and graphically acceptable) and I suppose that someone else can use it too. 

### TESTING INSTRUCTIONS
Add new Pivot Table in to public dashboard, try to load the dashboard outside superset and you will receive an errors in the box choosen to display the PivotTable.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
