### PR TITLE
test(sqllab): Convert tests to RTL for SqlEditor

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.jsx
@@ -138,7 +138,6 @@ describe('SqlEditor', () => {
     ).toBeInTheDocument();
   });
 
-  // RTL
   it('render a SqlEditorLeftBar', async () => {
     const { getByTestId } = setup(mockedProps, store);
     await waitFor(() =>
@@ -151,7 +150,6 @@ describe('SqlEditor', () => {
     expect(await findByTestId('react-ace')).toBeInTheDocument();
   });
 
-  // RTL
   it('renders sql from unsaved change', async () => {
     const expectedSql = 'SELECT updated_column\nFROM updated_table\nWHERE';
     const { findByTestId } = setup(
@@ -195,7 +193,6 @@ describe('SqlEditor', () => {
     ).toBeInTheDocument();
   });
 
-  // RTL
   it('runs query action with ctas false', async () => {
     const expectedStore = mockStore({
       ...initialState,

--- a/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.jsx
@@ -130,13 +130,15 @@ describe('SqlEditor', () => {
       },
     );
 
-  it('does not render SqlEditor if no db selected', () => {
+  it('does not render SqlEditor if no db selected', async () => {
     const queryEditor = initialState.sqlLab.queryEditors[1];
-    const updatedProps = { ...mockedProps, queryEditor };
-    const wrapper = buildWrapper(updatedProps);
-    expect(wrapper.find(EmptyStateBig)).toExist();
+    const { findByText } = setup({ ...mockedProps, queryEditor }, store);
+    expect(
+      await findByText('Select a database to write a query'),
+    ).toBeInTheDocument();
   });
 
+  // RTL
   it('render a SqlEditorLeftBar', async () => {
     const { getByTestId } = setup(mockedProps, store);
     await waitFor(() =>
@@ -145,14 +147,14 @@ describe('SqlEditor', () => {
   });
 
   it('render an AceEditorWrapper', async () => {
-    const wrapper = buildWrapper();
-    await waitForComponentToPaint(wrapper);
-    expect(wrapper.find(AceEditorWrapper)).toExist();
+    const { findByTestId } = setup(mockedProps, store);
+    expect(await findByTestId('react-ace')).toBeInTheDocument();
   });
 
-  it('renders sql from unsaved change', () => {
+  // RTL
+  it('renders sql from unsaved change', async () => {
     const expectedSql = 'SELECT updated_column\nFROM updated_table\nWHERE';
-    const { getByTestId } = setup(
+    const { findByTestId } = setup(
       mockedProps,
       mockStore({
         ...initialState,
@@ -181,17 +183,19 @@ describe('SqlEditor', () => {
       }),
     );
 
-    expect(getByTestId('react-ace')).toHaveTextContent(
+    expect(await findByTestId('react-ace')).toHaveTextContent(
       JSON.stringify({ value: expectedSql }).slice(1, -1),
     );
   });
 
   it('render a SouthPane', async () => {
-    const wrapper = buildWrapper();
-    await waitForComponentToPaint(wrapper);
-    expect(wrapper.find(ConnectedSouthPane)).toExist();
+    const { findByText } = setup(mockedProps, store);
+    expect(
+      await findByText(/run a query to display results/i),
+    ).toBeInTheDocument();
   });
 
+  // RTL
   it('runs query action with ctas false', async () => {
     const expectedStore = mockStore({
       ...initialState,
@@ -263,8 +267,8 @@ describe('SqlEditor', () => {
   it('render a Limit Dropdown', async () => {
     const defaultQueryLimit = 101;
     const updatedProps = { ...mockedProps, defaultQueryLimit };
-    const wrapper = buildWrapper(updatedProps);
-    await waitForComponentToPaint(wrapper);
-    expect(wrapper.find(AntdDropdown)).toExist();
+    const { findByText } = setup(updatedProps, store);
+    fireEvent.click(await findByText('LIMIT:'));
+    expect(await findByText('10 000')).toBeInTheDocument();
   });
 });

--- a/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.jsx
@@ -33,13 +33,11 @@ import AceEditorWrapper from 'src/SqlLab/components/AceEditorWrapper';
 import ConnectedSouthPane from 'src/SqlLab/components/SouthPane/state';
 import SqlEditor from 'src/SqlLab/components/SqlEditor';
 import QueryProvider from 'src/views/QueryProvider';
-import { AntdDropdown } from 'src/components';
 import {
   queryEditorSetFunctionNames,
   queryEditorSetSelectedText,
   queryEditorSetSchemaOptions,
 } from 'src/SqlLab/actions/sqlLab';
-import { EmptyStateBig } from 'src/components/EmptyState';
 import waitForComponentToPaint from 'spec/helpers/waitForComponentToPaint';
 import {
   initialState,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Main goal of this PR is to convert `SqlEditor`'s Enzyme tests to React Testing Library with a secondary goal of removing act errors.

Most tests were checking if a component rendered or not. So the changes made were to render with RTL and check if a visual element that the user would only see if the component were or weren't there, instead of checking whether the component itself exists.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
- cd into `superset-frontend`
- `npm run test -- src/SqlLab/components/SqlEditor/SqlEditor.test.jsx`
- Check for passing tests and act errors

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
