### PR TITLE
fix: Add scrollTopOnPagination property to Table

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/drilltodetail.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/drilltodetail.test.ts
@@ -196,6 +196,23 @@ describe('Drill to detail modal', () => {
           .then($rows => {
             expect($rows).to.contain('Victoria');
           });
+
+        // verify scroll top on pagination
+        cy.getBySelLike('Number-modal')
+          .find('.table-condensed')
+          .scrollTo(0, 100);
+
+        cy.get("[role='rowgroup'] [role='row']")
+          .contains('Miguel')
+          .should('not.be.visible');
+
+        cy.get(".pagination-container [role='navigation'] [role='button']")
+          .eq(1)
+          .click();
+
+        cy.get("[role='rowgroup'] [role='row']")
+          .contains('Aaron')
+          .should('be.visible');
       });
     });
 

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
@@ -243,6 +243,7 @@ export default function DrillDetailPane({
             margin-bottom: 0;
           }
         `}
+        scrollTopOnPagination
       />
     );
   }

--- a/superset-frontend/src/components/TableView/TableView.stories.tsx
+++ b/superset-frontend/src/components/TableView/TableView.stories.tsx
@@ -77,6 +77,7 @@ InteractiveTableView.args = {
   showRowCount: true,
   withPagination: true,
   columnsForWrapText: ['Summary'],
+  scrollTopOnPagination: false,
 };
 
 InteractiveTableView.argTypes = {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Fixes an issue for the Drill to detail modal which wasn't scrolling back up on pagination. It does so by adding a new property to the table component called `scrollTopOnPagination`.

### AFTER

https://user-images.githubusercontent.com/60598000/201683052-38caf4d3-2a8a-4faf-882c-947976b94c86.mp4

### TESTING INSTRUCTIONS
1. Set `DRILL_TO_DETAIL` feature flag to True
2. Open a Dashboard and right click to drill to detail
3. Scroll the table to the bottom
4. Change page
5. The table should scroll back up

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
