### PR TITLE
chore: deprecate /superset/datasources/

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -211,6 +211,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @has_access_api
     @event_logger.log_this
     @expose("/datasources/")
+    @deprecated()
     def datasources(self) -> FlaskResponse:
         return self.json_response(
             sorted(


### PR DESCRIPTION
### SUMMARY

Continuing the effort on deprecating all /superset/ REST API endpoints
Deprecates `/superset/datasources/`, found no references on superset-frontend

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
