### PR TITLE
feat: Flow for tables that already have a dataset

### DIFF
--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/DatasetPanel.test.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/DatasetPanel.test.tsx
@@ -24,7 +24,7 @@ import DatasetPanel, {
   tableColumnDefinition,
   COLUMN_TITLE,
 } from './DatasetPanel';
-import { exampleColumns } from './fixtures';
+import { exampleColumns, exampleDataset } from './fixtures';
 import {
   SELECT_MESSAGE,
   CREATE_MESSAGE,
@@ -44,7 +44,7 @@ jest.mock(
 );
 
 describe('DatasetPanel', () => {
-  it('renders a blank state DatasetPanel', () => {
+  test('renders a blank state DatasetPanel', () => {
     render(<DatasetPanel hasError={false} columnList={[]} loading={false} />);
 
     const blankDatasetImg = screen.getByRole('img', { name: /empty/i });
@@ -65,7 +65,7 @@ describe('DatasetPanel', () => {
     expect(sqlLabLink).toBeVisible();
   });
 
-  it('renders a no columns screen', () => {
+  test('renders a no columns screen', () => {
     render(
       <DatasetPanel
         tableName="Name"
@@ -83,7 +83,7 @@ describe('DatasetPanel', () => {
     expect(noColumnsDescription).toBeVisible();
   });
 
-  it('renders a loading screen', () => {
+  test('renders a loading screen', () => {
     render(
       <DatasetPanel
         tableName="Name"
@@ -99,7 +99,7 @@ describe('DatasetPanel', () => {
     expect(blankDatasetTitle).toBeVisible();
   });
 
-  it('renders an error screen', () => {
+  test('renders an error screen', () => {
     render(
       <DatasetPanel
         tableName="Name"
@@ -115,7 +115,7 @@ describe('DatasetPanel', () => {
     expect(errorDescription).toBeVisible();
   });
 
-  it('renders a table with columns displayed', async () => {
+  test('renders a table with columns displayed', async () => {
     const tableName = 'example_name';
     render(
       <DatasetPanel
@@ -137,5 +137,24 @@ describe('DatasetPanel', () => {
       expect(screen.getByText(row.name)).toBeInTheDocument();
       expect(screen.getByText(row.type)).toBeInTheDocument();
     });
+  });
+
+  test('renders an info banner if table already has a dataset', async () => {
+    render(
+      <DatasetPanel
+        tableName="example_table"
+        hasError={false}
+        columnList={exampleColumns}
+        loading={false}
+        linkedDatasets={exampleDataset}
+      />,
+    );
+
+    // This is text in the info banner
+    expect(
+      await screen.findByText(
+        /you can only associate one dataset with one table. this table already has a dataset associated with it in preset./i,
+      ),
+    ).toBeVisible();
   });
 });

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/DatasetPanel.test.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/DatasetPanel.test.tsx
@@ -153,7 +153,7 @@ describe('DatasetPanel', () => {
     // This is text in the info banner
     expect(
       await screen.findByText(
-        /you can only associate one dataset with one table. this table already has a dataset associated with it in preset./i,
+        /this table already has a dataset associated with it. you can only associate one dataset with a table./i,
       ),
     ).toBeVisible();
   });

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/DatasetPanel.test.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/DatasetPanel.test.tsx
@@ -146,7 +146,7 @@ describe('DatasetPanel', () => {
         hasError={false}
         columnList={exampleColumns}
         loading={false}
-        linkedDatasets={exampleDataset}
+        datasets={exampleDataset}
       />,
     );
 

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/DatasetPanel.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/DatasetPanel.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { supersetTheme, t, styled } from '@superset-ui/core';
+import { t, styled, useTheme } from '@superset-ui/core';
 import Icons from 'src/components/Icons';
 import Alert from 'src/components/Alert';
 import Table, { ColumnsType, TableSize } from 'src/components/Table';
@@ -55,45 +55,51 @@ const HALF = 0.5;
 const MARGIN_MULTIPLIER = 3;
 
 const StyledHeader = styled.div<StyledHeaderProps>`
+  ${({ theme }) => `
   position: ${(props: StyledHeaderProps) => props.position};
-  margin: ${({ theme }) => theme.gridUnit * (MARGIN_MULTIPLIER + 1)}px
-    ${({ theme }) => theme.gridUnit * MARGIN_MULTIPLIER}px
-    ${({ theme }) => theme.gridUnit * MARGIN_MULTIPLIER}px
-    ${({ theme }) => theme.gridUnit * (MARGIN_MULTIPLIER + 3)}px;
-  font-size: ${({ theme }) => theme.gridUnit * 6}px;
-  font-weight: ${({ theme }) => theme.typography.weights.medium};
-  padding-bottom: ${({ theme }) => theme.gridUnit * MARGIN_MULTIPLIER}px;
+  margin: ${theme.gridUnit * (MARGIN_MULTIPLIER + 1)}px
+    ${theme.gridUnit * MARGIN_MULTIPLIER}px
+    ${theme.gridUnit * MARGIN_MULTIPLIER}px
+    ${theme.gridUnit * (MARGIN_MULTIPLIER + 3)}px;
+  font-size: ${theme.gridUnit * 6}px;
+  font-weight: ${theme.typography.weights.medium};
+  padding-bottom: ${theme.gridUnit * MARGIN_MULTIPLIER}px;
 
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 
   .anticon:first-of-type {
-    margin-right: ${({ theme }) => theme.gridUnit * (MARGIN_MULTIPLIER + 1)}px;
+    margin-right: ${theme.gridUnit * (MARGIN_MULTIPLIER + 1)}px;
   }
 
   .anticon:nth-of-type(2) {
-    margin-left: ${({ theme }) => theme.gridUnit * (MARGIN_MULTIPLIER + 1)}px;
-  }
+    margin-left: ${theme.gridUnit * (MARGIN_MULTIPLIER + 1)}px;
+  `}
 `;
 
 const StyledTitle = styled.div`
-  margin-left: ${({ theme }) => theme.gridUnit * (MARGIN_MULTIPLIER + 3)}px;
-  margin-bottom: ${({ theme }) => theme.gridUnit * MARGIN_MULTIPLIER}px;
-  font-weight: ${({ theme }) => theme.typography.weights.bold};
+  ${({ theme }) => `
+  margin-left: ${theme.gridUnit * (MARGIN_MULTIPLIER + 3)}px;
+  margin-bottom: ${theme.gridUnit * MARGIN_MULTIPLIER}px;
+  font-weight: ${theme.typography.weights.bold};
+  `}
 `;
 
 const LoaderContainer = styled.div`
-  padding: ${({ theme }) => theme.gridUnit * 8}px
-    ${({ theme }) => theme.gridUnit * 6}px;
+  ${({ theme }) => `
+  padding: ${theme.gridUnit * 8}px
+    ${theme.gridUnit * 6}px;
 
   display: flex;
   align-items: center;
   justify-content: center;
   height: 100%;
+  `}
 `;
 
 const StyledLoader = styled.div`
+  ${({ theme }) => `
   max-width: 50%;
   width: ${LOADER_WIDTH}px;
 
@@ -104,20 +110,23 @@ const StyledLoader = styled.div`
 
   div {
     width: 100%;
-    margin-top: ${({ theme }) => theme.gridUnit * MARGIN_MULTIPLIER}px;
+    margin-top: ${theme.gridUnit * MARGIN_MULTIPLIER}px;
     text-align: center;
-    font-weight: ${({ theme }) => theme.typography.weights.normal};
-    font-size: ${({ theme }) => theme.typography.sizes.l}px;
-    color: ${({ theme }) => theme.colors.grayscale.light1};
+    font-weight: ${theme.typography.weights.normal};
+    font-size: ${theme.typography.sizes.l}px;
+    color: ${theme.colors.grayscale.light1};
   }
+  `}
 `;
 
 const TableContainer = styled.div`
+  ${({ theme }) => `
   position: relative;
-  margin: ${({ theme }) => theme.gridUnit * MARGIN_MULTIPLIER}px;
-  margin-left: ${({ theme }) => theme.gridUnit * (MARGIN_MULTIPLIER + 3)}px;
+  margin: ${theme.gridUnit * MARGIN_MULTIPLIER}px;
+  margin-left: ${theme.gridUnit * (MARGIN_MULTIPLIER + 3)}px;
   overflow: scroll;
-  height: calc(100% - ${({ theme }) => theme.gridUnit * 36}px);
+  height: calc(100% - ${theme.gridUnit * 36}px);
+  `}
 `;
 
 const StyledTable = styled(Table)`
@@ -129,21 +138,23 @@ const StyledTable = styled(Table)`
 `;
 
 const StyledAlert = styled(Alert)`
-  border: 1px solid ${supersetTheme.colors.info.base};
-  padding: ${supersetTheme.gridUnit * 4}px;
-  margin: ${supersetTheme.gridUnit * 6}px ${supersetTheme.gridUnit * 6}px
-    ${supersetTheme.gridUnit * 8}px;
+  ${({ theme }) => `
+  border: 1px solid ${theme.colors.info.base};
+  padding: ${theme.gridUnit * 4}px;
+  margin: ${theme.gridUnit * 6}px ${theme.gridUnit * 6}px
+    ${theme.gridUnit * 8}px;
   .view-dataset-button {
     position: absolute;
-    top: ${supersetTheme.gridUnit * 4}px;
-    right: ${supersetTheme.gridUnit * 4}px;
-    font-weight: ${supersetTheme.typography.weights.normal};
+    top: ${theme.gridUnit * 4}px;
+    right: ${theme.gridUnit * 4}px;
+    font-weight: ${theme.typography.weights.normal};
 
     &:hover {
-      color: ${supersetTheme.colors.secondary.dark3};
+      color: ${theme.colors.secondary.dark3};
       text-decoration: underline;
     }
   }
+  `}
 `;
 
 export const REFRESHING = t('Refreshing columns');
@@ -194,7 +205,12 @@ export interface IDatasetPanelProps {
   linkedDatasets?: DatasetObject[] | undefined;
 }
 
-const renderExistingDatasetAlert = (linkedDataset: any) => (
+const EXISTING_DATASET_DESCRIPTION = t(
+  'You can only associate one dataset with one table. This table already has a dataset associated with it in Preset.\n',
+);
+const VIEW_DATASET = t('View Dataset');
+
+const renderExistingDatasetAlert = (linkedDataset?: DatasetObject) => (
   <StyledAlert
     closable={false}
     type="info"
@@ -202,14 +218,12 @@ const renderExistingDatasetAlert = (linkedDataset: any) => (
     message={t('This table already has a dataset')}
     description={
       <>
-        {t(
-          'You can only associate one dataset with one table. This table already has a dataset associated with it in Preset.\n',
-        )}
+        {EXISTING_DATASET_DESCRIPTION}
         <span
           role="button"
           onClick={() => {
             window.open(
-              linkedDataset.explore_url,
+              linkedDataset?.explore_url,
               '_blank',
               'noreferer noopener popup=false',
             );
@@ -217,7 +231,7 @@ const renderExistingDatasetAlert = (linkedDataset: any) => (
           tabIndex={0}
           className="view-dataset-button"
         >
-          {t('View Dataset')}
+          {VIEW_DATASET}
         </span>
       </>
     }
@@ -231,6 +245,7 @@ const DatasetPanel = ({
   hasError,
   linkedDatasets,
 }: IDatasetPanelProps) => {
+  const theme = useTheme();
   const hasColumns = columnList?.length > 0 ?? false;
   const linkedDatasetNames = linkedDatasets?.map(dataset => dataset.table_name);
 
@@ -285,7 +300,7 @@ const DatasetPanel = ({
             title={tableName || ''}
           >
             {tableName && (
-              <Icons.Table iconColor={supersetTheme.colors.grayscale.base} />
+              <Icons.Table iconColor={theme.colors.grayscale.base} />
             )}
             {tableName}
           </StyledHeader>

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/DatasetPanel.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/DatasetPanel.tsx
@@ -225,7 +225,7 @@ const renderExistingDatasetAlert = (dataset?: DatasetObject) => (
             window.open(
               dataset?.explore_url,
               '_blank',
-              'noreferer noopener popup=false',
+              'noreferrer noopener popup=false',
             );
           }}
           tabIndex={0}

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/DatasetPanel.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/DatasetPanel.tsx
@@ -208,7 +208,11 @@ const renderExistingDatasetAlert = (linkedDataset: any) => (
         <span
           role="button"
           onClick={() => {
-            window.location.href = linkedDataset.explore_url;
+            window.open(
+              linkedDataset.explore_url,
+              '_blank',
+              'noreferer noopener popup=false',
+            );
           }}
           tabIndex={0}
           className="view-dataset-button"

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/DatasetPanel.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/DatasetPanel.tsx
@@ -140,7 +140,7 @@ const StyledAlert = styled(Alert)`
     font-weight: ${supersetTheme.typography.weights.normal};
 
     &:hover {
-      color: ${supersetTheme.colors.secondary.dark1};
+      color: ${supersetTheme.colors.secondary.dark3};
       text-decoration: underline;
     }
   }

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/DatasetPanel.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/DatasetPanel.tsx
@@ -206,7 +206,7 @@ export interface IDatasetPanelProps {
 }
 
 const EXISTING_DATASET_DESCRIPTION = t(
-  'You can only associate one dataset with one table. This table already has a dataset associated with it in Preset.\n',
+  'This table already has a dataset associated with it. You can only associate one dataset with a table.\n',
 );
 const VIEW_DATASET = t('View Dataset');
 

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/DatasetPanel.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/DatasetPanel.tsx
@@ -94,7 +94,7 @@ const LoaderContainer = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 100%;
+  height: 98%;
   `}
 `;
 

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/DatasetPanel.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/DatasetPanel.tsx
@@ -202,7 +202,7 @@ export interface IDatasetPanelProps {
    * Boolean indicating if the component is in a loading state
    */
   loading: boolean;
-  linkedDatasets?: DatasetObject[] | undefined;
+  datasets?: DatasetObject[] | undefined;
 }
 
 const EXISTING_DATASET_DESCRIPTION = t(
@@ -210,7 +210,7 @@ const EXISTING_DATASET_DESCRIPTION = t(
 );
 const VIEW_DATASET = t('View Dataset');
 
-const renderExistingDatasetAlert = (linkedDataset?: DatasetObject) => (
+const renderExistingDatasetAlert = (dataset?: DatasetObject) => (
   <StyledAlert
     closable={false}
     type="info"
@@ -223,7 +223,7 @@ const renderExistingDatasetAlert = (linkedDataset?: DatasetObject) => (
           role="button"
           onClick={() => {
             window.open(
-              linkedDataset?.explore_url,
+              dataset?.explore_url,
               '_blank',
               'noreferer noopener popup=false',
             );
@@ -243,11 +243,11 @@ const DatasetPanel = ({
   columnList,
   loading,
   hasError,
-  linkedDatasets,
+  datasets,
 }: IDatasetPanelProps) => {
   const theme = useTheme();
   const hasColumns = columnList?.length > 0 ?? false;
-  const linkedDatasetNames = linkedDatasets?.map(dataset => dataset.table_name);
+  const datasetNames = datasets?.map(dataset => dataset.table_name);
 
   let component;
   if (loading) {
@@ -289,9 +289,9 @@ const DatasetPanel = ({
     <>
       {tableName && (
         <>
-          {linkedDatasetNames?.includes(tableName) &&
+          {datasetNames?.includes(tableName) &&
             renderExistingDatasetAlert(
-              linkedDatasets?.find(dataset => dataset.table_name === tableName),
+              datasets?.find(dataset => dataset.table_name === tableName),
             )}
           <StyledHeader
             position={

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/DatasetPanel.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/DatasetPanel.tsx
@@ -90,11 +90,16 @@ const LoaderContainer = styled.div`
   ${({ theme }) => `
   padding: ${theme.gridUnit * 8}px
     ${theme.gridUnit * 6}px;
-
+  box-sizing: border-box;
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 98%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
   `}
 `;
 
@@ -250,8 +255,9 @@ const DatasetPanel = ({
   const datasetNames = datasets?.map(dataset => dataset.table_name);
 
   let component;
+  let loader;
   if (loading) {
-    component = (
+    loader = (
       <LoaderContainer>
         <StyledLoader>
           <img alt={ALT_LOADING} src={LOADING_GIF} />
@@ -259,30 +265,33 @@ const DatasetPanel = ({
         </StyledLoader>
       </LoaderContainer>
     );
-  } else if (tableName && hasColumns && !hasError) {
-    component = (
-      <>
-        <StyledTitle>{COLUMN_TITLE}</StyledTitle>
-        <TableContainer>
-          <StyledTable
-            loading={loading}
-            size={TableSize.SMALL}
-            columns={tableColumnDefinition}
-            data={columnList}
-            pageSizeOptions={pageSizeOptions}
-            defaultPageSize={10}
-          />
-        </TableContainer>
-      </>
-    );
-  } else {
-    component = (
-      <MessageContent
-        hasColumns={hasColumns}
-        hasError={hasError}
-        tableName={tableName}
-      />
-    );
+  }
+  if (!loading) {
+    if (!loading && tableName && hasColumns && !hasError) {
+      component = (
+        <>
+          <StyledTitle>{COLUMN_TITLE}</StyledTitle>
+          <TableContainer>
+            <StyledTable
+              loading={loading}
+              size={TableSize.SMALL}
+              columns={tableColumnDefinition}
+              data={columnList}
+              pageSizeOptions={pageSizeOptions}
+              defaultPageSize={10}
+            />
+          </TableContainer>
+        </>
+      );
+    } else {
+      component = (
+        <MessageContent
+          hasColumns={hasColumns}
+          hasError={hasError}
+          tableName={tableName}
+        />
+      );
+    }
   }
 
   return (
@@ -307,6 +316,7 @@ const DatasetPanel = ({
         </>
       )}
       {component}
+      {loader}
     </>
   );
 };

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/DatasetPanel.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/DatasetPanel.tsx
@@ -138,6 +138,11 @@ const StyledAlert = styled(Alert)`
     top: ${supersetTheme.gridUnit * 4}px;
     right: ${supersetTheme.gridUnit * 4}px;
     font-weight: ${supersetTheme.typography.weights.normal};
+
+    &:hover {
+      color: ${supersetTheme.colors.secondary.dark1};
+      text-decoration: underline;
+    }
   }
 `;
 

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/fixtures.ts
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/fixtures.ts
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { DatasetObject } from 'src/views/CRUD/data/dataset/AddDataset/types';
 import { ITableColumn } from './types';
 
 export const exampleColumns: ITableColumn[] = [
@@ -30,5 +31,18 @@ export const exampleColumns: ITableColumn[] = [
   {
     name: 'birth_date',
     type: 'DATE',
+  },
+];
+
+export const exampleDataset: DatasetObject[] = [
+  {
+    db: {
+      id: 1,
+      database_name: 'test_database',
+      owners: [1],
+    },
+    schema: 'test_schema',
+    dataset_name: 'example_dataset',
+    table_name: 'example_table',
   },
 ];

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/index.tsx
@@ -54,7 +54,7 @@ export interface IDatasetPanelWrapperProps {
    */
   schema?: string | null;
   setHasColumns?: Function;
-  linkedDatasets?: DatasetObject[] | undefined;
+  datasets?: DatasetObject[] | undefined;
 }
 
 const DatasetPanelWrapper = ({
@@ -62,7 +62,7 @@ const DatasetPanelWrapper = ({
   dbId,
   schema,
   setHasColumns,
-  linkedDatasets,
+  datasets,
 }: IDatasetPanelWrapperProps) => {
   const [columnList, setColumnList] = useState<ITableColumn[]>([]);
   const [loading, setLoading] = useState(false);
@@ -123,7 +123,7 @@ const DatasetPanelWrapper = ({
       hasError={hasError}
       loading={loading}
       tableName={tableName}
-      linkedDatasets={linkedDatasets}
+      datasets={datasets}
     />
   );
 };

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/index.tsx
@@ -53,7 +53,7 @@ export interface IDatasetPanelWrapperProps {
    */
   schema?: string | null;
   setHasColumns?: Function;
-  linkedDatasets?: string | undefined;
+  linkedDatasets?: DatasetObject[] | undefined;
 }
 
 const DatasetPanelWrapper = ({

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/index.tsx
@@ -18,6 +18,7 @@
  */
 import React, { useEffect, useState, useRef } from 'react';
 import { SupersetClient } from '@superset-ui/core';
+import { DatasetObject } from 'src/views/CRUD/data/dataset/AddDataset/types';
 import DatasetPanel from './DatasetPanel';
 import { ITableColumn, IDatabaseTable, isIDatabaseTable } from './types';
 
@@ -61,6 +62,7 @@ const DatasetPanelWrapper = ({
   dbId,
   schema,
   setHasColumns,
+  linkedDatasets,
 }: IDatasetPanelWrapperProps) => {
   const [columnList, setColumnList] = useState<ITableColumn[]>([]);
   const [loading, setLoading] = useState(false);
@@ -111,7 +113,7 @@ const DatasetPanelWrapper = ({
     if (tableName && schema && dbId) {
       getTableMetadata({ tableName, dbId, schema });
     }
-    // getTableMetadata is a const and should not be independency array
+    // getTableMetadata is a const and should not be in dependency array
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tableName, dbId, schema]);
 
@@ -121,6 +123,7 @@ const DatasetPanelWrapper = ({
       hasError={hasError}
       loading={loading}
       tableName={tableName}
+      linkedDatasets={linkedDatasets}
     />
   );
 };

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/DatasetPanel/index.tsx
@@ -53,6 +53,7 @@ export interface IDatasetPanelWrapperProps {
    */
   schema?: string | null;
   setHasColumns?: Function;
+  linkedDatasets?: string | undefined;
 }
 
 const DatasetPanelWrapper = ({

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/Footer/Footer.test.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/Footer/Footer.test.tsx
@@ -66,10 +66,9 @@ describe('Footer', () => {
   });
 
   test('create button becomes disabled when table already has a dataset', () => {
-    render(
-      <Footer linkedDatasets={['real_info']} {...mockPropsWithDataset} />,
-      { useRedux: true },
-    );
+    render(<Footer datasets={['real_info']} {...mockPropsWithDataset} />, {
+      useRedux: true,
+    });
 
     const createButton = screen.getByRole('button', {
       name: /Create/i,

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/Footer/Footer.test.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/Footer/Footer.test.tsx
@@ -40,7 +40,7 @@ const mockPropsWithDataset = {
 };
 
 describe('Footer', () => {
-  it('renders a Footer with a cancel button and a disabled create button', () => {
+  test('renders a Footer with a cancel button and a disabled create button', () => {
     render(<Footer {...mockedProps} />, { useRedux: true });
 
     const saveButton = screen.getByRole('button', {
@@ -55,7 +55,7 @@ describe('Footer', () => {
     expect(createButton).toBeDisabled();
   });
 
-  it('renders a Create Dataset button when a table is selected', () => {
+  test('renders a Create Dataset button when a table is selected', () => {
     render(<Footer {...mockPropsWithDataset} />, { useRedux: true });
 
     const createButton = screen.getByRole('button', {
@@ -63,5 +63,18 @@ describe('Footer', () => {
     });
 
     expect(createButton).toBeEnabled();
+  });
+
+  test('create button becomes disabled when table already has a dataset', () => {
+    render(
+      <Footer linkedDatasets={['real_info']} {...mockPropsWithDataset} />,
+      { useRedux: true },
+    );
+
+    const createButton = screen.getByRole('button', {
+      name: /Create/i,
+    });
+
+    expect(createButton).toBeDisabled();
   });
 });

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/Footer/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/Footer/index.tsx
@@ -37,7 +37,7 @@ interface FooterProps {
   datasetObject?: Partial<DatasetObject> | null;
   onDatasetAdd?: (dataset: DatasetObject) => void;
   hasColumns?: boolean;
-  linkedDatasets?: (string | null | undefined)[] | undefined;
+  datasets?: (string | null | undefined)[] | undefined;
 }
 
 const INPUT_FIELDS = ['db', 'schema', 'table_name'];
@@ -53,7 +53,7 @@ function Footer({
   datasetObject,
   addDangerToast,
   hasColumns = false,
-  linkedDatasets,
+  datasets,
 }: FooterProps) {
   const { createResource } = useSingleViewResource<Partial<DatasetObject>>(
     'dataset',
@@ -114,7 +114,7 @@ function Footer({
   const disabledCheck =
     !datasetObject?.table_name ||
     !hasColumns ||
-    linkedDatasets?.includes(datasetObject?.table_name);
+    datasets?.includes(datasetObject?.table_name);
 
   return (
     <>

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/Footer/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/Footer/index.tsx
@@ -37,6 +37,7 @@ interface FooterProps {
   datasetObject?: Partial<DatasetObject> | null;
   onDatasetAdd?: (dataset: DatasetObject) => void;
   hasColumns?: boolean;
+  linkedDatasets?: (string | null | undefined)[] | undefined;
 }
 
 const INPUT_FIELDS = ['db', 'schema', 'table_name'];
@@ -52,6 +53,7 @@ function Footer({
   datasetObject,
   addDangerToast,
   hasColumns = false,
+  linkedDatasets,
 }: FooterProps) {
   const { createResource } = useSingleViewResource<Partial<DatasetObject>>(
     'dataset',
@@ -113,7 +115,11 @@ function Footer({
       <Button onClick={cancelButtonOnClick}>Cancel</Button>
       <Button
         buttonStyle="primary"
-        disabled={!datasetObject?.table_name || !hasColumns}
+        disabled={
+          !datasetObject?.table_name ||
+          !hasColumns ||
+          linkedDatasets?.includes(datasetObject?.table_name)
+        }
         tooltip={!datasetObject?.table_name ? tooltipText : undefined}
         onClick={onSave}
       >

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/Footer/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/Footer/index.tsx
@@ -110,20 +110,22 @@ function Footer({
     }
   };
 
+  const CREATE_DATASET_TEXT = t('Create Dataset');
+  const disabledCheck =
+    !datasetObject?.table_name ||
+    !hasColumns ||
+    linkedDatasets?.includes(datasetObject?.table_name);
+
   return (
     <>
       <Button onClick={cancelButtonOnClick}>Cancel</Button>
       <Button
         buttonStyle="primary"
-        disabled={
-          !datasetObject?.table_name ||
-          !hasColumns ||
-          linkedDatasets?.includes(datasetObject?.table_name)
-        }
+        disabled={disabledCheck}
         tooltip={!datasetObject?.table_name ? tooltipText : undefined}
         onClick={onSave}
       >
-        {t('Create Dataset')}
+        {CREATE_DATASET_TEXT}
       </Button>
     </>
   );

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/LeftPanel.test.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/LeftPanel.test.tsx
@@ -247,7 +247,7 @@ test('renders a warning icon when a table name has a pre-existing dataset', asyn
       setDataset={mockFun}
       schema="schema_a"
       dbId={1}
-      linkedDatasets={['Sheet2']}
+      datasets={['Sheet2']}
     />,
     {
       useRedux: true,

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/LeftPanel.test.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/LeftPanel.test.tsx
@@ -209,6 +209,7 @@ test('searches for a table name', async () => {
     useRedux: true,
   });
 
+  // Click 'test-postgres' database to access schemas
   const databaseSelect = screen.getByRole('combobox', {
     name: /select database or type database name/i,
   });
@@ -221,6 +222,7 @@ test('searches for a table name', async () => {
 
   await waitFor(() => expect(schemaSelect).toBeEnabled());
 
+  // Click 'public' schema to access tables
   userEvent.click(schemaSelect);
   userEvent.click(screen.getAllByText('public')[1]);
 
@@ -237,4 +239,47 @@ test('searches for a table name', async () => {
     expect(screen.getByText('Sheet2')).toBeInTheDocument();
     expect(screen.queryByText('Sheet3')).not.toBeInTheDocument();
   });
+});
+
+test('renders a warning icon when a table name has a pre-existing dataset', async () => {
+  render(
+    <LeftPanel
+      setDataset={mockFun}
+      schema="schema_a"
+      dbId={1}
+      linkedDatasets={['Sheet2']}
+    />,
+    {
+      useRedux: true,
+    },
+  );
+
+  // Click 'test-postgres' database to access schemas
+  const databaseSelect = screen.getByRole('combobox', {
+    name: /select database or type database name/i,
+  });
+  userEvent.click(databaseSelect);
+  userEvent.click(await screen.findByText('test-postgres'));
+
+  const schemaSelect = screen.getByRole('combobox', {
+    name: /select schema or type schema name/i,
+  });
+
+  await waitFor(() => expect(schemaSelect).toBeEnabled());
+
+  // Warning icon should not show yet
+  expect(
+    screen.queryByRole('img', { name: 'warning' }),
+  ).not.toBeInTheDocument();
+
+  // Click 'public' schema to access tables
+  userEvent.click(schemaSelect);
+  userEvent.click(screen.getAllByText('public')[1]);
+
+  await waitFor(() => {
+    expect(screen.getByText('Sheet2')).toBeInTheDocument();
+  });
+
+  // Sheet2 should now show the warning icon
+  expect(screen.getByRole('img', { name: 'warning' })).toBeVisible();
 });

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/index.tsx
@@ -22,7 +22,8 @@ import {
   t,
   styled,
   css,
-  supersetTheme,
+  useTheme,
+  logging,
 } from '@superset-ui/core';
 import { Input } from 'src/components/Input';
 import { Form } from 'src/components/Form';
@@ -141,6 +142,8 @@ export default function LeftPanel({
   dbId,
   linkedDatasets,
 }: LeftPanelProps) {
+  const theme = useTheme();
+
   const [tableOptions, setTableOptions] = useState<Array<TableOption>>([]);
   const [resetTables, setResetTables] = useState(false);
   const [loadTables, setLoadTables] = useState(false);
@@ -182,7 +185,9 @@ export default function LeftPanel({
         setResetTables(false);
         setRefresh(false);
       })
-      .catch(error => console.log('There was an error fetching tables', error));
+      .catch(error =>
+        logging.error('There was an error fetching tables', error),
+      );
   };
 
   const setSchema = (schema: string) => {
@@ -226,21 +231,32 @@ export default function LeftPanel({
     </div>
   );
 
+  const SELECT_DATABASE_AND_SCHEMA_TEXT = t('Select database & schema');
+  const TABLE_LOADING_TEXT = t('Table loading');
+  const NO_TABLES_FOUND_TITLE = t('No database tables found');
+  const NO_TABLES_FOUND_DESCRIPTION = t('Try selecting a different schema');
+  const SELECT_DATABASE_TABLE_TEXT = t('Select database table');
+  const REFRESH_TABLE_LIST_TOOLTIP = t('Refresh table list');
+  const REFRESH_TABLES_TEXT = t('Refresh tables');
+  const SEARCH_TABLES_PLACEHOLDER_TEXT = t('Search tables');
+
   return (
     <LeftPanelStyle>
-      <p className="section-title db-schema">{t('Select database & schema')}</p>
+      <p className="section-title db-schema">
+        {SELECT_DATABASE_AND_SCHEMA_TEXT}
+      </p>
       <DatabaseSelector
         handleError={addDangerToast}
         onDbChange={setDatabase}
         onSchemaChange={setSchema}
       />
-      {loadTables && !refresh && Loader('Table loading')}
+      {loadTables && !refresh && Loader(TABLE_LOADING_TEXT)}
       {schema && !loadTables && !tableOptions.length && !searchVal && (
         <div className="emptystate">
           <EmptyStateMedium
             image="empty-table.svg"
-            title={t('No database tables found')}
-            description={t('Try selecting a different schema')}
+            title={NO_TABLES_FOUND_TITLE}
+            description={NO_TABLES_FOUND_DESCRIPTION}
           />
         </div>
       )}
@@ -248,15 +264,15 @@ export default function LeftPanel({
       {schema && (tableOptions.length > 0 || searchVal.length > 0) && (
         <>
           <Form>
-            <p className="table-title">{t('Select database table')}</p>
+            <p className="table-title">{SELECT_DATABASE_TABLE_TEXT}</p>
             <RefreshLabel
               onClick={() => {
                 setLoadTables(true);
                 setRefresh(true);
               }}
-              tooltipContent={t('Refresh table list')}
+              tooltipContent={REFRESH_TABLE_LIST_TOOLTIP}
             />
-            {refresh && Loader(t('Refresh tables'))}
+            {refresh && Loader(REFRESH_TABLES_TEXT)}
             {!refresh && (
               <Input
                 value={searchVal}
@@ -265,7 +281,7 @@ export default function LeftPanel({
                   setSearchVal(evt.target.value);
                 }}
                 className="table-form"
-                placeholder={t('Search tables')}
+                placeholder={SEARCH_TABLES_PLACEHOLDER_TEXT}
                 allowClear
               />
             )}
@@ -287,12 +303,12 @@ export default function LeftPanel({
                     <Icons.Warning
                       iconColor={
                         selectedTable === i
-                          ? supersetTheme.colors.grayscale.light5
-                          : supersetTheme.colors.info.base
+                          ? theme.colors.grayscale.light5
+                          : theme.colors.info.base
                       }
                       iconSize="m"
                       css={css`
-                        margin-right: ${supersetTheme.gridUnit * 6}px;
+                        margin-right: ${theme.gridUnit * 6}px;
                       `}
                     />
                   )}

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/index.tsx
@@ -43,7 +43,7 @@ interface LeftPanelProps {
   setDataset: Dispatch<SetStateAction<object>>;
   schema?: string | null | undefined;
   dbId?: number;
-  linkedDatasets?: (string | null | undefined)[] | undefined;
+  datasets?: (string | null | undefined)[] | undefined;
 }
 
 const SearchIcon = styled(Icons.Search)`
@@ -140,7 +140,7 @@ export default function LeftPanel({
   setDataset,
   schema,
   dbId,
-  linkedDatasets,
+  datasets,
 }: LeftPanelProps) {
   const theme = useTheme();
 
@@ -299,7 +299,7 @@ export default function LeftPanel({
                   onClick={() => setTable(option.value, i)}
                 >
                   {option.label}
-                  {linkedDatasets?.includes(option.value) && (
+                  {datasets?.includes(option.value) && (
                     <Icons.Warning
                       iconColor={
                         selectedTable === i

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/index.tsx
@@ -17,7 +17,13 @@
  * under the License.
  */
 import React, { useEffect, useState, SetStateAction, Dispatch } from 'react';
-import { SupersetClient, t, styled } from '@superset-ui/core';
+import {
+  SupersetClient,
+  t,
+  styled,
+  css,
+  supersetTheme,
+} from '@superset-ui/core';
 import { Input } from 'src/components/Input';
 import { Form } from 'src/components/Form';
 import Icons from 'src/components/Icons';
@@ -36,6 +42,7 @@ interface LeftPanelProps {
   setDataset: Dispatch<SetStateAction<object>>;
   schema?: string | null | undefined;
   dbId?: number;
+  linkedDatasets?: string | undefined;
 }
 
 const SearchIcon = styled(Icons.Search)`
@@ -78,6 +85,7 @@ const LeftPanelStyle = styled.div`
       top: ${theme.gridUnit * 92.25}px;
       left: ${theme.gridUnit * 3.25}px;
       right: 0;
+
       .options {
         cursor: pointer;
         padding: ${theme.gridUnit * 1.75}px;
@@ -86,12 +94,19 @@ const LeftPanelStyle = styled.div`
           background-color: ${theme.colors.grayscale.light4}
         }
       }
+
       .options-highlighted {
         cursor: pointer;
         padding: ${theme.gridUnit * 1.75}px;
         border-radius: ${theme.borderRadius}px;
         background-color: ${theme.colors.primary.dark1};
         color: ${theme.colors.grayscale.light5};
+      }
+
+      .options, .options-highlighted {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
       }
     }
     form > span[aria-label="refresh"] {
@@ -124,6 +139,7 @@ export default function LeftPanel({
   setDataset,
   schema,
   dbId,
+  linkedDatasets,
 }: LeftPanelProps) {
   const [tableOptions, setTableOptions] = useState<Array<TableOption>>([]);
   const [resetTables, setResetTables] = useState(false);
@@ -166,9 +182,7 @@ export default function LeftPanel({
         setResetTables(false);
         setRefresh(false);
       })
-      .catch(e => {
-        console.log('error', e);
-      });
+      .catch(error => console.log('There was an error fetching tables', error));
   };
 
   const setSchema = (schema: string) => {
@@ -214,7 +228,7 @@ export default function LeftPanel({
 
   return (
     <LeftPanelStyle>
-      <p className="section-title db-schema">Select database & schema</p>
+      <p className="section-title db-schema">{t('Select database & schema')}</p>
       <DatabaseSelector
         handleError={addDangerToast}
         onDbChange={setDatabase}
@@ -234,7 +248,7 @@ export default function LeftPanel({
       {schema && (tableOptions.length > 0 || searchVal.length > 0) && (
         <>
           <Form>
-            <p className="table-title">Select database table</p>
+            <p className="table-title">{t('Select database table')}</p>
             <RefreshLabel
               onClick={() => {
                 setLoadTables(true);
@@ -242,7 +256,7 @@ export default function LeftPanel({
               }}
               tooltipContent={t('Refresh table list')}
             />
-            {refresh && Loader('Refresh tables')}
+            {refresh && Loader(t('Refresh tables'))}
             {!refresh && (
               <Input
                 value={searchVal}
@@ -269,6 +283,19 @@ export default function LeftPanel({
                   onClick={() => setTable(option.value, i)}
                 >
                   {option.label}
+                  {linkedDatasets && option.value.includes(linkedDatasets) && (
+                    <Icons.Warning
+                      iconColor={
+                        selectedTable === i
+                          ? supersetTheme.colors.grayscale.light5
+                          : supersetTheme.colors.info.base
+                      }
+                      iconSize="m"
+                      css={css`
+                        margin-right: ${supersetTheme.gridUnit * 6}px;
+                      `}
+                    />
+                  )}
                 </div>
               ))}
           </div>

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/index.tsx
@@ -42,7 +42,7 @@ interface LeftPanelProps {
   setDataset: Dispatch<SetStateAction<object>>;
   schema?: string | null | undefined;
   dbId?: number;
-  linkedDatasets?: string | undefined;
+  linkedDatasets?: (string | null | undefined)[] | undefined;
 }
 
 const SearchIcon = styled(Icons.Search)`
@@ -283,7 +283,7 @@ export default function LeftPanel({
                   onClick={() => setTable(option.value, i)}
                 >
                   {option.label}
-                  {linkedDatasets && option.value.includes(linkedDatasets) && (
+                  {linkedDatasets?.includes(option.value) && (
                     <Icons.Warning
                       iconColor={
                         selectedTable === i

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/index.tsx
@@ -77,7 +77,6 @@ export default function AddDataset() {
   >(datasetReducer, null);
   const [hasColumns, setHasColumns] = useState(false);
   const [datasets, setDatasets] = useState<DatasetObject[]>([]);
-  console.log(datasets);
   const datasetNames = datasets.map(dataset => dataset.table_name);
   const encodedSchema = dataset?.schema
     ? encodeURIComponent(dataset?.schema)

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/index.tsx
@@ -132,7 +132,12 @@ export default function AddDataset() {
   );
 
   const FooterComponent = () => (
-    <Footer url={prevUrl} datasetObject={dataset} hasColumns={hasColumns} />
+    <Footer
+      url={prevUrl}
+      datasetObject={dataset}
+      hasColumns={hasColumns}
+      linkedDatasets={linkedDatasetNames}
+    />
   );
 
   return (

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useReducer, Reducer, useEffect, useState } from 'react';
-import { SupersetClient } from '@superset-ui/core';
+import { SupersetClient, logging } from '@superset-ui/core';
 import rison from 'rison';
 import Header from './Header';
 import DatasetPanel from './DatasetPanel';
@@ -100,12 +100,14 @@ export default function AddDataset() {
         );
       })
       .catch(error =>
-        console.log('There was an error fetching dataset', error),
+        logging.error('There was an error fetching dataset', error),
       );
   };
 
   useEffect(() => {
-    if (dataset?.schema) getDatasetsList();
+    if (dataset?.schema) {
+      getDatasetsList();
+    }
   }, [dataset?.schema]);
 
   const HeaderComponent = () => (

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/index.tsx
@@ -75,8 +75,8 @@ export default function AddDataset() {
     Reducer<Partial<DatasetObject> | null, DSReducerActionType>
   >(datasetReducer, null);
   const [hasColumns, setHasColumns] = useState(false);
-  const [linkedDatasets, setLinkedDatasets] = useState<string>();
-
+  const [linkedDatasets, setLinkedDatasets] = useState<DatasetObject[]>([]);
+  const linkedDatasetNames = linkedDatasets.map(dataset => dataset.table_name);
   const encodedSchema = dataset?.schema
     ? encodeURIComponent(dataset?.schema)
     : undefined;
@@ -96,7 +96,7 @@ export default function AddDataset() {
     })
       .then(({ json }) => {
         json.result.map((dataset: any) =>
-          setLinkedDatasets(dataset.table_name),
+          setLinkedDatasets(linkedDatasets => [...linkedDatasets, dataset]),
         );
       })
       .catch(error =>
@@ -117,7 +117,7 @@ export default function AddDataset() {
       setDataset={setDataset}
       schema={dataset?.schema}
       dbId={dataset?.db?.id}
-      linkedDatasets={linkedDatasets}
+      linkedDatasets={linkedDatasetNames}
     />
   );
 

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/index.tsx
@@ -17,7 +17,8 @@
  * under the License.
  */
 import React, { useReducer, Reducer, useEffect, useState } from 'react';
-import { SupersetClient, logging } from '@superset-ui/core';
+import { logging } from '@superset-ui/core';
+import { UseGetDatasetsList } from 'src/views/CRUD/data/hooks';
 import rison from 'rison';
 import Header from './Header';
 import DatasetPanel from './DatasetPanel';
@@ -75,8 +76,8 @@ export default function AddDataset() {
     Reducer<Partial<DatasetObject> | null, DSReducerActionType>
   >(datasetReducer, null);
   const [hasColumns, setHasColumns] = useState(false);
-  const [linkedDatasets, setLinkedDatasets] = useState<DatasetObject[]>([]);
-  const linkedDatasetNames = linkedDatasets.map(dataset => dataset.table_name);
+  const [datasets, setDatasets] = useState<DatasetObject[]>([]);
+  const datasetNames = datasets.map(dataset => dataset.table_name);
   const encodedSchema = dataset?.schema
     ? encodeURIComponent(dataset?.schema)
     : undefined;
@@ -90,13 +91,11 @@ export default function AddDataset() {
       })
     : undefined;
 
-  const getDatasetsList = () => {
-    SupersetClient.get({
-      endpoint: `/api/v1/dataset/?q=${queryParams}`,
-    })
-      .then(({ json }) => {
-        json.result.map((dataset: any) =>
-          setLinkedDatasets(linkedDatasets => [...linkedDatasets, dataset]),
+  const getDatasetsList = async () => {
+    await UseGetDatasetsList(queryParams)
+      .then(json => {
+        json?.result.map((dataset: DatasetObject) =>
+          setDatasets(datasets => [...datasets, dataset]),
         );
       })
       .catch(error =>
@@ -119,7 +118,7 @@ export default function AddDataset() {
       setDataset={setDataset}
       schema={dataset?.schema}
       dbId={dataset?.db?.id}
-      linkedDatasets={linkedDatasetNames}
+      datasets={datasetNames}
     />
   );
 
@@ -129,7 +128,7 @@ export default function AddDataset() {
       dbId={dataset?.db?.id}
       schema={dataset?.schema}
       setHasColumns={setHasColumns}
-      linkedDatasets={linkedDatasets}
+      datasets={datasets}
     />
   );
 
@@ -138,7 +137,7 @@ export default function AddDataset() {
       url={prevUrl}
       datasetObject={dataset}
       hasColumns={hasColumns}
-      linkedDatasets={linkedDatasetNames}
+      datasets={datasetNames}
     />
   );
 

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/index.tsx
@@ -77,6 +77,7 @@ export default function AddDataset() {
   >(datasetReducer, null);
   const [hasColumns, setHasColumns] = useState(false);
   const [datasets, setDatasets] = useState<DatasetObject[]>([]);
+  console.log(datasets);
   const datasetNames = datasets.map(dataset => dataset.table_name);
   const encodedSchema = dataset?.schema
     ? encodeURIComponent(dataset?.schema)
@@ -94,9 +95,7 @@ export default function AddDataset() {
   const getDatasetsList = async () => {
     await UseGetDatasetsList(queryParams)
       .then(json => {
-        json?.result.map((dataset: DatasetObject) =>
-          setDatasets(datasets => [...datasets, dataset]),
-        );
+        setDatasets(json?.result);
       })
       .catch(error =>
         logging.error('There was an error fetching dataset', error),

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/types.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/types.tsx
@@ -32,6 +32,7 @@ export interface DatasetObject {
   schema?: string | null;
   dataset_name: string;
   table_name?: string | null;
+  explore_url?: string;
 }
 
 export interface DatasetReducerPayloadType {

--- a/superset-frontend/src/views/CRUD/data/dataset/styles.ts
+++ b/superset-frontend/src/views/CRUD/data/dataset/styles.ts
@@ -82,6 +82,7 @@ export const StyledLayoutLeftPanel = styled.div`
 
 export const StyledLayoutDatasetPanel = styled.div`
   width: 100%;
+  position: relative;
 `;
 
 export const StyledLayoutRightPanel = styled.div`

--- a/superset-frontend/src/views/CRUD/data/hooks.ts
+++ b/superset-frontend/src/views/CRUD/data/hooks.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { useState, useEffect } from 'react';
+import { SupersetClient, logging } from '@superset-ui/core';
 
 type BaseQueryObject = {
   id: number;
@@ -73,3 +74,12 @@ export function useQueryPreviewState<D extends BaseQueryObject = any>({
     disableNext,
   };
 }
+
+export const UseGetDatasetsList = (queryParams: string | undefined) =>
+  SupersetClient.get({
+    endpoint: `/api/v1/dataset/?q=${queryParams}`,
+  })
+    .then(({ json }) => json)
+    .catch(error =>
+      logging.error('There was an error fetching dataset', error),
+    );


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This implements a flow in the new dataset creation page for when a table already has a dataset. It uses a simplified dataset fetch in the `AddDataset/index.tsx` file to cross-reference with the table list. If the table has a dataset, it gets a warning icon in the left panel. If the table is selected, the table's columns are still displayed, but the "Create Dataset" button is disabled and it has an info banner at the top informing the user of the pre-existing dataset with a link to that dataset in the upper-left corner of the alert. Clicking the "View Dataset" button in this alert will bring the user to the explore view of the existing dataset in a new tab.

### ANIMATED GIF / SCREENSHOT
<!--- Skip this if not applicable -->
#### Screenshot of selected table with existing dataset
<img width="1388" alt="Screenshot 2022-11-15 at 7 01 47 PM" src="https://user-images.githubusercontent.com/55605634/202057625-a50027ee-bd71-483f-a32e-b3cebfa83990.png">

#### Left panel warning icons
![existingDSleftPanel](https://user-images.githubusercontent.com/55605634/202057245-1debb1d0-d6db-4b3a-8390-1b23ccd70102.gif)

#### "View dataset"
![existingDSViewDS](https://user-images.githubusercontent.com/55605634/202057751-40b064d7-e2fb-4f86-9502-f3dcbcaa7327.gif)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Go to `http://localhost:9000/dataset/add/?testing`
- Select a database and a schema
- Observe that any tables in the left panel with a pre-existing dataset will have a warning icon
- Click a table with a dataset
- Observe that the "Create dataset" button is disabled and there is an info banner at the top informing of the pre-existing dataset
- Click "View dataset" in the alert
- Observe that you are taken to the explore view of the existing dataset in a new tab

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
