### PR TITLE
fix: Missing applied filters indicator 

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1182,8 +1182,7 @@ def merge_extra_filters(form_data: Dict[str, Any]) -> None:
     # that are external to the slice definition. We use those for dynamic
     # interactive filters like the ones emitted by the "Filter Box" visualization.
     # Note extra_filters only support simple filters.
-    applied_time_extras: Dict[str, str] = {}
-    form_data["applied_time_extras"] = applied_time_extras
+    form_data.setdefault("applied_time_extras", {})
     adhoc_filters = form_data.get("adhoc_filters", [])
     form_data["adhoc_filters"] = adhoc_filters
     merge_extra_form_data(form_data)
@@ -1226,7 +1225,7 @@ def merge_extra_filters(form_data: Dict[str, Any]) -> None:
                 time_extra_value = filtr.get("val")
                 if time_extra_value and time_extra_value != NO_TIME_RANGE:
                     form_data[time_extra] = time_extra_value
-                    applied_time_extras[filter_column] = time_extra_value
+                    form_data["applied_time_extras"][filter_column] = time_extra_value
             elif filtr["val"]:
                 # Merge column filters
                 filter_key = get_filter_key(filtr)

--- a/tests/integration_tests/utils_tests.py
+++ b/tests/integration_tests/utils_tests.py
@@ -539,6 +539,18 @@ class TestUtils(SupersetTestCase):
         merge_extra_filters(form_data)
         self.assertEqual(form_data, expected)
 
+    def test_merge_extra_filters_when_applied_time_extras_predefined(self):
+        form_data = {"applied_time_extras": {"__time_range": "Last week"}}
+        merge_extra_filters(form_data)
+
+        self.assertEqual(
+            form_data,
+            {
+                "applied_time_extras": {"__time_range": "Last week"},
+                "adhoc_filters": [],
+            },
+        )
+
     def test_merge_request_params_when_url_params_undefined(self):
         form_data = {"since": "2000", "until": "now"}
         url_params = {"form_data": form_data, "dashboard_ids": "(1,2,3,4,5)"}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR fixes a bug which is exemplifies all that is wrong with Superset. Spaghetti code (exacerbated by the fact that the native and legacy filters use different form-data encodings) and half baked features—legacy charts vs. ECharts. 

Specifically this issue—where the applied filter indicator is missing—seems to only surface for NVD3TimeSeriesViz charts with time comparisons using the non-native temporal filters. The non-native filters _seem_ to encode which filters are applied using the [applied_time_extras](https://github.com/apache/superset/blob/a9b229dd1dd9cb9dc8166b1392179fcccb4da138/superset/viz.py#L499-L502) form-data field which is defined in the [merge_extra_filters](https://github.com/apache/superset/blob/e23efefc462fcc6f76a456f52f57f81e0c241a0a/superset/utils/core.py#L1185-L1186) method via an extraction of the `extra_filters` field—which is then disposed of. 

The problem lies when this method is called multiple times. This the case when Advanced Analytics are used which requires running extra queries and re-evaluating the query object thus re-invoking the `merge_extra_filters` method, however this time with the `extra_filters` field missing from the form-data. The result is the `applied_time_extras` is now empty which translates to the filter indicator not reflecting that the temporal field has been defined. The solution is merely to preserve (as opposed to overwrite) the `applied_time_extras` field. 

Note this issue only impacted the applied filter indicator, i.e., the filters were correctly applied to the underlying chart.


<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE

<img width="1368" alt="Screen Shot 2022-11-15 at 9 31 50 PM" src="https://user-images.githubusercontent.com/4567245/202096555-47138967-5ee0-48de-9e86-ea50e9f83dae.png">

#### AFTER

<img width="1367" alt="Screen Shot 2022-11-15 at 9 33 05 PM" src="https://user-images.githubusercontent.com/4567245/202096430-7ee22c29-4b3b-4147-9451-618556515537.png">

### TESTING INSTRUCTIONS

Added unit tests and tested locally.
 
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
