### PR TITLE
feat: auto select schema

### DIFF
--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -221,6 +221,13 @@ export default function DatabaseSelector({
     );
   }, [db]);
 
+  function changeSchema(schema: SchemaValue) {
+    setCurrentSchema(schema);
+    if (onSchemaChange) {
+      onSchemaChange(schema.value);
+    }
+  }
+
   useEffect(() => {
     if (currentDb) {
       setLoadingSchemas(true);
@@ -240,6 +247,7 @@ export default function DatabaseSelector({
           }
           setSchemaOptions(options);
           setLoadingSchemas(false);
+          if (options.length === 1) changeSchema(options[0]);
           if (refresh > 0) addSuccessToast('List refreshed');
         })
         .catch(err => {
@@ -267,13 +275,6 @@ export default function DatabaseSelector({
     }
     if (onSchemaChange) {
       onSchemaChange(undefined);
-    }
-  }
-
-  function changeSchema(schema: SchemaValue) {
-    setCurrentSchema(schema);
-    if (onSchemaChange) {
-      onSchemaChange(schema.value);
     }
   }
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When choosing a database, if it has only a single schema, auto select it for the user.

I thought of doing the same when the schema has only a single table, but selecting a table triggers a preview and the user might not want to do that.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Load any database in SQL Lab that has only one schema.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
