### PR TITLE
fix:  the legend does not preserves the order of metrics

### DIFF
--- a/superset/utils/pandas_postprocessing/pivot.py
+++ b/superset/utils/pandas_postprocessing/pivot.py
@@ -89,6 +89,7 @@ def pivot(  # pylint: disable=too-many-arguments,too-many-locals
             for metric in aggfunc.keys():
                 series_set.add(str(tuple([metric]) + tuple(row[1:])))
 
+    cur_df=df
     df = df.pivot_table(
         values=aggfunc.keys(),
         index=index,
@@ -99,6 +100,7 @@ def pivot(  # pylint: disable=too-many-arguments,too-many-locals
         margins=marginal_distributions,
         margins_name=marginal_distribution_name,
     )
+    df = df[[x for x in cur_df.columns.values.tolist() if x in df.columns.values.tolist()]]
 
     if not drop_missing_columns and len(series_set) > 0 and not df.empty:
         for col in df.columns:


### PR DESCRIPTION
### SUMMARY
fix https://github.com/apache/superset/issues/22162
Pandas pivot_table modifies the order of columns.
Reorder the table columns to preserve the legend order

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![WX20221118-151319](https://user-images.githubusercontent.com/34932975/202653438-d35938b6-4b98-43ee-bf0e-bf96aa9a45a7.png)
![WX20221118-151838](https://user-images.githubusercontent.com/34932975/202653444-4441d973-7229-4c06-802d-e4c76f6fc29c.png)


### TESTING INSTRUCTIONS


### ADDITIONAL INFORMATION


- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Migration is atomic, supports rollback & is backwards-compatible
- [ ] Confirm DB migration upgrade and downgrade tested
- [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API