### PR TITLE
docs: Connecting to local database when using Superset docker image

### DIFF
--- a/docs/docs/databases/mysql.mdx
+++ b/docs/docs/databases/mysql.mdx
@@ -17,7 +17,8 @@ mysql://{username}:{password}@{host}/{database}
 
 Host:
 
-- For Localhost or Docker running Linux: `localhost` or `127.0.0.1`
+- For Localhost: `localhost` or `127.0.0.1`
+- Docker running Linux: `172.18.0.1`
 - For On Prem: IP address or Host name
 - For Docker running in OSX: `docker.for.mac.host.internal`
   Port: `3306` by default


### PR DESCRIPTION
### SUMMARY
When using superset docker image, connecting to a local database using `127.0.0.1` or `localhost` as the database hose does not work and throws the following error. https://docs.sqlalchemy.org/en/14/errors.html#error-e3q8 

The correct host address should be `172.18.0.1` instead of `localhost` or `127.0.0.1` as written in the superset documentation on this page - https://superset.apache.org/docs/installation/installing-superset-using-docker-compose#5-connecting-superset-to-your-local-database-instance

