### PR TITLE
fix: Adds time grain to Pivot Table v2

### DIFF
--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -144,6 +144,7 @@ export default function PivotTableChart(props: PivotTableProps) {
     metricColorFormatters,
     dateFormatters,
     onContextMenu,
+    timeGrainSqla,
   } = props;
 
   const theme = useTheme();
@@ -375,14 +376,15 @@ export default function PivotTableChart(props: PivotTableProps) {
         if (colKey && colKey.length > 1) {
           colKey.forEach((val, i) => {
             const col = cols[i];
-            const formattedVal =
-              dateFormatters[col]?.(val as number) || String(val);
+            const formatter = dateFormatters[col];
+            const formattedVal = formatter?.(val as number) || String(val);
             if (i > 0) {
               filters.push({
                 col,
                 op: '==',
                 val,
                 formattedVal,
+                grain: formatter ? timeGrainSqla : undefined,
               });
             }
           });
@@ -390,20 +392,21 @@ export default function PivotTableChart(props: PivotTableProps) {
         if (rowKey) {
           rowKey.forEach((val, i) => {
             const col = rows[i];
-            const formattedVal =
-              dateFormatters[col]?.(val as number) || String(val);
+            const formatter = dateFormatters[col];
+            const formattedVal = formatter?.(val as number) || String(val);
             filters.push({
               col,
               op: '==',
               val,
               formattedVal,
+              grain: formatter ? timeGrainSqla : undefined,
             });
           });
         }
         onContextMenu(e.clientX, e.clientY, filters);
       }
     },
-    [cols, dateFormatters, onContextMenu, rows],
+    [cols, dateFormatters, onContextMenu, rows, timeGrainSqla],
   );
 
   return (

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/transformProps.ts
@@ -101,6 +101,7 @@ export default function transformProps(chartProps: ChartProps<QueryFormData>) {
     emitFilter,
     metricsLayout,
     conditionalFormatting,
+    timeGrainSqla,
   } = formData;
   const { selectedFilters } = filterState;
   const granularity = extractTimegrain(rawFormData);
@@ -165,5 +166,6 @@ export default function transformProps(chartProps: ChartProps<QueryFormData>) {
     metricColorFormatters,
     dateFormatters,
     onContextMenu,
+    timeGrainSqla,
   };
 }

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/types.ts
@@ -79,7 +79,7 @@ interface PivotTableCustomizeProps {
     clientY: number,
     filters?: BinaryQueryObjectFilterClause[],
   ) => void;
-  timeGrainSqla: TimeGranularity;
+  timeGrainSqla?: TimeGranularity;
 }
 
 export type PivotTableQueryFormData = QueryFormData &

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/types.ts
@@ -27,6 +27,7 @@ import {
   QueryFormMetric,
   QueryFormColumn,
   BinaryQueryObjectFilterClause,
+  TimeGranularity,
 } from '@superset-ui/core';
 import { ColorFormatters } from '@superset-ui/chart-controls';
 
@@ -78,6 +79,7 @@ interface PivotTableCustomizeProps {
     clientY: number,
     filters?: BinaryQueryObjectFilterClause[],
   ) => void;
+  timeGrainSqla: TimeGranularity;
 }
 
 export type PivotTableQueryFormData = QueryFormData &


### PR DESCRIPTION
### SUMMARY
Fix a bug where the time grain was not being added to the Pivot Table v2.

Hat tip to @zhaoyongjie for helping with the issue!

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/202797372-3570a3bb-1939-4bf1-84d9-c251a3fd4b3e.mov

https://user-images.githubusercontent.com/70410625/202797413-99ddee3c-2c9a-4ed3-b071-a5582c1f4c24.mov

### TESTING INSTRUCTIONS
- Create a Pivot Table v2 with a time dimension
- Check that drilling to detail works when selecting a value from the time dimension

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
