### PR TITLE
fix: don't stringify extraJson in form

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx
@@ -471,7 +471,7 @@ const ExtraOptions = ({
               value={
                 !Object.keys(extraJson?.engine_params || {}).length
                   ? ''
-                  : JSON.stringify(extraJson?.engine_params)
+                  : extraJson?.engine_params
               }
               placeholder={t('Engine Parameters')}
               onChange={(json: string) =>


### PR DESCRIPTION
### SUMMARY
This fixes a bug where the extra parameters field in the database connection modal was adding an extra layer of json encoding. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: 
![testrail_bq](https://user-images.githubusercontent.com/5186919/202825117-6e4e32a6-3322-41d1-97f0-a352bd23fc02.png)

After:
![_DEV__Superset](https://user-images.githubusercontent.com/5186919/202825127-eeef604c-a316-495e-bad0-dce3f10fe15b.png)



### TESTING INSTRUCTIONS
typing and pasting into the extra engine parameters field should not encode the characters. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
