### PR TITLE
fix: SQL Lab QuerySource via referrer

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -412,7 +412,7 @@ class Database(
                     source = utils.QuerySource.DASHBOARD
                 elif "/explore/" in request.referrer:
                     source = utils.QuerySource.CHART
-                elif "/superset/sqllab/" in request.referrer:
+                elif "/superset/sqllab" in request.referrer:
                     source = utils.QuerySource.SQL_LAB
 
             sqlalchemy_url, params = DB_CONNECTION_MUTATOR(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

At Airbnb we've noticed in the logs (see attached) that the QuerySource is undefined which occurs the referrer is of the form `.../superset/sqllab` i.e., without the trailing `/`. 

<img width="1429" alt="Screen Shot 2022-11-19 at 1 19 59 AM" src="https://user-images.githubusercontent.com/4567245/202844043-cc132d1b-242b-4846-8912-42eab0a24305.png">

Grokking through the code there are a number of examples where the trailing `/` isn't provided, hence it seems prudent to relax the requirement that the trailing `/` is required to match queries originating from SQL Lab. 

```
$ git grep "/sqllab?"
docs/docs/installation/sql-templating.mdx:  coworker in Spain the following SQL Lab URL `www.example.com/superset/sqllab?countrycode=ES`
docs/docs/installation/sql-templating.mdx:  and your coworker in the USA the following SQL Lab URL `www.example.com/superset/sqllab?countrycode=US`
superset-frontend/src/SqlLab/components/QueryTable/index.tsx:  const url = `/superset/sqllab?queryId=${id}`;
superset-frontend/src/views/CRUD/data/query/QueryList.tsx:            <a href={`/superset/sqllab?queryId=${id}`}>
superset-frontend/src/views/CRUD/data/query/QueryList.tsx:            window.location.assign(`/superset/sqllab?queryId=${id}`)
superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:    window.open(`${window.location.origin}/superset/sqllab?new=true`);
superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:    window.open(`${window.location.origin}/superset/sqllab?savedQueryId=${id}`);
superset-frontend/src/views/CRUD/data/savedquery/SavedQueryList.tsx:          `${window.location.origin}/superset/sqllab?savedQueryId=${id}`,
superset-frontend/src/views/CRUD/hooks.ts:      `${window.location.origin}/superset/sqllab?savedQueryId=${id}`,
superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx:  if ('sql' in entity) return `/superset/sqllab?savedQueryId=${entity.id}`;
superset-frontend/src/views/CRUD/welcome/EmptyState.tsx:    [WelcomeTable.SavedQueries]: '/superset/sqllab?new=true',
superset-frontend/src/views/CRUD/welcome/SavedQueries.tsx:            window.location.href = `/superset/sqllab?savedQueryId=${query.id}`;
superset-frontend/src/views/CRUD/welcome/SavedQueries.tsx:              window.location.href = '/superset/sqllab?new=true';
superset-frontend/src/views/CRUD/welcome/SavedQueries.tsx:                window.location.href = `/superset/sqllab?savedQueryId=${q.id}`;
superset-frontend/src/views/CRUD/welcome/SavedQueries.tsx:                url={`/superset/sqllab?savedQueryId=${q.id}`}
superset-frontend/src/views/components/Menu.test.tsx:    url: '/superset/sqllab?new=true',
superset-frontend/src/views/components/RightMenu.test.tsx:    url: '/superset/sqllab?new=true',
superset-frontend/src/views/components/RightMenu.tsx:      url: '/superset/sqllab?new=true',
superset/jinja_context.py:        `?foo=bar`, as in `{domain}/superset/sqllab?foo=bar`. Then if your query is
superset/models/sql_lab.py:            <a href="/superset/sqllab?savedQueryId={self.id}">
superset/models/sql_lab.py:        return "/superset/sqllab?savedQueryId={0}".format(self.id)
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
