### PR TITLE
fix: chart id mapping in dashboard api

### DIFF
--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -71,6 +71,7 @@ get_fav_star_ids_schema = {"type": "array", "items": {"type": "integer"}}
 #
 # Column schema descriptions
 #
+id_description = "The id of the chart."
 slice_name_description = "The name of the chart."
 description_description = "A description of the chart propose."
 viz_type_description = "The type of chart visualization used."
@@ -153,7 +154,7 @@ class ChartEntityResponseSchema(Schema):
     Schema for a chart object
     """
 
-    slice_id = fields.Integer()
+    id = fields.Integer(description=id_description)
     slice_name = fields.String(description=slice_name_description)
     cache_timeout = fields.Integer(description=cache_timeout_description)
     changed_on = fields.String(description=changed_on_description)

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -275,10 +275,22 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
         response = self.get_assert_metric(uri, "get_charts")
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data.decode("utf-8"))
-        self.assertEqual(len(data["result"]), 1)
-        self.assertEqual(
-            data["result"][0]["slice_name"], dashboard.slices[0].slice_name
-        )
+        assert len(data["result"]) == 1
+        result = data["result"][0]
+        assert set(result.keys()) == {
+            "cache_timeout",
+            "certification_details",
+            "certified_by",
+            "changed_on",
+            "description",
+            "description_markeddown",
+            "form_data",
+            "id",
+            "slice_name",
+            "slice_url",
+        }
+        assert result["id"] == dashboard.slices[0].id
+        assert result["slice_name"] == dashboard.slices[0].slice_name
 
     @pytest.mark.usefixtures("create_dashboards")
     def test_get_dashboard_charts_by_slug(self):


### PR DESCRIPTION
### SUMMARY
The result payload of the `/api/v1/dashboard/<pk>/charts` endpoint is currently missing the chart's id due to the field being mapped incorrectly to `slice_id` (it's `id` in the model). This fixes the error and adds a description to the `id` field.

### AFTER
Now the playload contains the `id` of the chart in accordance with the OpenAPI spec:
![image](https://user-images.githubusercontent.com/33317356/203067526-76d9294e-d274-409c-865d-06cbfac28473.png)

### BEFORE
Previously the `id` was missing due to incorrectly being referenced as `slice_id`:
![image](https://user-images.githubusercontent.com/33317356/203067580-68ab1983-1ff2-45a2-97c9-486d06e6082b.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
