### PR TITLE
build(docker): Push websocket image

### DIFF
--- a/.github/workflows/docker_build_push.sh
+++ b/.github/workflows/docker_build_push.sh
@@ -90,4 +90,5 @@ else
   docker logout
   docker login --username "${DOCKERHUB_USER}" --password "${DOCKERHUB_TOKEN}"
   docker push --all-tags "${REPO_NAME}"
+  docker push --all-tags "${REPO_NAME}-websocket"
 fi


### PR DESCRIPTION
### SUMMARY

This PR is a followup to #21954 which was missing the step to actually push the freshly-built `superset-websocket` image to Docker hub.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TESTING INSTRUCTIONS

This can only be tested after merge, since the publication step is only run on `master`. After successful merge, we should see an `apache/superset-websocket` image in Docker hub, with the same tags as the main image.

### ADDITIONAL INFORMATION
- [x] Has associated issue: #22126
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
