### PR TITLE
fix: Empty Error Alert Modal 

### DIFF
--- a/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
@@ -132,7 +132,7 @@ export default function ErrorAlert({
       {description && (
         <div className="error-body">
           <p>{description}</p>
-          {!isExpandable && (
+          {!isExpandable && body && (
             <span
               role="button"
               tabIndex={0}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The Error Alert in the database modal was showing users a "See More" link that was displaying an empty modal. 

Looking into this issue, there seemed to be a disconnect between a description and a body. With a body being the additional information that we want to display to a user should it not all fit in the original Error Alert. This PR adds a conditional to the Error Alert that checks for a body to be present in order to show the "See More" text. 


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:
![image](https://user-images.githubusercontent.com/48933336/203171178-4b7b6a56-5418-46bc-acde-ce08f37ede77.png)

After:

https://user-images.githubusercontent.com/48933336/203171317-dcb1c4e1-b829-4e20-9e6c-e0fc1b66e774.mov



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
