### PR TITLE
fix(reports): force data generation in csv reports

### DIFF
--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -135,8 +135,7 @@ class ChartDataRestApi(ChartRestApi):
             "format", ChartDataResultFormat.JSON
         )
         json_body["result_type"] = request.args.get("type", ChartDataResultType.FULL)
-        if request.args.get("force"):
-            json_body["force"] = request.args.get("force")
+        json_body["force"] = request.args.get("force")
 
         try:
             query_context = self._create_query_context_from_form(json_body)

--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -135,7 +135,7 @@ class ChartDataRestApi(ChartRestApi):
             "format", ChartDataResultFormat.JSON
         )
         json_body["result_type"] = request.args.get("type", ChartDataResultType.FULL)
-        json_body["force"] = request.args.get("force", False)
+        json_body["force"] = request.args.get("force")
 
         try:
             query_context = self._create_query_context_from_form(json_body)

--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -135,7 +135,8 @@ class ChartDataRestApi(ChartRestApi):
             "format", ChartDataResultFormat.JSON
         )
         json_body["result_type"] = request.args.get("type", ChartDataResultType.FULL)
-        json_body["force"] = request.args.get("force")
+        if request.args.get("force"):
+            json_body["force"] = request.args.get("force")
 
         try:
             query_context = self._create_query_context_from_form(json_body)

--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -89,6 +89,11 @@ class ChartDataRestApi(ChartRestApi):
             description: The type in which the data should be returned
             schema:
               type: string
+          - in: query
+            name: force
+            description: Should the queries be forced to load from the source
+            schema:
+                type: boolean
           responses:
             200:
               description: Query result
@@ -130,6 +135,7 @@ class ChartDataRestApi(ChartRestApi):
             "format", ChartDataResultFormat.JSON
         )
         json_body["result_type"] = request.args.get("type", ChartDataResultType.FULL)
+        json_body["force"] = request.args.get("force", False)
 
         try:
             query_context = self._create_query_context_from_form(json_body)

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -1204,6 +1204,7 @@ class ChartDataQueryContextSchema(Schema):
     force = fields.Boolean(
         description="Should the queries be forced to load from the source. "
         "Default: `false`",
+        allow_none=True,
     )
 
     result_type = EnumField(ChartDataResultType, by_value=True)

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -900,24 +900,17 @@ class TestGetChartDataApi(BaseTestChartDataApi):
             }
         )
 
-        self.get_assert_metric(f"api/v1/chart/{chart.id}/data/", "get_data")
+        self.get_assert_metric(f"api/v1/chart/{chart.id}/data/?force=true", "get_data")
 
+        # should burst cache
         rv = self.get_assert_metric(
             f"api/v1/chart/{chart.id}/data/?force=true", "get_data"
         )
-
-        data = json.loads(rv.data.decode("utf-8"))
         assert rv.json["result"][0]["is_cached"] is None
-        assert rv.mimetype == "application/json"
-        assert data["result"][0]["status"] == "success"
-        assert data["result"][0]["rowcount"] == 2
 
+        # should get response from the cache
         rv = self.get_assert_metric(f"api/v1/chart/{chart.id}/data/", "get_data")
-        data = json.loads(rv.data.decode("utf-8"))
-        assert rv.json["result"][0]["is_cached"] is not None
-        assert rv.mimetype == "application/json"
-        assert data["result"][0]["status"] == "success"
-        assert data["result"][0]["rowcount"] == 2
+        assert rv.json["result"][0]["is_cached"]
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     @with_feature_flags(GLOBAL_ASYNC_QUERIES=True)

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -863,6 +863,59 @@ class TestGetChartDataApi(BaseTestChartDataApi):
         assert data["result"][0]["rowcount"] == 2
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+    def test_chart_data_get_forced(self):
+        """
+        Chart data API: Test GET endpoint with force cache parameter
+        """
+        chart = db.session.query(Slice).filter_by(slice_name="Genders").one()
+        chart.query_context = json.dumps(
+            {
+                "datasource": {"id": chart.table.id, "type": "table"},
+                "force": False,
+                "queries": [
+                    {
+                        "time_range": "1900-01-01T00:00:00 : 2000-01-01T00:00:00",
+                        "granularity": "ds",
+                        "filters": [],
+                        "extras": {
+                            "having": "",
+                            "having_druid": [],
+                            "where": "",
+                        },
+                        "applied_time_extras": {},
+                        "columns": ["gender"],
+                        "metrics": ["sum__num"],
+                        "orderby": [["sum__num", False]],
+                        "annotation_layers": [],
+                        "row_limit": 50000,
+                        "timeseries_limit": 0,
+                        "order_desc": True,
+                        "url_params": {},
+                        "custom_params": {},
+                        "custom_form_data": {},
+                    }
+                ],
+                "result_format": "json",
+                "result_type": "full",
+            }
+        )
+
+        # wrapping original class, so we can test output too.
+        with mock.patch(
+            "superset.charts.data.api.ChartDataCommand", wraps=ChartDataCommand
+        ) as command:
+            rv = self.get_assert_metric(
+                f"api/v1/chart/{chart.id}/data/?force=true", "get_data"
+            )
+            data = json.loads(rv.data.decode("utf-8"))
+            query_context = command.call_args.args[0]
+
+            assert query_context.force == True
+            assert rv.mimetype == "application/json"
+            assert data["result"][0]["status"] == "success"
+            assert data["result"][0]["rowcount"] == 2
+
+    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     @with_feature_flags(GLOBAL_ASYNC_QUERIES=True)
     @mock.patch("superset.charts.data.api.QueryContextCacheLoader")
     def test_chart_data_cache(self, cache_loader):

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -901,19 +901,25 @@ class TestGetChartDataApi(BaseTestChartDataApi):
         )
 
         # wrapping original class, so we can test output too.
-        with mock.patch(
-            "superset.charts.data.api.ChartDataCommand", wraps=ChartDataCommand
-        ) as command:
-            rv = self.get_assert_metric(
-                f"api/v1/chart/{chart.id}/data/?force=true", "get_data"
-            )
-            data = json.loads(rv.data.decode("utf-8"))
-            query_context = command.call_args.args[0]
 
-            assert query_context.force == True
-            assert rv.mimetype == "application/json"
-            assert data["result"][0]["status"] == "success"
-            assert data["result"][0]["rowcount"] == 2
+        self.get_assert_metric(f"api/v1/chart/{chart.id}/data/", "get_data")
+
+        rv = self.get_assert_metric(
+            f"api/v1/chart/{chart.id}/data/?force=true", "get_data"
+        )
+
+        data = json.loads(rv.data.decode("utf-8"))
+        assert rv.json["result"][0]["is_cached"] is None
+        assert rv.mimetype == "application/json"
+        assert data["result"][0]["status"] == "success"
+        assert data["result"][0]["rowcount"] == 2
+
+        rv = self.get_assert_metric(f"api/v1/chart/{chart.id}/data/", "get_data")
+        data = json.loads(rv.data.decode("utf-8"))
+        assert rv.json["result"][0]["is_cached"] is not None
+        assert rv.mimetype == "application/json"
+        assert data["result"][0]["status"] == "success"
+        assert data["result"][0]["rowcount"] == 2
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     @with_feature_flags(GLOBAL_ASYNC_QUERIES=True)

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -900,8 +900,6 @@ class TestGetChartDataApi(BaseTestChartDataApi):
             }
         )
 
-        # wrapping original class, so we can test output too.
-
         self.get_assert_metric(f"api/v1/chart/{chart.id}/data/", "get_data")
 
         rv = self.get_assert_metric(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
fixes: #22189 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. create table chart
2. setup csv report on that chart and enable `Ignore cache when generating screenshot`
3. update data in datasource without bursting cache
4. check csv in the report received, should contain new data

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #22189 
- [x] Required feature flags: `ALERTS_REPORTS`
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
