### PR TITLE
chore: rename 'Change dataset' action to 'Swap dataset'

### DIFF
--- a/superset-frontend/src/components/Datasource/ChangeDatasourceModal.tsx
+++ b/superset-frontend/src/components/Datasource/ChangeDatasourceModal.tsx
@@ -251,7 +251,7 @@ const ChangeDatasourceModal: FunctionComponent<ChangeDatasourceModalProps> = ({
       show={show}
       onHide={onHide}
       responsive
-      title={t('Change dataset')}
+      title={t('Swap dataset')}
       width={confirmChange ? '432px' : ''}
       height={confirmChange ? 'auto' : '540px'}
       hideFooter={!confirmChange}

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
@@ -94,17 +94,17 @@ test('Should open a menu', async () => {
   render(<DatasourceControl {...props} />);
 
   expect(screen.queryByText('Edit dataset')).not.toBeInTheDocument();
-  expect(screen.queryByText('Change dataset')).not.toBeInTheDocument();
+  expect(screen.queryByText('Swap dataset')).not.toBeInTheDocument();
   expect(screen.queryByText('View in SQL Lab')).not.toBeInTheDocument();
 
   userEvent.click(screen.getByTestId('datasource-menu-trigger'));
 
   expect(await screen.findByText('Edit dataset')).toBeInTheDocument();
-  expect(screen.getByText('Change dataset')).toBeInTheDocument();
+  expect(screen.getByText('Swap dataset')).toBeInTheDocument();
   expect(screen.getByText('View in SQL Lab')).toBeInTheDocument();
 });
 
-test('Click on Change dataset option', async () => {
+test('Click on Swap dataset option', async () => {
   const props = createProps();
   SupersetClientGet.mockImplementation(
     async ({ endpoint }: { endpoint: string }) => {
@@ -123,7 +123,7 @@ test('Click on Change dataset option', async () => {
   userEvent.click(screen.getByTestId('datasource-menu-trigger'));
 
   await act(async () => {
-    userEvent.click(screen.getByText('Change dataset'));
+    userEvent.click(screen.getByText('Swap dataset'));
   });
   expect(
     screen.getByText(

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -302,7 +302,7 @@ class DatasourceControl extends React.PureComponent {
             )}
           </Menu.Item>
         )}
-        <Menu.Item key={CHANGE_DATASET}>{t('Change dataset')}</Menu.Item>
+        <Menu.Item key={CHANGE_DATASET}>{t('Swap dataset')}</Menu.Item>
         {datasource && (
           <Menu.Item key={VIEW_IN_SQL_LAB}>{t('View in SQL Lab')}</Menu.Item>
         )}
@@ -421,7 +421,7 @@ class DatasourceControl extends React.PureComponent {
                         this.handleMenuItemClick({ key: CHANGE_DATASET })
                       }
                     >
-                      {t('Change dataset')}
+                      {t('Swap dataset')}
                     </Button>
                   </p>
                 </>


### PR DESCRIPTION
We received feedback around the two options (right above/under one another in a dropdown action list in explore) labeled `Edit dataset` and `Change dataset` are confusing. This PR renames `Change dataset` to `Swap dataset`, which is more clear about the actual action taking place.

We considered other options like: `Switch dataset` or `Point to another dataset` and felt like `Swap dataset` was shorter/clearer.

We also consider re-labeling `Edit dataset` to `Edit dataset properties` but felt it was long and unnecessary.
