### PR TITLE
fix(explore): Value undefined and Unhashable type errors

### DIFF
--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -37,6 +37,7 @@ import {
   SupersetTheme,
   useTheme,
   isDefined,
+  JsonValue,
 } from '@superset-ui/core';
 import {
   ControlPanelSectionConfig,
@@ -276,21 +277,33 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
   >(state => state.explore.controlsTransferred);
 
   useEffect(() => {
+    const removeDatasourceWarningFromControl = (
+      value: JsonValue | undefined,
+    ) => {
+      if (
+        typeof value === 'object' &&
+        isDefined(value) &&
+        'datasourceWarning' in value
+      ) {
+        return { ...value, datasourceWarning: false };
+      }
+      return value;
+    };
     if (props.chart.chartStatus === 'success') {
       controlsTransferred?.forEach(controlName => {
-        const alteredControls = ensureIsArray(
-          props.controls[controlName].value,
-        ).map(value => {
-          if (
-            typeof value === 'object' &&
-            isDefined(value) &&
-            'datasourceWarning' in value
-          ) {
-            return { ...value, datasourceWarning: false };
-          }
-          return value;
-        });
-        props.actions.setControlValue(controlName, alteredControls);
+        if (Array.isArray(props.controls[controlName].value)) {
+          const alteredControls = ensureIsArray(
+            props.controls[controlName].value,
+          )?.map(removeDatasourceWarningFromControl);
+          props.actions.setControlValue(controlName, alteredControls);
+        } else {
+          props.actions.setControlValue(
+            controlName,
+            removeDatasourceWarningFromControl(
+              props.controls[controlName].value,
+            ),
+          );
+        }
       });
     }
   }, [

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -291,6 +291,9 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
     };
     if (props.chart.chartStatus === 'success') {
       controlsTransferred?.forEach(controlName => {
+        if (!isDefined(props.controls[controlName])) {
+          return;
+        }
         if (Array.isArray(props.controls[controlName].value)) {
           const alteredControls = ensureIsArray(
             props.controls[controlName].value,


### PR DESCRIPTION

### SUMMARY
This PR fixes 2 issues:
1. Due to some faulty logic on the frontend, sometimes we converted `metric` control value from a string to an array. That resulted in `Unhashable type: 'list' error`.
2. When user opened a chart, changed dataset, then changed viz type, and then clicked "Update chart", Explore would crash with `undefined` error. That's because of the fact that we were expecting all the controls from the previous viz type to still be available and have values, which might not be the case after changing viz type.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

1.

https://user-images.githubusercontent.com/15073128/203598667-a73f8fd8-c648-423e-8914-e010144c35a5.mov

2.


https://user-images.githubusercontent.com/15073128/203598799-73d5e33f-b679-4cb5-8b5e-42e8315a26b0.mov


After:

1.


https://user-images.githubusercontent.com/15073128/203600227-494d33ec-07f4-4d1c-aac2-9bd122243bc3.mov



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
