### PR TITLE
fix(explore): undefined alteredControl value

### DIFF
--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -278,6 +278,9 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
   useEffect(() => {
     if (props.chart.chartStatus === 'success') {
       controlsTransferred?.forEach(controlName => {
+        if (!props.controls[controlName]) {
+          return;
+        }
         const alteredControls = ensureIsArray(
           props.controls[controlName].value,
         ).map(value => {


### PR DESCRIPTION
### SUMMARY

Related to #20934 change, the following `props.controls[controlName].value` can be undefined when alteredControls are not existed on props.controls.

https://github.com/apache/superset/blob/888f43c6ad8444100cdcbf42c2ee0ae4f80c5ea3/superset-frontend/src/explore/components/ControlPanelsContainer.tsx#L278-L283

This commit fixes the following undefined property access error due to this change.

```
react-dom.production.min.js:209 TypeError: Cannot read properties of undefined (reading 'value')
    at ControlPanelsContainer.tsx:282:39
    at Array.forEach (<anonymous>)
    at ControlPanelsContainer.tsx:280:28
    at il (react-dom.production.min.js:211:320)
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

<img width="1678" alt="image (9)" src="https://user-images.githubusercontent.com/1392866/203626623-1ccfcfd2-b87c-40aa-9537-53be0ce0df23.png">

After:

N/A

### TESTING INSTRUCTIONS
- click Create Chart in SQL Lab, it opens the explore view 
- runs the query by default
- that query finished running is when I got this error and the UI broke

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @ktmud @john-bodley 