### PR TITLE
fix(dashboard): Fix hover labels for horizontal overflow native filter dividers

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterDivider.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterDivider.test.tsx
@@ -59,6 +59,7 @@ test('horizontal mode, title', () => {
       orientation={FilterBarOrientation.HORIZONTAL}
       title={SAMPLE_TITLE}
       description=""
+      overflow
     />,
   );
 
@@ -88,9 +89,7 @@ test('horizontal mode, title and description', async () => {
   const descriptionIcon = screen.getByTestId('divider-description-icon');
   expect(descriptionIcon).toBeVisible();
   userEvent.hover(descriptionIcon);
-  const tooltip = await screen.findByRole('tooltip', {
-    name: SAMPLE_DESCRIPTION,
-  });
+  const tooltip = await screen.findByRole('tooltip');
 
   expect(tooltip).toBeInTheDocument();
   expect(tooltip).toHaveTextContent(SAMPLE_DESCRIPTION);

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterDivider.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterDivider.tsx
@@ -35,7 +35,7 @@ const VerticalDivider = ({ title, description }: FilterDividerProps) => (
 const HorizontalDivider = ({ title, description }: FilterDividerProps) => {
   const theme = useTheme();
   const [titleRef, titleIsTruncated] =
-    useCSSTextTruncation<HTMLHeadingElement>(title);
+    useCSSTextTruncation<HTMLHeadingElement>();
 
   const tooltipOverlay = (
     <>
@@ -95,10 +95,10 @@ const HorizontalOverflowDivider = ({
 }: FilterDividerProps) => {
   const theme = useTheme();
   const [titleRef, titleIsTruncated] =
-    useCSSTextTruncation<HTMLHeadingElement>(title);
+    useCSSTextTruncation<HTMLHeadingElement>();
 
   const [descriptionRef, descriptionIsTruncated] =
-    useCSSTextTruncation<HTMLHeadingElement>(description);
+    useCSSTextTruncation<HTMLHeadingElement>();
 
   return (
     <div

--- a/superset-frontend/src/hooks/useTruncation/useCSSTextTruncation.ts
+++ b/superset-frontend/src/hooks/useTruncation/useCSSTextTruncation.ts
@@ -36,16 +36,27 @@ export const truncationCSS = css`
  * to be displayed, this hook returns a ref to attach to the text
  * element and a boolean for whether that element is currently truncated.
  */
-const useCSSTextTruncation = <T extends HTMLElement>(
-  text: string,
-): [React.RefObject<T>, boolean] => {
-  const ref = useRef<T>(null);
+const useCSSTextTruncation = <T extends HTMLElement>(): [
+  React.RefObject<T>,
+  boolean,
+] => {
   const [isTruncated, setIsTruncated] = useState(true);
+  const ref = useRef<T>(null);
+  const { offsetWidth, scrollWidth } = ref.current ?? {};
+  const prevWidths = useRef({ offsetWidth, scrollWidth });
+  const { offsetWidth: prevOffsetWidth, scrollWidth: prevScrollWidth } =
+    prevWidths.current;
+
   useEffect(() => {
-    if (ref.current) {
-      setIsTruncated(ref.current.offsetWidth < ref.current.scrollWidth);
+    if (
+      offsetWidth &&
+      scrollWidth &&
+      (offsetWidth !== prevOffsetWidth || scrollWidth !== prevScrollWidth)
+    ) {
+      prevWidths.current = { offsetWidth, scrollWidth };
+      setIsTruncated(offsetWidth < scrollWidth);
     }
-  }, [text]);
+  }, [offsetWidth, prevOffsetWidth, prevScrollWidth, scrollWidth]);
 
   return [ref, isTruncated];
 };


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR is based on #22169 and fixes hover labels that weren't appearing for dividers in horizontal native filters overflow dropdown.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
<img width="358" alt="Screen Shot 2022-11-23 at 3 08 58 PM" src="https://user-images.githubusercontent.com/13007381/203654255-2a876006-870f-40f9-97d9-adfe2640548d.png">

After:
<img width="418" alt="Screen Shot 2022-11-23 at 3 08 30 PM" src="https://user-images.githubusercontent.com/13007381/203654292-b7da4c98-36ab-48a1-8cee-a4863dcabf97.png">
<img width="429" alt="Screen Shot 2022-11-23 at 3 08 41 PM" src="https://user-images.githubusercontent.com/13007381/203654300-3224f190-ae39-45ce-b1c2-9f65c9048abe.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Ensure that dividers in the horizontal overflow dropdown show tooltips for titles and descriptions that are truncated.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Required feature flags: `HORIZONTAL_FILTER_BAR`
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
