### PR TITLE
fix: (dashboard) Adds optional chaining to avoid runtime error

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/utils.ts
@@ -146,7 +146,7 @@ export function nativeFilterGate(behaviors: Behavior[]): boolean {
 const isComponentATab = (
   dashboardLayout: DashboardLayout,
   componentId: string,
-) => dashboardLayout[componentId].type === TAB_TYPE;
+) => dashboardLayout[componentId]?.type === TAB_TYPE;
 
 const findTabsWithChartsInScopeHelper = (
   dashboardLayout: DashboardLayout,
@@ -156,19 +156,19 @@ const findTabsWithChartsInScopeHelper = (
   tabsToHighlight: Set<string>,
 ) => {
   if (
-    dashboardLayout[componentId].type === CHART_TYPE &&
-    chartsInScope.includes(dashboardLayout[componentId].meta.chartId)
+    dashboardLayout[componentId]?.type === CHART_TYPE &&
+    chartsInScope.includes(dashboardLayout[componentId]?.meta?.chartId)
   ) {
     tabIds.forEach(tabsToHighlight.add, tabsToHighlight);
   }
   if (
-    dashboardLayout[componentId].children.length === 0 ||
+    dashboardLayout[componentId]?.children?.length === 0 ||
     (isComponentATab(dashboardLayout, componentId) &&
       tabsToHighlight.has(componentId))
   ) {
     return;
   }
-  dashboardLayout[componentId].children.forEach(childId =>
+  dashboardLayout[componentId]?.children.forEach(childId =>
     findTabsWithChartsInScopeHelper(
       dashboardLayout,
       chartsInScope,
@@ -188,7 +188,7 @@ export const findTabsWithChartsInScope = (
   const hasTopLevelTabs = rootChildId !== DASHBOARD_GRID_ID;
   const tabsInScope = new Set<string>();
   if (hasTopLevelTabs) {
-    dashboardLayout[rootChildId].children?.forEach(tabId =>
+    dashboardLayout[rootChildId]?.children?.forEach(tabId =>
       findTabsWithChartsInScopeHelper(
         dashboardLayout,
         chartsInScope,
@@ -199,7 +199,7 @@ export const findTabsWithChartsInScope = (
     );
   } else {
     Object.values(dashboardLayout)
-      .filter(element => element.type === TAB_TYPE)
+      .filter(element => element?.type === TAB_TYPE)
       .forEach(element =>
         findTabsWithChartsInScopeHelper(
           dashboardLayout,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds optional chaining to avoid runtime error when performing dot operator on null or undefined value.  In the case a bad componentId was provided to these utility functions the code would throw a runtime error in loop causing the removal of a component or dashboard tab to fail.  

If there is a dashboard filter (even if not applied) deleting a tab will hit the line that causes error with a bad componentId.  If there is a dashboard filter AND it is applied, then removing a component will hit the line that causes error with a bad componentId.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
