### PR TITLE
chore(dashboard): Ignore empty json value for overwrite confirm

### DIFF
--- a/superset-frontend/src/dashboard/util/getOverwriteItems.ts
+++ b/superset-frontend/src/dashboard/util/getOverwriteItems.ts
@@ -33,8 +33,10 @@ export default function getOverwriteItems(prev: JsonObject, next: JsonObject) {
     keyPath,
     ...(keyPath.split('.').find(key => JSON_KEYS.has(key))
       ? {
-          oldValue: JSON.stringify(extractValue(prev, keyPath), null, 2) || '',
-          newValue: JSON.stringify(extractValue(next, keyPath), null, 2) || '',
+          oldValue:
+            JSON.stringify(extractValue(prev, keyPath), null, 2) || '{}',
+          newValue:
+            JSON.stringify(extractValue(next, keyPath), null, 2) || '{}',
         }
       : {
           oldValue: extractValue(prev, keyPath) || '',


### PR DESCRIPTION
### SUMMARY

Minor regression from #21819 
When user change a single layout but no filter_scope updates, there's unrelated overwrite confirmation kept popping up because the default json value is not empty string but an empty object `{}`.

This commit updates the default json value to skip the unnecessary overwrite warning.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://user-images.githubusercontent.com/1392866/203666144-493d55cd-6fa5-408e-a457-2532ba9d60c9.mov

After:

No overwrite confirm


### TESTING INSTRUCTIONS
- Enable `CONFIRM_DASHBOARD_DIFF`
- Edit dashboard and change one chart position
- Save and check the confirmation

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @ktmud @john-bodley 