### PR TITLE
build(compose): forcing docker compose files to use linux/amd64 to make it easier for…

### DIFF
--- a/docker-compose-non-dev.yml
+++ b/docker-compose-non-dev.yml
@@ -26,6 +26,7 @@ x-superset-volumes: &superset-volumes
 version: "3.7"
 services:
   redis:
+    platform: linux/amd64
     image: redis:latest
     container_name: superset_cache
     restart: unless-stopped
@@ -33,6 +34,7 @@ services:
       - redis:/data
 
   db:
+    platform: linux/amd64
     env_file: docker/.env-non-dev
     image: postgres:10
     container_name: superset_db
@@ -41,6 +43,7 @@ services:
       - db_home:/var/lib/postgresql/data
 
   superset:
+    platform: linux/amd64
     env_file: docker/.env-non-dev
     image: *superset-image
     container_name: superset_app
@@ -53,6 +56,7 @@ services:
     volumes: *superset-volumes
 
   superset-init:
+    platform: linux/amd64
     image: *superset-image
     container_name: superset_init
     command: ["/app/docker/docker-init.sh"]
@@ -64,6 +68,7 @@ services:
       disable: true
 
   superset-worker:
+    platform: linux/amd64
     image: *superset-image
     container_name: superset_worker
     command: ["/app/docker/docker-bootstrap.sh", "worker"]
@@ -76,6 +81,7 @@ services:
       test: ["CMD-SHELL", "celery inspect ping -A superset.tasks.celery_app:app -d celery@$$HOSTNAME"]
 
   superset-worker-beat:
+    platform: linux/amd64
     image: *superset-image
     container_name: superset_worker_beat
     command: ["/app/docker/docker-bootstrap.sh", "beat"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ x-superset-volumes: &superset-volumes
 version: "3.7"
 services:
   redis:
+    platform: linux/amd64
     image: redis:latest
     container_name: superset_cache
     restart: unless-stopped
@@ -39,6 +40,7 @@ services:
       - redis:/data
 
   db:
+    platform: linux/amd64
     env_file: docker/.env
     image: postgres:14
     container_name: superset_db
@@ -49,6 +51,7 @@ services:
       - db_home:/var/lib/postgresql/data
 
   superset:
+    platform: linux/amd64
     env_file: docker/.env
     image: *superset-image
     container_name: superset_app
@@ -63,6 +66,7 @@ services:
       CYPRESS_CONFIG: "${CYPRESS_CONFIG}"
 
   superset-websocket:
+    platform: linux/amd64
     container_name: superset_websocket
     build: ./superset-websocket
     image: superset-websocket
@@ -91,6 +95,7 @@ services:
       - REDIS_SSL=false
 
   superset-init:
+    platform: linux/amd64
     image: *superset-image
     container_name: superset_init
     command: ["/app/docker/docker-init.sh"]
@@ -104,6 +109,7 @@ services:
       disable: true
 
   superset-node:
+    platform: linux/amd64
     image: node:16
     container_name: superset_node
     command: ["/app/docker/docker-frontend.sh"]
@@ -112,6 +118,7 @@ services:
     volumes: *superset-volumes
 
   superset-worker:
+    platform: linux/amd64
     image: *superset-image
     container_name: superset_worker
     command: ["/app/docker/docker-bootstrap.sh", "worker"]
@@ -127,6 +134,7 @@ services:
     # mem_reservation: 128M
 
   superset-worker-beat:
+    platform: linux/amd64
     image: *superset-image
     container_name: superset_worker_beat
     command: ["/app/docker/docker-bootstrap.sh", "beat"]
@@ -139,6 +147,7 @@ services:
       disable: true
 
   superset-tests-worker:
+    platform: linux/amd64
     image: *superset-image
     container_name: superset_tests_worker
     command: ["/app/docker/docker-bootstrap.sh", "worker"]


### PR DESCRIPTION
… developers with arm based machines

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Developers with apple m1/2 or other arm based machines have difficulties building superset as not all dependencies are available.

This will set docker compose to use linux/amd64 for them so there is less questions/issues/hassles for new developers and they can run docker compose straight away

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
