### PR TITLE
fix: the TimePicker overlay the AdhocFilter

### DIFF
--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -343,13 +343,14 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
           {actualTimeRange}
         </Label>
       </Tooltip>
+      {/* the zIndex value is from trying so that the Modal doesn't overlay the AdhocFilter when GENERIC_CHART_AXES is enabled */}
       <Modal
         title={title}
         show={show}
         onHide={toggleOverlay}
         width="600px"
         hideFooter
-        zIndex={Number.MAX_SAFE_INTEGER}
+        zIndex={1030}
       >
         {overlayContent}
       </Modal>


### PR DESCRIPTION
### SUMMARY
When the `GENERIC_CHART_AXES` is enabled, the `DateFilter` in the modal has overlaid the `AdhocFilter`. This PR intends to fix it.




### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

#### After
![image](https://user-images.githubusercontent.com/2016594/204183285-d2b0a3d3-69b3-46c8-bed0-c4303cdb6883.png)


#### Before
![image](https://user-images.githubusercontent.com/2016594/204183348-c6a0a31c-8791-46d5-9b33-e787d8142243.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
