### PR TITLE
chore: Add a migration that removes filter_bar_orientation from dashboard's json_metadata

### DIFF
--- a/superset/migrations/versions/2022-11-28_17-51_4ce1d9b25135_remove_filter_bar_orientation.py
+++ b/superset/migrations/versions/2022-11-28_17-51_4ce1d9b25135_remove_filter_bar_orientation.py
@@ -1,0 +1,67 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""remove_filter_bar_orientation
+
+Revision ID: 4ce1d9b25135
+Revises: deb4c9d4a4ef
+Create Date: 2022-11-28 17:51:08.954439
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "4ce1d9b25135"
+down_revision = "deb4c9d4a4ef"
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.ext.declarative import declarative_base
+
+from superset import db
+
+Base = declarative_base()
+
+
+class Dashboard(Base):
+    __tablename__ = "dashboards"
+    id = sa.Column(sa.Integer, primary_key=True)
+    json_metadata = sa.Column(sa.Text)
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    dashboards = (
+        session.query(Dashboard)
+        .filter(Dashboard.json_metadata.like('%"filter_bar_orientation"%'))
+        .all()
+    )
+    for dashboard in dashboards:
+        try:
+            json_meta = json.loads(dashboard.json_metadata)
+            json_meta.pop("filter_bar_orientation", None)
+            dashboard.json_metadata = json.dumps(json_meta)
+        except:
+            pass
+    session.commit()
+    session.close()

--- a/superset/migrations/versions/2022-11-28_17-51_4ce1d9b25135_remove_filter_bar_orientation.py
+++ b/superset/migrations/versions/2022-11-28_17-51_4ce1d9b25135_remove_filter_bar_orientation.py
@@ -57,11 +57,9 @@ def downgrade():
         .all()
     )
     for dashboard in dashboards:
-        try:
-            json_meta = json.loads(dashboard.json_metadata)
-            json_meta.pop("filter_bar_orientation", None)
+        json_meta = json.loads(dashboard.json_metadata)
+        filter_bar_orientation = json_meta.pop("filter_bar_orientation", None)
+        if filter_bar_orientation:
             dashboard.json_metadata = json.dumps(json_meta)
-        except:
-            pass
     session.commit()
     session.close()


### PR DESCRIPTION
### SUMMARY
This PR adds a downgrade migration that removes `filter_bar_orientation` field from dashboard's `json_metadata`.
It's related to the horizontal filter bar feature that's currently in development and is locked behind a `HORIZONTAL_FILTER_BAR` feature flag.
It's a required cleanup step when downgrading Superset version, because the horizontal filter bar project adds `filter_bar_orientation` field to `DashboardJSONMetadataSchema` schema.
Upgrade is not required - we simply default to `VERTICAL` if `filter_bar_orientation` is not present

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided
  `
    Current: 0.26 s 
    10+: 0.40 s
    100+: 0.41 s
    1000+: 0.25 s
`
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
