### PR TITLE
fix(file_upload): Fix columnar and Excel upload forms

### DIFF
--- a/superset/views/database/forms.py
+++ b/superset/views/database/forms.py
@@ -293,7 +293,7 @@ class ExcelToDatabaseForm(UploadToDatabaseForm):
         widget=BS3TextFieldWidget(),
     )
 
-    con = QuerySelectField(
+    database = QuerySelectField(
         _("Database"),
         query_factory=UploadToDatabaseForm.file_allowed_dbs,
         get_pk=lambda a: a.id,
@@ -424,7 +424,7 @@ class ColumnarToDatabaseForm(UploadToDatabaseForm):
         ],
     )
 
-    con = QuerySelectField(
+    database = QuerySelectField(
         _("Database"),
         query_factory=UploadToDatabaseForm.file_allowed_dbs,
         get_pk=lambda a: a.id,

--- a/superset/views/database/views.py
+++ b/superset/views/database/views.py
@@ -262,7 +262,7 @@ class ExcelToDatabaseView(SimpleFormView):
         form.sheet_name.data = ""
 
     def form_post(self, form: ExcelToDatabaseForm) -> Response:
-        database = form.con.data
+        database = form.database.data
         excel_table = Table(table=form.name.data, schema=form.schema.data)
 
         if not schema_allows_file_upload(database, excel_table.schema):
@@ -301,7 +301,7 @@ class ExcelToDatabaseView(SimpleFormView):
 
             database = (
                 db.session.query(models.Database)
-                .filter_by(id=form.data.get("con").data.get("id"))
+                .filter_by(id=form.data.get("database").data.get("id"))
                 .one()
             )
 
@@ -378,7 +378,7 @@ class ExcelToDatabaseView(SimpleFormView):
         flash(message, "info")
         event_logger.log_with_context(
             action="successful_excel_upload",
-            database=form.con.data.name,
+            database=form.database.data.name,
             schema=form.schema.data,
             table=form.name.data,
         )
@@ -397,7 +397,7 @@ class ColumnarToDatabaseView(SimpleFormView):
     def form_post(  # pylint: disable=too-many-locals
         self, form: ColumnarToDatabaseForm
     ) -> Response:
-        database = form.con.data
+        database = form.database.data
         columnar_table = Table(table=form.name.data, schema=form.schema.data)
         files = form.columnar_file.data
         file_type = {file.filename.split(".")[-1] for file in files}
@@ -442,7 +442,7 @@ class ColumnarToDatabaseView(SimpleFormView):
 
             database = (
                 db.session.query(models.Database)
-                .filter_by(id=form.data.get("con").data.get("id"))
+                .filter_by(id=form.data.get("database").data.get("id"))
                 .one()
             )
 
@@ -519,7 +519,7 @@ class ColumnarToDatabaseView(SimpleFormView):
         flash(message, "info")
         event_logger.log_with_context(
             action="successful_columnar_upload",
-            database=form.con.data.name,
+            database=form.database.data.name,
             schema=form.schema.data,
             table=form.name.data,
         )

--- a/tests/integration_tests/csv_upload_tests.py
+++ b/tests/integration_tests/csv_upload_tests.py
@@ -144,7 +144,7 @@ def upload_excel(
     form_data = {
         "excel_file": open(filename, "rb"),
         "name": table_name,
-        "con": excel_upload_db_id,
+        "database": excel_upload_db_id,
         "sheet_name": "Sheet1",
         "if_exists": "fail",
         "index_label": "test_label",
@@ -165,7 +165,7 @@ def upload_columnar(
     form_data = {
         "columnar_file": open(filename, "rb"),
         "name": table_name,
-        "con": columnar_upload_db_id,
+        "database": columnar_upload_db_id,
         "if_exists": "fail",
         "index_label": "test_label",
     }


### PR DESCRIPTION
### SUMMARY
One of the form fields we changed when working on CSV forms was the not very descriptive "con" field, which was renamed to "database". Now, we are updating Columnar and Excel forms so they both stop displaying an error message. Additionally, we updated our tests.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After:
<img width="1647" alt="test1" src="https://user-images.githubusercontent.com/38889534/204373959-08f6c9ec-918c-4dc7-90d2-b58661d391c7.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
