### PR TITLE
feat: Adds overflow to the DropdownContainer popover

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,7 @@
 
 /superset-frontend/src/components/Select/ @michael-s-molina @geido @ktmud
 /superset-frontend/src/components/MetadataBar/ @michael-s-molina
+/superset-frontend/src/components/DropdownContainer/ @michael-s-molina
 
 # Notify Helm Chart maintainers about changes in it
 

--- a/superset-frontend/src/components/DropdownContainer/DropdownContainer.stories.tsx
+++ b/superset-frontend/src/components/DropdownContainer/DropdownContainer.stories.tsx
@@ -24,7 +24,7 @@ import Button from '../Button';
 import DropdownContainer, { DropdownContainerProps, Ref } from '.';
 
 export default {
-  title: 'DropdownContainer',
+  title: 'Design System/Components/DropdownContainer',
   component: DropdownContainer,
 };
 

--- a/superset-frontend/src/components/DropdownContainer/Overview.stories.mdx
+++ b/superset-frontend/src/components/DropdownContainer/Overview.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Source } from '@storybook/addon-docs';
 
-<Meta title="DropdownContainer/Overview" />
+<Meta title="Design System/Components/DropdownContainer/Overview" />
 
 # Usage
 
@@ -14,4 +14,4 @@ the available width, they are displayed vertically in a dropdown. Some of the co
 
 The component accepts any React element which ensures a high level of variability in Superset.
 
-To check the component in detail and its interactions, check the [DropdownContainer](/story/dropdowncontainer--component) page.
+To check the component in detail and its interactions, check the [DropdownContainer](/story/design-system-components-dropdowncontainer--component) page.

--- a/superset-frontend/src/components/DropdownContainer/index.tsx
+++ b/superset-frontend/src/components/DropdownContainer/index.tsx
@@ -28,6 +28,7 @@ import React, {
   useState,
   useRef,
 } from 'react';
+import { Global } from '@emotion/react';
 import { css, t, useTheme } from '@superset-ui/core';
 import { useResizeDetector } from 'react-resize-detector';
 import { usePrevious } from 'src/hooks/usePrevious';
@@ -245,7 +246,6 @@ const DropdownContainer = forwardRef(
         overflowingCount,
         theme.gridUnit,
         dropdownStyle,
-        targetRef,
         overflowedItems,
       ],
     );
@@ -294,39 +294,63 @@ const DropdownContainer = forwardRef(
           {notOverflowedItems.map(item => item.element)}
         </div>
         {popoverContent && (
-          <Popover
-            content={popoverContent}
-            trigger="click"
-            visible={popoverVisible}
-            onVisibleChange={visible => setPopoverVisible(visible)}
-            placement="bottom"
-            overlayInnerStyle={{
-              maxHeight: MAX_HEIGHT,
-              overflow: showOverflow ? 'auto' : 'visible',
-            }}
-          >
-            <Button buttonStyle="secondary">
-              {dropdownTriggerIcon}
-              {dropdownTriggerText}
-              <Badge
-                count={dropdownTriggerCount ?? overflowingCount}
-                css={css`
-                  margin-left: ${dropdownTriggerCount ?? overflowingCount
-                    ? `${theme.gridUnit * 2}px`
-                    : '0'};
-                `}
-              />
-              <Icons.DownOutlined
-                iconSize="m"
-                iconColor={theme.colors.grayscale.light1}
-                css={css`
-                  .anticon {
-                    display: flex;
+          <>
+            <Global
+              styles={css`
+                .ant-popover-inner-content {
+                  max-height: ${MAX_HEIGHT}px;
+                  overflow: ${showOverflow ? 'auto' : 'visible'};
+                  padding: ${theme.gridUnit * 3}px ${theme.gridUnit * 4}px;
+
+                  // Some OS versions only show the scroll when hovering.
+                  // These settings will make the scroll always visible.
+                  ::-webkit-scrollbar {
+                    -webkit-appearance: none;
+                    width: 14px;
                   }
-                `}
-              />
-            </Button>
-          </Popover>
+                  ::-webkit-scrollbar-thumb {
+                    border-radius: 9px;
+                    background-color: ${theme.colors.grayscale.light1};
+                    border: 3px solid transparent;
+                    background-clip: content-box;
+                  }
+                  ::-webkit-scrollbar-track {
+                    background-color: ${theme.colors.grayscale.light4};
+                    border-left: 1px solid ${theme.colors.grayscale.light2};
+                  }
+                }
+              `}
+            />
+            <Popover
+              content={popoverContent}
+              trigger="click"
+              visible={popoverVisible}
+              onVisibleChange={visible => setPopoverVisible(visible)}
+              placement="bottom"
+            >
+              <Button buttonStyle="secondary">
+                {dropdownTriggerIcon}
+                {dropdownTriggerText}
+                <Badge
+                  count={dropdownTriggerCount ?? overflowingCount}
+                  css={css`
+                    margin-left: ${dropdownTriggerCount ?? overflowingCount
+                      ? `${theme.gridUnit * 2}px`
+                      : '0'};
+                  `}
+                />
+                <Icons.DownOutlined
+                  iconSize="m"
+                  iconColor={theme.colors.grayscale.light1}
+                  css={css`
+                    .anticon {
+                      display: flex;
+                    }
+                  `}
+                />
+              </Button>
+            </Popover>
+          </>
         )}
       </div>
     );


### PR DESCRIPTION
### SUMMARY
Adds overflow to the `DropdownContainer` popover.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/204400117-c1275fea-4f6d-476b-a877-27a8a8fad707.mov

### TESTING INSTRUCTIONS
- Check that no overflow is set if the popover height is less than MAX_HEIGHT
- Check that an overflow is set if the popover height is greater than MAX_HEIGHT

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
