### PR TITLE
chore(ssh-tunnel): create `contextmanager` for sql.inspect

### DIFF
--- a/superset/databases/commands/test_connection.py
+++ b/superset/databases/commands/test_connection.py
@@ -108,7 +108,9 @@ class TestConnectionDatabaseCommand(BaseCommand):
                 with closing(engine.raw_connection()) as conn:
                     return engine.dialect.do_ping(conn)
 
-            with database.get_sqla_engine_with_context(override_ssh_tunnel=ssh_tunnel) as engine:
+            with database.get_sqla_engine_with_context(
+                override_ssh_tunnel=ssh_tunnel
+            ) as engine:
                 try:
                     alive = func_timeout(
                         app.config["TEST_DATABASE_CONNECTION_TIMEOUT"].total_seconds(),

--- a/superset/databases/commands/test_connection.py
+++ b/superset/databases/commands/test_connection.py
@@ -32,6 +32,7 @@ from superset.databases.commands.exceptions import (
     DatabaseTestConnectionUnexpectedError,
 )
 from superset.databases.dao import DatabaseDAO
+from superset.databases.ssh_tunnel.models import SSHTunnel
 from superset.databases.utils import make_url_safe
 from superset.errors import ErrorLevel, SupersetErrorType
 from superset.exceptions import (
@@ -90,10 +91,13 @@ class TestConnectionDatabaseCommand(BaseCommand):
             database.set_sqlalchemy_uri(uri)
             database.db_engine_spec.mutate_db_for_connection_test(database)
 
-            # TODO: (hughhh) uncomment in API enablement PR
+            # Generate tunnel if present in the properties
             ssh_tunnel = None
-            # if self._properties.get("ssh_tunnel"):
-            #     ssh_tunnel = SSHTunnel(**self._properties["ssh_tunnel"])
+            if ssh_tunnel := self._properties.get("ssh_tunnel"):
+                url = make_url_safe(database.sqlalchemy_uri_decrypted)
+                ssh_tunnel["bind_host"] = url.host
+                ssh_tunnel["bind_port"] = url.port
+                ssh_tunnel = SSHTunnel(**ssh_tunnel)
 
             event_logger.log_with_context(
                 action="test_connection_attempt",
@@ -104,7 +108,7 @@ class TestConnectionDatabaseCommand(BaseCommand):
                 with closing(engine.raw_connection()) as conn:
                     return engine.dialect.do_ping(conn)
 
-            with database.get_sqla_engine_with_context(ssh_tunnel=ssh_tunnel) as engine:
+            with database.get_sqla_engine_with_context(override_ssh_tunnel=ssh_tunnel) as engine:
                 try:
                     alive = func_timeout(
                         app.config["TEST_DATABASE_CONNECTION_TIMEOUT"].total_seconds(),

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -471,10 +471,6 @@ class DatabaseSSHTunnel(Schema):
     private_key = fields.String(required=False)
     private_key_password = fields.String(required=False)
 
-    # remote binding port
-    bind_host = fields.String()
-    bind_port = fields.Integer()
-
 
 class DatabaseTestConnectionSchema(Schema, DatabaseParametersSchemaMixin):
 

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -502,7 +502,7 @@ class DatabaseTestConnectionSchema(Schema, DatabaseParametersSchemaMixin):
         validate=[Length(1, 1024), sqlalchemy_uri_validator],
     )
 
-    ssh_tunnel_credentials = fields.Nested(DatabaseSSHTunnel, allow_none=True)
+    ssh_tunnel = fields.Nested(DatabaseSSHTunnel, allow_none=True)
 
 
 class TableMetadataOptionsResponseSchema(Schema):

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -565,8 +565,8 @@ class Database(
 
     @property
     def inspector(self) -> Inspector:
-        with self.get_sqla_engine_with_context() as engine:
-            return sqla.inspect(engine)
+        engine = self._get_sqla_engine()
+        return sqla.inspect(engine)
 
     @cache_util.memoized_func(
         key="db:{self.id}:schema:{schema}:table_list",
@@ -591,8 +591,7 @@ class Database(
         :return: The table/schema pairs
         """
         try:
-            with self.get_sqla_engine_with_context() as engine:
-                inspector = sqla.inspect(engine)
+            with self.get_inspector_with_context() as inspector:
                 tables = {
                     (table, schema)
                     for table in self.db_engine_spec.get_table_names(
@@ -628,8 +627,7 @@ class Database(
         :return: set of views
         """
         try:
-            with self.get_sqla_engine_with_context() as engine:
-                inspector = sqla.inspect(engine)
+            with self.get_inspector_with_context() as inspector:
                 return {
                     (view, schema)
                     for view in self.db_engine_spec.get_view_names(
@@ -667,8 +665,7 @@ class Database(
         :return: schema list
         """
         try:
-            with self.get_sqla_engine_with_context() as engine:
-                inspector = sqla.inspect(engine)
+            with self.get_inspector_with_context() as inspector:
                 return self.db_engine_spec.get_schema_names(inspector)
         except Exception as ex:
             raise self.db_engine_spec.get_dbapi_mapped_exception(ex) from ex

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -375,9 +375,9 @@ class Database(
         override_ssh_tunnel: Optional["SSHTunnel"] = None,
     ) -> Engine:
         ssh_params = {}
-        from superset.databases.dao import (
+        from superset.databases.dao import ( # pylint: disable=import-outside-toplevel
             DatabaseDAO,
-        )  # pylint: disable=import-outside-toplevel
+        )  
 
         if ssh_tunnel := override_ssh_tunnel or DatabaseDAO.get_ssh_tunnel(
             database_id=self.id

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2405,6 +2405,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             }
             execution_context = SqlJsonExecutionContext(request.json)
             command = self._create_sql_json_command(execution_context, log_params)
+            # breakpoint()
             command_result: CommandResult = command.run()
             return self._create_response_from_execution_context(command_result)
         except SqlLabException as ex:

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2405,7 +2405,6 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             }
             execution_context = SqlJsonExecutionContext(request.json)
             command = self._create_sql_json_command(execution_context, log_params)
-            # breakpoint()
             command_result: CommandResult = command.run()
             return self._create_response_from_execution_context(command_result)
         except SqlLabException as ex:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,8 +70,9 @@ def example_db_provider() -> Callable[[], Database]:
 
 @fixture(scope="session")
 def example_db_engine(example_db_provider: Callable[[], Database]) -> Engine:
-    with example_db_provider().get_sqla_engine_with_context() as engine:
-        return engine
+    with create_app().app_context():
+        with example_db_provider().get_sqla_engine_with_context() as engine:
+            return engine
 
 
 @fixture(scope="session")


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To grab metadata from the database, we enclose the engine property into an inspect class. With ssh tunneling enabled, we need todo the same thing to this function and create a contextmanager to create ssh tunnel and tear it down on any request to the db.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
