### PR TITLE
fix(dashboard): Change horizontal filter bar divider truncation logic

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterDivider.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterDivider.tsx
@@ -37,17 +37,6 @@ const HorizontalDivider = ({ title, description }: FilterDividerProps) => {
   const [titleRef, titleIsTruncated] =
     useCSSTextTruncation<HTMLHeadingElement>();
 
-  const tooltipOverlay = (
-    <>
-      {titleIsTruncated ? (
-        <div>
-          <strong>{title}</strong>
-        </div>
-      ) : null}
-      {description ? <div>{description}</div> : null}
-    </>
-  );
-
   return (
     <div
       css={css`
@@ -58,21 +47,23 @@ const HorizontalDivider = ({ title, description }: FilterDividerProps) => {
         padding-left: ${4 * theme.gridUnit}px;
       `}
     >
-      <h3
-        ref={titleRef}
-        css={css`
-          ${truncationCSS}
-          max-width: ${theme.gridUnit * 32.5}px;
-          font-size: ${theme.typography.sizes.m}px;
-          font-weight: ${theme.typography.weights.normal};
-          margin: 0;
-          color: ${theme.colors.grayscale.dark1};
-        `}
-      >
-        {title}
-      </h3>
-      {titleIsTruncated || description ? (
-        <Tooltip overlay={tooltipOverlay}>
+      <Tooltip overlay={titleIsTruncated ? title : null}>
+        <h3
+          ref={titleRef}
+          css={css`
+            ${truncationCSS}
+            max-width: ${theme.gridUnit * 32.5}px;
+            font-size: ${theme.typography.sizes.m}px;
+            font-weight: ${theme.typography.weights.normal};
+            margin: 0;
+            color: ${theme.colors.grayscale.dark1};
+          `}
+        >
+          {title}
+        </h3>
+      </Tooltip>
+      {description ? (
+        <Tooltip overlay={description}>
           <Icons.BookOutlined
             data-test="divider-description-icon"
             iconSize="l"


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, non-overflowed horizontal native filter dividers follow the following truncation logic:
- If the divider title is truncated or there is a divider description set or both, the description icon is visible
- Hovering over the description icon will show one or both of the following:
  - The full title in bold, if the title is truncated
  - The description if present

This PR modifies that behavior to the following:
- If the divider title is truncated, hovering over the title will show the full title in standard font weight
- If and only if there is a divider description set, the description icon will be visible and hovering over it will show the full description

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

https://user-images.githubusercontent.com/13007381/204424076-99c389c9-f808-4e32-a018-32d691503157.mov

After:

https://user-images.githubusercontent.com/13007381/204424101-b3650161-becb-424b-8153-0d44c0b1c38d.mov


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- For dividers with a non-truncated title and no description, confirm that there is no description icon and no tooltips
- For dividers with a non-truncated title and a description, confirm that there's no tooltip when hovering over the title and that the description icon is visible and shows a tooltip with the description when hovered over
- For dividers with a truncated title and no description, confirm that there's a tooltip with the full title when hovering over the truncated title and that there's no description icon
- For dividers with a truncated title and a description, confirm that there's a tooltip with the full title when hovering over the truncated title and that the description icon is visible and shows a tooltip with the description when hovered over

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Required feature flags: `HORIZONTAL_FILTER_BAR`
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
