### PR TITLE
fix: allow datasource imports on Windows

### DIFF
--- a/superset/commands/importers/v1/utils.py
+++ b/superset/commands/importers/v1/utils.py
@@ -14,7 +14,7 @@
 # under the License.
 
 import logging
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Dict, List, Optional
 from zipfile import ZipFile
 
@@ -34,8 +34,8 @@ logger = logging.getLogger(__name__)
 
 def remove_root(file_path: str) -> str:
     """Remove the first directory of a path"""
-    full_path = Path(file_path)
-    relative_path = Path(*full_path.parts[1:])
+    full_path = PurePosixPath(file_path)
+    relative_path = PurePosixPath(*full_path.parts[1:])
     return str(relative_path)
 
 


### PR DESCRIPTION
### SUMMARY
No sources are added when importing zip files on Windows, as file paths are parsed using `pathlib.PureWindowsPath`. Schemas are defined using prefixes with trailing slashes, therefore file paths in zipfiles should instead be treated as `pathlib.PurePosixPath`s.

Although Superset does not have official Windows support, this change fixes imports without changing the behaviour on Unix, since instantiating `pathlib.Path` creates a `pathlib.PurePosixPath`.

### TESTING INSTRUCTIONS
Import zipfile (e.g. `superset import_dashboards -p dashboard_export.zip`) on WIndows