### PR TITLE
fix(alerts): cron picker alignment issues

### DIFF
--- a/superset-frontend/src/components/CronPicker/CronPicker.tsx
+++ b/superset-frontend/src/components/CronPicker/CronPicker.tsx
@@ -122,4 +122,10 @@ export const CronPicker = styled((props: CronProps) => (
   .react-js-cron-custom-select > div:first-of-type {
     border-radius: ${({ theme }) => theme.gridUnit}px;
   }
+  .react-js-cron-custom-select .ant-select-selection-placeholder {
+    flex: auto;
+  }
+  .react-js-cron-custom-select .ant-select-selection-overflow-item {
+    align-self: center;
+  }
 `;


### PR DESCRIPTION
### SUMMARY

Following the latest antd upgrade, the cron job picker in the alerts/report present some alignment issues in the selects.
This PR addresses those.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

<img width="457" alt="old" src="https://user-images.githubusercontent.com/17252075/204816623-82e6a19c-b2dd-4940-bd28-c977f69754c8.png">

After:

<img width="445" alt="Screenshot 2022-11-30 at 10 54 38" src="https://user-images.githubusercontent.com/17252075/204816663-55cf7992-a22e-4612-bd3d-660189be03f3.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
