### PR TITLE
fix: Horizontal filter bar resizing

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
@@ -144,6 +144,7 @@ const FilterControls: FC<FilterControlsProps> = ({
         css`
           padding-left: ${theme.gridUnit * 4}px;
           min-width: 0;
+          flex: 1;
         `
       }
     >


### PR DESCRIPTION
### SUMMARY
Fixes horizontal filter bar resizing by making the central container use the available space. This also aligns the Apply and Clear All buttons to the right in a similar way they are aligned to the bottom when in vertical mode.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/204903515-1c2104e5-7b44-40c2-9c0b-0b35667894b2.mov

### TESTING INSTRUCTIONS
Check the video for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
