### PR TITLE
feat: Automatically closes the DropdownContainer when scrolling outside of the component

### DIFF
--- a/superset-frontend/src/components/DropdownContainer/index.tsx
+++ b/superset-frontend/src/components/DropdownContainer/index.tsx
@@ -274,11 +274,13 @@ const DropdownContainer = forwardRef(
 
     // Closes the popover when scrolling on the document
     useEffect(() => {
-      document.onscroll = () => setPopoverVisible(false);
+      document.onscroll = popoverVisible
+        ? () => setPopoverVisible(false)
+        : null;
       return () => {
         document.onscroll = null;
       };
-    }, []);
+    }, [popoverVisible]);
 
     return (
       <div

--- a/superset-frontend/src/components/DropdownContainer/index.tsx
+++ b/superset-frontend/src/components/DropdownContainer/index.tsx
@@ -272,6 +272,14 @@ const DropdownContainer = forwardRef(
       [ref],
     );
 
+    // Closes the popover when scrolling on the document
+    useEffect(() => {
+      document.onscroll = () => setPopoverVisible(false);
+      return () => {
+        document.onscroll = null;
+      };
+    }, []);
+
     return (
       <div
         ref={ref}


### PR DESCRIPTION
### SUMMARY
Automatically closes the `DropdownContainer` when scrolling outside of the component.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/204912730-974ed14f-ec05-443f-b6c2-5236ba12eaaf.mov

### TESTING INSTRUCTIONS
Check the video for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
