### PR TITLE
fix(native-filters): Misc spacing fixes for horizontal and horizontal overflow filter bar items

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
@@ -97,8 +97,11 @@ const HorizontalFilterControlContainer = styled(Form)`
 const HorizontalOverflowFilterControlContainer = styled(
   VerticalFilterControlContainer,
 )`
-  && .ant-form-item-label > label {
-    padding-right: unset;
+  && .ant-form-item-label {
+    line-height: 1;
+    & > label {
+      padding-right: unset;
+    }
   }
 `;
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
@@ -114,6 +114,7 @@ const FilterControls: FC<FilterControlsProps> = ({
         id: filter.id,
         element: (
           <div
+            className="filter-item-wrapper"
             css={css`
               flex-shrink: 0;
             `}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterDivider.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterDivider.tsx
@@ -42,7 +42,7 @@ const HorizontalDivider = ({ title, description }: FilterDividerProps) => {
       css={css`
         display: flex;
         align-items: center;
-        height: ${8 * theme.gridUnit}px;
+        height: ${6 * theme.gridUnit}px;
         border-left: 1px solid ${theme.colors.grayscale.light2};
         padding-left: ${4 * theme.gridUnit}px;
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterDivider.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterDivider.tsx
@@ -114,6 +114,7 @@ const HorizontalOverflowDivider = ({
             font-weight: ${theme.typography.weights.normal};
             font-size: ${theme.typography.sizes.m}px;
             margin: 0 0 ${theme.gridUnit}px 0;
+            line-height: 1;
           `}
         >
           {title}
@@ -129,7 +130,8 @@ const HorizontalOverflowDivider = ({
               display: block;
               font-size: ${theme.typography.sizes.s}px;
               color: ${theme.colors.grayscale.base};
-              margin: 0;
+              margin: ${theme.gridUnit * 2.5}px 0 0 0;
+              line-height: 1;
             `}
           >
             {description}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterDivider.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterDivider.tsx
@@ -45,6 +45,11 @@ const HorizontalDivider = ({ title, description }: FilterDividerProps) => {
         height: ${8 * theme.gridUnit}px;
         border-left: 1px solid ${theme.colors.grayscale.light2};
         padding-left: ${4 * theme.gridUnit}px;
+
+        .filter-item-wrapper:first-child & {
+          border-left: none;
+          padding-left: 0;
+        }
       `}
     >
       <Tooltip overlay={titleIsTruncated ? title : null}>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FiltersDropdownContent/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FiltersDropdownContent/index.tsx
@@ -38,6 +38,7 @@ export const FiltersDropdownContent = ({
     css={(theme: SupersetTheme) =>
       css`
         width: ${theme.gridUnit * 56}px;
+        padding: ${theme.gridUnit}px 0;
       `
     }
   >
@@ -46,6 +47,7 @@ export const FiltersDropdownContent = ({
       <FiltersOutOfScopeCollapsible
         filtersOutOfScope={filtersOutOfScope}
         renderer={renderer}
+        horizontalOverflow
       />
     )}
   </div>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FiltersOutOfScopeCollapsible/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FiltersOutOfScopeCollapsible/index.tsx
@@ -18,46 +18,66 @@
  */
 import React, { ReactNode } from 'react';
 import { css } from '@emotion/react';
-import { Divider, Filter, t } from '@superset-ui/core';
+import { Divider, Filter, SupersetTheme, t } from '@superset-ui/core';
 import { AntdCollapse } from 'src/components';
 
 export interface FiltersOutOfScopeCollapsibleProps {
   filtersOutOfScope: (Filter | Divider)[];
   renderer: (filter: Filter | Divider) => ReactNode;
   hasTopMargin?: boolean;
+  horizontalOverflow?: boolean;
 }
 
 export const FiltersOutOfScopeCollapsible = ({
   filtersOutOfScope,
-  hasTopMargin,
   renderer,
+  hasTopMargin,
+  horizontalOverflow,
 }: FiltersOutOfScopeCollapsibleProps) => (
   <AntdCollapse
     ghost
     bordered
     expandIconPosition="right"
     collapsible={filtersOutOfScope.length === 0 ? 'disabled' : undefined}
-    css={theme => css`
-      &.ant-collapse {
-        margin-top: ${hasTopMargin
-          ? theme.gridUnit * 6
-          : theme.gridUnit * -3}px;
-        & > .ant-collapse-item {
-          & > .ant-collapse-header {
-            padding-left: 0;
-            padding-bottom: ${theme.gridUnit * 2}px;
+    css={(theme: SupersetTheme) =>
+      horizontalOverflow
+        ? css`
+            &.ant-collapse > .ant-collapse-item {
+              & > .ant-collapse-header {
+                padding: 0;
 
-            & > .ant-collapse-arrow {
-              right: ${theme.gridUnit}px;
+                & > .ant-collapse-arrow {
+                  right: 0;
+                  padding: 0;
+                }
+              }
+
+              & .ant-collapse-content-box {
+                padding: ${theme.gridUnit * 4}px 0 0;
+                margin-bottom: ${theme.gridUnit * -4}px;
+              }
             }
-          }
+          `
+        : css`
+            &.ant-collapse {
+              margin-top: ${hasTopMargin ? theme.gridUnit * 6 : 0}px;
+              & > .ant-collapse-item {
+                & > .ant-collapse-header {
+                  padding-left: 0;
+                  padding-bottom: ${theme.gridUnit * 2}px;
 
-          & .ant-collapse-content-box {
-            padding: ${theme.gridUnit * 4}px 0 0;
-          }
-        }
-      }
-    `}
+                  & > .ant-collapse-arrow {
+                    right: ${theme.gridUnit}px;
+                  }
+                }
+
+                & .ant-collapse-content-box {
+                  padding: ${theme.gridUnit * 4}px 0 0;
+                }
+              }
+            }
+          `
+    }
   >
     <AntdCollapse.Panel
       header={t('Filters out of scope (%d)', filtersOutOfScope.length)}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR tightens up some styles:
- There is no longer double divider lines when a divider is the first item in the horizontal filter bar.
- The initial divider line and the other divider lines in the horizontal filter bar are now the same height.
- Text spacing in the overflow menu is now more uniform.
- The "Filters out of scope" item in horizontal overflow no longer has unbalanced top/bottom margin when it's the only item.
- "Filters out of scope" in horizontal overflow contents are now more consistently spaced.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
<img width="594" alt="Screen Shot 2022-11-30 at 4 24 02 PM" src="https://user-images.githubusercontent.com/13007381/204933929-add0be3f-a0bb-41f1-9690-845fd7c5490a.png">
<img width="647" alt="Screen Shot 2022-11-30 at 4 24 34 PM" src="https://user-images.githubusercontent.com/13007381/204933942-898e4627-0e44-416c-9b04-e02465b4c595.png">
<img width="384" alt="Screen Shot 2022-11-30 at 4 24 59 PM" src="https://user-images.githubusercontent.com/13007381/204933948-c7a8083d-660f-43cf-be75-49bf5009e4bb.png">
<img width="444" alt="Screen Shot 2022-11-30 at 4 25 03 PM" src="https://user-images.githubusercontent.com/13007381/204933955-e40b698c-1b54-4fe7-9ec9-4c84f3f6a0e7.png">

After:
<img width="629" alt="Screen Shot 2022-11-30 at 4 22 34 PM" src="https://user-images.githubusercontent.com/13007381/204933886-0b11581d-ec25-4f3a-ade9-79ef1886a5dd.png">
<img width="647" alt="Screen Shot 2022-11-30 at 4 22 45 PM" src="https://user-images.githubusercontent.com/13007381/204933894-a837aad4-6b42-496f-92ee-e619d78d11bf.png">
<img width="410" alt="Screen Shot 2022-11-30 at 4 23 08 PM" src="https://user-images.githubusercontent.com/13007381/204933907-11fffecf-7347-47df-b4ea-16f96fcb9c22.png">
<img width="508" alt="Screen Shot 2022-11-30 at 4 23 13 PM" src="https://user-images.githubusercontent.com/13007381/204933920-d4b42121-0929-4fc6-b532-4086c02f2052.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Check that the above spacing/styling issues are resolved.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Required feature flags: `HORIZONTAL_FILTER_BAR`
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
