### PR TITLE
Avoid filtering falsy values from clipboard output

### DIFF
--- a/superset-frontend/src/utils/common.js
+++ b/superset-frontend/src/utils/common.js
@@ -86,7 +86,7 @@ export function prepareCopyToClipboardTabularData(data, columns) {
       // JavaScript does not maintain the order of a mixed set of keys (i.e integers and strings)
       // the below function orders the keys based on the column names.
       const key = columns[j].name || columns[j];
-      if (key in data[i]) {
+      if (data[i][key] === undefined || data[i][key] === null) {
         row[j] = data[i][key];
       } else {
         row[j] = data[i][parseFloat(key)];


### PR DESCRIPTION
<!---
Fix for https://github.com/apache/superset/issues/22291: copy falsy values correctly
-->

### SUMMARY
JS incorrectly filters any falsy values (e.g. 0, false)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
See linked issue.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
