### PR TITLE
fix(init): Initialize _jwt_cookie_name  in AsyncQueryManager __init__ 

### DIFF
--- a/superset/utils/async_query_manager.py
+++ b/superset/utils/async_query_manager.py
@@ -77,7 +77,7 @@ class AsyncQueryManager:
         self._stream_prefix: str = ""
         self._stream_limit: Optional[int]
         self._stream_limit_firehose: Optional[int]
-        self._jwt_cookie_name: str
+        self._jwt_cookie_name: str = ""
         self._jwt_cookie_secure: bool = False
         self._jwt_cookie_domain: Optional[str]
         self._jwt_secret: str


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We face an issue. After setting `GLOBAL_ASYNC_QUERIES` to `True` and switching back again to `False` we gain errors `'AsyncQueryManager' object has no attribute '_jwt_cookie_name'`. 
Stacktrace of this error:
```
File "/usr/local/lib/python3.7/site-packages/flask_appbuilder/api/__init__.py", line 85, in wraps
    return f(self, *args, **kwargs)
  File "/app/superset/async_events/api.py", line 92, in events
    async_channel_id = async_query_manager.parse_jwt_from_request(request)[
  File "/app/superset/utils/async_query_manager.py", line 162, in parse_jwt_from_request
    token = req.cookies.get(self._jwt_cookie_name)
AttributeError: 'AsyncQueryManager' object has no attribute '_jwt_cookie_name'
```

Initializing this field inside `__init__ ` fixes this issue.
