### PR TITLE
feat: New time range label

### DIFF
--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -44,8 +44,8 @@ import {
   CalendarFrame,
   CustomFrame,
   AdvancedFrame,
+  DateLabel,
 } from './components';
-import { DateLabel } from './components/DateLabel';
 
 const StyledRangeType = styled(Select)`
   width: 272px;

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -179,7 +179,15 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
           const tooltipTitle = labelIsTruncated ? (
             <div>
               <strong>{actualRange}</strong>
-              {value && <div>{value}</div>}
+              {value && (
+                <div
+                  css={css`
+                    margin-top: ${theme.gridUnit}px;
+                  `}
+                >
+                  {value}
+                </div>
+              )}
             </div>
           ) : (
             value || null

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -16,8 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useState, useEffect, useMemo } from 'react';
-import { css, styled, t, useTheme, NO_TIME_RANGE } from '@superset-ui/core';
+import React, { ReactNode, useState, useEffect, useMemo } from 'react';
+import {
+  css,
+  styled,
+  t,
+  useTheme,
+  NO_TIME_RANGE,
+  SupersetTheme,
+} from '@superset-ui/core';
 import Button from 'src/components/Button';
 import ControlHeader from 'src/explore/components/ControlHeader';
 import Modal from 'src/components/Modal';
@@ -121,6 +128,28 @@ const IconWrapper = styled.span`
   }
 `;
 
+const getTooltipTitle = (
+  isLabelTruncated: boolean,
+  label: string | undefined,
+  range: string | undefined,
+) =>
+  isLabelTruncated ? (
+    <div>
+      {label && <strong>{label}</strong>}
+      {range && (
+        <div
+          css={(theme: SupersetTheme) => css`
+            margin-top: ${theme.gridUnit}px;
+          `}
+        >
+          {range}
+        </div>
+      )}
+    </div>
+  ) : (
+    range || null
+  );
+
 export default function DateFilterLabel(props: DateFilterControlProps) {
   const {
     onChange,
@@ -140,7 +169,7 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
   const [timeRangeValue, setTimeRangeValue] = useState(value);
   const [validTimeRange, setValidTimeRange] = useState<boolean>(false);
   const [evalResponse, setEvalResponse] = useState<string>(value);
-  const [tooltipTitle, setTooltipTitle] = useState<string | null>(value);
+  const [tooltipTitle, setTooltipTitle] = useState<ReactNode | null>(value);
   const theme = useTheme();
   const [labelRef, labelIsTruncated] = useCSSTextTruncation<HTMLSpanElement>();
 
@@ -174,26 +203,14 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
           guessedFrame === 'No filter'
         ) {
           setActualTimeRange(value);
-          setTooltipTitle(labelIsTruncated ? value : null);
-        } else {
-          const tooltipTitle = labelIsTruncated ? (
-            <div>
-              <strong>{actualRange}</strong>
-              {value && (
-                <div
-                  css={css`
-                    margin-top: ${theme.gridUnit}px;
-                  `}
-                >
-                  {value}
-                </div>
-              )}
-            </div>
-          ) : (
-            value || null
+          setTooltipTitle(
+            getTooltipTitle(labelIsTruncated, value, actualRange),
           );
+        } else {
           setActualTimeRange(actualRange || '');
-          setTooltipTitle(tooltipTitle);
+          setTooltipTitle(
+            getTooltipTitle(labelIsTruncated, actualRange, value),
+          );
         }
         setValidTimeRange(true);
       }

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -177,12 +177,10 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
           setTooltipTitle(labelIsTruncated ? value : null);
         } else {
           const tooltipTitle = labelIsTruncated ? (
-            <>
-              <div>
-                <strong>{actualRange}</strong>
-                {value && <div>{value}</div>}
-              </div>
-            </>
+            <div>
+              <strong>{actualRange}</strong>
+              {value && <div>{value}</div>}
+            </div>
           ) : (
             value || null
           );

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -20,7 +20,6 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { css, styled, t, useTheme, NO_TIME_RANGE } from '@superset-ui/core';
 import Button from 'src/components/Button';
 import ControlHeader from 'src/explore/components/ControlHeader';
-import Label from 'src/components/Label';
 import Modal from 'src/components/Modal';
 import { Divider } from 'src/components';
 import Icons from 'src/components/Icons';
@@ -45,6 +44,7 @@ import {
   CustomFrame,
   AdvancedFrame,
 } from './components';
+import { DateLabel } from './components/DateLabel';
 
 const StyledRangeType = styled(Select)`
   width: 272px;
@@ -322,12 +322,12 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
       overlayStyle={{ width: '600px' }}
     >
       <Tooltip placement="top" title={tooltipTitle}>
-        <Label
-          className="pointer"
+        <DateLabel
+          label={actualTimeRange}
+          isActive={show}
+          isPlaceholder={actualTimeRange === NO_TIME_RANGE}
           data-test={DATE_FILTER_TEST_KEY.popoverOverlay}
-        >
-          {actualTimeRange}
-        </Label>
+        />
       </Tooltip>
     </ControlPopover>
   );
@@ -335,13 +335,13 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
   const modalContent = (
     <>
       <Tooltip placement="top" title={tooltipTitle}>
-        <Label
-          className="pointer"
+        <DateLabel
           onClick={toggleOverlay}
+          label={actualTimeRange}
+          isActive={show}
+          isPlaceholder={actualTimeRange === NO_TIME_RANGE}
           data-test={DATE_FILTER_TEST_KEY.modalOverlay}
-        >
-          {actualTimeRange}
-        </Label>
+        />
       </Tooltip>
       {/* the zIndex value is from trying so that the Modal doesn't overlay the AdhocFilter when GENERIC_CHART_AXES is enabled */}
       <Modal

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/components/DateLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/components/DateLabel.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { ReactNode } from 'react';
+import React, { forwardRef, ReactNode, RefObject } from 'react';
 import { css, styled, useTheme } from '@superset-ui/core';
 import Icons from 'src/components/Icons';
 
@@ -79,15 +79,19 @@ const LabelContainer = styled.div<{
   `}
 `;
 
-export const DateLabel = (props: DateLabelProps) => {
-  const theme = useTheme();
-  return (
-    <LabelContainer {...props}>
-      <span className="date-label-content">{props.label}</span>
-      <Icons.CalendarOutlined
-        iconSize="s"
-        iconColor={theme.colors.grayscale.base}
-      />
-    </LabelContainer>
-  );
-};
+export const DateLabel = forwardRef(
+  (props: DateLabelProps, ref: RefObject<HTMLSpanElement>) => {
+    const theme = useTheme();
+    return (
+      <LabelContainer {...props}>
+        <span className="date-label-content" ref={ref}>
+          {props.label}
+        </span>
+        <Icons.CalendarOutlined
+          iconSize="s"
+          iconColor={theme.colors.grayscale.base}
+        />
+      </LabelContainer>
+    );
+  },
+);

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/components/DateLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/components/DateLabel.tsx
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { ReactNode } from 'react';
+import { css, styled, useTheme } from '@superset-ui/core';
+import Icons from 'src/components/Icons';
+
+export type DateLabelProps = {
+  label: ReactNode;
+  isActive?: boolean;
+  isPlaceholder?: boolean;
+  onClick?: (event: React.MouseEvent) => void;
+};
+
+// This is the color that antd components (such as Select or Input) use on hover
+// TODO: use theme.colors.primary.base here and in antd components
+const ACTIVE_BORDER_COLOR = '#45BED6';
+
+const LabelContainer = styled.div<{
+  isActive?: boolean;
+  isPlaceholder?: boolean;
+}>`
+  ${({ theme, isActive, isPlaceholder }) => css`
+    width: 100%;
+    height: ${theme.gridUnit * 8}px;
+
+    display: flex;
+    align-items: center;
+    flex-wrap: nowrap;
+
+    padding: 0 ${theme.gridUnit * 3}px;
+
+    background-color: ${theme.colors.grayscale.light5};
+
+    border: 1px solid
+      ${isActive ? ACTIVE_BORDER_COLOR : theme.colors.grayscale.light2};
+    border-radius: ${theme.borderRadius}px;
+
+    transition: border-color 0.3s cubic-bezier(0.65, 0.05, 0.36, 1);
+    :hover {
+      border-color: ${ACTIVE_BORDER_COLOR};
+    }
+
+    .date-label-content {
+      color: ${isPlaceholder
+        ? theme.colors.grayscale.light1
+        : theme.colors.grayscale.dark1};
+      overflow: hidden;
+      text-overflow: ellipsis;
+      min-width: 0;
+      flex-shrink: 1;
+      white-space: nowrap;
+    }
+
+    span[role='img'] {
+      margin-left: auto;
+      padding-left: ${theme.gridUnit}px;
+
+      & > span[role='img'] {
+        line-height: 0;
+      }
+    }
+  `}
+`;
+
+export const DateLabel = (props: DateLabelProps) => {
+  const theme = useTheme();
+  return (
+    <LabelContainer {...props}>
+      <span className="date-label-content">{props.label}</span>
+      <Icons.CalendarOutlined
+        iconSize="s"
+        iconColor={theme.colors.grayscale.base}
+      />
+    </LabelContainer>
+  );
+};

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/components/DateLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/components/DateLabel.tsx
@@ -52,8 +52,11 @@ const LabelContainer = styled.div<{
       ${isActive ? ACTIVE_BORDER_COLOR : theme.colors.grayscale.light2};
     border-radius: ${theme.borderRadius}px;
 
+    cursor: pointer;
+
     transition: border-color 0.3s cubic-bezier(0.65, 0.05, 0.36, 1);
-    :hover {
+    :hover,
+    :focus {
       border-color: ${ACTIVE_BORDER_COLOR};
     }
 
@@ -83,7 +86,7 @@ export const DateLabel = forwardRef(
   (props: DateLabelProps, ref: RefObject<HTMLSpanElement>) => {
     const theme = useTheme();
     return (
-      <LabelContainer {...props}>
+      <LabelContainer {...props} tabIndex={0}>
         <span className="date-label-content" ref={ref}>
           {props.label}
         </span>

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/components/index.ts
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/components/index.ts
@@ -20,3 +20,4 @@ export { CommonFrame } from './CommonFrame';
 export { CalendarFrame } from './CalendarFrame';
 export { CustomFrame } from './CustomFrame';
 export { AdvancedFrame } from './AdvancedFrame';
+export { DateLabel } from './DateLabel';

--- a/superset-frontend/src/filters/components/Time/TimeFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Time/TimeFilterPlugin.tsx
@@ -38,6 +38,7 @@ const ControlContainer = styled.div<{
   display: flex;
   height: 100%;
   max-width: 100%;
+  width: 100%;
   padding: 2px;
   & > span,
   & > span:hover {

--- a/superset-frontend/src/filters/components/Time/TimeFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Time/TimeFilterPlugin.tsx
@@ -39,28 +39,10 @@ const ControlContainer = styled.div<{
   height: 100%;
   max-width: 100%;
   width: 100%;
-  padding: 2px;
-  & > span,
-  & > span:hover {
-    border: 2px solid transparent;
-    display: inline-block;
-    border: ${({ theme, validateStatus }) =>
-      validateStatus && `2px solid ${theme.colors[validateStatus]?.base}`};
-  }
-  &:focus {
-    & > span {
-      border: 2px solid
-        ${({ theme, validateStatus }) =>
-          validateStatus
-            ? theme.colors[validateStatus]?.base
-            : theme.colors.primary.base};
-      outline: 0;
-      box-shadow: 0 0 0 2px
-        ${({ validateStatus }) =>
-          validateStatus
-            ? 'rgba(224, 67, 85, 12%)'
-            : 'rgba(32, 167, 201, 0.2)'};
-    }
+  & > div,
+  & > div:hover {
+    ${({ validateStatus, theme }) =>
+      validateStatus && `border-color: ${theme.colors[validateStatus]?.base}`}
   }
 `;
 
@@ -100,7 +82,6 @@ export default function TimeFilterPlugin(props: PluginFilterTimeProps) {
   return props.formData?.inView ? (
     <TimeFilterStyles width={width} height={height}>
       <ControlContainer
-        tabIndex={-1}
         ref={inputRef}
         validateStatus={filterState.validateStatus}
         onFocus={setFocusedFilter}


### PR DESCRIPTION

### SUMMARY
This PR implements the new design for time range pill. Functionality wise it works the same as before, except that I added additional tooltip when the label is truncated.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->


https://user-images.githubusercontent.com/15073128/205328748-10f7a70b-1caf-4ecb-9df7-ba75023c82ab.mov



### TESTING INSTRUCTIONS
Test the new time range pill in native filters (horizontal and vertical), in native filters config modal and in Explore adhoc filters.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
