### PR TITLE
fix: DropdownContainer resize algorithm

### DIFF
--- a/superset-frontend/src/components/DropdownContainer/DropdownContainer.stories.tsx
+++ b/superset-frontend/src/components/DropdownContainer/DropdownContainer.stories.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { isEqual } from 'lodash';
 import { css } from '@superset-ui/core';
 import Select from '../Select/Select';
@@ -63,10 +63,15 @@ export const Component = (props: DropdownContainerProps) => {
   const [items, setItems] = useState<ItemsType>([]);
   const [overflowingState, setOverflowingState] = useState<OverflowingState>();
   const containerRef = React.useRef<Ref>(null);
-
-  useEffect(() => {
-    setItems(generateItems(overflowingState));
-  }, [overflowingState]);
+  const onOverflowingStateChange = useCallback(
+    value => {
+      if (!isEqual(overflowingState, value)) {
+        setItems(generateItems(value));
+        setOverflowingState(value);
+      }
+    },
+    [overflowingState],
+  );
 
   return (
     <div>
@@ -86,11 +91,7 @@ export const Component = (props: DropdownContainerProps) => {
         <DropdownContainer
           {...props}
           items={items}
-          onOverflowingStateChange={value => {
-            if (!isEqual(overflowingState, value)) {
-              setOverflowingState(value);
-            }
-          }}
+          onOverflowingStateChange={onOverflowingStateChange}
           ref={containerRef}
         />
       </div>

--- a/superset-frontend/src/components/DropdownContainer/index.tsx
+++ b/superset-frontend/src/components/DropdownContainer/index.tsx
@@ -142,33 +142,42 @@ const DropdownContainer = forwardRef(
         const childrenArray = Array.from(children);
 
         // Stores items width once
-        if (itemsWidth.length === 0) {
+        if (itemsWidth.length === 0 && childrenArray.length > 0) {
           setItemsWidth(
             childrenArray.map(child => child.getBoundingClientRect().width),
           );
         }
 
         // Calculates the index of the first overflowed element
+        // +1 is to give at least one pixel of difference and avoid flakiness
         const index = childrenArray.findIndex(
           child =>
             child.getBoundingClientRect().right >
-            container.getBoundingClientRect().right,
+            container.getBoundingClientRect().right + 1,
         );
-        setOverflowingIndex(index === -1 ? children.length : index);
 
-        if (width > previousWidth && overflowingIndex !== -1) {
+        let newOverflowingIndex = index === -1 ? children.length : index;
+
+        if (width > previousWidth && newOverflowingIndex !== -1) {
           // Calculates remaining space in the container
           const button = current?.children.item(1);
           const buttonRight = button?.getBoundingClientRect().right || 0;
           const containerRight = current?.getBoundingClientRect().right || 0;
           const remainingSpace = containerRight - buttonRight;
-          // Checks if the first element in the dropdown fits in the remaining space
-          const fitsInRemainingSpace = remainingSpace >= itemsWidth[0];
-          if (fitsInRemainingSpace && overflowingIndex < items.length) {
-            // Moves element from dropdown to container
-            setOverflowingIndex(overflowingIndex + 1);
+
+          // Checks if some elements in the dropdown fits in the remaining space
+          let sum = 0;
+          for (let i = newOverflowingIndex; i < items.length; i += 1) {
+            sum += itemsWidth[i];
+            if (sum <= remainingSpace) {
+              newOverflowingIndex = i + 1;
+            } else {
+              break;
+            }
           }
         }
+
+        setOverflowingIndex(newOverflowingIndex);
       }
     }, [
       current,
@@ -206,7 +215,7 @@ const DropdownContainer = forwardRef(
     const [overflowedItems, overflowedIds] = useMemo(
       () =>
         overflowingIndex !== -1
-          ? reduceItems(items.slice(overflowingIndex, items.length))
+          ? reduceItems(items.slice(overflowingIndex))
           : [[], []],
       [items, overflowingIndex],
     );
@@ -296,7 +305,7 @@ const DropdownContainer = forwardRef(
             align-items: center;
             gap: ${theme.gridUnit * 4}px;
             margin-right: ${theme.gridUnit * 3}px;
-            min-width: 100px;
+            min-width: 0px;
           `}
           data-test="container"
           style={style}

--- a/superset-frontend/src/components/DropdownContainer/index.tsx
+++ b/superset-frontend/src/components/DropdownContainer/index.tsx
@@ -135,59 +135,6 @@ const DropdownContainer = forwardRef(
 
     const [showOverflow, setShowOverflow] = useState(false);
 
-    useLayoutEffect(() => {
-      const container = current?.children.item(0);
-      if (container) {
-        const { children } = container;
-        const childrenArray = Array.from(children);
-
-        // Stores items width once
-        if (itemsWidth.length === 0 && childrenArray.length > 0) {
-          setItemsWidth(
-            childrenArray.map(child => child.getBoundingClientRect().width),
-          );
-        }
-
-        // Calculates the index of the first overflowed element
-        // +1 is to give at least one pixel of difference and avoid flakiness
-        const index = childrenArray.findIndex(
-          child =>
-            child.getBoundingClientRect().right >
-            container.getBoundingClientRect().right + 1,
-        );
-
-        let newOverflowingIndex = index === -1 ? children.length : index;
-
-        if (width > previousWidth && newOverflowingIndex !== -1) {
-          // Calculates remaining space in the container
-          const button = current?.children.item(1);
-          const buttonRight = button?.getBoundingClientRect().right || 0;
-          const containerRight = current?.getBoundingClientRect().right || 0;
-          const remainingSpace = containerRight - buttonRight;
-
-          // Checks if some elements in the dropdown fits in the remaining space
-          let sum = 0;
-          for (let i = newOverflowingIndex; i < items.length; i += 1) {
-            sum += itemsWidth[i];
-            if (sum <= remainingSpace) {
-              newOverflowingIndex = i + 1;
-            } else {
-              break;
-            }
-          }
-        }
-
-        setOverflowingIndex(newOverflowingIndex);
-      }
-    }, [
-      current,
-      items.length,
-      itemsWidth,
-      overflowingIndex,
-      previousWidth,
-      width,
-    ]);
-
     const reduceItems = (items: Item[]): [Item[], string[]] =>
       items.reduce(
         ([items, ids], item) => {
@@ -219,6 +166,71 @@ const DropdownContainer = forwardRef(
           : [[], []],
       [items, overflowingIndex],
     );
+
+    useEffect(() => {
+      if (itemsWidth.length !== items.length) {
+        const container = current?.children.item(0);
+        if (container) {
+          const { children } = container;
+          const childrenArray = Array.from(children);
+          setItemsWidth(
+            childrenArray.map(child => child.getBoundingClientRect().width),
+          );
+        }
+      }
+    }, [current?.children, items.length, itemsWidth.length]);
+
+    useLayoutEffect(() => {
+      const container = current?.children.item(0);
+      if (container) {
+        const { children } = container;
+        const childrenArray = Array.from(children);
+
+        // Calculates the index of the first overflowed element
+        // +1 is to give at least one pixel of difference and avoid flakiness
+        const index = childrenArray.findIndex(
+          child =>
+            child.getBoundingClientRect().right >
+            container.getBoundingClientRect().right + 1,
+        );
+
+        // If elements fit (-1) and there's overflowed items
+        // then preserve the overflow index. We can't use overflowIndex
+        // directly because the items may have been modified
+        let newOverflowingIndex =
+          index === -1 && overflowedItems.length > 0
+            ? items.length - overflowedItems.length
+            : index;
+
+        if (width > previousWidth) {
+          // Calculates remaining space in the container
+          const button = current?.children.item(1);
+          const buttonRight = button?.getBoundingClientRect().right || 0;
+          const containerRight = current?.getBoundingClientRect().right || 0;
+          const remainingSpace = containerRight - buttonRight;
+
+          // Checks if some elements in the dropdown fits in the remaining space
+          let sum = 0;
+          for (let i = childrenArray.length; i < items.length; i += 1) {
+            sum += itemsWidth[i];
+            if (sum <= remainingSpace) {
+              newOverflowingIndex = i + 1;
+            } else {
+              break;
+            }
+          }
+        }
+
+        setOverflowingIndex(newOverflowingIndex);
+      }
+    }, [
+      current,
+      items.length,
+      itemsWidth,
+      overflowedItems.length,
+      previousWidth,
+      width,
+    ]);
 
     useEffect(() => {
       if (onOverflowingStateChange) {


### PR DESCRIPTION
### SUMMARY
Fixes a bug in the `DropdownContainer` resize algorithm. Previously, the algorithm did not consider moving more than one element simultaneously when there was enough width available.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/205335437-cbfa7d86-4b38-49b1-a8c6-a9efd53032d4.mov

https://user-images.githubusercontent.com/70410625/205334932-ccf377b6-69e3-446d-a410-daf737d2c4cf.mov

### TESTING INSTRUCTIONS
- Open the Storybook or horizontal filter bar
- Resize the screen and check the elements are correctly rendered

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
