### PR TITLE
fix(dashboard): Fix dashboard's left side being cut off

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -22,11 +22,11 @@ import React, {
   FC,
   useCallback,
   useEffect,
-  useState,
   useMemo,
   useRef,
+  useState,
 } from 'react';
-import { JsonObject, styled, css, t } from '@superset-ui/core';
+import { css, JsonObject, styled, t } from '@superset-ui/core';
 import { Global } from '@emotion/react';
 import { useDispatch, useSelector } from 'react-redux';
 import ErrorBoundary from 'src/components/ErrorBoundary';
@@ -57,8 +57,8 @@ import {
 } from 'src/dashboard/actions/dashboardLayout';
 import {
   DASHBOARD_GRID_ID,
-  DASHBOARD_ROOT_ID,
   DASHBOARD_ROOT_DEPTH,
+  DASHBOARD_ROOT_ID,
   DashboardStandaloneMode,
 } from 'src/dashboard/util/constants';
 import FilterBar from 'src/dashboard/components/nativeFilters/FilterBar';
@@ -72,10 +72,10 @@ import {
   FILTER_BAR_HEADER_HEIGHT,
   FILTER_BAR_TABS_HEIGHT,
   MAIN_HEADER_HEIGHT,
-  OPEN_FILTER_BAR_WIDTH,
   OPEN_FILTER_BAR_MAX_WIDTH,
+  OPEN_FILTER_BAR_WIDTH,
 } from 'src/dashboard/constants';
-import { shouldFocusTabs, getRootLevelTabsComponent } from './utils';
+import { getRootLevelTabsComponent, shouldFocusTabs } from './utils';
 import DashboardContainer from './DashboardContainer';
 import { useNativeFilters } from './state';
 
@@ -168,6 +168,7 @@ const StyledDashboardContent = styled.div<{
   dashboardFiltersOpen: boolean;
   editMode: boolean;
   nativeFiltersEnabled: boolean;
+  filterBarOrientation: FilterBarOrientation;
 }>`
   display: flex;
   flex-direction: row;
@@ -193,8 +194,14 @@ const StyledDashboardContent = styled.div<{
       dashboardFiltersOpen,
       editMode,
       nativeFiltersEnabled,
+      filterBarOrientation,
     }) => {
-      if (!dashboardFiltersOpen && !editMode && nativeFiltersEnabled) {
+      if (
+        !dashboardFiltersOpen &&
+        !editMode &&
+        nativeFiltersEnabled &&
+        filterBarOrientation !== FilterBarOrientation.HORIZONTAL
+      ) {
         return 0;
       }
       return theme.gridUnit * 8;
@@ -335,9 +342,19 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
   const draggableStyle = useMemo(
     () => ({
       marginLeft:
-        dashboardFiltersOpen || editMode || !nativeFiltersEnabled ? 0 : -32,
+        dashboardFiltersOpen ||
+        editMode ||
+        !nativeFiltersEnabled ||
+        filterBarOrientation === FilterBarOrientation.HORIZONTAL
+          ? 0
+          : -32,
     }),
-    [dashboardFiltersOpen, editMode, nativeFiltersEnabled],
+    [
+      dashboardFiltersOpen,
+      editMode,
+      filterBarOrientation,
+      nativeFiltersEnabled,
+    ],
   );
 
   // If a new tab was added, update the directPathToChild to reflect it
@@ -505,6 +522,7 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
             dashboardFiltersOpen={dashboardFiltersOpen}
             editMode={editMode}
             nativeFiltersEnabled={nativeFiltersEnabled}
+            filterBarOrientation={filterBarOrientation}
           >
             {showDashboard ? (
               <DashboardContainer topLevelTabs={topLevelTabs} />


### PR DESCRIPTION

### SUMMARY
When native filter's bar was empty and in horizontal mode, dashboard's left side was cut off. This PR fixes that bug.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1791" alt="image" src="https://user-images.githubusercontent.com/15073128/205369356-89b7ff1e-0987-43c5-af1d-388e36e8254b.png">

After:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/15073128/205369191-e615040e-68cc-42f6-a126-1b5cbd210709.png">


### TESTING INSTRUCTIONS
1. Enable HORIZONTAL_FILTER_BAR ff
2. Open a dashboard that has horizontal mode set and 0 filters added
3. Verify that the spacing on the left side is correct
4. Add filters and verify that it still works

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
