### PR TITLE
fix: convert <NA> values to None instead of stringifying

### DIFF
--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -67,7 +67,11 @@ def stringify_values(array: np.ndarray) -> np.ndarray:
 
     with np.nditer(result, flags=["refs_ok"], op_flags=["readwrite"]) as it:
         for obj in it:
-            obj[...] = stringify(obj)
+            if pd.isna(obj):
+                # pandas <NA> type cannot be converted to string
+                obj[pd.isna(obj)] = None
+            else:
+                obj[...] = stringify(obj)
 
     return result
 

--- a/tests/unit_tests/result_set_test.py
+++ b/tests/unit_tests/result_set_test.py
@@ -18,6 +18,13 @@
 # pylint: disable=import-outside-toplevel, unused-argument
 
 
+import numpy as np
+import pandas as pd
+from numpy.core.multiarray import array
+
+from superset.result_set import stringify_values
+
+
 def test_column_names_as_bytes() -> None:
     """
     Test that we can handle column names as bytes.
@@ -65,3 +72,37 @@ def test_column_names_as_bytes() -> None:
 |  1 | 2016-01-27 | 392.444 | 396.843 | 391.782 | 394.972 |     394.972 | 47424400 |
     """.strip()
     )
+
+
+def test_stringify_with_null_integers():
+    """
+    Test that we can safely handle type errors when an integer column has a null value
+    """
+
+    data = [
+        ("foo", "bar", pd.NA, None),
+        ("foo", "bar", pd.NA, True),
+        ("foo", "bar", pd.NA, None),
+    ]
+    numpy_dtype = [
+        ("id", "object"),
+        ("value", "object"),
+        ("num", "object"),
+        ("bool", "object"),
+    ]
+
+    array2 = np.array(data, dtype=numpy_dtype)
+    column_names = ["id", "value", "num", "bool"]
+
+    result_set = np.array([stringify_values(array2[column]) for column in column_names])
+
+    expected = np.array(
+        [
+            array(['"foo"', '"foo"', '"foo"'], dtype=object),
+            array(['"bar"', '"bar"', '"bar"'], dtype=object),
+            array([None, None, None], dtype=object),
+            array([None, "true", None], dtype=object),
+        ]
+    )
+
+    assert np.array_equal(result_set, expected)


### PR DESCRIPTION
### SUMMARY
With the pandas pyathena driver, we are seeing some issues with null values for integer columns. The bug is happening at this point where we get a type error 

`TypeError: Unserializable object <NA> of type <class 'pandas._libs.missing.NAType'>` and then we catch the error and try to stringify it, which resulted in `pyarrow.lib.ArrowInvalid: Could not convert <NA> with type NAType: did not recognize Python value type when inferring an Arrow data type`

For this fix, I am returning `None` for all pandas <NA> values so that the printed value looks like other nullable printed values.

### AFTER SCREENSHOTS OR ANIMATED GIF
![_DEV__Superset](https://user-images.githubusercontent.com/5186919/205395465-fdf53145-3558-4fea-ba70-b749c71c6ae4.png)

### TESTING INSTRUCTIONS
An athena db with the pyathena+pandas schema should be able to fetch values that are integer types with null values. 


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
