### PR TITLE
fix(sqllab): Fix autocomplete for SQL Lab

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/SqlEditorLeftBar.test.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/SqlEditorLeftBar.test.jsx
@@ -110,8 +110,8 @@ test('should toggle the table when the header is clicked', async () => {
   userEvent.click(header);
 
   await waitFor(() => {
-    expect(store.getActions()).toHaveLength(2);
-    expect(store.getActions()[1].type).toEqual('COLLAPSE_TABLE');
+    expect(store.getActions()).toHaveLength(4);
+    expect(store.getActions()[3].type).toEqual('COLLAPSE_TABLE');
   });
 });
 

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -185,8 +185,7 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
   } = useTables({
     dbId: database?.id,
     schema: currentSchema,
-    onSuccess: (data: { options: Table[] }) => {
-      onTablesLoad?.(data.options);
+    onSuccess: () => {
       if (isFetched) {
         addSuccessToast(t('List updated'));
       }
@@ -202,6 +201,14 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
       });
     },
   });
+
+  useEffect(() => {
+    // Set the tableOptions in the queryEditor so autocomplete
+    // works on new tabs
+    if (data && isFetched) {
+      onTablesLoad?.(data.options);
+    }
+  }, [data, isFetched, onTablesLoad]);
 
   const tableOptions = useMemo<TableOption[]>(
     () =>


### PR DESCRIPTION
### SUMMARY
Autocompleter uses the table name in the reducer, but info is not being updated so it fails to provide autocomplete options. when opening new tabs. With these changes we make sure such info is available so options can be properly displayed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![error](https://user-images.githubusercontent.com/38889534/205689153-526feb1e-efad-4f55-bc7f-0b4406e38989.gif)

After:
![test](https://user-images.githubusercontent.com/38889534/205689081-25b90ded-5328-4a94-bcb4-c643ebd428e3.gif)


### TESTING INSTRUCTIONS
1. Open SQL Lab and verify the autocomplete for columns work as expected on new tabs

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
