### PR TITLE
chore(datasets): Add /api/v1/dataset/{pk}/column endpoint

### DIFF
--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -257,7 +257,7 @@
       "AnnotationLayerRestApi.get_list": {
         "properties": {
           "changed_by": {
-            "$ref": "#/components/schemas/AnnotationLayerRestApi.get_list.User1"
+            "$ref": "#/components/schemas/AnnotationLayerRestApi.get_list.User"
           },
           "changed_on": {
             "format": "date-time",
@@ -268,7 +268,7 @@
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/AnnotationLayerRestApi.get_list.User"
+            "$ref": "#/components/schemas/AnnotationLayerRestApi.get_list.User1"
           },
           "created_on": {
             "format": "date-time",
@@ -414,13 +414,13 @@
       "AnnotationRestApi.get_list": {
         "properties": {
           "changed_by": {
-            "$ref": "#/components/schemas/AnnotationRestApi.get_list.User1"
+            "$ref": "#/components/schemas/AnnotationRestApi.get_list.User"
           },
           "changed_on_delta_humanized": {
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/AnnotationRestApi.get_list.User"
+            "$ref": "#/components/schemas/AnnotationRestApi.get_list.User1"
           },
           "end_dttm": {
             "format": "date-time",
@@ -543,6 +543,17 @@
             "description": "The annotation start date time",
             "format": "date-time",
             "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "AvailableDomainsSchema": {
+        "properties": {
+          "domains": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           }
         },
         "type": "object"
@@ -822,17 +833,12 @@
       },
       "ChartDataExtras": {
         "properties": {
-          "druid_time_origin": {
-            "description": "Starting point for time grain counting on legacy Druid datasources. Used to change e.g. Monday/Sunday first-day-of-week.",
-            "nullable": true,
-            "type": "string"
-          },
           "having": {
             "description": "HAVING clause to be added to aggregate queries using AND operator.",
             "type": "string"
           },
           "having_druid": {
-            "description": "HAVING filters to be added to legacy Druid datasource queries.",
+            "description": "HAVING filters to be added to legacy Druid datasource queries. This field is deprecated",
             "items": {
               "$ref": "#/components/schemas/ChartDataFilter"
             },
@@ -920,18 +926,20 @@
               "NOT IN",
               "REGEX",
               "IS TRUE",
-              "IS FALSE"
+              "IS FALSE",
+              "TEMPORAL_RANGE"
             ],
             "example": "IN",
             "type": "string"
           },
           "val": {
-            "description": "The value or values to compare against. Can be a string, integer, decimal or list, depending on the operator.",
+            "description": "The value or values to compare against. Can be a string, integer, decimal, None or list, depending on the operator.",
             "example": [
               "China",
               "France",
               "Japan"
-            ]
+            ],
+            "nullable": true
           }
         },
         "required": [
@@ -1060,13 +1068,13 @@
           "operation": {
             "description": "Post processing operation type",
             "enum": [
-              "_flatten_column_after_pivot",
               "aggregate",
               "boxplot",
               "compare",
               "contribution",
               "cum",
               "diff",
+              "escape_separator",
               "flatten",
               "geodetic_parse",
               "geohash_decode",
@@ -1077,7 +1085,8 @@
               "resample",
               "rolling",
               "select",
-              "sort"
+              "sort",
+              "unescape_separator"
             ],
             "example": "aggregate",
             "type": "string"
@@ -1174,11 +1183,18 @@
       },
       "ChartDataQueryContextSchema": {
         "properties": {
+          "custom_cache_timeout": {
+            "description": "Override the default cache timeout",
+            "format": "int32",
+            "nullable": true,
+            "type": "integer"
+          },
           "datasource": {
             "$ref": "#/components/schemas/ChartDataDatasource"
           },
           "force": {
             "description": "Should the queries be forced to load from the source. Default: `false`",
+            "nullable": true,
             "type": "boolean"
           },
           "form_data": {
@@ -1436,7 +1452,7 @@
             "type": "string"
           },
           "cache_timeout": {
-            "description": "Cache timeout in following order: custom timeout, datasource timeout, default config timeout.",
+            "description": "Cache timeout in following order: custom timeout, datasource timeout, cache default timeout, config default cache timeout.",
             "format": "int32",
             "nullable": true,
             "type": "integer"
@@ -1557,12 +1573,19 @@
             "nullable": true,
             "type": "string"
           },
+          "changed_on_delta_humanized": {
+            "readOnly": true
+          },
           "dashboards": {
             "$ref": "#/components/schemas/ChartDataRestApi.get.Dashboard"
           },
           "description": {
             "nullable": true,
             "type": "string"
+          },
+          "id": {
+            "format": "int32",
+            "type": "integer"
           },
           "is_managed_externally": {
             "type": "boolean"
@@ -1582,6 +1605,12 @@
             "maxLength": 250,
             "nullable": true,
             "type": "string"
+          },
+          "thumbnail_url": {
+            "readOnly": true
+          },
+          "url": {
+            "readOnly": true
           },
           "viz_type": {
             "maxLength": 250,
@@ -1651,7 +1680,7 @@
             "type": "string"
           },
           "changed_by": {
-            "$ref": "#/components/schemas/ChartDataRestApi.get_list.User"
+            "$ref": "#/components/schemas/ChartDataRestApi.get_list.User2"
           },
           "changed_by_name": {
             "readOnly": true
@@ -1666,7 +1695,13 @@
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/ChartDataRestApi.get_list.User1"
+            "$ref": "#/components/schemas/ChartDataRestApi.get_list.User"
+          },
+          "created_on_delta_humanized": {
+            "readOnly": true
+          },
+          "dashboards": {
+            "$ref": "#/components/schemas/ChartDataRestApi.get_list.Dashboard"
           },
           "datasource_id": {
             "format": "int32",
@@ -1707,7 +1742,7 @@
             "type": "string"
           },
           "last_saved_by": {
-            "$ref": "#/components/schemas/ChartDataRestApi.get_list.User2"
+            "$ref": "#/components/schemas/ChartDataRestApi.get_list.User3"
           },
           "owners": {
             "$ref": "#/components/schemas/ChartDataRestApi.get_list.User1"
@@ -1738,6 +1773,20 @@
         },
         "type": "object"
       },
+      "ChartDataRestApi.get_list.Dashboard": {
+        "properties": {
+          "dashboard_title": {
+            "maxLength": 500,
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
       "ChartDataRestApi.get_list.SqlaTable": {
         "properties": {
           "default_endpoint": {
@@ -1759,6 +1808,10 @@
           "first_name": {
             "maxLength": 64,
             "type": "string"
+          },
+          "id": {
+            "format": "int32",
+            "type": "integer"
           },
           "last_name": {
             "maxLength": 64,
@@ -1802,10 +1855,6 @@
           "first_name": {
             "maxLength": 64,
             "type": "string"
-          },
-          "id": {
-            "format": "int32",
-            "type": "integer"
           },
           "last_name": {
             "maxLength": 64,
@@ -2231,7 +2280,8 @@
             "description": "Form data from the Explore controls used to form the chart's data query.",
             "type": "object"
           },
-          "slice_id": {
+          "id": {
+            "description": "The id of the chart.",
             "format": "int32",
             "type": "integer"
           },
@@ -2315,12 +2365,19 @@
             "nullable": true,
             "type": "string"
           },
+          "changed_on_delta_humanized": {
+            "readOnly": true
+          },
           "dashboards": {
             "$ref": "#/components/schemas/ChartRestApi.get.Dashboard"
           },
           "description": {
             "nullable": true,
             "type": "string"
+          },
+          "id": {
+            "format": "int32",
+            "type": "integer"
           },
           "is_managed_externally": {
             "type": "boolean"
@@ -2340,6 +2397,12 @@
             "maxLength": 250,
             "nullable": true,
             "type": "string"
+          },
+          "thumbnail_url": {
+            "readOnly": true
+          },
+          "url": {
+            "readOnly": true
           },
           "viz_type": {
             "maxLength": 250,
@@ -2409,7 +2472,7 @@
             "type": "string"
           },
           "changed_by": {
-            "$ref": "#/components/schemas/ChartRestApi.get_list.User"
+            "$ref": "#/components/schemas/ChartRestApi.get_list.User2"
           },
           "changed_by_name": {
             "readOnly": true
@@ -2424,7 +2487,13 @@
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/ChartRestApi.get_list.User1"
+            "$ref": "#/components/schemas/ChartRestApi.get_list.User"
+          },
+          "created_on_delta_humanized": {
+            "readOnly": true
+          },
+          "dashboards": {
+            "$ref": "#/components/schemas/ChartRestApi.get_list.Dashboard"
           },
           "datasource_id": {
             "format": "int32",
@@ -2465,7 +2534,7 @@
             "type": "string"
           },
           "last_saved_by": {
-            "$ref": "#/components/schemas/ChartRestApi.get_list.User2"
+            "$ref": "#/components/schemas/ChartRestApi.get_list.User3"
           },
           "owners": {
             "$ref": "#/components/schemas/ChartRestApi.get_list.User1"
@@ -2496,6 +2565,20 @@
         },
         "type": "object"
       },
+      "ChartRestApi.get_list.Dashboard": {
+        "properties": {
+          "dashboard_title": {
+            "maxLength": 500,
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
       "ChartRestApi.get_list.SqlaTable": {
         "properties": {
           "default_endpoint": {
@@ -2517,6 +2600,10 @@
           "first_name": {
             "maxLength": 64,
             "type": "string"
+          },
+          "id": {
+            "format": "int32",
+            "type": "integer"
           },
           "last_name": {
             "maxLength": 64,
@@ -2560,10 +2647,6 @@
           "first_name": {
             "maxLength": 64,
             "type": "string"
-          },
-          "id": {
-            "format": "int32",
-            "type": "integer"
           },
           "last_name": {
             "maxLength": 64,
@@ -2856,13 +2939,13 @@
       "CssTemplateRestApi.get_list": {
         "properties": {
           "changed_by": {
-            "$ref": "#/components/schemas/CssTemplateRestApi.get_list.User1"
+            "$ref": "#/components/schemas/CssTemplateRestApi.get_list.User"
           },
           "changed_on_delta_humanized": {
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/CssTemplateRestApi.get_list.User"
+            "$ref": "#/components/schemas/CssTemplateRestApi.get_list.User1"
           },
           "created_on": {
             "format": "date-time",
@@ -3044,8 +3127,7 @@
           },
           "owners": {
             "items": {
-              "format": "int32",
-              "type": "integer"
+              "type": "object"
             },
             "type": "array"
           },
@@ -3180,15 +3262,23 @@
       },
       "DashboardPermalinkPostSchema": {
         "properties": {
-          "filterState": {
-            "description": "Native filter state",
+          "activeTabs": {
+            "description": "Current active dashboard tabs",
+            "items": {
+              "type": "string"
+            },
             "nullable": true,
-            "type": "object"
+            "type": "array"
           },
-          "hash": {
-            "description": "Optional anchor link",
+          "anchor": {
+            "description": "Optional anchor link added to url hash",
             "nullable": true,
             "type": "string"
+          },
+          "dataMask": {
+            "description": "Data mask used for native filter state",
+            "nullable": true,
+            "type": "object"
           },
           "urlParams": {
             "description": "URL Parameters",
@@ -3222,7 +3312,7 @@
             "type": "string"
           },
           "changed_by": {
-            "$ref": "#/components/schemas/DashboardRestApi.get_list.User"
+            "$ref": "#/components/schemas/DashboardRestApi.get_list.User2"
           },
           "changed_by_name": {
             "readOnly": true
@@ -3237,10 +3327,7 @@
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/DashboardRestApi.get_list.User2"
-          },
-          "created_on_delta_humanized": {
-            "readOnly": true
+            "$ref": "#/components/schemas/DashboardRestApi.get_list.User"
           },
           "created_on_delta_humanized": {
             "readOnly": true
@@ -3266,7 +3353,7 @@
             "type": "string"
           },
           "owners": {
-            "$ref": "#/components/schemas/DashboardRestApi.get_list.User2"
+            "$ref": "#/components/schemas/DashboardRestApi.get_list.User1"
           },
           "position_json": {
             "nullable": true,
@@ -3325,16 +3412,11 @@
           "last_name": {
             "maxLength": 64,
             "type": "string"
-          },
-          "username": {
-            "maxLength": 64,
-            "type": "string"
           }
         },
         "required": [
           "first_name",
-          "last_name",
-          "username"
+          "last_name"
         ],
         "type": "object"
       },
@@ -3382,11 +3464,16 @@
           "last_name": {
             "maxLength": 64,
             "type": "string"
+          },
+          "username": {
+            "maxLength": 64,
+            "type": "string"
           }
         },
         "required": [
           "first_name",
-          "last_name"
+          "last_name",
+          "username"
         ],
         "type": "object"
       },
@@ -3560,17 +3647,6 @@
           },
           "name": {
             "type": "string"
-          },
-          "engine_information": {
-            "type": "object"
-          }
-        },
-        "type": "object"
-      },
-      "Database1": {
-        "properties": {
-          "database_name": {
-            "type": "string"
           }
         },
         "type": "object"
@@ -3711,9 +3787,11 @@
             "maxLength": 250,
             "type": "string"
           },
-          "encrypted_extra": {
-            "nullable": true,
-            "type": "string"
+          "driver": {
+            "readOnly": true
+          },
+          "engine_information": {
+            "readOnly": true
           },
           "expose_in_sqllab": {
             "nullable": true,
@@ -3739,6 +3817,9 @@
           "is_managed_externally": {
             "type": "boolean"
           },
+          "masked_encrypted_extra": {
+            "readOnly": true
+          },
           "parameters": {
             "readOnly": true
           },
@@ -3752,9 +3833,6 @@
           "sqlalchemy_uri": {
             "maxLength": 1024,
             "type": "string"
-          },
-          "engine_information": {
-            "readOnly": true
           }
         },
         "required": [
@@ -3815,6 +3893,9 @@
           "disable_data_preview": {
             "readOnly": true
           },
+          "engine_information": {
+            "readOnly": true
+          },
           "explore_database_id": {
             "readOnly": true
           },
@@ -3834,9 +3915,6 @@
           "id": {
             "format": "int32",
             "type": "integer"
-          },
-          "engine_information": {
-            "readOnly": true
           }
         },
         "required": [
@@ -3899,8 +3977,8 @@
             "minLength": 1,
             "type": "string"
           },
-          "encrypted_extra": {
-            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive, Presto, and BigQuery, which do not conform to the username:password syntax normally used by SQLAlchemy.</p>",
+          "driver": {
+            "description": "SQLAlchemy driver to use",
             "nullable": true,
             "type": "string"
           },
@@ -3936,6 +4014,11 @@
             "nullable": true,
             "type": "boolean"
           },
+          "masked_encrypted_extra": {
+            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive, Presto, and BigQuery, which do not conform to the username:password syntax normally used by SQLAlchemy.</p>",
+            "nullable": true,
+            "type": "string"
+          },
           "parameters": {
             "additionalProperties": {},
             "description": "DB-specific parameters for configuration",
@@ -3950,6 +4033,9 @@
             "description": "<p>Refer to the <a href=\"https://docs.sqlalchemy.org/en/rel_1_2/core/engines.html#database-urls\">SqlAlchemy docs</a> for more information on how to structure your URI.</p>",
             "maxLength": 1024,
             "minLength": 1,
+            "type": "string"
+          },
+          "uuid": {
             "type": "string"
           }
         },
@@ -3997,8 +4083,8 @@
             "nullable": true,
             "type": "string"
           },
-          "encrypted_extra": {
-            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive, Presto, and BigQuery, which do not conform to the username:password syntax normally used by SQLAlchemy.</p>",
+          "driver": {
+            "description": "SQLAlchemy driver to use",
             "nullable": true,
             "type": "string"
           },
@@ -4034,6 +4120,11 @@
             "nullable": true,
             "type": "boolean"
           },
+          "masked_encrypted_extra": {
+            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive, Presto, and BigQuery, which do not conform to the username:password syntax normally used by SQLAlchemy.</p>",
+            "nullable": true,
+            "type": "string"
+          },
           "parameters": {
             "additionalProperties": {},
             "description": "DB-specific parameters for configuration",
@@ -4066,8 +4157,8 @@
             "nullable": true,
             "type": "string"
           },
-          "encrypted_extra": {
-            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive, Presto, and BigQuery, which do not conform to the username:password syntax normally used by SQLAlchemy.</p>",
+          "driver": {
+            "description": "SQLAlchemy driver to use",
             "nullable": true,
             "type": "string"
           },
@@ -4083,6 +4174,11 @@
           "impersonate_user": {
             "description": "If Presto, all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled, will run the queries as service account, but impersonate the currently logged on user via hive.server2.proxy.user property.",
             "type": "boolean"
+          },
+          "masked_encrypted_extra": {
+            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive, Presto, and BigQuery, which do not conform to the username:password syntax normally used by SQLAlchemy.</p>",
+            "nullable": true,
+            "type": "string"
           },
           "parameters": {
             "additionalProperties": {},
@@ -4105,6 +4201,13 @@
       },
       "DatabaseValidateParametersSchema": {
         "properties": {
+          "catalog": {
+            "additionalProperties": {
+              "nullable": true
+            },
+            "description": "Gsheets specific column for managing label to sheet urls",
+            "type": "object"
+          },
           "configuration_method": {
             "description": "Configuration_method is used on the frontend to inform the backend whether to explode parameters or to provide only a sqlalchemy_uri."
           },
@@ -4115,8 +4218,8 @@
             "nullable": true,
             "type": "string"
           },
-          "encrypted_extra": {
-            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive, Presto, and BigQuery, which do not conform to the username:password syntax normally used by SQLAlchemy.</p>",
+          "driver": {
+            "description": "SQLAlchemy driver to use",
             "nullable": true,
             "type": "string"
           },
@@ -4128,9 +4231,20 @@
             "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
             "type": "string"
           },
+          "id": {
+            "description": "Database ID (for updates)",
+            "format": "int32",
+            "nullable": true,
+            "type": "integer"
+          },
           "impersonate_user": {
             "description": "If Presto, all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled, will run the queries as service account, but impersonate the currently logged on user via hive.server2.proxy.user property.",
             "type": "boolean"
+          },
+          "masked_encrypted_extra": {
+            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive, Presto, and BigQuery, which do not conform to the username:password syntax normally used by SQLAlchemy.</p>",
+            "nullable": true,
+            "type": "string"
           },
           "parameters": {
             "additionalProperties": {
@@ -4149,6 +4263,174 @@
           "configuration_method",
           "engine"
         ],
+        "type": "object"
+      },
+      "Dataset": {
+        "properties": {
+          "cache_timeout": {
+            "description": "Duration (in seconds) of the caching timeout for this dataset.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "column_formats": {
+            "description": "Column formats.",
+            "type": "object"
+          },
+          "columns": {
+            "description": "Columns metadata.",
+            "items": {
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "database": {
+            "description": "Database associated with the dataset.",
+            "type": "object"
+          },
+          "datasource_name": {
+            "description": "Dataset name.",
+            "type": "string"
+          },
+          "default_endpoint": {
+            "description": "Default endpoint for the dataset.",
+            "type": "string"
+          },
+          "description": {
+            "description": "Dataset description.",
+            "type": "string"
+          },
+          "edit_url": {
+            "description": "The URL for editing the dataset.",
+            "type": "string"
+          },
+          "extra": {
+            "description": "JSON string containing extra configuration elements.",
+            "type": "object"
+          },
+          "fetch_values_predicate": {
+            "description": "Predicate used when fetching values from the dataset.",
+            "type": "string"
+          },
+          "filter_select": {
+            "description": "SELECT filter applied to the dataset.",
+            "type": "boolean"
+          },
+          "filter_select_enabled": {
+            "description": "If the SELECT filter is enabled.",
+            "type": "boolean"
+          },
+          "granularity_sqla": {
+            "description": "Name of temporal column used for time filtering for SQL datasources. This field is deprecated, use `granularity` instead.",
+            "items": {
+              "items": {
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "health_check_message": {
+            "description": "Health check message.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Dataset ID.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "is_sqllab_view": {
+            "description": "If the dataset is a SQL Lab view.",
+            "type": "boolean"
+          },
+          "main_dttm_col": {
+            "description": "The main temporal column.",
+            "type": "string"
+          },
+          "metrics": {
+            "description": "Dataset metrics.",
+            "items": {
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "name": {
+            "description": "Dataset name.",
+            "type": "string"
+          },
+          "offset": {
+            "description": "Dataset offset.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "order_by_choices": {
+            "description": "List of order by columns.",
+            "items": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "owners": {
+            "description": "List of owners identifiers",
+            "items": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "params": {
+            "description": "Extra params for the dataset.",
+            "type": "object"
+          },
+          "perm": {
+            "description": "Permission expression.",
+            "type": "string"
+          },
+          "schema": {
+            "description": "Dataset schema.",
+            "type": "string"
+          },
+          "select_star": {
+            "description": "Select all clause.",
+            "type": "string"
+          },
+          "sql": {
+            "description": "A SQL statement that defines the dataset.",
+            "type": "string"
+          },
+          "table_name": {
+            "description": "The name of the table associated with the dataset.",
+            "type": "string"
+          },
+          "template_params": {
+            "description": "Table template params.",
+            "type": "object"
+          },
+          "time_grain_sqla": {
+            "description": "List of temporal granularities supported by the dataset.",
+            "items": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "type": {
+            "description": "Dataset type.",
+            "type": "string"
+          },
+          "uid": {
+            "description": "Dataset unique identifier.",
+            "type": "string"
+          },
+          "verbose_map": {
+            "description": "Mapping from raw name to verbose name.",
+            "type": "object"
+          }
+        },
         "type": "object"
       },
       "DatasetColumnsPut": {
@@ -4228,11 +4510,80 @@
       },
       "DatasetColumnsRestApi.get_list": {
         "properties": {
+          "advanced_data_type": {
+            "maxLength": 255,
+            "nullable": true,
+            "type": "string"
+          },
+          "changed_on": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "column_name": {
+            "maxLength": 255,
+            "type": "string"
+          },
+          "created_on": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "description": {
+            "nullable": true,
+            "type": "string"
+          },
+          "expression": {
+            "nullable": true,
+            "type": "string"
+          },
+          "extra": {
+            "nullable": true,
+            "type": "string"
+          },
+          "filterable": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "groupby": {
+            "nullable": true,
+            "type": "boolean"
+          },
           "id": {
             "format": "int32",
             "type": "integer"
+          },
+          "is_active": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "is_dttm": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "python_date_format": {
+            "maxLength": 255,
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "nullable": true,
+            "type": "string"
+          },
+          "uuid": {
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          },
+          "verbose_name": {
+            "maxLength": 1024,
+            "nullable": true,
+            "type": "string"
           }
         },
+        "required": [
+          "column_name"
+        ],
         "type": "object"
       },
       "DatasetColumnsRestApi.post": {
@@ -4446,8 +4797,30 @@
             "nullable": true,
             "type": "integer"
           },
+          "changed_by": {
+            "$ref": "#/components/schemas/DatasetRestApi.get.User2"
+          },
+          "changed_on": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "changed_on_humanized": {
+            "readOnly": true
+          },
           "columns": {
             "$ref": "#/components/schemas/DatasetRestApi.get.TableColumn"
+          },
+          "created_by": {
+            "$ref": "#/components/schemas/DatasetRestApi.get.User"
+          },
+          "created_on": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "created_on_humanized": {
+            "readOnly": true
           },
           "database": {
             "$ref": "#/components/schemas/DatasetRestApi.get.Database"
@@ -4503,12 +4876,15 @@
             "type": "integer"
           },
           "owners": {
-            "$ref": "#/components/schemas/DatasetRestApi.get.User"
+            "$ref": "#/components/schemas/DatasetRestApi.get.User1"
           },
           "schema": {
             "maxLength": 255,
             "nullable": true,
             "type": "string"
+          },
+          "select_star": {
+            "readOnly": true
           },
           "sql": {
             "nullable": true,
@@ -4591,11 +4967,6 @@
           },
           "metric_type": {
             "maxLength": 32,
-            "nullable": true,
-            "type": "string"
-          },
-          "uuid": {
-            "format": "uuid",
             "nullable": true,
             "type": "string"
           },
@@ -4702,6 +5073,23 @@
             "maxLength": 64,
             "type": "string"
           },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "last_name"
+        ],
+        "type": "object"
+      },
+      "DatasetRestApi.get.User1": {
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
           "id": {
             "format": "int32",
             "type": "integer"
@@ -4722,10 +5110,27 @@
         ],
         "type": "object"
       },
+      "DatasetRestApi.get.User2": {
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "last_name"
+        ],
+        "type": "object"
+      },
       "DatasetRestApi.get_list": {
         "properties": {
           "changed_by": {
-            "$ref": "#/components/schemas/DatasetRestApi.get_list.User1"
+            "$ref": "#/components/schemas/DatasetRestApi.get_list.User"
           },
           "changed_by_name": {
             "readOnly": true
@@ -4768,7 +5173,7 @@
             "readOnly": true
           },
           "owners": {
-            "$ref": "#/components/schemas/DatasetRestApi.get_list.User"
+            "$ref": "#/components/schemas/DatasetRestApi.get_list.User1"
           },
           "schema": {
             "maxLength": 255,
@@ -4812,6 +5217,23 @@
             "maxLength": 64,
             "type": "string"
           },
+          "username": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "username"
+        ],
+        "type": "object"
+      },
+      "DatasetRestApi.get_list.User1": {
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
           "id": {
             "format": "int32",
             "type": "integer"
@@ -4828,23 +5250,6 @@
         "required": [
           "first_name",
           "last_name",
-          "username"
-        ],
-        "type": "object"
-      },
-      "DatasetRestApi.get_list.User1": {
-        "properties": {
-          "first_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
-          "username": {
-            "maxLength": 64,
-            "type": "string"
-          }
-        },
-        "required": [
-          "first_name",
           "username"
         ],
         "type": "object"
@@ -4873,6 +5278,10 @@
           "schema": {
             "maxLength": 250,
             "minLength": 0,
+            "type": "string"
+          },
+          "sql": {
+            "nullable": true,
             "type": "string"
           },
           "table_name": {
@@ -5114,76 +5523,21 @@
         },
         "type": "object"
       },
-      "ExplorePermalinkPostSchema": {
+      "ExploreContextSchema": {
         "properties": {
-          "allowed_domains": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "allowed_domains"
-        ],
-        "type": "object"
-      },
-      "EmbeddedDashboardResponseSchema": {
-        "properties": {
-          "allowed_domains": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
+          "dataset": {
+            "$ref": "#/components/schemas/Dataset"
           },
-          "changed_by": {
-            "$ref": "#/components/schemas/User"
+          "form_data": {
+            "description": "Form data from the Explore controls used to form the chart's data query.",
+            "type": "object"
           },
-          "changed_on": {
-            "format": "date-time",
+          "message": {
+            "description": "Any message related to the processed request.",
             "type": "string"
           },
-          "dashboard_id": {
-            "type": "string"
-          },
-          "uuid": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "EmbeddedDashboardRestApi.get": {
-        "properties": {
-          "uuid": {
-            "format": "uuid",
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "EmbeddedDashboardRestApi.get_list": {
-        "properties": {
-          "uuid": {
-            "format": "uuid",
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "EmbeddedDashboardRestApi.post": {
-        "properties": {
-          "uuid": {
-            "format": "uuid",
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "EmbeddedDashboardRestApi.put": {
-        "properties": {
-          "uuid": {
-            "format": "uuid",
-            "type": "string"
+          "slice": {
+            "$ref": "#/components/schemas/Slice"
           }
         },
         "type": "object"
@@ -5730,8 +6084,7 @@
             "type": "string"
           },
           "tracking_url": {
-            "nullable": true,
-            "type": "string"
+            "readOnly": true
           }
         },
         "required": [
@@ -5840,6 +6193,10 @@
       },
       "RelatedResultResponse": {
         "properties": {
+          "extra": {
+            "description": "The extra metadata for related item",
+            "type": "object"
+          },
           "text": {
             "description": "The related item string representation",
             "type": "string"
@@ -6027,6 +6384,9 @@
             "nullable": true,
             "type": "string"
           },
+          "extra": {
+            "readOnly": true
+          },
           "force_screenshot": {
             "nullable": true,
             "type": "boolean"
@@ -6211,7 +6571,7 @@
             "type": "boolean"
           },
           "changed_by": {
-            "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.User"
+            "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.User2"
           },
           "changed_on": {
             "format": "date-time",
@@ -6227,7 +6587,7 @@
             "type": "integer"
           },
           "created_by": {
-            "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.User2"
+            "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.User"
           },
           "created_on": {
             "format": "date-time",
@@ -6254,6 +6614,9 @@
           "description": {
             "nullable": true,
             "type": "string"
+          },
+          "extra": {
+            "readOnly": true
           },
           "id": {
             "format": "int32",
@@ -7143,6 +7506,9 @@
             "nullable": true,
             "type": "string"
           },
+          "extra": {
+            "type": "object"
+          },
           "force_screenshot": {
             "type": "boolean"
           },
@@ -7867,6 +8233,9 @@
       },
       "SavedQueryRestApi.get": {
         "properties": {
+          "changed_on_delta_humanized": {
+            "readOnly": true
+          },
           "created_by": {
             "$ref": "#/components/schemas/SavedQueryRestApi.get.User"
           },
@@ -7897,6 +8266,10 @@
           },
           "sql_tables": {
             "readOnly": true
+          },
+          "template_parameters": {
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -8059,6 +8432,10 @@
           "sql": {
             "nullable": true,
             "type": "string"
+          },
+          "template_parameters": {
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -8087,6 +8464,10 @@
           "sql": {
             "nullable": true,
             "type": "string"
+          },
+          "template_parameters": {
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -8107,6 +8488,85 @@
         "properties": {
           "result": {
             "description": "SQL select star",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Slice": {
+        "properties": {
+          "cache_timeout": {
+            "description": "Duration (in seconds) of the caching timeout for this chart.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "certification_details": {
+            "description": "Details of the certification.",
+            "type": "string"
+          },
+          "certified_by": {
+            "description": "Person or group that has certified this dashboard.",
+            "type": "string"
+          },
+          "changed_on": {
+            "description": "Timestamp of the last modification.",
+            "type": "string"
+          },
+          "changed_on_humanized": {
+            "description": "Timestamp of the last modification in human readable form.",
+            "type": "string"
+          },
+          "datasource": {
+            "description": "Datasource identifier.",
+            "type": "string"
+          },
+          "description": {
+            "description": "Slice description.",
+            "type": "string"
+          },
+          "description_markeddown": {
+            "description": "Sanitized HTML version of the chart description.",
+            "type": "string"
+          },
+          "edit_url": {
+            "description": "The URL for editing the slice.",
+            "type": "string"
+          },
+          "form_data": {
+            "description": "Form data associated with the slice.",
+            "type": "object"
+          },
+          "is_managed_externally": {
+            "description": "If the chart is managed outside externally.",
+            "type": "boolean"
+          },
+          "modified": {
+            "description": "Last modification in human readable form.",
+            "type": "string"
+          },
+          "owners": {
+            "description": "Owners identifiers.",
+            "items": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "query_context": {
+            "description": "The context associated with the query.",
+            "type": "object"
+          },
+          "slice_id": {
+            "description": "The slice ID.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "slice_name": {
+            "description": "The slice name.",
+            "type": "string"
+          },
+          "slice_url": {
+            "description": "The slice URL.",
             "type": "string"
           }
         },
@@ -8677,99 +9137,6 @@
   "paths": {
     "/api/v1/advanced_data_type/convert": {
       "get": {
-        "parameters": [
-          {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/advanced_data_type_convert_schema"
-                }
-              }
-            },
-            "in": "query",
-            "name": "q"
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AdvancedDataTypeSchema"
-                }
-              }
-            },
-            "description": "AdvancedDataTypeResponse object has been returned."
-          },
-          "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          }
-        ],
-        "summary": "Returns a AdvancedDataTypeResponse object populated with the passed in args.",
-        "tags": [
-          "Advanced Data Type"
-        ]
-      }
-    },
-    "/api/v1/advanced_data_type/types": {
-      "get": {
-        "description": "Returns a list of available advanced data types.",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "result": {
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "a successful return of the available advanced data types has taken place."
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          }
-        ],
-        "tags": [
-          "Advanced Data Type"
-        ]
-      }
-    },
-    "/api/v1/annotation_layer/": {
-      "delete": {
-        "description": "Deletes multiple annotation layers in a bulk operation.",
         "parameters": [
           {
             "content": {
@@ -10023,6 +10390,42 @@
         ]
       }
     },
+    "/api/v1/available_domains/": {
+      "get": {
+        "description": "Get all available domains",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "$ref": "#/components/schemas/AvailableDomainsSchema"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "a list of available domains"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Available Domains"
+        ]
+      }
+    },
     "/api/v1/cachekey/invalidate": {
       "post": {
         "description": "Takes a list of datasources, finds the associated cache records and invalidates them and removes the database records",
@@ -11003,6 +11406,14 @@
             "name": "type",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "description": "Should the queries be forced to load from the source",
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "boolean"
             }
           }
         ],
@@ -13806,6 +14217,16 @@
                         "description": "Name of the SQLAlchemy engine",
                         "type": "string"
                       },
+                      "engine_information": {
+                        "description": "Dict with public properties form the DB Engine",
+                        "properties": {
+                          "supports_file_upload": {
+                            "description": "Whether the engine supports file uploads",
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object"
+                      },
                       "name": {
                         "description": "Name of the database",
                         "type": "string"
@@ -13821,10 +14242,6 @@
                       "sqlalchemy_uri_placeholder": {
                         "description": "Example placeholder for the SQLAlchemy URI",
                         "type": "string"
-                      },
-                      "engine_information": {
-                        "description": "Object with properties we want to expose from our DB engine",
-                        "type": "object"
                       }
                     },
                     "type": "object"
@@ -14576,75 +14993,6 @@
         ]
       }
     },
-    "/api/v1/database/{pk}/select_star/{table_name}/{schema_name}/": {
-      "get": {
-        "description": "Get database select star for table",
-        "parameters": [
-          {
-            "description": "The database id",
-            "in": "path",
-            "name": "pk",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Table name",
-            "in": "path",
-            "name": "table_name",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Table schema",
-            "in": "path",
-            "name": "schema_name",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SelectStarResponseSchema"
-                }
-              }
-            },
-            "description": "SQL statement for a select star for table"
-          },
-          "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          }
-        ],
-        "tags": [
-          "Database"
-        ]
-      }
-    },
     "/api/v1/database/{pk}/table/{table_name}/{schema_name}/": {
       "get": {
         "description": "Get database table metadata",
@@ -14784,7 +15132,7 @@
         ]
       }
     },
-    "/api/v1/database/{pk}/validate_sql": {
+    "/api/v1/database/{pk}/validate_sql/": {
       "post": {
         "description": "Validates arbitrary SQL.",
         "parameters": [
@@ -15220,16 +15568,6 @@
     "/api/v1/dataset/duplicate": {
       "post": {
         "description": "Duplicates a Dataset",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "pk",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -15242,20 +15580,23 @@
           "required": true
         },
         "responses": {
-          "200": {
+          "201": {
             "content": {
               "application/json": {
                 "schema": {
                   "properties": {
-                    "message": {
-                      "type": "string"
+                    "id": {
+                      "type": "number"
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/DatasetDuplicateSchema"
                     }
                   },
                   "type": "object"
                 }
               }
             },
-            "description": "Dataset duplicate"
+            "description": "Dataset duplicated"
           },
           "400": {
             "$ref": "#/components/responses/400"
@@ -15575,7 +15916,7 @@
                       "type": "object"
                     },
                     "result": {
-                      "$ref": "#/components/schemas/DatasetRestApi.get"
+                      "$ref": "#/components/schemas/DatasetColumnsRestApi.get"
                     },
                     "show_columns": {
                       "description": "A list of columns",
@@ -15681,6 +16022,85 @@
           },
           "404": {
             "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Datasets"
+        ]
+      }
+    },
+    "/api/v1/dataset/{pk}/column/": {
+      "get": {
+        "description": "Get a list of dataset columns",
+        "parameters": [
+          {
+            "description": "The dataset id for these columns",
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_list_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "count": {
+                      "description": "The total record count on the backend",
+                      "type": "number"
+                    },
+                    "ids": {
+                      "description": "A list of column ids",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "result": {
+                      "description": "The result from the get list query",
+                      "items": {
+                        "$ref": "#/components/schemas/DatasetColumnsRestApi.get_list"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Columns from dataset"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
           },
           "422": {
             "$ref": "#/components/responses/422"
@@ -15928,68 +16348,6 @@
         ]
       }
     },
-    "/api/v1/dataset/{pk}/samples": {
-      "get": {
-        "description": "get samples from a Dataset",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "pk",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "force",
-            "schema": {
-              "type": "boolean"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "result": {
-                      "$ref": "#/components/schemas/ChartDataResponseResult"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Dataset samples"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          }
-        ],
-        "tags": [
-          "Datasets"
-        ]
-      }
-    },
     "/api/v1/embedded_dashboard/{uuid}": {
       "get": {
         "description": "Get a report schedule log",
@@ -16037,6 +16395,84 @@
         ],
         "tags": [
           "Embedded Dashboard"
+        ]
+      }
+    },
+    "/api/v1/explore/": {
+      "get": {
+        "description": "Assembles Explore related information (form_data, slice, dataset)\\n in a single endpoint.<br/><br/>\\nThe information can be assembled from:<br/> - The cache using a form_data_key<br/> - The metadata database using a permalink_key<br/> - Build from scratch using dataset or slice identifiers.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "form_data_key",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "permalink_key",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "slice_id",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dataset_id",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dataset_type",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExploreContextSchema"
+                }
+              }
+            },
+            "description": "Returns the initial context."
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Assembles Explore related information (form_data, slice, dataset)\\n in a single endpoint.",
+        "tags": [
+          "Explore"
         ]
       }
     },

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/utils.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/utils.ts
@@ -146,8 +146,8 @@ export function interceptUnfav() {
   cy.intercept(`/superset/favstar/Dashboard/*/unselect/`).as('unselect');
 }
 
-export function interceptDataset() {
-  cy.intercept('GET', `/api/v1/dataset/*`).as('getDataset');
+export function interceptDatasetColumns() {
+  cy.intercept('GET', `/api/v1/dataset/*/column`).as('getDatasetColumns');
 }
 
 export function interceptCharts() {
@@ -209,13 +209,13 @@ export function collapseFilterOnLeftPanel() {
  * @summary helper for enter native filter edit modal
  ************************************************************************* */
 export function enterNativeFilterEditModal(waitForDataset = true) {
-  interceptDataset();
+  interceptDatasetColumns();
   cy.get(nativeFilters.filterFromDashboardView.createFilterButton).click({
     force: true,
   });
   cy.get(nativeFilters.modal.container).should('be.visible');
   if (waitForDataset) {
-    cy.wait('@getDataset');
+    cy.wait('@getDatasetColumns');
   }
 }
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ColumnSelect.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ColumnSelect.test.tsx
@@ -24,26 +24,22 @@ import { Column, JsonObject } from '@superset-ui/core';
 import userEvent from '@testing-library/user-event';
 import { ColumnSelect } from './ColumnSelect';
 
-fetchMock.get('glob:*/api/v1/dataset/123', {
+fetchMock.get('glob:*/api/v1/dataset/123/column', {
   body: {
-    result: {
-      columns: [
-        { column_name: 'column_name_01', is_dttm: true },
-        { column_name: 'column_name_02', is_dttm: false },
-        { column_name: 'column_name_03', is_dttm: false },
-      ],
-    },
+    result: [
+      { column_name: 'column_name_01', is_dttm: true },
+      { column_name: 'column_name_02', is_dttm: false },
+      { column_name: 'column_name_03', is_dttm: false },
+    ],
   },
 });
-fetchMock.get('glob:*/api/v1/dataset/456', {
+fetchMock.get('glob:*/api/v1/dataset/456/column', {
   body: {
-    result: {
-      columns: [
-        { column_name: 'column_name_04', is_dttm: false },
-        { column_name: 'column_name_05', is_dttm: false },
-        { column_name: 'column_name_06', is_dttm: false },
-      ],
-    },
+    result: [
+      { column_name: 'column_name_04', is_dttm: false },
+      { column_name: 'column_name_05', is_dttm: false },
+      { column_name: 'column_name_06', is_dttm: false },
+    ],
   },
 });
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ColumnSelect.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ColumnSelect.tsx
@@ -98,17 +98,17 @@ export function ColumnSelect({
     }
     if (datasetId != null) {
       cachedSupersetGet({
-        endpoint: `/api/v1/dataset/${datasetId}`,
+        endpoint: `/api/v1/dataset/${datasetId}/column`,
       }).then(
         ({ json: { result } }) => {
           const lookupValue = Array.isArray(value) ? value : [value];
-          const valueExists = result.columns.some((column: Column) =>
+          const valueExists = result.some((column: Column) =>
             lookupValue?.includes(column.column_name),
           );
           if (!valueExists) {
             resetColumnField();
           }
-          setColumns(result.columns);
+          setColumns(result);
         },
         async badResponse => {
           const { error, message } = await getClientErrorObject(badResponse);


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Per [SIP-64](https://github.com/apache/superset/issues/14383) this PR adds the `/api/v1/dataset/{pk}/column` endpoints for obtaining just the columns associated with a dataset to aid the performance of the native filters.

As indicated in the SIP the `/api/v1/dataset/{pk}` endpoint is highly inefficient when fetching a dataset comprising of a large number of columns and/or metrics, i.e., specifically at Airbnb we have a virtual dataset which houses thousands of metrics and dimensions which results in an interim query which computes the cross product of `# metrics` x `# columns` x `# owners`—resulting in millions of rows.

Given the native filters only use the columns/metrics independently from the `/api/v1/dataset/{pk}` endpoint this PR simply adds a new endpoint to fetch only the columns metadata associated with said dataset.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Added unit tests. Also tested the new endpoint with a dataset comprising of ~ 7,000 columns and the `/api/v1/dataset/{pk}/column` endpoint returned in ~ 1 second whereas `/api/v1/dataset/{pk}` timed out.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
