### PR TITLE
chore: return 404 instead of 500 for datasource not found

### DIFF
--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -41,6 +41,7 @@ from superset.charts.post_processing import apply_post_process
 from superset.charts.schemas import ChartDataQueryContextSchema
 from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
 from superset.connectors.base.models import BaseDatasource
+from superset.dao.exceptions import DatasourceNotFound
 from superset.exceptions import QueryObjectValidationError
 from superset.extensions import event_logger
 from superset.utils.async_query_manager import AsyncQueryTokenException
@@ -141,6 +142,8 @@ class ChartDataRestApi(ChartRestApi):
             query_context = self._create_query_context_from_form(json_body)
             command = ChartDataCommand(query_context)
             command.validate()
+        except DatasourceNotFound as error:
+            return self.response_404(message=error)
         except QueryObjectValidationError as error:
             return self.response_400(message=error.message)
         except ValidationError as error:
@@ -229,6 +232,8 @@ class ChartDataRestApi(ChartRestApi):
             query_context = self._create_query_context_from_form(json_body)
             command = ChartDataCommand(query_context)
             command.validate()
+        except DatasourceNotFound as error:
+            return self.response_404(message=error)
         except QueryObjectValidationError as error:
             return self.response_400(message=error.message)
         except ValidationError as error:

--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -143,7 +143,7 @@ class ChartDataRestApi(ChartRestApi):
             command = ChartDataCommand(query_context)
             command.validate()
         except DatasourceNotFound as error:
-            return self.response_404(message=error)
+            return self.response_404()
         except QueryObjectValidationError as error:
             return self.response_400(message=error.message)
         except ValidationError as error:
@@ -233,7 +233,7 @@ class ChartDataRestApi(ChartRestApi):
             command = ChartDataCommand(query_context)
             command.validate()
         except DatasourceNotFound as error:
-            return self.response_404(message=error)
+            return self.response_404()
         except QueryObjectValidationError as error:
             return self.response_400(message=error.message)
         except ValidationError as error:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Errors bubbling up from DAO where the underlying datasource has been deleted, but then users who try to view a chart or dashboard are getting 500s instead of 404s. User's will see the following when they goto where the datasource is not found.

![Screen Shot 2022-12-05 at 6 26 55 PM](https://user-images.githubusercontent.com/27827808/205766416-ea6adb82-2040-40e0-a2fa-63d9651cbc46.png)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
