### PR TITLE
fix: Styling fixes for horizontal filter bar

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
@@ -286,7 +286,7 @@ describe('Horizontal FilterBar', () => {
     setFilterBarOrientation('horizontal');
 
     cy.getBySel('form-item-value').should('have.length', 3);
-    cy.viewport(800, 1024);
+    cy.viewport(768, 1024);
     cy.getBySel('form-item-value').should('have.length', 0);
     openMoreFilters();
     cy.getBySel('form-item-value').should('have.length', 3);

--- a/superset-frontend/src/components/DropdownContainer/index.tsx
+++ b/superset-frontend/src/components/DropdownContainer/index.tsx
@@ -316,7 +316,7 @@ const DropdownContainer = forwardRef(
             display: flex;
             align-items: center;
             gap: ${theme.gridUnit * 4}px;
-            margin-right: ${theme.gridUnit * 3}px;
+            margin-right: ${theme.gridUnit * 4}px;
             min-width: 0px;
           `}
           data-test="container"

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
@@ -88,6 +88,7 @@ const verticalStyle = (theme: SupersetTheme, width: number) => css`
 
 const horizontalStyle = (theme: SupersetTheme) => css`
   align-items: center;
+  margin-left: auto;
   && > .filter-clear-all-button {
     text-transform: capitalize;
     font-weight: ${theme.typography.weights.normal};

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
@@ -87,7 +87,7 @@ const verticalStyle = (theme: SupersetTheme, width: number) => css`
 `;
 
 const horizontalStyle = (theme: SupersetTheme) => css`
-  margin: 0 ${theme.gridUnit * 4}px;
+  align-items: center;
   && > .filter-clear-all-button {
     text-transform: capitalize;
     font-weight: ${theme.typography.weights.normal};

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
@@ -160,7 +160,7 @@ const FilterControls: FC<FilterControlsProps> = ({
     <div
       css={(theme: SupersetTheme) =>
         css`
-          padding-left: ${theme.gridUnit * 4}px;
+          padding: 0 ${theme.gridUnit * 4}px;
           min-width: 0;
           flex: 1;
         `

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterDivider.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterDivider.tsx
@@ -56,7 +56,7 @@ const HorizontalDivider = ({ title, description }: FilterDividerProps) => {
         <h3
           ref={titleRef}
           css={css`
-            ${truncationCSS}
+            ${truncationCSS};
             max-width: ${theme.gridUnit * 32.5}px;
             font-size: ${theme.typography.sizes.m}px;
             font-weight: ${theme.typography.weights.normal};
@@ -108,13 +108,12 @@ const HorizontalOverflowDivider = ({
         <h3
           ref={titleRef}
           css={css`
-            ${truncationCSS}
+            ${truncationCSS};
             display: block;
             color: ${theme.colors.grayscale.dark1};
             font-weight: ${theme.typography.weights.normal};
             font-size: ${theme.typography.sizes.m}px;
             margin: 0 0 ${theme.gridUnit}px 0;
-            line-height: 1;
           `}
         >
           {title}
@@ -126,12 +125,11 @@ const HorizontalOverflowDivider = ({
             ref={descriptionRef}
             data-test="divider-description"
             css={css`
-              ${truncationCSS}
+              ${truncationCSS};
               display: block;
               font-size: ${theme.typography.sizes.s}px;
               color: ${theme.colors.grayscale.base};
-              margin: ${theme.gridUnit * 2}px 0 0 0;
-              line-height: 1;
+              margin: ${theme.gridUnit}px 0 0 0;
             `}
           >
             {description}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/index.tsx
@@ -35,29 +35,40 @@ import { RootState } from 'src/dashboard/types';
 import { getFilterBarTestId } from '../utils';
 import FilterBarOrientationSelect from '../FilterBarOrientationSelect';
 
-const TitleArea = styled.h4`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  margin: 0;
-  padding: ${({ theme }) => theme.gridUnit * 2}px;
+const TitleArea = styled.div`
+  ${({ theme }) => css`
+    display: flex;
+    align-items: center;
+    flex-direction: row;
+    justify-content: space-between;
+    margin: 0;
+    padding: 0 ${theme.gridUnit * 2}px ${theme.gridUnit * 2}px;
 
-  & > span {
-    flex-grow: 1;
-  }
+    & > span {
+      font-size: ${theme.typography.sizes.l}px;
+      flex-grow: 1;
+      font-weight: ${theme.typography.weights.bold};
+    }
+
+    & > div:first-of-type {
+      line-height: 0;
+    }
+
+    & > button > span.anticon {
+      line-height: 0;
+    }
+  `}
 `;
 
 const HeaderButton = styled(Button)`
   padding: 0;
-
-  .anticon {
-    padding-top: ${({ theme }) => `${theme.gridUnit + 2}px`};
-  }
 `;
 
 const Wrapper = styled.div`
   ${({ theme }) => `
-    padding: ${theme.gridUnit}px ${theme.gridUnit * 2}px;
+    padding: ${theme.gridUnit * 3}px ${theme.gridUnit * 2}px ${
+    theme.gridUnit
+  }px;
 
     .ant-dropdown-trigger span {
       padding-right: ${theme.gridUnit * 2}px;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Horizontal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Horizontal.tsx
@@ -29,7 +29,9 @@ import FilterConfigurationLink from './FilterConfigurationLink';
 
 const HorizontalBar = styled.div`
   ${({ theme }) => `
-    padding: ${theme.gridUnit * 2}px ${theme.gridUnit * 2}px;
+    padding: ${theme.gridUnit * 3}px ${theme.gridUnit * 2}px ${
+    theme.gridUnit * 3
+  }px ${theme.gridUnit * 4}px;
     background: ${theme.colors.grayscale.light5};
     box-shadow: inset 0px -2px 2px -1px ${theme.colors.grayscale.light2};
   `}
@@ -42,7 +44,6 @@ const HorizontalBarContent = styled.div`
     flex-wrap: nowrap;
     align-items: center;
     justify-content: flex-start;
-    padding: 0 ${theme.gridUnit * 2}px;
     line-height: 0;
 
     .loading {
@@ -54,7 +55,7 @@ const HorizontalBarContent = styled.div`
 
 const FilterBarEmptyStateContainer = styled.div`
   ${({ theme }) => `
-    margin: 0 ${theme.gridUnit * 2}px 0 ${theme.gridUnit * 4}px;
+    margin-left: ${theme.gridUnit * 4}px;
     font-weight: ${theme.typography.weights.bold};
     color: ${theme.colors.grayscale.base};
     font-size: ${theme.typography.sizes.s}px;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Horizontal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Horizontal.tsx
@@ -55,7 +55,6 @@ const HorizontalBarContent = styled.div`
 
 const FilterBarEmptyStateContainer = styled.div`
   ${({ theme }) => `
-    margin-left: ${theme.gridUnit * 4}px;
     font-weight: ${theme.typography.weights.bold};
     color: ${theme.colors.grayscale.base};
     font-size: ${theme.typography.sizes.s}px;
@@ -107,11 +106,6 @@ const HorizontalFilterBar: React.FC<HorizontalBarProps> = ({
         ) : (
           <>
             {canEdit && <FilterBarOrientationSelect />}
-            {!hasFilters && (
-              <FilterBarEmptyStateContainer data-test="horizontal-filterbar-empty">
-                {t('No filters are currently added to this dashboard.')}
-              </FilterBarEmptyStateContainer>
-            )}
             {canEdit && (
               <FiltersLinkContainer hasFilters={hasFilters}>
                 <FilterConfigurationLink
@@ -121,6 +115,11 @@ const HorizontalFilterBar: React.FC<HorizontalBarProps> = ({
                   <Icons.PlusSmall /> {t('Add/Edit Filters')}
                 </FilterConfigurationLink>
               </FiltersLinkContainer>
+            )}
+            {!hasFilters && (
+              <FilterBarEmptyStateContainer data-test="horizontal-filterbar-empty">
+                {t('No filters are currently added to this dashboard.')}
+              </FilterBarEmptyStateContainer>
             )}
             {hasFilters && (
               <FilterControls


### PR DESCRIPTION
### SUMMARY
A few styling fixes related to horizontal native filters bar (and 1 for vertical):
- Remove extra right padding from empty state text
- Remove extra spacing to right of Add/Edit Filters button
- Make Apply and Clear All buttons aligned with each other
- Increase padding at end of non-overflowed items
- Increase top/bottom padding of horizontal bar
- Align Apply and Clear All buttons with other Dashboard buttons

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @kasiazjc @codyml for review