### PR TITLE
fix: Time filter position and click in Horizontal FilterBar

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
@@ -199,7 +199,7 @@ describe('Time range filter', () => {
         });
         cy.get('[data-test=cancel-button]').click();
         cy.wait(500);
-        cy.get('.ant-popover').should('not.be.visible');
+        cy.get('.ant-popover').should('not.exist');
       });
   });
 

--- a/superset-frontend/src/components/DropdownContainer/index.tsx
+++ b/superset-frontend/src/components/DropdownContainer/index.tsx
@@ -256,7 +256,6 @@ const DropdownContainer = forwardRef(
             data-test="dropdown-content"
             style={dropdownStyle}
             ref={targetRef}
-            className="dropdowncontainer"
           >
             {dropdownContent
               ? dropdownContent(overflowedItems)

--- a/superset-frontend/src/components/DropdownContainer/index.tsx
+++ b/superset-frontend/src/components/DropdownContainer/index.tsx
@@ -256,6 +256,7 @@ const DropdownContainer = forwardRef(
             data-test="dropdown-content"
             style={dropdownStyle}
             ref={targetRef}
+            className="dropdowncontainer"
           >
             {dropdownContent
               ? dropdownContent(overflowedItems)

--- a/superset-frontend/src/explore/components/controls/ControlPopover/ControlPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/ControlPopover/ControlPopover.tsx
@@ -59,7 +59,7 @@ const ControlPopover: React.FC<PopoverProps> = ({
     const visibilityRatio = getVisibilityRatio(triggerElementRef.current!);
     if (visibilityRatio < 0.35 && placement !== 'rightTop') {
       setPlacement('rightTop');
-    } else if (visibilityRatio > 0.65  && placement !== 'rightBottom') {
+    } else if (visibilityRatio > 0.65 && placement !== 'rightBottom') {
       setPlacement('rightBottom');
     } else {
       setPlacement('right');
@@ -137,7 +137,7 @@ const ControlPopover: React.FC<PopoverProps> = ({
     if (visible) {
       calculatePlacement();
     }
-  }, [visible, calculatePlacement])
+  }, [visible, calculatePlacement]);
 
   return (
     <Popover

--- a/superset-frontend/src/explore/components/controls/ControlPopover/ControlPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/ControlPopover/ControlPopover.tsx
@@ -29,7 +29,7 @@ export const getSectionContainerElement = () =>
 
 const getElementYVisibilityRatioOnContainer = (node: HTMLElement) => {
   const containerHeight = window?.innerHeight;
-  const nodePositionInViewport = node.getBoundingClientRect()?.top;
+  const nodePositionInViewport = node?.getBoundingClientRect()?.top;
   if (!containerHeight || !nodePositionInViewport) {
     return 0;
   }
@@ -45,6 +45,7 @@ const ControlPopover: React.FC<PopoverProps> = ({
   getPopupContainer,
   getVisibilityRatio = getElementYVisibilityRatioOnContainer,
   visible: visibleProp,
+  destroyTooltipOnHide = false,
   ...props
 }) => {
   const triggerElementRef = useRef<HTMLElement>();
@@ -56,9 +57,9 @@ const ControlPopover: React.FC<PopoverProps> = ({
 
   const calculatePlacement = useCallback(() => {
     const visibilityRatio = getVisibilityRatio(triggerElementRef.current!);
-    if (visibilityRatio < 0.35) {
+    if (visibilityRatio < 0.35 && placement !== 'rightTop') {
       setPlacement('rightTop');
-    } else if (visibilityRatio > 0.65) {
+    } else if (visibilityRatio > 0.65  && placement !== 'rightBottom') {
       setPlacement('rightBottom');
     } else {
       setPlacement('right');
@@ -67,10 +68,6 @@ const ControlPopover: React.FC<PopoverProps> = ({
 
   const changeContainerScrollStatus = useCallback(
     visible => {
-      if (triggerElementRef.current && visible) {
-        calculatePlacement();
-      }
-
       const element = getSectionContainerElement();
       if (element) {
         element.style.setProperty(
@@ -86,9 +83,6 @@ const ControlPopover: React.FC<PopoverProps> = ({
   const handleGetPopupContainer = useCallback(
     (triggerNode: HTMLElement) => {
       triggerElementRef.current = triggerNode;
-      setTimeout(() => {
-        calculatePlacement();
-      }, 0);
 
       return getPopupContainer?.(triggerNode) || document.body;
     },
@@ -139,6 +133,12 @@ const ControlPopover: React.FC<PopoverProps> = ({
     };
   }, [handleDocumentKeyDownListener, visible]);
 
+  useEffect(() => {
+    if (visible) {
+      calculatePlacement();
+    }
+  }, [visible, calculatePlacement])
+
   return (
     <Popover
       {...props}
@@ -147,6 +147,7 @@ const ControlPopover: React.FC<PopoverProps> = ({
       placement={placement}
       onVisibleChange={handleOnVisibleChange}
       getPopupContainer={handleGetPopupContainer}
+      destroyTooltipOnHide={destroyTooltipOnHide}
     />
   );
 };

--- a/superset-frontend/src/explore/components/controls/ControlPopover/ControlPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/ControlPopover/ControlPopover.tsx
@@ -56,7 +56,6 @@ const ControlPopover: React.FC<PopoverProps> = ({
 
   const calculatePlacement = useCallback(() => {
     const visibilityRatio = getVisibilityRatio(triggerElementRef.current!);
-
     if (visibilityRatio < 0.35) {
       setPlacement('rightTop');
     } else if (visibilityRatio > 0.65) {

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -156,6 +156,7 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
     onOpenPopover = noOp,
     onClosePopover = noOp,
     overlayStyle = 'Popover',
+    isOverflowingFilterBar = false,
   } = props;
   const defaultTimeFilter = useDefaultTimeFilter();
 
@@ -356,6 +357,13 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
       visible={show}
       onVisibleChange={toggleOverlay}
       overlayStyle={{ width: '600px' }}
+      getPopupContainer={() =>
+        isOverflowingFilterBar
+          ? (document.getElementsByClassName(
+              'dropdowncontainer',
+            )[0] as HTMLElement)
+          : document.body
+      }
     >
       <Tooltip placement="top" title={tooltipTitle}>
         <DateLabel

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -357,13 +357,12 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
       visible={show}
       onVisibleChange={toggleOverlay}
       overlayStyle={{ width: '600px' }}
-      getPopupContainer={() =>
+      getPopupContainer={(triggerNode) =>
         isOverflowingFilterBar
-          ? (document.getElementsByClassName(
-              'dropdowncontainer',
-            )[0] as HTMLElement)
+          ? triggerNode.parentNode as HTMLElement
           : document.body
       }
+      destroyTooltipOnHide
     >
       <Tooltip placement="top" title={tooltipTitle}>
         <DateLabel

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -357,9 +357,9 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
       visible={show}
       onVisibleChange={toggleOverlay}
       overlayStyle={{ width: '600px' }}
-      getPopupContainer={(triggerNode) =>
+      getPopupContainer={triggerNode =>
         isOverflowingFilterBar
-          ? triggerNode.parentNode as HTMLElement
+          ? (triggerNode.parentNode as HTMLElement)
           : document.body
       }
       destroyTooltipOnHide

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/types.ts
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/types.ts
@@ -97,4 +97,5 @@ export interface DateFilterControlProps {
   onOpenPopover?: () => void;
   onClosePopover?: () => void;
   overlayStyle?: 'Modal' | 'Popover';
+  isOverflowingFilterBar?: boolean;
 }

--- a/superset-frontend/src/filters/components/Time/TimeFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Time/TimeFilterPlugin.tsx
@@ -58,6 +58,7 @@ export default function TimeFilterPlugin(props: PluginFilterTimeProps) {
     height,
     filterState,
     inputRef,
+    isOverflowingFilterBar = false,
   } = props;
 
   const handleTimeRangeChange = useCallback(
@@ -97,6 +98,7 @@ export default function TimeFilterPlugin(props: PluginFilterTimeProps) {
           onChange={handleTimeRangeChange}
           onOpenPopover={() => setFilterActive(true)}
           onClosePopover={() => setFilterActive(false)}
+          isOverflowingFilterBar={isOverflowingFilterBar}
         />
       </ControlContainer>
     </TimeFilterStyles>

--- a/superset-frontend/src/filters/components/Time/transformProps.ts
+++ b/superset-frontend/src/filters/components/Time/transformProps.ts
@@ -60,5 +60,6 @@ export default function transformProps(chartProps: ChartProps) {
     width,
     inputRef,
     filterBarOrientation: displaySettings?.filterBarOrientation,
+    isOverflowingFilterBar: displaySettings?.isOverflowingFilterBar,
   };
 }

--- a/superset-frontend/src/filters/components/Time/types.ts
+++ b/superset-frontend/src/filters/components/Time/types.ts
@@ -39,6 +39,7 @@ export type PluginFilterTimeProps = PluginFilterStylesProps & {
   formData: PluginFilterSelectQueryFormData;
   filterState: FilterState;
   inputRef: RefObject<HTMLInputElement>;
+  isOverflowingFilterBar?: boolean;
 } & PluginFilterHooks;
 
 export const DEFAULT_FORM_DATA: PluginFilterTimeCustomizeProps = {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Fixes positioning of the Time filter popover as well as a bug that would close the popover when clicking on the filter from within the Horizontal FilterBar dropdown container.

### BEFORE

https://user-images.githubusercontent.com/60598000/205947478-9a0234a2-5f85-438b-8816-f0b25567e826.mp4

### AFTER

https://user-images.githubusercontent.com/60598000/205947555-cc029f0c-7f80-4c7b-bc8a-f97eea32c24c.mp4

### TESTING INSTRUCTIONS
See repro steps in the videos

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [] Has associated issue:
- [x] Required feature flags: HORIZONTAL_FILTER_BAR
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
