### PR TITLE
fix: Missing spacing in adhoc filters popover

### DIFF
--- a/superset-frontend/src/components/Select/styles.tsx
+++ b/superset-frontend/src/components/Select/styles.tsx
@@ -70,7 +70,7 @@ export const StyledSelect = styled(AntdSelect, {
           min-width: 0px;
         }
       `
-    }
+    };
  `}
 `;
 


### PR DESCRIPTION
### SUMMARY
Fix missing margins around Select component in Adhoc Filter popover.

Missing semicolon resulted in a conditional expression adding a prefix `undefined` to styles added with `css` prop, which caused the margins in adhoc filters popover to not be displayed (in CSS, instead of `margin-bottom: 16px;` we had `undefined margin-bottom: 16px;`)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

![image](https://user-images.githubusercontent.com/15073128/205993822-2e6f8b2c-7357-4448-b077-3f0f1dd07bb7.png)

After:
<img width="394" alt="image" src="https://user-images.githubusercontent.com/15073128/205993685-fb3c3578-c38a-404d-b3e2-74ecf8240172.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
