### PR TITLE
chore(docs): adding community calendar link to the community page

### DIFF
--- a/docs/src/pages/community.tsx
+++ b/docs/src/pages/community.tsx
@@ -38,6 +38,11 @@ const links = [
     'participate in conversations with committers and contributors',
   ],
   [
+    'https://calendar.google.com/calendar/u/2?cid=c3VwZXJzZXQuY29tbWl0dGVyc0BnbWFpbC5jb20',
+    'Superset Community Calendar',
+    'join us for working group sessions and other community gatherings',
+  ],
+  [
     'https://stackoverflow.com/questions/tagged/superset+apache-superset',
     'Stack Overflow',
     'our growing knowledge base',


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This merely adds a link to the community calendar (GCcal) to the community links page alongside Slack and other resources

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
