### PR TITLE
fix(bigquery): Properly display errors for BigQuery DBs

### DIFF
--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -586,7 +586,7 @@ class BigQueryEngineSpec(BaseEngineSpec):
     @classmethod
     def parse_error_exception(cls, exception: Exception) -> Exception:
         try:
-            return Exception(str(exception).splitlines()[0].rsplit(":")[1].strip())
+            return Exception(str(exception).splitlines()[0].strip())
         except Exception:  # pylint: disable=broad-except
             # If for some reason we get an exception, for example, no new line
             # We will return the original exception

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -251,7 +251,7 @@ def test_parse_error_message() -> None:
     Test that we parse a received message and just extract the useful information.
 
     Example errors:
-    bigquery error: 400 Table \"case_detail_all_suites\" must be qualified with a dataset (e.g. dataset.table).
+    bigquery error: 400 Syntax error:  Table \"case_detail_all_suites\" must be qualified with a dataset (e.g. dataset.table).
 
     (job ID: ddf30b05-44e8-4fbf-aa29-40bfccaed886)
                                                 -----Query Job SQL Follows-----
@@ -259,8 +259,8 @@ def test_parse_error_message() -> None:
     """
     from superset.db_engine_specs.bigquery import BigQueryEngineSpec
 
-    message = 'bigquery error: 400 Table "case_detail_all_suites" must be qualified with a dataset (e.g. dataset.table).\n\n(job ID: ddf30b05-44e8-4fbf-aa29-40bfccaed886)\n\n     -----Query Job SQL Follows-----     \n\n    |    .    |    .    |    .    |\n   1:select * from case_detail_all_suites\n   2:LIMIT 1001\n    |    .    |    .    |    .    |'
-    expected_result = '400 Table "case_detail_all_suites" must be qualified with a dataset (e.g. dataset.table).'
+    message = 'bigquery error: 400 Syntax error: Table "case_detail_all_suites" must be qualified with a dataset (e.g. dataset.table).\n\n(job ID: ddf30b05-44e8-4fbf-aa29-40bfccaed886)\n\n     -----Query Job SQL Follows-----     \n\n    |    .    |    .    |    .    |\n   1:select * from case_detail_all_suites\n   2:LIMIT 1001\n    |    .    |    .    |    .    |'
+    expected_result = 'bigquery error: 400 Syntax error: Table "case_detail_all_suites" must be qualified with a dataset (e.g. dataset.table).'
     assert (
         str(BigQueryEngineSpec.parse_error_exception(Exception(message)))
         == expected_result
@@ -277,9 +277,9 @@ def test_parse_error_raises_exception() -> None:
     """
     from superset.db_engine_specs.bigquery import BigQueryEngineSpec
 
-    message = 'bigquery error: 400 Table "case_detail_all_suites" must be qualified with a dataset (e.g. dataset.table).'
+    message = 'bigquery error: 400 Syntax error: Table "case_detail_all_suites" must be qualified with a dataset (e.g. dataset.table).'
     message_2 = "6"
-    expected_result = '400 Table "case_detail_all_suites" must be qualified with a dataset (e.g. dataset.table).'
+    expected_result = 'bigquery error: 400 Syntax error: Table "case_detail_all_suites" must be qualified with a dataset (e.g. dataset.table).'
     assert (
         str(BigQueryEngineSpec.parse_error_exception(Exception(message)))
         == expected_result


### PR DESCRIPTION
### SUMMARY
This PR is fixing the wrong error messages we are seeing with BigQuery after we introduced these changes: https://github.com/apache/superset/pull/22024 .

Initially we were trying to get rid of `bigquery error:` section in the message, so we decided to split the exception message. However,  the engine is NOT adding such section into the message, instead it's just returning: `400 Syntax error: ...` for example, and it's us the ones adding that in this method: `extract_error_message` from the `BaseEngineSpec` class.

So, these proposed changes are not splitting the message, just getting the first line (if multiple), and we keep the `bigquery error:` section in it. We could also override the `extract_error_message` in `BigQueryEngineSpec` to remove that section, however, I'd like to be consistent with all our other engines.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![Screen Shot 2022-12-06 at 19 24 19](https://user-images.githubusercontent.com/38889534/206038084-165b0a9e-1cdf-49ec-9062-d857785c22a6.png)

After:
![Screen Shot 2022-12-06 at 19 22 03](https://user-images.githubusercontent.com/38889534/206038107-6bcdfb8a-b9fd-48d4-a585-af867da42cc0.png)


### TESTING INSTRUCTIONS
1. Open SQL Lab and force a Syntax error when querying a BigQuery DB
2. Error message should display properly
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
