### PR TITLE
fix(snowflake): Allow encrypted_extra field to be imported

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -163,7 +163,7 @@ class Database(
         "allow_file_upload",
         "extra",
     ]
-    extra_import_fields = ["password", "is_managed_externally", "external_url"]
+    extra_import_fields = ["password", "is_managed_externally", "external_url", 'encrypted_extra']
     export_children = ["tables"]
 
     def __repr__(self) -> str:

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -163,7 +163,12 @@ class Database(
         "allow_file_upload",
         "extra",
     ]
-    extra_import_fields = ["password", "is_managed_externally", "external_url", 'encrypted_extra']
+    extra_import_fields = [
+        "password",
+        "is_managed_externally",
+        "external_url",
+        "encrypted_extra",
+    ]
     export_children = ["tables"]
 
     def __repr__(self) -> str:


### PR DESCRIPTION
### SUMMARY
The `encrypted_extra` field holds the keypair to authenticate to Snowflake. However, this field can't be imported currently.

See https://github.com/apache/superset/issues/22348.

### TESTING INSTRUCTIONS

Here are my test steps:
1. Add a new Snowflake connection called "Snowflake UI" using the UI. Choose SQLAchemy as the option and use provide the keypair in the SECURE EXTRA [following the instruction](https://superset.apache.org/docs/databases/snowflake/).
2. Construct a new snowflake-import.yaml in this format:
```
databases:
  - database_name: Snowflake from Import
    sqlalchemy_uri: $url
    cache_timeout: null
    expose_in_sqllab: true
    allow_run_async: false
    allow_ctas: false
    allow_cvas: false
    allow_csv_upload: false
    version: 1.0.0
    encrypted_extra: $encrypted_extra
```
where `$url` is the sqlachemy URL and `encrypted_extra` is the JSON encoded JSON block. So it looks something like this:
```
"{\n  \"auth_method\": \"keypair\",\n  \"auth_params\": {\n      \"privatekey_body\": \"-----BEGIN ENCRYPTED PRIVATE KEY-----\\nblablabla\\n-----END ENCRYPTED PRIVATE KEY-----\",\n      \"privatekey_pass\": \"mypassword\"\n  }\n}"
```
3. Run `superset import_datasources -p snowflake-import.yaml` 
4. Inspect that `dbs` table and verify that both the UI entry and the imported entry are identical.
  - Of course, test the connection from the UI too. :)

Prior to the fix, step 4 would fail. The `encrypted_extra` column would be empty for the imported entry.

### ADDITIONAL INFORMATION
Fixes https://github.com/apache/superset/issues/22348
