### PR TITLE
chore: Use visibilityToggle prop to control password input visibility

### DIFF
--- a/superset-frontend/src/components/Form/LabeledErrorBoundInput.test.jsx
+++ b/superset-frontend/src/components/Form/LabeledErrorBoundInput.test.jsx
@@ -81,7 +81,6 @@ describe('LabeledErrorBoundInput', () => {
     defaultProps.visibilityToggle = true;
     render(<LabeledErrorBoundInput {...defaultProps} />);
 
-    // screen.logTestingPlaygroundURL();
     expect(await screen.findByRole('img', { name: /eye/i })).toBeVisible();
   });
 

--- a/superset-frontend/src/components/Form/LabeledErrorBoundInput.test.jsx
+++ b/superset-frontend/src/components/Form/LabeledErrorBoundInput.test.jsx
@@ -89,7 +89,6 @@ describe('LabeledErrorBoundInput', () => {
     defaultProps.name = 'password';
     render(<LabeledErrorBoundInput {...defaultProps} />);
 
-    // screen.logTestingPlaygroundURL();
     expect(await screen.findByRole('img', { name: /eye/i })).toBeVisible();
   });
 });

--- a/superset-frontend/src/components/Form/LabeledErrorBoundInput.test.jsx
+++ b/superset-frontend/src/components/Form/LabeledErrorBoundInput.test.jsx
@@ -60,6 +60,7 @@ describe('LabeledErrorBoundInput', () => {
     expect(textboxInput).toBeVisible();
     expect(errorText).toBeVisible();
   });
+
   it('renders a LabeledErrorBoundInput with a InfoTooltip', async () => {
     defaultProps.hasTooltip = true;
     render(<LabeledErrorBoundInput {...defaultProps} />);
@@ -74,5 +75,21 @@ describe('LabeledErrorBoundInput', () => {
     expect(label).toBeVisible();
     expect(textboxInput).toBeVisible();
     expect(await screen.findByText('This is a tooltip')).toBeInTheDocument();
+  });
+
+  it('becomes a password input if visibilityToggle prop is passed in', async () => {
+    defaultProps.visibilityToggle = true;
+    render(<LabeledErrorBoundInput {...defaultProps} />);
+
+    // screen.logTestingPlaygroundURL();
+    expect(await screen.findByRole('img', { name: /eye/i })).toBeVisible();
+  });
+
+  it('becomes a password input if props.name === password (backwards compatibility)', async () => {
+    defaultProps.name = 'password';
+    render(<LabeledErrorBoundInput {...defaultProps} />);
+
+    // screen.logTestingPlaygroundURL();
+    expect(await screen.findByRole('img', { name: /eye/i })).toBeVisible();
   });
 });

--- a/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
+++ b/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
@@ -37,6 +37,7 @@ export interface LabeledErrorBoundInputProps {
   tooltipText?: string | null;
   id?: string;
   classname?: string;
+  showPasswordField?: boolean;
   [x: string]: any;
 }
 
@@ -101,6 +102,7 @@ const LabeledErrorBoundInput = ({
   tooltipText,
   id,
   className,
+  showPasswordField,
   ...props
 }: LabeledErrorBoundInputProps) => (
   <StyledFormGroup className={className}>
@@ -119,7 +121,7 @@ const LabeledErrorBoundInput = ({
       help={errorMessage || helpText}
       hasFeedback={!!errorMessage}
     >
-      {props.name === 'password' ? (
+      {showPasswordField || props.name === 'password' ? (
         <StyledInputPassword
           {...props}
           {...validationMethods}

--- a/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
+++ b/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
@@ -37,6 +37,7 @@ export interface LabeledErrorBoundInputProps {
   tooltipText?: string | null;
   id?: string;
   classname?: string;
+  visibilityToggle?: boolean;
   [x: string]: any;
 }
 

--- a/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
+++ b/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
@@ -37,7 +37,6 @@ export interface LabeledErrorBoundInputProps {
   tooltipText?: string | null;
   id?: string;
   classname?: string;
-  shouldShowToggleVisibility?: boolean;
   [x: string]: any;
 }
 
@@ -102,7 +101,7 @@ const LabeledErrorBoundInput = ({
   tooltipText,
   id,
   className,
-  shouldShowToggleVisibility,
+  visibilityToggle,
   ...props
 }: LabeledErrorBoundInputProps) => (
   <StyledFormGroup className={className}>
@@ -121,7 +120,7 @@ const LabeledErrorBoundInput = ({
       help={errorMessage || helpText}
       hasFeedback={!!errorMessage}
     >
-      {shouldShowToggleVisibility || props.name === 'password' ? (
+      {visibilityToggle || props.name === 'password' ? (
         <StyledInputPassword
           {...props}
           {...validationMethods}

--- a/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
+++ b/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
@@ -37,7 +37,7 @@ export interface LabeledErrorBoundInputProps {
   tooltipText?: string | null;
   id?: string;
   classname?: string;
-  showPasswordField?: boolean;
+  shouldShowToggleVisibility?: boolean;
   [x: string]: any;
 }
 
@@ -102,7 +102,7 @@ const LabeledErrorBoundInput = ({
   tooltipText,
   id,
   className,
-  showPasswordField,
+  shouldShowToggleVisibility,
   ...props
 }: LabeledErrorBoundInputProps) => (
   <StyledFormGroup className={className}>
@@ -121,7 +121,7 @@ const LabeledErrorBoundInput = ({
       help={errorMessage || helpText}
       hasFeedback={!!errorMessage}
     >
-      {showPasswordField || props.name === 'password' ? (
+      {shouldShowToggleVisibility || props.name === 'password' ? (
         <StyledInputPassword
           {...props}
           {...validationMethods}

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm/CommonParameters.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm/CommonParameters.tsx
@@ -153,7 +153,7 @@ export const passwordField = ({
     placeholder={t('e.g. ********')}
     label={t('Password')}
     onChange={changeMethods.onParametersChange}
-    showPasswordField
+    shouldShowToggleVisibility
   />
 );
 export const accessTokenField = ({

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm/CommonParameters.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm/CommonParameters.tsx
@@ -153,6 +153,7 @@ export const passwordField = ({
     placeholder={t('e.g. ********')}
     label={t('Password')}
     onChange={changeMethods.onParametersChange}
+    showPasswordField
   />
 );
 export const accessTokenField = ({

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm/CommonParameters.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm/CommonParameters.tsx
@@ -153,7 +153,6 @@ export const passwordField = ({
     placeholder={t('e.g. ********')}
     label={t('Password')}
     onChange={changeMethods.onParametersChange}
-    shouldShowToggleVisibility
   />
 );
 export const accessTokenField = ({


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds the `visibilityToggle` prop to the input field to show/hide the password toggle functionality rather than just looking for fields called "password". I left the original check (props.name === "password") in order to ensure backwards compatibility.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Go to the database connection modal and check that the password field still shows properly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
