### PR TITLE
fix: Button resizing in horizontal filter bar

### DIFF
--- a/superset-frontend/src/components/Badge/index.tsx
+++ b/superset-frontend/src/components/Badge/index.tsx
@@ -28,8 +28,8 @@ export interface BadgeProps extends AntdBadgeProps {
 const Badge = styled(
   (
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    { textColor, ...props }: BadgeProps,
-  ) => <AntdBadge {...props} />,
+    { textColor, color, text, ...props }: BadgeProps,
+  ) => <AntdBadge text={text} color={text ? color : undefined} {...props} />,
 )`
   & > sup {
     padding: 0 ${({ theme }) => theme.gridUnit * 2}px;

--- a/superset-frontend/src/components/DropdownContainer/index.tsx
+++ b/superset-frontend/src/components/DropdownContainer/index.tsx
@@ -376,10 +376,14 @@ const DropdownContainer = forwardRef(
                   {dropdownTriggerText}
                   <Badge
                     count={dropdownTriggerCount ?? overflowingCount}
+                    color={
+                      (dropdownTriggerCount ?? overflowingCount) > 0
+                        ? theme.colors.primary.base
+                        : theme.colors.grayscale.light1
+                    }
+                    showZero
                     css={css`
-                      margin-left: ${dropdownTriggerCount ?? overflowingCount
-                        ? `${theme.gridUnit * 2}px`
-                        : '0'};
+                      margin-left: ${theme.gridUnit * 2}px;
                     `}
                   />
                   <Icons.DownOutlined


### PR DESCRIPTION
### SUMMARY
Previously, the `DropdownContainer` only showed the badge count when the value was greater than zero. When the badge count was updated, the button would change its width to incorporate the badge count. That behavior could really impact user experience because the position of the button can totally change if that needed extra space ends up pushing another element to the popover. To resolve that, this PR always displays the badge count even if the value is zero.

@kasiazjc Another possible solution would be to have more spacing between the button elements when there's no badge and less spacing when there's a badge. The important part would be to keep a constant button width. Let me know if you prefer that approach.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/206307568-213b5cdd-42f1-4961-b551-f6f781ef827b.mov

### TESTING INSTRUCTIONS
Check the video for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
