### PR TITLE
[WIP] style: inconsistent button styles in antD confirmation modal

### DIFF
--- a/superset-frontend/src/components/Datasource/DatasourceModal.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal.tsx
@@ -27,6 +27,7 @@ import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
 import withToasts from 'src/components/MessageToasts/withToasts';
+import './styles.css';
 
 const DatasourceEditor = AsyncEsmComponent(() => import('./DatasourceEditor'));
 
@@ -152,7 +153,7 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
     setErrors(err);
   };
 
-  const renderSaveDialog = () => (
+  const renderConfirmationMessage = () => (
     <div>
       <Alert
         css={theme => ({
@@ -168,14 +169,43 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
                 in undesirable ways.`)}
       />
       {t('Are you sure you want to save and apply changes?')}
+      <Button
+        data-test="datasource-modal-cancel"
+        buttonSize="small"
+        className="async_confirm"
+        onClick={onHide}
+      >
+        {t('Cancel')}
+      </Button>
+      <Button
+        buttonSize="small"
+        buttonStyle="primary"
+        data-test="datasource-modal-save"
+        onClick={onConfirmSave}
+        disabled={
+          isSaving ||
+          errors.length > 0 ||
+          currentDatasource.is_managed_externally
+        }
+        tooltip={
+          currentDatasource.is_managed_externally
+            ? t(
+                "This dataset is managed externally, and can't be edited in Superset",
+              )
+            : ''
+        }
+      >
+        {t('Save')}
+      </Button>
     </div>
   );
 
   const onClickSave = () => {
     dialog.current = modal.confirm({
       title: t('Confirm save'),
-      content: renderSaveDialog(),
+      content: renderConfirmationMessage(),
       onOk: onConfirmSave,
+      className: 'async_confirm',
       icon: null,
     });
   };

--- a/superset-frontend/src/components/Datasource/styles.css
+++ b/superset-frontend/src/components/Datasource/styles.css
@@ -1,0 +1,3 @@
+.async_confirm .ant-modal-confirm-btns {
+  display: none;
+}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR changes the confirmation modal button styling to match the button styling in the datasource modal. It achieves this by hiding the default buttons in the confirmation modal and creating two buttons with the correct styling that make the function calls on click as the default buttons. Fixes: #16775

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
From the original issue:
![](https://user-images.githubusercontent.com/335541/134261030-e25fccc6-bd3c-44b6-9069-cd4b143a6dff.png)

With the changes in this PR applied:
![image](https://user-images.githubusercontent.com/43706296/206338558-925047cb-a3fd-403a-acdd-91fd382c52b7.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
