### PR TITLE
chore(viz): rename v1 and v2 charts

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/chart_list/filter.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/chart_list/filter.test.ts
@@ -50,7 +50,7 @@ describe('Charts filters', () => {
     });
 
     it('should filter by viz type correctly', () => {
-      setFilter('Chart type', 'Area Chart');
+      setFilter('Chart type', 'Area Chart (legacy)');
       cy.getBySel('styled-card').should('have.length', 3);
       setFilter('Chart type', 'Bubble Chart');
       cy.getBySel('styled-card').should('have.length', 2);
@@ -91,7 +91,7 @@ describe('Charts filters', () => {
     });
 
     it('should filter by viz type correctly', () => {
-      setFilter('Chart type', 'Area Chart');
+      setFilter('Chart type', 'Area Chart (legacy)');
       cy.getBySel('table-row').should('have.length', 3);
       setFilter('Chart type', 'Bubble Chart');
       cy.getBySel('table-row').should('have.length', 2);

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/drilltodetail.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/drilltodetail.test.ts
@@ -339,7 +339,7 @@ describe('Drill to detail modal', () => {
       });
     });
 
-    describe('Time-series Bar Chart V2', () => {
+    describe('Time-series Bar Chart', () => {
       it('opens the modal with the correct filters', () => {
         interceptSamples();
 
@@ -591,7 +591,7 @@ describe('Drill to detail modal', () => {
       });
     });
 
-    describe('Treemap V2', () => {
+    describe('Treemap', () => {
       it('opens the modal with the correct filters', () => {
         interceptSamples();
 

--- a/superset-frontend/plugins/legacy-plugin-chart-pivot-table/src/index.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-pivot-table/src/index.js
@@ -27,7 +27,7 @@ const metadata = new ChartMetadata({
     t(`Used to summarize a set of data by grouping together multiple statistics along two axes. Examples: Sales numbers by region and month, tasks by status and assignee, active users by age and location.
 
   This chart is being deprecated and we recommend checking out Pivot Table V2 instead!`),
-  name: t('Pivot Table'),
+  name: t('Pivot Table (legacy)'),
   tags: [t('Legacy')],
   thumbnail,
   useLegacyApi: true,

--- a/superset-frontend/plugins/legacy-plugin-chart-treemap/src/index.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-treemap/src/index.js
@@ -37,7 +37,7 @@ const metadata = new ChartMetadata({
     { url: example3 },
     { url: example4 },
   ],
-  name: t('Treemap'),
+  name: t('Treemap (legacy)'),
   tags: [
     t('Categorical'),
     t('Legacy'),

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Area/index.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Area/index.js
@@ -38,7 +38,7 @@ const metadata = new ChartMetadata({
     { url: example3, caption: t('Video game consoles') },
     { url: example4, caption: t('Vehicle Types') },
   ],
-  name: t('Area Chart'),
+  name: t('Area Chart (legacy)'),
   supportedAnnotationTypes: [ANNOTATION_TYPES.INTERVAL, ANNOTATION_TYPES.EVENT],
   tags: [
     t('Aesthetic'),

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bar/index.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bar/index.js
@@ -32,7 +32,7 @@ const metadata = new ChartMetadata({
     'Visualize how a metric changes over time using bars. Add a group by column to visualize group level metrics and how they change over time.',
   ),
   exampleGallery: [{ url: example1 }, { url: example2 }, { url: example3 }],
-  name: t('Time-series Bar Chart'),
+  name: t('Time-series Bar Chart (legacy)'),
   supportedAnnotationTypes: [ANNOTATION_TYPES.INTERVAL, ANNOTATION_TYPES.EVENT],
   tags: [
     t('Bar'),

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Line/index.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Line/index.js
@@ -35,7 +35,7 @@ const metadata = new ChartMetadata({
     { url: example2 },
     { url: battery, caption: t('Battery level over time') },
   ],
-  name: t('Line Chart'),
+  name: t('Line Chart (legacy)'),
   supportedAnnotationTypes: [
     ANNOTATION_TYPES.TIME_SERIES,
     ANNOTATION_TYPES.INTERVAL,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Area/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Area/index.ts
@@ -68,7 +68,7 @@ export default class EchartsAreaChartPlugin extends ChartPlugin<
           AnnotationType.Timeseries,
         ],
         name: hasGenericChartAxes
-          ? t('Area Chart v2')
+          ? t('Area Chart')
           : t('Time-series Area Chart'),
         tags: [
           t('ECharts'),

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/index.ts
@@ -75,9 +75,7 @@ export default class EchartsTimeseriesBarChartPlugin extends ChartPlugin<
           AnnotationType.Interval,
           AnnotationType.Timeseries,
         ],
-        name: hasGenericChartAxes
-          ? t('Bar Chart v2')
-          : t('Time-series Bar Chart v2'),
+        name: hasGenericChartAxes ? t('Bar Chart') : t('Time-series Bar Chart'),
         tags: [
           t('ECharts'),
           t('Predictive'),

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/index.ts
@@ -73,7 +73,7 @@ export default class EchartsTimeseriesLineChartPlugin extends ChartPlugin<
           AnnotationType.Timeseries,
         ],
         name: hasGenericChartAxes
-          ? t('Line Chart v2')
+          ? t('Line Chart')
           : t('Time-series Line Chart'),
         tags: [
           t('ECharts'),

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/index.ts
@@ -53,7 +53,7 @@ export default class EchartsTreemapChartPlugin extends ChartPlugin<
           'Show hierarchical relationships of data, with with the value represented by area, showing proportion and contribution to the whole.',
         ),
         exampleGallery: [{ url: example1 }, { url: example2 }],
-        name: t('Treemap v2'),
+        name: t('Treemap'),
         tags: [
           t('Aesthetic'),
           t('Categorical'),

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/index.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/index.ts
@@ -51,7 +51,7 @@ export default class PivotTableChartPlugin extends ChartPlugin<
       description: t(
         'Used to summarize a set of data by grouping together multiple statistics along two axes. Examples: Sales numbers by region and month, tasks by status and assignee, active users by age and location. Not the most visually stunning visualization, but highly informative and versatile.',
       ),
-      name: t('Pivot Table v2'),
+      name: t('Pivot Table'),
       tags: [t('Additive'), t('Report'), t('Tabular'), t('Popular')],
       thumbnail,
     });

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.tsx
@@ -139,7 +139,7 @@ describe('VizTypeControl', () => {
     ).toBeInTheDocument();
     expect(
       within(screen.getByTestId('fast-viz-switcher')).getByText(
-        'Time-series Bar Chart v2',
+        'Time-series Bar Chart',
       ),
     ).toBeInTheDocument();
     expect(
@@ -251,7 +251,7 @@ describe('VizTypeControl', () => {
       within(visualizations).getByText('Time-series Line Chart'),
     ).toBeVisible();
     expect(
-      within(visualizations).getByText('Time-series Bar Chart v2'),
+      within(visualizations).getByText('Time-series Bar Chart'),
     ).toBeVisible();
     expect(
       within(visualizations).queryByText('Line Chart'),
@@ -269,9 +269,7 @@ describe('VizTypeControl', () => {
     renderWrapper();
     userEvent.click(screen.getByRole('button', { name: 'ballot All charts' }));
     const visualizations = screen.getByTestId(getTestId('viz-row'));
-    userEvent.click(
-      within(visualizations).getByText('Time-series Bar Chart v2'),
-    );
+    userEvent.click(within(visualizations).getByText('Time-series Bar Chart'));
 
     expect(defaultProps.onChange).not.toBeCalled();
     userEvent.dblClick(


### PR DESCRIPTION
### SUMMARY
This makes the "v2" charts the "official ones" by removing the version suffix, and add "(legacy)" to the old ones that they're replacing.

### AFTER
Now the viz switcher doesn't feature the v2 name (here I'm using generic x-axis):
<img width="935" alt="image" src="https://user-images.githubusercontent.com/33317356/206448938-dd76c039-d4e0-424b-a14e-9e5ea7869869.png">

### BEFORE
Currently many charts feature a "v2" suffix:
<img width="926" alt="image" src="https://user-images.githubusercontent.com/33317356/206449235-454b1e9f-55dd-4e56-8333-f1c56807b9f1.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
