### PR TITLE
fix: DropdownContainer items width calculation

### DIFF
--- a/superset-frontend/src/components/DropdownContainer/index.tsx
+++ b/superset-frontend/src/components/DropdownContainer/index.tsx
@@ -167,24 +167,24 @@ const DropdownContainer = forwardRef(
       [items, overflowingIndex],
     );
 
-    useEffect(() => {
-      if (itemsWidth.length !== items.length) {
-        const container = current?.children.item(0);
-        if (container) {
-          const { children } = container;
-          const childrenArray = Array.from(children);
-          setItemsWidth(
-            childrenArray.map(child => child.getBoundingClientRect().width),
-          );
-        }
-      }
-    }, [current?.children, items.length, itemsWidth.length]);
-
     useLayoutEffect(() => {
       const container = current?.children.item(0);
       if (container) {
         const { children } = container;
         const childrenArray = Array.from(children);
+
+        // If items length change, add all items to the container
+        // and recalculate the widths
+        if (itemsWidth.length !== items.length) {
+          if (childrenArray.length === items.length) {
+            setItemsWidth(
+              childrenArray.map(child => child.getBoundingClientRect().width),
+            );
+          } else {
+            setOverflowingIndex(-1);
+            return;
+          }
+        }
 
         // Calculates the index of the first overflowed element
         // +1 is to give at least one pixel of difference and avoid flakiness


### PR DESCRIPTION
### SUMMARY
Updates `DropdownContainer` to correctly calculate the width of the items when the `items` property changes.
Previously, the width calculation was only considering visible items which lead to resizing errors.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/206473058-aec4c115-5978-472b-ae09-918d1e0f918f.mov

https://user-images.githubusercontent.com/70410625/206473121-1cd820c2-890b-4d05-ad9b-4141176ca1ba.mov

### TESTING INSTRUCTIONS
Check the videos for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
