### PR TITLE
fix: Add tooltip to dropdown trigger in horizontal filter bar

### DIFF
--- a/superset-frontend/src/components/DropdownContainer/DropdownContainer.test.tsx
+++ b/superset-frontend/src/components/DropdownContainer/DropdownContainer.test.tsx
@@ -141,3 +141,16 @@ test('renders a dropdown with custom content', async () => {
     expect(screen.getByText('Custom content')).toBeInTheDocument();
   });
 });
+
+test('Shows tooltip on dropdown trigger hover', async () => {
+  await mockOverflowingIndex(3, async () => {
+    render(
+      <DropdownContainer
+        items={generateItems(5)}
+        dropdownTriggerTooltip="Test tooltip"
+      />,
+    );
+    userEvent.hover(screen.getByText('More'));
+    expect(await screen.findByText('Test tooltip')).toBeInTheDocument();
+  });
+});

--- a/superset-frontend/src/components/DropdownContainer/index.tsx
+++ b/superset-frontend/src/components/DropdownContainer/index.tsx
@@ -27,6 +27,7 @@ import React, {
   useMemo,
   useState,
   useRef,
+  ReactNode,
 } from 'react';
 import { Global } from '@emotion/react';
 import { css, t, useTheme } from '@superset-ui/core';
@@ -36,6 +37,7 @@ import Badge from '../Badge';
 import Icons from '../Icons';
 import Button from '../Button';
 import Popover from '../Popover';
+import { Tooltip } from '../Tooltip';
 
 const MAX_HEIGHT = 500;
 
@@ -96,6 +98,10 @@ export interface DropdownContainerProps {
    */
   dropdownTriggerText?: string;
   /**
+   * Text of the dropdown trigger tooltip
+   */
+  dropdownTriggerTooltip?: ReactNode | null;
+  /**
    * Main container additional style properties.
    */
   style?: CSSProperties;
@@ -114,6 +120,7 @@ const DropdownContainer = forwardRef(
       dropdownTriggerCount,
       dropdownTriggerIcon,
       dropdownTriggerText = t('More'),
+      dropdownTriggerTooltip = null,
       style,
     }: DropdownContainerProps,
     outerRef: RefObject<Ref>,
@@ -360,30 +367,32 @@ const DropdownContainer = forwardRef(
               placement="bottom"
               destroyTooltipOnHide
             >
-              <Button
-                buttonStyle="secondary"
-                data-test="dropdown-container-btn"
-              >
-                {dropdownTriggerIcon}
-                {dropdownTriggerText}
-                <Badge
-                  count={dropdownTriggerCount ?? overflowingCount}
-                  css={css`
-                    margin-left: ${dropdownTriggerCount ?? overflowingCount
-                      ? `${theme.gridUnit * 2}px`
-                      : '0'};
-                  `}
-                />
-                <Icons.DownOutlined
-                  iconSize="m"
-                  iconColor={theme.colors.grayscale.light1}
-                  css={css`
-                    .anticon {
-                      display: flex;
-                    }
-                  `}
-                />
-              </Button>
+              <Tooltip title={dropdownTriggerTooltip}>
+                <Button
+                  buttonStyle="secondary"
+                  data-test="dropdown-container-btn"
+                >
+                  {dropdownTriggerIcon}
+                  {dropdownTriggerText}
+                  <Badge
+                    count={dropdownTriggerCount ?? overflowingCount}
+                    css={css`
+                      margin-left: ${dropdownTriggerCount ?? overflowingCount
+                        ? `${theme.gridUnit * 2}px`
+                        : '0'};
+                    `}
+                  />
+                  <Icons.DownOutlined
+                    iconSize="m"
+                    iconColor={theme.colors.grayscale.light1}
+                    css={css`
+                      .anticon {
+                        display: flex;
+                      }
+                    `}
+                  />
+                </Button>
+              </Tooltip>
             </Popover>
           </>
         )}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
@@ -153,7 +153,7 @@ const FilterControls: FC<FilterControlsProps> = ({
     () =>
       overflowedFiltersInScope.filter(filter =>
         isNativeFilterWithDataMask(filter),
-      ).length,
+      ),
     [overflowedFiltersInScope],
   );
 
@@ -180,7 +180,17 @@ const FilterControls: FC<FilterControlsProps> = ({
           />
         }
         dropdownTriggerText={t('More filters')}
-        dropdownTriggerCount={activeOverflowedFiltersInScope}
+        dropdownTriggerCount={activeOverflowedFiltersInScope.length}
+        dropdownTriggerTooltip={
+          activeOverflowedFiltersInScope.length === 0
+            ? t('No applied filters')
+            : t(
+                'Applied filters: %s',
+                activeOverflowedFiltersInScope
+                  .map(filter => filter.name)
+                  .join(', '),
+              )
+        }
         dropdownContent={
           overflowedFiltersInScope.length ||
           (filtersOutOfScope.length && showCollapsePanel)


### PR DESCRIPTION

### SUMMARY
Adds a tooltip with list of applied filter names to the dropdown trigger in horizontal filter bar

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="340" alt="image" src="https://user-images.githubusercontent.com/15073128/206487797-0cc8ac51-6524-4b4d-a2cd-ef8cc2618642.png">

<img width="317" alt="image" src="https://user-images.githubusercontent.com/15073128/206487879-3b3809a5-c635-4d85-a488-a6e76a099e7f.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
