### PR TITLE
fix: correct exception level in log and add error message

### DIFF
--- a/superset/tasks/scheduler.py
+++ b/superset/tasks/scheduler.py
@@ -69,7 +69,7 @@ def scheduler() -> None:
                         active_schedule.id,
                         schedule,
                     ),
-                    **async_options
+                    **async_options,
                 )
 
 
@@ -97,7 +97,10 @@ def execute(self: Celery.task, report_schedule_id: int, scheduled_dttm: str) -> 
     except CommandException as ex:
         logger_func, level = get_logger_from_status(ex.status)
         logger_func(
-            "A downstream %s occurred while generating a report: %s", level, task_id
+            "A downstream {} occurred while generating a report: {}. {}".format(
+                level, task_id, ex.message
+            ),
+            exc_info=True,
         )
         if level == LoggerLevel.EXCEPTION:
             self.update_state(state="FAILURE")

--- a/tests/integration_tests/reports/scheduler_tests.py
+++ b/tests/integration_tests/reports/scheduler_tests.py
@@ -179,3 +179,35 @@ def test_execute_task(update_state_mock, command_mock, init_mock, owners):
 
         db.session.delete(report_schedule)
         db.session.commit()
+
+
+@pytest.mark.usefixtures("owners")
+@patch("superset.reports.commands.execute.AsyncExecuteReportScheduleCommand.__init__")
+@patch("superset.reports.commands.execute.AsyncExecuteReportScheduleCommand.run")
+@patch("superset.tasks.scheduler.execute.update_state")
+@patch("superset.utils.log.logger")
+def test_execute_task_with_command_exception(
+    logger_mock, update_state_mock, command_mock, init_mock, owners
+):
+    from superset.commands.exceptions import CommandException
+
+    with app.app_context():
+        report_schedule = insert_report_schedule(
+            type=ReportScheduleType.ALERT,
+            name=f"report-{randint(0,1000)}",
+            crontab="0 4 * * *",
+            timezone="America/New_York",
+            owners=owners,
+        )
+        init_mock.return_value = None
+        command_mock.side_effect = CommandException("Unexpected error")
+        with freeze_time("2020-01-01T09:00:00Z"):
+            execute(report_schedule.id, "2020-01-01T09:00:00Z")
+            update_state_mock.assert_called_with(state="FAILURE")
+            logger_mock.exception.assert_called_with(
+                "A downstream exception occurred while generating a report: None. Unexpected error",
+                exc_info=True,
+            )
+
+        db.session.delete(report_schedule)
+        db.session.commit()


### PR DESCRIPTION
### SUMMARY
Followup to https://github.com/apache/superset/pull/21971, this PR makes a slight correction to print the string value of the logger level in the logs, and also passes in the error message. I'm also including the stack trace for warning level logs. 


### TESTING INSTRUCTIONS
If you were to run this manually, you would see that error messages correctly say `A downstream exception occurred while generating a report` instead of `A downstream LoggerLevel.EXCEPTION occurred while generating a report` and also have an added message at the end of the log and a stack trace for both exceptions and warnings.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
