### PR TITLE
chore(plugin-chart-echarts): upgrade to echarts 5.4.1

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -27709,12 +27709,12 @@
       }
     },
     "node_modules/echarts": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.4.0.tgz",
-      "integrity": "sha512-uPsO9VRUIKAdFOoH3B0aNg7NRVdN7aM39/OjovjO9MwmWsAkfGyeXJhK+dbRi51iDrQWliXV60/XwLA7kg3z0w==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.4.1.tgz",
+      "integrity": "sha512-9ltS3M2JB0w2EhcYjCdmtrJ+6haZcW6acBolMGIuf01Hql1yrIV01L1aRj7jsaaIULJslEP9Z3vKlEmnJaWJVQ==",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "5.4.0"
+        "zrender": "5.4.1"
       }
     },
     "node_modules/echarts/node_modules/tslib": {
@@ -55676,9 +55676,9 @@
       }
     },
     "node_modules/zrender": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.4.0.tgz",
-      "integrity": "sha512-rOS09Z2HSVGFs2dn/TuYk5BlCaZcVe8UDLLjj1ySYF828LATKKdxuakSZMvrDz54yiKPDYVfjdKqcX8Jky3BIA==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.4.1.tgz",
+      "integrity": "sha512-M4Z05BHWtajY2241EmMPHglDQAJ1UyHQcYsxDNzD9XLSkPDqMq4bB28v9Pb4mvHnVQ0GxyTklZ/69xCFP6RXBA==",
       "dependencies": {
         "tslib": "2.3.0"
       }
@@ -57180,7 +57180,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "d3-array": "^1.2.0",
-        "echarts": "^5.4.0",
+        "echarts": "^5.4.1",
         "lodash": "^4.17.15",
         "moment": "^2.26.0"
       },
@@ -71159,7 +71159,7 @@
       "version": "file:plugins/plugin-chart-echarts",
       "requires": {
         "d3-array": "^1.2.0",
-        "echarts": "^5.4.0",
+        "echarts": "^5.4.1",
         "lodash": "^4.17.15",
         "moment": "^2.26.0"
       }
@@ -79559,12 +79559,12 @@
       }
     },
     "echarts": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.4.0.tgz",
-      "integrity": "sha512-uPsO9VRUIKAdFOoH3B0aNg7NRVdN7aM39/OjovjO9MwmWsAkfGyeXJhK+dbRi51iDrQWliXV60/XwLA7kg3z0w==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.4.1.tgz",
+      "integrity": "sha512-9ltS3M2JB0w2EhcYjCdmtrJ+6haZcW6acBolMGIuf01Hql1yrIV01L1aRj7jsaaIULJslEP9Z3vKlEmnJaWJVQ==",
       "requires": {
         "tslib": "2.3.0",
-        "zrender": "5.4.0"
+        "zrender": "5.4.1"
       },
       "dependencies": {
         "tslib": {
@@ -100946,9 +100946,9 @@
       }
     },
     "zrender": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.4.0.tgz",
-      "integrity": "sha512-rOS09Z2HSVGFs2dn/TuYk5BlCaZcVe8UDLLjj1ySYF828LATKKdxuakSZMvrDz54yiKPDYVfjdKqcX8Jky3BIA==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.4.1.tgz",
+      "integrity": "sha512-M4Z05BHWtajY2241EmMPHglDQAJ1UyHQcYsxDNzD9XLSkPDqMq4bB28v9Pb4mvHnVQ0GxyTklZ/69xCFP6RXBA==",
       "requires": {
         "tslib": "2.3.0"
       },

--- a/superset-frontend/plugins/plugin-chart-echarts/package.json
+++ b/superset-frontend/plugins/plugin-chart-echarts/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "d3-array": "^1.2.0",
-    "echarts": "^5.4.0",
+    "echarts": "^5.4.1",
     "lodash": "^4.17.15",
     "moment": "^2.26.0"
   },


### PR DESCRIPTION
### SUMMARY

Bump ECharts to 5.4.1. Changelog: https://echarts.apache.org/en/changelog.html

More specifically for Superset, this patch release fixes an issue that @zhaoyongjie spotted in this review commen: https://github.com/apache/superset/pull/22218#issuecomment-1326254783 (link to original fix PR: https://github.com/apache/echarts/pull/17715)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
