### PR TITLE
perf: Prevent rerendering and re-querying metadata of filters in horizontal bar

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
@@ -17,6 +17,11 @@
  * under the License.
  */
 import React, { useContext, useMemo, useState } from 'react';
+import {
+  createHtmlPortalNode,
+  InPortal,
+  OutPortal,
+} from 'react-reverse-portal';
 import { styled, SupersetTheme } from '@superset-ui/core';
 import { FormItem as StyledFormItem, Form } from 'src/components/Form';
 import { Tooltip } from 'src/components/Tooltip';
@@ -224,6 +229,7 @@ const FilterControl = ({
   orientation = FilterBarOrientation.VERTICAL,
   overflow = false,
 }: FilterControlProps) => {
+  const portalNode = useMemo(() => createHtmlPortalNode(), []);
   const [isFilterActive, setIsFilterActive] = useState(false);
 
   const { name = '<undefined>' } = filter;
@@ -276,40 +282,45 @@ const FilterControl = ({
   }, [orientation, overflow]);
 
   return (
-    <FilterControlContainer
-      layout={
-        orientation === FilterBarOrientation.HORIZONTAL && !overflow
-          ? 'horizontal'
-          : 'vertical'
-      }
-    >
-      <FilterCard
-        filter={filter}
-        isVisible={!isFilterActive && !isScrolling}
-        placement={filterCardPlacement}
+    <>
+      <InPortal node={portalNode}>
+        <FilterValue
+          dataMaskSelected={dataMaskSelected}
+          filter={filter}
+          showOverflow={showOverflow}
+          focusedFilterId={focusedFilterId}
+          onFilterSelectionChange={onFilterSelectionChange}
+          inView={inView}
+          parentRef={parentRef}
+          setFilterActive={setIsFilterActive}
+          orientation={orientation}
+          overflow={overflow}
+        />
+      </InPortal>
+      <FilterControlContainer
+        layout={
+          orientation === FilterBarOrientation.HORIZONTAL && !overflow
+            ? 'horizontal'
+            : 'vertical'
+        }
       >
-        <div>
-          <FormItem
-            label={label}
-            required={filter?.controlValues?.enableEmptyFilter}
-            validateStatus={isMissingRequiredValue ? 'error' : undefined}
-          >
-            <FilterValue
-              dataMaskSelected={dataMaskSelected}
-              filter={filter}
-              showOverflow={showOverflow}
-              focusedFilterId={focusedFilterId}
-              onFilterSelectionChange={onFilterSelectionChange}
-              inView={inView}
-              parentRef={parentRef}
-              setFilterActive={setIsFilterActive}
-              orientation={orientation}
-              overflow={overflow}
-            />
-          </FormItem>
-        </div>
-      </FilterCard>
-    </FilterControlContainer>
+        <FilterCard
+          filter={filter}
+          isVisible={!isFilterActive && !isScrolling}
+          placement={filterCardPlacement}
+        >
+          <div>
+            <FormItem
+              label={label}
+              required={filter?.controlValues?.enableEmptyFilter}
+              validateStatus={isMissingRequiredValue ? 'error' : undefined}
+            >
+              <OutPortal node={portalNode} />
+            </FormItem>
+          </div>
+        </FilterCard>
+      </FilterControlContainer>
+    </>
   );
 };
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
@@ -319,4 +319,4 @@ const FilterValue: React.FC<FilterControlProps> = ({
     </StyledDiv>
   );
 };
-export default FilterValue;
+export default React.memo(FilterValue);


### PR DESCRIPTION

### SUMMARY
Because of how the component structure changes when filters move in/out of "More filters" dropdown, the `FilterValue` component is getting unmounted and re-mounted, which causes the whole filter to rerender and resend its metadata query.
To prevent that behaviour, this PR uses `react-reverse-portal` to ensure that `FilterValue` component's lifecycle is independent of how its wrappers change. It's a similar pattern that we already use in `FilterControls` component.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/15073128/207066510-8e6f4b23-0ccc-4408-bd20-5964c7cb27d1.mov

After:

https://user-images.githubusercontent.com/15073128/207066081-4b85e42b-11d9-4a6f-ad48-b84733c96754.mov


### TESTING INSTRUCTIONS
1. Enable `HORIZONTAL_FILTER_BAR` ff
2. Add some filters and switch filter bar to horizontal mode
3. Change window size so that some filters go into/out of "More filters" dropdown and observe that there is no spinner indicating that request is being made. Check that there are no new requests in Network tab

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @codyml for review