### PR TITLE
fix(sqla): copy temporal range logic to helper

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -65,6 +65,7 @@ from sqlalchemy_utils import UUIDType
 from superset import app, is_feature_enabled, security_manager
 from superset.advanced_data_type.types import AdvancedDataTypeResponse
 from superset.common.db_query_status import QueryStatus
+from superset.common.utils.time_range_utils import get_since_until_from_time_range
 from superset.constants import EMPTY_STRING, NULL_STRING
 from superset.db_engine_specs.base import TimestampExpression
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
@@ -1236,8 +1237,8 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
     def get_time_filter(
         self,
         time_col: Dict[str, Any],
-        start_dttm: sa.DateTime,
-        end_dttm: sa.DateTime,
+        start_dttm: Optional[sa.DateTime],
+        end_dttm: Optional[sa.DateTime],
     ) -> ColumnElement:
         label = "__time"
         col = time_col.get("column_name")
@@ -1779,6 +1780,23 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                         where_clause_and.append(sqla_col.like(eq))
                     elif op == utils.FilterOperator.ILIKE.value:
                         where_clause_and.append(sqla_col.ilike(eq))
+                    elif (
+                        op == utils.FilterOperator.TEMPORAL_RANGE.value
+                        and isinstance(eq, str)
+                        and col_obj is not None
+                    ):
+                        _since, _until = get_since_until_from_time_range(
+                            time_range=eq,
+                            time_shift=time_shift,
+                            extras=extras,
+                        )
+                        where_clause_and.append(
+                            self.get_time_filter(
+                                time_col=col_obj,
+                                start_dttm=_since,
+                                end_dttm=_until,
+                            )
+                        )
                     else:
                         raise QueryObjectValidationError(
                             _("Invalid filter operation type: %(op)s", op=op)


### PR DESCRIPTION
### SUMMARY
When exploring a query containing a temporal column I noticed that the query would fail unless persisted as a virtual dataset when the `GENERIC_CHART_AXES` feature flag is enabled. Digging around I noticed that the `ExploreMixin` class in the `superset.models.helpers` module (introduced in #20281) duplicates essentially all logic from the 
`SqlaTable` class in the `superset.connectors.sqla.models` module. From a maintenance perspective this is highly problematic, as the SQLA connector model is by far one of the biggest pieces of tech debt in the backend with poor test coverage, while simultaneously being very fragile and frequently receiving minor tweaks/fixes. Duplicating this code without having tests in place to ensure that they're in sync makes it difficult for contributors to know that changes need to be applied in both modules.

This is just a hotfix to make the `ExploreMixin` class from the helpers module work with `GENERIC_CHART_AXES`. However, IMO we need to deduplicate this code ASAP, as they've already diverged quite a bit, with many fixes to the SQLA model not having made their way into the helpers module (#22280 is an example of such). I haven't reviewed the original PR, but a simple solution that comes to mind is removing the original logic and adding `ExploreMixin` to `SqlaTable`, which ensures that the legacy model (which is still the main one in use) uses the exact same logic as the new models.

### AFTER
Now a query that hasn't been saved as a virtual dataset works with temporal filters:
![image](https://user-images.githubusercontent.com/33317356/207261359-79c98aff-9fb4-45bd-801f-9707908ce53c.png)

### BEFORE
Previously the same chart would fail.
![image](https://user-images.githubusercontent.com/33317356/207261597-bc3d165d-2395-42bd-bb14-9c912bbbdb29.png)



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
