### PR TITLE
chore: show database UUID in API

### DIFF
--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -115,6 +115,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     base_filters = [["id", DatabaseFilter, lambda: []]]
     show_columns = [
         "id",
+        "uuid",
         "database_name",
         "cache_timeout",
         "expose_in_sqllab",
@@ -157,6 +158,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         "extra",
         "force_ctas_schema",
         "id",
+        "uuid",
         "disable_data_preview",
         "engine_information",
     ]

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -201,6 +201,7 @@ class TestDatabaseApi(SupersetTestCase):
             "extra",
             "force_ctas_schema",
             "id",
+            "uuid",
         ]
 
         self.assertGreater(response["count"], 0)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->


### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Show the database UUID in the `/api/v1/database/` endpoint. This is useful for a lot of integrations (Databricks, dbt) I've been working on.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

WIP

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
