### PR TITLE
chore(sqla): Add explicit bidirectional performant relationships for SQLA model

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -68,7 +68,14 @@ from sqlalchemy import (
 )
 from sqlalchemy.engine.base import Connection
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import backref, Query, relationship, RelationshipProperty, Session
+from sqlalchemy.orm import (
+    backref,
+    Mapped,
+    Query,
+    relationship,
+    RelationshipProperty,
+    Session,
+)
 from sqlalchemy.orm.mapper import Mapper
 from sqlalchemy.schema import UniqueConstraint
 from sqlalchemy.sql import column, ColumnElement, literal_column, table
@@ -224,10 +231,10 @@ class TableColumn(Model, BaseColumn, CertificationMixin):
     __tablename__ = "table_columns"
     __table_args__ = (UniqueConstraint("table_id", "column_name"),)
     table_id = Column(Integer, ForeignKey("tables.id"))
-    table: SqlaTable = relationship(
+    table: Mapped["SqlaTable"] = relationship(
         "SqlaTable",
-        backref=backref("columns", cascade="all, delete-orphan"),
-        foreign_keys=[table_id],
+        back_populates="columns",
+        lazy="joined",  # Eager loading for efficient parent referencing with selectin.
     )
     is_dttm = Column(Boolean, default=False)
     expression = Column(MediumText())
@@ -439,10 +446,10 @@ class SqlMetric(Model, BaseMetric, CertificationMixin):
     __tablename__ = "sql_metrics"
     __table_args__ = (UniqueConstraint("table_id", "metric_name"),)
     table_id = Column(Integer, ForeignKey("tables.id"))
-    table = relationship(
+    table: Mapped["SqlaTable"] = relationship(
         "SqlaTable",
-        backref=backref("metrics", cascade="all, delete-orphan"),
-        foreign_keys=[table_id],
+        back_populates="metrics",
+        lazy="joined",  # Eager loading for efficient parent referencing with selectin.
     )
     expression = Column(MediumText(), nullable=False)
     extra = Column(Text)
@@ -535,13 +542,23 @@ def _process_sql_expression(
 
 
 class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-methods
-    """An ORM object for SqlAlchemy table references"""
+    """An ORM object for SqlAlchemy table references."""
 
     type = "table"
     query_language = "sql"
     is_rls_supported = True
-    columns: List[TableColumn] = []
-    metrics: List[SqlMetric] = []
+    columns: Mapped[List[TableColumn]] = relationship(
+        TableColumn,
+        back_populates="table",
+        cascade="all, delete-orphan",
+        lazy="selectin",  # Only non-eager loading that works with bidirectional joined.
+    )
+    metrics: Mapped[List[SqlMetric]] = relationship(
+        SqlMetric,
+        back_populates="table",
+        cascade="all, delete-orphan",
+        lazy="selectin",  # Only non-eager loading that works with bidirectional joined.
+    )
     metric_class = SqlMetric
     column_class = TableColumn
     owner_class = security_manager.user_model

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -242,6 +242,9 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         DatasetDuplicateSchema,
     )
 
+    list_outer_default_load = True
+    show_outer_default_load = True
+
     @expose("/", methods=["POST"])
     @protect()
     @safe

--- a/superset/examples/birth_names.py
+++ b/superset/examples/birth_names.py
@@ -144,8 +144,8 @@ def _add_table_metrics(datasource: SqlaTable) -> None:
         metrics.append(SqlMetric(metric_name="sum__num", expression=f"SUM({col})"))
 
     for col in columns:
-        if col.column_name == "ds":
-            col.is_dttm = True
+        if col.column_name == "ds":  # type: ignore
+            col.is_dttm = True  # type: ignore
             break
 
     datasource.columns = columns

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -423,11 +423,6 @@ class Dashboard(Model, AuditMixinNullable, ImportExportMixin):
                 remote_id=eager_datasource.id,
                 database_name=eager_datasource.database.name,
             )
-            datasource_class = copied_datasource.__class__
-            for field_name in datasource_class.export_children:
-                field_val = getattr(eager_datasource, field_name).copy()
-                # set children without creating ORM relations
-                copied_datasource.__dict__[field_name] = field_val
             eager_datasources.append(copied_datasource)
 
         return json.dumps(

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -327,7 +327,10 @@ class ImportExportMixin:
         # Recursively create children
         if recursive:
             for child in cls.export_children:
-                child_class = cls.__mapper__.relationships[child].argument.class_
+                argument = cls.__mapper__.relationships[child].argument
+                child_class = (
+                    argument.class_ if hasattr(argument, "class_") else argument
+                )
                 added = []
                 for c_obj in new_children.get(child, []):
                     added.append(

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -1315,9 +1315,10 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
 
         chart.owners = []
         dataset.owners = []
-        database.owners = []
         db.session.delete(chart)
+        db.session.commit()
         db.session.delete(dataset)
+        db.session.commit()
         db.session.delete(database)
         db.session.commit()
 
@@ -1387,9 +1388,10 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
 
         chart.owners = []
         dataset.owners = []
-        database.owners = []
         db.session.delete(chart)
+        db.session.commit()
         db.session.delete(dataset)
+        db.session.commit()
         db.session.delete(database)
         db.session.commit()
 

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -1987,8 +1987,8 @@ class TestDatabaseApi(SupersetTestCase):
         assert str(dataset.uuid) == dataset_config["uuid"]
 
         dataset.owners = []
-        database.owners = []
         db.session.delete(dataset)
+        db.session.commit()
         db.session.delete(database)
         db.session.commit()
 
@@ -2058,8 +2058,8 @@ class TestDatabaseApi(SupersetTestCase):
         )
         dataset = database.tables[0]
         dataset.owners = []
-        database.owners = []
         db.session.delete(dataset)
+        db.session.commit()
         db.session.delete(database)
         db.session.commit()
 

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -1988,8 +1988,8 @@ class TestDatasetApi(SupersetTestCase):
         assert str(dataset.uuid) == dataset_config["uuid"]
 
         dataset.owners = []
-        database.owners = []
         db.session.delete(dataset)
+        db.session.commit()
         db.session.delete(database)
         db.session.commit()
 
@@ -2090,8 +2090,8 @@ class TestDatasetApi(SupersetTestCase):
         dataset = database.tables[0]
 
         dataset.owners = []
-        database.owners = []
         db.session.delete(dataset)
+        db.session.commit()
         db.session.delete(database)
         db.session.commit()
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR partially addresses recommendation #&#x2060;1 in https://github.com/apache/superset/issues/14383 by defining the explicit bidirectional relationship mapping between the `SqlaTable` model (parent) and the corresponding `SqlMetric` and `TableColumn` models (children) to improve the performance of the `GET` `/api/v1/dataset/{pk}` endpoint—in conjunction with https://github.com/dpgaspar/Flask-AppBuilder/pull/1961. This PR is a rehash of https://github.com/apache/superset/pull/22332 after it was discovered there were numerous shortcomings.

The motivation was driven by a specific (and somewhat atypical) virtual dataset at Airbnb which is comprised of over 7,000 columns and 30,000 metrics where previously the `/api/v1/dataset/{pk}` endpoint would timeout due to:

1. FAB was using [Joined Eager Loading](https://docs.sqlalchemy.org/en/14/orm/loading_relationships.html#joined-eager-loading) which "eagerly" loads the children alongside the parent, however this results in a slew of `LEFT OUTER JOIN`s which will rapidly result into a expansive interim result set—from a multiplicative combinatorial sense—given that the `SqlaTable` model has potentially multiple high cardinality relationships (owners, columns, metrics). Furthermore the result set—which is repetitive in nature—requires further overhead by SQLAlchemy to [de-duplicate](https://docs.sqlalchemy.org/en/14/orm/loading_relationships.html#joined-eager-loading-and-result-set-batching) the rows against the actual model record.
2. Superset was using lazy loading (see [this](https://apache-superset.slack.com/archives/G013HAE6Y0K/p1670880289179439) Slack thread) when back referencing the `TableColumn.table` field when evaluating the `columns.type_generic` field which resulted in a `SELECT` statement per column, i.e., for each column it would execute a SQL statement to fetch the corresponding table ID.

The first issue is partially addressed in https://github.com/dpgaspar/Flask-AppBuilder/pull/1961 in conjunction with this change—as FAB defers the relationship loading logic to Superset—which meant that the response time (excluding downloading of the payload) went from timing out to ~ 20 seconds. The second issue was addressed by defining eager loading of the back (parent) references which are pre-defined whilst fetching the `SqlaTable` model. This further reduced the response time to ~ 5 seconds. Note this PR is safe to  merge prior to the FAB change as in the context of FAB the `selectin`—a more extensible form of `select` which can be used when fetching multiple `SqlaTable` columns—relationship loading technique is ignored given that FAB is using an explicit [joinedload](https://docs.sqlalchemy.org/en/14/orm/loading_relationships.html#sqlalchemy.orm.joinedload) which is akin to `lazy="joined"`.

Note to further improve the performance of the `GET` `/api/v1/dataset/{pk}` endpoint all requests should likely provide a filter which includes only the subset of the columns required. This should both reduce the backend complexity as well as reduce the size of the response payload.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI. Tested locally. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: https://github.com/apache/superset/issues/14383
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
