### PR TITLE
fix: fix comment in Docker environment files

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -23,7 +23,7 @@ DATABASE_PASSWORD=superset
 DATABASE_USER=superset
 
 # database engine specific environment variables
-# change the below if you prefers another database engine
+# change the below if you prefer another database engine
 DATABASE_PORT=5432
 DATABASE_DIALECT=postgresql
 POSTGRES_DB=superset

--- a/docker/.env-non-dev
+++ b/docker/.env-non-dev
@@ -23,7 +23,7 @@ DATABASE_PASSWORD=superset
 DATABASE_USER=superset
 
 # database engine specific environment variables
-# change the below if you prefers another database engine
+# change the below if you prefer another database engine
 DATABASE_PORT=5432
 DATABASE_DIALECT=postgresql
 POSTGRES_DB=superset


### PR DESCRIPTION
Fix comment in `docker/.env` and `docker/.env-non-dev` files (changed from `prefers` to `prefer`).