### PR TITLE
fix: Allow empty CSS in Handlebars

### DIFF
--- a/superset-frontend/plugins/plugin-chart-handlebars/src/components/ControlHeader/controlHeader.tsx
+++ b/superset-frontend/plugins/plugin-chart-handlebars/src/components/ControlHeader/controlHeader.tsx
@@ -26,8 +26,6 @@ export const ControlHeader = ({
   children,
 }: ControlHeaderProps): JSX.Element => (
   <div className="ControlHeader">
-    <div className="pull-left">
-      <span role="button">{children}</span>
-    </div>
+    <div className="pull-left">{children}</div>
   </div>
 );

--- a/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controls/style.tsx
+++ b/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controls/style.tsx
@@ -20,8 +20,9 @@ import {
   ControlSetItem,
   CustomControlConfig,
   sharedControls,
+  InfoTooltipWithTrigger,
 } from '@superset-ui/chart-controls';
-import { t } from '@superset-ui/core';
+import { t, useTheme } from '@superset-ui/core';
 import React from 'react';
 import { CodeEditor } from '../../components/CodeEditor/CodeEditor';
 import { ControlHeader } from '../../components/ControlHeader/controlHeader';
@@ -32,17 +33,32 @@ interface StyleCustomControlProps {
 }
 
 const StyleControl = (props: CustomControlConfig<StyleCustomControlProps>) => {
-  const val = String(
-    props?.value ? props?.value : props?.default ? props?.default : '',
-  );
+  const theme = useTheme();
+
+  const defaultValue = props?.value
+    ? undefined
+    : `/*
+  .data-list {
+    background-color: yellow;
+  }
+*/`;
 
   return (
     <div>
-      <ControlHeader>{props.label}</ControlHeader>
+      <ControlHeader>
+        <div>
+          {props.label}
+          <InfoTooltipWithTrigger
+            iconsStyle={{ marginLeft: theme.gridUnit }}
+            tooltip={t('You need to configure HTML sanitization to use CSS')}
+          />
+        </div>
+      </ControlHeader>
       <CodeEditor
         theme="dark"
         mode="css"
-        value={val}
+        value={props.value}
+        defaultValue={defaultValue}
         onChange={source => {
           debounceFunc(props.onChange, source || '');
         }}
@@ -58,11 +74,6 @@ export const styleControlSetItem: ControlSetItem = {
     type: StyleControl,
     label: t('CSS Styles'),
     description: t('CSS applied to the chart'),
-    default: `/*
-.data-list {
-  background-color: yellow;
-}
-*/`,
     isInt: false,
     renderTrigger: true,
 


### PR DESCRIPTION
### SUMMARY
Allow empty CSS in Handlebars and also add a tooltip about the required HTML sanitization when using CSS.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/207725368-a3fed70d-9481-4645-bc95-4fca08d8a9c4.mov

### TESTING INSTRUCTIONS
- You should be able to save a Handlebar without any CSS text.
- A tooltip is displayed about the required HTML sanitization when using CSS.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
