### PR TITLE
chore(viz): Rename legacy non-time-series Bar Chart

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js
@@ -35,7 +35,7 @@ const metadata = new ChartMetadata({
     { url: example2, caption: 'Grouped style' },
     { url: example3 },
   ],
-  name: t('Bar Chart'),
+  name: t('Bar Chart (legacy)'),
   tags: [
     t('Additive'),
     t('Bar'),

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js
@@ -16,7 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t, ChartMetadata, ChartPlugin } from '@superset-ui/core';
+import {
+  t,
+  ChartMetadata,
+  ChartPlugin,
+  hasGenericChartAxes,
+} from '@superset-ui/core';
 import transformProps from '../transformProps';
 import thumbnail from './images/thumbnail.png';
 import example1 from './images/Bar_Chart.jpg';
@@ -35,7 +40,7 @@ const metadata = new ChartMetadata({
     { url: example2, caption: 'Grouped style' },
     { url: example3 },
   ],
-  name: t('Bar Chart (legacy)'),
+  name: hasGenericChartAxes ? t('Bar Chart (legacy)') : t('Bar Chart'),
   tags: [
     t('Additive'),
     t('Bar'),


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As a follow-up to https://github.com/apache/superset/pull/22369, this PR renames the legacy non-time-series Bar Chart to Bar Chart (legacy).  There is both a legacy Bar Chart and a legacy Time-series Bar Chart along with the non-legacy Time-series Bar Chart.  When `GENERIC_CHART_AXES` is on, the non-legacy Time-series Bar Chart is displayed as just Bar Chart, so both the new and the old Bar Chart currently end up with the same name.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:
![localhost_9000_explore__form_data_key=S0jPOlJ9DaKJe4hgtUS5zL_ZCpruQkGvN0YWVoVQH59eZWoUElFVk3X_TH-QH5Vb slice_id=75 (1)](https://user-images.githubusercontent.com/13007381/207920022-29d20e95-c15c-4ad0-b336-cea27b95a74b.png)

After:
![localhost_9000_explore__form_data_key=S0jPOlJ9DaKJe4hgtUS5zL_ZCpruQkGvN0YWVoVQH59eZWoUElFVk3X_TH-QH5Vb slice_id=75](https://user-images.githubusercontent.com/13007381/207920069-35cae720-8a20-485d-a1d3-74bbf0ea2f1a.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Check that legacy time-series bar chart, legacy bar chart, and non-legacy time-series bar chart have different names when `GENERIC_CHART_AXES` is on and when it's off.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Required feature flags: `GENERIC_CHART_AXES`
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
