### PR TITLE
fix(hive): Fix regression from #21943

### DIFF
--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -225,22 +225,23 @@ class HiveEngineSpec(PrestoEngineSpec):
         ) as file:
             pq.write_table(pa.Table.from_pandas(df), where=file.name)
 
-            engine.execute(
-                text(
-                    f"""
-                    CREATE TABLE {str(table)} ({schema_definition})
-                    STORED AS PARQUET
-                    LOCATION :location
-                    """
-                ),
-                location=upload_to_s3(
-                    filename=file.name,
-                    upload_prefix=current_app.config[
-                        "CSV_TO_HIVE_UPLOAD_DIRECTORY_FUNC"
-                    ](database, g.user, table.schema),
-                    table=table,
-                ),
-            )
+            with cls.get_engine(database) as engine:
+                engine.execute(
+                    text(
+                        f"""
+                        CREATE TABLE {str(table)} ({schema_definition})
+                        STORED AS PARQUET
+                        LOCATION :location
+                        """
+                    ),
+                    location=upload_to_s3(
+                        filename=file.name,
+                        upload_prefix=current_app.config[
+                            "CSV_TO_HIVE_UPLOAD_DIRECTORY_FUNC"
+                        ](database, g.user, table.schema),
+                        table=table,
+                    ),
+                )
 
     @classmethod
     def convert_dttm(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR fixes a regression introduced in https://github.com/apache/superset/pull/21943 where no context manger was used to create the engine, thus preventing users from being able to upload a CSV file via Hive.

I thought both Pylint would have detected a "Local variable referenced before assignment" error, but maybe the if/context manager logic was simply too complex, as well as the unit tests—but alas this doesn't seem to be the case. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Tested locally.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
