### PR TITLE
chore: set Snowflake user agent

### DIFF
--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -163,11 +163,13 @@ class DatabricksNativeEngineSpec(DatabricksODBCEngineSpec, BasicParametersMixin)
         """
         Add a user agent to be used in the requests.
         """
-        extra = {
-            "http_headers": [("User-Agent", USER_AGENT)],
-            "_user_agent_entry": USER_AGENT,
-        }
-        extra.update(BaseEngineSpec.get_extra_params(database))
+        extra: Dict[str, Any] = BaseEngineSpec.get_extra_params(database)
+        engine_params: Dict[str, Any] = extra.setdefault("engine_params", {})
+        connect_args: Dict[str, Any] = engine_params.setdefault("connect_args", {})
+
+        connect_args.setdefault("http_headers", [("User-Agent", USER_AGENT)])
+        connect_args.setdefault("_user_agent_entry", USER_AGENT)
+
         return extra
 
     @classmethod

--- a/superset/db_engine_specs/snowflake.py
+++ b/superset/db_engine_specs/snowflake.py
@@ -31,8 +31,9 @@ from marshmallow import fields, Schema
 from sqlalchemy.engine.url import URL
 from typing_extensions import TypedDict
 
+from superset.constants import USER_AGENT
 from superset.databases.utils import make_url_safe
-from superset.db_engine_specs.base import BasicPropertiesType
+from superset.db_engine_specs.base import BaseEngineSpec, BasicPropertiesType
 from superset.db_engine_specs.postgres import PostgresBaseEngineSpec
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.models.sql_lab import Query
@@ -117,6 +118,19 @@ class SnowflakeEngineSpec(PostgresBaseEngineSpec):
             {},
         ),
     }
+
+    @staticmethod
+    def get_extra_params(database: "Database") -> Dict[str, Any]:
+        """
+        Add a user agent to be used in the requests.
+        """
+        extra: Dict[str, Any] = BaseEngineSpec.get_extra_params(database)
+        engine_params: Dict[str, Any] = extra.setdefault("engine_params", {})
+        connect_args: Dict[str, Any] = engine_params.setdefault("connect_args", {})
+
+        connect_args.setdefault("application", USER_AGENT)
+
+        return extra
 
     @classmethod
     def adjust_database_uri(

--- a/tests/integration_tests/db_engine_specs/databricks_tests.py
+++ b/tests/integration_tests/db_engine_specs/databricks_tests.py
@@ -44,16 +44,17 @@ class TestDatabricksDbEngineSpec(TestDbEngineSpec):
         db.extra = default_db_extra
         db.server_cert = None
         extras = DatabricksNativeEngineSpec.get_extra_params(db)
-        assert "connect_args" not in extras["engine_params"]
-
-    def test_extras_with_user_agent(self):
-        db = mock.Mock()
-        db.extra = default_db_extra
-        extras = DatabricksNativeEngineSpec.get_extra_params(db)
-        _, user_agent = extras["http_headers"][0]
-        user_agent_entry = extras["_user_agent_entry"]
-        assert user_agent == USER_AGENT
-        assert user_agent_entry == USER_AGENT
+        assert extras == {
+            "engine_params": {
+                "connect_args": {
+                    "_user_agent_entry": "Apache Superset",
+                    "http_headers": [("User-Agent", "Apache Superset")],
+                },
+            },
+            "metadata_cache_timeout": {},
+            "metadata_params": {},
+            "schemas_allowed_for_file_upload": [],
+        }
 
     def test_extras_with_ssl_custom(self):
         db = mock.Mock()


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Set a user agent header in the Snowflake DB Engine Spec indicating the request is coming from Superset.

I also fixed the Databricks user agent, the `get_extra_params` method was returning the incorrect payload.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Added unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
