### PR TITLE
fix: Removes duplicated Bar Chart when GENERIC_CHART_AXES is enabled

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js
@@ -16,7 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t, ChartMetadata, ChartPlugin } from '@superset-ui/core';
+import {
+  t,
+  ChartMetadata,
+  ChartPlugin,
+  hasGenericChartAxes,
+} from '@superset-ui/core';
 import transformProps from '../transformProps';
 import thumbnail from './images/thumbnail.png';
 import example1 from './images/Bar_Chart.jpg';
@@ -35,7 +40,7 @@ const metadata = new ChartMetadata({
     { url: example2, caption: 'Grouped style' },
     { url: example3 },
   ],
-  name: t('Bar Chart'),
+  name: hasGenericChartAxes ? t('Bar Chart (legacy)') : t('Bar Chart'),
   tags: [
     t('Additive'),
     t('Bar'),


### PR DESCRIPTION
### SUMMARY
Removes duplicated `Bar Chart` when `GENERIC_CHART_AXES` feature flag is enabled.

Follow-up of https://github.com/apache/superset/pull/22369

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1093" alt="Screen Shot 2022-12-15 at 4 18 58 PM" src="https://user-images.githubusercontent.com/70410625/207969627-fc18527c-8500-4e68-b31d-647e7d41dafb.png">
<img width="1093" alt="Screen Shot 2022-12-15 at 4 19 18 PM" src="https://user-images.githubusercontent.com/70410625/207969644-57d4d4fb-7203-40c7-9fae-32176295b7b1.png">

### TESTING INSTRUCTIONS
- Enable `GENERIC_CHART_AXES` feature flag
- Search for "bar chart" in viz gallery
- It should present "Bar Chart" and "Bar Chart (legacy)"

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
