### PR TITLE
fix(Annotation Layers): Error when render options with renamed columns

### DIFF
--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
@@ -28,7 +28,7 @@ import {
   validateNonEmpty,
   isValidExpression,
   styled,
-  getMetricLabel,
+  getColumnLabel,
   withTheme,
 } from '@superset-ui/core';
 
@@ -334,8 +334,8 @@ class AnnotationLayer extends React.PureComponent {
                     ...x,
                     data: {
                       ...x.data,
-                      groupby: x.data.groupby.map(metricOrColumn =>
-                        getMetricLabel(metricOrColumn),
+                      groupby: x.data.groupby.map(column =>
+                        getColumnLabel(column),
                       ),
                     },
                   },

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
@@ -28,6 +28,7 @@ import {
   validateNonEmpty,
   isValidExpression,
   styled,
+  getMetricLabel,
   withTheme,
 } from '@superset-ui/core';
 
@@ -326,7 +327,19 @@ class AnnotationLayer extends React.PureComponent {
                     metadata && metadata.canBeAnnotationType(annotationType)
                   );
                 })
-                .map(x => ({ value: x.id, label: x.title, slice: x })),
+                .map(x => ({
+                  value: x.id,
+                  label: x.title,
+                  slice: {
+                    ...x,
+                    data: {
+                      ...x.data,
+                      groupby: x.data.groupby.map(metricOrColumn =>
+                        getMetricLabel(metricOrColumn),
+                      ),
+                    },
+                  },
+                })),
             });
           },
         );
@@ -499,7 +512,7 @@ class AnnotationLayer extends React.PureComponent {
             isSelected
             title={t('Annotation Slice Configuration')}
             info={t(`This section allows you to configure how to use the slice
-               to generate annotations.`)}
+              to generate annotations.`)}
           >
             {(annotationType === ANNOTATION_TYPES.EVENT ||
               annotationType === ANNOTATION_TYPES.INTERVAL) && (


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Frontend returns an error if user tries to use renamed columns for the Annotation Layers.
I created fix for it using getMetricName function.
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
#### Before
![error](https://user-images.githubusercontent.com/66589759/208414318-478150b5-5cdf-434c-b1bc-1645a34c08b6.gif)

#### After
![fix-working](https://user-images.githubusercontent.com/66589759/208414355-f58b6583-206e-44bd-8f5b-cf7ef3d82973.gif)

<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Create an interval table with two SQL Expression columns `'1970-02-16 17:45+00'::timestamp` and `'1990-02-16 17:45+00'::timestamp`, name it `start` and `end`.
2. Go to the Birth Names Line chart, and try to add an interval annotation layer from a created table in step 1.
3. You will see an error because renamed columns were parsed incorrectly.


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
