### PR TITLE
fix(ui): disable json download when `can csv on Superset` is not allowed

### DIFF
--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
@@ -347,6 +347,7 @@ export const useExploreAdditionalActionsMenu = (
               {t('Export to .CSV')}
             </Menu.Item>
           )}
+          <Menu.Item key={MENU_KEYS.EXPORT_TO_JSON} icon={<FileOutlined />} disabled={!canDownloadCSV}>
           <Menu.Item
             key={MENU_KEYS.EXPORT_TO_JSON}
             icon={<Icons.FileOutlined css={iconReset} />}

--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
@@ -347,7 +347,6 @@ export const useExploreAdditionalActionsMenu = (
               {t('Export to .CSV')}
             </Menu.Item>
           )}
-          <Menu.Item key={MENU_KEYS.EXPORT_TO_JSON} icon={<FileOutlined />} disabled={!canDownloadCSV}>
           <Menu.Item
             key={MENU_KEYS.EXPORT_TO_JSON}
             icon={<Icons.FileOutlined css={iconReset} />}

--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
@@ -351,6 +351,7 @@ export const useExploreAdditionalActionsMenu = (
           <Menu.Item
             key={MENU_KEYS.EXPORT_TO_JSON}
             icon={<Icons.FileOutlined css={iconReset} />}
+            disabled={!canDownloadCSV}
           >
             {t('Export to .JSON')}
           </Menu.Item>


### PR DESCRIPTION
### SUMMARY

Disables saving artifacts to JSON when `canDownloadCSV` is not allowed. This is required to prevent leaking data from superset. `can csv on Superset` is a permission aiming to prevent downloading structured data from Superset but it's not covering JSON exports. This PR aims to fix this.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/19535
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
