### PR TITLE
fix(cypress): Fix failing/flaky E2E tests

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/drilltodetail.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/drilltodetail.test.ts
@@ -172,13 +172,13 @@ describe('Drill to detail modal', () => {
         openModalFromMenu('big_number_total');
         // checking the data
         cy.getBySel('row-count-label').should('contain', '75.7k rows');
-        cy.get('.virtual-table-cell').then($rows => {
+        cy.get('.virtual-table-cell').should($rows => {
           expect($rows).to.contain('Amy');
         });
         // checking the paginated data
         cy.get('.ant-pagination-item')
           .should('have.length', 6)
-          .then($pages => {
+          .should($pages => {
             expect($pages).to.contain('1');
             expect($pages).to.contain('1514');
           });
@@ -186,7 +186,7 @@ describe('Drill to detail modal', () => {
         // skips error on pagination
         cy.on('uncaught:exception', () => false);
         cy.wait('@samples');
-        cy.get('.virtual-table-cell').then($rows => {
+        cy.get('.virtual-table-cell').should($rows => {
           expect($rows).to.contain('Kelly');
         });
 

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
@@ -82,7 +82,7 @@ function prepareDashboardFilters(
   }).then(res => {
     const { body } = res;
     const dashboardId = body.result.id;
-    const allFilters: Record<string, any>[] = [];
+    const allFilters: Record<string, unknown>[] = [];
     filters.forEach((f, i) => {
       allFilters.push({
         id: `NATIVE_FILTER-fLH0pxFQ${i}`,

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
@@ -202,6 +202,7 @@ function openVerticalFilterBar() {
 
 function setFilterBarOrientation(orientation: 'vertical' | 'horizontal') {
   cy.getBySel('filterbar-orientation-icon').click();
+  cy.wait(250);
   cy.getBySel('dropdown-selectable-info')
     .contains('Orientation of filter bar')
     .should('exist');

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/utils.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/utils.ts
@@ -306,8 +306,7 @@ export function getNativeFilterPlaceholderWithIndex(index: number) {
 export function applyNativeFilterValueWithIndex(index: number, value: string) {
   cy.get(nativeFilters.filterFromDashboardView.filterValueInput)
     .eq(index)
-    .parent()
-    .should('be.visible', { timeout: 10000 })
+    .should('exist', { timeout: 10000 })
     .type(`${value}{enter}`);
   // click the title to dismiss shown options
   cy.get(nativeFilters.filterFromDashboardView.filterName)

--- a/superset-frontend/cypress-base/cypress/integration/explore/utils.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/utils.ts
@@ -82,6 +82,7 @@ export function saveChartToDashboard(dashboardName: string) {
   cy.wait('@update');
   cy.wait('@get');
   cy.wait('@getExplore');
+  cy.contains(`was added to dashboard [${dashboardName}]`);
 }
 
 export function visitSampleChartFromList(chartName: string) {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR attempts to fix some failing/flaky Cypress tests:
- [Horizontal FilterBar > should spot changes in "more filters" and apply their values](https://cloud.cypress.io/projects/ukwxzo/analytics/top-failures?branches=%5B%7B%22label%22%3A%22master%22%2C%22suggested%22%3Afalse%2C%22value%22%3A%22master%22%7D%5D&browsers=%5B%5D&chartRangeMostCommonErrors=%5B%5D&chartRangeSlowestTests=%5B%5D&chartRangeTopFailures=%5B%5D&committers=%5B%5D&cypressVersions=%5B%5D&flaky=%5B%5D&operatingSystems=%5B%5D&runGroups=%5B%5D&specFiles=%5B%5D&status=%5B%7B%22label%22%3A%22Passed%22%2C%22value%22%3A%22PASSED%22%7D%2C%7B%22label%22%3A%22Failed%22%2C%22value%22%3A%22FAILED%22%7D%5D&tags=%5B%5D&timeInterval=WEEK&timeRange=%7B%22startDate%22%3A%222022-12-09%22%2C%22endDate%22%3A%222022-12-16%22%7D&viewBy=TEST_CASE) (fail 23%, flake 22% on master last 7 days)
- [Drill to detail modal > Tier 1 charts > Modal actions > paginates](https://cloud.cypress.io/projects/ukwxzo/analytics/top-failures?branches=%5B%7B%22label%22%3A%22master%22%2C%22suggested%22%3Afalse%2C%22value%22%3A%22master%22%7D%5D&browsers=%5B%5D&chartRangeMostCommonErrors=%5B%5D&chartRangeSlowestTests=%5B%5D&chartRangeTopFailures=%5B%5D&committers=%5B%5D&cypressVersions=%5B%5D&flaky=%5B%5D&operatingSystems=%5B%5D&runGroups=%5B%5D&specFiles=%5B%5D&status=%5B%7B%22label%22%3A%22Passed%22%2C%22value%22%3A%22PASSED%22%7D%2C%7B%22label%22%3A%22Failed%22%2C%22value%22%3A%22FAILED%22%7D%5D&tags=%5B%5D&timeInterval=WEEK&timeRange=%7B%22startDate%22%3A%222022-12-09%22%2C%22endDate%22%3A%222022-12-16%22%7D&viewBy=TEST_CASE) (fail 8%, flake 30% on master last 7 days)
- [Charts list > Cross-referenced dashboards > should show the newly added dashboards in a tooltip](https://cloud.cypress.io/projects/ukwxzo/analytics/flaky-tests/e9d043f0-7498-ed77-9979-a2797190a8c2-c0116b8a-ddb8-8b57-1759-b48e538ee689?branches=%5B%7B%22label%22%3A%22master%22%2C%22suggested%22%3Afalse%2C%22value%22%3A%22master%22%7D%5D&browsers=%5B%5D&chartRangeMostCommonErrors=%5B%5D&chartRangeSlowestTests=%5B%5D&chartRangeTopFailures=%5B%5D&committers=%5B%5D&cypressVersions=%5B%5D&flaky=%5B%5D&operatingSystems=%5B%5D&runGroups=%5B%5D&specFiles=%5B%5D&status=%5B%7B%22label%22%3A%22Passed%22%2C%22value%22%3A%22PASSED%22%7D%2C%7B%22label%22%3A%22Failed%22%2C%22value%22%3A%22FAILED%22%7D%5D&tags=%5B%5D&timeInterval=WEEK&timeRange=%7B%22startDate%22%3A%222022-12-09%22%2C%22endDate%22%3A%222022-12-16%22%7D&viewBy=TEST_CASE) (fail 0%, flake 80% on master last 7 days)
- [Horizontal FilterBar > should go from vertical to horizontal and the opposite](https://cloud.cypress.io/projects/ukwxzo/analytics/flaky-tests/5201715e-e599-44ed-3368-c24dfbd9d03b-a3273b0a-3931-1ca7-6ec2-c5b4e69da9f0?branches=%5B%7B%22label%22%3A%22master%22%2C%22suggested%22%3Afalse%2C%22value%22%3A%22master%22%7D%5D&browsers=%5B%5D&chartRangeMostCommonErrors=%5B%5D&chartRangeSlowestTests=%5B%5D&chartRangeTopFailures=%5B%5D&committers=%5B%5D&cypressVersions=%5B%5D&flaky=%5B%5D&operatingSystems=%5B%5D&runGroups=%5B%5D&specFiles=%5B%5D&status=%5B%7B%22label%22%3A%22Passed%22%2C%22value%22%3A%22PASSED%22%7D%2C%7B%22label%22%3A%22Failed%22%2C%22value%22%3A%22FAILED%22%7D%5D&tags=%5B%5D&timeInterval=WEEK&timeRange=%7B%22startDate%22%3A%222022-12-09%22%2C%22endDate%22%3A%222022-12-16%22%7D&viewBy=TEST_CASE) (fail 3%, flake 22% on master last 7 days)
- [Horizontal FilterBar > should show all default actions in horizontal mode](https://cloud.cypress.io/projects/ukwxzo/analytics/flaky-tests/5201715e-e599-44ed-3368-c24dfbd9d03b-8307c144-5b35-99ab-9b76-9356ab7b1fc0?branches=%5B%7B%22label%22%3A%22master%22%2C%22suggested%22%3Afalse%2C%22value%22%3A%22master%22%7D%5D&browsers=%5B%5D&chartRangeMostCommonErrors=%5B%5D&chartRangeSlowestTests=%5B%5D&chartRangeTopFailures=%5B%5D&committers=%5B%5D&cypressVersions=%5B%5D&flaky=%5B%5D&operatingSystems=%5B%5D&runGroups=%5B%5D&specFiles=%5B%5D&status=%5B%7B%22label%22%3A%22Passed%22%2C%22value%22%3A%22PASSED%22%7D%2C%7B%22label%22%3A%22Failed%22%2C%22value%22%3A%22FAILED%22%7D%5D&tags=%5B%5D&timeInterval=WEEK&timeRange=%7B%22startDate%22%3A%222022-12-09%22%2C%22endDate%22%3A%222022-12-16%22%7D&viewBy=TEST_CASE) (fail 0%, flake 13% on master last 7 days)
- [Horizontal FilterBar > should display newly added filter](https://cloud.cypress.io/projects/ukwxzo/analytics/flaky-tests/5201715e-e599-44ed-3368-c24dfbd9d03b-1632140b-352c-46df-5fac-cdb0258e9854?branches=%5B%7B%22label%22%3A%22master%22%2C%22suggested%22%3Afalse%2C%22value%22%3A%22master%22%7D%5D&browsers=%5B%5D&chartRangeMostCommonErrors=%5B%5D&chartRangeSlowestTests=%5B%5D&chartRangeTopFailures=%5B%5D&committers=%5B%5D&cypressVersions=%5B%5D&flaky=%5B%5D&operatingSystems=%5B%5D&runGroups=%5B%5D&specFiles=%5B%5D&status=%5B%7B%22label%22%3A%22Passed%22%2C%22value%22%3A%22PASSED%22%7D%2C%7B%22label%22%3A%22Failed%22%2C%22value%22%3A%22FAILED%22%7D%5D&tags=%5B%5D&timeInterval=WEEK&timeRange=%7B%22startDate%22%3A%222022-12-09%22%2C%22endDate%22%3A%222022-12-16%22%7D&viewBy=TEST_CASE) (fail 2%, flake 13% on master last 7 days)

The code changes include:
- Replacing `.then` with `.should` calls in `drilltodetail.test.ts` to allow for retries within the callback
- Adding a timed `.wait` in `nativeFilters.test.ts` to give the filter bar orientation menu time to change orientation after scrolling into position
- Switching the target for `.type` from the `input`'s parent to the `input` itself in horizontal filter bar tests, as the `input`'s parent was at times not considered "visible" by Cypress
- Making Cypress wait for the confirmation toast to appear after saving a chart to a dashboard before navigating away from the page

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Check that E2E tests pass on CI, and feel free to re-run a few times to try to catch any extra issues
- Run Cypress E2E tests locally several times with throttling enabled, specifically looking for issues in:
  - `dashboard/drilltodetail.test.ts`
  - `dashboard/nativeFilters.test.ts`
  - `chart_list/list.test.ts`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
