### PR TITLE
fix(dashboard): export & import chart description and certification details

### DIFF
--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -1368,9 +1368,9 @@ class GetFavStarIdsSchema(Schema):
 
 class ImportV1ChartSchema(Schema):
     slice_name = fields.String(required=True)
-    description = fields.String(allow_none=True, default=False)
-    certified_by = fields.String(allow_none=True, default=False)
-    certification_details = fields.String(allow_none=True, default=False)
+    description = fields.String(allow_none=True)
+    certified_by = fields.String(allow_none=True)
+    certification_details = fields.String(allow_none=True)
     viz_type = fields.String(required=True)
     params = fields.Dict()
     query_context = fields.String(allow_none=True, validate=utils.validate_json)

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -1368,6 +1368,9 @@ class GetFavStarIdsSchema(Schema):
 
 class ImportV1ChartSchema(Schema):
     slice_name = fields.String(required=True)
+    description = fields.String(allow_none=True, default=False)
+    certified_by = fields.String(allow_none=True, default=False)
+    certification_details = fields.String(allow_none=True, default=False)
     viz_type = fields.String(required=True)
     params = fields.Dict()
     query_context = fields.String(allow_none=True, validate=utils.validate_json)

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -110,6 +110,9 @@ class Slice(  # pylint: disable=too-many-public-methods
 
     export_fields = [
         "slice_name",
+        "description",
+        "certified_by",
+        "certification_details",
         "datasource_type",
         "datasource_name",
         "viz_type",

--- a/tests/integration_tests/charts/commands_tests.py
+++ b/tests/integration_tests/charts/commands_tests.py
@@ -72,6 +72,9 @@ class TestExportChartsCommand(SupersetTestCase):
 
         assert metadata == {
             "slice_name": "Energy Sankey",
+            "description": None,
+            "certification_details": None,
+            "certified_by": None,
             "viz_type": "sankey",
             "params": {
                 "collapsed_fieldsets": "",
@@ -110,6 +113,9 @@ class TestExportChartsCommand(SupersetTestCase):
 
         assert metadata == {
             "slice_name": "Heatmap",
+            "description": None,
+            "certification_details": None,
+            "certified_by": None,
             "viz_type": "heatmap",
             "params": {
                 "all_columns_x": "source",
@@ -168,6 +174,9 @@ class TestExportChartsCommand(SupersetTestCase):
         )
         assert list(metadata.keys()) == [
             "slice_name",
+            "description",
+            "certification_details",
+            "certified_by",
             "viz_type",
             "params",
             "cache_timeout",

--- a/tests/integration_tests/charts/commands_tests.py
+++ b/tests/integration_tests/charts/commands_tests.py
@@ -73,8 +73,8 @@ class TestExportChartsCommand(SupersetTestCase):
         assert metadata == {
             "slice_name": "Energy Sankey",
             "description": None,
-            "certification_details": None,
             "certified_by": None,
+            "certification_details": None,
             "viz_type": "sankey",
             "params": {
                 "collapsed_fieldsets": "",
@@ -114,8 +114,8 @@ class TestExportChartsCommand(SupersetTestCase):
         assert metadata == {
             "slice_name": "Heatmap",
             "description": None,
-            "certification_details": None,
             "certified_by": None,
+            "certification_details": None,
             "viz_type": "heatmap",
             "params": {
                 "all_columns_x": "source",
@@ -175,8 +175,8 @@ class TestExportChartsCommand(SupersetTestCase):
         assert list(metadata.keys()) == [
             "slice_name",
             "description",
-            "certification_details",
             "certified_by",
+            "certification_details",
             "viz_type",
             "params",
             "cache_timeout",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->


### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes a bug of missing chart description and certification details when exporting and importing dashboards.
In the video I export dashboard containing chart with description and certification details from localhost:8087 and import it to localhost:8086.

### BEFORE

### AFTER
<!--- Skip this if not applicable -->

https://user-images.githubusercontent.com/53895552/208696491-55eb22a7-d61a-42b9-bdce-49a6932b0fb5.mp4


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/22257
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
