### PR TITLE
fix(chart-list): Hide 'Dashboards added to' column.

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/chart_list/list.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/chart_list/list.test.ts
@@ -114,11 +114,11 @@ describe('Charts list', () => {
       cy.getBySel('sort-header').eq(1).contains('Chart');
       cy.getBySel('sort-header').eq(2).contains('Visualization type');
       cy.getBySel('sort-header').eq(3).contains('Dataset');
-      cy.getBySel('sort-header').eq(4).contains('Dashboards added to');
-      cy.getBySel('sort-header').eq(5).contains('Modified by');
-      cy.getBySel('sort-header').eq(6).contains('Last modified');
-      cy.getBySel('sort-header').eq(7).contains('Created by');
-      cy.getBySel('sort-header').eq(8).contains('Actions');
+      // cy.getBySel('sort-header').eq(4).contains('Dashboards added to');
+      cy.getBySel('sort-header').eq(4).contains('Modified by');
+      cy.getBySel('sort-header').eq(5).contains('Last modified');
+      cy.getBySel('sort-header').eq(6).contains('Created by');
+      cy.getBySel('sort-header').eq(7).contains('Actions');
     });
 
     it('should sort correctly in list mode', () => {

--- a/superset-frontend/cypress-base/cypress/integration/chart_list/list.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/chart_list/list.test.ts
@@ -58,7 +58,7 @@ describe('Charts list', () => {
     cy.preserveLogin();
   });
 
-  describe('Cross-referenced dashboards', () => {
+  describe.skip('Cross-referenced dashboards', () => {
     beforeEach(() => {
       cy.createSampleDashboards([0, 1, 2, 3]);
       cy.createSampleCharts([0]);
@@ -105,6 +105,8 @@ describe('Charts list', () => {
 
   describe('list mode', () => {
     before(() => {
+      cy.createSampleDashboards([0, 1, 2, 3]);
+      cy.createSampleCharts([0]);
       visitChartList();
       setGridMode('list');
     });

--- a/superset-frontend/src/views/CRUD/chart/ChartList.tsx
+++ b/superset-frontend/src/views/CRUD/chart/ChartList.tsx
@@ -401,6 +401,7 @@ function ChartList(props: ChartListProps) {
         accessor: 'dashboards',
         disableSortBy: true,
         size: 'xxl',
+        hidden: true,
       },
       {
         Cell: ({


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Hides the "Dashboards added to" column in the chart CRUD view, as infinite re-renders in its use of `useTruncation` are causing full-page crashes in some reported cases.  This is a temporary fix until a permanent fix can be found.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
<img width="1479" alt="Screen Shot 2022-12-20 at 6 44 17 PM" src="https://user-images.githubusercontent.com/13007381/208742579-541abfda-3ca1-476f-87e8-7a7012acb22e.png">

After:
<img width="1479" alt="Screen Shot 2022-12-20 at 6 44 35 PM" src="https://user-images.githubusercontent.com/13007381/208742591-512351f5-1916-4c39-bb19-d08d39968425.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Confirm that page still loads as expected
- Confirm that it's still possible to filter by dashboards added to

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
