### PR TITLE
feat: Adds the Default Temporal Column

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/sections/echartsTimeSeriesQuery.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/sections/echartsTimeSeriesQuery.tsx
@@ -25,11 +25,16 @@ import {
   xAxisSortAscControl,
 } from '../shared-controls';
 
-const controlsWithoutXAxis: ControlSetRow[] = [
+const assembleControls = (xAxisSort: boolean): ControlSetRow[] => [
+  [hasGenericChartAxes ? 'x_axis' : null],
+  [hasGenericChartAxes ? 'time_grain_sqla' : null],
+  [hasGenericChartAxes && xAxisSort ? xAxisSortControl : null],
+  [hasGenericChartAxes && xAxisSort ? xAxisSortAscControl : null],
   ['metrics'],
   ['groupby'],
   [contributionModeControl],
   ['adhoc_filters'],
+  [hasGenericChartAxes ? 'default_temporal_column' : null],
   emitFilterControl,
   ['limit'],
   ['timeseries_limit_metric'],
@@ -42,21 +47,11 @@ const controlsWithoutXAxis: ControlSetRow[] = [
 export const echartsTimeSeriesQuery: ControlPanelSectionConfig = {
   label: t('Query'),
   expanded: true,
-  controlSetRows: [
-    [hasGenericChartAxes ? 'x_axis' : null],
-    [hasGenericChartAxes ? 'time_grain_sqla' : null],
-    ...controlsWithoutXAxis,
-  ],
+  controlSetRows: assembleControls(false),
 };
 
 export const echartsTimeSeriesQueryWithXAxisSort: ControlPanelSectionConfig = {
   label: t('Query'),
   expanded: true,
-  controlSetRows: [
-    [hasGenericChartAxes ? 'x_axis' : null],
-    [hasGenericChartAxes ? 'time_grain_sqla' : null],
-    [hasGenericChartAxes ? xAxisSortControl : null],
-    [hasGenericChartAxes ? xAxisSortAscControl : null],
-    ...controlsWithoutXAxis,
-  ],
+  controlSetRows: assembleControls(true),
 };

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/mixins.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/mixins.tsx
@@ -66,6 +66,7 @@ export const temporalColumnMixin: Pick<BaseControlConfig, 'mapStateToProps'> = {
   },
 };
 
+// TODO: This needs to change
 export const datePickerInAdhocFilterMixin: Pick<
   BaseControlConfig,
   'initialValue'

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/mixins.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/mixins.tsx
@@ -66,52 +66,30 @@ export const temporalColumnMixin: Pick<BaseControlConfig, 'mapStateToProps'> = {
   },
 };
 
-// TODO: This needs to change
 export const datePickerInAdhocFilterMixin: Pick<
   BaseControlConfig,
   'initialValue'
 > = {
   initialValue: (control: ControlState, state: ControlPanelState | null) => {
-    // skip initialValue if
-    // 1) GENERIC_CHART_AXES is disabled
-    // 2) there was a time filter in adhoc filters
-    if (
-      !hasGenericChartAxes ||
-      ensureIsArray(control.value).findIndex(
-        (flt: any) => flt?.operator === 'TEMPORAL_RANGE',
-      ) > -1
-    ) {
-      return undefined;
-    }
-
-    // should migrate original granularity_sqla and time_range into adhoc filter
-    // 1) granularity_sqla and time_range are existed
-    if (state?.form_data?.granularity_sqla && state?.form_data?.time_range) {
-      return [
-        ...ensureIsArray(control.value),
-        {
-          clause: 'WHERE',
-          subject: state.form_data.granularity_sqla,
-          operator: 'TEMPORAL_RANGE',
-          comparator: state.form_data.time_range,
-          expressionType: 'SIMPLE',
-        },
-      ];
-    }
-
-    // should apply the default time filter into adhoc filter
-    // 1) temporal column is existed in current datasource
+    // If GENERIC_CHART_AXES is enabled and
+    // DEFAULT_TIME_FILTER has a value different than NO_TIME_RANGE and
+    // the dataset contains a temporal column,
+    // apply a default time filter into the adhoc filter
     const temporalColumn =
       state?.datasource &&
       getTemporalColumns(state.datasource).defaultTemporalColumn;
-    if (hasGenericChartAxes && temporalColumn) {
+    if (
+      hasGenericChartAxes &&
+      temporalColumn &&
+      state?.common?.conf?.DEFAULT_TIME_FILTER !== NO_TIME_RANGE
+    ) {
       return [
         ...ensureIsArray(control.value),
         {
           clause: 'WHERE',
           subject: temporalColumn,
           operator: 'TEMPORAL_RANGE',
-          comparator: state?.common?.conf?.DEFAULT_TIME_FILTER || NO_TIME_RANGE,
+          comparator: state?.common?.conf?.DEFAULT_TIME_FILTER,
           expressionType: 'SIMPLE',
         },
       ];

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
@@ -57,6 +57,7 @@ import {
   D3_TIME_FORMAT_DOCS,
   DEFAULT_TIME_FORMAT,
   DEFAULT_NUMBER_FORMAT,
+  getTemporalColumns,
 } from '../utils';
 import { TIME_FILTER_LABELS } from '../constants';
 import {
@@ -248,6 +249,30 @@ const row_limit: SharedControlConfig<'SelectControl'> = {
   description: t('Limits the number of rows that get displayed.'),
 };
 
+const defaultTemporalColumn: SharedControlConfig<'SelectControl'> = {
+  type: 'SelectControl',
+  label: t('Default Temporal Column'),
+  mapStateToProps: state => {
+    const { datasource, form_data } = state;
+    const { default_temporal_column } = form_data;
+    const { temporalColumns, defaultTemporalColumn } =
+      getTemporalColumns(datasource);
+    const choices = temporalColumns.map(column => [
+      column.column_name ?? column.name,
+      column.column_name ?? column.name,
+    ]);
+    return {
+      choices,
+      clearable: false,
+      freeForm: false,
+      value: default_temporal_column || defaultTemporalColumn,
+    };
+  },
+  description: t(
+    'Default temporal column is used for time-based filtering in the dashboard.',
+  ),
+};
+
 const order_desc: SharedControlConfig<'CheckboxControl'> = {
   type: 'CheckboxControl',
   label: t('Sort Descending'),
@@ -401,4 +426,5 @@ export default {
   x_axis: dndXAxisControl,
   show_empty_columns,
   temporal_columns_lookup,
+  default_temporal_column: defaultTemporalColumn,
 };

--- a/superset-frontend/packages/superset-ui-core/test/query/buildQueryContext.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/buildQueryContext.test.ts
@@ -164,6 +164,8 @@ describe('buildQueryContext', () => {
     expect(spyNormalizeTimeColumn).not.toBeCalled();
     spyNormalizeTimeColumn.mockRestore();
   });
+  // TODO: We can keep this test case as it's a valid use case but we should also create one
+  // for testing with a default temporal column
   it('should orverride time filter if GENERIC_CHART_AXES is enabled', () => {
     Object.defineProperty(getXAxisModule, 'hasGenericChartAxes', {
       value: true,

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -718,21 +718,17 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
         />
       </div>
       <Modal
+        width="480px"
         title={t(
           'Do you want to change the default temporal column to match the x-axis column?',
         )}
         footer={
           <>
-            <Button
-              htmlType="button"
-              cta
-              onClick={() => setShowXAxisModal(false)}
-            >
+            <Button htmlType="button" onClick={() => setShowXAxisModal(false)}>
               {t('No')}
             </Button>
             <Button
               htmlType="button"
-              cta
               buttonStyle="primary"
               onClick={() => {
                 actions.setControlValue(DEFAULT_TEMPORAL_COLUMN, x_axis);

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndAdhocFilterOption.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndAdhocFilterOption.tsx
@@ -46,6 +46,7 @@ export default function DndAdhocFilterOption({
   partitionColumn,
   index,
 }: DndAdhocFilterOptionProps) {
+  // TODO: This needs to change
   const { actualTimeRange, title } = useGetTimeRangeLabel(adhocFilter);
 
   return (

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterOption/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterOption/index.tsx
@@ -52,6 +52,7 @@ export default function AdhocFilterOption({
   sections,
   operators,
 }: AdhocFilterOptionProps) {
+  // TODO: This needs to change
   const { actualTimeRange, title } = useGetTimeRangeLabel(adhocFilter);
 
   return (

--- a/superset-frontend/src/explore/components/controls/FilterControl/utils/useGetTimeRangeLabel.test.ts
+++ b/superset-frontend/src/explore/components/controls/FilterControl/utils/useGetTimeRangeLabel.test.ts
@@ -23,6 +23,8 @@ import * as FetchTimeRangeModule from 'src/explore/components/controls/DateFilte
 import { useGetTimeRangeLabel } from './useGetTimeRangeLabel';
 import AdhocFilter, { CLAUSES, EXPRESSION_TYPES } from '../AdhocFilter';
 
+// TODO: The tests will change
+
 test('should return empty object if operator is not TEMPORAL_RANGE', () => {
   const adhocFilter = new AdhocFilter({
     expressionType: EXPRESSION_TYPES.SIMPLE,

--- a/superset-frontend/src/explore/components/controls/FilterControl/utils/useGetTimeRangeLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/utils/useGetTimeRangeLabel.tsx
@@ -27,6 +27,7 @@ interface Results {
   title?: string;
 }
 
+// TODO: This needs to change
 export const useGetTimeRangeLabel = (adhocFilter: AdhocFilter): Results => {
   const [actualTimeRange, setActualTimeRange] = useState<Results>({});
 

--- a/superset/common/utils/time_range_utils.py
+++ b/superset/common/utils/time_range_utils.py
@@ -61,6 +61,7 @@ def get_since_until_from_query_object(
             extras=query_object.extras,
         )
 
+    # TODO: This needs to change
     time_range = None
     for flt in query_object.filter:
         if (

--- a/tests/integration_tests/query_context_tests.py
+++ b/tests/integration_tests/query_context_tests.py
@@ -1020,6 +1020,8 @@ def test_time_grain_and_time_offset_on_legacy_query(app_context, physical_datase
     )
 
 
+# TODO: We can keep this test case as it's a valid use case but we should also create one
+# for testing with a default temporal column
 def test_time_offset_with_temporal_range_filter(app_context, physical_dataset):
     qc = QueryContextFactory().create(
         datasource={

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -866,6 +866,8 @@ def test__normalize_prequery_result_type(
         assert normalized == result
 
 
+# TODO: We can keep this test case as it's a valid use case but we should also create one
+# for testing with a default temporal column
 def test__temporal_range_operator_in_adhoc_filter(app_context, physical_dataset):
     result = physical_dataset.query(
         {

--- a/tests/unit_tests/common/test_time_range_utils.py
+++ b/tests/unit_tests/common/test_time_range_utils.py
@@ -75,6 +75,8 @@ def test__since_until_from_time_range(dummy_query_object):
     )
 
 
+# TODO: We can keep this test case as it's a valid use case but we should also create one
+# for testing with a default temporal column
 @pytest.mark.query_object(
     {
         "filters": [{"col": "dttm", "op": "TEMPORAL_RANGE", "val": "2001 : 2002"}],


### PR DESCRIPTION
### SUMMARY
This PR is a follow-up https://github.com/apache/superset/pull/21767 and introduces the Default Temporal Column control to non-legacy charts. Previously, the default temporal column used by time-based filters such as Time Range was defined in the Filters control of Explore. When creating a new chart with a dataset containing a temporal column, the application would automatically add that column as a filter in the Filters control and use it as the source for time-based filters. That strategy resulted in some problems with our clients when evaluating the Generic X-axis feature:
- It was not clear that the automatically added filter was used by time-based filters such as Time Range
- Some users deleted the filter without knowing the consequences and then complained that Time Range was not working
- It was not clear that a Time Range filter would be applied to ALL temporal columns present in the Filters control

After internal discussion, we concluded that the best place to make these configurations would be in the native filters module, where a user, when creating a Time Range filter, could potentially select all the temporal columns affected by the filter, even if they come from different datasets. This would give the users the flexibility to create different filter configurations and also clearly show which columns are being affected by the filter. We would like to prototype and validate the solution with our users before changing the native filters module. Meanwhile, we want to provide a solution to the problems stated above, and this PR proposes the following changes:
- Create a new control called Default Temporal Column below the Filters control for non-legacy charts
- This control only appears when `GENERIC_CHART_AXES` is enabled and the dataset has at least one temporal column
- The control should allow the selection of temporal columns or a custom SQL and cannot have its value removed
- When creating a new chart, the control will be automatically filled with the default dataset temporal column
- If the user, drags a temporal column to the X-axis, and it is a different column than the one in the Default Temporal Column, we'll present a modal asking the user if they wish to use the value in the X-axis as the Default Temporal Column
- We're also going to display a tooltip in the control to explain its use with time-based filters
- We'll remove the previous behavior where a filter was automatically added to the Filters control
- If a user defines a temporal filter in Explore (they don't have to), and the column involved in the filter is the same as the one defined in Default Temporal Column then we should replace its value. If the column used in the filter is different than the one in Default Temporal Column, then the filter will not be affected by a Time Range.
- We'll create a migration script to update the Default Temporal Column of charts with the first temporal column in the Filters control or dataset if such a temporal column exists.

Here's a preview of how the feature will look like:

![image](https://user-images.githubusercontent.com/70410625/208772172-848d7360-caa6-45c1-8a5e-5ad567b8a418.png)
![image](https://user-images.githubusercontent.com/70410625/208772509-c4be9d92-9f1a-4b68-90d9-0ef299d11a3b.png)

The PR description will be updated after the changes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
TODO - It will be updated after the changes

### TESTING INSTRUCTIONS
TODO - It will be updated after the changes

@codyml @kasiazjc @lauderbaugh

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
