### PR TITLE
chore(celery) & docs(celery): update celery config variables names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,9 @@ little bit helps, and credit will always be given.
   - [Revert Guidelines](#revert-guidelines)
   - [Setup Local Environment for Development](#setup-local-environment-for-development)
     - [Documentation](#documentation)
-      - [Images](#images)
+      - [Local Development](#local-development)
+      - [Build](#build)
+      - [Deployment](#deployment)
     - [Flask server](#flask-server)
       - [OS Dependencies](#os-dependencies)
       - [Dependencies](#dependencies)
@@ -1293,7 +1295,7 @@ To do this, you'll need to:
 - Start up a celery worker
 
   ```shell script
-  celery --app=superset.tasks.celery_app:app worker -Ofair
+  celery --app=superset.tasks.celery_app:app worker -O fair
   ```
 
 Note that:

--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -37,7 +37,7 @@ fi
 
 if [[ "${1}" == "worker" ]]; then
   echo "Starting Celery worker..."
-  celery --app=superset.tasks.celery_app:app worker -Ofair -l INFO
+  celery --app=superset.tasks.celery_app:app worker -O fair -l INFO
 elif [[ "${1}" == "beat" ]]; then
   echo "Starting Celery beat..."
   celery --app=superset.tasks.celery_app:app beat --pidfile /tmp/celerybeat.pid -l INFO -s "${SUPERSET_HOME}"/celerybeat-schedule

--- a/docker/pythonpath_dev/superset_config.py
+++ b/docker/pythonpath_dev/superset_config.py
@@ -81,13 +81,12 @@ DATA_CACHE_CONFIG = CACHE_CONFIG
 
 
 class CeleryConfig(object):
-    BROKER_URL = f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_CELERY_DB}"
-    CELERY_IMPORTS = ("superset.sql_lab",)
-    CELERY_RESULT_BACKEND = f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_RESULTS_DB}"
-    CELERYD_LOG_LEVEL = "DEBUG"
-    CELERYD_PREFETCH_MULTIPLIER = 1
-    CELERY_ACKS_LATE = False
-    CELERYBEAT_SCHEDULE = {
+    broker_url = f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_CELERY_DB}"
+    imports = ("superset.sql_lab",)
+    result_backend = f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_RESULTS_DB}"
+    worker_prefetch_multiplier = 1
+    task_acks_late = False
+    beat_schedule = {
         "reports.scheduler": {
             "task": "reports.scheduler",
             "schedule": crontab(minute="*", hour="*"),

--- a/superset/config.py
+++ b/superset/config.py
@@ -845,7 +845,6 @@ class CeleryConfig:  # pylint: disable=too-few-public-methods
     broker_url = "sqla+sqlite:///celerydb.sqlite"
     imports = ("superset.sql_lab",)
     result_backend = "db+sqlite:///celery_results.sqlite"
-    worker_log_level = "DEBUG"
     worker_prefetch_multiplier = 1
     task_acks_late = False
     task_annotations = {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
1. Class attributes of `CeleryConfig` in `docker/pythonpath_dev/superset_config.py` are updated due to the [lowercase settings](https://docs.celeryq.dev/en/stable/userguide/configuration.html#conf-old-settings-map) introduced in version 4.0. 
2. Variable `worker_log_level` contained in `config.py` is not mentioned anywhere in the celery documentation, therefore should be removed. It can be replaced with `CELERYD_LOG_LEVEL` or could be removed. To configure logging level option `-l` is used as mentioned [here](https://docs.celeryq.dev/en/stable/reference/cli.html#cmdoption-celery-beat-l). This option is already used in `docker-bootstrap.sh`: https://github.com/apache/superset/blob/b954f8f56080270fa7f1f68aa962c9e789e96728/docker/docker-bootstrap.sh#L40 hence its usage is excessive in both `config.py` and `superset_config.py` and could be removed.
3. For some reason [optimization option `-O`](https://docs.celeryq.dev/en/stable/reference/cli.html#cmdoption-celery-worker-O) was glued to its value `fair` like this: `-Ofair`. Suggested change unglues them in `docker-bootstrap.sh` and `CONTRIBUTING.md`.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/20808
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
