### PR TITLE
fix(helm): Updated Chart.yaml with the latest versions of postgresql and redis for superset

### DIFF
--- a/helm/superset/Chart.lock
+++ b/helm/superset/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.1.22
+  version: 12.1.6
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.3.1
-digest: sha256:f80cc4ec2bb6f327d348bc15e9192cc6ab2163781c1e35f85720565a36a1cb14
-generated: "2022-10-13T16:59:44.305764+02:00"
+  version: 17.3.17
+digest: sha256:3bfff146fa89077705c0bedea59bbe2c9f15715220f9ea84f493335f0413af6e
+generated: "2022-12-21T17:07:27.948067+05:30"

--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -29,7 +29,7 @@ maintainers:
   - name: craig-rueda
     email: craig@craigrueda.com
     url: https://github.com/craig-rueda
-version: 0.7.7
+version: 0.7.8
 dependencies:
   - name: postgresql
     version: 12.1.6

--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -32,10 +32,10 @@ maintainers:
 version: 0.7.7
 dependencies:
   - name: postgresql
-    version: 11.1.22
+    version: 12.1.6
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: redis
-    version: 16.3.1
+    version: 17.3.17
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled

--- a/helm/superset/README.md
+++ b/helm/superset/README.md
@@ -19,7 +19,7 @@
 
 # superset
 
-![Version: 0.7.7](https://img.shields.io/badge/Version-0.7.7-informational?style=flat-square)
+![Version: 0.7.8](https://img.shields.io/badge/Version-0.7.8-informational?style=flat-square)
 
 Apache Superset is a modern, enterprise-ready business intelligence web application
 
@@ -40,8 +40,8 @@ helm install my-superset superset/superset
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 11.1.22 |
-| https://charts.bitnami.com/bitnami | redis | 16.3.1 |
+| https://charts.bitnami.com/bitnami | postgresql | 12.1.6  |
+| https://charts.bitnami.com/bitnami | redis | 17.3.17 |
 
 ## Values
 


### PR DESCRIPTION
### Title
fix(helm chart): Updated Chart.yaml with the latest versions of PostgreSQL and Redis for the superset

### SUMMARY
Chart versions for PostgreSQL and Redis were outdated causing the `helm dependency build` to fail.

Updated these charts versions for the latest ones, which supports the build and solves the issue.

Before pushing this commit, changes have been tested on the local system, and also tried deploying the updated charts or local Kubernetes cluster (created using r3d) 


### TESTING INSTRUCTIONS
Following the commands mentioned here to test out the changes
https://superset.apache.org/docs/installation/installing-superset-from-scratch#installing-superset-with-helm-in-kubernetes

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
