### PR TITLE
refactor: rename filter_rel_fields to base_related_field_filters

### DIFF
--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -243,7 +243,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
         "slices": ("slice_name", "asc"),
         "owners": ("first_name", "asc"),
     }
-    filter_rel_fields = {
+    base_related_field_filters = {
         "owners": [["id", BaseFilterRelatedUsers, lambda: []]],
         "created_by": [["id", BaseFilterRelatedUsers, lambda: []]],
     }

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -241,7 +241,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         "owners": ("first_name", "asc"),
         "roles": ("name", "asc"),
     }
-    filter_rel_fields = {
+    base_related_field_filters = {
         "owners": [["id", BaseFilterRelatedUsers, lambda: []]],
         "created_by": [["id", BaseFilterRelatedUsers, lambda: []]],
     }

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -218,7 +218,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     ]
     openapi_spec_tag = "Datasets"
 
-    filter_rel_fields = {
+    base_related_field_filters = {
         "owners": [["id", BaseFilterRelatedUsers, lambda: []]],
         "database": [["id", DatabaseFilter, lambda: []]],
     }

--- a/superset/queries/api.py
+++ b/superset/queries/api.py
@@ -109,7 +109,7 @@ class QueryRestApi(BaseSupersetModelRestApi):
         "tab_name",
         "user.first_name",
     ]
-    filter_rel_fields = {
+    base_related_field_filters = {
         "created_by": [["id", BaseFilterRelatedUsers, lambda: []]],
         "user": [["id", BaseFilterRelatedUsers, lambda: []]],
     }
@@ -120,6 +120,6 @@ class QueryRestApi(BaseSupersetModelRestApi):
 
     search_columns = ["changed_on", "database", "sql", "status", "user", "start_time"]
 
-    filter_rel_fields = {"database": [["id", DatabaseFilter, lambda: []]]}
+    base_related_field_filters = {"database": [["id", DatabaseFilter, lambda: []]]}
     allowed_rel_fields = {"database", "user"}
     allowed_distinct_fields = {"status"}

--- a/superset/queries/saved_queries/api.py
+++ b/superset/queries/saved_queries/api.py
@@ -155,7 +155,7 @@ class SavedQueryRestApi(BaseSupersetModelRestApi):
     related_field_filters = {
         "database": "database_name",
     }
-    filter_rel_fields = {"database": [["id", DatabaseFilter, lambda: []]]}
+    base_related_field_filters = {"database": [["id", DatabaseFilter, lambda: []]]}
     allowed_rel_fields = {"database"}
     allowed_distinct_fields = {"schema"}
 

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -209,7 +209,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
     search_filters = {"name": [ReportScheduleAllTextFilter]}
     allowed_rel_fields = {"owners", "chart", "dashboard", "database", "created_by"}
 
-    filter_rel_fields = {
+    base_related_field_filters = {
         "chart": [["id", ChartFilter, lambda: []]],
         "dashboard": [["id", DashboardAccessFilter, lambda: []]],
         "database": [["id", DatabaseFilter, lambda: []]],

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -195,21 +195,24 @@ class BaseSupersetModelRestApi(ModelRestApi):
         }
     """
 
+    base_related_field_filters: Dict[str, BaseFilter] = {}
+    """
+    This is used to specify a base filter for related fields
+    when they are accessed through the '/related/<column_name>' endpoint.
+    When combined with the `related_field_filters` attribute, 
+    this filter will be applied in addition to the latest::
+    
+        base_related_field_filters = {
+            "<RELATED_FIELD>": "<FILTER>")
+        }
+    """
+
     related_field_filters: Dict[str, Union[RelatedFieldFilter, str]] = {}
     """
     Declare the filters for related fields::
 
         related_fields = {
             "<RELATED_FIELD>": <RelatedFieldFilter>)
-        }
-    """
-
-    base_related_field_filters: Dict[str, BaseFilter] = {}
-    """
-    Declare the related field base filter::
-
-        base_related_field_filters = {
-            "<RELATED_FIELD>": "<FILTER>")
         }
     """
     allowed_rel_fields: Set[str] = set()

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -199,9 +199,9 @@ class BaseSupersetModelRestApi(ModelRestApi):
     """
     This is used to specify a base filter for related fields
     when they are accessed through the '/related/<column_name>' endpoint.
-    When combined with the `related_field_filters` attribute, 
+    When combined with the `related_field_filters` attribute,
     this filter will be applied in addition to the latest::
-    
+
         base_related_field_filters = {
             "<RELATED_FIELD>": "<FILTER>")
         }

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -209,7 +209,10 @@ class BaseSupersetModelRestApi(ModelRestApi):
 
     related_field_filters: Dict[str, Union[RelatedFieldFilter, str]] = {}
     """
-    Declare the filters for related fields::
+    Specify a filter for related fields when they are accessed
+    through the '/related/<column_name>' endpoint.
+    When combined with the `base_related_field_filters` attribute,
+    this filter will be applied in prior to the latest::
 
         related_fields = {
             "<RELATED_FIELD>": <RelatedFieldFilter>)

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -204,11 +204,11 @@ class BaseSupersetModelRestApi(ModelRestApi):
         }
     """
 
-    filter_rel_fields: Dict[str, BaseFilter] = {}
+    base_related_field_filters: Dict[str, BaseFilter] = {}
     """
     Declare the related field base filter::
 
-        filter_rel_fields_field = {
+        base_related_field_filters = {
             "<RELATED_FIELD>": "<FILTER>")
         }
     """
@@ -299,7 +299,7 @@ class BaseSupersetModelRestApi(ModelRestApi):
         filter_field = cast(RelatedFieldFilter, filter_field)
         search_columns = [filter_field.field_name] if filter_field else None
         filters = datamodel.get_filters(search_columns)
-        base_filters = self.filter_rel_fields.get(column_name)
+        base_filters = self.base_related_field_filters.get(column_name)
         if base_filters:
             filters.add_filter_list(base_filters)
         if value and filter_field:

--- a/superset/views/filters.py
+++ b/superset/views/filters.py
@@ -61,7 +61,7 @@ class BaseFilterRelatedUsers(BaseFilter):  # pylint: disable=too-few-public-meth
 
     Use in the api by adding something like:
     ```
-    filter_rel_fields = {
+    base_related_field_filters = {
         "owners": [["id", BaseFilterRelatedUsers, lambda: []]],
         "created_by": [["id", BaseFilterRelatedUsers, lambda: []]],
     }


### PR DESCRIPTION
### SUMMARY

Small refactor to improve the current confusing names for declaring related filters on `ModelRestApi`

Renames: `filter_rel_fields` to `base_related_field_filters`

currently we have:
`filter_rel_fields`: That declared a base filter that is always applied on the declared related fields
`related_field_filters`: That applies a filter on related fields



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
