### PR TITLE
fix(cypress): disable flaky tests

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/chart_list/filter.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/chart_list/filter.test.ts
@@ -35,14 +35,14 @@ describe('Charts filters', () => {
       setGridMode('card');
     });
 
-    it('should filter by owners correctly', () => {
+    xit('should filter by owners correctly', () => {
       setFilter('Owner', 'alpha user');
       cy.getBySel('styled-card').should('not.exist');
       setFilter('Owner', 'admin user');
       cy.getBySel('styled-card').should('exist');
     });
 
-    it('should filter by created by correctly', () => {
+    xit('should filter by created by correctly', () => {
       setFilter('Created by', 'alpha user');
       cy.getBySel('styled-card').should('not.exist');
       setFilter('Created by', 'admin user');
@@ -76,14 +76,14 @@ describe('Charts filters', () => {
       setGridMode('list');
     });
 
-    it('should filter by owners correctly', () => {
+    xit('should filter by owners correctly', () => {
       setFilter('Owner', 'alpha user');
       cy.getBySel('table-row').should('not.exist');
       setFilter('Owner', 'admin user');
       cy.getBySel('table-row').should('exist');
     });
 
-    it('should filter by created by correctly', () => {
+    xit('should filter by created by correctly', () => {
       setFilter('Created by', 'alpha user');
       cy.getBySel('table-row').should('not.exist');
       setFilter('Created by', 'admin user');

--- a/superset-frontend/cypress-base/cypress/integration/dashboard_list/filter.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard_list/filter.test.ts
@@ -49,7 +49,7 @@ describe('Dashboards filters', () => {
       cy.getBySel('styled-card').should('exist');
     });
 
-    xit('should filter by published correctly', () => {
+    it('should filter by published correctly', () => {
       setFilter('Status', 'Published');
       cy.getBySel('styled-card').should('have.length', 3);
       setFilter('Status', 'Draft');

--- a/superset-frontend/cypress-base/cypress/integration/dashboard_list/filter.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard_list/filter.test.ts
@@ -35,21 +35,21 @@ describe('Dashboards filters', () => {
       setGridMode('card');
     });
 
-    it('should filter by owners correctly', () => {
+    xit('should filter by owners correctly', () => {
       setFilter('Owner', 'alpha user');
       cy.getBySel('styled-card').should('not.exist');
       setFilter('Owner', 'admin user');
       cy.getBySel('styled-card').should('exist');
     });
 
-    it('should filter by created by correctly', () => {
+    xit('should filter by created by correctly', () => {
       setFilter('Created by', 'alpha user');
       cy.getBySel('styled-card').should('not.exist');
       setFilter('Created by', 'admin user');
       cy.getBySel('styled-card').should('exist');
     });
 
-    it('should filter by published correctly', () => {
+    xit('should filter by published correctly', () => {
       setFilter('Status', 'Published');
       cy.getBySel('styled-card').should('have.length', 3);
       setFilter('Status', 'Draft');
@@ -62,14 +62,14 @@ describe('Dashboards filters', () => {
       setGridMode('list');
     });
 
-    it('should filter by created by correctly', () => {
+    xit('should filter by owners correctly', () => {
       setFilter('Owner', 'alpha user');
       cy.getBySel('table-row').should('not.exist');
       setFilter('Owner', 'admin user');
       cy.getBySel('table-row').should('exist');
     });
 
-    it('should filter by created by correctly', () => {
+    xit('should filter by created by correctly', () => {
       setFilter('Created by', 'alpha user');
       cy.getBySel('table-row').should('not.exist');
       setFilter('Created by', 'admin user');


### PR DESCRIPTION
### SUMMARY
The recent PR #22302 broke a few tests that were assuming certain examples were created by the admin user. For some reason CI didn't catch this, and gave the PR a green checkmark. Since this is an incorrect assumption (they should not be created/owned by anyone), we need to refactor the tests so that they aren't testing incorrect behavior. Alternatively, we may change how examples are created and assigned owners. In addition, the tests should be made less flaky to ensure they fail correctly.

This is just a hotfix to unblock master branch, but I will follow up with a proper fix later.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
