### PR TITLE
chore: Convert direct uses of antd icons to 'Icons' component

### DIFF
--- a/superset-frontend/src/components/Datasource/DatasourceEditor.test.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceEditor.test.jsx
@@ -24,13 +24,17 @@ import DatasourceEditor from 'src/components/Datasource/DatasourceEditor';
 import mockDatasource from 'spec/fixtures/mockDatasource';
 import * as featureFlags from 'src/featureFlags';
 
-jest.mock('src/components/Icons/Icon', () => ({ fileName, role, ...rest }) => (
-  <span
-    role={role ?? 'img'}
-    aria-label={fileName.replace('_', '-')}
-    {...rest}
-  />
-));
+jest.mock('src/components/Icons/Icon', () => ({
+  __esModule: true,
+  default: ({ fileName, role, ...rest }) => (
+    <span
+      role={role ?? 'img'}
+      aria-label={fileName.replace('_', '-')}
+      {...rest}
+    />
+  ),
+  StyledIcon: () => <span />,
+}));
 
 const props = {
   datasource: mockDatasource['7__table'],

--- a/superset-frontend/src/components/Form/LabeledErrorBoundInput.test.jsx
+++ b/superset-frontend/src/components/Form/LabeledErrorBoundInput.test.jsx
@@ -81,13 +81,13 @@ describe('LabeledErrorBoundInput', () => {
     defaultProps.visibilityToggle = true;
     render(<LabeledErrorBoundInput {...defaultProps} />);
 
-    expect(await screen.findByRole('img', { name: /eye/i })).toBeVisible();
+    expect(await screen.findByTestId('icon-eye')).toBeVisible();
   });
 
   it('becomes a password input if props.name === password (backwards compatibility)', async () => {
     defaultProps.name = 'password';
     render(<LabeledErrorBoundInput {...defaultProps} />);
 
-    expect(await screen.findByRole('img', { name: /eye/i })).toBeVisible();
+    expect(await screen.findByTestId('icon-eye')).toBeVisible();
   });
 });

--- a/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
+++ b/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
@@ -18,9 +18,9 @@
  */
 import React from 'react';
 import { Input, Tooltip } from 'antd';
-import { EyeInvisibleOutlined, EyeOutlined } from '@ant-design/icons';
 import { styled, css, SupersetTheme, t } from '@superset-ui/core';
 import InfoTooltip from 'src/components/InfoTooltip';
+import Icons from 'src/components/Icons';
 import errorIcon from 'src/assets/images/icons/error.svg';
 import FormItem from './FormItem';
 import FormLabel from './FormLabel';
@@ -92,6 +92,12 @@ const StyledFormLabel = styled(FormLabel)`
   margin-bottom: 0;
 `;
 
+const iconReset = css`
+  &.anticon > * {
+    line-height: 0;
+  }
+`;
+
 const LabeledErrorBoundInput = ({
   label,
   validationMethods,
@@ -128,11 +134,11 @@ const LabeledErrorBoundInput = ({
           iconRender={visible =>
             visible ? (
               <Tooltip title={t('Hide password.')}>
-                <EyeInvisibleOutlined />
+                <Icons.EyeInvisibleOutlined iconSize="m" css={iconReset} />
               </Tooltip>
             ) : (
               <Tooltip title={t('Show password.')}>
-                <EyeOutlined />
+                <Icons.EyeOutlined iconSize="m" css={iconReset} />
               </Tooltip>
             )
           }

--- a/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
+++ b/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
@@ -138,7 +138,11 @@ const LabeledErrorBoundInput = ({
               </Tooltip>
             ) : (
               <Tooltip title={t('Show password.')}>
-                <Icons.EyeOutlined iconSize="m" css={iconReset} />
+                <Icons.EyeOutlined
+                  iconSize="m"
+                  css={iconReset}
+                  data-test="icon-eye"
+                />
               </Tooltip>
             )
           }

--- a/superset-frontend/src/components/ListView/ListView.test.jsx
+++ b/superset-frontend/src/components/ListView/ListView.test.jsx
@@ -35,7 +35,11 @@ import Pagination from 'src/components/Pagination/Wrapper';
 
 import waitForComponentToPaint from 'spec/helpers/waitForComponentToPaint';
 
-jest.mock('src/components/Icons/Icon', () => () => <span />);
+jest.mock('src/components/Icons/Icon', () => ({
+  __esModule: true,
+  default: () => <span />,
+  StyledIcon: () => <span />,
+}));
 
 function makeMockLocation(query) {
   const queryStr = encodeURIComponent(query);

--- a/superset-frontend/src/components/ReportModal/HeaderReportDropdown/index.test.tsx
+++ b/superset-frontend/src/components/ReportModal/HeaderReportDropdown/index.test.tsx
@@ -24,7 +24,11 @@ import HeaderReportDropdown, { HeaderReportProps } from '.';
 
 let isFeatureEnabledMock: jest.MockInstance<boolean, [string]>;
 
-jest.mock('src/components/Icons/Icon', () => () => <span />);
+jest.mock('src/components/Icons/Icon', () => ({
+  __esModule: true,
+  default: () => <span />,
+  StyledIcon: () => <span />,
+}));
 
 const createProps = () => ({
   dashboardId: 1,

--- a/superset-frontend/src/components/ReportModal/ReportModal.test.tsx
+++ b/superset-frontend/src/components/ReportModal/ReportModal.test.tsx
@@ -33,7 +33,11 @@ fetchMock.get(REPORT_ENDPOINT, {});
 
 const NOOP = () => {};
 
-jest.mock('src/components/Icons/Icon', () => () => <span />);
+jest.mock('src/components/Icons/Icon', () => ({
+  __esModule: true,
+  default: () => <span />,
+  StyledIcon: () => <span />,
+}));
 
 const defaultProps = {
   addDangerToast: NOOP,

--- a/superset-frontend/src/components/Select/utils.tsx
+++ b/superset-frontend/src/components/Select/utils.tsx
@@ -19,7 +19,7 @@
 import { ensureIsArray, t } from '@superset-ui/core';
 import AntdSelect, { LabeledValue as AntdLabeledValue } from 'antd/lib/select';
 import React, { ReactElement, RefObject } from 'react';
-import { DownOutlined, SearchOutlined } from '@ant-design/icons';
+import Icons from 'src/components/Icons';
 import { StyledHelperText, StyledLoadingText, StyledSpin } from './styles';
 import { LabeledValue, RawValue, SelectOptionsType, V } from './types';
 
@@ -132,9 +132,9 @@ export const getSuffixIcon = (
     return <StyledSpin size="small" />;
   }
   if (showSearch && isDropdownVisible) {
-    return <SearchOutlined />;
+    return <Icons.SearchOutlined iconSize="s" />;
   }
-  return <DownOutlined />;
+  return <Icons.DownOutlined iconSize="s" />;
 };
 
 export const dropDownRenderHelper = (

--- a/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel/DetailsPanel.test.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel/DetailsPanel.test.tsx
@@ -102,13 +102,11 @@ test('Should render "appliedCrossFilterIndicators"', () => {
   userEvent.click(screen.getByTestId('details-panel-content'));
   expect(screen.getByText('Applied Cross Filters (1)')).toBeInTheDocument();
   expect(
-    screen.getByRole('button', { name: 'search Clinical Stage' }),
+    screen.getByRole('button', { name: 'Clinical Stage' }),
   ).toBeInTheDocument();
 
   expect(props.onHighlightFilterSource).toBeCalledTimes(0);
-  userEvent.click(
-    screen.getByRole('button', { name: 'search Clinical Stage' }),
-  );
+  userEvent.click(screen.getByRole('button', { name: 'Clinical Stage' }));
   expect(props.onHighlightFilterSource).toBeCalledTimes(1);
   expect(props.onHighlightFilterSource).toBeCalledWith([
     'ROOT_ID',
@@ -135,12 +133,10 @@ test('Should render "appliedIndicators"', () => {
 
   userEvent.click(screen.getByTestId('details-panel-content'));
   expect(screen.getByText('Applied Filters (1)')).toBeInTheDocument();
-  expect(
-    screen.getByRole('button', { name: 'search Country' }),
-  ).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Country' })).toBeInTheDocument();
 
   expect(props.onHighlightFilterSource).toBeCalledTimes(0);
-  userEvent.click(screen.getByRole('button', { name: 'search Country' }));
+  userEvent.click(screen.getByRole('button', { name: 'Country' }));
   expect(props.onHighlightFilterSource).toBeCalledTimes(1);
   expect(props.onHighlightFilterSource).toBeCalledWith([
     'ROOT_ID',
@@ -168,12 +164,12 @@ test('Should render "incompatibleIndicators"', () => {
   userEvent.click(screen.getByTestId('details-panel-content'));
   expect(screen.getByText('Incompatible Filters (1)')).toBeInTheDocument();
   expect(
-    screen.getByRole('button', { name: 'search Vaccine Approach Copy' }),
+    screen.getByRole('button', { name: 'Vaccine Approach Copy' }),
   ).toBeInTheDocument();
 
   expect(props.onHighlightFilterSource).toBeCalledTimes(0);
   userEvent.click(
-    screen.getByRole('button', { name: 'search Vaccine Approach Copy' }),
+    screen.getByRole('button', { name: 'Vaccine Approach Copy' }),
   );
   expect(props.onHighlightFilterSource).toBeCalledTimes(1);
   expect(props.onHighlightFilterSource).toBeCalledWith([
@@ -202,13 +198,11 @@ test('Should render "unsetIndicators"', () => {
   userEvent.click(screen.getByTestId('details-panel-content'));
   expect(screen.getByText('Unset Filters (1)')).toBeInTheDocument();
   expect(
-    screen.getByRole('button', { name: 'search Vaccine Approach' }),
+    screen.getByRole('button', { name: 'Vaccine Approach' }),
   ).toBeInTheDocument();
 
   expect(props.onHighlightFilterSource).toBeCalledTimes(0);
-  userEvent.click(
-    screen.getByRole('button', { name: 'search Vaccine Approach' }),
-  );
+  userEvent.click(screen.getByRole('button', { name: 'Vaccine Approach' }));
   expect(props.onHighlightFilterSource).toBeCalledTimes(1);
   expect(props.onHighlightFilterSource).toBeCalledWith([
     'ROOT_ID',

--- a/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel/index.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel/index.tsx
@@ -20,11 +20,6 @@ import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Global, css } from '@emotion/react';
 import { t, useTheme } from '@superset-ui/core';
-import {
-  MinusCircleFilled,
-  CheckCircleFilled,
-  ExclamationCircleFilled,
-} from '@ant-design/icons';
 import Popover from 'src/components/Popover';
 import Collapse from 'src/components/Collapse';
 import Icons from 'src/components/Icons';
@@ -37,6 +32,12 @@ import {
 import { Indicator } from 'src/dashboard/components/FiltersBadge/selectors';
 import FilterIndicator from 'src/dashboard/components/FiltersBadge/FilterIndicator';
 import { RootState } from 'src/dashboard/types';
+
+const iconReset = css`
+  span {
+    line-height: 0;
+  }
+`;
 
 export interface DetailsPanelProps {
   appliedCrossFilterIndicators: Indicator[];
@@ -206,7 +207,7 @@ const DetailsPanelPopover = ({
               key="applied"
               header={
                 <Title bold color={theme.colors.success.base}>
-                  <CheckCircleFilled />{' '}
+                  <Icons.CheckCircleFilled css={iconReset} iconSize="m" />{' '}
                   {t('Applied Filters (%d)', appliedIndicators.length)}
                 </Title>
               }
@@ -227,7 +228,7 @@ const DetailsPanelPopover = ({
               key="incompatible"
               header={
                 <Title bold color={theme.colors.alert.base}>
-                  <ExclamationCircleFilled />{' '}
+                  <Icons.ExclamationCircleFilled css={iconReset} iconSize="m" />{' '}
                   {t(
                     'Incompatible Filters (%d)',
                     incompatibleIndicators.length,
@@ -251,7 +252,7 @@ const DetailsPanelPopover = ({
               key="unset"
               header={
                 <Title bold color={theme.colors.grayscale.light1}>
-                  <MinusCircleFilled />{' '}
+                  <Icons.MinusCircleFilled css={iconReset} iconSize="m" />{' '}
                   {t('Unset Filters (%d)', unsetIndicators.length)}
                 </Title>
               }

--- a/superset-frontend/src/dashboard/components/FiltersBadge/FilterIndicator/FilterIndicator.test.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/FilterIndicator/FilterIndicator.test.tsx
@@ -43,9 +43,9 @@ test('Should render', () => {
   render(<FilterIndicator {...props} />);
 
   expect(
-    screen.getByRole('button', { name: 'search Vaccine Approach' }),
+    screen.getByRole('button', { name: 'Vaccine Approach' }),
   ).toBeInTheDocument();
-  expect(screen.getByRole('img', { name: 'search' })).toBeInTheDocument();
+  expect(screen.getByRole('img')).toBeInTheDocument();
 });
 
 test('Should call "onClick"', () => {
@@ -53,9 +53,7 @@ test('Should call "onClick"', () => {
   render(<FilterIndicator {...props} />);
 
   expect(props.onClick).toBeCalledTimes(0);
-  userEvent.click(
-    screen.getByRole('button', { name: 'search Vaccine Approach' }),
-  );
+  userEvent.click(screen.getByRole('button', { name: 'Vaccine Approach' }));
   expect(props.onClick).toBeCalledTimes(1);
 });
 
@@ -66,7 +64,7 @@ test('Should render "value"', () => {
 
   expect(
     screen.getByRole('button', {
-      name: 'search Vaccine Approach: any, string',
+      name: 'Vaccine Approach: any, string',
     }),
   ).toBeInTheDocument();
 });
@@ -77,9 +75,7 @@ test('Should render with default props', () => {
   render(<FilterIndicator indicator={props.indicator} />);
 
   expect(
-    screen.getByRole('button', { name: 'search Vaccine Approach' }),
+    screen.getByRole('button', { name: 'Vaccine Approach' }),
   ).toBeInTheDocument();
-  userEvent.click(
-    screen.getByRole('button', { name: 'search Vaccine Approach' }),
-  );
+  userEvent.click(screen.getByRole('button', { name: 'Vaccine Approach' }));
 });

--- a/superset-frontend/src/dashboard/components/FiltersBadge/FilterIndicator/index.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/FilterIndicator/index.tsx
@@ -17,8 +17,9 @@
  * under the License.
  */
 
-import { SearchOutlined } from '@ant-design/icons';
 import React, { FC } from 'react';
+import { css } from '@superset-ui/core';
+import Icons from 'src/components/Icons';
 import { getFilterValueForDisplay } from 'src/dashboard/components/nativeFilters/FilterBar/FilterSets/utils';
 import {
   FilterIndicatorText,
@@ -46,7 +47,14 @@ const FilterIndicator: FC<IndicatorProps> = ({
       <Item onClick={() => onClick([...path, `LABEL-${column}`])}>
         <Title bold>
           <ItemIcon>
-            <SearchOutlined />
+            <Icons.SearchOutlined
+              iconSize="m"
+              css={css`
+                span {
+                  vertical-align: 0;
+                }
+              `}
+            />
           </ItemIcon>
           {name}
           {resultValue ? ': ' : ''}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/EditSection.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/EditSection.tsx
@@ -22,7 +22,7 @@ import { Typography, AntdTooltip } from 'src/components';
 import { useDispatch } from 'react-redux';
 import Button from 'src/components/Button';
 import { updateFilterSet } from 'src/dashboard/actions/nativeFilters';
-import { WarningOutlined } from '@ant-design/icons';
+import Icons from 'src/components/Icons';
 import { ActionButtons } from './Footer';
 import { useNativeFiltersDataMask, useFilters, useFilterSets } from '../state';
 import { APPLY_FILTERS_HINT, findExistingFilterSet } from './utils';
@@ -160,7 +160,7 @@ const EditSection: FC<EditSectionProps> = ({
       </ActionButtons>
       {isDuplicateFilterSet && (
         <Warning mark>
-          <WarningOutlined />
+          <Icons.WarningOutlined iconSize="m" />
           {t('This filter set is identical to: "%s"', foundFilterSet?.name)}
         </Warning>
       )}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/FilterSetUnit.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/FilterSetUnit.test.tsx
@@ -32,7 +32,7 @@ const createProps = () => ({
 });
 
 function openDropdown() {
-  const dropdownIcon = screen.getByRole('img', { name: 'ellipsis' });
+  const dropdownIcon = screen.getAllByRole('img', { name: '' })[0];
   userEvent.click(dropdownIcon);
 }
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/FilterSetUnit.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterSets/FilterSetUnit.tsx
@@ -27,7 +27,7 @@ import {
   useTheme,
   t,
 } from '@superset-ui/core';
-import { CheckOutlined, EllipsisOutlined } from '@ant-design/icons';
+import Icons from 'src/components/Icons';
 import Button from 'src/components/Button';
 import { Tooltip } from 'src/components/Tooltip';
 import FiltersHeader from './FiltersHeader';
@@ -107,7 +107,10 @@ const FilterSetUnit: FC<FilterSetUnitProps> = ({
         </Typography.Text>
         <IconsBlock>
           {isApplied && (
-            <CheckOutlined style={{ color: theme.colors.success.base }} />
+            <Icons.CheckOutlined
+              iconSize="m"
+              iconColor={theme.colors.success.base}
+            />
           )}
           {onDelete && (
             <AntdDropdown
@@ -124,7 +127,7 @@ const FilterSetUnit: FC<FilterSetUnitProps> = ({
                 buttonStyle="link"
                 buttonSize="xsmall"
               >
-                <EllipsisOutlined />
+                <Icons.EllipsisOutlined iconSize="m" />
               </HeaderButton>
             </AntdDropdown>
           )}

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.test.tsx
@@ -30,12 +30,13 @@ import { DndMetricSelect } from 'src/explore/components/controls/DndColumnSelect
 import { AGGREGATES } from 'src/explore/constants';
 import { EXPRESSION_TYPES } from '../MetricControl/AdhocMetric';
 
-jest.mock(
-  'src/components/Icons/Icon',
-  () =>
-    ({ fileName }: { fileName: string }) =>
-      <span role="img" aria-label={fileName.replace('_', '-')} />,
-);
+jest.mock('src/components/Icons/Icon', () => ({
+  __esModule: true,
+  default: ({ fileName }: { fileName: string }) => (
+    <span role="img" aria-label={fileName.replace('_', '-')} />
+  ),
+  StyledIcon: () => <span />,
+}));
 
 const defaultProps = {
   savedMetrics: [

--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
@@ -18,8 +18,8 @@
  */
 import React, { useCallback, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { FileOutlined, FileImageOutlined } from '@ant-design/icons';
 import { css, styled, t, useTheme } from '@superset-ui/core';
+import Icons from 'src/components/Icons';
 import { Menu } from 'src/components/Menu';
 import ModalTrigger from 'src/components/ModalTrigger';
 import Button from 'src/components/Button';
@@ -90,6 +90,13 @@ export const MenuTrigger = styled(Button)`
       color: ${theme.colors.primary.light1};
     }
   `}
+`;
+
+const iconReset = css`
+  .ant-dropdown-menu-item > & > .anticon:first-child {
+    margin-right: 0;
+    vertical-align: 0;
+  }
 `;
 
 export const useExploreAdditionalActionsMenu = (
@@ -271,14 +278,14 @@ export const useExploreAdditionalActionsMenu = (
             <>
               <Menu.Item
                 key={MENU_KEYS.EXPORT_TO_CSV}
-                icon={<FileOutlined />}
+                icon={<Icons.FileOutlined css={iconReset} />}
                 disabled={!canDownloadCSV}
               >
                 {t('Export to original .CSV')}
               </Menu.Item>
               <Menu.Item
                 key={MENU_KEYS.EXPORT_TO_CSV_PIVOTED}
-                icon={<FileOutlined />}
+                icon={<Icons.FileOutlined css={iconReset} />}
                 disabled={!canDownloadCSV}
               >
                 {t('Export to pivoted .CSV')}
@@ -287,18 +294,21 @@ export const useExploreAdditionalActionsMenu = (
           ) : (
             <Menu.Item
               key={MENU_KEYS.EXPORT_TO_CSV}
-              icon={<FileOutlined />}
+              icon={<Icons.FileOutlined css={iconReset} />}
               disabled={!canDownloadCSV}
             >
               {t('Export to .CSV')}
             </Menu.Item>
           )}
-          <Menu.Item key={MENU_KEYS.EXPORT_TO_JSON} icon={<FileOutlined />}>
+          <Menu.Item
+            key={MENU_KEYS.EXPORT_TO_JSON}
+            icon={<Icons.FileOutlined css={iconReset} />}
+          >
             {t('Export to .JSON')}
           </Menu.Item>
           <Menu.Item
             key={MENU_KEYS.DOWNLOAD_AS_IMAGE}
-            icon={<FileImageOutlined />}
+            icon={<Icons.FileImageOutlined css={iconReset} />}
           >
             {t('Download as image')}
           </Menu.Item>

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm/EncryptedField.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm/EncryptedField.tsx
@@ -21,7 +21,7 @@ import { SupersetTheme, t } from '@superset-ui/core';
 import { AntdButton, AntdSelect } from 'src/components';
 import InfoTooltip from 'src/components/InfoTooltip';
 import FormLabel from 'src/components/Form/FormLabel';
-import { DeleteFilled } from '@ant-design/icons';
+import Icons from 'src/components/Icons';
 import { FieldPropTypes } from '.';
 import { infoTooltip, labelMarginBotton, CredentialInfoForm } from '../styles';
 
@@ -152,7 +152,8 @@ export const EncryptedField = ({
             {fileToUpload && (
               <div className="input-upload-current">
                 {fileToUpload}
-                <DeleteFilled
+                <Icons.DeleteFilled
+                  iconSize="m"
                   onClick={() => {
                     setFileToUpload(null);
                     changeMethods.onParametersChange({

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm/TableCatalog.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm/TableCatalog.tsx
@@ -17,10 +17,10 @@
  * under the License.
  */
 import React from 'react';
-import { t } from '@superset-ui/core';
+import { css, SupersetTheme, t } from '@superset-ui/core';
 import ValidatedInput from 'src/components/Form/LabeledErrorBoundInput';
 import FormLabel from 'src/components/Form/FormLabel';
-import { CloseOutlined } from '@ant-design/icons';
+import Icons from 'src/components/Icons';
 import { FieldPropTypes } from '.';
 import { StyledFooterButton, StyledCatalogTable } from '../styles';
 import { CatalogObject } from '../../types';
@@ -64,8 +64,17 @@ export const TableCatalog = ({
                 value={sheet.name}
               />
               {tableCatalog?.length > 1 && (
-                <CloseOutlined
-                  className="catalog-delete"
+                <Icons.CloseOutlined
+                  css={(theme: SupersetTheme) => css`
+                    align-self: center;
+                    background: ${theme.colors.grayscale.light4};
+                    margin: 5px 5px 8px 5px;
+
+                    &.anticon > * {
+                      line-height: 0;
+                    }
+                  `}
+                  iconSize="m"
                   onClick={() => changeMethods.onRemoveTableCatalog(idx)}
                 />
               )}

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/styles.ts
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/styles.ts
@@ -605,12 +605,6 @@ export const StyledCatalogTable = styled.div`
     width: 95%;
   }
 
-  .catalog-delete {
-    align-self: center;
-    background: ${({ theme }) => theme.colors.grayscale.light4};
-    margin: 5px 5px 8px 5px;
-  }
-
   .catalog-add-btn {
     width: 95%;
   }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR finishes up the work from https://github.com/apache/superset/pull/21823, replacing all uses of icon components from `@ant-design/icons` with uses of Superset's `Icons` component in an effort to make icon use more consistent.  Superset's `Icons` component applies slightly different styling rules, so this PR includes some styling tweaks to make icons look the same as before, and it fixes some tests that the conversion breaks.  This PR only replaces icons in `superset-frontend/src`: there are a few direct uses of `@ant-design/icons` in `superset-frontend/packages` and `superset-frontend/plugins`, but because `Icons` lives in `src/components`, replacing these would risk circular dependencies.  A follow-up PR could move `Icons` into `@superset-ui/core` and finish the job.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

This is a hopefully comprehensive before/after comparison of every icon affected.  The only exception is icons in `src/dashboard/nativeFilters/FilterBar/FilterSets` – I couldn't figure out what this code package does or how to find these icons.  I think maybe it's a deprecated feature and the code should be removed?  Not sure though.

<details>

#### `superset-frontend/src/components/Form/LabeledErrorBoundInput`

`EyeOutlined` before:
![EyeOutlined before](https://user-images.githubusercontent.com/13007381/209237545-509ddb06-7acf-4b18-9943-6a1317110875.png)

`EyeOutlined` after:
![EyeOutlined after](https://user-images.githubusercontent.com/13007381/209237552-c4a23767-52ed-4d99-aa6a-856881157d6f.png)

`EyeInvisibleOutlined` before:
![EyeInvisibleOutlined before](https://user-images.githubusercontent.com/13007381/209237560-2555e9b8-c116-4e75-87e6-41c9348c4dfa.png)

`EyeInvisibleOutlined` after:
![EyeInvisibleOutlined after](https://user-images.githubusercontent.com/13007381/209237568-f2e67871-1e3b-4a46-ad97-9f839b3e5065.png)

#### `superset-frontend/src/components/Select/utils`

`DownOutlined` before:
<img width="1165" alt="DownOutlined before" src="https://user-images.githubusercontent.com/13007381/209236869-d8d4c519-521a-4c27-bc95-5fe39d2b5548.png">

`DownOutlined` after:
<img width="1165" alt="DownOutlined after" src="https://user-images.githubusercontent.com/13007381/209236890-ccecae91-6ddf-4b73-abd0-80f865993d93.png">

`SearchOutlined` before:
<img width="1165" alt="SearchOutlined before" src="https://user-images.githubusercontent.com/13007381/209236906-01a63265-de44-4501-88fa-91cc23b59235.png">

`SearchOutlined` after:
<img width="1165" alt="SearchOutlined after" src="https://user-images.githubusercontent.com/13007381/209236934-a729b4f3-a495-47b4-9b14-e032a337a801.png">

#### `superset-frontend/src/dashboard/components/FiltersBadge/DetailsPanel/index`

Before:
![Before](https://user-images.githubusercontent.com/13007381/209236976-1826acff-8f9d-4c6a-ad2f-f4b39c2ab0b0.png)

After:
![After](https://user-images.githubusercontent.com/13007381/209236992-a4a465dd-154c-46c7-af17-9303ee5cdde1.png)

#### `superset-frontend/src/dashboard/components/FiltersBadge/FilterIndicator/index`

Before:
![Before](https://user-images.githubusercontent.com/13007381/209237188-4cdbd886-a9f3-422e-b09d-4b6b9db1b553.png)

After:
![After](https://user-images.githubusercontent.com/13007381/209237201-260ec8df-31cf-4446-b1ec-e5b94396b7e0.png)

#### `superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index`

Non-pivot before:
![Non-pivot before](https://user-images.githubusercontent.com/13007381/209237229-10a85821-7f7c-4b66-b25f-6e0ca24c637c.png)

Non-pivot after:
![Non-pivot after](https://user-images.githubusercontent.com/13007381/209237239-5e9e1c09-bedb-4cd1-8392-d43a60c57b74.png)

Pivot before:
![Pivot before](https://user-images.githubusercontent.com/13007381/209237249-e32a5562-43d2-483f-8b66-8a5aa4b18f1b.png)

Pivot after:
![Pivot after](https://user-images.githubusercontent.com/13007381/209237269-148560ef-16fb-43d3-8015-ec4d55ec4c9f.png)

#### `superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm/EncryptedField`

Before:
![Before](https://user-images.githubusercontent.com/13007381/209237313-541af679-20e8-4984-83ba-ac563647afa7.png)

After:
![After](https://user-images.githubusercontent.com/13007381/209237327-d9404fa8-3bee-4724-9388-e21d8fb20b0b.png)

#### `superset-frontend/src/views/CRUD/data/database/DatabaseModal/DatabaseConnectionForm/TableCatalog`

Before:
![Before](https://user-images.githubusercontent.com/13007381/209237351-054e2081-cbf4-4bfe-a42d-d7b7458e8044.png)

After:
![After](https://user-images.githubusercontent.com/13007381/209237361-952e73fc-758c-42b3-8484-0763fd41b92c.png)

</details>

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Check that all of the icons listed in the above section look the same as before.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
