### PR TITLE
fix(explore): support saving undefined time grain

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
@@ -193,7 +193,9 @@ const time_grain_sqla: SharedControlConfig<'SelectControl'> = {
     // If a chart is a new one that isn't saved, metadata is null. In this
     // case we want to default P1D. If the chart has been saved, we want
     // to use whichever value was chosen, either nothing or valid a time grain.
-    return state.metadata ? state.form_data?.time_grain_sqla : 'P1D';
+    return state.metadata || 'time_grain_sqla' in (state?.form_data ?? {})
+      ? state.form_data?.time_grain_sqla
+      : 'P1D';
   },
   description: t(
     'The time granularity for the visualization. This ' +

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
@@ -184,15 +184,16 @@ const granularity: SharedControlConfig<'SelectControl'> = {
 const time_grain_sqla: SharedControlConfig<'SelectControl'> = {
   type: 'SelectControl',
   label: TIME_FILTER_LABELS.time_grain_sqla,
+  placeholder: t('None'),
   initialValue: (control: ControlState, state: ControlPanelState) => {
     if (!isDefined(state)) {
       // If a chart is in a Dashboard, the ControlPanelState is empty.
       return control.value;
     }
-    // If a chart is a new one that isn't saved, the 'time_grain_sqla' isn't in the form_data.
-    return 'time_grain_sqla' in (state?.form_data ?? {})
-      ? state.form_data?.time_grain_sqla
-      : 'P1D';
+    // If a chart is a new one that isn't saved, metadata is null. In this
+    // case we want to default P1D. If the chart has been saved, we want
+    // to use whichever value was chosen, either nothing or valid a time grain.
+    return state.metadata ? state.form_data?.time_grain_sqla : 'P1D';
   },
   description: t(
     'The time granularity for the visualization. This ' +
@@ -264,6 +265,7 @@ const limit: SharedControlConfig<'SelectControl'> = {
   type: 'SelectControl',
   freeForm: true,
   label: t('Series limit'),
+  placeholder: t('None'),
   validators: [legacyValidateInteger],
   choices: formatSelectOptions(SERIES_LIMITS),
   clearable: true,
@@ -279,6 +281,7 @@ const series_limit: SharedControlConfig<'SelectControl'> = {
   type: 'SelectControl',
   freeForm: true,
   label: t('Series limit'),
+  placeholder: t('None'),
   validators: [legacyValidateInteger],
   choices: formatSelectOptions(SERIES_LIMITS),
   description: t(

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
@@ -193,8 +193,8 @@ const time_grain_sqla: SharedControlConfig<'SelectControl'> = {
     // If a chart is a new one that isn't saved, metadata is null. In this
     // case we want to default P1D. If the chart has been saved, we want
     // to use whichever value was chosen, either nothing or valid a time grain.
-    return state.metadata || 'time_grain_sqla' in (state?.form_data ?? {})
-      ? state.form_data?.time_grain_sqla
+    return state?.metadata || 'time_grain_sqla' in (state?.form_data ?? {})
+      ? state?.form_data?.time_grain_sqla
       : 'P1D';
   },
   description: t(

--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -88,6 +88,7 @@ export interface ControlPanelState {
   datasource: Dataset | QueryResponse | null;
   controls: ControlStateMapping;
   common: JsonObject;
+  metadata?: JsonObject | null;
 }
 
 /**

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -97,7 +97,6 @@ class TimeGrain(NamedTuple):
 
 
 builtin_time_grains: Dict[Optional[str], str] = {
-    None: __("Original value"),
     "PT1S": __("Second"),
     "PT5S": __("5 second"),
     "PT30S": __("30 second"),


### PR DESCRIPTION
### SUMMARY
Continuing the work from #21644, when saving a chart without a time grain, the chart reverts to the default time grain after the chart reloads in Explore view. To get around this, the user must choose the "Original value" option from the time grain dropdown. While this works, there should only be one way of clearing the time grain. A summary of changes introduced by this PR:
- When saving the chart with the time grain control in cleared state, the `time_grain_sqla` entry is removed from the form data. To get around this, we check if the chart has been saved by looking at the `metadata` property of the chart state - if it's defined, we know the chart has been saved, in which case we know that the time grain has been explicitly set to `undefined`.
- Remove the "Original value" option from the time grain dropdown. After this the time grain should be cleared to be removed. 
- Add a "None" placeholder when the time grain is cleared. Use the same placeholder for "Series limit", as that seems more appropriate for that one, too (currently it shows "Select ...")

The change has been tested to work in the following scenarios:
- Chart saved with "Original value" prior to the change - it renders the chart without the time grain as expected, but with the time grain control in cleared state (as opposed to with "Original value")
- Chart saved with time grain
- Chart saved without time grain
- All of the above on a dashboard (verified by looking at the rendered query to confirm that the time grain was applied correctly)

### AFTER
With these changes, the time grain remains cleared even after saving:

https://user-images.githubusercontent.com/33317356/210207589-6d6a3fb2-2b3a-4443-aa61-b5e3d99db666.mp4

### BEFORE
Previously, the chart would revert back to the default time grain `P1D` when the chart reloaded in Explore view:

https://user-images.githubusercontent.com/33317356/210207787-51cd2089-213d-4762-baf8-213a3ec425bc.mp4

### TESTING INSTRUCTIONS
1. Create a line chart and remove the time grain
2. Save the chart and notice that the default time grain is reapplied.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
