### PR TITLE
fix(cypress): make test chart time range deterministic

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
@@ -154,7 +154,7 @@ describe('Test datatable', () => {
   });
   it('Data Pane opens and loads results', () => {
     cy.contains('Results').click();
-    cy.get('[data-test="row-count-label"]').contains('44 rows');
+    cy.get('[data-test="row-count-label"]').contains('26 rows');
     cy.get('.ant-empty-description').should('not.exist');
   });
   it('Datapane loads view samples', () => {

--- a/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/explore/control.test.ts
@@ -154,7 +154,7 @@ describe('Test datatable', () => {
   });
   it('Data Pane opens and loads results', () => {
     cy.contains('Results').click();
-    cy.get('[data-test="row-count-label"]').contains('26 rows');
+    cy.get('[data-test="row-count-label"]').contains('44 rows');
     cy.get('.ant-empty-description').should('not.exist');
   });
   it('Datapane loads view samples', () => {

--- a/superset/examples/birth_names.py
+++ b/superset/examples/birth_names.py
@@ -168,12 +168,10 @@ def create_slices(tbl: SqlaTable) -> Tuple[List[Slice], List[Slice]]:
         "compare_lag": "10",
         "compare_suffix": "o10Y",
         "limit": "25",
-        "time_range": "No filter",
         "granularity_sqla": "ds",
         "groupby": [],
         "row_limit": app.config["ROW_LIMIT"],
-        "since": "100 years ago",
-        "until": "now",
+        "time_range": "100 years ago : now",
         "viz_type": "table",
         "markup_type": "markdown",
     }

--- a/superset/examples/birth_names.py
+++ b/superset/examples/birth_names.py
@@ -419,8 +419,7 @@ def create_slices(tbl: SqlaTable) -> Tuple[List[Slice], List[Slice]]:
             params=get_slice_json(
                 defaults,
                 groupby=["ds"],
-                since="1950-01-01",
-                until="2020-01-01",
+                time_range="1983 : 2023",
                 viz_type="table",
                 metrics=metrics,
             ),

--- a/superset/examples/birth_names.py
+++ b/superset/examples/birth_names.py
@@ -419,8 +419,8 @@ def create_slices(tbl: SqlaTable) -> Tuple[List[Slice], List[Slice]]:
             params=get_slice_json(
                 defaults,
                 groupby=["ds"],
-                since="40 years ago",
-                until="now",
+                since="1950-01-01",
+                until="2020-01-01",
                 viz_type="table",
                 metrics=metrics,
             ),


### PR DESCRIPTION
### SUMMARY
Cypress is currently failing due to a test chart having a "40 years ago" time range, causing the row count to drop by one every year (hence it's now 25 rows and not 26 rows):

<img width="1063" alt="image" src="https://user-images.githubusercontent.com/33317356/210245535-597ed208-7c24-4ef7-9ab5-c61786f38339.png">

Here we're changing the time range to be deterministic so we don't have to do this change annually. In addition, `since` and `until` are moved into `time_range` from the birth names defaults, as they're overlapping with `time_range`.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
