### PR TITLE
chore: upgrade interweave

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -76,7 +76,7 @@
         "global-box": "^1.2.0",
         "html-webpack-plugin": "^5.3.2",
         "immer": "^9.0.6",
-        "interweave": "^11.2.0",
+        "interweave": "^13.0.0",
         "jquery": "^3.5.1",
         "js-levenshtein": "^1.1.6",
         "js-yaml-loader": "^1.2.2",
@@ -33728,16 +33728,18 @@
       }
     },
     "node_modules/interweave": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/interweave/-/interweave-11.2.0.tgz",
-      "integrity": "sha512-33h9LOXbT52tMin3IyLBPcd5RbiwroP/Sxr0OamnJJU7A/jh0XtZKGvdcSNKYRC7sLZuDk+ZJ2XVrmkcMU5i6w==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/interweave/-/interweave-13.0.0.tgz",
+      "integrity": "sha512-Mckwj+ix/VtrZu1bRBIIohwrsXj12ZTvJCoYUMZlJmgtvIaQCj0i77eSZ63ckbA1TsPrz2VOvLW9/kTgm5d+mw==",
       "dependencies": {
-        "@types/react": "*",
-        "escape-html": "^1.0.3",
-        "prop-types": "^15.7.2"
+        "escape-html": "^1.0.3"
+      },
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/milesjohnson"
       },
       "peerDependencies": {
-        "react": "^16.3.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/invariant": {
@@ -84001,13 +84003,11 @@
       "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw=="
     },
     "interweave": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/interweave/-/interweave-11.2.0.tgz",
-      "integrity": "sha512-33h9LOXbT52tMin3IyLBPcd5RbiwroP/Sxr0OamnJJU7A/jh0XtZKGvdcSNKYRC7sLZuDk+ZJ2XVrmkcMU5i6w==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/interweave/-/interweave-13.0.0.tgz",
+      "integrity": "sha512-Mckwj+ix/VtrZu1bRBIIohwrsXj12ZTvJCoYUMZlJmgtvIaQCj0i77eSZ63ckbA1TsPrz2VOvLW9/kTgm5d+mw==",
       "requires": {
-        "@types/react": "*",
-        "escape-html": "^1.0.3",
-        "prop-types": "^15.7.2"
+        "escape-html": "^1.0.3"
       }
     },
     "invariant": {

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -140,7 +140,7 @@
     "global-box": "^1.2.0",
     "html-webpack-plugin": "^5.3.2",
     "immer": "^9.0.6",
-    "interweave": "^11.2.0",
+    "interweave": "^13.0.0",
     "jquery": "^3.5.1",
     "js-levenshtein": "^1.1.6",
     "js-yaml-loader": "^1.2.2",

--- a/superset-frontend/src/components/MessageToasts/Toast.tsx
+++ b/superset-frontend/src/components/MessageToasts/Toast.tsx
@@ -18,7 +18,7 @@
  */
 import { styled, css, SupersetTheme } from '@superset-ui/core';
 import cx from 'classnames';
-import Interweave from 'interweave';
+import { Interweave } from 'interweave';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import Icons from 'src/components/Icons';
 import { ToastType, ToastMeta } from './types';


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- current version of interweave does not support react 18, so interweave need to be upgraded before react 18 upgrade

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
