### PR TITLE
chore: upgrade react-ace

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -96,7 +96,7 @@
         "query-string": "^6.13.7",
         "re-resizable": "^6.6.1",
         "react": "^16.13.1",
-        "react-ace": "^9.4.4",
+        "react-ace": "^10.1.0",
         "react-checkbox-tree": "^1.5.1",
         "react-color": "^2.13.8",
         "react-datetime": "^3.0.4",
@@ -45043,19 +45043,19 @@
       }
     },
     "node_modules/react-ace": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-9.5.0.tgz",
-      "integrity": "sha512-4l5FgwGh6K7A0yWVMQlPIXDItM4Q9zzXRqOae8KkCl6MkOob7sC1CzHxZdOGvV+QioKWbX2p5HcdOVUv6cAdSg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-10.1.0.tgz",
+      "integrity": "sha512-VkvUjZNhdYTuKOKQpMIZi7uzZZVgzCjM7cLYu6F64V0mejY8a2XTyPUIMszC6A4trbeMIHbK5fYFcT/wkP/8VA==",
       "dependencies": {
-        "ace-builds": "^1.4.13",
+        "ace-builds": "^1.4.14",
         "diff-match-patch": "^1.0.5",
         "lodash.get": "^4.4.2",
         "lodash.isequal": "^4.5.0",
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
-        "react": "^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0",
-        "react-dom": "^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0"
+        "react": "^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-base16-styling": {
@@ -55557,7 +55557,7 @@
     },
     "packages/superset-ui-chart-controls": {
       "name": "@superset-ui/chart-controls",
-      "version": "0.18.25",
+      "version": "0.18.26",
       "license": "Apache-2.0",
       "dependencies": {
         "@react-icons/all-files": "^4.1.0",
@@ -55580,7 +55580,7 @@
         "brace": "^0.11.1",
         "memoize-one": "^5.1.1",
         "react": "^16.13.1",
-        "react-ace": "^9.4.4",
+        "react-ace": "^10.1.0",
         "react-dom": "^16.13.1"
       }
     },
@@ -57031,7 +57031,7 @@
     },
     "plugins/plugin-chart-handlebars": {
       "name": "@superset-ui/plugin-chart-handlebars",
-      "version": "0.18.25",
+      "version": "0.18.26",
       "license": "Apache-2.0",
       "dependencies": {
         "handlebars": "^4.7.7",
@@ -57049,7 +57049,7 @@
         "lodash": "^4.17.11",
         "moment": "^2.26.0",
         "react": "^16.13.1",
-        "react-ace": "^9.4.4",
+        "react-ace": "^10.1.0",
         "react-dom": "^16.13.1"
       }
     },
@@ -92671,11 +92671,11 @@
       }
     },
     "react-ace": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-9.5.0.tgz",
-      "integrity": "sha512-4l5FgwGh6K7A0yWVMQlPIXDItM4Q9zzXRqOae8KkCl6MkOob7sC1CzHxZdOGvV+QioKWbX2p5HcdOVUv6cAdSg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-10.1.0.tgz",
+      "integrity": "sha512-VkvUjZNhdYTuKOKQpMIZi7uzZZVgzCjM7cLYu6F64V0mejY8a2XTyPUIMszC6A4trbeMIHbK5fYFcT/wkP/8VA==",
       "requires": {
-        "ace-builds": "^1.4.13",
+        "ace-builds": "^1.4.14",
         "diff-match-patch": "^1.0.5",
         "lodash.get": "^4.4.2",
         "lodash.isequal": "^4.5.0",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -160,7 +160,7 @@
     "query-string": "^6.13.7",
     "re-resizable": "^6.6.1",
     "react": "^16.13.1",
-    "react-ace": "^9.4.4",
+    "react-ace": "^10.1.0",
     "react-checkbox-tree": "^1.5.1",
     "react-color": "^2.13.8",
     "react-datetime": "^3.0.4",

--- a/superset-frontend/packages/superset-ui-chart-controls/package.json
+++ b/superset-frontend/packages/superset-ui-chart-controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/chart-controls",
-  "version": "0.18.25",
+  "version": "0.18.26",
   "description": "Superset UI control-utils",
   "keywords": [
     "superset"
@@ -43,7 +43,7 @@
     "brace": "^0.11.1",
     "memoize-one": "^5.1.1",
     "react": "^16.13.1",
-    "react-ace": "^9.4.4",
+    "react-ace": "^10.1.0",
     "react-dom": "^16.13.1"
   },
   "publishConfig": {

--- a/superset-frontend/plugins/plugin-chart-handlebars/package.json
+++ b/superset-frontend/plugins/plugin-chart-handlebars/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/plugin-chart-handlebars",
-  "version": "0.18.25",
+  "version": "0.18.26",
   "description": "Superset Chart - Write a handlebars template to render the data",
   "sideEffects": false,
   "main": "lib/index.js",
@@ -36,7 +36,7 @@
     "lodash": "^4.17.11",
     "moment": "^2.26.0",
     "react": "^16.13.1",
-    "react-ace": "^9.4.4",
+    "react-ace": "^10.1.0",
     "react-dom": "^16.13.1"
   },
   "devDependencies": {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
- current version react-ace does not support react 18, react-ace need to be upgraded before react 18 upgrade

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
