### PR TITLE
fix: Talisman configuration

### DIFF
--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -601,9 +601,9 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
             logger.warning(
                 "We haven't found any Content Security Policy (CSP) defined in "
                 "the configurations. Please make sure to configure CSP using the "
-                "TALISMAN_ENABLED and TALISMAN_CONFIG keys or any other external software. "
-                "Failing to configure CSP have serious security implications. Check "
-                "https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP for more "
+                "TALISMAN_ENABLED and TALISMAN_CONFIG keys or any other external "
+                "software. Failing to configure CSP have serious security implications. "
+                "Check https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP for more "
                 "information. You can disable this warning using the "
                 "CONTENT_SECURITY_POLICY_WARNING key."
             )

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -577,24 +577,32 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         # Flask-Compress
         Compress(self.superset_app)
 
+        # Talisman
+        talisman_enabled = self.config["TALISMAN_ENABLED"]
+        talisman_config = self.config["TALISMAN_CONFIG"]
+        csp_warning = self.config["CONTENT_SECURITY_POLICY_WARNING"]
+
+        if talisman_enabled:
+            talisman.init_app(self.superset_app, **talisman_config)
+
         show_csp_warning = False
         if (
-            self.config["CONTENT_SECURITY_POLICY_WARNING"]
+            csp_warning
             and not self.superset_app.debug
+            and (
+                not talisman_enabled
+                or not talisman_config
+                or not talisman_config.get("content_security_policy")
+            )
         ):
-            if self.config["TALISMAN_ENABLED"]:
-                talisman.init_app(self.superset_app, **self.config["TALISMAN_CONFIG"])
-                if not self.config["TALISMAN_CONFIG"].get("content_security_policy"):
-                    show_csp_warning = True
-            else:
-                show_csp_warning = True
+            show_csp_warning = True
 
         if show_csp_warning:
             logger.warning(
                 "We haven't found any Content Security Policy (CSP) defined in "
                 "the configurations. Please make sure to configure CSP using the "
-                "TALISMAN_CONFIG key or any other external software. Failing to "
-                "configure CSP have serious security implications. Check "
+                "TALISMAN_ENABLED and TALISMAN_CONFIG keys or any other external software. "
+                "Failing to configure CSP have serious security implications. Check "
                 "https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP for more "
                 "information. You can disable this warning using the "
                 "CONTENT_SECURITY_POLICY_WARNING key."


### PR DESCRIPTION
### SUMMARY
https://github.com/apache/superset/pull/21874 introduced a CSP check for production environments but ended up making the Talisman configuration dependent on the `CONTENT_SECURITY_POLICY_WARNING` key. This PR fixes this by loading Talisman values independently of the CSP warning.

### TESTING INSTRUCTIONS
1 - Play with Talisman configurations
2 - Check that the Talisman configurations are applied independently of the CSP warning

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
