### PR TITLE
chore(docs): update slack invite url

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -106,7 +106,7 @@ This statement thanks the following, on which it draws for content and inspirati
 
 # Slack Community Guidelines
 
-If you decide to join the [Community Slack](https://join.slack.com/t/apache-superset/shared_invite/zt-1jp6hjzrq-H0PlFtToyLWuPiJDuRWCNw), please adhere to the following rules:
+If you decide to join the [Community Slack](https://join.slack.com/t/apache-superset/shared_invite/zt-1mh158vmv-y67mOpmxjJyOKmJTUmYGhw), please adhere to the following rules:
 
 **1. Treat everyone in the community with respect.**
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ under the License.
 [![PyPI version](https://badge.fury.io/py/apache-superset.svg)](https://badge.fury.io/py/apache-superset)
 [![Coverage Status](https://codecov.io/github/apache/superset/coverage.svg?branch=master)](https://codecov.io/github/apache/superset)
 [![PyPI](https://img.shields.io/pypi/pyversions/apache-superset.svg?maxAge=2592000)](https://pypi.python.org/pypi/apache-superset)
-[![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](https://join.slack.com/t/apache-superset/shared_invite/zt-1jp6hjzrq-H0PlFtToyLWuPiJDuRWCNw)
+[![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](https://join.slack.com/t/apache-superset/shared_invite/zt-1mh158vmv-y67mOpmxjJyOKmJTUmYGhw)
 [![Documentation](https://img.shields.io/badge/docs-apache.org-blue.svg)](https://superset.apache.org)
 
 <img

--- a/docs/docs/contributing/contributing-page.mdx
+++ b/docs/docs/contributing/contributing-page.mdx
@@ -12,7 +12,7 @@ The core contributors (or committers) to Superset communicate primarily in the f
 which can be joined by anyone):
 
 - [Mailing list](https://lists.apache.org/list.html?dev@superset.apache.org)
-- [Apache Superset Slack community](https://join.slack.com/t/apache-superset/shared_invite/zt-1jp6hjzrq-H0PlFtToyLWuPiJDuRWCNw)
+- [Apache Superset Slack community](https://join.slack.com/t/apache-superset/shared_invite/zt-1mh158vmv-y67mOpmxjJyOKmJTUmYGhw)
 - [GitHub issues and PR's](https://github.com/apache/superset/issues)
 
 More references:

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -211,7 +211,7 @@ const config = {
               },
               {
                 label: 'Slack',
-                href: 'https://join.slack.com/t/apache-superset/shared_invite/zt-1jp6hjzrq-H0PlFtToyLWuPiJDuRWCNw',
+                href: 'https://join.slack.com/t/apache-superset/shared_invite/zt-1mh158vmv-y67mOpmxjJyOKmJTUmYGhw',
               },
               {
                 label: 'Mailing List',

--- a/docs/src/pages/community.tsx
+++ b/docs/src/pages/community.tsx
@@ -23,7 +23,7 @@ import Layout from '@theme/Layout';
 
 const links = [
   [
-    'https://join.slack.com/t/apache-superset/shared_invite/zt-1jp6hjzrq-H0PlFtToyLWuPiJDuRWCNw',
+    'https://join.slack.com/t/apache-superset/shared_invite/zt-1mh158vmv-y67mOpmxjJyOKmJTUmYGhw',
     'Slack',
     'interact with other Superset users and community members',
   ],


### PR DESCRIPTION
Updating the url since previous one is expired as reported [here](https://github.com/apache/superset/discussions/22076#discussioncomment-4593941).

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
