### PR TITLE
fix(sqllab): Overflow bigint in json-tree view

### DIFF
--- a/superset-frontend/src/components/FilterableTable/FilterableTable.test.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.test.tsx
@@ -21,6 +21,7 @@ import { ReactWrapper } from 'enzyme';
 import { styledMount as mount } from 'spec/helpers/theming';
 import FilterableTable, {
   MAX_COLUMNS_FOR_TABLE,
+  renderBigIntStrToNumber,
 } from 'src/components/FilterableTable';
 import { render, screen } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
@@ -330,4 +331,20 @@ describe('FilterableTable sorting - RTL', () => {
     expect(gridCells[5]).toHaveTextContent('2021-10-01');
     expect(gridCells[6]).toHaveTextContent('2022-01-02');
   });
+});
+
+test('renders bigInt value in a number format', () => {
+  expect(renderBigIntStrToNumber('123')).toBe('123');
+  expect(renderBigIntStrToNumber('some string value')).toBe(
+    'some string value',
+  );
+  expect(renderBigIntStrToNumber('{ a: 123 }')).toBe('{ a: 123 }');
+  expect(renderBigIntStrToNumber('"Not a Number"')).toBe('"Not a Number"');
+  // trim quotes for bigint string format
+  expect(renderBigIntStrToNumber('"-12345678901234567890"')).toBe(
+    '-12345678901234567890',
+  );
+  expect(renderBigIntStrToNumber('"12345678901234567890"')).toBe(
+    '12345678901234567890',
+  );
 });

--- a/superset-frontend/src/components/FilterableTable/index.tsx
+++ b/superset-frontend/src/components/FilterableTable/index.tsx
@@ -53,7 +53,7 @@ function safeJsonObjectParse(
 
   // We know `data` is a string starting with '{' or '[', so try to parse it as a valid object
   try {
-    const jsonData = JSON.parse(data);
+    const jsonData = JSONbig({ storeAsString: true }).parse(data);
     if (jsonData && typeof jsonData === 'object') {
       return jsonData;
     }
@@ -61,6 +61,13 @@ function safeJsonObjectParse(
   } catch (_) {
     return null;
   }
+}
+
+export function renderBigIntStrToNumber(value: string) {
+  if (typeof value === 'string' && /^"-?\d+"$/.test(value)) {
+    return value.substring(1, value.length - 1);
+  }
+  return value;
 }
 
 const GRID_POSITION_ADJUSTMENT = 4;
@@ -405,7 +412,13 @@ const FilterableTable = ({
     jsonString: CellDataType,
   ) => (
     <ModalTrigger
-      modalBody={<JSONTree data={jsonObject} theme={getJsonTreeTheme()} />}
+      modalBody={
+        <JSONTree
+          data={jsonObject}
+          theme={getJsonTreeTheme()}
+          valueRenderer={renderBigIntStrToNumber}
+        />
+      }
       modalFooter={
         <Button>
           <CopyToClipboard shouldShowText={false} text={jsonString} />


### PR DESCRIPTION
### SUMMARY
The json explore view in sqllab is displaying incorrect values which seemed to be due to Javascript's max integer on 64 bit IDs.
This commit updates the JSON.parser by JSONBig parser as well as custom rendering logic to trim the unnecessary quote   format in a bigint string format.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

- Before

https://user-images.githubusercontent.com/1392866/210884982-67147df3-1575-40a8-8b1a-658a4b4bac8a.mov

- After

https://user-images.githubusercontent.com/1392866/210884977-232a1e40-a9ae-4b24-98c6-7a8a1ceb6149.mov


### TESTING INSTRUCTIONS
specs are added

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

@ktmud  cc: @john-bodley 