### PR TITLE
fix: Report screenshot cut off on left and right sides

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -452,17 +452,19 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
                 >
                   <StickyPanel ref={containerRef} width={filterBarWidth}>
                     <ErrorBoundary>
-                      <FilterBar
-                        focusedFilterId={focusedFilterId}
-                        orientation={FilterBarOrientation.VERTICAL}
-                        verticalConfig={{
-                          filtersOpen: dashboardFiltersOpen,
-                          toggleFiltersBar: toggleDashboardFiltersOpen,
-                          width: filterBarWidth,
-                          height: filterBarHeight,
-                          offset: filterBarOffset,
-                        }}
-                      />
+                      {!isReport && (
+                        <FilterBar
+                          focusedFilterId={focusedFilterId}
+                          orientation={FilterBarOrientation.VERTICAL}
+                          verticalConfig={{
+                            filtersOpen: dashboardFiltersOpen,
+                            toggleFiltersBar: toggleDashboardFiltersOpen,
+                            width: filterBarWidth,
+                            height: filterBarHeight,
+                            offset: filterBarOffset,
+                          }}
+                        />
+                      )}
                     </ErrorBoundary>
                   </StickyPanel>
                 </FiltersPanel>

--- a/superset/utils/screenshots.py
+++ b/superset/utils/screenshots.py
@@ -212,7 +212,7 @@ class ChartScreenshot(BaseScreenshot):
 
 class DashboardScreenshot(BaseScreenshot):
     thumbnail_type: str = "dashboard"
-    element: str = "grid-container"
+    element: str = "standalone"
 
     def __init__(
         self,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes report screenshot width. Screenshots were being cut off on the left and right. I fixed this by having the screenshot capture by class `standalone` and removing the filter bar when `standalone=3`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### BEFORE:
![reportBefore](https://user-images.githubusercontent.com/55605634/210910175-47050578-2a38-4b3e-a91a-eb684fd41283.png)

#### AFTER:
![reportAfter](https://user-images.githubusercontent.com/55605634/210910259-344ccff9-e969-45a1-8c4c-a0901aba6fd1.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Add a report and set the notification method to email
  - Set it to send every minute for quicker testing
- Check your email
- Ensure that the report is properly bordered on the left and right

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
