### PR TITLE
chore: bump sqloxide to 0.1.30

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -97,7 +97,7 @@ s3transfer==0.5.0
     # via boto3
 sasl==0.3.1
     # via pyhive
-sqloxide==0.1.26
+sqloxide==0.1.30
     # via -r requirements/development.in
 stack-data==0.2.0
     # via ipython

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -97,7 +97,7 @@ s3transfer==0.5.0
     # via boto3
 sasl==0.3.1
     # via pyhive
-sqloxide==0.1.17
+sqloxide==0.1.26
     # via -r requirements/development.in
 stack-data==0.2.0
     # via ipython


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
updating sqloxide to 0.1.30 along with https://github.com/apache/superset/pull/22623 will allow arm based users to build superset locally

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
