### PR TITLE
chore: skip puppeteer chromium download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,9 @@
 ARG PY_VER=3.8.13-slim
 FROM node:16-slim AS superset-node
 
-RUN apt-get update -y \
-    && apt-get install -y chromium
-
 ARG NPM_BUILD_CMD="build"
 ENV BUILD_CMD=${NPM_BUILD_CMD}
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
 # NPM ci first, as to NOT invalidate previous steps except for when package.json changes
 RUN mkdir -p /app/superset-frontend

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@
 ARG PY_VER=3.8.13-slim
 FROM node:16-slim AS superset-node
 
+RUN apt-get update -y \
+    && apt-get install -y chromium
+
 ARG NPM_BUILD_CMD="build"
 ENV BUILD_CMD=${NPM_BUILD_CMD}
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Skipping puppeteer chromium download in the build docker stage along with https://github.com/apache/superset/pull/22615 will allow arm based users to finally build locally 

Adding this will fix this error when building on m1 macs

 > [superset-node 7/8] RUN /frontend-mem-nag.sh && cd /app/superset-frontend && npm ci:
https://github.com/apache/superset/issues/18 0.141 Memory check Ok [12.1407 GB free]
https://github.com/apache/superset/issues/18 108.2 npm notice
https://github.com/apache/superset/issues/18 108.2 npm notice New major version of npm available! 7.24.2 -> 9.2.0
https://github.com/apache/superset/issues/18 108.2 npm notice Changelog: https://github.com/npm/cli/releases/tag/v9.2.0
https://github.com/apache/superset/issues/18 108.2 npm notice Run npm install -g npm@9.2.0 to update!
https://github.com/apache/superset/issues/18 108.2 npm notice
https://github.com/apache/superset/issues/18 108.2 npm ERR! code 1
https://github.com/apache/superset/issues/18 108.2 npm ERR! path /app/superset-frontend/node_modules/puppeteer
https://github.com/apache/superset/issues/18 108.2 npm ERR! command failed
https://github.com/apache/superset/issues/18 108.2 npm ERR! command sh -c node install.js
https://github.com/apache/superset/issues/18 108.2 npm ERR! The chromium binary is not available for arm64.
https://github.com/apache/superset/issues/18 108.2 npm ERR! If you are on Ubuntu, you can install with:
https://github.com/apache/superset/issues/18 108.2 npm ERR!
https://github.com/apache/superset/issues/18 108.2 npm ERR! sudo apt install chromium
https://github.com/apache/superset/issues/18 108.2 npm ERR!
https://github.com/apache/superset/issues/18 108.2 npm ERR!
https://github.com/apache/superset/issues/18 108.2 npm ERR! sudo apt install chromium-browser
https://github.com/apache/superset/issues/18 108.2 npm ERR!
https://github.com/apache/superset/issues/18 108.2 npm ERR! /app/superset-frontend/node_modules/puppeteer/lib/cjs/puppeteer/node/BrowserFetcher.js:115
https://github.com/apache/superset/issues/18 108.2 npm ERR! throw new Error();
https://github.com/apache/superset/issues/18 108.2 npm ERR! ^
https://github.com/apache/superset/issues/18 108.2 npm ERR!
https://github.com/apache/superset/issues/18 108.2 npm ERR! Error
https://github.com/apache/superset/issues/18 108.2 npm ERR! at /app/superset-frontend/node_modules/puppeteer/lib/cjs/puppeteer/node/BrowserFetcher.js:115:27
https://github.com/apache/superset/issues/18 108.2 npm ERR! at FSReqCallback.oncomplete (node:fs:202:21)
https://github.com/apache/superset/issues/18 108.3
https://github.com/apache/superset/issues/18 108.3 npm ERR! A complete log of this run can be found in:
https://github.com/apache/superset/issues/18 108.3 npm ERR! /root/.npm/_logs/2023-01-11T17_24_26_860Z-debug.log

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
