### PR TITLE
fix: stringify ValueErrors for NaT types

### DIFF
--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -135,6 +135,7 @@ class SupersetResultSet:
                     pa.lib.ArrowInvalid,
                     pa.lib.ArrowTypeError,
                     pa.lib.ArrowNotImplementedError,
+                    ValueError,
                     TypeError,  # this is super hackey,
                     # https://issues.apache.org/jira/browse/ARROW-7855
                 ):

--- a/tests/unit_tests/dataframe_test.py
+++ b/tests/unit_tests/dataframe_test.py
@@ -19,6 +19,7 @@ from datetime import datetime
 
 import pytest
 from pandas import Timestamp
+from pandas._libs.tslibs import NaT
 
 from superset.dataframe import df_to_records
 from superset.superset_typing import DbapiDescription
@@ -38,6 +39,23 @@ def test_df_to_records() -> None:
     assert df_to_records(df) == [
         {"a": "a1", "b": "b1", "c": "c1"},
         {"a": "a2", "b": "b2", "c": "c2"},
+    ]
+
+
+def test_df_to_records_NaT_type() -> None:
+    from superset.db_engine_specs import BaseEngineSpec
+    from superset.result_set import SupersetResultSet
+
+    data = [(NaT,), (Timestamp("2023-01-06 20:50:31.749000+0000", tz="UTC"),)]
+    cursor_descr: DbapiDescription = [
+        ("date", "timestamp with time zone", None, None, None, None, False)
+    ]
+    results = SupersetResultSet(data, cursor_descr, BaseEngineSpec)
+    df = results.to_pandas_df()
+
+    assert df_to_records(df) == [
+        {"date": None},
+        {"date": '"2023-01-06T20:50:31.749000+00:00"'},
     ]
 
 

--- a/tests/unit_tests/result_set_test.py
+++ b/tests/unit_tests/result_set_test.py
@@ -106,3 +106,37 @@ def test_stringify_with_null_integers():
     )
 
     assert np.array_equal(result_set, expected)
+
+
+def test_stringify_with_null_timestamps():
+    """
+    Test that we can safely handle type errors when a timestamp column has a null value
+    """
+
+    data = [
+        ("foo", "bar", pd.NaT, None),
+        ("foo", "bar", pd.NaT, True),
+        ("foo", "bar", pd.NaT, None),
+    ]
+    numpy_dtype = [
+        ("id", "object"),
+        ("value", "object"),
+        ("num", "object"),
+        ("bool", "object"),
+    ]
+
+    array2 = np.array(data, dtype=numpy_dtype)
+    column_names = ["id", "value", "num", "bool"]
+
+    result_set = np.array([stringify_values(array2[column]) for column in column_names])
+
+    expected = np.array(
+        [
+            array(['"foo"', '"foo"', '"foo"'], dtype=object),
+            array(['"bar"', '"bar"', '"bar"'], dtype=object),
+            array([None, None, None], dtype=object),
+            array([None, "true", None], dtype=object),
+        ]
+    )
+
+    assert np.array_equal(result_set, expected)


### PR DESCRIPTION
### SUMMARY
similar to https://github.com/apache/superset/pull/22321/files, PyArrow will through a ValueError if converting an NaT type to a pa.array. I'm using the same stringify function that we're using for TypeErrors here.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![_DEV__Superset](https://user-images.githubusercontent.com/5186919/211112098-5f02a288-d10d-406e-b011-48c67df78d72.png)


After:
![_DEV__Superset](https://user-images.githubusercontent.com/5186919/211112167-d4957d98-512c-4199-bc25-e9ddc48fa66d.png)



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
