### PR TITLE
chore: using bitly to manage expiring Slack invitation links

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -106,7 +106,7 @@ This statement thanks the following, on which it draws for content and inspirati
 
 # Slack Community Guidelines
 
-If you decide to join the [Community Slack](bit.ly/join-superset-slack), please adhere to the following rules:
+If you decide to join the [Community Slack](http://bit.ly/join-superset-slack), please adhere to the following rules:
 
 **1. Treat everyone in the community with respect.**
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -106,7 +106,7 @@ This statement thanks the following, on which it draws for content and inspirati
 
 # Slack Community Guidelines
 
-If you decide to join the [Community Slack](https://join.slack.com/t/apache-superset/shared_invite/zt-1jp6hjzrq-H0PlFtToyLWuPiJDuRWCNw), please adhere to the following rules:
+If you decide to join the [Community Slack](bit.ly/join-superset-slack), please adhere to the following rules:
 
 **1. Treat everyone in the community with respect.**
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ under the License.
 [![PyPI version](https://badge.fury.io/py/apache-superset.svg)](https://badge.fury.io/py/apache-superset)
 [![Coverage Status](https://codecov.io/github/apache/superset/coverage.svg?branch=master)](https://codecov.io/github/apache/superset)
 [![PyPI](https://img.shields.io/pypi/pyversions/apache-superset.svg?maxAge=2592000)](https://pypi.python.org/pypi/apache-superset)
-[![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](bit.ly/join-superset-slack)
+[![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](http://bit.ly/join-superset-slack)
 [![Documentation](https://img.shields.io/badge/docs-apache.org-blue.svg)](https://superset.apache.org)
 
 <img
@@ -129,7 +129,7 @@ Want to add support for your datastore or data engine? Read more [here](https://
 ## Get Involved
 
 - Ask and answer questions on [StackOverflow](https://stackoverflow.com/questions/tagged/apache-superset) using the **apache-superset** tag
-- [Join our community's Slack](bit.ly/join-superset-slack)
+- [Join our community's Slack](http://bit.ly/join-superset-slack)
   and please read our [Slack Community Guidelines](https://github.com/apache/superset/blob/master/CODE_OF_CONDUCT.md#slack-community-guidelines)
 - [Join our dev@superset.apache.org Mailing list](https://lists.apache.org/list.html?dev@superset.apache.org)
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ under the License.
 [![PyPI version](https://badge.fury.io/py/apache-superset.svg)](https://badge.fury.io/py/apache-superset)
 [![Coverage Status](https://codecov.io/github/apache/superset/coverage.svg?branch=master)](https://codecov.io/github/apache/superset)
 [![PyPI](https://img.shields.io/pypi/pyversions/apache-superset.svg?maxAge=2592000)](https://pypi.python.org/pypi/apache-superset)
-[![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](https://join.slack.com/t/apache-superset/shared_invite/zt-1jp6hjzrq-H0PlFtToyLWuPiJDuRWCNw)
+[![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](bit.ly/join-superset-slack)
 [![Documentation](https://img.shields.io/badge/docs-apache.org-blue.svg)](https://superset.apache.org)
 
 <img
@@ -129,7 +129,7 @@ Want to add support for your datastore or data engine? Read more [here](https://
 ## Get Involved
 
 - Ask and answer questions on [StackOverflow](https://stackoverflow.com/questions/tagged/apache-superset) using the **apache-superset** tag
-- [Join our community's Slack](https://join.slack.com/t/apache-superset/shared_invite/zt-1jp6hjzrq-H0PlFtToyLWuPiJDuRWCNw)
+- [Join our community's Slack](bit.ly/join-superset-slack)
   and please read our [Slack Community Guidelines](https://github.com/apache/superset/blob/master/CODE_OF_CONDUCT.md#slack-community-guidelines)
 - [Join our dev@superset.apache.org Mailing list](https://lists.apache.org/list.html?dev@superset.apache.org)
 

--- a/docs/docs/contributing/contributing-page.mdx
+++ b/docs/docs/contributing/contributing-page.mdx
@@ -12,7 +12,7 @@ The core contributors (or committers) to Superset communicate primarily in the f
 which can be joined by anyone):
 
 - [Mailing list](https://lists.apache.org/list.html?dev@superset.apache.org)
-- [Apache Superset Slack community](bit.ly/join-superset-slack)
+- [Apache Superset Slack community](http://bit.ly/join-superset-slack)
 - [GitHub issues and PR's](https://github.com/apache/superset/issues)
 
 More references:

--- a/docs/docs/contributing/contributing-page.mdx
+++ b/docs/docs/contributing/contributing-page.mdx
@@ -12,7 +12,7 @@ The core contributors (or committers) to Superset communicate primarily in the f
 which can be joined by anyone):
 
 - [Mailing list](https://lists.apache.org/list.html?dev@superset.apache.org)
-- [Apache Superset Slack community](https://join.slack.com/t/apache-superset/shared_invite/zt-1jp6hjzrq-H0PlFtToyLWuPiJDuRWCNw)
+- [Apache Superset Slack community](bit.ly/join-superset-slack)
 - [GitHub issues and PR's](https://github.com/apache/superset/issues)
 
 More references:

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -211,7 +211,7 @@ const config = {
               },
               {
                 label: 'Slack',
-                href: 'bit.ly/join-superset-slack',
+                href: 'http://bit.ly/join-superset-slack',
               },
               {
                 label: 'Mailing List',

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -211,7 +211,7 @@ const config = {
               },
               {
                 label: 'Slack',
-                href: 'https://join.slack.com/t/apache-superset/shared_invite/zt-1jp6hjzrq-H0PlFtToyLWuPiJDuRWCNw',
+                href: 'bit.ly/join-superset-slack',
               },
               {
                 label: 'Mailing List',

--- a/docs/src/pages/community.tsx
+++ b/docs/src/pages/community.tsx
@@ -23,7 +23,7 @@ import Layout from '@theme/Layout';
 
 const links = [
   [
-    'bit.ly/join-superset-slack',
+    'http://bit.ly/join-superset-slack',
     'Slack',
     'interact with other Superset users and community members',
   ],

--- a/docs/src/pages/community.tsx
+++ b/docs/src/pages/community.tsx
@@ -23,7 +23,7 @@ import Layout from '@theme/Layout';
 
 const links = [
   [
-    'https://join.slack.com/t/apache-superset/shared_invite/zt-1jp6hjzrq-H0PlFtToyLWuPiJDuRWCNw',
+    'bit.ly/join-superset-slack',
     'Slack',
     'interact with other Superset users and community members',
   ],

--- a/superset/config.py
+++ b/superset/config.py
@@ -374,7 +374,7 @@ LANGUAGES = {
 }
 # Turning off i18n by default as translation in most languages are
 # incomplete and not well maintained.
-# LANGUAGES = {}
+LANGUAGES = {}
 
 # ---------------------------------------------------
 # Feature flags

--- a/superset/config.py
+++ b/superset/config.py
@@ -374,7 +374,7 @@ LANGUAGES = {
 }
 # Turning off i18n by default as translation in most languages are
 # incomplete and not well maintained.
-LANGUAGES = {}
+# LANGUAGES = {}
 
 # ---------------------------------------------------
 # Feature flags


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
The Slack invitation links posted all over the codebase, issues/PRs, and throughout the known universe, are always expiring. They either expire due to TTL, or as soon as 400 people join. 

This PR replaces the links in the codebase with a bitly link. 

That bitly link can be updated through a bitly account, which the PMC (and committers?) should have access to. This will be added to the new 1Password account - any PMC members who need access to this, please reach out.

When (not if) the link expires, please update the bitly link accordingly, and all the aliases floating around out there should remain functional. This will be a lot less disruptive and hopefully lead to more people joining!

<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Try this! bit.ly/join-superset-slack
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: Fixes https://github.com/apache/superset/issues/22672
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
