### PR TITLE
chore: upgrade use-immer

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -139,7 +139,7 @@
         "shortid": "^2.2.6",
         "tinycolor2": "^1.4.2",
         "urijs": "^1.19.8",
-        "use-immer": "^0.6.0",
+        "use-immer": "^0.8.1",
         "use-query-params": "^1.1.9",
         "yargs": "^15.4.1"
       },
@@ -51980,12 +51980,12 @@
       }
     },
     "node_modules/use-immer": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/use-immer/-/use-immer-0.6.0.tgz",
-      "integrity": "sha512-dFGRfvWCqPDTOt/S431ETYTg6+uxbpb7A1pptufwXVzGJY3RlXr38+3wyLNpc6SbbmAKjWl6+EP6uW74fkEsXQ==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/use-immer/-/use-immer-0.8.1.tgz",
+      "integrity": "sha512-OfTFf1pL+ICjjcLPn9+ZnaJO/Yg4MBzYZtACEe2mZ/W2A5col28PNUnwowOAaBuOogACOK/37TU17KgsIhUpOw==",
       "peerDependencies": {
         "immer": ">=2.0.0",
-        "react": "^16.8.0 || ^17.0.1"
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0"
       }
     },
     "node_modules/use-isomorphic-layout-effect": {
@@ -98027,9 +98027,9 @@
       }
     },
     "use-immer": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/use-immer/-/use-immer-0.6.0.tgz",
-      "integrity": "sha512-dFGRfvWCqPDTOt/S431ETYTg6+uxbpb7A1pptufwXVzGJY3RlXr38+3wyLNpc6SbbmAKjWl6+EP6uW74fkEsXQ==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/use-immer/-/use-immer-0.8.1.tgz",
+      "integrity": "sha512-OfTFf1pL+ICjjcLPn9+ZnaJO/Yg4MBzYZtACEe2mZ/W2A5col28PNUnwowOAaBuOogACOK/37TU17KgsIhUpOw==",
       "requires": {}
     },
     "use-isomorphic-layout-effect": {

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -203,7 +203,7 @@
     "shortid": "^2.2.6",
     "tinycolor2": "^1.4.2",
     "urijs": "^1.19.8",
-    "use-immer": "^0.6.0",
+    "use-immer": "^0.8.1",
     "use-query-params": "^1.1.9",
     "yargs": "^15.4.1"
   },


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- upgrade use-immer to the latest for react 18 upgrade

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
