### PR TITLE
chore: Migrate SqlLab API to API v1

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -347,9 +347,8 @@ export function runQuery(query) {
 
     const search = window.location.search || '';
     return SupersetClient.post({
-      endpoint: `/superset/sql_json/${search}`,
-      body: JSON.stringify(postPayload),
-      headers: { 'Content-Type': 'application/json' },
+      endpoint: `/api/v1/sqllab/execute/sql/${search}`,
+      jsonPayload: postPayload,
       parseMethod: 'json-bigint',
     })
       .then(({ json }) => {

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -148,6 +148,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         from superset.reports.api import ReportScheduleRestApi
         from superset.reports.logs.api import ReportExecutionLogRestApi
         from superset.security.api import SecurityRestApi
+        from superset.sqllab.api import SqlLabRestApi
         from superset.views.access_requests import AccessRequestsModelView
         from superset.views.alerts import AlertView, ReportView
         from superset.views.annotations import AnnotationLayerView
@@ -180,6 +181,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
             SavedQueryView,
             SavedQueryViewApi,
             SqlLab,
+            SqlLabView,
             TableSchemaView,
             TabStateView,
         )
@@ -216,6 +218,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         appbuilder.add_api(ReportScheduleRestApi)
         appbuilder.add_api(ReportExecutionLogRestApi)
         appbuilder.add_api(SavedQueryRestApi)
+        appbuilder.add_api(SqlLabRestApi)
         #
         # Setup regular views
         #
@@ -310,6 +313,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         appbuilder.add_view_no_menu(SavedQueryViewApi)
         appbuilder.add_view_no_menu(SliceAsync)
         appbuilder.add_view_no_menu(SqlLab)
+        appbuilder.add_view_no_menu(SqlLabView)
         appbuilder.add_view_no_menu(SqlMetricInlineView)
         appbuilder.add_view_no_menu(Superset)
         appbuilder.add_view_no_menu(TableColumnInlineView)

--- a/superset/sqllab/api.py
+++ b/superset/sqllab/api.py
@@ -68,7 +68,7 @@ class SqlLabRestApi(BaseApi):
     )
     def get(self) -> Response:
         """Assembles SqlLab related information (defaultDbId, tab_state_ids, active_tab)
-         in a single endpoint.
+        in a single endpoint.
         """
         payload = {
             "defaultDbId": conf["SQLLAB_DEFAULT_DBID"],
@@ -116,9 +116,7 @@ def _create_sql_json_command(
     query_dao = QueryDAO()
     sql_json_executor = _create_sql_json_executor(execution_context, query_dao)
     execution_context_convertor = ExecutionContextConvertor()
-    execution_context_convertor.set_max_row_in_display(
-        int(conf.get("DISPLAY_MAX_ROW"))
-    )
+    execution_context_convertor.set_max_row_in_display(int(conf.get("DISPLAY_MAX_ROW")))
     return ExecuteSqlCommand(
         execution_context,
         query_dao,

--- a/superset/sqllab/api.py
+++ b/superset/sqllab/api.py
@@ -1,0 +1,163 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import json
+import logging
+from typing import Any, cast, Dict, Optional
+
+from flask import request, Response
+from flask_appbuilder.api import BaseApi, expose, protect, safe
+
+from superset import conf, event_logger, is_feature_enabled
+from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP, RouteMethod
+from superset.databases.dao import DatabaseDAO
+from superset.jinja_context import get_template_processor
+from superset.queries.dao import QueryDAO
+from superset.sql_lab import get_sql_results
+from superset.sqllab.command import CommandResult, ExecuteSqlCommand
+from superset.sqllab.command_status import SqlJsonExecutionStatus
+from superset.sqllab.exceptions import (
+    QueryIsForbiddenToAccessException,
+    SqlLabException,
+)
+from superset.sqllab.execution_context_convertor import ExecutionContextConvertor
+from superset.sqllab.query_render import SqlQueryRenderImpl
+from superset.sqllab.sql_json_executer import (
+    ASynchronousSqlJsonExecutor,
+    SqlJsonExecutor,
+    SynchronousSqlJsonExecutor,
+)
+from superset.sqllab.sqllab_execution_context import SqlJsonExecutionContext
+from superset.sqllab.tabs import _get_sqllab_tabs
+from superset.sqllab.validators import CanAccessQueryValidatorImpl
+from superset.superset_typing import FlaskResponse
+from superset.utils import core as utils
+from superset.utils.core import get_user_id
+from superset.views.base import json_error_response, json_success
+from superset.views.sql_lab.schemas import SqlJsonPayloadSchema
+
+logger = logging.getLogger(__name__)
+
+
+class SqlLabRestApi(BaseApi):
+    method_permission_name = MODEL_API_RW_METHOD_PERMISSION_MAP
+    allow_browser_login = True
+    class_permission_name = "SqlLab"
+    resource_name = "sqllab"
+    openapi_spec_tag = "SqlLab"
+
+    @expose("/", methods=["GET"])
+    @protect()
+    @safe
+    @event_logger.log_this_with_context(
+        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.get",
+        log_to_statsd=True,
+    )
+    def get(self) -> Response:
+        """Assembles SqlLab related information (defaultDbId, tab_state_ids, active_tab)
+         in a single endpoint.
+        """
+        payload = {
+            "defaultDbId": conf["SQLLAB_DEFAULT_DBID"],
+            **_get_sqllab_tabs(get_user_id()),
+        }
+
+        bootstrap_data = json.dumps(
+            payload, default=utils.pessimistic_json_iso_dttm_ser
+        )
+        return json_success(bootstrap_data, 200)
+
+    @expose("/execute/sql/", methods=["POST"])
+    @protect()
+    @safe
+    @event_logger.log_this_with_context(
+        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.execute",
+        log_to_statsd=False,
+    )
+    def execute_sql(self) -> Response:
+        """
+        Execute the SQL query and return dataframe.
+        """
+        errors = SqlJsonPayloadSchema().validate(request.json)
+        if errors:
+            return json_error_response(status=400, payload=errors)
+
+        try:
+            log_params = {
+                "user_agent": cast(Optional[str], request.headers.get("USER_AGENT"))
+            }
+            execution_context = SqlJsonExecutionContext(request.json)
+            command = _create_sql_json_command(execution_context, log_params)
+            command_result: CommandResult = command.run()
+            return _create_response_from_execution_context(command_result)
+        except SqlLabException as ex:
+            logger.error(ex.message)
+            _set_http_status_into_sql_lab_exception(ex)
+            payload = {"errors": [ex.to_dict()]}
+            return json_error_response(status=ex.status, payload=payload)
+
+
+def _create_sql_json_command(
+    execution_context: SqlJsonExecutionContext, log_params: Optional[Dict[str, Any]]
+) -> ExecuteSqlCommand:
+    query_dao = QueryDAO()
+    sql_json_executor = _create_sql_json_executor(execution_context, query_dao)
+    execution_context_convertor = ExecutionContextConvertor()
+    execution_context_convertor.set_max_row_in_display(
+        int(conf.get("DISPLAY_MAX_ROW"))
+    )
+    return ExecuteSqlCommand(
+        execution_context,
+        query_dao,
+        DatabaseDAO(),
+        CanAccessQueryValidatorImpl(),
+        SqlQueryRenderImpl(get_template_processor),
+        sql_json_executor,
+        execution_context_convertor,
+        conf.get("SQLLAB_CTAS_NO_LIMIT"),
+        log_params,
+    )
+
+
+def _create_sql_json_executor(
+    execution_context: SqlJsonExecutionContext, query_dao: QueryDAO
+) -> SqlJsonExecutor:
+    sql_json_executor: SqlJsonExecutor
+    if execution_context.is_run_asynchronous():
+        sql_json_executor = ASynchronousSqlJsonExecutor(query_dao, get_sql_results)
+    else:
+        sql_json_executor = SynchronousSqlJsonExecutor(
+            query_dao,
+            get_sql_results,
+            conf.get("SQLLAB_TIMEOUT"),
+            is_feature_enabled("SQLLAB_BACKEND_PERSISTENCE"),
+        )
+    return sql_json_executor
+
+
+def _set_http_status_into_sql_lab_exception(ex: SqlLabException) -> None:
+    if isinstance(ex, QueryIsForbiddenToAccessException):
+        ex.status = 403
+
+
+def _create_response_from_execution_context(
+    command_result: CommandResult,
+) -> FlaskResponse:
+
+    status_code = 200
+    if command_result["status"] == SqlJsonExecutionStatus.QUERY_IS_RUNNING:
+        status_code = 202
+    return json_success(command_result["payload"], status_code)

--- a/superset/sqllab/tabs.py
+++ b/superset/sqllab/tabs.py
@@ -1,0 +1,63 @@
+from typing import Any, Dict, Optional
+
+from superset import db, is_feature_enabled
+from superset.databases.dao import DatabaseDAO
+from superset.models.sql_lab import Query, TabState
+
+DATABASE_KEYS = [
+    "allow_file_upload",
+    "allow_ctas",
+    "allow_cvas",
+    "allow_dml",
+    "allow_run_async",
+    "allows_subquery",
+    "backend",
+    "database_name",
+    "expose_in_sqllab",
+    "force_ctas_schema",
+    "id",
+    "disable_data_preview",
+]
+
+
+def _get_sqllab_tabs(user_id: Optional[int]) -> Dict[str, Any]:
+    # send list of tab state ids
+    tabs_state = (
+        db.session.query(TabState.id, TabState.label).filter_by(user_id=user_id).all()
+    )
+    tab_state_ids = [str(tab_state[0]) for tab_state in tabs_state]
+    # return first active tab, or fallback to another one if no tab is active
+    active_tab = (
+        db.session.query(TabState)
+        .filter_by(user_id=user_id)
+        .order_by(TabState.active.desc())
+        .first()
+    )
+
+    databases: Dict[int, Any] = {}
+    for database in DatabaseDAO.find_all():
+        databases[database.id] = {
+            k: v for k, v in database.to_json().items() if k in DATABASE_KEYS
+        }
+        databases[database.id]["backend"] = database.backend
+    queries: Dict[str, Any] = {}
+
+    # These are unnecessary if sqllab backend persistence is disabled
+    if is_feature_enabled("SQLLAB_BACKEND_PERSISTENCE"):
+        # return all user queries associated with existing SQL editors
+        user_queries = (
+            db.session.query(Query)
+            .filter_by(user_id=user_id)
+            .filter(Query.sql_editor_id.in_(tab_state_ids))
+            .all()
+        )
+        queries = {
+            query.client_id: dict(query.to_dict().items()) for query in user_queries
+        }
+
+    return {
+        "tab_state_ids": tabs_state,
+        "active_tab": active_tab.to_dict() if active_tab else None,
+        "databases": databases,
+        "queries": queries,
+    }

--- a/superset/sqllab/tabs.py
+++ b/superset/sqllab/tabs.py
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 from typing import Any, Dict, Optional
 
 from superset import db, is_feature_enabled

--- a/superset/views/sql_lab/views.py
+++ b/superset/views/sql_lab/views.py
@@ -18,13 +18,13 @@ import logging
 
 import simplejson as json
 from flask import g, redirect, request, Response
-from flask_appbuilder import expose
+from flask_appbuilder import expose, permission_name
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder.security.decorators import has_access, has_access_api
 from flask_babel import lazy_gettext as _
 from sqlalchemy import and_
 
-from superset import db
+from superset import db, event_logger
 from superset.constants import MODEL_VIEW_RW_METHOD_PERMISSION_MAP, RouteMethod
 from superset.models.sql_lab import Query, SavedQuery, TableSchema, TabState
 from superset.superset_typing import FlaskResponse
@@ -38,6 +38,18 @@ from superset.views.base import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class SqlLabView(BaseSupersetView):
+    route_base = "/sqllab"
+    class_permission_name = "SqlLab"
+
+    @expose("/")
+    @has_access
+    @permission_name("read")
+    @event_logger.log_this
+    def root(self) -> FlaskResponse:
+        return super().render_app_template()
 
 
 class SavedQueryView(  # pylint: disable=too-many-ancestors

--- a/tests/integration_tests/core_tests.py
+++ b/tests/integration_tests/core_tests.py
@@ -28,6 +28,7 @@ from urllib.parse import quote
 
 import superset.utils.database
 from superset.utils.core import backend
+from superset.sqllab.tabs import _get_sqllab_tabs
 from tests.integration_tests.fixtures.birth_names_dashboard import (
     load_birth_names_dashboard_with_slices,
     load_birth_names_data,
@@ -1472,7 +1473,7 @@ class TestCore(SupersetTestCase):
 
         # we should have only 1 query returned, since the second one is not
         # associated with any tabs
-        payload = views.Superset._get_sqllab_tabs(user_id=user_id)
+        payload = _get_sqllab_tabs(user_id=user_id)
         self.assertEqual(len(payload["queries"]), 1)
 
     @mock.patch.dict(


### PR DESCRIPTION
### SUMMARY
Created `api/v1/sqllab/`API for future SPA migration of SQL Lab
Migrated `superset/sql_json/` to `/api/v1/sqllab/execute/sql/`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
