### PR TITLE
fix(dockerfile): fix "unhealthy" container state

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ RUN mkdir -p ${PYTHONPATH} \
         && apt-get update -y \
         && apt-get install -y --no-install-recommends \
             build-essential \
+            curl \
             default-libmysqlclient-dev \
             libsasl2-dev \
             libsasl2-modules-gssapi-mit \


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`curl` should be installed in dockerfile for healthcheck to run successfully.  

### BEFORE
By running `docker inspect` one could get these logs:
```
"Id": "bc38b7d06cd8dbd77e6f21e3b1f37ef4a92decb8a1011c7e87b72bfa2bd33142",
"Created": "2023-01-10T08:58:57.630882874Z",
"Path": "/bin/sh",
"Args": [
    "-c",
    "/app/docker/docker-ci.sh"
],
"State": {
    "Status": "running",
    "Running": true,
    "Paused": false,
    "Restarting": false,
    "OOMKilled": false,
    "Dead": false,
    "Pid": 266447,
    "ExitCode": 0,
    "Error": "",
    "StartedAt": "2023-01-10T08:58:58.043622806Z",
    "FinishedAt": "0001-01-01T00:00:00Z",
    "Health": {
        "Status": "unhealthy",
        "FailingStreak": 380,
        "Log": [
            {
                "Start": "2023-01-10T15:07:33.895631604+03:00",
                "End": "2023-01-10T15:07:33.993237455+03:00",
                "ExitCode": 127,
                "Output": "/bin/sh: 1: curl: not found\n"
            },
```

BEFORE/AFTER: ![image](https://user-images.githubusercontent.com/53895552/211548845-d69606c8-fb67-4e07-9758-27f8a5427ef6.png)


### TESTING INSTRUCTIONS
Run `docker build`, run container and check its status.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: fixes #12895
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
