### PR TITLE
fix: remove whitespace from http_path for databricks

### DIFF
--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -162,6 +162,7 @@ class DatabricksNativeEngineSpec(DatabricksODBCEngineSpec, BasicParametersMixin)
     def get_extra_params(database: "Database") -> Dict[str, Any]:
         """
         Add a user agent to be used in the requests.
+        Trim whitespace from connect_args to avoid databricks driver errors
         """
         extra: Dict[str, Any] = BaseEngineSpec.get_extra_params(database)
         engine_params: Dict[str, Any] = extra.setdefault("engine_params", {})
@@ -169,6 +170,10 @@ class DatabricksNativeEngineSpec(DatabricksODBCEngineSpec, BasicParametersMixin)
 
         connect_args.setdefault("http_headers", [("User-Agent", USER_AGENT)])
         connect_args.setdefault("_user_agent_entry", USER_AGENT)
+
+        # trim whitespace from http_path to avoid databricks errors on connecting
+        if http_path := connect_args.get("http_path"):
+            connect_args["http_path"] = http_path.strip()
 
         return extra
 

--- a/tests/unit_tests/db_engine_specs/test_databricks.py
+++ b/tests/unit_tests/db_engine_specs/test_databricks.py
@@ -175,3 +175,25 @@ def test_get_extra_params(mocker: MockerFixture) -> None:
             }
         }
     }
+
+    # it should also remove whitespace from http_path
+    database.extra = json.dumps(
+        {
+            "engine_params": {
+                "connect_args": {
+                    "http_headers": [("User-Agent", "Custom user agent")],
+                    "_user_agent_entry": "Custom user agent",
+                    "http_path": "/some_path_here_with_whitespace ",
+                }
+            }
+        }
+    )
+    assert DatabricksNativeEngineSpec.get_extra_params(database) == {
+        "engine_params": {
+            "connect_args": {
+                "http_headers": [["User-Agent", "Custom user agent"]],
+                "_user_agent_entry": "Custom user agent",
+                "http_path": "/some_path_here_with_whitespace",
+            }
+        }
+    }


### PR DESCRIPTION
### SUMMARY
The databricks connector driver will error if there's a space in the http_path. Fixing this at the db engine spec level to catch at the lowest level. The ui for the database connection modal already strips on the client side, so adding an extra layer here for api handling.


### TESTING INSTRUCTIONS
Curl the api with a trailing string in the http_path field for either validate/edit/or db connection. The connection should work regardless of any leading/trailing whitespace. 


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
