### PR TITLE
fix(localization): localize legacy pivot table

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -51,7 +51,7 @@ import polyline
 import simplejson as json
 from dateutil import relativedelta as rdelta
 from flask import request
-from flask_babel import lazy_gettext as _
+from flask_babel import gettext as __, lazy_gettext as _
 from geopy.point import Point
 from pandas.tseries.frequencies import to_offset
 
@@ -1004,6 +1004,7 @@ class PivotTableViz(BaseViz):
             values=metrics,
             aggfunc=aggfuncs,
             margins=self.form_data.get("pivot_margins"),
+            margins_name=__("Total"),
         )
 
         # Re-order the columns adhering to the metric ordering.


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently in the legacy "Pivot table" visualization word "All" is not localized as it comes from `pandas.DataFrame.pivot_table`. Since some people still use this visualization, I suggest localizing it.

### BEFORE
<!--- Skip this if not applicable -->
![image](https://user-images.githubusercontent.com/53895552/211749974-cd672c4d-f1f5-47ca-9244-16aff1f465f8.png)

### AFTER
![image](https://user-images.githubusercontent.com/53895552/211750064-e4dc51d8-2ae4-468e-a1a6-265062276112.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
