### PR TITLE
fix(explore): Restore missing dataset states

### DIFF
--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
@@ -18,10 +18,11 @@
  */
 
 import React from 'react';
-import { render, screen, act, waitFor } from 'spec/helpers/testing-library';
+import fetchMock from 'fetch-mock';
 import userEvent from '@testing-library/user-event';
 import { DatasourceType, JsonObject, SupersetClient } from '@superset-ui/core';
-import fetchMock from 'fetch-mock';
+import { render, screen, act, waitFor } from 'spec/helpers/testing-library';
+import { fallbackExploreInitialData } from 'src/explore/fixtures';
 import DatasourceControl from '.';
 
 const SupersetClientGet = jest.spyOn(SupersetClient, 'get');
@@ -394,4 +395,29 @@ test('should not set the temporal column', async () => {
       null,
     );
   });
+});
+
+test('should show missing params state', () => {
+  const props = createProps({ datasource: fallbackExploreInitialData.dataset });
+  render(<DatasourceControl {...props} />, { useRedux: true });
+  expect(screen.getByText(/missing dataset/i)).toBeVisible();
+  expect(screen.getByText(/missing url parameters/i)).toBeVisible();
+  expect(
+    screen.getByText(
+      /the url is missing the dataset_id or slice_id parameters\./i,
+    ),
+  ).toBeVisible();
+});
+
+test('should show missing dataset state', () => {
+  delete window.location;
+  window.location = { search: '?slice_id=152' };
+  const props = createProps({ datasource: fallbackExploreInitialData.dataset });
+  render(<DatasourceControl {...props} />, { useRedux: true });
+  expect(screen.getAllByText(/missing dataset/i)).toHaveLength(2);
+  expect(
+    screen.getByText(
+      /the dataset linked to this chart may have been deleted\./i,
+    ),
+  ).toBeVisible();
 });

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
@@ -410,7 +410,9 @@ test('should show missing params state', () => {
 });
 
 test('should show missing dataset state', () => {
+  // @ts-ignore
   delete window.location;
+  // @ts-ignore
   window.location = { search: '?slice_id=152' };
   const props = createProps({ datasource: fallbackExploreInitialData.dataset });
   render(<DatasourceControl {...props} />, { useRedux: true });

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -267,7 +267,7 @@ class DatasourceControl extends React.PureComponent {
       showSaveDatasetModal,
     } = this.state;
     const { datasource, onChange, theme } = this.props;
-    const isMissingDatasource = datasource?.id == null;
+    const isMissingDatasource = !datasource || datasource.id === 0;
     let isMissingParams = false;
     if (isMissingDatasource) {
       const datasourceId = getUrlParam(URL_PARAMS.datasourceId);
@@ -288,7 +288,7 @@ class DatasourceControl extends React.PureComponent {
 
     const defaultDatasourceMenu = (
       <Menu onClick={this.handleMenuItemClick}>
-        {this.props.isEditable && (
+        {this.props.isEditable && !isMissingDatasource && (
           <Menu.Item
             key={EDIT_DATASET}
             data-test="edit-dataset"
@@ -308,7 +308,7 @@ class DatasourceControl extends React.PureComponent {
           </Menu.Item>
         )}
         <Menu.Item key={CHANGE_DATASET}>{t('Swap dataset')}</Menu.Item>
-        {datasource && canAccessSqlLab && (
+        {!isMissingDatasource && canAccessSqlLab && (
           <Menu.Item key={VIEW_IN_SQL_LAB}>{t('View in SQL Lab')}</Menu.Item>
         )}
       </Menu>

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -267,7 +267,7 @@ class DatasourceControl extends React.PureComponent {
       showSaveDatasetModal,
     } = this.state;
     const { datasource, onChange, theme } = this.props;
-    const isMissingDatasource = !!datasource?.id;
+    const isMissingDatasource = !datasource?.id;
     let isMissingParams = false;
     if (isMissingDatasource) {
       const datasourceId = getUrlParam(URL_PARAMS.datasourceId);

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -272,6 +272,13 @@ class DatasourceControl extends React.PureComponent {
     if (isMissingDatasource) {
       const datasourceId = getUrlParam(URL_PARAMS.datasourceId);
       const sliceId = getUrlParam(URL_PARAMS.sliceId);
+      console.log(
+        'HELLO',
+        datasourceId,
+        sliceId,
+        window.location.search,
+        'hello',
+      );
       if (!datasourceId && !sliceId) {
         isMissingParams = true;
       }
@@ -358,7 +365,10 @@ class DatasourceControl extends React.PureComponent {
       }
     }
 
-    const titleText = getDatasourceTitle(datasource);
+    const titleText = isMissingDatasource
+      ? t('Missing dataset')
+      : getDatasourceTitle(datasource);
+
     const tooltip = titleText;
 
     return (

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -272,13 +272,7 @@ class DatasourceControl extends React.PureComponent {
     if (isMissingDatasource) {
       const datasourceId = getUrlParam(URL_PARAMS.datasourceId);
       const sliceId = getUrlParam(URL_PARAMS.sliceId);
-      console.log(
-        'HELLO',
-        datasourceId,
-        sliceId,
-        window.location.search,
-        'hello',
-      );
+
       if (!datasourceId && !sliceId) {
         isMissingParams = true;
       }

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -267,7 +267,7 @@ class DatasourceControl extends React.PureComponent {
       showSaveDatasetModal,
     } = this.state;
     const { datasource, onChange, theme } = this.props;
-    const isMissingDatasource = !datasource || datasource.id === 0;
+    const isMissingDatasource = !!datasource?.id;
     let isMissingParams = false;
     if (isMissingDatasource) {
       const datasourceId = getUrlParam(URL_PARAMS.datasourceId);


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes Explore's dataset control so it correctly displays the intended UI when the chart's dataset doesn't exist or Explore has been opened without a specified chart or dataset.

Prior to moving Explore into the SPA, `DatasourceControl` (the dataset picker in the upper left) would check for a dataset ID of `null` to determine if the current chart's dataset existed.  As part of moving Explore into the SPA, the initial Explore state in Redux was set to [this object](https://github.com/apache/superset/blob/539936522fbbda46ebb39b65ed298f6e251a548f/superset-frontend/src/explore/fixtures.tsx#L146), which has the dataset ID set to `0`.  When a user opens Explore for a chart whose dataset does not exist, or when Explore is opened without a specified chart (this happens for new charts) and also without a dataset specified (this should only happen by accident), the initial Explore state's dataset object is not overwritten.  Because `DatasourceControl` is checking for an ID of `null`, it doesn't correctly identify these cases as empty dataset situations, and shows options that should only be present in situations when there is a dataset and don't work correctly when no dataset is present.

This PR:
- Makes Explore check for a dataset ID of 0, so the empty dataset alerts that were already present in code appear again
- Hides the "Edit Dataset" and "View in SQL Lab" menu items, which don't work without a dataset
- Makes the "missing dataset" text translated and a little more human-readable
- Adds tests

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Chart with missing dataset, before:
![localhost_9000_explore__slice_id=152 (1)](https://user-images.githubusercontent.com/13007381/211907567-22027b54-112e-421a-b0a3-7dc161ee67a8.png)

Chart with missing dataset, after:
![localhost_9000_explore__slice_id=152 (2)](https://user-images.githubusercontent.com/13007381/211907653-c9ac7e27-218c-4430-b670-01a2cd3a9329.png)

No chart with no dataset specified (e.g. from visiting `/explore` with no query string), before:
![localhost_9000_explore_](https://user-images.githubusercontent.com/13007381/211907582-54084b82-c8c3-47a4-ae79-f93e7c6feb80.png)

No chart with no dataset specified, after:
![localhost_9000_explore_ (1)](https://user-images.githubusercontent.com/13007381/211907630-0ae991bb-6992-4f7c-b3c0-4953c9b3159e.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Create and save a chart based on a dataset, then delete that dataset.  Open that chart again and confirm that the correct message (dataset was deleted) appears under `DatasourceControl` and that the only menu option in the `DatasourceControl` three-dots menu is "Swap dataset".
- Check that swapping the dataset via button or via menu item makes the message disappear and allows for chart editing/saving.
- Visit `/explore` and confirm that the correct message (missing URL params) appears under `DatasourceControl` and that the only menu option in the `DatasourceControl` three-dots menu is "Swap dataset".
- Check that swapping the dataset via menu item makes the message disappear and allows for chart editing/saving.
- Check that creating charts from the Add Chart page works the same as before.
- Check that editing existing charts with existing datasets works the same as before.
- Check that creating charts from a SQL Lab query works the same, before and after saving the dataset.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
