### PR TITLE
chore(superset-ui): bump superset-ui-chart-controls and plugin-chart-handlebars back to version 0.18.25

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -55595,7 +55595,7 @@
     },
     "packages/superset-ui-chart-controls": {
       "name": "@superset-ui/chart-controls",
-      "version": "0.18.26",
+      "version": "0.18.25",
       "license": "Apache-2.0",
       "dependencies": {
         "@react-icons/all-files": "^4.1.0",
@@ -56531,7 +56531,7 @@
     },
     "packages/superset-ui-switchboard": {
       "name": "@superset-ui/switchboard",
-      "version": "0.18.26-0",
+      "version": "0.18.26-1",
       "license": "Apache-2.0"
     },
     "plugins/legacy-plugin-chart-calendar": {
@@ -57069,7 +57069,7 @@
     },
     "plugins/plugin-chart-handlebars": {
       "name": "@superset-ui/plugin-chart-handlebars",
-      "version": "0.18.26",
+      "version": "0.18.25",
       "license": "Apache-2.0",
       "dependencies": {
         "handlebars": "^4.7.7",

--- a/superset-frontend/packages/superset-ui-chart-controls/package.json
+++ b/superset-frontend/packages/superset-ui-chart-controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/chart-controls",
-  "version": "0.18.26",
+  "version": "0.18.25",
   "description": "Superset UI control-utils",
   "keywords": [
     "superset"

--- a/superset-frontend/plugins/plugin-chart-handlebars/package.json
+++ b/superset-frontend/plugins/plugin-chart-handlebars/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/plugin-chart-handlebars",
-  "version": "0.18.26",
+  "version": "0.18.25",
   "description": "Superset Chart - Write a handlebars template to render the data",
   "sideEffects": false,
   "main": "lib/index.js",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Unblock the release workflow on CI, bump superset-ui-chart-controls and plugin-chart-handlebars back to version 0.18.25 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
