### PR TITLE
fix(sqllab): Invalid schema fetch for deprecated value

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -128,10 +128,22 @@ export function getUpToDateQuery(rootState, queryEditor, key) {
     sqlLab: { unsavedQueryEditor },
   } = rootState;
   const id = key ?? queryEditor.id;
-  return {
+  const updatedQueryEditor = {
     ...queryEditor,
     ...(id === unsavedQueryEditor.id && unsavedQueryEditor),
   };
+
+  if (
+    'schema' in updatedQueryEditor &&
+    !updatedQueryEditor.schemaOptions?.find(
+      ({ value }) => value === updatedQueryEditor.schema,
+    )
+  ) {
+    // remove the deprecated schema option
+    delete updatedQueryEditor.schema;
+  }
+
+  return updatedQueryEditor;
 }
 
 export function resetState() {

--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.js
@@ -316,6 +316,54 @@ describe('async actions', () => {
     });
   });
 
+  describe('getUpToDateQuery', () => {
+    const id = 'randomidvalue2';
+    const unsavedQueryEditor = {
+      id,
+      sql: 'some query here',
+      schemaOptions: [{ value: 'testSchema' }, { value: 'schema2' }],
+    };
+
+    it('returns payload with the updated queryEditor', () => {
+      const queryEditor = {
+        id,
+        name: 'Dummy query editor',
+        schema: 'testSchema',
+      };
+      const state = {
+        sqlLab: {
+          tabHistory: [id],
+          queryEditors: [queryEditor],
+          unsavedQueryEditor,
+        },
+      };
+      expect(actions.getUpToDateQuery(state, queryEditor)).toEqual({
+        ...queryEditor,
+        ...unsavedQueryEditor,
+      });
+    });
+
+    it('ignores the deprecated schema option', () => {
+      const queryEditor = {
+        id,
+        name: 'Dummy query editor',
+        schema: 'oldSchema',
+      };
+      const state = {
+        sqlLab: {
+          tabHistory: [id],
+          queryEditors: [queryEditor],
+          unsavedQueryEditor,
+        },
+      };
+      expect(actions.getUpToDateQuery(state, queryEditor)).toEqual({
+        ...queryEditor,
+        ...unsavedQueryEditor,
+        schema: undefined,
+      });
+    });
+  });
+
   describe('postStopQuery', () => {
     const stopQueryEndpoint = 'glob:*/superset/stop_query/*';
     fetchMock.post(stopQueryEndpoint, {});

--- a/superset-frontend/src/SqlLab/components/ShareSqlLabQuery/ShareSqlLabQuery.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ShareSqlLabQuery/ShareSqlLabQuery.test.tsx
@@ -43,6 +43,7 @@ const mockQueryEditor = {
   autorun: false,
   sql: 'SELECT * FROM ...',
   remoteId: 999,
+  schemaOptions: [{ value: 'query_schema' }, { value: 'query_schema_updated' }],
 };
 const disabled = {
   id: 'disabledEditorId',
@@ -82,6 +83,7 @@ const standardProviderWithUnsaved: React.FC = ({ children }) => (
         ...initialState,
         sqlLab: {
           ...initialState.sqlLab,
+          queryEditors: [mockQueryEditor],
           unsavedQueryEditor,
         },
       })}
@@ -123,7 +125,7 @@ describe('ShareSqlLabQuery', () => {
         });
       });
       const button = screen.getByRole('button');
-      const { id, remoteId, ...expected } = mockQueryEditor;
+      const { id, remoteId, schemaOptions, ...expected } = mockQueryEditor;
       const storeQuerySpy = jest.spyOn(utils, 'storeQuery');
       userEvent.click(button);
       expect(storeQuerySpy.mock.calls).toHaveLength(1);

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/SqlEditorLeftBar.test.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/SqlEditorLeftBar.test.jsx
@@ -41,15 +41,22 @@ const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
 const store = mockStore(initialState);
 
-fetchMock.get('glob:*/api/v1/database/*/schemas/?*', { result: [] });
-fetchMock.get('glob:*/superset/tables/**', {
-  options: [
-    {
-      label: 'ab_user',
-      value: 'ab_user',
-    },
-  ],
-  tableLength: 1,
+beforeEach(() => {
+  fetchMock.get('glob:*/api/v1/database/**', { result: [] });
+  fetchMock.get('glob:*/api/v1/database/*/schemas/?*', { result: [] });
+  fetchMock.get('glob:*/superset/tables/**', {
+    options: [
+      {
+        label: 'ab_user',
+        value: 'ab_user',
+      },
+    ],
+    tableLength: 1,
+  });
+});
+
+afterEach(() => {
+  fetchMock.restore();
 });
 
 const renderAndWait = (props, store) =>
@@ -110,8 +117,9 @@ test('should toggle the table when the header is clicked', async () => {
   userEvent.click(header);
 
   await waitFor(() => {
-    expect(store.getActions()).toHaveLength(4);
-    expect(store.getActions()[3].type).toEqual('COLLAPSE_TABLE');
+    expect(store.getActions()[store.getActions().length - 1].type).toEqual(
+      'COLLAPSE_TABLE',
+    );
   });
 });
 
@@ -129,14 +137,77 @@ test('When changing database the table list must be updated', async () => {
         database_name: 'new_db',
         backend: 'postgresql',
       }}
-      queryEditor={{ ...mockedProps.queryEditor, schema: 'new_schema' }}
+      queryEditorId={defaultQueryEditor.id}
       tables={[{ ...mockedProps.tables[0], dbId: 2, name: 'new_table' }]}
     />,
     {
       useRedux: true,
-      initialState,
+      store: mockStore({
+        ...initialState,
+        sqlLab: {
+          ...initialState.sqlLab,
+          unsavedQueryEditor: {
+            id: defaultQueryEditor.id,
+            schema: 'new_schema',
+          },
+        },
+      }),
     },
   );
   expect(await screen.findByText(/new_db/i)).toBeInTheDocument();
   expect(await screen.findByText(/new_table/i)).toBeInTheDocument();
+});
+
+test('ignore schema api when current schema is deprecated', async () => {
+  const invalidSchemaName = 'None';
+  await renderAndWait(
+    mockedProps,
+    mockStore({
+      ...initialState,
+      sqlLab: {
+        ...initialState.sqlLab,
+        unsavedQueryEditor: {
+          id: defaultQueryEditor.id,
+          schema: invalidSchemaName,
+        },
+      },
+    }),
+  );
+
+  expect(await screen.findByText(/Database/i)).toBeInTheDocument();
+  expect(screen.queryByText(/None/i)).not.toBeInTheDocument();
+  expect(fetchMock.calls()).not.toContainEqual(
+    expect.arrayContaining([
+      expect.stringContaining(
+        `/tables/${mockedProps.database.id}/${invalidSchemaName}/`,
+      ),
+    ]),
+  );
+});
+
+test('fetches schema api when current schema is among the list', async () => {
+  const validSchema = 'schema1';
+  await renderAndWait(
+    mockedProps,
+    mockStore({
+      ...initialState,
+      sqlLab: {
+        ...initialState.sqlLab,
+        unsavedQueryEditor: {
+          id: defaultQueryEditor.id,
+          schema: validSchema,
+          schemaOptions: [{ name: validSchema, value: validSchema }],
+        },
+      },
+    }),
+  );
+
+  expect(await screen.findByText(/schema1/i)).toBeInTheDocument();
+  expect(fetchMock.calls()).toContainEqual(
+    expect.arrayContaining([
+      expect.stringContaining(
+        `/tables/${mockedProps.database.id}/${validSchema}/`,
+      ),
+    ]),
+  );
 });

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
@@ -103,22 +103,12 @@ const SqlEditorLeftBar = ({
   setEmptyState,
 }: SqlEditorLeftBarProps) => {
   const dispatch = useDispatch();
-  const queryEditor = useQueryEditor(queryEditorId, [
-    'dbId',
-    'schema',
-    'schemaOptions',
-  ]);
+  const queryEditor = useQueryEditor(queryEditorId, ['dbId', 'schema']);
   const [emptyResultsWithSearch, setEmptyResultsWithSearch] = useState(false);
   const [userSelectedDb, setUserSelected] = useState<DatabaseObject | null>(
     null,
   );
-  const schemaOptionsMap = useMemo(
-    () => new Set(queryEditor.schemaOptions?.map(({ value }) => value)),
-    [queryEditor.schemaOptions],
-  );
-  const schema = schemaOptionsMap.has(queryEditor.schema)
-    ? queryEditor.schema
-    : undefined;
+  const { schema } = queryEditor;
 
   useEffect(() => {
     const bool = querystring.parse(window.location.search).db;

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
@@ -103,13 +103,22 @@ const SqlEditorLeftBar = ({
   setEmptyState,
 }: SqlEditorLeftBarProps) => {
   const dispatch = useDispatch();
-  const queryEditor = useQueryEditor(queryEditorId, ['dbId', 'schema']);
-
+  const queryEditor = useQueryEditor(queryEditorId, [
+    'dbId',
+    'schema',
+    'schemaOptions',
+  ]);
   const [emptyResultsWithSearch, setEmptyResultsWithSearch] = useState(false);
   const [userSelectedDb, setUserSelected] = useState<DatabaseObject | null>(
     null,
   );
-  const { schema } = queryEditor;
+  const schemaOptionsMap = useMemo(
+    () => new Set(queryEditor.schemaOptions?.map(({ value }) => value)),
+    [queryEditor.schemaOptions],
+  );
+  const schema = schemaOptionsMap.has(queryEditor.schema)
+    ? queryEditor.schema
+    : undefined;
 
   useEffect(() => {
     const bool = querystring.parse(window.location.search).db;

--- a/superset-frontend/src/SqlLab/hooks/useQueryEditor/index.ts
+++ b/superset-frontend/src/SqlLab/hooks/useQueryEditor/index.ts
@@ -25,7 +25,10 @@ export default function useQueryEditor<T extends keyof QueryEditor>(
   sqlEditorId: string,
   attributes: ReadonlyArray<T>,
 ) {
-  const queryEditor = useSelector<SqlLabRootState, Pick<QueryEditor, T | 'id'>>(
+  const queryEditor = useSelector<
+    SqlLabRootState,
+    Pick<QueryEditor, T | 'id' | 'schema'>
+  >(
     ({ sqlLab: { unsavedQueryEditor, queryEditors } }) =>
       pick(
         {
@@ -33,7 +36,7 @@ export default function useQueryEditor<T extends keyof QueryEditor>(
           ...(sqlEditorId === unsavedQueryEditor.id && unsavedQueryEditor),
         },
         ['id'].concat(attributes),
-      ) as Pick<QueryEditor, T | 'id'>,
+      ) as Pick<QueryEditor, T | 'id' | 'schema'>,
     shallowEqual,
   );
   const { schema, schemaOptions } = useSelector<
@@ -56,9 +59,9 @@ export default function useQueryEditor<T extends keyof QueryEditor>(
     [schemaOptions],
   );
 
-  if ('schema' in queryEditor && !schemaOptionsMap.has(schema)) {
+  if ('schema' in queryEditor && schema && !schemaOptionsMap.has(schema)) {
     delete queryEditor.schema;
   }
 
-  return queryEditor;
+  return queryEditor as Pick<QueryEditor, T | 'id'>;
 }

--- a/superset-frontend/src/SqlLab/hooks/useQueryEditor/useQueryEditor.test.ts
+++ b/superset-frontend/src/SqlLab/hooks/useQueryEditor/useQueryEditor.test.ts
@@ -70,7 +70,7 @@ test('includes id implicitly', () => {
 test('returns updated values from unsaved change', () => {
   const expectedSql = 'SELECT updated_column\nFROM updated_table\nWHERE';
   const { result } = renderHook(
-    () => useQueryEditor(defaultQueryEditor.id, ['id', 'sql']),
+    () => useQueryEditor(defaultQueryEditor.id, ['id', 'sql', 'schema']),
     {
       wrapper: createWrapper({
         useRedux: true,
@@ -88,5 +88,31 @@ test('returns updated values from unsaved change', () => {
     },
   );
   expect(result.current.id).toEqual(defaultQueryEditor.id);
+  expect(result.current.schema).toEqual(defaultQueryEditor.schema);
   expect(result.current.sql).toEqual(expectedSql);
+});
+
+test('skips the deprecated schema option', () => {
+  const expectedSql = 'SELECT updated_column\nFROM updated_table\nWHERE';
+  const { result } = renderHook(
+    () => useQueryEditor(defaultQueryEditor.id, ['schema']),
+    {
+      wrapper: createWrapper({
+        useRedux: true,
+        store: mockStore({
+          ...initialState,
+          sqlLab: {
+            ...initialState.sqlLab,
+            unsavedQueryEditor: {
+              id: defaultQueryEditor.id,
+              sql: expectedSql,
+              schema: 'deprecated schema',
+            },
+          },
+        }),
+      }),
+    },
+  );
+  expect(result.current.schema).not.toEqual(defaultQueryEditor.schema);
+  expect(result.current.schema).toBeUndefined();
 });

--- a/superset-frontend/src/SqlLab/types.ts
+++ b/superset-frontend/src/SqlLab/types.ts
@@ -35,7 +35,7 @@ export interface QueryEditor {
   id: string;
   dbId?: number;
   name: string;
-  schema: string;
+  schema?: string;
   autorun: boolean;
   sql: string;
   remoteId: number | null;


### PR DESCRIPTION
### SUMMARY
When a selected schema option in a old saved tab has been deprecated, it would fail to query since the selected schema is no longer existed. 
This commit adds the validation logic for the current selected schema option and then discard the schema option if no longer existed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

After:

<img width="398" alt="Screenshot_2023-01-11_at_3_14_23_PM" src="https://user-images.githubusercontent.com/1392866/211938466-223b5473-be41-4de1-89e4-6cc19021afc1.png">

No error thrown

Before:

<img width="415" alt="Screenshot_2023-01-09_at_3_55_57_PM" src="https://user-images.githubusercontent.com/1392866/211938201-af50da2a-3a5b-4fec-b479-e15e98eb2060.png">

<img width="900" alt="Superset-2" src="https://user-images.githubusercontent.com/1392866/211938150-e2d3d9a7-1566-4787-ab9e-cde8a645de16.png">


<img width="746" alt="superset-goalie_-_Airbnb_-_Slack" src="https://user-images.githubusercontent.com/1392866/211938400-bfb1560a-272e-4ea5-b450-261e7ab42b00.png">


### TESTING INSTRUCTIONS

- Select a schema from the list and then close
- delete the above selected schema
- reopen the sqllab and check the error

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
