### PR TITLE
chore: chart deletion test for slice user

### DIFF
--- a/superset/charts/commands/delete.py
+++ b/superset/charts/commands/delete.py
@@ -31,8 +31,9 @@ from superset.charts.dao import ChartDAO
 from superset.commands.base import BaseCommand
 from superset.dao.exceptions import DAODeleteFailedError
 from superset.exceptions import SupersetSecurityException
+from superset.extensions import db
 from superset.models.dashboard import Dashboard
-from superset.models.slice import Slice
+from superset.models.slice import Slice, slice_user
 from superset.reports.dao import ReportScheduleDAO
 
 logger = logging.getLogger(__name__)
@@ -47,6 +48,9 @@ class DeleteChartCommand(BaseCommand):
         self.validate()
         try:
             Dashboard.clear_cache_for_slice(slice_id=self._model_id)
+            db.session.execute(
+                slice_user.delete().where(slice_user.c.slice_id == self._model_id)
+            )
             chart = ChartDAO.delete(self._model)
         except DAODeleteFailedError as ex:
             logger.exception(ex.exception)

--- a/superset/charts/commands/delete.py
+++ b/superset/charts/commands/delete.py
@@ -48,9 +48,6 @@ class DeleteChartCommand(BaseCommand):
         self.validate()
         try:
             Dashboard.clear_cache_for_slice(slice_id=self._model_id)
-            db.session.execute(
-                slice_user.delete().where(slice_user.c.slice_id == self._model_id)
-            )
             chart = ChartDAO.delete(self._model)
         except DAODeleteFailedError as ex:
             logger.exception(ex.exception)

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -36,7 +36,7 @@ from sqlalchemy import (
     Text,
 )
 from sqlalchemy.engine.base import Connection
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import backref, relationship
 from sqlalchemy.orm.mapper import Mapper
 
 from superset import db, is_feature_enabled, security_manager
@@ -59,8 +59,8 @@ slice_user = Table(
     "slice_user",
     metadata,
     Column("id", Integer, primary_key=True),
-    Column("user_id", Integer, ForeignKey("ab_user.id")),
-    Column("slice_id", Integer, ForeignKey("slices.id")),
+    Column("user_id", Integer, ForeignKey("ab_user.id", ondelete="CASCADE")),
+    Column("slice_id", Integer, ForeignKey("slices.id", ondelete="CASCADE")),
 )
 logger = logging.getLogger(__name__)
 
@@ -96,7 +96,12 @@ class Slice(  # pylint: disable=too-many-public-methods
     last_saved_by = relationship(
         security_manager.user_model, foreign_keys=[last_saved_by_fk]
     )
-    owners = relationship(security_manager.user_model, secondary=slice_user)
+    owners = relationship(
+        security_manager.user_model,
+        secondary=slice_user,
+        cascade="all, delete",
+        passive_deletes=True,
+    )
     table = relationship(
         "SqlaTable",
         foreign_keys=[datasource_id],

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -229,7 +229,7 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         self.assertEqual(rv.status_code, 200)
         model = db.session.query(Slice).get(chart_id)
         slice_user_model = db.session.execute(
-            slice_user.select().where(slice_user.user_id == admin_id)
+            slice_user.select().where(slice_user.c.slice_id == chart_id)
         )
         self.assertEqual(model, None)
         self.assertEqual(slice_user_model, None)

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -32,7 +32,7 @@ from superset.extensions import cache_manager, db
 from superset.models.core import Database, FavStar, FavStarClassName
 from superset.models.dashboard import Dashboard
 from superset.reports.models import ReportSchedule, ReportScheduleType
-from superset.models.slice import Slice
+from superset.models.slice import Slice, slice_user
 from superset.utils.core import get_example_default_schema
 
 from tests.integration_tests.base_api_tests import ApiOwnersTestCaseMixin
@@ -228,7 +228,11 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         rv = self.delete_assert_metric(uri, "delete")
         self.assertEqual(rv.status_code, 200)
         model = db.session.query(Slice).get(chart_id)
+        slice_user_model = db.session.execute(
+            slice_user.select().where(slice_user.user_id == admin_id)
+        )
         self.assertEqual(model, None)
+        self.assertEqual(slice_user_model, None)
 
     def test_delete_bulk_charts(self):
         """

--- a/tests/unit_tests/charts/dao/dao_tests.py
+++ b/tests/unit_tests/charts/dao/dao_tests.py
@@ -18,9 +18,12 @@
 from typing import Iterator
 
 import pytest
+from flask_appbuilder.security.sqla.models import User
 from sqlalchemy.orm.session import Session
 
 from superset.utils.core import DatasourceType
+
+SAMPLE_USERS = [1, 2, 3, 4]
 
 
 @pytest.fixture
@@ -40,6 +43,41 @@ def session_with_data(session: Session) -> Iterator[Session]:
 
     session.add(slice_obj)
     session.commit()
+    yield session
+    session.rollback()
+
+
+@pytest.fixture
+def session_with_data_and_owners(session: Session) -> Iterator[Session]:
+    from superset.models.slice import Slice
+
+    obj_owners = list()
+    engine = session.get_bind()
+    Slice.metadata.create_all(engine)
+
+    for user in SAMPLE_USERS:
+        test_user = User(
+            id=user,
+            username=str(user),
+            first_name=str(user),
+            last_name=str(user),
+            email=str(user),
+        )
+        session.add(test_user)
+        obj_owners.append(test_user)
+
+    slice_obj = Slice(
+        id=1,
+        datasource_id=1,
+        datasource_type=DatasourceType.TABLE,
+        datasource_name="test_table",
+        slice_name="sliced_name",
+        owners=obj_owners,
+    )
+
+    session.add(slice_obj)
+    session.commit()
+    session.flush()
     yield session
     session.rollback()
 
@@ -65,3 +103,28 @@ def test_datasource_find_by_id_skip_base_filter_not_found(
         125326326, session=session_with_data, skip_base_filter=True
     )
     assert result is None
+
+
+def test_delete_slice_check_slice_user(session_with_data_and_owners: Session) -> None:
+    from superset.charts.dao import ChartDAO
+    from superset.models.slice import slice_user
+
+    result = ChartDAO.find_by_id(
+        1, session=session_with_data_and_owners, skip_base_filter=True
+    )
+    assert result
+    slice_user_model = session_with_data_and_owners.execute(
+        slice_user.select().where(slice_user.c.user_id == SAMPLE_USERS[0])
+    )
+    assert slice_user_model is not None
+    ChartDAO.delete(result)
+    session_with_data_and_owners.flush()
+    # requery the session to check to make sure everything is deleted properly
+    result_after_delete = ChartDAO.find_by_id(
+        1, session=session_with_data_and_owners, skip_base_filter=True
+    )
+    slice_user_model_delete = session_with_data_and_owners.execute(
+        slice_user.select().where(slice_user.c.slice_id == 1)
+    )
+    assert result_after_delete is None
+    assert slice_user_model_delete is None


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Some users were experiencing an foreign key error when trying to delete a chart or a dashboard for slice_user and sqlatable_user. Just adding some test to makes sure those possibilities are taken into account. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
