### PR TITLE
feat: Generic X-axis improvements

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterConfigurePane.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterConfigurePane.tsx
@@ -46,7 +46,7 @@ const ContentHolder = styled.div`
 `;
 
 const TitlesContainer = styled.div`
-  width: 270px;
+  min-width: 270px;
   border-right: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
 `;
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -258,6 +258,19 @@ const StyledAsterisk = styled.span`
   }
 `;
 
+const TimeRangeInfo = styled.div`
+  ${({ theme }) => `
+    width: 49%;
+    font-size: ${theme.typography.sizes.s}px;
+    color: ${theme.colors.grayscale.light1};
+    margin:
+      ${-theme.gridUnit * 2}px
+      0px
+      ${theme.gridUnit * 4}px
+      ${theme.gridUnit * 4}px;
+  `}
+`;
+
 const FilterTabs = {
   configuration: {
     key: 'configuration',
@@ -795,6 +808,13 @@ const FiltersConfigForm = (
             />
           </StyledFormItem>
         </StyledContainer>
+        {filterToEdit?.filterType === 'filter_time' && (
+          <TimeRangeInfo>
+            {t(`Dashboard time range filters apply to temporal columns defined in
+          the filter section of each chart. Add temporal columns to the chart
+          filters to have this dashboard filter impact those charts.`)}
+          </TimeRangeInfo>
+        )}
         {hasDataset && (
           <StyledRowContainer>
             {showDataset ? (

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -258,7 +258,7 @@ const StyledAsterisk = styled.span`
   }
 `;
 
-const TimeRangeInfo = styled.div`
+const FilterTypeInfo = styled.div`
   ${({ theme }) => `
     width: 49%;
     font-size: ${theme.typography.sizes.s}px;
@@ -809,11 +809,11 @@ const FiltersConfigForm = (
           </StyledFormItem>
         </StyledContainer>
         {formFilter?.filterType === 'filter_time' && (
-          <TimeRangeInfo>
+          <FilterTypeInfo>
             {t(`Dashboard time range filters apply to temporal columns defined in
           the filter section of each chart. Add temporal columns to the chart
           filters to have this dashboard filter impact those charts.`)}
-          </TimeRangeInfo>
+          </FilterTypeInfo>
         )}
         {hasDataset && (
           <StyledRowContainer>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -808,7 +808,7 @@ const FiltersConfigForm = (
             />
           </StyledFormItem>
         </StyledContainer>
-        {filterToEdit?.filterType === 'filter_time' && (
+        {formFilter?.filterType === 'filter_time' && (
           <TimeRangeInfo>
             {t(`Dashboard time range filters apply to temporal columns defined in
           the filter section of each chart. Add temporal columns to the chart

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -487,12 +487,10 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
           valueToBeDeleted: Record<string, any>,
           values: Record<string, any>[],
         ) => {
-          const isTemporalRange =
-            valueToBeDeleted.operator === Operators.TEMPORAL_RANGE;
-          if (isTemporalRange) {
-            const count = values.filter(
-              value => value.operator === Operators.TEMPORAL_RANGE,
-            ).length;
+          const isTemporalRange = (filter: Record<string, any>) =>
+            filter.operator === Operators.TEMPORAL_RANGE;
+          if (isTemporalRange(valueToBeDeleted)) {
+            const count = values.filter(isTemporalRange).length;
             if (count < 2) {
               return true;
             }
@@ -504,7 +502,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
         ),
         confirmationText: t(
           `This filter is the last temporal filter. If you proceed,
-          your charts won't be affected by time range filters in dashboards.`,
+          this chart won't be affected by time range filters in dashboards.`,
         ),
       };
     }

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -38,6 +38,7 @@ import {
   useTheme,
   isDefined,
   JsonValue,
+  NO_TIME_RANGE,
 } from '@superset-ui/core';
 import {
   ControlPanelSectionConfig,
@@ -55,6 +56,7 @@ import Collapse from 'src/components/Collapse';
 import Tabs from 'src/components/Tabs';
 import { PluginContext } from 'src/components/DynamicPlugins';
 import Loading from 'src/components/Loading';
+import Modal from 'src/components/Modal';
 
 import { usePrevious } from 'src/hooks/usePrevious';
 import { getSectionsToRender } from 'src/explore/controlUtils';
@@ -67,6 +69,8 @@ import Control from './Control';
 import { ExploreAlert } from './ExploreAlert';
 import { RunQueryButton } from './RunQueryButton';
 import { Operators } from '../constants';
+
+const { confirm } = Modal;
 
 export type ControlPanelsContainerProps = {
   exploreState: ExplorePageState['explore'];
@@ -278,6 +282,55 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
     string[] | undefined
   >(state => state.explore.controlsTransferred);
 
+  const defaultTimeFilter = useSelector<ExplorePageState>(
+    state => state.common?.conf?.DEFAULT_TIME_FILTER,
+  );
+
+  const { form_data, actions } = props;
+  const { setControlValue } = actions;
+  const { x_axis, adhoc_filters } = form_data;
+
+  const previousXAxis = usePrevious(x_axis);
+
+  useEffect(() => {
+    if (x_axis && x_axis !== previousXAxis) {
+      const noFilter =
+        !adhoc_filters ||
+        !adhoc_filters.find(
+          filter =>
+            filter.expressionType === 'SIMPLE' &&
+            filter.operator === 'TEMPORAL_RANGE' &&
+            filter.subject === x_axis,
+        );
+      if (noFilter) {
+        confirm({
+          title: t('The X-axis is not on the filters list'),
+          content:
+            t(`The X-axis is not on the filters list which will prevent it from being used in
+            time range filters in dashboards. Would you like to add it to the filters list?`),
+          onOk: () => {
+            setControlValue('adhoc_filters', [
+              ...(adhoc_filters || []),
+              {
+                clause: 'WHERE',
+                subject: x_axis,
+                operator: 'TEMPORAL_RANGE',
+                comparator: defaultTimeFilter || NO_TIME_RANGE,
+                expressionType: 'SIMPLE',
+              },
+            ]);
+          },
+        });
+      }
+    }
+  }, [
+    x_axis,
+    adhoc_filters,
+    setControlValue,
+    defaultTimeFilter,
+    previousXAxis,
+  ]);
+
   useEffect(() => {
     let shouldUpdateControls = false;
     const removeDatasourceWarningFromControl = (
@@ -347,15 +400,11 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
   } = useMemo(
     () =>
       getState(
-        props.form_data.viz_type,
+        form_data.viz_type,
         props.exploreState.datasource,
         props.datasource_type,
       ),
-    [
-      props.exploreState.datasource,
-      props.form_data.viz_type,
-      props.datasource_type,
-    ],
+    [props.exploreState.datasource, form_data.viz_type, props.datasource_type],
   );
 
   const resetTransferredControls = useCallback(() => {
@@ -476,7 +525,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
 
   const sectionHasHadNoErrors = useResetOnChangeRef(
     () => ({}),
-    props.form_data.viz_type,
+    form_data.viz_type,
   );
 
   const renderControlPanelSection = (
@@ -644,7 +693,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
 
   const dataTabHasHadNoErrors = useResetOnChangeRef(
     () => false,
-    props.form_data.viz_type,
+    form_data.viz_type,
   );
 
   const dataTabTitle = useMemo(() => {
@@ -690,10 +739,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
   ]);
 
   const controlPanelRegistry = getChartControlPanelRegistry();
-  if (
-    !controlPanelRegistry.has(props.form_data.viz_type) &&
-    pluginContext.loading
-  ) {
+  if (!controlPanelRegistry.has(form_data.viz_type) && pluginContext.loading) {
     return <Loading />;
   }
 

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -66,6 +66,7 @@ import ControlRow from './ControlRow';
 import Control from './Control';
 import { ExploreAlert } from './ExploreAlert';
 import { RunQueryButton } from './RunQueryButton';
+import { Operators } from '../constants';
 
 export type ControlPanelsContainerProps = {
   exploreState: ExplorePageState['explore'];
@@ -430,6 +431,34 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
       typeof baseDescription === 'function'
         ? baseDescription(exploreState, controls[name], chart)
         : baseDescription;
+
+    if (name === 'adhoc_filters') {
+      restProps.confirmDeletion = {
+        triggerCondition: (
+          valueToBeDeleted: Record<string, any>,
+          values: Record<string, any>[],
+        ) => {
+          const isTemporalRange =
+            valueToBeDeleted.operator === Operators.TEMPORAL_RANGE;
+          if (isTemporalRange) {
+            const count = values.filter(
+              value => value.operator === Operators.TEMPORAL_RANGE,
+            ).length;
+            if (count < 2) {
+              return true;
+            }
+          }
+          return false;
+        },
+        confirmationTitle: t(
+          'Are you sure you want to remove the last temporal filter?',
+        ),
+        confirmationText: t(
+          `This filter is the last temporal filter. If you proceed,
+          your charts won't be affected by time range filters in dashboards.`,
+        ),
+      };
+    }
 
     return (
       <Control

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl/index.jsx
@@ -42,6 +42,7 @@ import {
   LabelsContainer,
 } from 'src/explore/components/controls/OptionControls';
 import Icons from 'src/components/Icons';
+import Modal from 'src/components/Modal';
 import AdhocFilterPopoverTrigger from 'src/explore/components/controls/FilterControl/AdhocFilterPopoverTrigger';
 import AdhocFilterOption from 'src/explore/components/controls/FilterControl/AdhocFilterOption';
 import AdhocFilter, {
@@ -50,6 +51,8 @@ import AdhocFilter, {
 } from 'src/explore/components/controls/FilterControl/AdhocFilter';
 import adhocFilterType from 'src/explore/components/controls/FilterControl/adhocFilterType';
 import columnType from 'src/explore/components/controls/FilterControl/columnType';
+
+const { confirm } = Modal;
 
 const selectedMetricType = PropTypes.oneOfType([
   PropTypes.string,
@@ -71,6 +74,11 @@ const propTypes = {
     PropTypes.arrayOf(selectedMetricType),
   ]),
   isLoading: PropTypes.bool,
+  confirmDeletion: PropTypes.shape({
+    triggerCondition: PropTypes.func,
+    confirmationTitle: PropTypes.string,
+    confirmationText: PropTypes.string,
+  }),
 };
 
 const defaultProps = {
@@ -96,6 +104,7 @@ class AdhocFilterControl extends React.Component {
     this.onChange = this.onChange.bind(this);
     this.mapOption = this.mapOption.bind(this);
     this.getMetricExpression = this.getMetricExpression.bind(this);
+    this.removeFilter = this.removeFilter.bind(this);
 
     const filters = (this.props.value || []).map(filter =>
       isDictionaryForAdhocFilter(filter) ? new AdhocFilter(filter) : filter,
@@ -173,7 +182,7 @@ class AdhocFilterControl extends React.Component {
     }
   }
 
-  onRemoveFilter(index) {
+  removeFilter(index) {
     const valuesCopy = [...this.state.values];
     valuesCopy.splice(index, 1);
     this.setState(prevState => ({
@@ -181,6 +190,26 @@ class AdhocFilterControl extends React.Component {
       values: valuesCopy,
     }));
     this.props.onChange(valuesCopy);
+  }
+
+  onRemoveFilter(index) {
+    const { confirmDeletion } = this.props;
+    const { values } = this.state;
+    if (confirmDeletion) {
+      const { confirmationText, confirmationTitle, triggerCondition } =
+        confirmDeletion;
+      if (triggerCondition(values[index], values)) {
+        confirm({
+          title: confirmationTitle,
+          content: confirmationText,
+          onOk() {
+            this.removeFilter(index);
+          },
+        });
+        return;
+      }
+    }
+    this.removeFilter(index);
   }
 
   onNewFilter(newFilter) {

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.jsx
@@ -52,6 +52,7 @@ const propTypes = {
   theme: PropTypes.object,
   sections: PropTypes.arrayOf(PropTypes.string),
   operators: PropTypes.arrayOf(PropTypes.string),
+  requireSave: PropTypes.bool,
 };
 
 const ResizeIcon = styled.i`
@@ -181,12 +182,14 @@ export default class AdhocFilterEditPopover extends React.Component {
       partitionColumn,
       theme,
       operators,
+      requireSave,
       ...popoverProps
     } = this.props;
 
     const { adhocFilter } = this.state;
     const stateIsValid = adhocFilter.isValid();
-    const hasUnsavedChanges = !adhocFilter.equals(propsAdhocFilter);
+    const hasUnsavedChanges =
+      requireSave || !adhocFilter.equals(propsAdhocFilter);
 
     return (
       <FilterPopoverContentContainer

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterPopoverTrigger/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterPopoverTrigger/index.tsx
@@ -36,6 +36,7 @@ interface AdhocFilterPopoverTriggerProps {
   visible?: boolean;
   togglePopover?: (visible: boolean) => void;
   closePopover?: () => void;
+  requireSave?: boolean;
 }
 
 interface AdhocFilterPopoverTriggerState {
@@ -96,6 +97,7 @@ class AdhocFilterPopoverTrigger extends React.PureComponent<
           sections={this.props.sections}
           operators={this.props.operators}
           onChange={this.props.onFilterEdit}
+          requireSave={this.props.requireSave}
         />
       </ExplorePopoverContent>
     );

--- a/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
+++ b/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
@@ -308,7 +308,10 @@ export const OptionControlLabel = ({
       <CloseContainer
         role="button"
         data-test="remove-control-button"
-        onClick={onRemove}
+        onClick={e => {
+          e.stopPropagation();
+          onRemove();
+        }}
       >
         <Icons.XSmall iconColor={theme.colors.grayscale.light1} />
       </CloseContainer>


### PR DESCRIPTION
### SUMMARY
- Asks for confirmation when deleting the last temporal filter
- When changing a temporal X-axis and the value is not on the filters list, presents an option to add it
- Adds an information message to Time Range native filter explaining the relationship with temporal columns
- Enables the save button when adding a new Time Range with No Filter value

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/212560229-4b89b48e-4723-401c-882b-bbb2de5d4a72.mov

### TESTING INSTRUCTIONS
- Check that a modal requiring confirmation is presented when deleting the last temporal filter
- Check that Time Range native filters present a message describing it relationship with temporal columns

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
