### PR TITLE
fix: Spacing in alert modal

### DIFF
--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -171,6 +171,10 @@ const StyledSectionContainer = styled.div`
   display: flex;
   flex-direction: column;
 
+  .control-label {
+    margin-top: ${({ theme }) => theme.gridUnit}px;
+  }
+
   .header-section {
     display: flex;
     flex: 0 0 auto;
@@ -339,6 +343,7 @@ const StyledRadioGroup = styled(Radio.Group)`
 
 const StyledCheckbox = styled(AntdCheckbox)`
   margin-left: ${({ theme }) => theme.gridUnit * 5.5}px;
+  margin-top: ${({ theme }) => theme.gridUnit}px;
 `;
 
 // Notification Method components
@@ -353,6 +358,12 @@ const StyledNotificationAddButton = styled.div`
   &.disabled {
     color: ${({ theme }) => theme.colors.grayscale.light1};
     cursor: default;
+  }
+`;
+
+const StyledNotificationMethodWrapper = styled.div`
+  .input-container {
+    margin-left: 0 !important;
   }
 `;
 
@@ -1445,18 +1456,20 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
               <span className="required">*</span>
             </StyledSectionTitle>
             {notificationSettings.map((notificationSetting, i) => (
-              <NotificationMethod
-                setting={notificationSetting}
-                index={i}
-                key={`NotificationMethod-${i}`}
-                onUpdate={updateNotificationSetting}
-                onRemove={removeNotificationSetting}
-                css={css`
-                  .input-container {
-                    margin-left: 0;
-                  }
-                `}
-              />
+              <StyledNotificationMethodWrapper>
+                <NotificationMethod
+                  setting={notificationSetting}
+                  index={i}
+                  key={`NotificationMethod-${i}`}
+                  onUpdate={updateNotificationSetting}
+                  onRemove={removeNotificationSetting}
+                  css={css`
+                    .input-container {
+                      margin-left: 0 !important;
+                    }
+                  `}
+                />
+              </StyledNotificationMethodWrapper>
             ))}
             <NotificationMethodAdd
               data-test="notification-add"

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -362,8 +362,8 @@ const StyledNotificationAddButton = styled.div`
 `;
 
 const StyledNotificationMethodWrapper = styled.div`
-  .input-container {
-    margin-left: 0 !important;
+  .inline-container .input-container {
+    margin-left: 0;
   }
 `;
 

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -1463,11 +1463,6 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                   key={`NotificationMethod-${i}`}
                   onUpdate={updateNotificationSetting}
                   onRemove={removeNotificationSetting}
-                  css={css`
-                    .input-container {
-                      margin-left: 0 !important;
-                    }
-                  `}
                 />
               </StyledNotificationMethodWrapper>
             ))}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes the spacing in the alert modal. The control labels and the "Ignore cache when generating a screenshot" checkbox got a 4px top margin and the Notification Method dropdown had its left margin spacing removed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### BEFORE:
![alertModalBefore](https://user-images.githubusercontent.com/55605634/212206545-830b229c-60cf-404d-98e6-e22f90674689.png)

#### AFTER:
![alertModalAfter](https://user-images.githubusercontent.com/55605634/212206561-b7b3e991-a043-4c66-9384-a38c061c5d03.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Go to the Alerts & reports page and click the "+ ALERT" button
- Observe the spacing between elements

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
