### PR TITLE
docs(k8s): add note about authlib requirement to oauth setup example

### DIFF
--- a/docs/docs/installation/running-on-kubernetes.mdx
+++ b/docs/docs/installation/running-on-kubernetes.mdx
@@ -226,6 +226,14 @@ Those will also be mounted as secrets and can include sensitive parameters.
 
 #### Setting up OAuth
 
+:::note
+
+OAuth setup requires that the [authlib](https://authlib.org/) Python library is installed. This can
+be done using `pip` by updating the `bootstrapScript`. See the [Dependencies](#dependencies) section
+for more information.
+
+:::
+
 ```yaml
 extraEnv:
   AUTH_DOMAIN: example.com


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Adds a note to the "Setting up OAuth" configuration example calling out that `authlib` must be installed.

### TESTING INSTRUCTIONS

Read the note. ;)


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
