### PR TITLE
docs(security): clarify CSP requirements and provide example TALISMAN_CONFIG

### DIFF
--- a/docs/docs/security.mdx
+++ b/docs/docs/security.mdx
@@ -153,6 +153,43 @@ of a policy and if it's not able to find one, it will issue a warning with the s
 where CSP policies are defined outside of Superset using other software, administrators can disable
 the warning using the `CONTENT_SECURITY_POLICY_WARNING` key in `config.py`.
 
+#### CSP Requirements
+
+* Superset needs both the `'unsafe-eval'` and `'unsafe-inline'` CSP keywords in order to operate.
+
+  ```
+  default-src 'self' 'unsafe-eval' 'unsafe-inline'
+  ```
+
+* Some dashbaords load images using data URIs and require `data:` in their `img-src`
+
+  ```
+  img-src 'self' data:
+  ```
+
+* MapBox charts use workers and need to connect to MapBox servers in addition to the Superset origin
+
+  ```
+  worker-src 'self' blob:
+  connect-src 'self' https://api.mapbox.com https://events.mapbox.com
+  ```
+
+This is a basic example `TALISMAN_CONFIG` that implements the above requirements, uses `'self'` to
+limit content to the same origin as the Superset server, and disallows outdated HTML elements by
+setting `object-src` to `'none'`.
+
+```python
+TALISMAN_CONFIG = {
+    "content_security_policy": {
+        "default-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
+        "img-src": ["'self'", "data:"],
+        "worker-src": ["'self'", "blob:"],
+        "connect-src": ["'self'", "https://api.mapbox.com", "https://events.mapbox.com"],
+        "object-src": "'none'",
+    }
+}
+```
+
 ### Reporting Security Vulnerabilities
 
 Apache Software Foundation takes a rigorous standpoint in annihilating the security issues in its


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This is an attempt to provide some more clarity around the CSP requirements and to add a basic example `TALISMAN_CONFIG`.

I've been submitting docs updates for issues I hit during an initial deployment of Superset on Kubernetes. Upon deployment, I started seeing CSP warnings from the `CONTENT_SECURITY_POLICY_WARNING` setting in my logs, but the docs did not provide much information about what sort of CSP Superset requires in order to function.

I first tried a basic strict CSP of `default-src: 'self'; object-src: 'none'`. This resulted Superset's UI failing to run with a number of errors related to `unsafe-inline` and `unsafe-eval`. Adding those keywords to the basic policy allowed Superset's UI to operate in our deployment.

* Does this capture all the necessary requirements for Superset's CSP? Are there other considerations that should be highlighted?
* Is there any reason to break out individual CSP sections like `script-src` and `style-src` vs using `default-src` in the example? I'd favor simplicity as a starting point if there's no compelling reason to break them out.

### TESTING INSTRUCTIONS

Read the new docs. 

* Does this seem like a reasonable description of the CSP requirements? 
* Is the example given a reasonable default configuration?

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
