### PR TITLE
docs(k8s): add note about database driver dependencies to k8s setup

### DIFF
--- a/docs/docs/installation/running-on-kubernetes.mdx
+++ b/docs/docs/installation/running-on-kubernetes.mdx
@@ -123,9 +123,20 @@ init:
 
 #### Dependencies
 
-Install additional packages and do any other bootstrap configuration in this script. For production clusters it's
-recommended to build own image with this step done in CI. The following example installs the Big Query and Elasticsearch
-database drivers so that you can connect to those datasources in your Superset installation.
+Install additional packages and do any other bootstrap configuration in the bootstrap script.
+For production clusters it's recommended to build own image with this step done in CI.
+
+:::note
+
+Superset requires a Python DB-API database driver and a SQLAlchemy
+dialect to be installed for each datastore you want to connect to.
+
+See [Install Database Drivers](/docs/databases/installing-database-drivers) for more information
+
+:::
+
+The following example installs the Big Query and Elasticsearch database drivers so that you can
+connect to those datasources in your Superset installation:
 
 ```yaml
 bootstrapScript: |


### PR DESCRIPTION
### SUMMARY

Adds a note to the "Dependencies" section of the Kubernetes installation guide calling out that Python drivers are required for each connected datastore and referencing the relevant documentation page.

### TESTING INSTRUCTIONS

Read the note — does it explain the requirement for DB drivers sufficiently?

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
