### PR TITLE
feat(ssh_tunnel): Rename allow_ssh_tunneling and change the default value to False

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.test.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.test.tsx
@@ -141,7 +141,7 @@ fetchMock.mock(AVAILABLE_DB_ENDPOINT, {
       preferred: true,
       engine_information: {
         supports_file_upload: true,
-        allow_ssh_tunneling: false,
+        allow_ssh_tunneling: true,
       },
     },
     {
@@ -194,7 +194,7 @@ fetchMock.mock(AVAILABLE_DB_ENDPOINT, {
         'mysql://user:password@host:port/dbname[?key=value&key=value...]',
       engine_information: {
         supports_file_upload: true,
-        allow_ssh_tunneling: false,
+        allow_ssh_tunneling: true,
       },
     },
     {
@@ -214,7 +214,7 @@ fetchMock.mock(AVAILABLE_DB_ENDPOINT, {
       preferred: false,
       engine_information: {
         supports_file_upload: true,
-        allow_ssh_tunneling: false,
+        allow_ssh_tunneling: true,
       },
     },
     {

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.test.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.test.tsx
@@ -131,7 +131,7 @@ fetchMock.mock(AVAILABLE_DB_ENDPOINT, {
         'postgresql://user:password@host:port/dbname[?key=value&key=value...]',
       engine_information: {
         supports_file_upload: true,
-        allow_ssh_tunneling: true,
+        disable_ssh_tunneling: false,
       },
     },
     {
@@ -141,7 +141,7 @@ fetchMock.mock(AVAILABLE_DB_ENDPOINT, {
       preferred: true,
       engine_information: {
         supports_file_upload: true,
-        allow_ssh_tunneling: true,
+        disable_ssh_tunneling: false,
       },
     },
     {
@@ -194,7 +194,7 @@ fetchMock.mock(AVAILABLE_DB_ENDPOINT, {
         'mysql://user:password@host:port/dbname[?key=value&key=value...]',
       engine_information: {
         supports_file_upload: true,
-        allow_ssh_tunneling: true,
+        disable_ssh_tunneling: false,
       },
     },
     {
@@ -204,7 +204,7 @@ fetchMock.mock(AVAILABLE_DB_ENDPOINT, {
       preferred: true,
       engine_information: {
         supports_file_upload: true,
-        allow_ssh_tunneling: true,
+        disable_ssh_tunneling: false,
       },
     },
     {
@@ -214,7 +214,7 @@ fetchMock.mock(AVAILABLE_DB_ENDPOINT, {
       preferred: false,
       engine_information: {
         supports_file_upload: true,
-        allow_ssh_tunneling: true,
+        disable_ssh_tunneling: false,
       },
     },
     {
@@ -239,7 +239,7 @@ fetchMock.mock(AVAILABLE_DB_ENDPOINT, {
       sqlalchemy_uri_placeholder: 'bigquery://{project_id}',
       engine_information: {
         supports_file_upload: true,
-        allow_ssh_tunneling: false,
+        disable_ssh_tunneling: true,
       },
     },
     {
@@ -250,7 +250,7 @@ fetchMock.mock(AVAILABLE_DB_ENDPOINT, {
       preferred: false,
       engine_information: {
         supports_file_upload: false,
-        allow_ssh_tunneling: false,
+        disable_ssh_tunneling: true,
       },
     },
     {
@@ -1917,7 +1917,7 @@ describe('dbReducer', () => {
       payload: {
         engine_information: {
           supports_file_upload: true,
-          allow_ssh_tunneling: true,
+          disable_ssh_tunneling: false,
         },
         ...db,
         driver: db.driver,
@@ -1932,7 +1932,7 @@ describe('dbReducer', () => {
       configuration_method: db.configuration_method,
       engine_information: {
         supports_file_upload: true,
-        allow_ssh_tunneling: true,
+        disable_ssh_tunneling: false,
       },
       driver: db.driver,
       expose_in_sqllab: true,

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -543,12 +543,12 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
   const sslForced = isFeatureEnabled(
     FeatureFlag.FORCE_DATABASE_CONNECTIONS_SSL,
   );
-  const engineAllowsSSHTunneling = (
+  const disableSSHTunnelingForEngine = (
     availableDbs?.databases?.find(
       (DB: DatabaseObject) =>
         DB.backend === db?.engine || DB.engine === db?.engine,
     ) as DatabaseObject
-  )?.engine_information?.allow_ssh_tunneling;
+  )?.engine_information?.disable_ssh_tunneling;
   const sshTunneling = isFeatureEnabled(FeatureFlag.SSH_TUNNELING);
   const hasAlert =
     connectionAlert || !!(db?.engine && engineSpecificAlertMapping[db.engine]);
@@ -1493,7 +1493,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
                 testConnection={testConnection}
                 testInProgress={testInProgress}
               >
-                {sshTunneling && engineAllowsSSHTunneling && (
+                {sshTunneling && !disableSSHTunnelingForEngine && (
                   <SSHTunnelForm
                     isEditMode={isEditMode}
                     sshTunneling={sshTunneling}

--- a/superset-frontend/src/views/CRUD/data/database/types.ts
+++ b/superset-frontend/src/views/CRUD/data/database/types.ts
@@ -98,7 +98,7 @@ export type DatabaseObject = {
   // DB Engine Spec information
   engine_information?: {
     supports_file_upload?: boolean;
-    allow_ssh_tunneling?: boolean;
+    disable_ssh_tunneling?: boolean;
   };
 
   // SSH Tunnel information

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -1150,7 +1150,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
                             supports_file_upload:
                               description: Whether the engine supports file uploads
                               type: boolean
-                            allow_ssh_tunneling:
+                            disable_ssh_tunneling:
                               description: Whether the engine supports SSH Tunnels
                               type: boolean
             400:

--- a/superset/db_engine_specs/athena.py
+++ b/superset/db_engine_specs/athena.py
@@ -33,7 +33,7 @@ class AthenaEngineSpec(BaseEngineSpec):
     engine = "awsathena"
     engine_name = "Amazon Athena"
     allows_escaped_colons = False
-    allow_ssh_tunneling = False
+    disable_ssh_tunneling = True
 
     _time_grain_expressions = {
         None: "{col}",

--- a/superset/db_engine_specs/athena.py
+++ b/superset/db_engine_specs/athena.py
@@ -33,6 +33,7 @@ class AthenaEngineSpec(BaseEngineSpec):
     engine = "awsathena"
     engine_name = "Amazon Athena"
     allows_escaped_colons = False
+    allow_ssh_tunneling = False
 
     _time_grain_expressions = {
         None: "{col}",

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -193,7 +193,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     engine_aliases: Set[str] = set()
     drivers: Dict[str, str] = {}
     default_driver: Optional[str] = None
-    allow_ssh_tunneling = False
+    allow_ssh_tunneling = True
 
     _date_trunc_functions: Dict[str, str] = {}
     _time_grain_expressions: Dict[Optional[str], str] = {}

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -193,7 +193,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     engine_aliases: Set[str] = set()
     drivers: Dict[str, str] = {}
     default_driver: Optional[str] = None
-    allow_ssh_tunneling = True
+    disable_ssh_tunneling = False
 
     _date_trunc_functions: Dict[str, str] = {}
     _time_grain_expressions: Dict[Optional[str], str] = {}
@@ -1697,11 +1697,11 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         Construct a Dict with properties we want to expose.
 
         :returns: Dict with properties of our class like supports_file_upload
-        and allow_ssh_tunneling
+        and disable_ssh_tunneling
         """
         return {
             "supports_file_upload": cls.supports_file_upload,
-            "allow_ssh_tunneling": cls.allow_ssh_tunneling,
+            "disable_ssh_tunneling": cls.disable_ssh_tunneling,
         }
 
 

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -93,6 +93,7 @@ class BigQueryEngineSpec(BaseEngineSpec):
     engine = "bigquery"
     engine_name = "Google BigQuery"
     max_column_name_length = 128
+    allow_ssh_tunneling = False
 
     parameters_schema = BigQueryParametersSchema()
     default_driver = "bigquery"

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -93,7 +93,7 @@ class BigQueryEngineSpec(BaseEngineSpec):
     engine = "bigquery"
     engine_name = "Google BigQuery"
     max_column_name_length = 128
-    allow_ssh_tunneling = False
+    disable_ssh_tunneling = True
 
     parameters_schema = BigQueryParametersSchema()
     default_driver = "bigquery"

--- a/superset/db_engine_specs/gsheets.py
+++ b/superset/db_engine_specs/gsheets.py
@@ -69,6 +69,7 @@ class GSheetsEngineSpec(SqliteEngineSpec):
     engine_name = "Google Sheets"
     allows_joins = True
     allows_subqueries = True
+    allow_ssh_tunneling = False
 
     parameters_schema = GSheetsParametersSchema()
     default_driver = "apsw"

--- a/superset/db_engine_specs/gsheets.py
+++ b/superset/db_engine_specs/gsheets.py
@@ -69,7 +69,7 @@ class GSheetsEngineSpec(SqliteEngineSpec):
     engine_name = "Google Sheets"
     allows_joins = True
     allows_subqueries = True
-    allow_ssh_tunneling = False
+    disable_ssh_tunneling = True
 
     parameters_schema = GSheetsParametersSchema()
     default_driver = "apsw"

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -166,7 +166,6 @@ class PostgresBaseEngineSpec(BaseEngineSpec):
 class PostgresEngineSpec(PostgresBaseEngineSpec, BasicParametersMixin):
     engine = "postgresql"
     engine_aliases = {"postgres"}
-    allow_ssh_tunneling = True
 
     default_driver = "psycopg2"
     sqlalchemy_uri_placeholder = (

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -2304,7 +2304,7 @@ class TestDatabaseApi(SupersetTestCase):
                     "sqlalchemy_uri_placeholder": "postgresql://user:password@host:port/dbname[?key=value&key=value...]",
                     "engine_information": {
                         "supports_file_upload": True,
-                        "allow_ssh_tunneling": True,
+                        "disable_ssh_tunneling": False,
                     },
                 },
                 {
@@ -2327,7 +2327,7 @@ class TestDatabaseApi(SupersetTestCase):
                     "sqlalchemy_uri_placeholder": "bigquery://{project_id}",
                     "engine_information": {
                         "supports_file_upload": True,
-                        "allow_ssh_tunneling": False,
+                        "disable_ssh_tunneling": True,
                     },
                 },
                 {
@@ -2379,7 +2379,7 @@ class TestDatabaseApi(SupersetTestCase):
                     "sqlalchemy_uri_placeholder": "redshift+psycopg2://user:password@host:port/dbname[?key=value&key=value...]",
                     "engine_information": {
                         "supports_file_upload": True,
-                        "allow_ssh_tunneling": True,
+                        "disable_ssh_tunneling": False,
                     },
                 },
                 {
@@ -2402,7 +2402,7 @@ class TestDatabaseApi(SupersetTestCase):
                     "sqlalchemy_uri_placeholder": "gsheets://",
                     "engine_information": {
                         "supports_file_upload": False,
-                        "allow_ssh_tunneling": False,
+                        "disable_ssh_tunneling": True,
                     },
                 },
                 {
@@ -2454,7 +2454,7 @@ class TestDatabaseApi(SupersetTestCase):
                     "sqlalchemy_uri_placeholder": "mysql://user:password@host:port/dbname[?key=value&key=value...]",
                     "engine_information": {
                         "supports_file_upload": True,
-                        "allow_ssh_tunneling": True,
+                        "disable_ssh_tunneling": False,
                     },
                 },
                 {
@@ -2464,7 +2464,7 @@ class TestDatabaseApi(SupersetTestCase):
                     "preferred": False,
                     "engine_information": {
                         "supports_file_upload": True,
-                        "allow_ssh_tunneling": True,
+                        "disable_ssh_tunneling": False,
                     },
                 },
             ]
@@ -2495,7 +2495,7 @@ class TestDatabaseApi(SupersetTestCase):
                     "preferred": True,
                     "engine_information": {
                         "supports_file_upload": True,
-                        "allow_ssh_tunneling": True,
+                        "disable_ssh_tunneling": False,
                     },
                 },
                 {
@@ -2505,7 +2505,7 @@ class TestDatabaseApi(SupersetTestCase):
                     "preferred": False,
                     "engine_information": {
                         "supports_file_upload": True,
-                        "allow_ssh_tunneling": True,
+                        "disable_ssh_tunneling": False,
                     },
                 },
             ]

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -2379,7 +2379,7 @@ class TestDatabaseApi(SupersetTestCase):
                     "sqlalchemy_uri_placeholder": "redshift+psycopg2://user:password@host:port/dbname[?key=value&key=value...]",
                     "engine_information": {
                         "supports_file_upload": True,
-                        "allow_ssh_tunneling": False,
+                        "allow_ssh_tunneling": True,
                     },
                 },
                 {
@@ -2454,7 +2454,7 @@ class TestDatabaseApi(SupersetTestCase):
                     "sqlalchemy_uri_placeholder": "mysql://user:password@host:port/dbname[?key=value&key=value...]",
                     "engine_information": {
                         "supports_file_upload": True,
-                        "allow_ssh_tunneling": False,
+                        "allow_ssh_tunneling": True,
                     },
                 },
                 {
@@ -2464,7 +2464,7 @@ class TestDatabaseApi(SupersetTestCase):
                     "preferred": False,
                     "engine_information": {
                         "supports_file_upload": True,
-                        "allow_ssh_tunneling": False,
+                        "allow_ssh_tunneling": True,
                     },
                 },
             ]
@@ -2495,7 +2495,7 @@ class TestDatabaseApi(SupersetTestCase):
                     "preferred": True,
                     "engine_information": {
                         "supports_file_upload": True,
-                        "allow_ssh_tunneling": False,
+                        "allow_ssh_tunneling": True,
                     },
                 },
                 {
@@ -2505,7 +2505,7 @@ class TestDatabaseApi(SupersetTestCase):
                     "preferred": False,
                     "engine_information": {
                         "supports_file_upload": True,
-                        "allow_ssh_tunneling": False,
+                        "allow_ssh_tunneling": True,
                     },
                 },
             ]


### PR DESCRIPTION
### SUMMARY
- Rename the `allow_ssh_tunneling` flag so it's now `disable_ssh_tunneling`, always false except for those DB engines we know it's not supported (Amazon Athena, GSheets and BigQuery so far)
- Update tests

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
