### PR TITLE
chore: Use redis 7 on tests and pin on local dev and non-dev

### DIFF
--- a/.github/workflows/superset-applitool-cypress.yml
+++ b/.github/workflows/superset-applitool-cypress.yml
@@ -32,7 +32,7 @@ jobs:
         ports:
           - 15432:5432
       redis:
-        image: redis:5-alpine
+        image: redis:7-alpine
         ports:
           - 16379:6379
     steps:

--- a/.github/workflows/superset-cli.yml
+++ b/.github/workflows/superset-cli.yml
@@ -30,7 +30,7 @@ jobs:
           # GitHub action runner's default installations
           - 15432:5432
       redis:
-        image: redis:5-alpine
+        image: redis:7-alpine
         ports:
           - 16379:6379
     steps:

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -38,7 +38,7 @@ jobs:
         ports:
           - 15432:5432
       redis:
-        image: redis:5-alpine
+        image: redis:7-alpine
         ports:
           - 16379:6379
     steps:

--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -29,7 +29,7 @@ jobs:
         ports:
           - 13306:3306
       redis:
-        image: redis:5-alpine
+        image: redis:7-alpine
         options: --entrypoint redis-server
         ports:
           - 16379:6379
@@ -97,7 +97,7 @@ jobs:
           # GitHub action runner's default installations
           - 15432:5432
       redis:
-        image: redis:5-alpine
+        image: redis:7-alpine
         ports:
           - 16379:6379
     steps:
@@ -156,7 +156,7 @@ jobs:
         sqlite:///${{ github.workspace }}/.temp/unittest.db
     services:
       redis:
-        image: redis:5-alpine
+        image: redis:7-alpine
         ports:
           - 16379:6379
     steps:

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -41,7 +41,7 @@ jobs:
           # GitHub action runner's default installations
           - 15433:8080
       redis:
-        image: redis:5-alpine
+        image: redis:7-alpine
         ports:
           - 16379:6379
     steps:
@@ -110,7 +110,7 @@ jobs:
           # GitHub action runner's default installations
           - 15432:5432
       redis:
-        image: redis:5-alpine
+        image: redis:7-alpine
         ports:
           - 16379:6379
     steps:

--- a/docker-compose-non-dev.yml
+++ b/docker-compose-non-dev.yml
@@ -26,7 +26,7 @@ x-superset-volumes: &superset-volumes
 version: "3.7"
 services:
   redis:
-    image: redis:latest
+    image: redis:7
     container_name: superset_cache
     restart: unless-stopped
     volumes:
@@ -34,7 +34,7 @@ services:
 
   db:
     env_file: docker/.env-non-dev
-    image: postgres:10
+    image: postgres:14
     container_name: superset_db
     restart: unless-stopped
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ x-superset-volumes: &superset-volumes
 version: "3.7"
 services:
   redis:
-    image: redis:latest
+    image: redis:7
     container_name: superset_cache
     restart: unless-stopped
     ports:


### PR DESCRIPTION
### SUMMARY
Pins Redis to major version 7 on local dev and non-dev environments

Updates current tests to run against Redis version 7, current redis 5 has reached EOL: https://endoflife.date/redis
https://docs.redis.com/latest/rs/installing-upgrading/product-lifecycle/


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
