### PR TITLE
fix(ssh-tunnel): wrap pkey into StringIO buffer before creating the tunnel

### DIFF
--- a/superset/extensions/ssh.py
+++ b/superset/extensions/ssh.py
@@ -16,9 +16,11 @@
 # under the License.
 
 import importlib
+from io import StringIO
 from typing import TYPE_CHECKING
 
 from flask import Flask
+from paramiko import RSAKey
 from sshtunnel import open_tunnel, SSHTunnelForwarder
 
 from superset.databases.utils import make_url_safe
@@ -59,7 +61,9 @@ class SSHManager:
         if ssh_tunnel.password:
             params["ssh_password"] = ssh_tunnel.password
         elif ssh_tunnel.private_key:
-            params["private_key"] = ssh_tunnel.private_key
+            private_key_file = StringIO(ssh_tunnel.private_key)
+            private_key = RSAKey.from_private_key(private_key_file)
+            params["private_key"] = private_key
             params["private_key_password"] = ssh_tunnel.private_key_password
 
         return open_tunnel(**params)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding `StringIO` to wrap value before creating the tunnel to allow the pkg to properly read the private key needed to create the tunnel.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
