### PR TITLE
fix(ssh-tunnel): update fields for open tunnel with private + private key passwords

### DIFF
--- a/superset/extensions/ssh.py
+++ b/superset/extensions/ssh.py
@@ -63,8 +63,8 @@ class SSHManager:
         elif ssh_tunnel.private_key:
             private_key_file = StringIO(ssh_tunnel.private_key)
             private_key = RSAKey.from_private_key(private_key_file)
-            params["private_key"] = private_key
-            params["private_key_password"] = ssh_tunnel.private_key_password
+            params["ssh_pkey"] = private_key
+            params["ssh_private_key_password"] = ssh_tunnel.private_key_password
 
         return open_tunnel(**params)
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
With the new extensions class, we forgot to update the params to match the `ssh_tunnel.open_tunnel` function. 
`private_key` -> `ssh_pkey`
`ssh_private_key` -> `ssh_private_key_password`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
