### PR TITLE
feat(docker): Build multiple python version images

### DIFF
--- a/.github/workflows/docker_build_push.sh
+++ b/.github/workflows/docker_build_push.sh
@@ -50,38 +50,26 @@ docker build --target lean \
   -t "${REPO_NAME}:${SHA}" \
   -t "${REPO_NAME}:${REFSPEC}" \
   -t "${REPO_NAME}:${LATEST_TAG}" \
-  --build-arg PY_VER="3.8.16"\
+  --build-arg PY_VER="3.8"\
   --label "sha=${SHA}" \
   --label "built_at=$(date)" \
   --label "target=lean" \
   --label "build_actor=${GITHUB_ACTOR}" \
   .
 
+#
 # Build the "lean39" image
+#
 docker build --target lean \
   -t "${REPO_NAME}:${SHA}-py39" \
   -t "${REPO_NAME}:${REFSPEC}-py39" \
   -t "${REPO_NAME}:${LATEST_TAG}-py39" \
-  --build-arg PY_VER="3.9.16"\
+  --build-arg PY_VER="3.9"\
   --label "sha=${SHA}" \
   --label "built_at=$(date)" \
   --label "target=lean39" \
   --label "build_actor=${GITHUB_ACTOR}" \
   .
-
-
-# Build the "lean310" image
-docker build --target lean \
-  -t "${REPO_NAME}:${SHA}-py310" \
-  -t "${REPO_NAME}:${REFSPEC}-py310" \
-  -t "${REPO_NAME}:${LATEST_TAG}-py310" \
-  --build-arg PY_VER="3.10.9"\
-  --label "sha=${SHA}" \
-  --label "built_at=$(date)" \
-  --label "target=lean310" \
-  --label "build_actor=${GITHUB_ACTOR}" \
-  .
-
 
 #
 # Build the "websocket" image

--- a/.github/workflows/docker_build_push.sh
+++ b/.github/workflows/docker_build_push.sh
@@ -50,11 +50,38 @@ docker build --target lean \
   -t "${REPO_NAME}:${SHA}" \
   -t "${REPO_NAME}:${REFSPEC}" \
   -t "${REPO_NAME}:${LATEST_TAG}" \
+  --build-arg PY_VER="3.8.16"\
   --label "sha=${SHA}" \
   --label "built_at=$(date)" \
   --label "target=lean" \
   --label "build_actor=${GITHUB_ACTOR}" \
   .
+
+# Build the "lean39" image
+docker build --target lean \
+  -t "${REPO_NAME}:${SHA}-py39" \
+  -t "${REPO_NAME}:${REFSPEC}-py39" \
+  -t "${REPO_NAME}:${LATEST_TAG}-py39" \
+  --build-arg PY_VER="3.9.16"\
+  --label "sha=${SHA}" \
+  --label "built_at=$(date)" \
+  --label "target=lean39" \
+  --label "build_actor=${GITHUB_ACTOR}" \
+  .
+
+
+# Build the "lean310" image
+docker build --target lean \
+  -t "${REPO_NAME}:${SHA}-py310" \
+  -t "${REPO_NAME}:${REFSPEC}-py310" \
+  -t "${REPO_NAME}:${LATEST_TAG}-py310" \
+  --build-arg PY_VER="3.10.9"\
+  --label "sha=${SHA}" \
+  --label "built_at=$(date)" \
+  --label "target=lean310" \
+  --label "build_actor=${GITHUB_ACTOR}" \
+  .
+
 
 #
 # Build the "websocket" image
@@ -65,7 +92,7 @@ docker build \
   -t "${REPO_NAME}:${LATEST_TAG}-websocket" \
   --label "sha=${SHA}" \
   --label "built_at=$(date)" \
-  --label "target=lean" \
+  --label "target=websocket" \
   --label "build_actor=${GITHUB_ACTOR}" \
   superset-websocket
 

--- a/.github/workflows/docker_build_push.sh
+++ b/.github/workflows/docker_build_push.sh
@@ -50,7 +50,7 @@ docker build --target lean \
   -t "${REPO_NAME}:${SHA}" \
   -t "${REPO_NAME}:${REFSPEC}" \
   -t "${REPO_NAME}:${LATEST_TAG}" \
-  --build-arg PY_VER="3.8"\
+  --build-arg PY_VER="3.8-slim"\
   --label "sha=${SHA}" \
   --label "built_at=$(date)" \
   --label "target=lean" \
@@ -64,7 +64,7 @@ docker build --target lean \
   -t "${REPO_NAME}:${SHA}-py39" \
   -t "${REPO_NAME}:${REFSPEC}-py39" \
   -t "${REPO_NAME}:${LATEST_TAG}-py39" \
-  --build-arg PY_VER="3.9"\
+  --build-arg PY_VER="3.9-slim"\
   --label "sha=${SHA}" \
   --label "built_at=$(date)" \
   --label "target=lean39" \


### PR DESCRIPTION
### SUMMARY
We would like to use python3.9/3.10 in our custom configuration code to have some nice-to-have features. I don't really see a reason why there shouldn't be a python3.9/python3.10 version, the build arg even already exists?

### TESTING INSTRUCTIONS
Run the docker build and see it works with python3.9/python3.10

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [X] Introduces new feature or API
- [ ] Removes existing feature or API
