### PR TITLE
feat(explore): Save chart to many dashboards at once

### DIFF
--- a/superset-frontend/src/components/Select/CustomTag.tsx
+++ b/superset-frontend/src/components/Select/CustomTag.tsx
@@ -18,28 +18,40 @@
  */
 import React from 'react';
 import { Tag as AntdTag } from 'antd';
-import { styled } from '@superset-ui/core';
+import { css, styled } from '@superset-ui/core';
 import { useCSSTextTruncation } from 'src/hooks/useTruncation';
 import { Tooltip } from '../Tooltip';
 import { CustomTagProps } from './types';
 import { SELECT_ALL_VALUE } from './utils';
 import { NoElement } from './styles';
 
-const StyledTag = styled(AntdTag)`
-  & .ant-tag-close-icon {
-    display: inline-flex;
-    align-items: center;
-    margin-left: ${({ theme }) => theme.gridUnit}px;
-  }
+export const StyledTag = styled(AntdTag)`
+  ${({ theme }) => css`
+    & .ant-tag-close-icon {
+      display: inline-flex;
+      align-items: center;
+      margin-left: ${theme.gridUnit}px;
+    }
 
-  & .tag-content {
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
+    & .tag-content {
+      overflow: hidden;
+      text-overflow: ellipsis;
+
+      &:last-child {
+        padding-right: ${theme.gridUnit}px;
+      }
+    }
+  `}
 `;
 
 // TODO: use antd Tag props instead of any. Currently it's causing a typescript error
-const Tag = (props: any) => {
+export const Tag = (props: any) => (
+  <StyledTag {...props} className="ant-select-selection-item">
+    <span className="tag-content">{props.children}</span>
+  </StyledTag>
+);
+
+export const OneLineTag = (props: any) => {
   const [tagRef, tagIsTruncated] = useCSSTextTruncation<HTMLSpanElement>();
   return (
     <Tooltip title={tagIsTruncated ? props.children : null}>
@@ -73,9 +85,9 @@ export const customTagRender = (props: CustomTagProps) => {
 
   if (value !== SELECT_ALL_VALUE) {
     return (
-      <Tag onMouseDown={onPreventMouseDown} {...(props as object)}>
+      <OneLineTag onMouseDown={onPreventMouseDown} {...(props as object)}>
         {label}
-      </Tag>
+      </OneLineTag>
     );
   }
   return <NoElement />;

--- a/superset-frontend/src/components/Select/types.ts
+++ b/superset-frontend/src/components/Select/types.ts
@@ -27,7 +27,6 @@ import {
   SelectValue as AntdSelectValue,
   LabeledValue as AntdLabeledValue,
 } from 'antd/lib/select';
-import { TagProps } from 'antd/lib/tag';
 
 export type RawValue = string | number;
 
@@ -64,6 +63,7 @@ export type AntdExposedProps = Pick<
   | 'value'
   | 'getPopupContainer'
   | 'menuItemSelectedIcon'
+  | 'tagRender'
 >;
 
 export type SelectOptionsType = Exclude<AntdProps['options'], undefined>;
@@ -100,7 +100,7 @@ export interface BaseSelectProps extends AntdExposedProps {
    * It adds a helper text on top of the Select options
    * with additional context to help with the interaction.
    */
-  helperText?: string;
+  helperText?: ReactNode;
   /**
    * It allows to define which properties of the option object
    * should be looked for when searching.
@@ -210,8 +210,6 @@ export interface AsyncSelectProps extends BaseSelectProps {
   onError?: (error: string) => void;
 }
 
-export type CustomTagProps = HTMLSpanElement &
-  TagProps & {
-    label: ReactNode;
-    value: string;
-  };
+export type CustomTagProps = Parameters<
+  Required<Pick<SelectProps, 'tagRender'>>['tagRender']
+>[0];

--- a/superset-frontend/src/components/Select/utils.tsx
+++ b/superset-frontend/src/components/Select/utils.tsx
@@ -18,7 +18,7 @@
  */
 import { ensureIsArray, t } from '@superset-ui/core';
 import AntdSelect, { LabeledValue as AntdLabeledValue } from 'antd/lib/select';
-import React, { ReactElement, RefObject } from 'react';
+import React, { ReactElement, ReactNode, RefObject } from 'react';
 import { DownOutlined, SearchOutlined } from '@ant-design/icons';
 import { StyledHelperText, StyledLoadingText, StyledSpin } from './styles';
 import { LabeledValue, RawValue, SelectOptionsType, V } from './types';
@@ -142,7 +142,7 @@ export const dropDownRenderHelper = (
   isDropdownVisible: boolean,
   isLoading: boolean | undefined,
   optionsLength: number,
-  helperText: string | undefined,
+  helperText: ReactNode | undefined,
   errorComponent?: JSX.Element,
 ) => {
   if (!isDropdownVisible) {

--- a/superset-frontend/src/explore/actions/saveModalActions.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.js
@@ -33,12 +33,6 @@ export function fetchDashboardsFailed(userId) {
   return { type: FETCH_DASHBOARDS_FAILED, userId };
 }
 
-export const SET_SAVE_CHART_MODAL_VISIBILITY =
-  'SET_SAVE_CHART_MODAL_VISIBILITY';
-export function setSaveChartModalVisibility(isVisible) {
-  return { type: SET_SAVE_CHART_MODAL_VISIBILITY, isVisible };
-}
-
 export function fetchDashboards(userId) {
   return function fetchDashboardsThunk(dispatch) {
     return SupersetClient.get({
@@ -164,6 +158,7 @@ export const updateSlice =
         form_data: { url_params: _, ...formData },
       },
     } = getState();
+
     try {
       const response = await SupersetClient.put({
         endpoint: `/api/v1/chart/${sliceId}`,

--- a/superset-frontend/src/explore/actions/saveModalActions.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.js
@@ -198,11 +198,13 @@ export const createSlice =
   };
 
 //  Create new dashboard
-export const createDashboard = dashboardName => async dispatch => {
+export const createDashboard = dashboardNames => async dispatch => {
   try {
     const response = await SupersetClient.post({
-      endpoint: `/api/v1/dashboard/`,
-      jsonPayload: { dashboard_title: dashboardName },
+      endpoint: `/api/v1/dashboard/batch`,
+      jsonPayload: dashboardNames.map(name => ({
+        dashboard_title: name,
+      })),
     });
 
     return response.json;

--- a/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
@@ -23,7 +23,6 @@ import { render, screen, waitFor } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import * as chartAction from 'src/components/Chart/chartAction';
-import * as saveModalActions from 'src/explore/actions/saveModalActions';
 import * as downloadAsImage from 'src/utils/downloadAsImage';
 import * as exploreUtils from 'src/explore/exploreUtils';
 import { FeatureFlag } from '@superset-ui/core';
@@ -118,6 +117,7 @@ const createProps = (additionalProps = {}) => ({
   canOverwrite: false,
   canDownload: false,
   isStarred: false,
+  showSaveModal: jest.fn(),
   ...additionalProps,
 });
 
@@ -192,29 +192,21 @@ test('does not render the metadata bar when not saved', async () => {
 });
 
 test('Save chart', async () => {
-  const setSaveChartModalVisibility = jest.spyOn(
-    saveModalActions,
-    'setSaveChartModalVisibility',
-  );
   const props = createProps();
   render(<ExploreHeader {...props} />, { useRedux: true });
   expect(await screen.findByText('Save')).toBeInTheDocument();
   userEvent.click(screen.getByText('Save'));
-  expect(setSaveChartModalVisibility).toHaveBeenCalledWith(true);
-  setSaveChartModalVisibility.mockClear();
+  expect(props.showSaveModal).toHaveBeenCalled();
+  props.showSaveModal.mockClear();
 });
 
 test('Save disabled', async () => {
-  const setSaveChartModalVisibility = jest.spyOn(
-    saveModalActions,
-    'setSaveChartModalVisibility',
-  );
   const props = createProps();
   render(<ExploreHeader {...props} saveDisabled />, { useRedux: true });
   expect(await screen.findByText('Save')).toBeInTheDocument();
   userEvent.click(screen.getByText('Save'));
-  expect(setSaveChartModalVisibility).not.toHaveBeenCalled();
-  setSaveChartModalVisibility.mockClear();
+  expect(props.showSaveModal).not.toHaveBeenCalled();
+  props.showSaveModal.mockClear();
 });
 
 describe('Additional actions tests', () => {

--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
@@ -36,7 +36,6 @@ import PropertiesModal from 'src/explore/components/PropertiesModal';
 import { sliceUpdated } from 'src/explore/actions/exploreActions';
 import { PageHeaderWithActions } from 'src/components/PageHeaderWithActions';
 import MetadataBar, { MetadataType } from 'src/components/MetadataBar';
-import { setSaveChartModalVisibility } from 'src/explore/actions/saveModalActions';
 import { useExploreAdditionalActionsMenu } from '../useExploreAdditionalActionsMenu';
 
 const propTypes = {
@@ -53,6 +52,7 @@ const propTypes = {
   timeout: PropTypes.number,
   chart: chartPropShape,
   saveDisabled: PropTypes.bool,
+  showSaveModal: PropTypes.func.isRequired,
 };
 
 const saveButtonStyles = theme => css`
@@ -85,6 +85,7 @@ export const ExploreChartHeader = ({
   sliceName,
   saveDisabled,
   metadata,
+  showSaveModal,
 }) => {
   const dispatch = useDispatch();
   const { latestQueryFormData, sliceFormData } = chart;
@@ -139,10 +140,6 @@ export const ExploreChartHeader = ({
   const closePropertiesModal = () => {
     setIsPropertiesModalOpen(false);
   };
-
-  const showModal = useCallback(() => {
-    dispatch(setSaveChartModalVisibility(true));
-  }, [dispatch]);
 
   const updateSlice = useCallback(
     slice => {
@@ -259,7 +256,7 @@ export const ExploreChartHeader = ({
             <div>
               <Button
                 buttonStyle="secondary"
-                onClick={showModal}
+                onClick={showSaveModal}
                 disabled={saveDisabled}
                 data-test="query-save-button"
                 css={saveButtonStyles}

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -81,7 +81,6 @@ const propTypes = {
   impressionId: PropTypes.string,
   vizType: PropTypes.string,
   saveAction: PropTypes.string,
-  isSaveModalVisible: PropTypes.bool,
 };
 
 const ExploreContainer = styled.div`
@@ -244,6 +243,7 @@ function ExploreViewContainer(props) {
 
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [shouldForceUpdate, setShouldForceUpdate] = useState(-1);
+  const [isSaveModalVisible, setIsSaveModalVisible] = useState(false);
   const tabId = useTabId();
 
   const theme = useTheme();
@@ -523,25 +523,29 @@ function ExploreViewContainer(props) {
     return errorMessage;
   }, [props.controls]);
 
-  function renderChartContainer() {
-    return (
-      <ExploreChartPanel
-        {...props}
-        errorMessage={errorMessage}
-        chartIsStale={chartIsStale}
-        onQuery={onQuery}
-      />
-    );
-  }
+  const showSaveModal = () => {
+    setIsSaveModalVisible(true);
+  };
 
-  function getSidebarWidths(key) {
-    return getItem(key, defaultSidebarsWidth[key]);
-  }
+  const closeSaveModal = () => {
+    setIsSaveModalVisible(false);
+  };
 
-  function setSidebarWidths(key, dimension) {
+  const renderChartContainer = () => (
+    <ExploreChartPanel
+      {...props}
+      errorMessage={errorMessage}
+      chartIsStale={chartIsStale}
+      onQuery={onQuery}
+    />
+  );
+
+  const getSidebarWidths = key => getItem(key, defaultSidebarsWidth[key]);
+
+  const setSidebarWidths = (key, dimension) => {
     const newDimension = Number(getSidebarWidths(key)) + dimension.width;
     setItem(key, newDimension);
-  }
+  };
 
   if (props.standalone) {
     return renderChartContainer();
@@ -565,6 +569,7 @@ function ExploreViewContainer(props) {
         reports={props.reports}
         saveDisabled={errorMessage || props.chart.chartStatus === 'loading'}
         metadata={props.metadata}
+        showSaveModal={showSaveModal}
       />
       <ExplorePanelContainer id="explore-container">
         <Global
@@ -687,13 +692,15 @@ function ExploreViewContainer(props) {
           {renderChartContainer()}
         </div>
       </ExplorePanelContainer>
-      {props.isSaveModalVisible && (
+      {isSaveModalVisible && (
         <SaveModal
           addDangerToast={props.addDangerToast}
           actions={props.actions}
           form_data={props.form_data}
           sliceName={props.sliceName}
           dashboardId={props.dashboardId}
+          isVisible={isSaveModalVisible}
+          onClose={closeSaveModal}
         />
       )}
     </ExploreContainer>
@@ -761,7 +768,6 @@ function mapStateToProps(state) {
     reports,
     metadata,
     saveAction: explore.saveAction,
-    isSaveModalVisible: saveModal.isVisible,
   };
 }
 

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -710,16 +710,8 @@ function ExploreViewContainer(props) {
 ExploreViewContainer.propTypes = propTypes;
 
 function mapStateToProps(state) {
-  const {
-    explore,
-    charts,
-    common,
-    impressionId,
-    dataMask,
-    reports,
-    user,
-    saveModal,
-  } = state;
+  const { explore, charts, common, impressionId, dataMask, reports, user } =
+    state;
   const { controls, slice, datasource, metadata } = explore;
   const form_data = getFormDataFromControls(controls);
   const slice_id = form_data.slice_id ?? slice?.slice_id ?? 0; // 0 - unsaved chart

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -17,9 +17,8 @@
  * under the License.
  */
 /* eslint camelcase: 0 */
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { Dispatch } from 'redux';
-import { SelectValue } from 'antd/lib/select';
 import { connect } from 'react-redux';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
@@ -28,8 +27,8 @@ import {
   t,
   styled,
   DatasourceType,
-  isDefined,
-  ensureIsArray,
+  SupersetTheme,
+  withTheme,
 } from '@superset-ui/core';
 import { Input } from 'src/components/Input';
 import { Form, FormItem } from 'src/components/Form';
@@ -39,11 +38,11 @@ import { Radio } from 'src/components/Radio';
 import Button from 'src/components/Button';
 import { Select } from 'src/components';
 import Loading from 'src/components/Loading';
-import { setSaveChartModalVisibility } from 'src/explore/actions/saveModalActions';
-import { SaveActionType } from 'src/explore/types';
-
-// Session storage key for recent dashboard
-const SK_DASHBOARD_ID = 'save_chart_recent_dashboard';
+import { ExplorePageState, SaveActionType } from 'src/explore/types';
+import { Tag } from 'src/components/Select/CustomTag';
+import Icons from 'src/components/Icons';
+import { CustomTagProps, SelectOptionsType } from 'src/components/Select/types';
+import { Tooltip } from 'src/components/Tooltip';
 
 interface SaveModalProps extends RouteComponentProps {
   addDangerToast: (msg: string) => void;
@@ -51,24 +50,30 @@ interface SaveModalProps extends RouteComponentProps {
   form_data?: Record<string, any>;
   userId: number;
   dashboards: Array<any>;
-  alert?: string;
+  alert?: ReactNode;
   sliceName?: string;
   slice?: Record<string, any>;
   datasource?: Record<string, any>;
   dashboardId: '' | number | null;
   isVisible: boolean;
+  dashboardsAddedTo: { id: number; dashboard_title: string }[];
   dispatch: Dispatch;
+  theme: SupersetTheme;
+  onClose: () => void;
 }
 
 type SaveModalState = {
-  saveToDashboardId: number | string | null;
+  saveToDashboardIds: (number | string)[] | null;
+  navigateToDashboardId?: number;
   newSliceName?: string;
   newDashboardName?: string;
   datasetName: string;
-  alert: string | null;
+  alert: ReactNode | null;
   action: SaveActionType;
   isLoading: boolean;
   saveStatus?: string | null;
+  isNavigationModalVisible: boolean;
+  dashboardOptions: SelectOptionsType;
 };
 
 export const StyledModal = styled(Modal)`
@@ -82,28 +87,51 @@ export const StyledModal = styled(Modal)`
   }
 `;
 
+const deselectionNotAllowedTooltipText = t(
+  'You cannot deselect this dashboard, because you are not the owner.',
+);
+
+const newDashboardTooltipText = t(
+  'This is a new dashboard that will be created after you save the chart.',
+);
+
 class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
+  dashboardRemovedAlertShowed = false;
+
   constructor(props: SaveModalProps) {
     super(props);
     this.state = {
-      saveToDashboardId: null,
+      saveToDashboardIds: this.canOverwriteSlice()
+        ? props.dashboardsAddedTo.map(dashboard => dashboard.id)
+        : [],
+      navigateToDashboardId: undefined,
       newSliceName: props.sliceName,
       datasetName: props.datasource?.name,
       alert: null,
       action: this.canOverwriteSlice() ? 'overwrite' : 'saveas',
       isLoading: false,
+      isNavigationModalVisible: false,
+      dashboardOptions: [],
     };
-    this.onDashboardSelectChange = this.onDashboardSelectChange.bind(this);
+    this.onDashboardSaveSelectChange =
+      this.onDashboardSaveSelectChange.bind(this);
+    this.onDashboardNavigationSelectChange =
+      this.onDashboardNavigationSelectChange.bind(this);
     this.onSliceNameChange = this.onSliceNameChange.bind(this);
     this.changeAction = this.changeAction.bind(this);
     this.saveOrOverwrite = this.saveOrOverwrite.bind(this);
     this.isNewDashboard = this.isNewDashboard.bind(this);
     this.removeAlert = this.removeAlert.bind(this);
-    this.onHide = this.onHide.bind(this);
+    this.handleNavigation = this.handleNavigation.bind(this);
+    this.onHideSaveModal = this.onHideSaveModal.bind(this);
+    this.onHideNavigationModal = this.onHideNavigationModal.bind(this);
+    this.getNavigationModalProps = this.getNavigationModalProps.bind(this);
+    this.getSaveModalProps = this.getSaveModalProps.bind(this);
+    this.tagRenderer = this.tagRenderer.bind(this);
   }
 
   isNewDashboard(): boolean {
-    return !!(!this.state.saveToDashboardId && this.state.newDashboardName);
+    return !!(!this.state.saveToDashboardIds && this.state.newDashboardName);
   }
 
   canOverwriteSlice(): boolean {
@@ -115,27 +143,27 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
 
   componentDidMount() {
     this.props.actions.fetchDashboards(this.props.userId).then(() => {
-      if (ensureIsArray(this.props.dashboards).length === 0) {
-        return;
-      }
-      const dashboardIds = this.props.dashboards?.map(
-        dashboard => dashboard.value,
-      );
-      const lastDashboard = sessionStorage.getItem(SK_DASHBOARD_ID);
-      let recentDashboard = lastDashboard && parseInt(lastDashboard, 10);
-
-      if (this.props.dashboardId) {
-        recentDashboard = this.props.dashboardId;
-      }
-
-      if (
-        recentDashboard !== null &&
-        dashboardIds.indexOf(recentDashboard) !== -1
-      ) {
-        this.setState({
-          saveToDashboardId: recentDashboard,
-        });
-      }
+      const dashboardOptions = [
+        ...this.props.dashboardsAddedTo
+          .filter(
+            dashboardAddedTo =>
+              !this.props.dashboards.some(
+                dashboard => dashboard.value === dashboardAddedTo.id,
+              ),
+          )
+          .map(dashboard => ({
+            label: dashboard.dashboard_title,
+            value: dashboard.id,
+            customLabel: (
+              <Tooltip title={deselectionNotAllowedTooltipText}>
+                {dashboard.dashboard_title}
+              </Tooltip>
+            ),
+            disabled: true,
+          })),
+        ...this.props.dashboards,
+      ];
+      this.setState({ dashboardOptions });
     });
   }
 
@@ -148,31 +176,126 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
     this.setState({ newSliceName: event.target.value });
   }
 
-  onDashboardSelectChange(selected: SelectValue) {
-    const newDashboardName = selected ? String(selected) : undefined;
-    const saveToDashboardId =
-      selected && typeof selected === 'number' ? selected : null;
-    this.setState({ saveToDashboardId, newDashboardName });
+  onDashboardSaveSelectChange(selected: (string | number)[]) {
+    this.setState({ saveToDashboardIds: selected });
+    if (
+      this.props.dashboardsAddedTo.some(
+        dashboard => !selected.includes(dashboard.id),
+      ) &&
+      !this.dashboardRemovedAlertShowed
+    ) {
+      this.setState({
+        alert: (
+          <div
+            css={css`
+              p {
+                margin-bottom: ${this.props.theme.gridUnit}px;
+                line-height: 1.4;
+              }
+            `}
+          >
+            <p
+              css={css`
+                font-weight: ${this.props.theme.typography.weights.bold};
+              `}
+            >
+              {t('You removed dashboards this chart is already added to')}
+            </p>
+            <p>
+              {t(
+                'When you save the selection, chart will be removed from those dashboards.',
+              )}
+            </p>
+          </div>
+        ),
+      });
+      this.dashboardRemovedAlertShowed = true;
+    }
+  }
+
+  onDashboardNavigationSelectChange(selected: number) {
+    this.setState({ navigateToDashboardId: selected });
   }
 
   changeAction(action: SaveActionType) {
     this.setState({ action });
   }
 
-  onHide() {
-    this.props.dispatch(setSaveChartModalVisibility(false));
+  onHideSaveModal() {
+    this.props.onClose();
+  }
+
+  onHideNavigationModal() {
+    this.setState({ isNavigationModalVisible: false });
+    this.props.onClose();
+  }
+
+  tagRenderer(customTagProps: CustomTagProps) {
+    const onPreventMouseDown = (event: React.MouseEvent<HTMLElement>) => {
+      // if close icon is clicked, stop propagation to avoid opening the dropdown
+      const target = event.target as HTMLElement;
+      if (
+        target.tagName === 'svg' ||
+        target.tagName === 'path' ||
+        (target.tagName === 'span' &&
+          target.className.includes('ant-tag-close-icon'))
+      ) {
+        event.stopPropagation();
+      }
+    };
+
+    let closable = true;
+    let { label } = customTagProps;
+
+    if (
+      typeof customTagProps.value === 'number' &&
+      !this.props.dashboards.some(
+        dashboard => dashboard.value === customTagProps.value,
+      )
+    ) {
+      closable = false;
+      label = (
+        <Tooltip title={deselectionNotAllowedTooltipText}>
+          {this.props.dashboardsAddedTo.find(
+            dashboard => dashboard.id === customTagProps.value,
+          )?.dashboard_title ?? customTagProps.label}
+        </Tooltip>
+      );
+    }
+
+    if (typeof customTagProps.value === 'string') {
+      label = (
+        <Tooltip title={newDashboardTooltipText}>
+          <Icons.AppstoreAddOutlined
+            iconSize="xs"
+            iconColor={this.props.theme.colors.grayscale.base}
+            css={css`
+              margin-right: ${this.props.theme.gridUnit}px;
+              vertical-align: middle;
+              & > * {
+                line-height: 0;
+              }
+            `}
+          />
+          {customTagProps.label}
+        </Tooltip>
+      );
+    }
+
+    return (
+      <Tag
+        {...customTagProps}
+        onMouseDown={onPreventMouseDown}
+        closable={closable}
+      >
+        {label}
+      </Tag>
+    );
   }
 
   async saveOrOverwrite(gotodash: boolean) {
     this.setState({ alert: null, isLoading: true });
     this.props.actions.removeSaveModalAlert();
-
-    //  Create or retrieve dashboard
-    type DashboardGetResponse = {
-      id: number;
-      url: string;
-      dashboard_title: string;
-    };
 
     try {
       if (this.props.datasource?.type === DatasourceType.Query) {
@@ -198,30 +321,28 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
         );
       }
 
-      let dashboard: DashboardGetResponse | null = null;
-      if (this.state.newDashboardName || this.state.saveToDashboardId) {
-        let saveToDashboardId = this.state.saveToDashboardId || null;
-        if (!this.state.saveToDashboardId) {
-          const response = await this.props.actions.createDashboard(
-            this.state.newDashboardName,
-          );
-          saveToDashboardId = response.id;
-        }
-
-        const response = await this.props.actions.getDashboard(
-          saveToDashboardId,
+      // let dashboard: DashboardGetResponse | null = null;
+      if (this.state.saveToDashboardIds) {
+        const newDashboardNames = this.state.saveToDashboardIds.filter(
+          id => typeof id === 'string',
         );
-        dashboard = response.result;
-        if (isDefined(dashboard) && isDefined(dashboard?.id)) {
-          sliceDashboards = sliceDashboards.includes(dashboard.id)
-            ? sliceDashboards
-            : [...sliceDashboards, dashboard.id];
-          const { url_params, ...formData } = this.props.form_data || {};
-          this.props.actions.setFormData({
-            ...formData,
-            dashboards: sliceDashboards,
-          });
-        }
+        const newDashboardIds = (
+          await Promise.all(
+            newDashboardNames.map(id => this.props.actions.createDashboard(id)),
+          )
+        ).map(response => response.id);
+        sliceDashboards = this.state.saveToDashboardIds.map(id => {
+          if (typeof id === 'number') {
+            return id;
+          }
+          return newDashboardIds[newDashboardNames.indexOf(id)];
+        });
+        const { url_params, ...formData } = this.props.form_data || {};
+
+        this.props.actions.setFormData({
+          ...formData,
+          dashboards: sliceDashboards,
+        });
       }
 
       //  Update or create slice
@@ -231,36 +352,14 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
           this.props.slice,
           this.state.newSliceName,
           sliceDashboards,
-          dashboard
-            ? {
-                title: dashboard.dashboard_title,
-                new: !this.state.saveToDashboardId,
-              }
-            : null,
+          null,
         );
       } else {
         value = await this.props.actions.createSlice(
           this.state.newSliceName,
           sliceDashboards,
-          dashboard
-            ? {
-                title: dashboard.dashboard_title,
-                new: !this.state.saveToDashboardId,
-              }
-            : null,
+          null,
         );
-      }
-
-      if (dashboard) {
-        sessionStorage.setItem(SK_DASHBOARD_ID, `${dashboard.id}`);
-      } else {
-        sessionStorage.removeItem(SK_DASHBOARD_ID);
-      }
-
-      // Go to new dashboard url
-      if (gotodash && dashboard) {
-        this.props.history.push(dashboard.url);
-        return;
       }
 
       const searchParams = new URLSearchParams(window.location.search);
@@ -271,100 +370,137 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
       }
       this.props.history.replace(`/explore/?${searchParams.toString()}`);
 
-      this.setState({ isLoading: false });
-      this.onHide();
+      this.setState({ saveToDashboardIds: sliceDashboards, isLoading: false });
+      if (gotodash) {
+        this.setState({ isNavigationModalVisible: true });
+      } else {
+        this.onHideSaveModal();
+      }
     } finally {
       this.setState({ isLoading: false });
     }
   }
 
-  renderSaveChartModal = () => {
-    const dashboardSelectValue =
-      this.state.saveToDashboardId || this.state.newDashboardName;
-
-    return (
-      <Form data-test="save-modal-body" layout="vertical">
-        {(this.state.alert || this.props.alert) && (
-          <Alert
-            type="warning"
-            message={this.state.alert || this.props.alert}
-            onClose={this.removeAlert}
-          />
-        )}
-        <FormItem data-test="radio-group">
-          <Radio
-            id="overwrite-radio"
-            disabled={!this.canOverwriteSlice()}
-            checked={this.state.action === 'overwrite'}
-            onChange={() => this.changeAction('overwrite')}
-            data-test="save-overwrite-radio"
-          >
-            {t('Save (Overwrite)')}
-          </Radio>
-          <Radio
-            id="saveas-radio"
-            data-test="saveas-radio"
-            checked={this.state.action === 'saveas'}
-            onChange={() => this.changeAction('saveas')}
-          >
-            {t('Save as...')}
-          </Radio>
-        </FormItem>
-        <hr />
-        <FormItem label={t('Chart name')} required>
-          <Input
-            name="new_slice_name"
-            type="text"
-            placeholder="Name"
-            value={this.state.newSliceName}
-            onChange={this.onSliceNameChange}
-            data-test="new-chart-name"
-          />
-        </FormItem>
-        {this.props.datasource?.type === 'query' && (
-          <FormItem label={t('Dataset Name')} required>
-            <InfoTooltipWithTrigger
-              tooltip={t('A reusable dataset will be saved with your chart.')}
-              placement="right"
-            />
-            <Input
-              name="dataset_name"
-              type="text"
-              placeholder="Dataset Name"
-              value={this.state.datasetName}
-              onChange={this.handleDatasetNameChange}
-              data-test="new-dataset-name"
-            />
-          </FormItem>
-        )}
-        <FormItem
-          label={t('Add to dashboard')}
-          data-test="save-chart-modal-select-dashboard-form"
+  renderSaveChartModal = () => (
+    <Form data-test="save-modal-body" layout="vertical">
+      <FormItem data-test="radio-group">
+        <Radio
+          id="overwrite-radio"
+          disabled={!this.canOverwriteSlice()}
+          checked={this.state.action === 'overwrite'}
+          onChange={() => this.changeAction('overwrite')}
+          data-test="save-overwrite-radio"
         >
-          <Select
-            allowClear
-            allowNewOptions
-            ariaLabel={t('Select a dashboard')}
-            options={this.props.dashboards}
-            onChange={this.onDashboardSelectChange}
-            value={dashboardSelectValue || undefined}
-            placeholder={
-              <div>
-                <b>{t('Select')}</b>
-                {t(' a dashboard OR ')}
-                <b>{t('create')}</b>
-                {t(' a new one')}
-              </div>
-            }
+          {t('Save (Overwrite)')}
+        </Radio>
+        <Radio
+          id="saveas-radio"
+          data-test="saveas-radio"
+          checked={this.state.action === 'saveas'}
+          onChange={() => this.changeAction('saveas')}
+        >
+          {t('Save as...')}
+        </Radio>
+      </FormItem>
+      {(this.state.alert || this.props.alert) && (
+        <Alert
+          type="warning"
+          message={this.state.alert || this.props.alert}
+          onClose={this.removeAlert}
+          roomBelow
+        />
+      )}
+      <FormItem label={t('Chart name')} required>
+        <Input
+          name="new_slice_name"
+          type="text"
+          placeholder="Name"
+          value={this.state.newSliceName}
+          onChange={this.onSliceNameChange}
+          data-test="new-chart-name"
+        />
+      </FormItem>
+      {this.props.datasource?.type === 'query' && (
+        <FormItem label={t('Dataset Name')} required>
+          <InfoTooltipWithTrigger
+            tooltip={t('A reusable dataset will be saved with your chart.')}
+            placement="right"
+          />
+          <Input
+            name="dataset_name"
+            type="text"
+            placeholder="Dataset Name"
+            value={this.state.datasetName}
+            onChange={this.handleDatasetNameChange}
+            data-test="new-dataset-name"
           />
         </FormItem>
-      </Form>
-    );
-  };
+      )}
+      <FormItem
+        label={t('Added to dashboards')}
+        tooltip={
+          <div
+            css={css`
+              font-size: ${this.props.theme.typography.sizes.s}px;
+            `}
+          >
+            <div>
+              <span>
+                {t('You can add your chart to multiple dashboards at once.')}
+              </span>
+              {this.state.action === 'overwrite' && (
+                <span>
+                  {t(
+                    'If there are already some dashboards visible it means that this chart is already added to them.',
+                  )}
+                </span>
+              )}
+            </div>
+            <div
+              css={css`
+                margin-top: ${this.props.theme.gridUnit * 2}px;
+              `}
+            >
+              {t(
+                'You can create a new dashboard by typing the name and hitting enter.',
+              )}
+            </div>
+          </div>
+        }
+        data-test="save-chart-modal-select-dashboard-form"
+      >
+        <Select
+          allowClear
+          allowNewOptions
+          mode="multiple"
+          ariaLabel={t('Select a dashboard')}
+          options={this.state.dashboardOptions}
+          onChange={this.onDashboardSaveSelectChange}
+          value={this.state.saveToDashboardIds || undefined}
+          placeholder={
+            <div>
+              <b>{t('Select')}</b>
+              {t(' a dashboard OR ')}
+              <b>{t('create')}</b>
+              {t(' a new one')}
+            </div>
+          }
+          tagRender={this.tagRenderer}
+          helperText={
+            <div>
+              {t('Select dashboard or create a')}{' '}
+              <strong>{t('new dashboard')}</strong>{' '}
+              {t('by typing name and clicking enter')}
+            </div>
+          }
+        />
+      </FormItem>
+    </Form>
+  );
 
   renderFooter = () => (
     <div data-test="save-modal-footer">
-      <Button id="btn_cancel" buttonSize="small" onClick={this.onHide}>
+      <Button id="btn_cancel" buttonSize="small" onClick={this.onHideSaveModal}>
         {t('Cancel')}
       </Button>
       <Button
@@ -372,7 +508,7 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
         buttonSize="small"
         disabled={
           !this.state.newSliceName ||
-          (!this.state.saveToDashboardId && !this.state.newDashboardName) ||
+          (!this.state.saveToDashboardIds && !this.state.newDashboardName) ||
           (this.props.datasource?.type !== DatasourceType.Table &&
             !this.state.datasetName)
         }
@@ -411,27 +547,71 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
     this.setState({ alert: null });
   }
 
+  async handleNavigation() {
+    const response = await this.props.actions.getDashboard(
+      this.state.navigateToDashboardId,
+    );
+    const dashboard = response.result;
+    this.setState({ isNavigationModalVisible: false });
+    this.props.history.push(dashboard.url);
+  }
+
+  getSaveModalProps() {
+    return {
+      show: this.props.isVisible,
+      onHide: this.onHideSaveModal,
+      title: t('Save chart'),
+      footer: this.renderFooter(),
+      children: this.state.isLoading ? (
+        <div
+          css={css`
+            display: flex;
+            justify-content: center;
+          `}
+        >
+          <Loading position="normal" />
+        </div>
+      ) : (
+        this.renderSaveChartModal()
+      ),
+    };
+  }
+
+  getNavigationModalProps() {
+    return {
+      show: this.state.isNavigationModalVisible,
+      primaryButtonName: t('Go'),
+      disablePrimaryButton: !this.state.navigateToDashboardId,
+      onHandledPrimaryAction: this.handleNavigation,
+      onHide: this.onHideNavigationModal,
+      title: t('You added your chart to multiple dashboards'),
+      children: (
+        <Form data-test="navigation-modal-body" layout="vertical">
+          <FormItem label={t('Select a dashboard you want to open')}>
+            <Select
+              allowClear
+              ariaLabel={t('Select a dashboard')}
+              options={this.props.dashboardsAddedTo.map(dashboard => ({
+                value: dashboard.id,
+                label: dashboard.dashboard_title,
+              }))}
+              onChange={this.onDashboardNavigationSelectChange}
+              value={this.state.navigateToDashboardId}
+              placeholder={t('Select a dashboard')}
+            />
+          </FormItem>
+        </Form>
+      ),
+    };
+  }
+
   render() {
     return (
       <StyledModal
-        show={this.props.isVisible}
-        onHide={this.onHide}
-        title={t('Save chart')}
-        footer={this.renderFooter()}
-      >
-        {this.state.isLoading ? (
-          <div
-            css={css`
-              display: flex;
-              justify-content: center;
-            `}
-          >
-            <Loading position="normal" />
-          </div>
-        ) : (
-          this.renderSaveChartModal()
-        )}
-      </StyledModal>
+        {...(this.state.isNavigationModalVisible
+          ? this.getNavigationModalProps()
+          : this.getSaveModalProps())}
+      />
     );
   }
 }
@@ -441,23 +621,23 @@ interface StateProps {
   slice: any;
   userId: any;
   dashboards: any;
+  dashboardsAddedTo: { id: number; dashboard_title: string }[];
   alert: any;
-  isVisible: boolean;
 }
 
 function mapStateToProps({
   explore,
   saveModal,
   user,
-}: Record<string, any>): StateProps {
+}: ExplorePageState): StateProps {
   return {
     datasource: explore.datasource,
     slice: explore.slice,
     userId: user?.userId,
     dashboards: saveModal.dashboards,
+    dashboardsAddedTo: explore.metadata?.dashboards,
     alert: saveModal.saveModalAlert,
-    isVisible: saveModal.isVisible,
   };
 }
 
-export default withRouter(connect(mapStateToProps)(SaveModal));
+export default withRouter(withTheme(connect(mapStateToProps)(SaveModal)));

--- a/superset-frontend/src/explore/reducers/saveModalReducer.js
+++ b/superset-frontend/src/explore/reducers/saveModalReducer.js
@@ -22,9 +22,6 @@ import { HYDRATE_EXPLORE } from '../actions/hydrateExplore';
 
 export default function saveModalReducer(state = {}, action) {
   const actionHandlers = {
-    [actions.SET_SAVE_CHART_MODAL_VISIBILITY]() {
-      return { ...state, isVisible: action.isVisible };
-    },
     [actions.FETCH_DASHBOARDS_SUCCEEDED]() {
       return { ...state, dashboards: action.choices };
     },

--- a/superset-frontend/src/explore/types.ts
+++ b/superset-frontend/src/explore/types.ts
@@ -113,6 +113,19 @@ export interface ExplorePageState {
     standalone: boolean;
     force: boolean;
     common: JsonObject;
+    saveAction: SaveActionType | null;
+    metadata: {
+      changed_by: string;
+      changed_on_humanized: string;
+      created_on_humanized: string;
+      owners: string[];
+      dashboards: { id: number; dashboard_title: string }[];
+    };
+  };
+  saveModal: {
+    dashboards: { value: number; label: string }[];
+    saveModalAlert: string;
+    isVisible: boolean;
   };
   sliceEntities?: JsonObject; // propagated from Dashboard view
 }

--- a/superset/constants.py
+++ b/superset/constants.py
@@ -115,6 +115,7 @@ MODEL_API_RW_METHOD_PERMISSION_MAP = {
     "get_list": "read",
     "info": "read",
     "post": "write",
+    "bulk_create": "write",
     "put": "write",
     "related": "read",
     "related_objects": "read",

--- a/superset/dashboards/commands/bulk_create.py
+++ b/superset/dashboards/commands/bulk_create.py
@@ -1,0 +1,80 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import logging
+from typing import Any, Dict, List, Optional
+
+from flask_appbuilder.models.sqla import Model
+from marshmallow import ValidationError
+
+from superset.commands.base import BaseCommand, CreateMixin
+from superset.commands.utils import populate_roles
+from superset.dao.exceptions import DAOCreateFailedError
+from superset.dashboards.commands.exceptions import (
+    DashboardCreateFailedError,
+    DashboardInvalidError,
+    DashboardSlugExistsValidationError,
+)
+from superset.dashboards.dao import DashboardDAO
+
+logger = logging.getLogger(__name__)
+
+
+class BulkCreateDashboardCommand(CreateMixin, BaseCommand):
+    def __init__(self, data: List[Dict[str, Any]]):
+        self._properties = data.copy()
+
+    def run(self) -> List[Model]:
+        self.validate()
+        try:
+            dashboards = DashboardDAO.bulk_create(self._properties, commit=False)
+            dashboards = DashboardDAO.bulk_update_charts_owners(dashboards, commit=True)
+        except DAOCreateFailedError as ex:
+            logger.exception(ex.exception)
+            raise DashboardCreateFailedError() from ex
+        return dashboards
+
+    def validate(self) -> None:
+        exceptions: List[ValidationError] = []
+
+        for dashboard_properties in self._properties:
+            owner_ids: Optional[List[int]] = dashboard_properties.get("owners")
+            role_ids: Optional[List[int]] = dashboard_properties.get("roles")
+            slug: str = dashboard_properties.get("slug", "")
+
+            # Validate slug uniqueness
+            if not DashboardDAO.validate_slug_uniqueness(slug):
+                exceptions.append(DashboardSlugExistsValidationError())
+
+            try:
+                owners = self.populate_owners(owner_ids)
+                dashboard_properties["owners"] = owners
+            except ValidationError as ex:
+                exceptions.append(ex)
+            if exceptions:
+                exception = DashboardInvalidError()
+                exception.add_list(exceptions)
+                raise exception
+
+            try:
+                roles = populate_roles(role_ids)
+                dashboard_properties["roles"] = roles
+            except ValidationError as ex:
+                exceptions.append(ex)
+            if exceptions:
+                exception = DashboardInvalidError()
+                exception.add_list(exceptions)
+                raise exception

--- a/superset/dashboards/commands/exceptions.py
+++ b/superset/dashboards/commands/exceptions.py
@@ -54,6 +54,10 @@ class DashboardCreateFailedError(CreateFailedError):
     message = _("Dashboard could not be created.")
 
 
+class DashboardBulkCreateFailedError(CreateFailedError):
+    message = _("Dashboards could not be created.")
+
+
 class DashboardBulkDeleteFailedError(CreateFailedError):
     message = _("Dashboards could not be deleted.")
 


### PR DESCRIPTION

### SUMMARY
This PR implements a new flow of saving chart, allowing user to select multiple dashboards that the chart will be added to.

TODO: add unit tests

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
