### PR TITLE
chore: Migrate /superset/recent_activity/<user_id>/ to /api/v1/

### DIFF
--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -9,13 +9,13 @@
                 "message": {
                   "type": "string"
                 }
-              }, 
+              },
               "type": "object"
             }
           }
-        }, 
+        },
         "description": "Bad request"
-      }, 
+      },
       "401": {
         "content": {
           "application/json": {
@@ -24,13 +24,13 @@
                 "message": {
                   "type": "string"
                 }
-              }, 
+              },
               "type": "object"
             }
           }
-        }, 
+        },
         "description": "Unauthorized"
-      }, 
+      },
       "403": {
         "content": {
           "application/json": {
@@ -39,13 +39,13 @@
                 "message": {
                   "type": "string"
                 }
-              }, 
+              },
               "type": "object"
             }
           }
-        }, 
+        },
         "description": "Forbidden"
-      }, 
+      },
       "404": {
         "content": {
           "application/json": {
@@ -54,13 +54,13 @@
                 "message": {
                   "type": "string"
                 }
-              }, 
+              },
               "type": "object"
             }
           }
-        }, 
+        },
         "description": "Not found"
-      }, 
+      },
       "422": {
         "content": {
           "application/json": {
@@ -69,13 +69,13 @@
                 "message": {
                   "type": "string"
                 }
-              }, 
+              },
               "type": "object"
             }
           }
-        }, 
+        },
         "description": "Could not process entity"
-      }, 
+      },
       "500": {
         "content": {
           "application/json": {
@@ -84,9143 +84,9143 @@
                 "message": {
                   "type": "string"
                 }
-              }, 
+              },
               "type": "object"
             }
           }
-        }, 
+        },
         "description": "Fatal error"
       }
-    }, 
+    },
     "schemas": {
       "AdvancedDataTypeSchema": {
         "properties": {
           "display_value": {
-            "description": "The string representation of the parsed values", 
+            "description": "The string representation of the parsed values",
             "type": "string"
-          }, 
+          },
           "error_message": {
             "type": "string"
-          }, 
+          },
           "valid_filter_operators": {
             "items": {
               "type": "string"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "values": {
             "items": {
-              "description": "parsed value (can be any value)", 
+              "description": "parsed value (can be any value)",
               "type": "string"
-            }, 
+            },
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "AnnotationLayer": {
         "properties": {
           "annotationType": {
-            "description": "Type of annotation layer", 
+            "description": "Type of annotation layer",
             "enum": [
-              "FORMULA", 
-              "INTERVAL", 
-              "EVENT", 
+              "FORMULA",
+              "INTERVAL",
+              "EVENT",
               "TIME_SERIES"
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           "color": {
-            "description": "Layer color", 
-            "nullable": true, 
+            "description": "Layer color",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "descriptionColumns": {
-            "description": "Columns to use as the description. If none are provided, all will be shown.", 
+            "description": "Columns to use as the description. If none are provided, all will be shown.",
             "items": {
               "type": "string"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "hideLine": {
-            "description": "Should line be hidden. Only applies to line annotations", 
-            "nullable": true, 
+            "description": "Should line be hidden. Only applies to line annotations",
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "intervalEndColumn": {
-            "description": "Column containing end of interval. Only applies to interval layers", 
-            "nullable": true, 
+            "description": "Column containing end of interval. Only applies to interval layers",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "name": {
-            "description": "Name of layer", 
+            "description": "Name of layer",
             "type": "string"
-          }, 
+          },
           "opacity": {
-            "description": "Opacity of layer", 
+            "description": "Opacity of layer",
             "enum": [
-              "", 
-              "opacityLow", 
-              "opacityMedium", 
+              "",
+              "opacityLow",
+              "opacityMedium",
               "opacityHigh"
-            ], 
-            "nullable": true, 
+            ],
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "overrides": {
             "additionalProperties": {
               "nullable": true
-            }, 
-            "description": "which properties should be overridable", 
-            "nullable": true, 
+            },
+            "description": "which properties should be overridable",
+            "nullable": true,
             "type": "object"
-          }, 
+          },
           "show": {
-            "description": "Should the layer be shown", 
+            "description": "Should the layer be shown",
             "type": "boolean"
-          }, 
+          },
           "showLabel": {
-            "description": "Should the label always be shown", 
-            "nullable": true, 
+            "description": "Should the label always be shown",
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "showMarkers": {
-            "description": "Should markers be shown. Only applies to line annotations.", 
+            "description": "Should markers be shown. Only applies to line annotations.",
             "type": "boolean"
-          }, 
+          },
           "sourceType": {
-            "description": "Type of source for annotation data", 
+            "description": "Type of source for annotation data",
             "enum": [
-              "", 
-              "line", 
-              "NATIVE", 
+              "",
+              "line",
+              "NATIVE",
               "table"
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           "style": {
-            "description": "Line style. Only applies to time-series annotations", 
+            "description": "Line style. Only applies to time-series annotations",
             "enum": [
-              "dashed", 
-              "dotted", 
-              "solid", 
+              "dashed",
+              "dotted",
+              "solid",
               "longDashed"
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           "timeColumn": {
-            "description": "Column with event date or interval start date", 
-            "nullable": true, 
+            "description": "Column with event date or interval start date",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "titleColumn": {
-            "description": "Column with title", 
-            "nullable": true, 
+            "description": "Column with title",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "value": {
             "description": "For formula annotations, this contains the formula. For other types, this is the primary key of the source object."
-          }, 
+          },
           "width": {
-            "description": "Width of annotation line", 
-            "format": "float", 
-            "minimum": 0, 
+            "description": "Width of annotation line",
+            "format": "float",
+            "minimum": 0,
             "type": "number"
           }
-        }, 
+        },
         "required": [
-          "name", 
-          "show", 
-          "showMarkers", 
+          "name",
+          "show",
+          "showMarkers",
           "value"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "AnnotationLayerRestApi.get": {
         "properties": {
           "descr": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "name": {
-            "maxLength": 250, 
-            "nullable": true, 
+            "maxLength": 250,
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "AnnotationLayerRestApi.get_list": {
         "properties": {
           "changed_by": {
             "$ref": "#/components/schemas/AnnotationLayerRestApi.get_list.User1"
-          }, 
+          },
           "changed_on": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "changed_on_delta_humanized": {
             "readOnly": true
-          }, 
+          },
           "created_by": {
             "$ref": "#/components/schemas/AnnotationLayerRestApi.get_list.User"
-          }, 
+          },
           "created_on": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "descr": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "name": {
-            "maxLength": 250, 
-            "nullable": true, 
+            "maxLength": 250,
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "AnnotationLayerRestApi.get_list.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
+          "first_name",
           "last_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "AnnotationLayerRestApi.get_list.User1": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
+          "first_name",
           "last_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "AnnotationLayerRestApi.post": {
         "properties": {
           "descr": {
-            "description": "Give a description for this annotation layer", 
-            "nullable": true, 
+            "description": "Give a description for this annotation layer",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "name": {
-            "description": "The annotation layer name", 
-            "maxLength": 250, 
-            "minLength": 1, 
+            "description": "The annotation layer name",
+            "maxLength": 250,
+            "minLength": 1,
             "type": "string"
           }
-        }, 
+        },
         "required": [
           "name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "AnnotationLayerRestApi.put": {
         "properties": {
           "descr": {
-            "description": "Give a description for this annotation layer", 
+            "description": "Give a description for this annotation layer",
             "type": "string"
-          }, 
+          },
           "name": {
-            "description": "The annotation layer name", 
-            "maxLength": 250, 
-            "minLength": 1, 
+            "description": "The annotation layer name",
+            "maxLength": 250,
+            "minLength": 1,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "AnnotationRestApi.get": {
         "properties": {
           "end_dttm": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "json_metadata": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "layer": {
             "$ref": "#/components/schemas/AnnotationRestApi.get.AnnotationLayer"
-          }, 
+          },
           "long_descr": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "short_descr": {
-            "maxLength": 500, 
-            "nullable": true, 
+            "maxLength": 500,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "start_dttm": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "required": [
           "layer"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "AnnotationRestApi.get.AnnotationLayer": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "name": {
-            "maxLength": 250, 
-            "nullable": true, 
+            "maxLength": 250,
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "AnnotationRestApi.get_list": {
         "properties": {
           "changed_by": {
             "$ref": "#/components/schemas/AnnotationRestApi.get_list.User1"
-          }, 
+          },
           "changed_on_delta_humanized": {
             "readOnly": true
-          }, 
+          },
           "created_by": {
             "$ref": "#/components/schemas/AnnotationRestApi.get_list.User"
-          }, 
+          },
           "end_dttm": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "long_descr": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "short_descr": {
-            "maxLength": 500, 
-            "nullable": true, 
+            "maxLength": 500,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "start_dttm": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "AnnotationRestApi.get_list.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "required": [
           "first_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "AnnotationRestApi.get_list.User1": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "required": [
           "first_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "AnnotationRestApi.post": {
         "properties": {
           "end_dttm": {
-            "description": "The annotation end date time", 
-            "format": "date-time", 
+            "description": "The annotation end date time",
+            "format": "date-time",
             "type": "string"
-          }, 
+          },
           "json_metadata": {
-            "description": "JSON metadata", 
-            "nullable": true, 
+            "description": "JSON metadata",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "long_descr": {
-            "description": "A long description", 
-            "nullable": true, 
+            "description": "A long description",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "short_descr": {
-            "description": "A short description", 
-            "maxLength": 500, 
-            "minLength": 1, 
+            "description": "A short description",
+            "maxLength": 500,
+            "minLength": 1,
             "type": "string"
-          }, 
+          },
           "start_dttm": {
-            "description": "The annotation start date time", 
-            "format": "date-time", 
+            "description": "The annotation start date time",
+            "format": "date-time",
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "end_dttm", 
-          "short_descr", 
+          "end_dttm",
+          "short_descr",
           "start_dttm"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "AnnotationRestApi.put": {
         "properties": {
           "end_dttm": {
-            "description": "The annotation end date time", 
-            "format": "date-time", 
+            "description": "The annotation end date time",
+            "format": "date-time",
             "type": "string"
-          }, 
+          },
           "json_metadata": {
-            "description": "JSON metadata", 
-            "nullable": true, 
+            "description": "JSON metadata",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "long_descr": {
-            "description": "A long description", 
-            "nullable": true, 
+            "description": "A long description",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "short_descr": {
-            "description": "A short description", 
-            "maxLength": 500, 
-            "minLength": 1, 
+            "description": "A short description",
+            "maxLength": 500,
+            "minLength": 1,
             "type": "string"
-          }, 
+          },
           "start_dttm": {
-            "description": "The annotation start date time", 
-            "format": "date-time", 
+            "description": "The annotation start date time",
+            "format": "date-time",
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "AvailableDomainsSchema": {
         "properties": {
           "domains": {
             "items": {
               "type": "string"
-            }, 
+            },
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "CacheInvalidationRequestSchema": {
         "properties": {
           "datasource_uids": {
-            "description": "The uid of the dataset/datasource this new chart will use. A complete datasource identification needs `datasouce_uid` ", 
+            "description": "The uid of the dataset/datasource this new chart will use. A complete datasource identification needs `datasouce_uid` ",
             "items": {
               "type": "string"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "datasources": {
-            "description": "A list of the data source and database names", 
+            "description": "A list of the data source and database names",
             "items": {
               "$ref": "#/components/schemas/Datasource"
-            }, 
+            },
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "CacheRestApi.get": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "CacheRestApi.get_list": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "CacheRestApi.post": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "CacheRestApi.put": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ChartCacheScreenshotResponseSchema": {
         "properties": {
           "cache_key": {
-            "description": "The cache key", 
+            "description": "The cache key",
             "type": "string"
-          }, 
+          },
           "chart_url": {
-            "description": "The url to render the chart", 
+            "description": "The url to render the chart",
             "type": "string"
-          }, 
+          },
           "image_url": {
-            "description": "The url to fetch the screenshot", 
+            "description": "The url to fetch the screenshot",
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ChartDataAdhocMetricSchema": {
         "properties": {
           "aggregate": {
-            "description": "Aggregation operator. Only required for simple expression types.", 
+            "description": "Aggregation operator. Only required for simple expression types.",
             "enum": [
-              "AVG", 
-              "COUNT", 
-              "COUNT_DISTINCT", 
-              "MAX", 
-              "MIN", 
+              "AVG",
+              "COUNT",
+              "COUNT_DISTINCT",
+              "MAX",
+              "MIN",
               "SUM"
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           "column": {
             "$ref": "#/components/schemas/ChartDataColumn"
-          }, 
+          },
           "expressionType": {
-            "description": "Simple or SQL metric", 
+            "description": "Simple or SQL metric",
             "enum": [
-              "SIMPLE", 
+              "SIMPLE",
               "SQL"
-            ], 
-            "example": "SQL", 
+            ],
+            "example": "SQL",
             "type": "string"
-          }, 
+          },
           "hasCustomLabel": {
-            "description": "When false, the label will be automatically generated based on the aggregate expression. When true, a custom label has to be specified.", 
-            "example": true, 
+            "description": "When false, the label will be automatically generated based on the aggregate expression. When true, a custom label has to be specified.",
+            "example": true,
             "type": "boolean"
-          }, 
+          },
           "isExtra": {
-            "description": "Indicates if the filter has been added by a filter component as opposed to being a part of the original query.", 
+            "description": "Indicates if the filter has been added by a filter component as opposed to being a part of the original query.",
             "type": "boolean"
-          }, 
+          },
           "label": {
-            "description": "Label for the metric. Is automatically generated unless hasCustomLabel is true, in which case label must be defined.", 
-            "example": "Weighted observations", 
+            "description": "Label for the metric. Is automatically generated unless hasCustomLabel is true, in which case label must be defined.",
+            "example": "Weighted observations",
             "type": "string"
-          }, 
+          },
           "optionName": {
-            "description": "Unique identifier. Can be any string value, as long as all metrics have a unique identifier. If undefined, a random name will be generated.", 
-            "example": "metric_aec60732-fac0-4b17-b736-93f1a5c93e30", 
+            "description": "Unique identifier. Can be any string value, as long as all metrics have a unique identifier. If undefined, a random name will be generated.",
+            "example": "metric_aec60732-fac0-4b17-b736-93f1a5c93e30",
             "type": "string"
-          }, 
+          },
           "sqlExpression": {
-            "description": "The metric as defined by a SQL aggregate expression. Only required for SQL expression type.", 
-            "example": "SUM(weight * observations) / SUM(weight)", 
+            "description": "The metric as defined by a SQL aggregate expression. Only required for SQL expression type.",
+            "example": "SUM(weight * observations) / SUM(weight)",
             "type": "string"
-          }, 
+          },
           "timeGrain": {
-            "description": "Optional time grain for temporal filters", 
-            "example": "PT1M", 
+            "description": "Optional time grain for temporal filters",
+            "example": "PT1M",
             "type": "string"
           }
-        }, 
+        },
         "required": [
           "expressionType"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ChartDataAggregateOptionsSchema": {
         "properties": {
           "aggregates": {
-            "description": "The keys are the name of the aggregate column to be created, and the values specify the details of how to apply the aggregation. If an operator requires additional options, these can be passed here to be unpacked in the operator call. The following numpy operators are supported: average, argmin, argmax, cumsum, cumprod, max, mean, median, nansum, nanmin, nanmax, nanmean, nanmedian, min, percentile, prod, product, std, sum, var. Any options required by the operator can be passed to the `options` object.\n\nIn the example, a new column `first_quantile` is created based on values in the column `my_col` using the `percentile` operator with the `q=0.25` parameter.", 
+            "description": "The keys are the name of the aggregate column to be created, and the values specify the details of how to apply the aggregation. If an operator requires additional options, these can be passed here to be unpacked in the operator call. The following numpy operators are supported: average, argmin, argmax, cumsum, cumprod, max, mean, median, nansum, nanmin, nanmax, nanmean, nanmedian, min, percentile, prod, product, std, sum, var. Any options required by the operator can be passed to the `options` object.\n\nIn the example, a new column `first_quantile` is created based on values in the column `my_col` using the `percentile` operator with the `q=0.25` parameter.",
             "example": {
               "first_quantile": {
-                "column": "my_col", 
-                "operator": "percentile", 
+                "column": "my_col",
+                "operator": "percentile",
                 "options": {
                   "q": 0.25
                 }
               }
-            }, 
+            },
             "type": "object"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ChartDataAsyncResponseSchema": {
         "properties": {
           "channel_id": {
-            "description": "Unique session async channel ID", 
+            "description": "Unique session async channel ID",
             "type": "string"
-          }, 
+          },
           "job_id": {
-            "description": "Unique async job ID", 
+            "description": "Unique async job ID",
             "type": "string"
-          }, 
+          },
           "result_url": {
-            "description": "Unique result URL for fetching async query data", 
+            "description": "Unique result URL for fetching async query data",
             "type": "string"
-          }, 
+          },
           "status": {
-            "description": "Status value for async job", 
+            "description": "Status value for async job",
             "type": "string"
-          }, 
+          },
           "user_id": {
-            "description": "Requesting user ID", 
-            "nullable": true, 
+            "description": "Requesting user ID",
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ChartDataBoxplotOptionsSchema": {
         "properties": {
           "groupby": {
             "items": {
-              "description": "Columns by which to group the query.", 
+              "description": "Columns by which to group the query.",
               "type": "string"
-            }, 
-            "nullable": true, 
+            },
+            "nullable": true,
             "type": "array"
-          }, 
+          },
           "metrics": {
-            "description": "Aggregate expressions. Metrics can be passed as both references to datasource metrics (strings), or ad-hoc metricswhich are defined only within the query object. See `ChartDataAdhocMetricSchema` for the structure of ad-hoc metrics. When metrics is undefined or null, the query is executed without a groupby. However, when metrics is an array (length >= 0), a groupby clause is added to the query.", 
-            "items": {}, 
-            "nullable": true, 
+            "description": "Aggregate expressions. Metrics can be passed as both references to datasource metrics (strings), or ad-hoc metricswhich are defined only within the query object. See `ChartDataAdhocMetricSchema` for the structure of ad-hoc metrics. When metrics is undefined or null, the query is executed without a groupby. However, when metrics is an array (length >= 0), a groupby clause is added to the query.",
+            "items": {},
+            "nullable": true,
             "type": "array"
-          }, 
+          },
           "percentiles": {
-            "description": "Upper and lower percentiles for percentile whisker type.", 
+            "description": "Upper and lower percentiles for percentile whisker type.",
             "example": [
-              1, 
+              1,
               99
             ]
-          }, 
+          },
           "whisker_type": {
-            "description": "Whisker type. Any numpy function will work.", 
+            "description": "Whisker type. Any numpy function will work.",
             "enum": [
-              "tukey", 
-              "min/max", 
+              "tukey",
+              "min/max",
               "percentile"
-            ], 
-            "example": "tukey", 
+            ],
+            "example": "tukey",
             "type": "string"
           }
-        }, 
+        },
         "required": [
           "whisker_type"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ChartDataColumn": {
         "properties": {
           "column_name": {
-            "description": "The name of the target column", 
-            "example": "mycol", 
+            "description": "The name of the target column",
+            "example": "mycol",
             "type": "string"
-          }, 
+          },
           "type": {
-            "description": "Type of target column", 
-            "example": "BIGINT", 
+            "description": "Type of target column",
+            "example": "BIGINT",
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ChartDataContributionOptionsSchema": {
         "properties": {
           "orientation": {
-            "description": "Should cell values be calculated across the row or column.", 
+            "description": "Should cell values be calculated across the row or column.",
             "enum": [
-              "row", 
+              "row",
               "column"
-            ], 
-            "example": "row", 
+            ],
+            "example": "row",
             "type": "string"
           }
-        }, 
+        },
         "required": [
           "orientation"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ChartDataDatasource": {
         "properties": {
           "id": {
-            "description": "Datasource id", 
-            "format": "int32", 
+            "description": "Datasource id",
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "type": {
-            "description": "Datasource type", 
+            "description": "Datasource type",
             "enum": [
-              "sl_table", 
-              "table", 
-              "dataset", 
-              "query", 
-              "saved_query", 
+              "sl_table",
+              "table",
+              "dataset",
+              "query",
+              "saved_query",
               "view"
-            ], 
+            ],
             "type": "string"
           }
-        }, 
+        },
         "required": [
           "id"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ChartDataExtras": {
         "properties": {
           "having": {
-            "description": "HAVING clause to be added to aggregate queries using AND operator.", 
+            "description": "HAVING clause to be added to aggregate queries using AND operator.",
             "type": "string"
-          }, 
+          },
           "having_druid": {
-            "description": "HAVING filters to be added to legacy Druid datasource queries. This field is deprecated", 
+            "description": "HAVING filters to be added to legacy Druid datasource queries. This field is deprecated",
             "items": {
               "$ref": "#/components/schemas/ChartDataFilter"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "relative_end": {
-            "description": "End time for relative time deltas. Default: `config[\"DEFAULT_RELATIVE_START_TIME\"]`", 
+            "description": "End time for relative time deltas. Default: `config[\"DEFAULT_RELATIVE_START_TIME\"]`",
             "enum": [
-              "today", 
+              "today",
               "now"
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           "relative_start": {
-            "description": "Start time for relative time deltas. Default: `config[\"DEFAULT_RELATIVE_START_TIME\"]`", 
+            "description": "Start time for relative time deltas. Default: `config[\"DEFAULT_RELATIVE_START_TIME\"]`",
             "enum": [
-              "today", 
+              "today",
               "now"
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           "time_grain_sqla": {
-            "description": "To what level of granularity should the temporal column be aggregated. Supports [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) durations.", 
+            "description": "To what level of granularity should the temporal column be aggregated. Supports [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) durations.",
             "enum": [
-              "PT1S", 
-              "PT5S", 
-              "PT30S", 
-              "PT1M", 
-              "PT5M", 
-              "PT10M", 
-              "PT15M", 
-              "PT30M", 
-              "PT1H", 
-              "PT6H", 
-              "P1D", 
-              "P1W", 
-              "P1M", 
-              "P3M", 
-              "P1Y", 
-              "1969-12-28T00:00:00Z/P1W", 
-              "1969-12-29T00:00:00Z/P1W", 
-              "P1W/1970-01-03T00:00:00Z", 
+              "PT1S",
+              "PT5S",
+              "PT30S",
+              "PT1M",
+              "PT5M",
+              "PT10M",
+              "PT15M",
+              "PT30M",
+              "PT1H",
+              "PT6H",
+              "P1D",
+              "P1W",
+              "P1M",
+              "P3M",
+              "P1Y",
+              "1969-12-28T00:00:00Z/P1W",
+              "1969-12-29T00:00:00Z/P1W",
+              "P1W/1970-01-03T00:00:00Z",
               "P1W/1970-01-04T00:00:00Z"
-            ], 
-            "example": "P1D", 
-            "nullable": true, 
+            ],
+            "example": "P1D",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "where": {
-            "description": "WHERE clause to be added to queries using AND operator.", 
+            "description": "WHERE clause to be added to queries using AND operator.",
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ChartDataFilter": {
         "properties": {
           "col": {
-            "description": "The column to filter by. Can be either a string (physical or saved expression) or an object (adhoc column)", 
+            "description": "The column to filter by. Can be either a string (physical or saved expression) or an object (adhoc column)",
             "example": "country"
-          }, 
+          },
           "grain": {
-            "description": "Optional time grain for temporal filters", 
-            "example": "PT1M", 
+            "description": "Optional time grain for temporal filters",
+            "example": "PT1M",
             "type": "string"
-          }, 
+          },
           "isExtra": {
-            "description": "Indicates if the filter has been added by a filter component as opposed to being a part of the original query.", 
+            "description": "Indicates if the filter has been added by a filter component as opposed to being a part of the original query.",
             "type": "boolean"
-          }, 
+          },
           "op": {
-            "description": "The comparison operator.", 
+            "description": "The comparison operator.",
             "enum": [
-              "==", 
-              "!=", 
-              ">", 
-              "<", 
-              ">=", 
-              "<=", 
-              "LIKE", 
-              "ILIKE", 
-              "IS NULL", 
-              "IS NOT NULL", 
-              "IN", 
-              "NOT IN", 
-              "REGEX", 
-              "IS TRUE", 
-              "IS FALSE", 
+              "==",
+              "!=",
+              ">",
+              "<",
+              ">=",
+              "<=",
+              "LIKE",
+              "ILIKE",
+              "IS NULL",
+              "IS NOT NULL",
+              "IN",
+              "NOT IN",
+              "REGEX",
+              "IS TRUE",
+              "IS FALSE",
               "TEMPORAL_RANGE"
-            ], 
-            "example": "IN", 
+            ],
+            "example": "IN",
             "type": "string"
-          }, 
+          },
           "val": {
-            "description": "The value or values to compare against. Can be a string, integer, decimal, None or list, depending on the operator.", 
+            "description": "The value or values to compare against. Can be a string, integer, decimal, None or list, depending on the operator.",
             "example": [
-              "China", 
-              "France", 
+              "China",
+              "France",
               "Japan"
-            ], 
+            ],
             "nullable": true
           }
-        }, 
+        },
         "required": [
-          "col", 
+          "col",
           "op"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ChartDataGeodeticParseOptionsSchema": {
         "properties": {
           "altitude": {
-            "description": "Name of target column for decoded altitude. If omitted, altitude information in geodetic string is ignored.", 
+            "description": "Name of target column for decoded altitude. If omitted, altitude information in geodetic string is ignored.",
             "type": "string"
-          }, 
+          },
           "geodetic": {
-            "description": "Name of source column containing geodetic point strings", 
+            "description": "Name of source column containing geodetic point strings",
             "type": "string"
-          }, 
+          },
           "latitude": {
-            "description": "Name of target column for decoded latitude", 
+            "description": "Name of target column for decoded latitude",
             "type": "string"
-          }, 
+          },
           "longitude": {
-            "description": "Name of target column for decoded longitude", 
+            "description": "Name of target column for decoded longitude",
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "geodetic", 
-          "latitude", 
+          "geodetic",
+          "latitude",
           "longitude"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ChartDataGeohashDecodeOptionsSchema": {
         "properties": {
           "geohash": {
-            "description": "Name of source column containing geohash string", 
+            "description": "Name of source column containing geohash string",
             "type": "string"
-          }, 
+          },
           "latitude": {
-            "description": "Name of target column for decoded latitude", 
+            "description": "Name of target column for decoded latitude",
             "type": "string"
-          }, 
+          },
           "longitude": {
-            "description": "Name of target column for decoded longitude", 
+            "description": "Name of target column for decoded longitude",
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "geohash", 
-          "latitude", 
+          "geohash",
+          "latitude",
           "longitude"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ChartDataGeohashEncodeOptionsSchema": {
         "properties": {
           "geohash": {
-            "description": "Name of target column for encoded geohash string", 
+            "description": "Name of target column for encoded geohash string",
             "type": "string"
-          }, 
+          },
           "latitude": {
-            "description": "Name of source latitude column", 
+            "description": "Name of source latitude column",
             "type": "string"
-          }, 
+          },
           "longitude": {
-            "description": "Name of source longitude column", 
+            "description": "Name of source longitude column",
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "geohash", 
-          "latitude", 
+          "geohash",
+          "latitude",
           "longitude"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ChartDataPivotOptionsSchema": {
         "properties": {
           "aggregates": {
-            "description": "The keys are the name of the aggregate column to be created, and the values specify the details of how to apply the aggregation. If an operator requires additional options, these can be passed here to be unpacked in the operator call. The following numpy operators are supported: average, argmin, argmax, cumsum, cumprod, max, mean, median, nansum, nanmin, nanmax, nanmean, nanmedian, min, percentile, prod, product, std, sum, var. Any options required by the operator can be passed to the `options` object.\n\nIn the example, a new column `first_quantile` is created based on values in the column `my_col` using the `percentile` operator with the `q=0.25` parameter.", 
+            "description": "The keys are the name of the aggregate column to be created, and the values specify the details of how to apply the aggregation. If an operator requires additional options, these can be passed here to be unpacked in the operator call. The following numpy operators are supported: average, argmin, argmax, cumsum, cumprod, max, mean, median, nansum, nanmin, nanmax, nanmean, nanmedian, min, percentile, prod, product, std, sum, var. Any options required by the operator can be passed to the `options` object.\n\nIn the example, a new column `first_quantile` is created based on values in the column `my_col` using the `percentile` operator with the `q=0.25` parameter.",
             "example": {
               "first_quantile": {
-                "column": "my_col", 
-                "operator": "percentile", 
+                "column": "my_col",
+                "operator": "percentile",
                 "options": {
                   "q": 0.25
                 }
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           "column_fill_value": {
-            "description": "Value to replace missing pivot columns names with.", 
+            "description": "Value to replace missing pivot columns names with.",
             "type": "string"
-          }, 
+          },
           "columns": {
-            "description": "Columns to group by on the table columns", 
+            "description": "Columns to group by on the table columns",
             "items": {
               "type": "string"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "drop_missing_columns": {
-            "description": "Do not include columns whose entries are all missing (default: `true`).", 
+            "description": "Do not include columns whose entries are all missing (default: `true`).",
             "type": "boolean"
-          }, 
+          },
           "marginal_distribution_name": {
-            "description": "Name of marginal distribution row/column. (default: `All`)", 
+            "description": "Name of marginal distribution row/column. (default: `All`)",
             "type": "string"
-          }, 
+          },
           "marginal_distributions": {
-            "description": "Add totals for row/column. (default: `false`)", 
+            "description": "Add totals for row/column. (default: `false`)",
             "type": "boolean"
-          }, 
+          },
           "metric_fill_value": {
-            "description": "Value to replace missing values with in aggregate calculations.", 
+            "description": "Value to replace missing values with in aggregate calculations.",
             "type": "number"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ChartDataPostProcessingOperation": {
         "properties": {
           "operation": {
-            "description": "Post processing operation type", 
+            "description": "Post processing operation type",
             "enum": [
-              "aggregate", 
-              "boxplot", 
-              "compare", 
-              "contribution", 
-              "cum", 
-              "diff", 
-              "escape_separator", 
-              "flatten", 
-              "geodetic_parse", 
-              "geohash_decode", 
-              "geohash_encode", 
-              "pivot", 
-              "prophet", 
-              "rename", 
-              "resample", 
-              "rolling", 
-              "select", 
-              "sort", 
+              "aggregate",
+              "boxplot",
+              "compare",
+              "contribution",
+              "cum",
+              "diff",
+              "escape_separator",
+              "flatten",
+              "geodetic_parse",
+              "geohash_decode",
+              "geohash_encode",
+              "pivot",
+              "prophet",
+              "rename",
+              "resample",
+              "rolling",
+              "select",
+              "sort",
               "unescape_separator"
-            ], 
-            "example": "aggregate", 
+            ],
+            "example": "aggregate",
             "type": "string"
-          }, 
+          },
           "options": {
-            "description": "Options specifying how to perform the operation. Please refer to the respective post processing operation option schemas. For example, `ChartDataPostProcessingOperationOptions` specifies the required options for the pivot operation.", 
+            "description": "Options specifying how to perform the operation. Please refer to the respective post processing operation option schemas. For example, `ChartDataPostProcessingOperationOptions` specifies the required options for the pivot operation.",
             "example": {
               "aggregates": {
                 "age_mean": {
-                  "column": "age", 
+                  "column": "age",
                   "operator": "mean"
-                }, 
+                },
                 "age_q1": {
-                  "column": "age", 
-                  "operator": "percentile", 
+                  "column": "age",
+                  "operator": "percentile",
                   "options": {
                     "q": 0.25
                   }
                 }
-              }, 
+              },
               "groupby": [
-                "country", 
+                "country",
                 "gender"
               ]
-            }, 
+            },
             "type": "object"
           }
-        }, 
+        },
         "required": [
           "operation"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ChartDataProphetOptionsSchema": {
         "properties": {
           "confidence_interval": {
-            "description": "Width of predicted confidence interval", 
-            "example": 0.8, 
-            "format": "float", 
-            "maximum": 1, 
-            "minimum": 0, 
+            "description": "Width of predicted confidence interval",
+            "example": 0.8,
+            "format": "float",
+            "maximum": 1,
+            "minimum": 0,
             "type": "number"
-          }, 
+          },
           "monthly_seasonality": {
-            "description": "Should monthly seasonality be applied. An integer value will specify Fourier order of seasonality, `None` will automatically detect seasonality.", 
+            "description": "Should monthly seasonality be applied. An integer value will specify Fourier order of seasonality, `None` will automatically detect seasonality.",
             "example": false
-          }, 
+          },
           "periods": {
-            "example": 7, 
-            "format": "int32", 
+            "example": 7,
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "time_grain": {
-            "description": "Time grain used to specify time period increments in prediction. Supports [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) durations.", 
+            "description": "Time grain used to specify time period increments in prediction. Supports [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) durations.",
             "enum": [
-              "PT1S", 
-              "PT5S", 
-              "PT30S", 
-              "PT1M", 
-              "PT5M", 
-              "PT10M", 
-              "PT15M", 
-              "PT30M", 
-              "PT1H", 
-              "PT6H", 
-              "P1D", 
-              "P1W", 
-              "P1M", 
-              "P3M", 
-              "P1Y", 
-              "1969-12-28T00:00:00Z/P1W", 
-              "1969-12-29T00:00:00Z/P1W", 
-              "P1W/1970-01-03T00:00:00Z", 
+              "PT1S",
+              "PT5S",
+              "PT30S",
+              "PT1M",
+              "PT5M",
+              "PT10M",
+              "PT15M",
+              "PT30M",
+              "PT1H",
+              "PT6H",
+              "P1D",
+              "P1W",
+              "P1M",
+              "P3M",
+              "P1Y",
+              "1969-12-28T00:00:00Z/P1W",
+              "1969-12-29T00:00:00Z/P1W",
+              "P1W/1970-01-03T00:00:00Z",
               "P1W/1970-01-04T00:00:00Z"
-            ], 
-            "example": "P1D", 
+            ],
+            "example": "P1D",
             "type": "string"
-          }, 
+          },
           "weekly_seasonality": {
-            "description": "Should weekly seasonality be applied. An integer value will specify Fourier order of seasonality, `None` will automatically detect seasonality.", 
+            "description": "Should weekly seasonality be applied. An integer value will specify Fourier order of seasonality, `None` will automatically detect seasonality.",
             "example": false
-          }, 
+          },
           "yearly_seasonality": {
-            "description": "Should yearly seasonality be applied. An integer value will specify Fourier order of seasonality, `None` will automatically detect seasonality.", 
+            "description": "Should yearly seasonality be applied. An integer value will specify Fourier order of seasonality, `None` will automatically detect seasonality.",
             "example": false
           }
-        }, 
+        },
         "required": [
-          "confidence_interval", 
-          "periods", 
+          "confidence_interval",
+          "periods",
           "time_grain"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ChartDataQueryContextSchema": {
         "properties": {
           "custom_cache_timeout": {
-            "description": "Override the default cache timeout", 
-            "format": "int32", 
-            "nullable": true, 
+            "description": "Override the default cache timeout",
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "datasource": {
             "$ref": "#/components/schemas/ChartDataDatasource"
-          }, 
+          },
           "force": {
-            "description": "Should the queries be forced to load from the source. Default: `false`", 
-            "nullable": true, 
+            "description": "Should the queries be forced to load from the source. Default: `false`",
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "form_data": {
             "nullable": true
-          }, 
+          },
           "queries": {
             "items": {
               "$ref": "#/components/schemas/ChartDataQueryObject"
-            }, 
+            },
             "type": "array"
-          }, 
-          "result_format": {}, 
+          },
+          "result_format": {},
           "result_type": {}
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ChartDataQueryObject": {
         "properties": {
           "annotation_layers": {
-            "description": "Annotation layers to apply to chart", 
+            "description": "Annotation layers to apply to chart",
             "items": {
               "$ref": "#/components/schemas/AnnotationLayer"
-            }, 
-            "nullable": true, 
+            },
+            "nullable": true,
             "type": "array"
-          }, 
+          },
           "applied_time_extras": {
-            "description": "A mapping of temporal extras that have been applied to the query", 
+            "description": "A mapping of temporal extras that have been applied to the query",
             "example": {
               "__time_range": "1 year ago : now"
-            }, 
-            "nullable": true, 
+            },
+            "nullable": true,
             "type": "object"
-          }, 
+          },
           "apply_fetch_values_predicate": {
-            "description": "Add fetch values predicate (where clause) to query if defined in datasource", 
-            "nullable": true, 
+            "description": "Add fetch values predicate (where clause) to query if defined in datasource",
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "columns": {
-            "description": "Columns which to select in the query.", 
-            "items": {}, 
-            "nullable": true, 
+            "description": "Columns which to select in the query.",
+            "items": {},
+            "nullable": true,
             "type": "array"
-          }, 
+          },
           "datasource": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/ChartDataDatasource"
               }
-            ], 
+            ],
             "nullable": true
-          }, 
+          },
           "druid_time_origin": {
-            "description": "Starting point for time grain counting on legacy Druid datasources. Used to change e.g. Monday/Sunday first-day-of-week. This field is deprecated and should be passed to `extras` as `druid_time_origin`.", 
-            "nullable": true, 
+            "description": "Starting point for time grain counting on legacy Druid datasources. Used to change e.g. Monday/Sunday first-day-of-week. This field is deprecated and should be passed to `extras` as `druid_time_origin`.",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "extras": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/ChartDataExtras"
               }
-            ], 
-            "description": "Extra parameters to add to the query.", 
+            ],
+            "description": "Extra parameters to add to the query.",
             "nullable": true
-          }, 
+          },
           "filters": {
             "items": {
               "$ref": "#/components/schemas/ChartDataFilter"
-            }, 
-            "nullable": true, 
+            },
+            "nullable": true,
             "type": "array"
-          }, 
+          },
           "granularity": {
-            "description": "Name of temporal column used for time filtering. For legacy Druid datasources this defines the time grain.", 
-            "nullable": true, 
+            "description": "Name of temporal column used for time filtering. For legacy Druid datasources this defines the time grain.",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "granularity_sqla": {
-            "description": "Name of temporal column used for time filtering for SQL datasources. This field is deprecated, use `granularity` instead.", 
-            "nullable": true, 
+            "description": "Name of temporal column used for time filtering for SQL datasources. This field is deprecated, use `granularity` instead.",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "groupby": {
-            "description": "Columns by which to group the query. This field is deprecated, use `columns` instead.", 
-            "items": {}, 
-            "nullable": true, 
+            "description": "Columns by which to group the query. This field is deprecated, use `columns` instead.",
+            "items": {},
+            "nullable": true,
             "type": "array"
-          }, 
+          },
           "having": {
-            "description": "HAVING clause to be added to aggregate queries using AND operator. This field is deprecated and should be passed to `extras`.", 
-            "nullable": true, 
+            "description": "HAVING clause to be added to aggregate queries using AND operator. This field is deprecated and should be passed to `extras`.",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "having_filters": {
-            "description": "HAVING filters to be added to legacy Druid datasource queries. This field is deprecated and should be passed to `extras` as `having_druid`.", 
+            "description": "HAVING filters to be added to legacy Druid datasource queries. This field is deprecated and should be passed to `extras` as `having_druid`.",
             "items": {
               "$ref": "#/components/schemas/ChartDataFilter"
-            }, 
-            "nullable": true, 
+            },
+            "nullable": true,
             "type": "array"
-          }, 
+          },
           "is_rowcount": {
-            "description": "Should the rowcount of the actual query be returned", 
-            "nullable": true, 
+            "description": "Should the rowcount of the actual query be returned",
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "is_timeseries": {
-            "description": "Is the `query_object` a timeseries.", 
-            "nullable": true, 
+            "description": "Is the `query_object` a timeseries.",
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "metrics": {
-            "description": "Aggregate expressions. Metrics can be passed as both references to datasource metrics (strings), or ad-hoc metricswhich are defined only within the query object. See `ChartDataAdhocMetricSchema` for the structure of ad-hoc metrics.", 
-            "items": {}, 
-            "nullable": true, 
+            "description": "Aggregate expressions. Metrics can be passed as both references to datasource metrics (strings), or ad-hoc metricswhich are defined only within the query object. See `ChartDataAdhocMetricSchema` for the structure of ad-hoc metrics.",
+            "items": {},
+            "nullable": true,
             "type": "array"
-          }, 
+          },
           "order_desc": {
-            "description": "Reverse order. Default: `false`", 
-            "nullable": true, 
+            "description": "Reverse order. Default: `false`",
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "orderby": {
-            "description": "Expects a list of lists where the first element is the column name which to sort by, and the second element is a boolean.", 
+            "description": "Expects a list of lists where the first element is the column name which to sort by, and the second element is a boolean.",
             "example": [
               [
-                "my_col_1", 
+                "my_col_1",
                 false
-              ], 
+              ],
               [
-                "my_col_2", 
+                "my_col_2",
                 true
               ]
-            ], 
-            "items": {}, 
-            "nullable": true, 
+            ],
+            "items": {},
+            "nullable": true,
             "type": "array"
-          }, 
+          },
           "post_processing": {
-            "description": "Post processing operations to be applied to the result set. Operations are applied to the result set in sequential order.", 
+            "description": "Post processing operations to be applied to the result set. Operations are applied to the result set in sequential order.",
             "items": {
               "allOf": [
                 {
                   "$ref": "#/components/schemas/ChartDataPostProcessingOperation"
                 }
-              ], 
+              ],
               "nullable": true
-            }, 
-            "nullable": true, 
+            },
+            "nullable": true,
             "type": "array"
-          }, 
+          },
           "result_type": {
             "nullable": true
-          }, 
+          },
           "row_limit": {
-            "description": "Maximum row count (0=disabled). Default: `config[\"ROW_LIMIT\"]`", 
-            "format": "int32", 
-            "minimum": 0, 
-            "nullable": true, 
+            "description": "Maximum row count (0=disabled). Default: `config[\"ROW_LIMIT\"]`",
+            "format": "int32",
+            "minimum": 0,
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "row_offset": {
-            "description": "Number of rows to skip. Default: `0`", 
-            "format": "int32", 
-            "minimum": 0, 
-            "nullable": true, 
+            "description": "Number of rows to skip. Default: `0`",
+            "format": "int32",
+            "minimum": 0,
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "series_columns": {
-            "description": "Columns to use when limiting series count. All columns must be present in the `columns` property. Requires `series_limit` and `series_limit_metric` to be set.", 
-            "items": {}, 
-            "nullable": true, 
+            "description": "Columns to use when limiting series count. All columns must be present in the `columns` property. Requires `series_limit` and `series_limit_metric` to be set.",
+            "items": {},
+            "nullable": true,
             "type": "array"
-          }, 
+          },
           "series_limit": {
-            "description": "Maximum number of series. Requires `series` and `series_limit_metric` to be set.", 
-            "format": "int32", 
-            "nullable": true, 
+            "description": "Maximum number of series. Requires `series` and `series_limit_metric` to be set.",
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "series_limit_metric": {
-            "description": "Metric used to limit timeseries queries by. Requires `series` and `series_limit` to be set.", 
+            "description": "Metric used to limit timeseries queries by. Requires `series` and `series_limit` to be set.",
             "nullable": true
-          }, 
+          },
           "time_offsets": {
             "items": {
               "type": "string"
-            }, 
-            "nullable": true, 
+            },
+            "nullable": true,
             "type": "array"
-          }, 
+          },
           "time_range": {
-            "description": "A time rage, either expressed as a colon separated string `since : until` or human readable freeform. Valid formats for `since` and `until` are: \n- ISO 8601\n- X days/years/hours/day/year/weeks\n- X days/years/hours/day/year/weeks ago\n- X days/years/hours/day/year/weeks from now\n\nAdditionally, the following freeform can be used:\n\n- Last day\n- Last week\n- Last month\n- Last quarter\n- Last year\n- No filter\n- Last X seconds/minutes/hours/days/weeks/months/years\n- Next X seconds/minutes/hours/days/weeks/months/years\n", 
-            "example": "Last week", 
-            "nullable": true, 
+            "description": "A time rage, either expressed as a colon separated string `since : until` or human readable freeform. Valid formats for `since` and `until` are: \n- ISO 8601\n- X days/years/hours/day/year/weeks\n- X days/years/hours/day/year/weeks ago\n- X days/years/hours/day/year/weeks from now\n\nAdditionally, the following freeform can be used:\n\n- Last day\n- Last week\n- Last month\n- Last quarter\n- Last year\n- No filter\n- Last X seconds/minutes/hours/days/weeks/months/years\n- Next X seconds/minutes/hours/days/weeks/months/years\n",
+            "example": "Last week",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "time_shift": {
-            "description": "A human-readable date/time string. Please refer to [parsdatetime](https://github.com/bear/parsedatetime) documentation for details on valid values.", 
-            "nullable": true, 
+            "description": "A human-readable date/time string. Please refer to [parsdatetime](https://github.com/bear/parsedatetime) documentation for details on valid values.",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "timeseries_limit": {
-            "description": "Maximum row count for timeseries queries. This field is deprecated, use `series_limit` instead.Default: `0`", 
-            "format": "int32", 
-            "nullable": true, 
+            "description": "Maximum row count for timeseries queries. This field is deprecated, use `series_limit` instead.Default: `0`",
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "timeseries_limit_metric": {
-            "description": "Metric used to limit timeseries queries by. This field is deprecated, use `series_limit_metric` instead.", 
+            "description": "Metric used to limit timeseries queries by. This field is deprecated, use `series_limit_metric` instead.",
             "nullable": true
-          }, 
+          },
           "url_params": {
             "additionalProperties": {
-              "description": "The value of the query parameter", 
+              "description": "The value of the query parameter",
               "type": "string"
-            }, 
-            "description": "Optional query parameters passed to a dashboard or Explore view", 
-            "nullable": true, 
+            },
+            "description": "Optional query parameters passed to a dashboard or Explore view",
+            "nullable": true,
             "type": "object"
-          }, 
+          },
           "where": {
-            "description": "WHERE clause to be added to queries using AND operator.This field is deprecated and should be passed to `extras`.", 
-            "nullable": true, 
+            "description": "WHERE clause to be added to queries using AND operator.This field is deprecated and should be passed to `extras`.",
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ChartDataResponseResult": {
         "properties": {
           "annotation_data": {
-            "description": "All requested annotation data", 
+            "description": "All requested annotation data",
             "items": {
               "additionalProperties": {
                 "type": "string"
-              }, 
+              },
               "type": "object"
-            }, 
-            "nullable": true, 
+            },
+            "nullable": true,
             "type": "array"
-          }, 
+          },
           "applied_filters": {
-            "description": "A list with applied filters", 
+            "description": "A list with applied filters",
             "items": {
               "type": "object"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "cache_key": {
-            "description": "Unique cache key for query object", 
-            "nullable": true, 
+            "description": "Unique cache key for query object",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "cache_timeout": {
-            "description": "Cache timeout in following order: custom timeout, datasource timeout, cache default timeout, config default cache timeout.", 
-            "format": "int32", 
-            "nullable": true, 
+            "description": "Cache timeout in following order: custom timeout, datasource timeout, cache default timeout, config default cache timeout.",
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "cached_dttm": {
-            "description": "Cache timestamp", 
-            "nullable": true, 
+            "description": "Cache timestamp",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "colnames": {
-            "description": "A list of column names", 
+            "description": "A list of column names",
             "items": {
               "type": "string"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "coltypes": {
-            "description": "A list of generic data types of each column", 
+            "description": "A list of generic data types of each column",
             "items": {
-              "format": "int32", 
+              "format": "int32",
               "type": "integer"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "data": {
-            "description": "A list with results", 
+            "description": "A list with results",
             "items": {
               "type": "object"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "error": {
-            "description": "Error", 
-            "nullable": true, 
+            "description": "Error",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "from_dttm": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "is_cached": {
-            "description": "Is the result cached", 
+            "description": "Is the result cached",
             "type": "boolean"
-          }, 
+          },
           "query": {
-            "description": "The executed query statement", 
+            "description": "The executed query statement",
             "type": "string"
-          }, 
+          },
           "rejected_filters": {
-            "description": "A list with rejected filters", 
+            "description": "A list with rejected filters",
             "items": {
               "type": "object"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "rowcount": {
-            "description": "Amount of rows in result set", 
-            "format": "int32", 
+            "description": "Amount of rows in result set",
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "stacktrace": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "status": {
-            "description": "Status of the query", 
+            "description": "Status of the query",
             "enum": [
-              "stopped", 
-              "failed", 
-              "pending", 
-              "running", 
-              "scheduled", 
-              "success", 
+              "stopped",
+              "failed",
+              "pending",
+              "running",
+              "scheduled",
+              "success",
               "timed_out"
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           "to_dttm": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
           }
-        }, 
+        },
         "required": [
-          "cache_key", 
-          "cache_timeout", 
-          "cached_dttm", 
-          "is_cached", 
+          "cache_key",
+          "cache_timeout",
+          "cached_dttm",
+          "is_cached",
           "query"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ChartDataResponseSchema": {
         "properties": {
           "result": {
-            "description": "A list of results for each corresponding query in the request.", 
+            "description": "A list of results for each corresponding query in the request.",
             "items": {
               "$ref": "#/components/schemas/ChartDataResponseResult"
-            }, 
+            },
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ChartDataRestApi.get": {
         "properties": {
           "cache_timeout": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "certification_details": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "certified_by": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "changed_on_delta_humanized": {
             "readOnly": true
-          }, 
+          },
           "dashboards": {
             "$ref": "#/components/schemas/ChartDataRestApi.get.Dashboard"
-          }, 
+          },
           "description": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "is_managed_externally": {
             "type": "boolean"
-          }, 
+          },
           "owners": {
             "$ref": "#/components/schemas/ChartDataRestApi.get.User"
-          }, 
+          },
           "params": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "query_context": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "slice_name": {
-            "maxLength": 250, 
-            "nullable": true, 
+            "maxLength": 250,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "thumbnail_url": {
             "readOnly": true
-          }, 
+          },
           "url": {
             "readOnly": true
-          }, 
+          },
           "viz_type": {
-            "maxLength": 250, 
-            "nullable": true, 
+            "maxLength": 250,
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ChartDataRestApi.get.Dashboard": {
         "properties": {
           "dashboard_title": {
-            "maxLength": 500, 
-            "nullable": true, 
+            "maxLength": 500,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "json_metadata": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ChartDataRestApi.get.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "username": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
-          "last_name", 
+          "first_name",
+          "last_name",
           "username"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ChartDataRestApi.get_list": {
         "properties": {
           "cache_timeout": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "certification_details": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "certified_by": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "changed_by": {
             "$ref": "#/components/schemas/ChartDataRestApi.get_list.User1"
-          }, 
+          },
           "changed_by_name": {
             "readOnly": true
-          }, 
+          },
           "changed_by_url": {
             "readOnly": true
-          }, 
+          },
           "changed_on_delta_humanized": {
             "readOnly": true
-          }, 
+          },
           "changed_on_utc": {
             "readOnly": true
-          }, 
+          },
           "created_by": {
             "$ref": "#/components/schemas/ChartDataRestApi.get_list.User3"
-          }, 
+          },
           "created_on_delta_humanized": {
             "readOnly": true
-          }, 
+          },
           "dashboards": {
             "$ref": "#/components/schemas/ChartDataRestApi.get_list.Dashboard"
-          }, 
+          },
           "datasource_id": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "datasource_name_text": {
             "readOnly": true
-          }, 
+          },
           "datasource_type": {
-            "maxLength": 200, 
-            "nullable": true, 
+            "maxLength": 200,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "datasource_url": {
             "readOnly": true
-          }, 
+          },
           "description": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "description_markeddown": {
             "readOnly": true
-          }, 
+          },
           "edit_url": {
             "readOnly": true
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "is_managed_externally": {
             "type": "boolean"
-          }, 
+          },
           "last_saved_at": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "last_saved_by": {
             "$ref": "#/components/schemas/ChartDataRestApi.get_list.User"
-          }, 
+          },
           "owners": {
             "$ref": "#/components/schemas/ChartDataRestApi.get_list.User2"
-          }, 
+          },
           "params": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "slice_name": {
-            "maxLength": 250, 
-            "nullable": true, 
+            "maxLength": 250,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "table": {
             "$ref": "#/components/schemas/ChartDataRestApi.get_list.SqlaTable"
-          }, 
+          },
           "thumbnail_url": {
             "readOnly": true
-          }, 
+          },
           "url": {
             "readOnly": true
-          }, 
+          },
           "viz_type": {
-            "maxLength": 250, 
-            "nullable": true, 
+            "maxLength": 250,
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ChartDataRestApi.get_list.Dashboard": {
         "properties": {
           "dashboard_title": {
-            "maxLength": 500, 
-            "nullable": true, 
+            "maxLength": 500,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ChartDataRestApi.get_list.SqlaTable": {
         "properties": {
           "default_endpoint": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "table_name": {
-            "maxLength": 250, 
+            "maxLength": 250,
             "type": "string"
           }
-        }, 
+        },
         "required": [
           "table_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ChartDataRestApi.get_list.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
+          "first_name",
           "last_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ChartDataRestApi.get_list.User1": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
+          "first_name",
           "last_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ChartDataRestApi.get_list.User2": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "username": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
-          "last_name", 
+          "first_name",
+          "last_name",
           "username"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ChartDataRestApi.get_list.User3": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
+          "first_name",
           "last_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ChartDataRestApi.post": {
         "properties": {
           "cache_timeout": {
-            "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.", 
-            "format": "int32", 
-            "nullable": true, 
+            "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.",
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "certification_details": {
-            "description": "Details of the certification", 
-            "nullable": true, 
+            "description": "Details of the certification",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "certified_by": {
-            "description": "Person or group that has certified this chart", 
-            "nullable": true, 
+            "description": "Person or group that has certified this chart",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "dashboards": {
             "items": {
-              "description": "A list of dashboards to include this new chart to.", 
-              "format": "int32", 
+              "description": "A list of dashboards to include this new chart to.",
+              "format": "int32",
               "type": "integer"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "datasource_id": {
-            "description": "The id of the dataset/datasource this new chart will use. A complete datasource identification needs `datasouce_id` and `datasource_type`.", 
-            "format": "int32", 
+            "description": "The id of the dataset/datasource this new chart will use. A complete datasource identification needs `datasouce_id` and `datasource_type`.",
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "datasource_name": {
-            "description": "The datasource name.", 
-            "nullable": true, 
+            "description": "The datasource name.",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "datasource_type": {
-            "description": "The type of dataset/datasource identified on `datasource_id`.", 
+            "description": "The type of dataset/datasource identified on `datasource_id`.",
             "enum": [
-              "sl_table", 
-              "table", 
-              "dataset", 
-              "query", 
-              "saved_query", 
+              "sl_table",
+              "table",
+              "dataset",
+              "query",
+              "saved_query",
               "view"
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           "description": {
-            "description": "A description of the chart propose.", 
-            "nullable": true, 
+            "description": "A description of the chart propose.",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "external_url": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "is_managed_externally": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "owners": {
             "items": {
-              "description": "Owner are users ids allowed to delete or change this chart. If left empty you will be one of the owners of the chart.", 
-              "format": "int32", 
+              "description": "Owner are users ids allowed to delete or change this chart. If left empty you will be one of the owners of the chart.",
+              "format": "int32",
               "type": "integer"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "params": {
-            "description": "Parameters are generated dynamically when clicking the save or overwrite button in the explore view. This JSON object for power users who may want to alter specific parameters.", 
-            "nullable": true, 
+            "description": "Parameters are generated dynamically when clicking the save or overwrite button in the explore view. This JSON object for power users who may want to alter specific parameters.",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "query_context": {
-            "description": "The query context represents the queries that need to run in order to generate the data the visualization, and in what format the data should be returned.", 
-            "nullable": true, 
+            "description": "The query context represents the queries that need to run in order to generate the data the visualization, and in what format the data should be returned.",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "query_context_generation": {
-            "description": "The query context generation represents whether the query_contextis user generated or not so that it does not update user modfiedstate.", 
-            "nullable": true, 
+            "description": "The query context generation represents whether the query_contextis user generated or not so that it does not update user modfiedstate.",
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "slice_name": {
-            "description": "The name of the chart.", 
-            "maxLength": 250, 
-            "minLength": 1, 
+            "description": "The name of the chart.",
+            "maxLength": 250,
+            "minLength": 1,
             "type": "string"
-          }, 
+          },
           "viz_type": {
-            "description": "The type of chart visualization used.", 
+            "description": "The type of chart visualization used.",
             "example": [
-              "bar", 
-              "line_multi", 
-              "area", 
+              "bar",
+              "line_multi",
+              "area",
               "table"
-            ], 
-            "maxLength": 250, 
-            "minLength": 0, 
+            ],
+            "maxLength": 250,
+            "minLength": 0,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "datasource_id", 
-          "datasource_type", 
+          "datasource_id",
+          "datasource_type",
           "slice_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ChartDataRestApi.put": {
         "properties": {
           "cache_timeout": {
-            "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.", 
-            "format": "int32", 
-            "nullable": true, 
+            "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.",
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "certification_details": {
-            "description": "Details of the certification", 
-            "nullable": true, 
+            "description": "Details of the certification",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "certified_by": {
-            "description": "Person or group that has certified this chart", 
-            "nullable": true, 
+            "description": "Person or group that has certified this chart",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "dashboards": {
             "items": {
-              "description": "A list of dashboards to include this new chart to.", 
-              "format": "int32", 
+              "description": "A list of dashboards to include this new chart to.",
+              "format": "int32",
               "type": "integer"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "datasource_id": {
-            "description": "The id of the dataset/datasource this new chart will use. A complete datasource identification needs `datasouce_id` and `datasource_type`.", 
-            "format": "int32", 
-            "nullable": true, 
+            "description": "The id of the dataset/datasource this new chart will use. A complete datasource identification needs `datasouce_id` and `datasource_type`.",
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "datasource_type": {
-            "description": "The type of dataset/datasource identified on `datasource_id`.", 
+            "description": "The type of dataset/datasource identified on `datasource_id`.",
             "enum": [
-              "sl_table", 
-              "table", 
-              "dataset", 
-              "query", 
-              "saved_query", 
+              "sl_table",
+              "table",
+              "dataset",
+              "query",
+              "saved_query",
               "view"
-            ], 
-            "nullable": true, 
+            ],
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "description": {
-            "description": "A description of the chart propose.", 
-            "nullable": true, 
+            "description": "A description of the chart propose.",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "external_url": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "is_managed_externally": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "owners": {
             "items": {
-              "description": "Owner are users ids allowed to delete or change this chart. If left empty you will be one of the owners of the chart.", 
-              "format": "int32", 
+              "description": "Owner are users ids allowed to delete or change this chart. If left empty you will be one of the owners of the chart.",
+              "format": "int32",
               "type": "integer"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "params": {
-            "description": "Parameters are generated dynamically when clicking the save or overwrite button in the explore view. This JSON object for power users who may want to alter specific parameters.", 
-            "nullable": true, 
+            "description": "Parameters are generated dynamically when clicking the save or overwrite button in the explore view. This JSON object for power users who may want to alter specific parameters.",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "query_context": {
-            "description": "The query context represents the queries that need to run in order to generate the data the visualization, and in what format the data should be returned.", 
-            "nullable": true, 
+            "description": "The query context represents the queries that need to run in order to generate the data the visualization, and in what format the data should be returned.",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "query_context_generation": {
-            "description": "The query context generation represents whether the query_contextis user generated or not so that it does not update user modfiedstate.", 
-            "nullable": true, 
+            "description": "The query context generation represents whether the query_contextis user generated or not so that it does not update user modfiedstate.",
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "slice_name": {
-            "description": "The name of the chart.", 
-            "maxLength": 250, 
-            "minLength": 0, 
-            "nullable": true, 
+            "description": "The name of the chart.",
+            "maxLength": 250,
+            "minLength": 0,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "viz_type": {
-            "description": "The type of chart visualization used.", 
+            "description": "The type of chart visualization used.",
             "example": [
-              "bar", 
-              "line_multi", 
-              "area", 
+              "bar",
+              "line_multi",
+              "area",
               "table"
-            ], 
-            "maxLength": 250, 
-            "minLength": 0, 
-            "nullable": true, 
+            ],
+            "maxLength": 250,
+            "minLength": 0,
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ChartDataRollingOptionsSchema": {
         "properties": {
           "center": {
-            "description": "Should the label be at the center of the window. Default: `false`", 
-            "example": false, 
+            "description": "Should the label be at the center of the window. Default: `false`",
+            "example": false,
             "type": "boolean"
-          }, 
+          },
           "min_periods": {
-            "description": "The minimum amount of periods required for a row to be included in the result set.", 
-            "example": 7, 
-            "format": "int32", 
+            "description": "The minimum amount of periods required for a row to be included in the result set.",
+            "example": 7,
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "rolling_type": {
-            "description": "Type of rolling window. Any numpy function will work.", 
+            "description": "Type of rolling window. Any numpy function will work.",
             "enum": [
-              "average", 
-              "argmin", 
-              "argmax", 
-              "cumsum", 
-              "cumprod", 
-              "max", 
-              "mean", 
-              "median", 
-              "nansum", 
-              "nanmin", 
-              "nanmax", 
-              "nanmean", 
-              "nanmedian", 
-              "nanpercentile", 
-              "min", 
-              "percentile", 
-              "prod", 
-              "product", 
-              "std", 
-              "sum", 
+              "average",
+              "argmin",
+              "argmax",
+              "cumsum",
+              "cumprod",
+              "max",
+              "mean",
+              "median",
+              "nansum",
+              "nanmin",
+              "nanmax",
+              "nanmean",
+              "nanmedian",
+              "nanpercentile",
+              "min",
+              "percentile",
+              "prod",
+              "product",
+              "std",
+              "sum",
               "var"
-            ], 
-            "example": "percentile", 
+            ],
+            "example": "percentile",
             "type": "string"
-          }, 
+          },
           "rolling_type_options": {
-            "example": {}, 
+            "example": {},
             "type": "object"
-          }, 
+          },
           "win_type": {
-            "description": "Type of window function. See [SciPy window functions](https://docs.scipy.org/doc/scipy/reference/signal.windows.html#module-scipy.signal.windows) for more details. Some window functions require passing additional parameters to `rolling_type_options`. For instance, to use `gaussian`, the parameter `std` needs to be provided.", 
+            "description": "Type of window function. See [SciPy window functions](https://docs.scipy.org/doc/scipy/reference/signal.windows.html#module-scipy.signal.windows) for more details. Some window functions require passing additional parameters to `rolling_type_options`. For instance, to use `gaussian`, the parameter `std` needs to be provided.",
             "enum": [
-              "boxcar", 
-              "triang", 
-              "blackman", 
-              "hamming", 
-              "bartlett", 
-              "parzen", 
-              "bohman", 
-              "blackmanharris", 
-              "nuttall", 
-              "barthann", 
-              "kaiser", 
-              "gaussian", 
-              "general_gaussian", 
-              "slepian", 
+              "boxcar",
+              "triang",
+              "blackman",
+              "hamming",
+              "bartlett",
+              "parzen",
+              "bohman",
+              "blackmanharris",
+              "nuttall",
+              "barthann",
+              "kaiser",
+              "gaussian",
+              "general_gaussian",
+              "slepian",
               "exponential"
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           "window": {
-            "description": "Size of the rolling window in days.", 
-            "example": 7, 
-            "format": "int32", 
+            "description": "Size of the rolling window in days.",
+            "example": 7,
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "required": [
-          "rolling_type", 
+          "rolling_type",
           "window"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ChartDataSelectOptionsSchema": {
         "properties": {
           "columns": {
-            "description": "Columns which to select from the input data, in the desired order. If columns are renamed, the original column name should be referenced here.", 
+            "description": "Columns which to select from the input data, in the desired order. If columns are renamed, the original column name should be referenced here.",
             "example": [
-              "country", 
-              "gender", 
+              "country",
+              "gender",
               "age"
-            ], 
+            ],
             "items": {
               "type": "string"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "exclude": {
-            "description": "Columns to exclude from selection.", 
+            "description": "Columns to exclude from selection.",
             "example": [
               "my_temp_column"
-            ], 
+            ],
             "items": {
               "type": "string"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "rename": {
-            "description": "columns which to rename, mapping source column to target column. For instance, `{'y': 'y2'}` will rename the column `y` to `y2`.", 
+            "description": "columns which to rename, mapping source column to target column. For instance, `{'y': 'y2'}` will rename the column `y` to `y2`.",
             "example": [
               {
                 "age": "average_age"
               }
-            ], 
+            ],
             "items": {
               "type": "object"
-            }, 
+            },
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ChartDataSortOptionsSchema": {
         "properties": {
           "aggregates": {
-            "description": "The keys are the name of the aggregate column to be created, and the values specify the details of how to apply the aggregation. If an operator requires additional options, these can be passed here to be unpacked in the operator call. The following numpy operators are supported: average, argmin, argmax, cumsum, cumprod, max, mean, median, nansum, nanmin, nanmax, nanmean, nanmedian, min, percentile, prod, product, std, sum, var. Any options required by the operator can be passed to the `options` object.\n\nIn the example, a new column `first_quantile` is created based on values in the column `my_col` using the `percentile` operator with the `q=0.25` parameter.", 
+            "description": "The keys are the name of the aggregate column to be created, and the values specify the details of how to apply the aggregation. If an operator requires additional options, these can be passed here to be unpacked in the operator call. The following numpy operators are supported: average, argmin, argmax, cumsum, cumprod, max, mean, median, nansum, nanmin, nanmax, nanmean, nanmedian, min, percentile, prod, product, std, sum, var. Any options required by the operator can be passed to the `options` object.\n\nIn the example, a new column `first_quantile` is created based on values in the column `my_col` using the `percentile` operator with the `q=0.25` parameter.",
             "example": {
               "first_quantile": {
-                "column": "my_col", 
-                "operator": "percentile", 
+                "column": "my_col",
+                "operator": "percentile",
                 "options": {
                   "q": 0.25
                 }
               }
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           "columns": {
-            "description": "columns by by which to sort. The key specifies the column name, value specifies if sorting in ascending order.", 
+            "description": "columns by by which to sort. The key specifies the column name, value specifies if sorting in ascending order.",
             "example": {
-              "country": true, 
+              "country": true,
               "gender": false
-            }, 
+            },
             "type": "object"
           }
-        }, 
+        },
         "required": [
           "columns"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ChartEntityResponseSchema": {
         "properties": {
           "cache_timeout": {
-            "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.", 
-            "format": "int32", 
+            "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.",
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "certification_details": {
-            "description": "Details of the certification", 
+            "description": "Details of the certification",
             "type": "string"
-          }, 
+          },
           "certified_by": {
-            "description": "Person or group that has certified this chart", 
+            "description": "Person or group that has certified this chart",
             "type": "string"
-          }, 
+          },
           "changed_on": {
-            "description": "The ISO date that the chart was last changed.", 
+            "description": "The ISO date that the chart was last changed.",
             "type": "string"
-          }, 
+          },
           "description": {
-            "description": "A description of the chart propose.", 
+            "description": "A description of the chart propose.",
             "type": "string"
-          }, 
+          },
           "description_markeddown": {
-            "description": "Sanitized HTML version of the chart description.", 
+            "description": "Sanitized HTML version of the chart description.",
             "type": "string"
-          }, 
+          },
           "form_data": {
-            "description": "Form data from the Explore controls used to form the chart's data query.", 
+            "description": "Form data from the Explore controls used to form the chart's data query.",
             "type": "object"
-          }, 
+          },
           "id": {
-            "description": "The id of the chart.", 
-            "format": "int32", 
+            "description": "The id of the chart.",
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "slice_name": {
-            "description": "The name of the chart.", 
+            "description": "The name of the chart.",
             "type": "string"
-          }, 
+          },
           "slice_url": {
-            "description": "The URL of the chart.", 
+            "description": "The URL of the chart.",
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ChartFavStarResponseResult": {
         "properties": {
           "id": {
-            "description": "The Chart id", 
-            "format": "int32", 
+            "description": "The Chart id",
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "value": {
-            "description": "The FaveStar value", 
+            "description": "The FaveStar value",
             "type": "boolean"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ChartGetDatasourceObjectDataResponse": {
         "properties": {
           "datasource_id": {
-            "description": "The datasource identifier", 
-            "format": "int32", 
+            "description": "The datasource identifier",
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "datasource_type": {
-            "description": "The datasource type", 
-            "format": "int32", 
+            "description": "The datasource type",
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ChartGetDatasourceObjectResponse": {
         "properties": {
           "label": {
-            "description": "The name of the datasource", 
+            "description": "The name of the datasource",
             "type": "string"
-          }, 
+          },
           "value": {
             "$ref": "#/components/schemas/ChartGetDatasourceObjectDataResponse"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ChartGetDatasourceResponseSchema": {
         "properties": {
           "count": {
-            "description": "The total number of datasources", 
-            "format": "int32", 
+            "description": "The total number of datasources",
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "result": {
             "$ref": "#/components/schemas/ChartGetDatasourceObjectResponse"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ChartRestApi.get": {
         "properties": {
           "cache_timeout": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "certification_details": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "certified_by": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "changed_on_delta_humanized": {
             "readOnly": true
-          }, 
+          },
           "dashboards": {
             "$ref": "#/components/schemas/ChartRestApi.get.Dashboard"
-          }, 
+          },
           "description": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "is_managed_externally": {
             "type": "boolean"
-          }, 
+          },
           "owners": {
             "$ref": "#/components/schemas/ChartRestApi.get.User"
-          }, 
+          },
           "params": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "query_context": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "slice_name": {
-            "maxLength": 250, 
-            "nullable": true, 
+            "maxLength": 250,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "thumbnail_url": {
             "readOnly": true
-          }, 
+          },
           "url": {
             "readOnly": true
-          }, 
+          },
           "viz_type": {
-            "maxLength": 250, 
-            "nullable": true, 
+            "maxLength": 250,
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ChartRestApi.get.Dashboard": {
         "properties": {
           "dashboard_title": {
-            "maxLength": 500, 
-            "nullable": true, 
+            "maxLength": 500,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "json_metadata": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ChartRestApi.get.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "username": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
-          "last_name", 
+          "first_name",
+          "last_name",
           "username"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ChartRestApi.get_list": {
         "properties": {
           "cache_timeout": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "certification_details": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "certified_by": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "changed_by": {
             "$ref": "#/components/schemas/ChartRestApi.get_list.User1"
-          }, 
+          },
           "changed_by_name": {
             "readOnly": true
-          }, 
+          },
           "changed_by_url": {
             "readOnly": true
-          }, 
+          },
           "changed_on_delta_humanized": {
             "readOnly": true
-          }, 
+          },
           "changed_on_utc": {
             "readOnly": true
-          }, 
+          },
           "created_by": {
             "$ref": "#/components/schemas/ChartRestApi.get_list.User3"
-          }, 
+          },
           "created_on_delta_humanized": {
             "readOnly": true
-          }, 
+          },
           "dashboards": {
             "$ref": "#/components/schemas/ChartRestApi.get_list.Dashboard"
-          }, 
+          },
           "datasource_id": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "datasource_name_text": {
             "readOnly": true
-          }, 
+          },
           "datasource_type": {
-            "maxLength": 200, 
-            "nullable": true, 
+            "maxLength": 200,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "datasource_url": {
             "readOnly": true
-          }, 
+          },
           "description": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "description_markeddown": {
             "readOnly": true
-          }, 
+          },
           "edit_url": {
             "readOnly": true
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "is_managed_externally": {
             "type": "boolean"
-          }, 
+          },
           "last_saved_at": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "last_saved_by": {
             "$ref": "#/components/schemas/ChartRestApi.get_list.User"
-          }, 
+          },
           "owners": {
             "$ref": "#/components/schemas/ChartRestApi.get_list.User2"
-          }, 
+          },
           "params": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "slice_name": {
-            "maxLength": 250, 
-            "nullable": true, 
+            "maxLength": 250,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "table": {
             "$ref": "#/components/schemas/ChartRestApi.get_list.SqlaTable"
-          }, 
+          },
           "thumbnail_url": {
             "readOnly": true
-          }, 
+          },
           "url": {
             "readOnly": true
-          }, 
+          },
           "viz_type": {
-            "maxLength": 250, 
-            "nullable": true, 
+            "maxLength": 250,
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ChartRestApi.get_list.Dashboard": {
         "properties": {
           "dashboard_title": {
-            "maxLength": 500, 
-            "nullable": true, 
+            "maxLength": 500,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ChartRestApi.get_list.SqlaTable": {
         "properties": {
           "default_endpoint": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "table_name": {
-            "maxLength": 250, 
+            "maxLength": 250,
             "type": "string"
           }
-        }, 
+        },
         "required": [
           "table_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ChartRestApi.get_list.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
+          "first_name",
           "last_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ChartRestApi.get_list.User1": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
+          "first_name",
           "last_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ChartRestApi.get_list.User2": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "username": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
-          "last_name", 
+          "first_name",
+          "last_name",
           "username"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ChartRestApi.get_list.User3": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
+          "first_name",
           "last_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ChartRestApi.post": {
         "properties": {
           "cache_timeout": {
-            "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.", 
-            "format": "int32", 
-            "nullable": true, 
+            "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.",
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "certification_details": {
-            "description": "Details of the certification", 
-            "nullable": true, 
+            "description": "Details of the certification",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "certified_by": {
-            "description": "Person or group that has certified this chart", 
-            "nullable": true, 
+            "description": "Person or group that has certified this chart",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "dashboards": {
             "items": {
-              "description": "A list of dashboards to include this new chart to.", 
-              "format": "int32", 
+              "description": "A list of dashboards to include this new chart to.",
+              "format": "int32",
               "type": "integer"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "datasource_id": {
-            "description": "The id of the dataset/datasource this new chart will use. A complete datasource identification needs `datasouce_id` and `datasource_type`.", 
-            "format": "int32", 
+            "description": "The id of the dataset/datasource this new chart will use. A complete datasource identification needs `datasouce_id` and `datasource_type`.",
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "datasource_name": {
-            "description": "The datasource name.", 
-            "nullable": true, 
+            "description": "The datasource name.",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "datasource_type": {
-            "description": "The type of dataset/datasource identified on `datasource_id`.", 
+            "description": "The type of dataset/datasource identified on `datasource_id`.",
             "enum": [
-              "sl_table", 
-              "table", 
-              "dataset", 
-              "query", 
-              "saved_query", 
+              "sl_table",
+              "table",
+              "dataset",
+              "query",
+              "saved_query",
               "view"
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           "description": {
-            "description": "A description of the chart propose.", 
-            "nullable": true, 
+            "description": "A description of the chart propose.",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "external_url": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "is_managed_externally": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "owners": {
             "items": {
-              "description": "Owner are users ids allowed to delete or change this chart. If left empty you will be one of the owners of the chart.", 
-              "format": "int32", 
+              "description": "Owner are users ids allowed to delete or change this chart. If left empty you will be one of the owners of the chart.",
+              "format": "int32",
               "type": "integer"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "params": {
-            "description": "Parameters are generated dynamically when clicking the save or overwrite button in the explore view. This JSON object for power users who may want to alter specific parameters.", 
-            "nullable": true, 
+            "description": "Parameters are generated dynamically when clicking the save or overwrite button in the explore view. This JSON object for power users who may want to alter specific parameters.",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "query_context": {
-            "description": "The query context represents the queries that need to run in order to generate the data the visualization, and in what format the data should be returned.", 
-            "nullable": true, 
+            "description": "The query context represents the queries that need to run in order to generate the data the visualization, and in what format the data should be returned.",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "query_context_generation": {
-            "description": "The query context generation represents whether the query_contextis user generated or not so that it does not update user modfiedstate.", 
-            "nullable": true, 
+            "description": "The query context generation represents whether the query_contextis user generated or not so that it does not update user modfiedstate.",
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "slice_name": {
-            "description": "The name of the chart.", 
-            "maxLength": 250, 
-            "minLength": 1, 
+            "description": "The name of the chart.",
+            "maxLength": 250,
+            "minLength": 1,
             "type": "string"
-          }, 
+          },
           "viz_type": {
-            "description": "The type of chart visualization used.", 
+            "description": "The type of chart visualization used.",
             "example": [
-              "bar", 
-              "line_multi", 
-              "area", 
+              "bar",
+              "line_multi",
+              "area",
               "table"
-            ], 
-            "maxLength": 250, 
-            "minLength": 0, 
+            ],
+            "maxLength": 250,
+            "minLength": 0,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "datasource_id", 
-          "datasource_type", 
+          "datasource_id",
+          "datasource_type",
           "slice_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ChartRestApi.put": {
         "properties": {
           "cache_timeout": {
-            "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.", 
-            "format": "int32", 
-            "nullable": true, 
+            "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.",
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "certification_details": {
-            "description": "Details of the certification", 
-            "nullable": true, 
+            "description": "Details of the certification",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "certified_by": {
-            "description": "Person or group that has certified this chart", 
-            "nullable": true, 
+            "description": "Person or group that has certified this chart",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "dashboards": {
             "items": {
-              "description": "A list of dashboards to include this new chart to.", 
-              "format": "int32", 
+              "description": "A list of dashboards to include this new chart to.",
+              "format": "int32",
               "type": "integer"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "datasource_id": {
-            "description": "The id of the dataset/datasource this new chart will use. A complete datasource identification needs `datasouce_id` and `datasource_type`.", 
-            "format": "int32", 
-            "nullable": true, 
+            "description": "The id of the dataset/datasource this new chart will use. A complete datasource identification needs `datasouce_id` and `datasource_type`.",
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "datasource_type": {
-            "description": "The type of dataset/datasource identified on `datasource_id`.", 
+            "description": "The type of dataset/datasource identified on `datasource_id`.",
             "enum": [
-              "sl_table", 
-              "table", 
-              "dataset", 
-              "query", 
-              "saved_query", 
+              "sl_table",
+              "table",
+              "dataset",
+              "query",
+              "saved_query",
               "view"
-            ], 
-            "nullable": true, 
+            ],
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "description": {
-            "description": "A description of the chart propose.", 
-            "nullable": true, 
+            "description": "A description of the chart propose.",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "external_url": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "is_managed_externally": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "owners": {
             "items": {
-              "description": "Owner are users ids allowed to delete or change this chart. If left empty you will be one of the owners of the chart.", 
-              "format": "int32", 
+              "description": "Owner are users ids allowed to delete or change this chart. If left empty you will be one of the owners of the chart.",
+              "format": "int32",
               "type": "integer"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "params": {
-            "description": "Parameters are generated dynamically when clicking the save or overwrite button in the explore view. This JSON object for power users who may want to alter specific parameters.", 
-            "nullable": true, 
+            "description": "Parameters are generated dynamically when clicking the save or overwrite button in the explore view. This JSON object for power users who may want to alter specific parameters.",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "query_context": {
-            "description": "The query context represents the queries that need to run in order to generate the data the visualization, and in what format the data should be returned.", 
-            "nullable": true, 
+            "description": "The query context represents the queries that need to run in order to generate the data the visualization, and in what format the data should be returned.",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "query_context_generation": {
-            "description": "The query context generation represents whether the query_contextis user generated or not so that it does not update user modfiedstate.", 
-            "nullable": true, 
+            "description": "The query context generation represents whether the query_contextis user generated or not so that it does not update user modfiedstate.",
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "slice_name": {
-            "description": "The name of the chart.", 
-            "maxLength": 250, 
-            "minLength": 0, 
-            "nullable": true, 
+            "description": "The name of the chart.",
+            "maxLength": 250,
+            "minLength": 0,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "viz_type": {
-            "description": "The type of chart visualization used.", 
+            "description": "The type of chart visualization used.",
             "example": [
-              "bar", 
-              "line_multi", 
-              "area", 
+              "bar",
+              "line_multi",
+              "area",
               "table"
-            ], 
-            "maxLength": 250, 
-            "minLength": 0, 
-            "nullable": true, 
+            ],
+            "maxLength": 250,
+            "minLength": 0,
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "CssTemplateRestApi.get": {
         "properties": {
           "created_by": {
             "$ref": "#/components/schemas/CssTemplateRestApi.get.User"
-          }, 
+          },
           "css": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "template_name": {
-            "maxLength": 250, 
-            "nullable": true, 
+            "maxLength": 250,
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "CssTemplateRestApi.get.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
+          "first_name",
           "last_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "CssTemplateRestApi.get_list": {
         "properties": {
           "changed_by": {
             "$ref": "#/components/schemas/CssTemplateRestApi.get_list.User1"
-          }, 
+          },
           "changed_on_delta_humanized": {
             "readOnly": true
-          }, 
+          },
           "created_by": {
             "$ref": "#/components/schemas/CssTemplateRestApi.get_list.User"
-          }, 
+          },
           "created_on": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "css": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "template_name": {
-            "maxLength": 250, 
-            "nullable": true, 
+            "maxLength": 250,
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "CssTemplateRestApi.get_list.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
+          "first_name",
           "last_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "CssTemplateRestApi.get_list.User1": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
+          "first_name",
           "last_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "CssTemplateRestApi.post": {
         "properties": {
           "css": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "template_name": {
-            "maxLength": 250, 
-            "nullable": true, 
+            "maxLength": 250,
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "CssTemplateRestApi.put": {
         "properties": {
           "css": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "template_name": {
-            "maxLength": 250, 
-            "nullable": true, 
+            "maxLength": 250,
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DashboardDatasetSchema": {
         "properties": {
           "cache_timeout": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "column_formats": {
             "type": "object"
-          }, 
+          },
           "column_types": {
             "items": {
-              "format": "int32", 
+              "format": "int32",
               "type": "integer"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "columns": {
             "items": {
               "type": "object"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "database": {
             "$ref": "#/components/schemas/Database"
-          }, 
+          },
           "datasource_name": {
             "type": "string"
-          }, 
+          },
           "default_endpoint": {
             "type": "string"
-          }, 
+          },
           "edit_url": {
             "type": "string"
-          }, 
+          },
           "fetch_values_predicate": {
             "type": "string"
-          }, 
+          },
           "filter_select": {
             "type": "boolean"
-          }, 
+          },
           "filter_select_enabled": {
             "type": "boolean"
-          }, 
+          },
           "granularity_sqla": {
             "items": {
               "items": {
                 "type": "string"
-              }, 
+              },
               "type": "array"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "health_check_message": {
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "is_sqllab_view": {
             "type": "boolean"
-          }, 
+          },
           "main_dttm_col": {
             "type": "string"
-          }, 
+          },
           "metrics": {
             "items": {
               "type": "object"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "name": {
             "type": "string"
-          }, 
+          },
           "offset": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "order_by_choices": {
             "items": {
               "items": {
                 "type": "string"
-              }, 
+              },
               "type": "array"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "owners": {
             "items": {
               "type": "object"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "params": {
             "type": "string"
-          }, 
+          },
           "perm": {
             "type": "string"
-          }, 
+          },
           "schema": {
             "type": "string"
-          }, 
+          },
           "select_star": {
             "type": "string"
-          }, 
+          },
           "sql": {
             "type": "string"
-          }, 
+          },
           "table_name": {
             "type": "string"
-          }, 
+          },
           "template_params": {
             "type": "string"
-          }, 
+          },
           "time_grain_sqla": {
             "items": {
               "items": {
                 "type": "string"
-              }, 
+              },
               "type": "array"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "type": {
             "type": "string"
-          }, 
+          },
           "uid": {
             "type": "string"
-          }, 
+          },
           "verbose_map": {
             "additionalProperties": {
               "type": "string"
-            }, 
+            },
             "type": "object"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DashboardGetResponseSchema": {
         "properties": {
           "certification_details": {
-            "description": "Details of the certification", 
+            "description": "Details of the certification",
             "type": "string"
-          }, 
+          },
           "certified_by": {
-            "description": "Person or group that has certified this dashboard", 
+            "description": "Person or group that has certified this dashboard",
             "type": "string"
-          }, 
+          },
           "changed_by": {
             "$ref": "#/components/schemas/User"
-          }, 
+          },
           "changed_by_name": {
             "type": "string"
-          }, 
+          },
           "changed_by_url": {
             "type": "string"
-          }, 
+          },
           "changed_on": {
-            "format": "date-time", 
+            "format": "date-time",
             "type": "string"
-          }, 
+          },
           "changed_on_delta_humanized": {
             "type": "string"
-          }, 
+          },
           "charts": {
             "items": {
-              "description": "The names of the dashboard's charts. Names are used for legacy reasons.", 
+              "description": "The names of the dashboard's charts. Names are used for legacy reasons.",
               "type": "string"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "css": {
-            "description": "Override CSS for the dashboard.", 
+            "description": "Override CSS for the dashboard.",
             "type": "string"
-          }, 
+          },
           "dashboard_title": {
-            "description": "A title for the dashboard.", 
+            "description": "A title for the dashboard.",
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "is_managed_externally": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "json_metadata": {
-            "description": "This JSON object is generated dynamically when clicking the save or overwrite button in the dashboard view. It is exposed here for reference and for power users who may want to alter  specific parameters.", 
+            "description": "This JSON object is generated dynamically when clicking the save or overwrite button in the dashboard view. It is exposed here for reference and for power users who may want to alter  specific parameters.",
             "type": "string"
-          }, 
+          },
           "owners": {
             "items": {
               "$ref": "#/components/schemas/User"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "position_json": {
-            "description": "This json object describes the positioning of the widgets in the dashboard. It is dynamically generated when adjusting the widgets size and positions by using drag & drop in the dashboard view", 
+            "description": "This json object describes the positioning of the widgets in the dashboard. It is dynamically generated when adjusting the widgets size and positions by using drag & drop in the dashboard view",
             "type": "string"
-          }, 
+          },
           "published": {
             "type": "boolean"
-          }, 
+          },
           "roles": {
             "items": {
               "$ref": "#/components/schemas/Roles"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "slug": {
             "type": "string"
-          }, 
+          },
           "thumbnail_url": {
             "type": "string"
-          }, 
+          },
           "url": {
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DashboardPermalinkPostSchema": {
         "properties": {
           "activeTabs": {
-            "description": "Current active dashboard tabs", 
+            "description": "Current active dashboard tabs",
             "items": {
               "type": "string"
-            }, 
-            "nullable": true, 
+            },
+            "nullable": true,
             "type": "array"
-          }, 
+          },
           "anchor": {
-            "description": "Optional anchor link added to url hash", 
-            "nullable": true, 
+            "description": "Optional anchor link added to url hash",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "dataMask": {
-            "description": "Data mask used for native filter state", 
-            "nullable": true, 
+            "description": "Data mask used for native filter state",
+            "nullable": true,
             "type": "object"
-          }, 
+          },
           "urlParams": {
-            "description": "URL Parameters", 
+            "description": "URL Parameters",
             "items": {
-              "description": "URL Parameter key-value pair", 
+              "description": "URL Parameter key-value pair",
               "nullable": true
-            }, 
-            "nullable": true, 
+            },
+            "nullable": true,
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DashboardRestApi.get": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DashboardRestApi.get_list": {
         "properties": {
           "certification_details": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "certified_by": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "changed_by": {
             "$ref": "#/components/schemas/DashboardRestApi.get_list.User"
-          }, 
+          },
           "changed_by_name": {
             "readOnly": true
-          }, 
+          },
           "changed_by_url": {
             "readOnly": true
-          }, 
+          },
           "changed_on_delta_humanized": {
             "readOnly": true
-          }, 
+          },
           "changed_on_utc": {
             "readOnly": true
-          }, 
+          },
           "created_by": {
             "$ref": "#/components/schemas/DashboardRestApi.get_list.User2"
-          }, 
+          },
           "created_on_delta_humanized": {
             "readOnly": true
-          }, 
+          },
           "css": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "dashboard_title": {
-            "maxLength": 500, 
-            "nullable": true, 
+            "maxLength": 500,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "is_managed_externally": {
             "type": "boolean"
-          }, 
+          },
           "json_metadata": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "owners": {
             "$ref": "#/components/schemas/DashboardRestApi.get_list.User1"
-          }, 
+          },
           "position_json": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "published": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "roles": {
             "$ref": "#/components/schemas/DashboardRestApi.get_list.Role"
-          }, 
+          },
           "slug": {
-            "maxLength": 255, 
-            "nullable": true, 
+            "maxLength": 255,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "status": {
             "readOnly": true
-          }, 
+          },
           "thumbnail_url": {
             "readOnly": true
-          }, 
+          },
           "url": {
             "readOnly": true
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DashboardRestApi.get_list.Role": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
           "name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "DashboardRestApi.get_list.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "username": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
-          "last_name", 
+          "first_name",
+          "last_name",
           "username"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "DashboardRestApi.get_list.User1": {
         "properties": {
           "email": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "username": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "email", 
-          "first_name", 
-          "last_name", 
+          "email",
+          "first_name",
+          "last_name",
           "username"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "DashboardRestApi.get_list.User2": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
+          "first_name",
           "last_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "DashboardRestApi.post": {
         "properties": {
           "certification_details": {
-            "description": "Details of the certification", 
-            "nullable": true, 
+            "description": "Details of the certification",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "certified_by": {
-            "description": "Person or group that has certified this dashboard", 
-            "nullable": true, 
+            "description": "Person or group that has certified this dashboard",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "css": {
             "type": "string"
-          }, 
+          },
           "dashboard_title": {
-            "description": "A title for the dashboard.", 
-            "maxLength": 500, 
-            "minLength": 0, 
-            "nullable": true, 
+            "description": "A title for the dashboard.",
+            "maxLength": 500,
+            "minLength": 0,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "external_url": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "is_managed_externally": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "json_metadata": {
-            "description": "This JSON object is generated dynamically when clicking the save or overwrite button in the dashboard view. It is exposed here for reference and for power users who may want to alter  specific parameters.", 
+            "description": "This JSON object is generated dynamically when clicking the save or overwrite button in the dashboard view. It is exposed here for reference and for power users who may want to alter  specific parameters.",
             "type": "string"
-          }, 
+          },
           "owners": {
             "items": {
-              "description": "Owner are users ids allowed to delete or change this dashboard. If left empty you will be one of the owners of the dashboard.", 
-              "format": "int32", 
+              "description": "Owner are users ids allowed to delete or change this dashboard. If left empty you will be one of the owners of the dashboard.",
+              "format": "int32",
               "type": "integer"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "position_json": {
-            "description": "This json object describes the positioning of the widgets in the dashboard. It is dynamically generated when adjusting the widgets size and positions by using drag & drop in the dashboard view", 
+            "description": "This json object describes the positioning of the widgets in the dashboard. It is dynamically generated when adjusting the widgets size and positions by using drag & drop in the dashboard view",
             "type": "string"
-          }, 
+          },
           "published": {
-            "description": "Determines whether or not this dashboard is visible in the list of all dashboards.", 
+            "description": "Determines whether or not this dashboard is visible in the list of all dashboards.",
             "type": "boolean"
-          }, 
+          },
           "roles": {
             "items": {
-              "description": "Roles is a list which defines access to the dashboard. These roles are always applied in addition to restrictions on dataset level access. If no roles defined then the dashboard is available to all roles.", 
-              "format": "int32", 
+              "description": "Roles is a list which defines access to the dashboard. These roles are always applied in addition to restrictions on dataset level access. If no roles defined then the dashboard is available to all roles.",
+              "format": "int32",
               "type": "integer"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "slug": {
-            "description": "Unique identifying part for the web address of the dashboard.", 
-            "maxLength": 255, 
-            "minLength": 1, 
-            "nullable": true, 
+            "description": "Unique identifying part for the web address of the dashboard.",
+            "maxLength": 255,
+            "minLength": 1,
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DashboardRestApi.put": {
         "properties": {
           "certification_details": {
-            "description": "Details of the certification", 
-            "nullable": true, 
+            "description": "Details of the certification",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "certified_by": {
-            "description": "Person or group that has certified this dashboard", 
-            "nullable": true, 
+            "description": "Person or group that has certified this dashboard",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "css": {
-            "description": "Override CSS for the dashboard.", 
-            "nullable": true, 
+            "description": "Override CSS for the dashboard.",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "dashboard_title": {
-            "description": "A title for the dashboard.", 
-            "maxLength": 500, 
-            "minLength": 0, 
-            "nullable": true, 
+            "description": "A title for the dashboard.",
+            "maxLength": 500,
+            "minLength": 0,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "external_url": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "is_managed_externally": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "json_metadata": {
-            "description": "This JSON object is generated dynamically when clicking the save or overwrite button in the dashboard view. It is exposed here for reference and for power users who may want to alter  specific parameters.", 
-            "nullable": true, 
+            "description": "This JSON object is generated dynamically when clicking the save or overwrite button in the dashboard view. It is exposed here for reference and for power users who may want to alter  specific parameters.",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "owners": {
             "items": {
-              "description": "Owner are users ids allowed to delete or change this dashboard. If left empty you will be one of the owners of the dashboard.", 
-              "format": "int32", 
-              "nullable": true, 
+              "description": "Owner are users ids allowed to delete or change this dashboard. If left empty you will be one of the owners of the dashboard.",
+              "format": "int32",
+              "nullable": true,
               "type": "integer"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "position_json": {
-            "description": "This json object describes the positioning of the widgets in the dashboard. It is dynamically generated when adjusting the widgets size and positions by using drag & drop in the dashboard view", 
-            "nullable": true, 
+            "description": "This json object describes the positioning of the widgets in the dashboard. It is dynamically generated when adjusting the widgets size and positions by using drag & drop in the dashboard view",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "published": {
-            "description": "Determines whether or not this dashboard is visible in the list of all dashboards.", 
-            "nullable": true, 
+            "description": "Determines whether or not this dashboard is visible in the list of all dashboards.",
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "roles": {
             "items": {
-              "description": "Roles is a list which defines access to the dashboard. These roles are always applied in addition to restrictions on dataset level access. If no roles defined then the dashboard is available to all roles.", 
-              "format": "int32", 
-              "nullable": true, 
+              "description": "Roles is a list which defines access to the dashboard. These roles are always applied in addition to restrictions on dataset level access. If no roles defined then the dashboard is available to all roles.",
+              "format": "int32",
+              "nullable": true,
               "type": "integer"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "slug": {
-            "description": "Unique identifying part for the web address of the dashboard.", 
-            "maxLength": 255, 
-            "minLength": 0, 
-            "nullable": true, 
+            "description": "Unique identifying part for the web address of the dashboard.",
+            "maxLength": 255,
+            "minLength": 0,
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "Database": {
         "properties": {
           "allows_cost_estimate": {
             "type": "boolean"
-          }, 
+          },
           "allows_subquery": {
             "type": "boolean"
-          }, 
+          },
           "allows_virtual_table_explore": {
             "type": "boolean"
-          }, 
+          },
           "backend": {
             "type": "string"
-          }, 
+          },
           "disable_data_preview": {
             "type": "boolean"
-          }, 
+          },
           "explore_database_id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "name": {
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "Database1": {
         "properties": {
           "database_name": {
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DatabaseFunctionNamesResponse": {
         "properties": {
           "function_names": {
             "items": {
               "type": "string"
-            }, 
+            },
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DatabaseRelatedChart": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "slice_name": {
             "type": "string"
-          }, 
+          },
           "viz_type": {
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DatabaseRelatedCharts": {
         "properties": {
           "count": {
-            "description": "Chart count", 
-            "format": "int32", 
+            "description": "Chart count",
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "result": {
-            "description": "A list of dashboards", 
+            "description": "A list of dashboards",
             "items": {
               "$ref": "#/components/schemas/DatabaseRelatedChart"
-            }, 
+            },
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DatabaseRelatedDashboard": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "json_metadata": {
             "type": "object"
-          }, 
+          },
           "slug": {
             "type": "string"
-          }, 
+          },
           "title": {
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DatabaseRelatedDashboards": {
         "properties": {
           "count": {
-            "description": "Dashboard count", 
-            "format": "int32", 
+            "description": "Dashboard count",
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "result": {
-            "description": "A list of dashboards", 
+            "description": "A list of dashboards",
             "items": {
               "$ref": "#/components/schemas/DatabaseRelatedDashboard"
-            }, 
+            },
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DatabaseRelatedObjectsResponse": {
         "properties": {
           "charts": {
             "$ref": "#/components/schemas/DatabaseRelatedCharts"
-          }, 
+          },
           "dashboards": {
             "$ref": "#/components/schemas/DatabaseRelatedDashboards"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DatabaseRestApi.get": {
         "properties": {
           "allow_ctas": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "allow_cvas": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "allow_dml": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "allow_file_upload": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "allow_run_async": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "backend": {
             "readOnly": true
-          }, 
+          },
           "cache_timeout": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "configuration_method": {
-            "maxLength": 255, 
-            "nullable": true, 
+            "maxLength": 255,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "database_name": {
-            "maxLength": 250, 
+            "maxLength": 250,
             "type": "string"
-          }, 
+          },
           "driver": {
             "readOnly": true
-          }, 
+          },
           "engine_information": {
             "readOnly": true
-          }, 
+          },
           "expose_in_sqllab": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "extra": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "force_ctas_schema": {
-            "maxLength": 250, 
-            "nullable": true, 
+            "maxLength": 250,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "impersonate_user": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "is_managed_externally": {
             "type": "boolean"
-          }, 
+          },
           "masked_encrypted_extra": {
             "readOnly": true
-          }, 
+          },
           "parameters": {
             "readOnly": true
-          }, 
+          },
           "parameters_schema": {
             "readOnly": true
-          }, 
+          },
           "server_cert": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "sqlalchemy_uri": {
-            "maxLength": 1024, 
+            "maxLength": 1024,
             "type": "string"
-          }, 
+          },
           "uuid": {
-            "format": "uuid", 
-            "nullable": true, 
+            "format": "uuid",
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "database_name", 
+          "database_name",
           "sqlalchemy_uri"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "DatabaseRestApi.get_list": {
         "properties": {
           "allow_ctas": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "allow_cvas": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "allow_dml": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "allow_file_upload": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "allow_run_async": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "allows_cost_estimate": {
             "readOnly": true
-          }, 
+          },
           "allows_subquery": {
             "readOnly": true
-          }, 
+          },
           "allows_virtual_table_explore": {
             "readOnly": true
-          }, 
+          },
           "backend": {
             "readOnly": true
-          }, 
+          },
           "changed_on": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "changed_on_delta_humanized": {
             "readOnly": true
-          }, 
+          },
           "created_by": {
             "$ref": "#/components/schemas/DatabaseRestApi.get_list.User"
-          }, 
+          },
           "database_name": {
-            "maxLength": 250, 
+            "maxLength": 250,
             "type": "string"
-          }, 
+          },
           "disable_data_preview": {
             "readOnly": true
-          }, 
+          },
           "engine_information": {
             "readOnly": true
-          }, 
+          },
           "explore_database_id": {
             "readOnly": true
-          }, 
+          },
           "expose_in_sqllab": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "extra": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "force_ctas_schema": {
-            "maxLength": 250, 
-            "nullable": true, 
+            "maxLength": 250,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "uuid": {
-            "format": "uuid", 
-            "nullable": true, 
+            "format": "uuid",
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "required": [
           "database_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "DatabaseRestApi.get_list.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
+          "first_name",
           "last_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "DatabaseRestApi.post": {
         "properties": {
           "allow_ctas": {
-            "description": "Allow CREATE TABLE AS option in SQL Lab", 
+            "description": "Allow CREATE TABLE AS option in SQL Lab",
             "type": "boolean"
-          }, 
+          },
           "allow_cvas": {
-            "description": "Allow CREATE VIEW AS option in SQL Lab", 
+            "description": "Allow CREATE VIEW AS option in SQL Lab",
             "type": "boolean"
-          }, 
+          },
           "allow_dml": {
-            "description": "Allow users to run non-SELECT statements (UPDATE, DELETE, CREATE, ...) in SQL Lab", 
+            "description": "Allow users to run non-SELECT statements (UPDATE, DELETE, CREATE, ...) in SQL Lab",
             "type": "boolean"
-          }, 
+          },
           "allow_file_upload": {
-            "description": "Allow to upload CSV file data into this databaseIf selected, please set the schemas allowed for csv upload in Extra.", 
+            "description": "Allow to upload CSV file data into this databaseIf selected, please set the schemas allowed for csv upload in Extra.",
             "type": "boolean"
-          }, 
+          },
           "allow_run_async": {
-            "description": "Operate the database in asynchronous mode, meaning  that the queries are executed on remote workers as opposed to on the web server itself. This assumes that you have a Celery worker setup as well as a results backend. Refer to the installation docs for more information.", 
+            "description": "Operate the database in asynchronous mode, meaning  that the queries are executed on remote workers as opposed to on the web server itself. This assumes that you have a Celery worker setup as well as a results backend. Refer to the installation docs for more information.",
             "type": "boolean"
-          }, 
+          },
           "cache_timeout": {
-            "description": "Duration (in seconds) of the caching timeout for charts of this database. A timeout of 0 indicates that the cache never expires. Note this defaults to the global timeout if undefined.", 
-            "format": "int32", 
-            "nullable": true, 
+            "description": "Duration (in seconds) of the caching timeout for charts of this database. A timeout of 0 indicates that the cache never expires. Note this defaults to the global timeout if undefined.",
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "configuration_method": {
-            "default": "sqlalchemy_form", 
+            "default": "sqlalchemy_form",
             "description": "Configuration_method is used on the frontend to inform the backend whether to explode parameters or to provide only a sqlalchemy_uri."
-          }, 
+          },
           "database_name": {
-            "description": "A database name to identify this connection.", 
-            "maxLength": 250, 
-            "minLength": 1, 
+            "description": "A database name to identify this connection.",
+            "maxLength": 250,
+            "minLength": 1,
             "type": "string"
-          }, 
+          },
           "driver": {
-            "description": "SQLAlchemy driver to use", 
-            "nullable": true, 
+            "description": "SQLAlchemy driver to use",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "engine": {
-            "description": "SQLAlchemy engine to use", 
-            "nullable": true, 
+            "description": "SQLAlchemy engine to use",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "expose_in_sqllab": {
-            "description": "Expose this database to SQLLab", 
+            "description": "Expose this database to SQLLab",
             "type": "boolean"
-          }, 
+          },
           "external_url": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "extra": {
-            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>", 
+            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
             "type": "string"
-          }, 
+          },
           "force_ctas_schema": {
-            "description": "When allowing CREATE TABLE AS option in SQL Lab, this option forces the table to be created in this schema", 
-            "maxLength": 250, 
-            "minLength": 0, 
-            "nullable": true, 
+            "description": "When allowing CREATE TABLE AS option in SQL Lab, this option forces the table to be created in this schema",
+            "maxLength": 250,
+            "minLength": 0,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "impersonate_user": {
-            "description": "If Presto, all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled, will run the queries as service account, but impersonate the currently logged on user via hive.server2.proxy.user property.", 
+            "description": "If Presto, all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled, will run the queries as service account, but impersonate the currently logged on user via hive.server2.proxy.user property.",
             "type": "boolean"
-          }, 
+          },
           "is_managed_externally": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "masked_encrypted_extra": {
-            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive, Presto, and BigQuery, which do not conform to the username:password syntax normally used by SQLAlchemy.</p>", 
-            "nullable": true, 
+            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive, Presto, and BigQuery, which do not conform to the username:password syntax normally used by SQLAlchemy.</p>",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "parameters": {
-            "additionalProperties": {}, 
-            "description": "DB-specific parameters for configuration", 
+            "additionalProperties": {},
+            "description": "DB-specific parameters for configuration",
             "type": "object"
-          }, 
+          },
           "server_cert": {
-            "description": "<p>Optional CA_BUNDLE contents to validate HTTPS requests. Only available on certain database engines.</p>", 
-            "nullable": true, 
+            "description": "<p>Optional CA_BUNDLE contents to validate HTTPS requests. Only available on certain database engines.</p>",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "sqlalchemy_uri": {
-            "description": "<p>Refer to the <a href=\"https://docs.sqlalchemy.org/en/rel_1_2/core/engines.html#database-urls\">SqlAlchemy docs</a> for more information on how to structure your URI.</p>", 
-            "maxLength": 1024, 
-            "minLength": 1, 
+            "description": "<p>Refer to the <a href=\"https://docs.sqlalchemy.org/en/rel_1_2/core/engines.html#database-urls\">SqlAlchemy docs</a> for more information on how to structure your URI.</p>",
+            "maxLength": 1024,
+            "minLength": 1,
             "type": "string"
-          }, 
+          },
           "ssh_tunnel": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/DatabaseSSHTunnel"
               }
-            ], 
+            ],
             "nullable": true
-          }, 
+          },
           "uuid": {
             "type": "string"
           }
-        }, 
+        },
         "required": [
           "database_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "DatabaseRestApi.put": {
         "properties": {
           "allow_ctas": {
-            "description": "Allow CREATE TABLE AS option in SQL Lab", 
+            "description": "Allow CREATE TABLE AS option in SQL Lab",
             "type": "boolean"
-          }, 
+          },
           "allow_cvas": {
-            "description": "Allow CREATE VIEW AS option in SQL Lab", 
+            "description": "Allow CREATE VIEW AS option in SQL Lab",
             "type": "boolean"
-          }, 
+          },
           "allow_dml": {
-            "description": "Allow users to run non-SELECT statements (UPDATE, DELETE, CREATE, ...) in SQL Lab", 
+            "description": "Allow users to run non-SELECT statements (UPDATE, DELETE, CREATE, ...) in SQL Lab",
             "type": "boolean"
-          }, 
+          },
           "allow_file_upload": {
-            "description": "Allow to upload CSV file data into this databaseIf selected, please set the schemas allowed for csv upload in Extra.", 
+            "description": "Allow to upload CSV file data into this databaseIf selected, please set the schemas allowed for csv upload in Extra.",
             "type": "boolean"
-          }, 
+          },
           "allow_run_async": {
-            "description": "Operate the database in asynchronous mode, meaning  that the queries are executed on remote workers as opposed to on the web server itself. This assumes that you have a Celery worker setup as well as a results backend. Refer to the installation docs for more information.", 
+            "description": "Operate the database in asynchronous mode, meaning  that the queries are executed on remote workers as opposed to on the web server itself. This assumes that you have a Celery worker setup as well as a results backend. Refer to the installation docs for more information.",
             "type": "boolean"
-          }, 
+          },
           "cache_timeout": {
-            "description": "Duration (in seconds) of the caching timeout for charts of this database. A timeout of 0 indicates that the cache never expires. Note this defaults to the global timeout if undefined.", 
-            "format": "int32", 
-            "nullable": true, 
+            "description": "Duration (in seconds) of the caching timeout for charts of this database. A timeout of 0 indicates that the cache never expires. Note this defaults to the global timeout if undefined.",
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "configuration_method": {
-            "default": "sqlalchemy_form", 
+            "default": "sqlalchemy_form",
             "description": "Configuration_method is used on the frontend to inform the backend whether to explode parameters or to provide only a sqlalchemy_uri."
-          }, 
+          },
           "database_name": {
-            "description": "A database name to identify this connection.", 
-            "maxLength": 250, 
-            "minLength": 1, 
-            "nullable": true, 
+            "description": "A database name to identify this connection.",
+            "maxLength": 250,
+            "minLength": 1,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "driver": {
-            "description": "SQLAlchemy driver to use", 
-            "nullable": true, 
+            "description": "SQLAlchemy driver to use",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "engine": {
-            "description": "SQLAlchemy engine to use", 
-            "nullable": true, 
+            "description": "SQLAlchemy engine to use",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "expose_in_sqllab": {
-            "description": "Expose this database to SQLLab", 
+            "description": "Expose this database to SQLLab",
             "type": "boolean"
-          }, 
+          },
           "external_url": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "extra": {
-            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>", 
+            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
             "type": "string"
-          }, 
+          },
           "force_ctas_schema": {
-            "description": "When allowing CREATE TABLE AS option in SQL Lab, this option forces the table to be created in this schema", 
-            "maxLength": 250, 
-            "minLength": 0, 
-            "nullable": true, 
+            "description": "When allowing CREATE TABLE AS option in SQL Lab, this option forces the table to be created in this schema",
+            "maxLength": 250,
+            "minLength": 0,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "impersonate_user": {
-            "description": "If Presto, all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled, will run the queries as service account, but impersonate the currently logged on user via hive.server2.proxy.user property.", 
+            "description": "If Presto, all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled, will run the queries as service account, but impersonate the currently logged on user via hive.server2.proxy.user property.",
             "type": "boolean"
-          }, 
+          },
           "is_managed_externally": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "masked_encrypted_extra": {
-            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive, Presto, and BigQuery, which do not conform to the username:password syntax normally used by SQLAlchemy.</p>", 
-            "nullable": true, 
+            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive, Presto, and BigQuery, which do not conform to the username:password syntax normally used by SQLAlchemy.</p>",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "parameters": {
-            "additionalProperties": {}, 
-            "description": "DB-specific parameters for configuration", 
+            "additionalProperties": {},
+            "description": "DB-specific parameters for configuration",
             "type": "object"
-          }, 
+          },
           "server_cert": {
-            "description": "<p>Optional CA_BUNDLE contents to validate HTTPS requests. Only available on certain database engines.</p>", 
-            "nullable": true, 
+            "description": "<p>Optional CA_BUNDLE contents to validate HTTPS requests. Only available on certain database engines.</p>",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "sqlalchemy_uri": {
-            "description": "<p>Refer to the <a href=\"https://docs.sqlalchemy.org/en/rel_1_2/core/engines.html#database-urls\">SqlAlchemy docs</a> for more information on how to structure your URI.</p>", 
-            "maxLength": 1024, 
-            "minLength": 0, 
+            "description": "<p>Refer to the <a href=\"https://docs.sqlalchemy.org/en/rel_1_2/core/engines.html#database-urls\">SqlAlchemy docs</a> for more information on how to structure your URI.</p>",
+            "maxLength": 1024,
+            "minLength": 0,
             "type": "string"
-          }, 
+          },
           "ssh_tunnel": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/DatabaseSSHTunnel"
               }
-            ], 
+            ],
             "nullable": true
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DatabaseSSHTunnel": {
         "properties": {
           "id": {
-            "description": "SSH Tunnel ID (for updates)", 
-            "format": "int32", 
-            "nullable": true, 
+            "description": "SSH Tunnel ID (for updates)",
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "password": {
             "type": "string"
-          }, 
+          },
           "private_key": {
             "type": "string"
-          }, 
+          },
           "private_key_password": {
             "type": "string"
-          }, 
+          },
           "server_address": {
             "type": "string"
-          }, 
+          },
           "server_port": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "username": {
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DatabaseTestConnectionSchema": {
         "properties": {
           "configuration_method": {
-            "default": "sqlalchemy_form", 
+            "default": "sqlalchemy_form",
             "description": "Configuration_method is used on the frontend to inform the backend whether to explode parameters or to provide only a sqlalchemy_uri."
-          }, 
+          },
           "database_name": {
-            "description": "A database name to identify this connection.", 
-            "maxLength": 250, 
-            "minLength": 1, 
-            "nullable": true, 
+            "description": "A database name to identify this connection.",
+            "maxLength": 250,
+            "minLength": 1,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "driver": {
-            "description": "SQLAlchemy driver to use", 
-            "nullable": true, 
+            "description": "SQLAlchemy driver to use",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "engine": {
-            "description": "SQLAlchemy engine to use", 
-            "nullable": true, 
+            "description": "SQLAlchemy engine to use",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "extra": {
-            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>", 
+            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
             "type": "string"
-          }, 
+          },
           "impersonate_user": {
-            "description": "If Presto, all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled, will run the queries as service account, but impersonate the currently logged on user via hive.server2.proxy.user property.", 
+            "description": "If Presto, all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled, will run the queries as service account, but impersonate the currently logged on user via hive.server2.proxy.user property.",
             "type": "boolean"
-          }, 
+          },
           "masked_encrypted_extra": {
-            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive, Presto, and BigQuery, which do not conform to the username:password syntax normally used by SQLAlchemy.</p>", 
-            "nullable": true, 
+            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive, Presto, and BigQuery, which do not conform to the username:password syntax normally used by SQLAlchemy.</p>",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "parameters": {
-            "additionalProperties": {}, 
-            "description": "DB-specific parameters for configuration", 
+            "additionalProperties": {},
+            "description": "DB-specific parameters for configuration",
             "type": "object"
-          }, 
+          },
           "server_cert": {
-            "description": "<p>Optional CA_BUNDLE contents to validate HTTPS requests. Only available on certain database engines.</p>", 
-            "nullable": true, 
+            "description": "<p>Optional CA_BUNDLE contents to validate HTTPS requests. Only available on certain database engines.</p>",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "sqlalchemy_uri": {
-            "description": "<p>Refer to the <a href=\"https://docs.sqlalchemy.org/en/rel_1_2/core/engines.html#database-urls\">SqlAlchemy docs</a> for more information on how to structure your URI.</p>", 
-            "maxLength": 1024, 
-            "minLength": 1, 
+            "description": "<p>Refer to the <a href=\"https://docs.sqlalchemy.org/en/rel_1_2/core/engines.html#database-urls\">SqlAlchemy docs</a> for more information on how to structure your URI.</p>",
+            "maxLength": 1024,
+            "minLength": 1,
             "type": "string"
-          }, 
+          },
           "ssh_tunnel": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/DatabaseSSHTunnel"
               }
-            ], 
+            ],
             "nullable": true
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DatabaseValidateParametersSchema": {
         "properties": {
           "catalog": {
             "additionalProperties": {
               "nullable": true
-            }, 
-            "description": "Gsheets specific column for managing label to sheet urls", 
+            },
+            "description": "Gsheets specific column for managing label to sheet urls",
             "type": "object"
-          }, 
+          },
           "configuration_method": {
             "description": "Configuration_method is used on the frontend to inform the backend whether to explode parameters or to provide only a sqlalchemy_uri."
-          }, 
+          },
           "database_name": {
-            "description": "A database name to identify this connection.", 
-            "maxLength": 250, 
-            "minLength": 1, 
-            "nullable": true, 
+            "description": "A database name to identify this connection.",
+            "maxLength": 250,
+            "minLength": 1,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "driver": {
-            "description": "SQLAlchemy driver to use", 
-            "nullable": true, 
+            "description": "SQLAlchemy driver to use",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "engine": {
-            "description": "SQLAlchemy engine to use", 
+            "description": "SQLAlchemy engine to use",
             "type": "string"
-          }, 
+          },
           "extra": {
-            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>", 
+            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
             "type": "string"
-          }, 
+          },
           "id": {
-            "description": "Database ID (for updates)", 
-            "format": "int32", 
-            "nullable": true, 
+            "description": "Database ID (for updates)",
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "impersonate_user": {
-            "description": "If Presto, all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled, will run the queries as service account, but impersonate the currently logged on user via hive.server2.proxy.user property.", 
+            "description": "If Presto, all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled, will run the queries as service account, but impersonate the currently logged on user via hive.server2.proxy.user property.",
             "type": "boolean"
-          }, 
+          },
           "masked_encrypted_extra": {
-            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive, Presto, and BigQuery, which do not conform to the username:password syntax normally used by SQLAlchemy.</p>", 
-            "nullable": true, 
+            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive, Presto, and BigQuery, which do not conform to the username:password syntax normally used by SQLAlchemy.</p>",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "parameters": {
             "additionalProperties": {
               "nullable": true
-            }, 
-            "description": "DB-specific parameters for configuration", 
+            },
+            "description": "DB-specific parameters for configuration",
             "type": "object"
-          }, 
+          },
           "server_cert": {
-            "description": "<p>Optional CA_BUNDLE contents to validate HTTPS requests. Only available on certain database engines.</p>", 
-            "nullable": true, 
+            "description": "<p>Optional CA_BUNDLE contents to validate HTTPS requests. Only available on certain database engines.</p>",
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "configuration_method", 
+          "configuration_method",
           "engine"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "Dataset": {
         "properties": {
           "cache_timeout": {
-            "description": "Duration (in seconds) of the caching timeout for this dataset.", 
-            "format": "int32", 
+            "description": "Duration (in seconds) of the caching timeout for this dataset.",
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "column_formats": {
-            "description": "Column formats.", 
+            "description": "Column formats.",
             "type": "object"
-          }, 
+          },
           "columns": {
-            "description": "Columns metadata.", 
+            "description": "Columns metadata.",
             "items": {
               "type": "object"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "database": {
-            "description": "Database associated with the dataset.", 
+            "description": "Database associated with the dataset.",
             "type": "object"
-          }, 
+          },
           "datasource_name": {
-            "description": "Dataset name.", 
+            "description": "Dataset name.",
             "type": "string"
-          }, 
+          },
           "default_endpoint": {
-            "description": "Default endpoint for the dataset.", 
+            "description": "Default endpoint for the dataset.",
             "type": "string"
-          }, 
+          },
           "description": {
-            "description": "Dataset description.", 
+            "description": "Dataset description.",
             "type": "string"
-          }, 
+          },
           "edit_url": {
-            "description": "The URL for editing the dataset.", 
+            "description": "The URL for editing the dataset.",
             "type": "string"
-          }, 
+          },
           "extra": {
-            "description": "JSON string containing extra configuration elements.", 
+            "description": "JSON string containing extra configuration elements.",
             "type": "object"
-          }, 
+          },
           "fetch_values_predicate": {
-            "description": "Predicate used when fetching values from the dataset.", 
+            "description": "Predicate used when fetching values from the dataset.",
             "type": "string"
-          }, 
+          },
           "filter_select": {
-            "description": "SELECT filter applied to the dataset.", 
+            "description": "SELECT filter applied to the dataset.",
             "type": "boolean"
-          }, 
+          },
           "filter_select_enabled": {
-            "description": "If the SELECT filter is enabled.", 
+            "description": "If the SELECT filter is enabled.",
             "type": "boolean"
-          }, 
+          },
           "granularity_sqla": {
-            "description": "Name of temporal column used for time filtering for SQL datasources. This field is deprecated, use `granularity` instead.", 
+            "description": "Name of temporal column used for time filtering for SQL datasources. This field is deprecated, use `granularity` instead.",
             "items": {
               "items": {
                 "type": "object"
-              }, 
+              },
               "type": "array"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "health_check_message": {
-            "description": "Health check message.", 
+            "description": "Health check message.",
             "type": "string"
-          }, 
+          },
           "id": {
-            "description": "Dataset ID.", 
-            "format": "int32", 
+            "description": "Dataset ID.",
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "is_sqllab_view": {
-            "description": "If the dataset is a SQL Lab view.", 
+            "description": "If the dataset is a SQL Lab view.",
             "type": "boolean"
-          }, 
+          },
           "main_dttm_col": {
-            "description": "The main temporal column.", 
+            "description": "The main temporal column.",
             "type": "string"
-          }, 
+          },
           "metrics": {
-            "description": "Dataset metrics.", 
+            "description": "Dataset metrics.",
             "items": {
               "type": "object"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "name": {
-            "description": "Dataset name.", 
+            "description": "Dataset name.",
             "type": "string"
-          }, 
+          },
           "offset": {
-            "description": "Dataset offset.", 
-            "format": "int32", 
+            "description": "Dataset offset.",
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "order_by_choices": {
-            "description": "List of order by columns.", 
+            "description": "List of order by columns.",
             "items": {
               "items": {
                 "type": "string"
-              }, 
+              },
               "type": "array"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "owners": {
-            "description": "List of owners identifiers", 
+            "description": "List of owners identifiers",
             "items": {
-              "format": "int32", 
+              "format": "int32",
               "type": "integer"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "params": {
-            "description": "Extra params for the dataset.", 
+            "description": "Extra params for the dataset.",
             "type": "object"
-          }, 
+          },
           "perm": {
-            "description": "Permission expression.", 
+            "description": "Permission expression.",
             "type": "string"
-          }, 
+          },
           "schema": {
-            "description": "Dataset schema.", 
+            "description": "Dataset schema.",
             "type": "string"
-          }, 
+          },
           "select_star": {
-            "description": "Select all clause.", 
+            "description": "Select all clause.",
             "type": "string"
-          }, 
+          },
           "sql": {
-            "description": "A SQL statement that defines the dataset.", 
+            "description": "A SQL statement that defines the dataset.",
             "type": "string"
-          }, 
+          },
           "table_name": {
-            "description": "The name of the table associated with the dataset.", 
+            "description": "The name of the table associated with the dataset.",
             "type": "string"
-          }, 
+          },
           "template_params": {
-            "description": "Table template params.", 
+            "description": "Table template params.",
             "type": "object"
-          }, 
+          },
           "time_grain_sqla": {
-            "description": "List of temporal granularities supported by the dataset.", 
+            "description": "List of temporal granularities supported by the dataset.",
             "items": {
               "items": {
                 "type": "string"
-              }, 
+              },
               "type": "array"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "type": {
-            "description": "Dataset type.", 
+            "description": "Dataset type.",
             "type": "string"
-          }, 
+          },
           "uid": {
-            "description": "Dataset unique identifier.", 
+            "description": "Dataset unique identifier.",
             "type": "string"
-          }, 
+          },
           "verbose_map": {
-            "description": "Mapping from raw name to verbose name.", 
+            "description": "Mapping from raw name to verbose name.",
             "type": "object"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DatasetColumnsPut": {
         "properties": {
           "advanced_data_type": {
-            "maxLength": 255, 
-            "minLength": 1, 
-            "nullable": true, 
+            "maxLength": 255,
+            "minLength": 1,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "column_name": {
-            "maxLength": 255, 
-            "minLength": 1, 
+            "maxLength": 255,
+            "minLength": 1,
             "type": "string"
-          }, 
+          },
           "description": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "expression": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "extra": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "filterable": {
             "type": "boolean"
-          }, 
+          },
           "groupby": {
             "type": "boolean"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "is_active": {
             "type": "boolean"
-          }, 
+          },
           "is_dttm": {
             "type": "boolean"
-          }, 
+          },
           "python_date_format": {
-            "maxLength": 255, 
-            "minLength": 1, 
-            "nullable": true, 
+            "maxLength": 255,
+            "minLength": 1,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "type": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "uuid": {
-            "format": "uuid", 
-            "nullable": true, 
+            "format": "uuid",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "verbose_name": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "required": [
           "column_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "DatasetColumnsRestApi.get": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DatasetColumnsRestApi.get_list": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DatasetColumnsRestApi.post": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DatasetColumnsRestApi.put": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DatasetDuplicateSchema": {
         "properties": {
           "base_model_id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "table_name": {
-            "maxLength": 250, 
-            "minLength": 1, 
+            "maxLength": 250,
+            "minLength": 1,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "base_model_id", 
+          "base_model_id",
           "table_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "DatasetMetricRestApi.get": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DatasetMetricRestApi.get_list": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DatasetMetricRestApi.post": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DatasetMetricRestApi.put": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DatasetMetricsPut": {
         "properties": {
           "d3format": {
-            "maxLength": 128, 
-            "minLength": 1, 
-            "nullable": true, 
+            "maxLength": 128,
+            "minLength": 1,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "description": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "expression": {
             "type": "string"
-          }, 
+          },
           "extra": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "metric_name": {
-            "maxLength": 255, 
-            "minLength": 1, 
+            "maxLength": 255,
+            "minLength": 1,
             "type": "string"
-          }, 
+          },
           "metric_type": {
-            "maxLength": 32, 
-            "minLength": 1, 
-            "nullable": true, 
+            "maxLength": 32,
+            "minLength": 1,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "uuid": {
-            "format": "uuid", 
-            "nullable": true, 
+            "format": "uuid",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "verbose_name": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "warning_text": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "expression", 
+          "expression",
           "metric_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "DatasetRelatedChart": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "slice_name": {
             "type": "string"
-          }, 
+          },
           "viz_type": {
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DatasetRelatedCharts": {
         "properties": {
           "count": {
-            "description": "Chart count", 
-            "format": "int32", 
+            "description": "Chart count",
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "result": {
-            "description": "A list of dashboards", 
+            "description": "A list of dashboards",
             "items": {
               "$ref": "#/components/schemas/DatasetRelatedChart"
-            }, 
+            },
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DatasetRelatedDashboard": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "json_metadata": {
             "type": "object"
-          }, 
+          },
           "slug": {
             "type": "string"
-          }, 
+          },
           "title": {
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DatasetRelatedDashboards": {
         "properties": {
           "count": {
-            "description": "Dashboard count", 
-            "format": "int32", 
+            "description": "Dashboard count",
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "result": {
-            "description": "A list of dashboards", 
+            "description": "A list of dashboards",
             "items": {
               "$ref": "#/components/schemas/DatasetRelatedDashboard"
-            }, 
+            },
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DatasetRelatedObjectsResponse": {
         "properties": {
           "charts": {
             "$ref": "#/components/schemas/DatasetRelatedCharts"
-          }, 
+          },
           "dashboards": {
             "$ref": "#/components/schemas/DatasetRelatedDashboards"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DatasetRestApi.get": {
         "properties": {
           "cache_timeout": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "changed_by": {
             "$ref": "#/components/schemas/DatasetRestApi.get.User"
-          }, 
+          },
           "changed_on": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "changed_on_humanized": {
             "readOnly": true
-          }, 
+          },
           "columns": {
             "$ref": "#/components/schemas/DatasetRestApi.get.TableColumn"
-          }, 
+          },
           "created_by": {
             "$ref": "#/components/schemas/DatasetRestApi.get.User2"
-          }, 
+          },
           "created_on": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "created_on_humanized": {
             "readOnly": true
-          }, 
+          },
           "database": {
             "$ref": "#/components/schemas/DatasetRestApi.get.Database"
-          }, 
+          },
           "datasource_type": {
             "readOnly": true
-          }, 
+          },
           "default_endpoint": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "description": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "extra": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "fetch_values_predicate": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "filter_select_enabled": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "is_managed_externally": {
             "type": "boolean"
-          }, 
+          },
           "is_sqllab_view": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "kind": {
             "readOnly": true
-          }, 
+          },
           "main_dttm_col": {
-            "maxLength": 250, 
-            "nullable": true, 
+            "maxLength": 250,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "metrics": {
             "$ref": "#/components/schemas/DatasetRestApi.get.SqlMetric"
-          }, 
+          },
           "offset": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "owners": {
             "$ref": "#/components/schemas/DatasetRestApi.get.User1"
-          }, 
+          },
           "schema": {
-            "maxLength": 255, 
-            "nullable": true, 
+            "maxLength": 255,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "select_star": {
             "readOnly": true
-          }, 
+          },
           "sql": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "table_name": {
-            "maxLength": 250, 
+            "maxLength": 250,
             "type": "string"
-          }, 
+          },
           "template_params": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "url": {
             "readOnly": true
           }
-        }, 
+        },
         "required": [
-          "columns", 
-          "database", 
-          "metrics", 
+          "columns",
+          "database",
+          "metrics",
           "table_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "DatasetRestApi.get.Database": {
         "properties": {
           "backend": {
             "readOnly": true
-          }, 
+          },
           "database_name": {
-            "maxLength": 250, 
+            "maxLength": 250,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "required": [
           "database_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "DatasetRestApi.get.SqlMetric": {
         "properties": {
           "changed_on": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "created_on": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "d3format": {
-            "maxLength": 128, 
-            "nullable": true, 
+            "maxLength": 128,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "description": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "expression": {
             "type": "string"
-          }, 
+          },
           "extra": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "metric_name": {
-            "maxLength": 255, 
+            "maxLength": 255,
             "type": "string"
-          }, 
+          },
           "metric_type": {
-            "maxLength": 32, 
-            "nullable": true, 
+            "maxLength": 32,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "verbose_name": {
-            "maxLength": 1024, 
-            "nullable": true, 
+            "maxLength": 1024,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "warning_text": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "expression", 
+          "expression",
           "metric_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "DatasetRestApi.get.TableColumn": {
         "properties": {
           "advanced_data_type": {
-            "maxLength": 255, 
-            "nullable": true, 
+            "maxLength": 255,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "changed_on": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "column_name": {
-            "maxLength": 255, 
+            "maxLength": 255,
             "type": "string"
-          }, 
+          },
           "created_on": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "description": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "expression": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "extra": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "filterable": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "groupby": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "is_active": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "is_dttm": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "python_date_format": {
-            "maxLength": 255, 
-            "nullable": true, 
+            "maxLength": 255,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "type": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "type_generic": {
             "readOnly": true
-          }, 
+          },
           "uuid": {
-            "format": "uuid", 
-            "nullable": true, 
+            "format": "uuid",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "verbose_name": {
-            "maxLength": 1024, 
-            "nullable": true, 
+            "maxLength": 1024,
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "required": [
           "column_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "DatasetRestApi.get.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
+          "first_name",
           "last_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "DatasetRestApi.get.User1": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "username": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
-          "last_name", 
+          "first_name",
+          "last_name",
           "username"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "DatasetRestApi.get.User2": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
+          "first_name",
           "last_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "DatasetRestApi.get_list": {
         "properties": {
           "changed_by": {
             "$ref": "#/components/schemas/DatasetRestApi.get_list.User"
-          }, 
+          },
           "changed_by_name": {
             "readOnly": true
-          }, 
+          },
           "changed_by_url": {
             "readOnly": true
-          }, 
+          },
           "changed_on_delta_humanized": {
             "readOnly": true
-          }, 
+          },
           "changed_on_utc": {
             "readOnly": true
-          }, 
+          },
           "database": {
             "$ref": "#/components/schemas/DatasetRestApi.get_list.Database"
-          }, 
+          },
           "datasource_type": {
             "readOnly": true
-          }, 
+          },
           "default_endpoint": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "description": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "explore_url": {
             "readOnly": true
-          }, 
+          },
           "extra": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "kind": {
             "readOnly": true
-          }, 
+          },
           "owners": {
             "$ref": "#/components/schemas/DatasetRestApi.get_list.User1"
-          }, 
+          },
           "schema": {
-            "maxLength": 255, 
-            "nullable": true, 
+            "maxLength": 255,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "sql": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "table_name": {
-            "maxLength": 250, 
+            "maxLength": 250,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "database", 
+          "database",
           "table_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "DatasetRestApi.get_list.Database": {
         "properties": {
           "database_name": {
-            "maxLength": 250, 
+            "maxLength": 250,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "required": [
           "database_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "DatasetRestApi.get_list.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "username": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
+          "first_name",
           "username"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "DatasetRestApi.get_list.User1": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "username": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
-          "last_name", 
+          "first_name",
+          "last_name",
           "username"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "DatasetRestApi.post": {
         "properties": {
           "database": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "external_url": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "is_managed_externally": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "owners": {
             "items": {
-              "format": "int32", 
+              "format": "int32",
               "type": "integer"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "schema": {
-            "maxLength": 250, 
-            "minLength": 0, 
+            "maxLength": 250,
+            "minLength": 0,
             "type": "string"
-          }, 
+          },
           "sql": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "table_name": {
-            "maxLength": 250, 
-            "minLength": 1, 
+            "maxLength": 250,
+            "minLength": 1,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "database", 
+          "database",
           "table_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "DatasetRestApi.put": {
         "properties": {
           "cache_timeout": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "columns": {
             "items": {
               "$ref": "#/components/schemas/DatasetColumnsPut"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "database_id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "default_endpoint": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "description": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "external_url": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "extra": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "fetch_values_predicate": {
-            "maxLength": 1000, 
-            "minLength": 0, 
-            "nullable": true, 
+            "maxLength": 1000,
+            "minLength": 0,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "filter_select_enabled": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "is_managed_externally": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "is_sqllab_view": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "main_dttm_col": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "metrics": {
             "items": {
               "$ref": "#/components/schemas/DatasetMetricsPut"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "offset": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "owners": {
             "items": {
-              "format": "int32", 
+              "format": "int32",
               "type": "integer"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "schema": {
-            "maxLength": 255, 
-            "minLength": 0, 
-            "nullable": true, 
+            "maxLength": 255,
+            "minLength": 0,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "sql": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "table_name": {
-            "maxLength": 250, 
-            "minLength": 1, 
-            "nullable": true, 
+            "maxLength": 250,
+            "minLength": 1,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "template_params": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "Datasource": {
         "properties": {
           "database_name": {
-            "description": "Datasource name", 
+            "description": "Datasource name",
             "type": "string"
-          }, 
+          },
           "datasource_name": {
-            "description": "The datasource name.", 
+            "description": "The datasource name.",
             "type": "string"
-          }, 
+          },
           "datasource_type": {
-            "description": "The type of dataset/datasource identified on `datasource_id`.", 
+            "description": "The type of dataset/datasource identified on `datasource_id`.",
             "enum": [
-              "sl_table", 
-              "table", 
-              "dataset", 
-              "query", 
-              "saved_query", 
+              "sl_table",
+              "table",
+              "dataset",
+              "query",
+              "saved_query",
               "view"
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           "schema": {
-            "description": "Datasource schema", 
+            "description": "Datasource schema",
             "type": "string"
           }
-        }, 
+        },
         "required": [
           "datasource_type"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "DistincResponseSchema": {
         "properties": {
           "count": {
-            "description": "The total number of distinct values", 
-            "format": "int32", 
+            "description": "The total number of distinct values",
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "result": {
             "items": {
               "$ref": "#/components/schemas/DistinctResultResponse"
-            }, 
+            },
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "DistinctResultResponse": {
         "properties": {
           "text": {
-            "description": "The distinct item", 
+            "description": "The distinct item",
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "EmbeddedDashboardConfig": {
         "properties": {
           "allowed_domains": {
             "items": {
               "type": "string"
-            }, 
+            },
             "type": "array"
           }
-        }, 
+        },
         "required": [
           "allowed_domains"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "EmbeddedDashboardResponseSchema": {
         "properties": {
           "allowed_domains": {
             "items": {
               "type": "string"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "changed_by": {
             "$ref": "#/components/schemas/User"
-          }, 
+          },
           "changed_on": {
-            "format": "date-time", 
+            "format": "date-time",
             "type": "string"
-          }, 
+          },
           "dashboard_id": {
             "type": "string"
-          }, 
+          },
           "uuid": {
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "EmbeddedDashboardRestApi.get": {
         "properties": {
           "uuid": {
-            "format": "uuid", 
+            "format": "uuid",
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "EmbeddedDashboardRestApi.get_list": {
         "properties": {
           "uuid": {
-            "format": "uuid", 
+            "format": "uuid",
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "EmbeddedDashboardRestApi.post": {
         "properties": {
           "uuid": {
-            "format": "uuid", 
+            "format": "uuid",
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "EmbeddedDashboardRestApi.put": {
         "properties": {
           "uuid": {
-            "format": "uuid", 
+            "format": "uuid",
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ExploreContextSchema": {
         "properties": {
           "dataset": {
             "$ref": "#/components/schemas/Dataset"
-          }, 
+          },
           "form_data": {
-            "description": "Form data from the Explore controls used to form the chart's data query.", 
+            "description": "Form data from the Explore controls used to form the chart's data query.",
             "type": "object"
-          }, 
+          },
           "message": {
-            "description": "Any message related to the processed request.", 
+            "description": "Any message related to the processed request.",
             "type": "string"
-          }, 
+          },
           "slice": {
             "$ref": "#/components/schemas/Slice"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ExplorePermalinkPostSchema": {
         "properties": {
           "formData": {
-            "description": "Chart form data", 
+            "description": "Chart form data",
             "type": "object"
-          }, 
+          },
           "urlParams": {
-            "description": "URL Parameters", 
+            "description": "URL Parameters",
             "items": {
-              "description": "URL Parameter key-value pair", 
+              "description": "URL Parameter key-value pair",
               "nullable": true
-            }, 
-            "nullable": true, 
+            },
+            "nullable": true,
             "type": "array"
           }
-        }, 
+        },
         "required": [
           "formData"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "FilterSetRestApi.get": {
         "properties": {
           "dashboard_id": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "description": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "name": {
-            "maxLength": 500, 
+            "maxLength": 500,
             "type": "string"
-          }, 
+          },
           "owner_id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "owner_type": {
-            "maxLength": 255, 
+            "maxLength": 255,
             "type": "string"
-          }, 
+          },
           "params": {
             "readOnly": true
           }
-        }, 
+        },
         "required": [
-          "name", 
-          "owner_id", 
+          "name",
+          "owner_id",
           "owner_type"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "FilterSetRestApi.get_list": {
         "properties": {
           "changed_by_fk": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "changed_on": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "created_by_fk": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "created_on": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "dashboard_id": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "description": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "name": {
-            "maxLength": 500, 
+            "maxLength": 500,
             "type": "string"
-          }, 
+          },
           "owner_id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "owner_type": {
-            "maxLength": 255, 
+            "maxLength": 255,
             "type": "string"
-          }, 
+          },
           "params": {
             "readOnly": true
           }
-        }, 
+        },
         "required": [
-          "name", 
-          "owner_id", 
+          "name",
+          "owner_id",
           "owner_type"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "FilterSetRestApi.post": {
         "properties": {
           "description": {
-            "maxLength": 1000, 
-            "minLength": 1, 
-            "nullable": true, 
+            "maxLength": 1000,
+            "minLength": 1,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "json_metadata": {
             "type": "string"
-          }, 
+          },
           "name": {
-            "maxLength": 500, 
-            "minLength": 0, 
+            "maxLength": 500,
+            "minLength": 0,
             "type": "string"
-          }, 
+          },
           "owner_id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "owner_type": {
             "enum": [
-              "User", 
+              "User",
               "Dashboard"
-            ], 
+            ],
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "json_metadata", 
-          "name", 
+          "json_metadata",
+          "name",
           "owner_type"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "FilterSetRestApi.put": {
         "properties": {
           "description": {
-            "maxLength": 1000, 
-            "minLength": 1, 
+            "maxLength": 1000,
+            "minLength": 1,
             "type": "string"
-          }, 
+          },
           "json_metadata": {
             "type": "string"
-          }, 
+          },
           "name": {
-            "maxLength": 500, 
-            "minLength": 0, 
+            "maxLength": 500,
+            "minLength": 0,
             "type": "string"
-          }, 
+          },
           "owner_type": {
             "enum": [
               "Dashboard"
-            ], 
+            ],
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "FormDataPostSchema": {
         "properties": {
           "chart_id": {
-            "description": "The chart ID", 
-            "format": "int32", 
+            "description": "The chart ID",
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "datasource_id": {
-            "description": "The datasource ID", 
-            "format": "int32", 
+            "description": "The datasource ID",
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "datasource_type": {
-            "description": "The datasource type", 
+            "description": "The datasource type",
             "enum": [
-              "sl_table", 
-              "table", 
-              "dataset", 
-              "query", 
-              "saved_query", 
+              "sl_table",
+              "table",
+              "dataset",
+              "query",
+              "saved_query",
               "view"
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           "form_data": {
-            "description": "Any type of JSON supported text.", 
+            "description": "Any type of JSON supported text.",
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "datasource_id", 
-          "datasource_type", 
+          "datasource_id",
+          "datasource_type",
           "form_data"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "FormDataPutSchema": {
         "properties": {
           "chart_id": {
-            "description": "The chart ID", 
-            "format": "int32", 
+            "description": "The chart ID",
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "datasource_id": {
-            "description": "The datasource ID", 
-            "format": "int32", 
+            "description": "The datasource ID",
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "datasource_type": {
-            "description": "The datasource type", 
+            "description": "The datasource type",
             "enum": [
-              "sl_table", 
-              "table", 
-              "dataset", 
-              "query", 
-              "saved_query", 
+              "sl_table",
+              "table",
+              "dataset",
+              "query",
+              "saved_query",
               "view"
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           "form_data": {
-            "description": "Any type of JSON supported text.", 
+            "description": "Any type of JSON supported text.",
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "datasource_id", 
-          "datasource_type", 
+          "datasource_id",
+          "datasource_type",
           "form_data"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "GetFavStarIdsSchema": {
         "properties": {
           "result": {
-            "description": "A list of results for each corresponding chart in the request", 
+            "description": "A list of results for each corresponding chart in the request",
             "items": {
               "$ref": "#/components/schemas/ChartFavStarResponseResult"
-            }, 
+            },
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "GuestTokenCreate": {
         "properties": {
           "resources": {
             "items": {
               "$ref": "#/components/schemas/Resource"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "rls": {
             "items": {
               "$ref": "#/components/schemas/RlsRule"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "user": {
             "$ref": "#/components/schemas/User1"
           }
-        }, 
+        },
         "required": [
-          "resources", 
+          "resources",
           "rls"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "LogRestApi.get": {
         "properties": {
           "action": {
-            "maxLength": 512, 
-            "nullable": true, 
+            "maxLength": 512,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "dashboard_id": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "dttm": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "duration_ms": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "json": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "referrer": {
-            "maxLength": 1024, 
-            "nullable": true, 
+            "maxLength": 1024,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "slice_id": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "user": {
             "$ref": "#/components/schemas/LogRestApi.get.User"
-          }, 
+          },
           "user_id": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "LogRestApi.get.User": {
         "properties": {
           "username": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
           "username"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "LogRestApi.get_list": {
         "properties": {
           "action": {
-            "maxLength": 512, 
-            "nullable": true, 
+            "maxLength": 512,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "dashboard_id": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "dttm": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "duration_ms": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "json": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "referrer": {
-            "maxLength": 1024, 
-            "nullable": true, 
+            "maxLength": 1024,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "slice_id": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "user": {
             "$ref": "#/components/schemas/LogRestApi.get_list.User"
-          }, 
+          },
           "user_id": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "LogRestApi.get_list.User": {
         "properties": {
           "username": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
           "username"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "LogRestApi.post": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "LogRestApi.put": {
         "properties": {
           "action": {
-            "maxLength": 512, 
-            "nullable": true, 
+            "maxLength": 512,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "dttm": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "json": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "user": {
             "nullable": true
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "QueryRestApi.get": {
         "properties": {
           "changed_on": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "client_id": {
-            "maxLength": 11, 
+            "maxLength": 11,
             "type": "string"
-          }, 
+          },
           "database": {
             "$ref": "#/components/schemas/QueryRestApi.get.Database"
-          }, 
+          },
           "end_result_backend_time": {
-            "nullable": true, 
+            "nullable": true,
             "type": "number"
-          }, 
+          },
           "end_time": {
-            "nullable": true, 
+            "nullable": true,
             "type": "number"
-          }, 
+          },
           "error_message": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "executed_sql": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "limit": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "progress": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "results_key": {
-            "maxLength": 64, 
-            "nullable": true, 
+            "maxLength": 64,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "rows": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "schema": {
-            "maxLength": 256, 
-            "nullable": true, 
+            "maxLength": 256,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "select_as_cta": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "select_as_cta_used": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "select_sql": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "sql": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "sql_editor_id": {
-            "maxLength": 256, 
-            "nullable": true, 
+            "maxLength": 256,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "start_running_time": {
-            "nullable": true, 
+            "nullable": true,
             "type": "number"
-          }, 
+          },
           "start_time": {
-            "nullable": true, 
+            "nullable": true,
             "type": "number"
-          }, 
+          },
           "status": {
-            "maxLength": 16, 
-            "nullable": true, 
+            "maxLength": 16,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "tab_name": {
-            "maxLength": 256, 
-            "nullable": true, 
+            "maxLength": 256,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "tmp_schema_name": {
-            "maxLength": 256, 
-            "nullable": true, 
+            "maxLength": 256,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "tmp_table_name": {
-            "maxLength": 256, 
-            "nullable": true, 
+            "maxLength": 256,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "tracking_url": {
             "readOnly": true
           }
-        }, 
+        },
         "required": [
-          "client_id", 
+          "client_id",
           "database"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "QueryRestApi.get.Database": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "QueryRestApi.get_list": {
         "properties": {
           "changed_on": {
-            "format": "date-time", 
+            "format": "date-time",
             "type": "string"
-          }, 
+          },
           "database": {
             "$ref": "#/components/schemas/Database1"
-          }, 
+          },
           "end_time": {
-            "format": "float", 
+            "format": "float",
             "type": "number"
-          }, 
+          },
           "executed_sql": {
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "rows": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "schema": {
             "type": "string"
-          }, 
+          },
           "sql": {
             "type": "string"
-          }, 
+          },
           "sql_tables": {
             "readOnly": true
-          }, 
+          },
           "start_time": {
-            "format": "float", 
+            "format": "float",
             "type": "number"
-          }, 
+          },
           "status": {
             "type": "string"
-          }, 
+          },
           "tab_name": {
             "type": "string"
-          }, 
+          },
           "tmp_table_name": {
             "type": "string"
-          }, 
+          },
           "tracking_url": {
             "type": "string"
-          }, 
+          },
           "user": {
             "$ref": "#/components/schemas/User"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "QueryRestApi.post": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "QueryRestApi.put": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "RLSRestApi.get": {
         "properties": {
           "clause": {
-            "description": "This is the condition that will be added to the WHERE clause. For example, to only return rows for a particular client, you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role, a base filter can be created with the clause `1 = 0` (always false).", 
+            "description": "This is the condition that will be added to the WHERE clause. For example, to only return rows for a particular client, you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role, a base filter can be created with the clause `1 = 0` (always false).",
             "type": "string"
-          }, 
+          },
           "description": {
-            "description": "Detailed description", 
+            "description": "Detailed description",
             "type": "string"
-          }, 
+          },
           "filter_type": {
-            "description": "Regular filters add where clauses to queries if a user belongs to a role referenced in the filter, base filters apply filters to all queries except the roles defined in the filter, and can be used to define what users can see if no RLS filters within a filter group apply to them.", 
+            "description": "Regular filters add where clauses to queries if a user belongs to a role referenced in the filter, base filters apply filters to all queries except the roles defined in the filter, and can be used to define what users can see if no RLS filters within a filter group apply to them.",
             "enum": [
-              "Regular", 
+              "Regular",
               "Base"
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           "group_key": {
-            "description": "Filters with the same group key will be ORed together within the group, while different filter groups will be ANDed together. Undefined group keys are treated as unique groups, i.e. are not grouped together. For example, if a table has three filters, of which two are for departments Finance and Marketing (group key = 'department'), and one refers to the region Europe (group key = 'region'), the filter clause would apply the filter (department = 'Finance' OR department = 'Marketing') AND (region = 'Europe').", 
+            "description": "Filters with the same group key will be ORed together within the group, while different filter groups will be ANDed together. Undefined group keys are treated as unique groups, i.e. are not grouped together. For example, if a table has three filters, of which two are for departments Finance and Marketing (group key = 'department'), and one refers to the region Europe (group key = 'region'), the filter clause would apply the filter (department = 'Finance' OR department = 'Marketing') AND (region = 'Europe').",
             "type": "string"
-          }, 
+          },
           "id": {
-            "description": "Unique if of rls filter", 
-            "format": "int32", 
+            "description": "Unique if of rls filter",
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "name": {
-            "description": "Name of rls filter", 
+            "description": "Name of rls filter",
             "type": "string"
-          }, 
+          },
           "roles": {
             "items": {
               "$ref": "#/components/schemas/Roles1"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "tables": {
             "items": {
               "$ref": "#/components/schemas/Tables"
-            }, 
+            },
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "RLSRestApi.get_list": {
         "properties": {
           "changed_on_delta_humanized": {
             "readOnly": true
-          }, 
+          },
           "clause": {
-            "description": "This is the condition that will be added to the WHERE clause. For example, to only return rows for a particular client, you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role, a base filter can be created with the clause `1 = 0` (always false).", 
+            "description": "This is the condition that will be added to the WHERE clause. For example, to only return rows for a particular client, you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role, a base filter can be created with the clause `1 = 0` (always false).",
             "type": "string"
-          }, 
+          },
           "description": {
-            "description": "Detailed description", 
+            "description": "Detailed description",
             "type": "string"
-          }, 
+          },
           "filter_type": {
-            "description": "Regular filters add where clauses to queries if a user belongs to a role referenced in the filter, base filters apply filters to all queries except the roles defined in the filter, and can be used to define what users can see if no RLS filters within a filter group apply to them.", 
+            "description": "Regular filters add where clauses to queries if a user belongs to a role referenced in the filter, base filters apply filters to all queries except the roles defined in the filter, and can be used to define what users can see if no RLS filters within a filter group apply to them.",
             "enum": [
-              "Regular", 
+              "Regular",
               "Base"
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           "group_key": {
-            "description": "Filters with the same group key will be ORed together within the group, while different filter groups will be ANDed together. Undefined group keys are treated as unique groups, i.e. are not grouped together. For example, if a table has three filters, of which two are for departments Finance and Marketing (group key = 'department'), and one refers to the region Europe (group key = 'region'), the filter clause would apply the filter (department = 'Finance' OR department = 'Marketing') AND (region = 'Europe').", 
+            "description": "Filters with the same group key will be ORed together within the group, while different filter groups will be ANDed together. Undefined group keys are treated as unique groups, i.e. are not grouped together. For example, if a table has three filters, of which two are for departments Finance and Marketing (group key = 'department'), and one refers to the region Europe (group key = 'region'), the filter clause would apply the filter (department = 'Finance' OR department = 'Marketing') AND (region = 'Europe').",
             "type": "string"
-          }, 
+          },
           "id": {
-            "description": "Unique if of rls filter", 
-            "format": "int32", 
+            "description": "Unique if of rls filter",
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "name": {
-            "description": "Name of rls filter", 
+            "description": "Name of rls filter",
             "type": "string"
-          }, 
+          },
           "roles": {
             "items": {
               "$ref": "#/components/schemas/Roles1"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "tables": {
             "items": {
               "$ref": "#/components/schemas/Tables"
-            }, 
+            },
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "RLSRestApi.post": {
         "properties": {
           "clause": {
-            "description": "This is the condition that will be added to the WHERE clause. For example, to only return rows for a particular client, you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role, a base filter can be created with the clause `1 = 0` (always false).", 
+            "description": "This is the condition that will be added to the WHERE clause. For example, to only return rows for a particular client, you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role, a base filter can be created with the clause `1 = 0` (always false).",
             "type": "string"
-          }, 
+          },
           "description": {
-            "description": "Detailed description", 
-            "nullable": true, 
+            "description": "Detailed description",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "filter_type": {
-            "description": "Regular filters add where clauses to queries if a user belongs to a role referenced in the filter, base filters apply filters to all queries except the roles defined in the filter, and can be used to define what users can see if no RLS filters within a filter group apply to them.", 
+            "description": "Regular filters add where clauses to queries if a user belongs to a role referenced in the filter, base filters apply filters to all queries except the roles defined in the filter, and can be used to define what users can see if no RLS filters within a filter group apply to them.",
             "enum": [
-              "Regular", 
+              "Regular",
               "Base"
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           "group_key": {
-            "description": "Filters with the same group key will be ORed together within the group, while different filter groups will be ANDed together. Undefined group keys are treated as unique groups, i.e. are not grouped together. For example, if a table has three filters, of which two are for departments Finance and Marketing (group key = 'department'), and one refers to the region Europe (group key = 'region'), the filter clause would apply the filter (department = 'Finance' OR department = 'Marketing') AND (region = 'Europe').", 
-            "nullable": true, 
+            "description": "Filters with the same group key will be ORed together within the group, while different filter groups will be ANDed together. Undefined group keys are treated as unique groups, i.e. are not grouped together. For example, if a table has three filters, of which two are for departments Finance and Marketing (group key = 'department'), and one refers to the region Europe (group key = 'region'), the filter clause would apply the filter (department = 'Finance' OR department = 'Marketing') AND (region = 'Europe').",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "name": {
-            "description": "Name of rls filter", 
-            "maxLength": 255, 
-            "minLength": 1, 
+            "description": "Name of rls filter",
+            "maxLength": 255,
+            "minLength": 1,
             "type": "string"
-          }, 
+          },
           "roles": {
-            "description": "For regular filters, these are the roles this filter will be applied to. For base filters, these are the roles that the filter DOES NOT apply to, e.g. Admin if admin should see all data.", 
+            "description": "For regular filters, these are the roles this filter will be applied to. For base filters, these are the roles that the filter DOES NOT apply to, e.g. Admin if admin should see all data.",
             "items": {
-              "format": "int32", 
+              "format": "int32",
               "type": "integer"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "tables": {
-            "description": "These are the tables this filter will be applied to.", 
+            "description": "These are the tables this filter will be applied to.",
             "items": {
-              "format": "int32", 
+              "format": "int32",
               "type": "integer"
-            }, 
-            "minItems": 1, 
+            },
+            "minItems": 1,
             "type": "array"
           }
-        }, 
+        },
         "required": [
-          "clause", 
-          "filter_type", 
-          "name", 
-          "roles", 
+          "clause",
+          "filter_type",
+          "name",
+          "roles",
           "tables"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "RLSRestApi.put": {
         "properties": {
           "clause": {
-            "description": "This is the condition that will be added to the WHERE clause. For example, to only return rows for a particular client, you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role, a base filter can be created with the clause `1 = 0` (always false).", 
+            "description": "This is the condition that will be added to the WHERE clause. For example, to only return rows for a particular client, you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role, a base filter can be created with the clause `1 = 0` (always false).",
             "type": "string"
-          }, 
+          },
           "description": {
-            "description": "Detailed description", 
-            "nullable": true, 
+            "description": "Detailed description",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "filter_type": {
-            "description": "Regular filters add where clauses to queries if a user belongs to a role referenced in the filter, base filters apply filters to all queries except the roles defined in the filter, and can be used to define what users can see if no RLS filters within a filter group apply to them.", 
+            "description": "Regular filters add where clauses to queries if a user belongs to a role referenced in the filter, base filters apply filters to all queries except the roles defined in the filter, and can be used to define what users can see if no RLS filters within a filter group apply to them.",
             "enum": [
-              "Regular", 
+              "Regular",
               "Base"
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           "group_key": {
-            "description": "Filters with the same group key will be ORed together within the group, while different filter groups will be ANDed together. Undefined group keys are treated as unique groups, i.e. are not grouped together. For example, if a table has three filters, of which two are for departments Finance and Marketing (group key = 'department'), and one refers to the region Europe (group key = 'region'), the filter clause would apply the filter (department = 'Finance' OR department = 'Marketing') AND (region = 'Europe').", 
-            "nullable": true, 
+            "description": "Filters with the same group key will be ORed together within the group, while different filter groups will be ANDed together. Undefined group keys are treated as unique groups, i.e. are not grouped together. For example, if a table has three filters, of which two are for departments Finance and Marketing (group key = 'department'), and one refers to the region Europe (group key = 'region'), the filter clause would apply the filter (department = 'Finance' OR department = 'Marketing') AND (region = 'Europe').",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "name": {
-            "description": "Name of rls filter", 
-            "maxLength": 255, 
-            "minLength": 1, 
+            "description": "Name of rls filter",
+            "maxLength": 255,
+            "minLength": 1,
             "type": "string"
-          }, 
+          },
           "roles": {
-            "description": "For regular filters, these are the roles this filter will be applied to. For base filters, these are the roles that the filter DOES NOT apply to, e.g. Admin if admin should see all data.", 
+            "description": "For regular filters, these are the roles this filter will be applied to. For base filters, these are the roles that the filter DOES NOT apply to, e.g. Admin if admin should see all data.",
             "items": {
-              "format": "int32", 
+              "format": "int32",
               "type": "integer"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "tables": {
-            "description": "These are the tables this filter will be applied to.", 
+            "description": "These are the tables this filter will be applied to.",
             "items": {
-              "format": "int32", 
+              "format": "int32",
               "type": "integer"
-            }, 
+            },
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "RecentActivity": {
         "properties": {
           "action": {
-            "description": "Action taken describing type of activity", 
+            "description": "Action taken describing type of activity",
             "type": "string"
-          }, 
+          },
           "item_title": {
-            "description": "Title of item", 
+            "description": "Title of item",
             "type": "string"
-          }, 
+          },
           "item_type": {
-            "description": "Type of item, e.g. slice or dashboard", 
+            "description": "Type of item, e.g. slice or dashboard",
             "type": "string"
-          }, 
+          },
           "item_url": {
-            "description": "URL to item", 
+            "description": "URL to item",
             "type": "string"
-          }, 
+          },
           "time": {
-            "description": "Time of activity, in epoch milliseconds", 
-            "format": "float", 
+            "description": "Time of activity, in epoch milliseconds",
+            "format": "float",
             "type": "number"
-          }, 
+          },
           "time_delta_humanized": {
-            "description": "Human-readable description of how long ago activity took place", 
+            "description": "Human-readable description of how long ago activity took place",
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "RecentActivityResponseSchema": {
         "properties": {
           "result": {
-            "description": "A list of recent activity objects", 
+            "description": "A list of recent activity objects",
             "items": {
               "$ref": "#/components/schemas/RecentActivity"
-            }, 
+            },
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "RecentActivitySchema": {
         "properties": {
           "action": {
-            "description": "Action taken describing type of activity", 
+            "description": "Action taken describing type of activity",
             "type": "string"
-          }, 
+          },
           "item_title": {
-            "description": "Title of item", 
+            "description": "Title of item",
             "type": "string"
-          }, 
+          },
           "item_type": {
-            "description": "Type of item, e.g. slice or dashboard", 
+            "description": "Type of item, e.g. slice or dashboard",
             "type": "string"
-          }, 
+          },
           "item_url": {
-            "description": "URL to item", 
+            "description": "URL to item",
             "type": "string"
-          }, 
+          },
           "time": {
-            "description": "Time of activity, in epoch milliseconds", 
-            "format": "float", 
+            "description": "Time of activity, in epoch milliseconds",
+            "format": "float",
             "type": "number"
-          }, 
+          },
           "time_delta_humanized": {
-            "description": "Human-readable description of how long ago activity took place", 
+            "description": "Human-readable description of how long ago activity took place",
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "RelatedResponseSchema": {
         "properties": {
           "count": {
-            "description": "The total number of related values", 
-            "format": "int32", 
+            "description": "The total number of related values",
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "result": {
             "items": {
               "$ref": "#/components/schemas/RelatedResultResponse"
-            }, 
+            },
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "RelatedResultResponse": {
         "properties": {
           "extra": {
-            "description": "The extra metadata for related item", 
+            "description": "The extra metadata for related item",
             "type": "object"
-          }, 
+          },
           "text": {
-            "description": "The related item string representation", 
+            "description": "The related item string representation",
             "type": "string"
-          }, 
+          },
           "value": {
-            "description": "The related item identifier", 
-            "format": "int32", 
+            "description": "The related item identifier",
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ReportExecutionLogRestApi.get": {
         "properties": {
           "end_dttm": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "error_message": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "scheduled_dttm": {
-            "format": "date-time", 
+            "format": "date-time",
             "type": "string"
-          }, 
+          },
           "start_dttm": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "state": {
-            "maxLength": 50, 
+            "maxLength": 50,
             "type": "string"
-          }, 
+          },
           "uuid": {
-            "format": "uuid", 
-            "nullable": true, 
+            "format": "uuid",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "value": {
-            "format": "float", 
-            "nullable": true, 
+            "format": "float",
+            "nullable": true,
             "type": "number"
-          }, 
+          },
           "value_row_json": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "scheduled_dttm", 
+          "scheduled_dttm",
           "state"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ReportExecutionLogRestApi.get_list": {
         "properties": {
           "end_dttm": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "error_message": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "scheduled_dttm": {
-            "format": "date-time", 
+            "format": "date-time",
             "type": "string"
-          }, 
+          },
           "start_dttm": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "state": {
-            "maxLength": 50, 
+            "maxLength": 50,
             "type": "string"
-          }, 
+          },
           "uuid": {
-            "format": "uuid", 
-            "nullable": true, 
+            "format": "uuid",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "value": {
-            "format": "float", 
-            "nullable": true, 
+            "format": "float",
+            "nullable": true,
             "type": "number"
-          }, 
+          },
           "value_row_json": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "scheduled_dttm", 
+          "scheduled_dttm",
           "state"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ReportExecutionLogRestApi.post": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ReportExecutionLogRestApi.put": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ReportRecipient": {
         "properties": {
           "recipient_config_json": {
             "$ref": "#/components/schemas/ReportRecipientConfigJSON"
-          }, 
+          },
           "type": {
-            "description": "The recipient type, check spec for valid options", 
+            "description": "The recipient type, check spec for valid options",
             "enum": [
-              "Email", 
+              "Email",
               "Slack"
-            ], 
+            ],
             "type": "string"
           }
-        }, 
+        },
         "required": [
           "type"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ReportRecipientConfigJSON": {
         "properties": {
           "target": {
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ReportScheduleRestApi.get": {
         "properties": {
           "active": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "chart": {
             "$ref": "#/components/schemas/ReportScheduleRestApi.get.Slice"
-          }, 
+          },
           "context_markdown": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "creation_method": {
-            "maxLength": 255, 
-            "nullable": true, 
+            "maxLength": 255,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "crontab": {
-            "maxLength": 1000, 
+            "maxLength": 1000,
             "type": "string"
-          }, 
+          },
           "dashboard": {
             "$ref": "#/components/schemas/ReportScheduleRestApi.get.Dashboard"
-          }, 
+          },
           "database": {
             "$ref": "#/components/schemas/ReportScheduleRestApi.get.Database"
-          }, 
+          },
           "description": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "extra": {
             "readOnly": true
-          }, 
+          },
           "force_screenshot": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "grace_period": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "last_eval_dttm": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "last_state": {
-            "maxLength": 50, 
-            "nullable": true, 
+            "maxLength": 50,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "last_value": {
-            "format": "float", 
-            "nullable": true, 
+            "format": "float",
+            "nullable": true,
             "type": "number"
-          }, 
+          },
           "last_value_row_json": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "log_retention": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "name": {
-            "maxLength": 150, 
+            "maxLength": 150,
             "type": "string"
-          }, 
+          },
           "owners": {
             "$ref": "#/components/schemas/ReportScheduleRestApi.get.User"
-          }, 
+          },
           "recipients": {
             "$ref": "#/components/schemas/ReportScheduleRestApi.get.ReportRecipients"
-          }, 
+          },
           "report_format": {
-            "maxLength": 50, 
-            "nullable": true, 
+            "maxLength": 50,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "sql": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "timezone": {
-            "maxLength": 100, 
+            "maxLength": 100,
             "type": "string"
-          }, 
+          },
           "type": {
-            "maxLength": 50, 
+            "maxLength": 50,
             "type": "string"
-          }, 
+          },
           "validator_config_json": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "validator_type": {
-            "maxLength": 100, 
-            "nullable": true, 
+            "maxLength": 100,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "working_timeout": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
           }
-        }, 
+        },
         "required": [
-          "crontab", 
-          "name", 
-          "recipients", 
+          "crontab",
+          "name",
+          "recipients",
           "type"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ReportScheduleRestApi.get.Dashboard": {
         "properties": {
           "dashboard_title": {
-            "maxLength": 500, 
-            "nullable": true, 
+            "maxLength": 500,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ReportScheduleRestApi.get.Database": {
         "properties": {
           "database_name": {
-            "maxLength": 250, 
+            "maxLength": 250,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "required": [
           "database_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ReportScheduleRestApi.get.ReportRecipients": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "recipient_config_json": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "type": {
-            "maxLength": 50, 
+            "maxLength": 50,
             "type": "string"
           }
-        }, 
+        },
         "required": [
           "type"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ReportScheduleRestApi.get.Slice": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "slice_name": {
-            "maxLength": 250, 
-            "nullable": true, 
+            "maxLength": 250,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "viz_type": {
-            "maxLength": 250, 
-            "nullable": true, 
+            "maxLength": 250,
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ReportScheduleRestApi.get.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
+          "first_name",
           "last_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ReportScheduleRestApi.get_list": {
         "properties": {
           "active": {
-            "nullable": true, 
+            "nullable": true,
             "type": "boolean"
-          }, 
+          },
           "changed_by": {
             "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.User"
-          }, 
+          },
           "changed_on": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "changed_on_delta_humanized": {
             "readOnly": true
-          }, 
+          },
           "chart_id": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "created_by": {
             "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.User2"
-          }, 
+          },
           "created_on": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "creation_method": {
-            "maxLength": 255, 
-            "nullable": true, 
+            "maxLength": 255,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "crontab": {
-            "maxLength": 1000, 
+            "maxLength": 1000,
             "type": "string"
-          }, 
+          },
           "crontab_humanized": {
             "readOnly": true
-          }, 
+          },
           "dashboard_id": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "description": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "extra": {
             "readOnly": true
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "last_eval_dttm": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "last_state": {
-            "maxLength": 50, 
-            "nullable": true, 
+            "maxLength": 50,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "name": {
-            "maxLength": 150, 
+            "maxLength": 150,
             "type": "string"
-          }, 
+          },
           "owners": {
             "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.User1"
-          }, 
+          },
           "recipients": {
             "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.ReportRecipients"
-          }, 
+          },
           "timezone": {
-            "maxLength": 100, 
+            "maxLength": 100,
             "type": "string"
-          }, 
+          },
           "type": {
-            "maxLength": 50, 
+            "maxLength": 50,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "crontab", 
-          "name", 
-          "recipients", 
+          "crontab",
+          "name",
+          "recipients",
           "type"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ReportScheduleRestApi.get_list.ReportRecipients": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "type": {
-            "maxLength": 50, 
+            "maxLength": 50,
             "type": "string"
           }
-        }, 
+        },
         "required": [
           "type"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ReportScheduleRestApi.get_list.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
+          "first_name",
           "last_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ReportScheduleRestApi.get_list.User1": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
+          "first_name",
           "last_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ReportScheduleRestApi.get_list.User2": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
+          "first_name",
           "last_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ReportScheduleRestApi.post": {
         "properties": {
           "active": {
             "type": "boolean"
-          }, 
+          },
           "chart": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "context_markdown": {
-            "description": "Markdown description", 
-            "nullable": true, 
+            "description": "Markdown description",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "creation_method": {
             "description": "Creation method is used to inform the frontend whether the report/alert was created in the dashboard, chart, or alerts and reports UI."
-          }, 
+          },
           "crontab": {
-            "description": "A CRON expression.[Crontab Guru](https://crontab.guru/) is a helpful resource that can help you craft a CRON expression.", 
-            "example": "*/5 * * * *", 
-            "maxLength": 1000, 
-            "minLength": 1, 
+            "description": "A CRON expression.[Crontab Guru](https://crontab.guru/) is a helpful resource that can help you craft a CRON expression.",
+            "example": "*/5 * * * *",
+            "maxLength": 1000,
+            "minLength": 1,
             "type": "string"
-          }, 
+          },
           "dashboard": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "database": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "description": {
-            "description": "Use a nice description to give context to this Alert/Report", 
-            "example": "Daily sales dashboard to marketing", 
-            "nullable": true, 
+            "description": "Use a nice description to give context to this Alert/Report",
+            "example": "Daily sales dashboard to marketing",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "extra": {
             "type": "object"
-          }, 
+          },
           "force_screenshot": {
             "type": "boolean"
-          }, 
+          },
           "grace_period": {
-            "description": "Once an alert is triggered, how long, in seconds, before Superset nags you again. (in seconds)", 
-            "example": 14400, 
-            "format": "int32", 
-            "minimum": 1, 
+            "description": "Once an alert is triggered, how long, in seconds, before Superset nags you again. (in seconds)",
+            "example": 14400,
+            "format": "int32",
+            "minimum": 1,
             "type": "integer"
-          }, 
+          },
           "log_retention": {
-            "description": "How long to keep the logs around for this report (in days)", 
-            "example": 90, 
-            "format": "int32", 
-            "minimum": 1, 
+            "description": "How long to keep the logs around for this report (in days)",
+            "example": 90,
+            "format": "int32",
+            "minimum": 1,
             "type": "integer"
-          }, 
+          },
           "name": {
-            "description": "The report schedule name.", 
-            "example": "Daily dashboard email", 
-            "maxLength": 150, 
-            "minLength": 1, 
+            "description": "The report schedule name.",
+            "example": "Daily dashboard email",
+            "maxLength": 150,
+            "minLength": 1,
             "type": "string"
-          }, 
+          },
           "owners": {
             "items": {
-              "description": "Owner are users ids allowed to delete or change this report. If left empty you will be one of the owners of the report.", 
-              "format": "int32", 
+              "description": "Owner are users ids allowed to delete or change this report. If left empty you will be one of the owners of the report.",
+              "format": "int32",
               "type": "integer"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "recipients": {
             "items": {
               "$ref": "#/components/schemas/ReportRecipient"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "report_format": {
             "enum": [
-              "PNG", 
-              "CSV", 
+              "PNG",
+              "CSV",
               "TEXT"
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           "selected_tabs": {
             "items": {
-              "format": "int32", 
+              "format": "int32",
               "type": "integer"
-            }, 
-            "nullable": true, 
+            },
+            "nullable": true,
             "type": "array"
-          }, 
+          },
           "sql": {
-            "description": "A SQL statement that defines whether the alert should get triggered or not. The query is expected to return either NULL or a number value.", 
-            "example": "SELECT value FROM time_series_table", 
+            "description": "A SQL statement that defines whether the alert should get triggered or not. The query is expected to return either NULL or a number value.",
+            "example": "SELECT value FROM time_series_table",
             "type": "string"
-          }, 
+          },
           "timezone": {
-            "description": "A timezone string that represents the location of the timezone.", 
+            "description": "A timezone string that represents the location of the timezone.",
             "enum": [
-              "Africa/Abidjan", 
-              "Africa/Accra", 
-              "Africa/Addis_Ababa", 
-              "Africa/Algiers", 
-              "Africa/Asmara", 
-              "Africa/Asmera", 
-              "Africa/Bamako", 
-              "Africa/Bangui", 
-              "Africa/Banjul", 
-              "Africa/Bissau", 
-              "Africa/Blantyre", 
-              "Africa/Brazzaville", 
-              "Africa/Bujumbura", 
-              "Africa/Cairo", 
-              "Africa/Casablanca", 
-              "Africa/Ceuta", 
-              "Africa/Conakry", 
-              "Africa/Dakar", 
-              "Africa/Dar_es_Salaam", 
-              "Africa/Djibouti", 
-              "Africa/Douala", 
-              "Africa/El_Aaiun", 
-              "Africa/Freetown", 
-              "Africa/Gaborone", 
-              "Africa/Harare", 
-              "Africa/Johannesburg", 
-              "Africa/Juba", 
-              "Africa/Kampala", 
-              "Africa/Khartoum", 
-              "Africa/Kigali", 
-              "Africa/Kinshasa", 
-              "Africa/Lagos", 
-              "Africa/Libreville", 
-              "Africa/Lome", 
-              "Africa/Luanda", 
-              "Africa/Lubumbashi", 
-              "Africa/Lusaka", 
-              "Africa/Malabo", 
-              "Africa/Maputo", 
-              "Africa/Maseru", 
-              "Africa/Mbabane", 
-              "Africa/Mogadishu", 
-              "Africa/Monrovia", 
-              "Africa/Nairobi", 
-              "Africa/Ndjamena", 
-              "Africa/Niamey", 
-              "Africa/Nouakchott", 
-              "Africa/Ouagadougou", 
-              "Africa/Porto-Novo", 
-              "Africa/Sao_Tome", 
-              "Africa/Timbuktu", 
-              "Africa/Tripoli", 
-              "Africa/Tunis", 
-              "Africa/Windhoek", 
-              "America/Adak", 
-              "America/Anchorage", 
-              "America/Anguilla", 
-              "America/Antigua", 
-              "America/Araguaina", 
-              "America/Argentina/Buenos_Aires", 
-              "America/Argentina/Catamarca", 
-              "America/Argentina/ComodRivadavia", 
-              "America/Argentina/Cordoba", 
-              "America/Argentina/Jujuy", 
-              "America/Argentina/La_Rioja", 
-              "America/Argentina/Mendoza", 
-              "America/Argentina/Rio_Gallegos", 
-              "America/Argentina/Salta", 
-              "America/Argentina/San_Juan", 
-              "America/Argentina/San_Luis", 
-              "America/Argentina/Tucuman", 
-              "America/Argentina/Ushuaia", 
-              "America/Aruba", 
-              "America/Asuncion", 
-              "America/Atikokan", 
-              "America/Atka", 
-              "America/Bahia", 
-              "America/Bahia_Banderas", 
-              "America/Barbados", 
-              "America/Belem", 
-              "America/Belize", 
-              "America/Blanc-Sablon", 
-              "America/Boa_Vista", 
-              "America/Bogota", 
-              "America/Boise", 
-              "America/Buenos_Aires", 
-              "America/Cambridge_Bay", 
-              "America/Campo_Grande", 
-              "America/Cancun", 
-              "America/Caracas", 
-              "America/Catamarca", 
-              "America/Cayenne", 
-              "America/Cayman", 
-              "America/Chicago", 
-              "America/Chihuahua", 
-              "America/Coral_Harbour", 
-              "America/Cordoba", 
-              "America/Costa_Rica", 
-              "America/Creston", 
-              "America/Cuiaba", 
-              "America/Curacao", 
-              "America/Danmarkshavn", 
-              "America/Dawson", 
-              "America/Dawson_Creek", 
-              "America/Denver", 
-              "America/Detroit", 
-              "America/Dominica", 
-              "America/Edmonton", 
-              "America/Eirunepe", 
-              "America/El_Salvador", 
-              "America/Ensenada", 
-              "America/Fort_Nelson", 
-              "America/Fort_Wayne", 
-              "America/Fortaleza", 
-              "America/Glace_Bay", 
-              "America/Godthab", 
-              "America/Goose_Bay", 
-              "America/Grand_Turk", 
-              "America/Grenada", 
-              "America/Guadeloupe", 
-              "America/Guatemala", 
-              "America/Guayaquil", 
-              "America/Guyana", 
-              "America/Halifax", 
-              "America/Havana", 
-              "America/Hermosillo", 
-              "America/Indiana/Indianapolis", 
-              "America/Indiana/Knox", 
-              "America/Indiana/Marengo", 
-              "America/Indiana/Petersburg", 
-              "America/Indiana/Tell_City", 
-              "America/Indiana/Vevay", 
-              "America/Indiana/Vincennes", 
-              "America/Indiana/Winamac", 
-              "America/Indianapolis", 
-              "America/Inuvik", 
-              "America/Iqaluit", 
-              "America/Jamaica", 
-              "America/Jujuy", 
-              "America/Juneau", 
-              "America/Kentucky/Louisville", 
-              "America/Kentucky/Monticello", 
-              "America/Knox_IN", 
-              "America/Kralendijk", 
-              "America/La_Paz", 
-              "America/Lima", 
-              "America/Los_Angeles", 
-              "America/Louisville", 
-              "America/Lower_Princes", 
-              "America/Maceio", 
-              "America/Managua", 
-              "America/Manaus", 
-              "America/Marigot", 
-              "America/Martinique", 
-              "America/Matamoros", 
-              "America/Mazatlan", 
-              "America/Mendoza", 
-              "America/Menominee", 
-              "America/Merida", 
-              "America/Metlakatla", 
-              "America/Mexico_City", 
-              "America/Miquelon", 
-              "America/Moncton", 
-              "America/Monterrey", 
-              "America/Montevideo", 
-              "America/Montreal", 
-              "America/Montserrat", 
-              "America/Nassau", 
-              "America/New_York", 
-              "America/Nipigon", 
-              "America/Nome", 
-              "America/Noronha", 
-              "America/North_Dakota/Beulah", 
-              "America/North_Dakota/Center", 
-              "America/North_Dakota/New_Salem", 
-              "America/Nuuk", 
-              "America/Ojinaga", 
-              "America/Panama", 
-              "America/Pangnirtung", 
-              "America/Paramaribo", 
-              "America/Phoenix", 
-              "America/Port-au-Prince", 
-              "America/Port_of_Spain", 
-              "America/Porto_Acre", 
-              "America/Porto_Velho", 
-              "America/Puerto_Rico", 
-              "America/Punta_Arenas", 
-              "America/Rainy_River", 
-              "America/Rankin_Inlet", 
-              "America/Recife", 
-              "America/Regina", 
-              "America/Resolute", 
-              "America/Rio_Branco", 
-              "America/Rosario", 
-              "America/Santa_Isabel", 
-              "America/Santarem", 
-              "America/Santiago", 
-              "America/Santo_Domingo", 
-              "America/Sao_Paulo", 
-              "America/Scoresbysund", 
-              "America/Shiprock", 
-              "America/Sitka", 
-              "America/St_Barthelemy", 
-              "America/St_Johns", 
-              "America/St_Kitts", 
-              "America/St_Lucia", 
-              "America/St_Thomas", 
-              "America/St_Vincent", 
-              "America/Swift_Current", 
-              "America/Tegucigalpa", 
-              "America/Thule", 
-              "America/Thunder_Bay", 
-              "America/Tijuana", 
-              "America/Toronto", 
-              "America/Tortola", 
-              "America/Vancouver", 
-              "America/Virgin", 
-              "America/Whitehorse", 
-              "America/Winnipeg", 
-              "America/Yakutat", 
-              "America/Yellowknife", 
-              "Antarctica/Casey", 
-              "Antarctica/Davis", 
-              "Antarctica/DumontDUrville", 
-              "Antarctica/Macquarie", 
-              "Antarctica/Mawson", 
-              "Antarctica/McMurdo", 
-              "Antarctica/Palmer", 
-              "Antarctica/Rothera", 
-              "Antarctica/South_Pole", 
-              "Antarctica/Syowa", 
-              "Antarctica/Troll", 
-              "Antarctica/Vostok", 
-              "Arctic/Longyearbyen", 
-              "Asia/Aden", 
-              "Asia/Almaty", 
-              "Asia/Amman", 
-              "Asia/Anadyr", 
-              "Asia/Aqtau", 
-              "Asia/Aqtobe", 
-              "Asia/Ashgabat", 
-              "Asia/Ashkhabad", 
-              "Asia/Atyrau", 
-              "Asia/Baghdad", 
-              "Asia/Bahrain", 
-              "Asia/Baku", 
-              "Asia/Bangkok", 
-              "Asia/Barnaul", 
-              "Asia/Beirut", 
-              "Asia/Bishkek", 
-              "Asia/Brunei", 
-              "Asia/Calcutta", 
-              "Asia/Chita", 
-              "Asia/Choibalsan", 
-              "Asia/Chongqing", 
-              "Asia/Chungking", 
-              "Asia/Colombo", 
-              "Asia/Dacca", 
-              "Asia/Damascus", 
-              "Asia/Dhaka", 
-              "Asia/Dili", 
-              "Asia/Dubai", 
-              "Asia/Dushanbe", 
-              "Asia/Famagusta", 
-              "Asia/Gaza", 
-              "Asia/Harbin", 
-              "Asia/Hebron", 
-              "Asia/Ho_Chi_Minh", 
-              "Asia/Hong_Kong", 
-              "Asia/Hovd", 
-              "Asia/Irkutsk", 
-              "Asia/Istanbul", 
-              "Asia/Jakarta", 
-              "Asia/Jayapura", 
-              "Asia/Jerusalem", 
-              "Asia/Kabul", 
-              "Asia/Kamchatka", 
-              "Asia/Karachi", 
-              "Asia/Kashgar", 
-              "Asia/Kathmandu", 
-              "Asia/Katmandu", 
-              "Asia/Khandyga", 
-              "Asia/Kolkata", 
-              "Asia/Krasnoyarsk", 
-              "Asia/Kuala_Lumpur", 
-              "Asia/Kuching", 
-              "Asia/Kuwait", 
-              "Asia/Macao", 
-              "Asia/Macau", 
-              "Asia/Magadan", 
-              "Asia/Makassar", 
-              "Asia/Manila", 
-              "Asia/Muscat", 
-              "Asia/Nicosia", 
-              "Asia/Novokuznetsk", 
-              "Asia/Novosibirsk", 
-              "Asia/Omsk", 
-              "Asia/Oral", 
-              "Asia/Phnom_Penh", 
-              "Asia/Pontianak", 
-              "Asia/Pyongyang", 
-              "Asia/Qatar", 
-              "Asia/Qostanay", 
-              "Asia/Qyzylorda", 
-              "Asia/Rangoon", 
-              "Asia/Riyadh", 
-              "Asia/Saigon", 
-              "Asia/Sakhalin", 
-              "Asia/Samarkand", 
-              "Asia/Seoul", 
-              "Asia/Shanghai", 
-              "Asia/Singapore", 
-              "Asia/Srednekolymsk", 
-              "Asia/Taipei", 
-              "Asia/Tashkent", 
-              "Asia/Tbilisi", 
-              "Asia/Tehran", 
-              "Asia/Tel_Aviv", 
-              "Asia/Thimbu", 
-              "Asia/Thimphu", 
-              "Asia/Tokyo", 
-              "Asia/Tomsk", 
-              "Asia/Ujung_Pandang", 
-              "Asia/Ulaanbaatar", 
-              "Asia/Ulan_Bator", 
-              "Asia/Urumqi", 
-              "Asia/Ust-Nera", 
-              "Asia/Vientiane", 
-              "Asia/Vladivostok", 
-              "Asia/Yakutsk", 
-              "Asia/Yangon", 
-              "Asia/Yekaterinburg", 
-              "Asia/Yerevan", 
-              "Atlantic/Azores", 
-              "Atlantic/Bermuda", 
-              "Atlantic/Canary", 
-              "Atlantic/Cape_Verde", 
-              "Atlantic/Faeroe", 
-              "Atlantic/Faroe", 
-              "Atlantic/Jan_Mayen", 
-              "Atlantic/Madeira", 
-              "Atlantic/Reykjavik", 
-              "Atlantic/South_Georgia", 
-              "Atlantic/St_Helena", 
-              "Atlantic/Stanley", 
-              "Australia/ACT", 
-              "Australia/Adelaide", 
-              "Australia/Brisbane", 
-              "Australia/Broken_Hill", 
-              "Australia/Canberra", 
-              "Australia/Currie", 
-              "Australia/Darwin", 
-              "Australia/Eucla", 
-              "Australia/Hobart", 
-              "Australia/LHI", 
-              "Australia/Lindeman", 
-              "Australia/Lord_Howe", 
-              "Australia/Melbourne", 
-              "Australia/NSW", 
-              "Australia/North", 
-              "Australia/Perth", 
-              "Australia/Queensland", 
-              "Australia/South", 
-              "Australia/Sydney", 
-              "Australia/Tasmania", 
-              "Australia/Victoria", 
-              "Australia/West", 
-              "Australia/Yancowinna", 
-              "Brazil/Acre", 
-              "Brazil/DeNoronha", 
-              "Brazil/East", 
-              "Brazil/West", 
-              "CET", 
-              "CST6CDT", 
-              "Canada/Atlantic", 
-              "Canada/Central", 
-              "Canada/Eastern", 
-              "Canada/Mountain", 
-              "Canada/Newfoundland", 
-              "Canada/Pacific", 
-              "Canada/Saskatchewan", 
-              "Canada/Yukon", 
-              "Chile/Continental", 
-              "Chile/EasterIsland", 
-              "Cuba", 
-              "EET", 
-              "EST", 
-              "EST5EDT", 
-              "Egypt", 
-              "Eire", 
-              "Etc/GMT", 
-              "Etc/GMT+0", 
-              "Etc/GMT+1", 
-              "Etc/GMT+10", 
-              "Etc/GMT+11", 
-              "Etc/GMT+12", 
-              "Etc/GMT+2", 
-              "Etc/GMT+3", 
-              "Etc/GMT+4", 
-              "Etc/GMT+5", 
-              "Etc/GMT+6", 
-              "Etc/GMT+7", 
-              "Etc/GMT+8", 
-              "Etc/GMT+9", 
-              "Etc/GMT-0", 
-              "Etc/GMT-1", 
-              "Etc/GMT-10", 
-              "Etc/GMT-11", 
-              "Etc/GMT-12", 
-              "Etc/GMT-13", 
-              "Etc/GMT-14", 
-              "Etc/GMT-2", 
-              "Etc/GMT-3", 
-              "Etc/GMT-4", 
-              "Etc/GMT-5", 
-              "Etc/GMT-6", 
-              "Etc/GMT-7", 
-              "Etc/GMT-8", 
-              "Etc/GMT-9", 
-              "Etc/GMT0", 
-              "Etc/Greenwich", 
-              "Etc/UCT", 
-              "Etc/UTC", 
-              "Etc/Universal", 
-              "Etc/Zulu", 
-              "Europe/Amsterdam", 
-              "Europe/Andorra", 
-              "Europe/Astrakhan", 
-              "Europe/Athens", 
-              "Europe/Belfast", 
-              "Europe/Belgrade", 
-              "Europe/Berlin", 
-              "Europe/Bratislava", 
-              "Europe/Brussels", 
-              "Europe/Bucharest", 
-              "Europe/Budapest", 
-              "Europe/Busingen", 
-              "Europe/Chisinau", 
-              "Europe/Copenhagen", 
-              "Europe/Dublin", 
-              "Europe/Gibraltar", 
-              "Europe/Guernsey", 
-              "Europe/Helsinki", 
-              "Europe/Isle_of_Man", 
-              "Europe/Istanbul", 
-              "Europe/Jersey", 
-              "Europe/Kaliningrad", 
-              "Europe/Kiev", 
-              "Europe/Kirov", 
-              "Europe/Lisbon", 
-              "Europe/Ljubljana", 
-              "Europe/London", 
-              "Europe/Luxembourg", 
-              "Europe/Madrid", 
-              "Europe/Malta", 
-              "Europe/Mariehamn", 
-              "Europe/Minsk", 
-              "Europe/Monaco", 
-              "Europe/Moscow", 
-              "Europe/Nicosia", 
-              "Europe/Oslo", 
-              "Europe/Paris", 
-              "Europe/Podgorica", 
-              "Europe/Prague", 
-              "Europe/Riga", 
-              "Europe/Rome", 
-              "Europe/Samara", 
-              "Europe/San_Marino", 
-              "Europe/Sarajevo", 
-              "Europe/Saratov", 
-              "Europe/Simferopol", 
-              "Europe/Skopje", 
-              "Europe/Sofia", 
-              "Europe/Stockholm", 
-              "Europe/Tallinn", 
-              "Europe/Tirane", 
-              "Europe/Tiraspol", 
-              "Europe/Ulyanovsk", 
-              "Europe/Uzhgorod", 
-              "Europe/Vaduz", 
-              "Europe/Vatican", 
-              "Europe/Vienna", 
-              "Europe/Vilnius", 
-              "Europe/Volgograd", 
-              "Europe/Warsaw", 
-              "Europe/Zagreb", 
-              "Europe/Zaporozhye", 
-              "Europe/Zurich", 
-              "GB", 
-              "GB-Eire", 
-              "GMT", 
-              "GMT+0", 
-              "GMT-0", 
-              "GMT0", 
-              "Greenwich", 
-              "HST", 
-              "Hongkong", 
-              "Iceland", 
-              "Indian/Antananarivo", 
-              "Indian/Chagos", 
-              "Indian/Christmas", 
-              "Indian/Cocos", 
-              "Indian/Comoro", 
-              "Indian/Kerguelen", 
-              "Indian/Mahe", 
-              "Indian/Maldives", 
-              "Indian/Mauritius", 
-              "Indian/Mayotte", 
-              "Indian/Reunion", 
-              "Iran", 
-              "Israel", 
-              "Jamaica", 
-              "Japan", 
-              "Kwajalein", 
-              "Libya", 
-              "MET", 
-              "MST", 
-              "MST7MDT", 
-              "Mexico/BajaNorte", 
-              "Mexico/BajaSur", 
-              "Mexico/General", 
-              "NZ", 
-              "NZ-CHAT", 
-              "Navajo", 
-              "PRC", 
-              "PST8PDT", 
-              "Pacific/Apia", 
-              "Pacific/Auckland", 
-              "Pacific/Bougainville", 
-              "Pacific/Chatham", 
-              "Pacific/Chuuk", 
-              "Pacific/Easter", 
-              "Pacific/Efate", 
-              "Pacific/Enderbury", 
-              "Pacific/Fakaofo", 
-              "Pacific/Fiji", 
-              "Pacific/Funafuti", 
-              "Pacific/Galapagos", 
-              "Pacific/Gambier", 
-              "Pacific/Guadalcanal", 
-              "Pacific/Guam", 
-              "Pacific/Honolulu", 
-              "Pacific/Johnston", 
-              "Pacific/Kanton", 
-              "Pacific/Kiritimati", 
-              "Pacific/Kosrae", 
-              "Pacific/Kwajalein", 
-              "Pacific/Majuro", 
-              "Pacific/Marquesas", 
-              "Pacific/Midway", 
-              "Pacific/Nauru", 
-              "Pacific/Niue", 
-              "Pacific/Norfolk", 
-              "Pacific/Noumea", 
-              "Pacific/Pago_Pago", 
-              "Pacific/Palau", 
-              "Pacific/Pitcairn", 
-              "Pacific/Pohnpei", 
-              "Pacific/Ponape", 
-              "Pacific/Port_Moresby", 
-              "Pacific/Rarotonga", 
-              "Pacific/Saipan", 
-              "Pacific/Samoa", 
-              "Pacific/Tahiti", 
-              "Pacific/Tarawa", 
-              "Pacific/Tongatapu", 
-              "Pacific/Truk", 
-              "Pacific/Wake", 
-              "Pacific/Wallis", 
-              "Pacific/Yap", 
-              "Poland", 
-              "Portugal", 
-              "ROC", 
-              "ROK", 
-              "Singapore", 
-              "Turkey", 
-              "UCT", 
-              "US/Alaska", 
-              "US/Aleutian", 
-              "US/Arizona", 
-              "US/Central", 
-              "US/East-Indiana", 
-              "US/Eastern", 
-              "US/Hawaii", 
-              "US/Indiana-Starke", 
-              "US/Michigan", 
-              "US/Mountain", 
-              "US/Pacific", 
-              "US/Samoa", 
-              "UTC", 
-              "Universal", 
-              "W-SU", 
-              "WET", 
+              "Africa/Abidjan",
+              "Africa/Accra",
+              "Africa/Addis_Ababa",
+              "Africa/Algiers",
+              "Africa/Asmara",
+              "Africa/Asmera",
+              "Africa/Bamako",
+              "Africa/Bangui",
+              "Africa/Banjul",
+              "Africa/Bissau",
+              "Africa/Blantyre",
+              "Africa/Brazzaville",
+              "Africa/Bujumbura",
+              "Africa/Cairo",
+              "Africa/Casablanca",
+              "Africa/Ceuta",
+              "Africa/Conakry",
+              "Africa/Dakar",
+              "Africa/Dar_es_Salaam",
+              "Africa/Djibouti",
+              "Africa/Douala",
+              "Africa/El_Aaiun",
+              "Africa/Freetown",
+              "Africa/Gaborone",
+              "Africa/Harare",
+              "Africa/Johannesburg",
+              "Africa/Juba",
+              "Africa/Kampala",
+              "Africa/Khartoum",
+              "Africa/Kigali",
+              "Africa/Kinshasa",
+              "Africa/Lagos",
+              "Africa/Libreville",
+              "Africa/Lome",
+              "Africa/Luanda",
+              "Africa/Lubumbashi",
+              "Africa/Lusaka",
+              "Africa/Malabo",
+              "Africa/Maputo",
+              "Africa/Maseru",
+              "Africa/Mbabane",
+              "Africa/Mogadishu",
+              "Africa/Monrovia",
+              "Africa/Nairobi",
+              "Africa/Ndjamena",
+              "Africa/Niamey",
+              "Africa/Nouakchott",
+              "Africa/Ouagadougou",
+              "Africa/Porto-Novo",
+              "Africa/Sao_Tome",
+              "Africa/Timbuktu",
+              "Africa/Tripoli",
+              "Africa/Tunis",
+              "Africa/Windhoek",
+              "America/Adak",
+              "America/Anchorage",
+              "America/Anguilla",
+              "America/Antigua",
+              "America/Araguaina",
+              "America/Argentina/Buenos_Aires",
+              "America/Argentina/Catamarca",
+              "America/Argentina/ComodRivadavia",
+              "America/Argentina/Cordoba",
+              "America/Argentina/Jujuy",
+              "America/Argentina/La_Rioja",
+              "America/Argentina/Mendoza",
+              "America/Argentina/Rio_Gallegos",
+              "America/Argentina/Salta",
+              "America/Argentina/San_Juan",
+              "America/Argentina/San_Luis",
+              "America/Argentina/Tucuman",
+              "America/Argentina/Ushuaia",
+              "America/Aruba",
+              "America/Asuncion",
+              "America/Atikokan",
+              "America/Atka",
+              "America/Bahia",
+              "America/Bahia_Banderas",
+              "America/Barbados",
+              "America/Belem",
+              "America/Belize",
+              "America/Blanc-Sablon",
+              "America/Boa_Vista",
+              "America/Bogota",
+              "America/Boise",
+              "America/Buenos_Aires",
+              "America/Cambridge_Bay",
+              "America/Campo_Grande",
+              "America/Cancun",
+              "America/Caracas",
+              "America/Catamarca",
+              "America/Cayenne",
+              "America/Cayman",
+              "America/Chicago",
+              "America/Chihuahua",
+              "America/Coral_Harbour",
+              "America/Cordoba",
+              "America/Costa_Rica",
+              "America/Creston",
+              "America/Cuiaba",
+              "America/Curacao",
+              "America/Danmarkshavn",
+              "America/Dawson",
+              "America/Dawson_Creek",
+              "America/Denver",
+              "America/Detroit",
+              "America/Dominica",
+              "America/Edmonton",
+              "America/Eirunepe",
+              "America/El_Salvador",
+              "America/Ensenada",
+              "America/Fort_Nelson",
+              "America/Fort_Wayne",
+              "America/Fortaleza",
+              "America/Glace_Bay",
+              "America/Godthab",
+              "America/Goose_Bay",
+              "America/Grand_Turk",
+              "America/Grenada",
+              "America/Guadeloupe",
+              "America/Guatemala",
+              "America/Guayaquil",
+              "America/Guyana",
+              "America/Halifax",
+              "America/Havana",
+              "America/Hermosillo",
+              "America/Indiana/Indianapolis",
+              "America/Indiana/Knox",
+              "America/Indiana/Marengo",
+              "America/Indiana/Petersburg",
+              "America/Indiana/Tell_City",
+              "America/Indiana/Vevay",
+              "America/Indiana/Vincennes",
+              "America/Indiana/Winamac",
+              "America/Indianapolis",
+              "America/Inuvik",
+              "America/Iqaluit",
+              "America/Jamaica",
+              "America/Jujuy",
+              "America/Juneau",
+              "America/Kentucky/Louisville",
+              "America/Kentucky/Monticello",
+              "America/Knox_IN",
+              "America/Kralendijk",
+              "America/La_Paz",
+              "America/Lima",
+              "America/Los_Angeles",
+              "America/Louisville",
+              "America/Lower_Princes",
+              "America/Maceio",
+              "America/Managua",
+              "America/Manaus",
+              "America/Marigot",
+              "America/Martinique",
+              "America/Matamoros",
+              "America/Mazatlan",
+              "America/Mendoza",
+              "America/Menominee",
+              "America/Merida",
+              "America/Metlakatla",
+              "America/Mexico_City",
+              "America/Miquelon",
+              "America/Moncton",
+              "America/Monterrey",
+              "America/Montevideo",
+              "America/Montreal",
+              "America/Montserrat",
+              "America/Nassau",
+              "America/New_York",
+              "America/Nipigon",
+              "America/Nome",
+              "America/Noronha",
+              "America/North_Dakota/Beulah",
+              "America/North_Dakota/Center",
+              "America/North_Dakota/New_Salem",
+              "America/Nuuk",
+              "America/Ojinaga",
+              "America/Panama",
+              "America/Pangnirtung",
+              "America/Paramaribo",
+              "America/Phoenix",
+              "America/Port-au-Prince",
+              "America/Port_of_Spain",
+              "America/Porto_Acre",
+              "America/Porto_Velho",
+              "America/Puerto_Rico",
+              "America/Punta_Arenas",
+              "America/Rainy_River",
+              "America/Rankin_Inlet",
+              "America/Recife",
+              "America/Regina",
+              "America/Resolute",
+              "America/Rio_Branco",
+              "America/Rosario",
+              "America/Santa_Isabel",
+              "America/Santarem",
+              "America/Santiago",
+              "America/Santo_Domingo",
+              "America/Sao_Paulo",
+              "America/Scoresbysund",
+              "America/Shiprock",
+              "America/Sitka",
+              "America/St_Barthelemy",
+              "America/St_Johns",
+              "America/St_Kitts",
+              "America/St_Lucia",
+              "America/St_Thomas",
+              "America/St_Vincent",
+              "America/Swift_Current",
+              "America/Tegucigalpa",
+              "America/Thule",
+              "America/Thunder_Bay",
+              "America/Tijuana",
+              "America/Toronto",
+              "America/Tortola",
+              "America/Vancouver",
+              "America/Virgin",
+              "America/Whitehorse",
+              "America/Winnipeg",
+              "America/Yakutat",
+              "America/Yellowknife",
+              "Antarctica/Casey",
+              "Antarctica/Davis",
+              "Antarctica/DumontDUrville",
+              "Antarctica/Macquarie",
+              "Antarctica/Mawson",
+              "Antarctica/McMurdo",
+              "Antarctica/Palmer",
+              "Antarctica/Rothera",
+              "Antarctica/South_Pole",
+              "Antarctica/Syowa",
+              "Antarctica/Troll",
+              "Antarctica/Vostok",
+              "Arctic/Longyearbyen",
+              "Asia/Aden",
+              "Asia/Almaty",
+              "Asia/Amman",
+              "Asia/Anadyr",
+              "Asia/Aqtau",
+              "Asia/Aqtobe",
+              "Asia/Ashgabat",
+              "Asia/Ashkhabad",
+              "Asia/Atyrau",
+              "Asia/Baghdad",
+              "Asia/Bahrain",
+              "Asia/Baku",
+              "Asia/Bangkok",
+              "Asia/Barnaul",
+              "Asia/Beirut",
+              "Asia/Bishkek",
+              "Asia/Brunei",
+              "Asia/Calcutta",
+              "Asia/Chita",
+              "Asia/Choibalsan",
+              "Asia/Chongqing",
+              "Asia/Chungking",
+              "Asia/Colombo",
+              "Asia/Dacca",
+              "Asia/Damascus",
+              "Asia/Dhaka",
+              "Asia/Dili",
+              "Asia/Dubai",
+              "Asia/Dushanbe",
+              "Asia/Famagusta",
+              "Asia/Gaza",
+              "Asia/Harbin",
+              "Asia/Hebron",
+              "Asia/Ho_Chi_Minh",
+              "Asia/Hong_Kong",
+              "Asia/Hovd",
+              "Asia/Irkutsk",
+              "Asia/Istanbul",
+              "Asia/Jakarta",
+              "Asia/Jayapura",
+              "Asia/Jerusalem",
+              "Asia/Kabul",
+              "Asia/Kamchatka",
+              "Asia/Karachi",
+              "Asia/Kashgar",
+              "Asia/Kathmandu",
+              "Asia/Katmandu",
+              "Asia/Khandyga",
+              "Asia/Kolkata",
+              "Asia/Krasnoyarsk",
+              "Asia/Kuala_Lumpur",
+              "Asia/Kuching",
+              "Asia/Kuwait",
+              "Asia/Macao",
+              "Asia/Macau",
+              "Asia/Magadan",
+              "Asia/Makassar",
+              "Asia/Manila",
+              "Asia/Muscat",
+              "Asia/Nicosia",
+              "Asia/Novokuznetsk",
+              "Asia/Novosibirsk",
+              "Asia/Omsk",
+              "Asia/Oral",
+              "Asia/Phnom_Penh",
+              "Asia/Pontianak",
+              "Asia/Pyongyang",
+              "Asia/Qatar",
+              "Asia/Qostanay",
+              "Asia/Qyzylorda",
+              "Asia/Rangoon",
+              "Asia/Riyadh",
+              "Asia/Saigon",
+              "Asia/Sakhalin",
+              "Asia/Samarkand",
+              "Asia/Seoul",
+              "Asia/Shanghai",
+              "Asia/Singapore",
+              "Asia/Srednekolymsk",
+              "Asia/Taipei",
+              "Asia/Tashkent",
+              "Asia/Tbilisi",
+              "Asia/Tehran",
+              "Asia/Tel_Aviv",
+              "Asia/Thimbu",
+              "Asia/Thimphu",
+              "Asia/Tokyo",
+              "Asia/Tomsk",
+              "Asia/Ujung_Pandang",
+              "Asia/Ulaanbaatar",
+              "Asia/Ulan_Bator",
+              "Asia/Urumqi",
+              "Asia/Ust-Nera",
+              "Asia/Vientiane",
+              "Asia/Vladivostok",
+              "Asia/Yakutsk",
+              "Asia/Yangon",
+              "Asia/Yekaterinburg",
+              "Asia/Yerevan",
+              "Atlantic/Azores",
+              "Atlantic/Bermuda",
+              "Atlantic/Canary",
+              "Atlantic/Cape_Verde",
+              "Atlantic/Faeroe",
+              "Atlantic/Faroe",
+              "Atlantic/Jan_Mayen",
+              "Atlantic/Madeira",
+              "Atlantic/Reykjavik",
+              "Atlantic/South_Georgia",
+              "Atlantic/St_Helena",
+              "Atlantic/Stanley",
+              "Australia/ACT",
+              "Australia/Adelaide",
+              "Australia/Brisbane",
+              "Australia/Broken_Hill",
+              "Australia/Canberra",
+              "Australia/Currie",
+              "Australia/Darwin",
+              "Australia/Eucla",
+              "Australia/Hobart",
+              "Australia/LHI",
+              "Australia/Lindeman",
+              "Australia/Lord_Howe",
+              "Australia/Melbourne",
+              "Australia/NSW",
+              "Australia/North",
+              "Australia/Perth",
+              "Australia/Queensland",
+              "Australia/South",
+              "Australia/Sydney",
+              "Australia/Tasmania",
+              "Australia/Victoria",
+              "Australia/West",
+              "Australia/Yancowinna",
+              "Brazil/Acre",
+              "Brazil/DeNoronha",
+              "Brazil/East",
+              "Brazil/West",
+              "CET",
+              "CST6CDT",
+              "Canada/Atlantic",
+              "Canada/Central",
+              "Canada/Eastern",
+              "Canada/Mountain",
+              "Canada/Newfoundland",
+              "Canada/Pacific",
+              "Canada/Saskatchewan",
+              "Canada/Yukon",
+              "Chile/Continental",
+              "Chile/EasterIsland",
+              "Cuba",
+              "EET",
+              "EST",
+              "EST5EDT",
+              "Egypt",
+              "Eire",
+              "Etc/GMT",
+              "Etc/GMT+0",
+              "Etc/GMT+1",
+              "Etc/GMT+10",
+              "Etc/GMT+11",
+              "Etc/GMT+12",
+              "Etc/GMT+2",
+              "Etc/GMT+3",
+              "Etc/GMT+4",
+              "Etc/GMT+5",
+              "Etc/GMT+6",
+              "Etc/GMT+7",
+              "Etc/GMT+8",
+              "Etc/GMT+9",
+              "Etc/GMT-0",
+              "Etc/GMT-1",
+              "Etc/GMT-10",
+              "Etc/GMT-11",
+              "Etc/GMT-12",
+              "Etc/GMT-13",
+              "Etc/GMT-14",
+              "Etc/GMT-2",
+              "Etc/GMT-3",
+              "Etc/GMT-4",
+              "Etc/GMT-5",
+              "Etc/GMT-6",
+              "Etc/GMT-7",
+              "Etc/GMT-8",
+              "Etc/GMT-9",
+              "Etc/GMT0",
+              "Etc/Greenwich",
+              "Etc/UCT",
+              "Etc/UTC",
+              "Etc/Universal",
+              "Etc/Zulu",
+              "Europe/Amsterdam",
+              "Europe/Andorra",
+              "Europe/Astrakhan",
+              "Europe/Athens",
+              "Europe/Belfast",
+              "Europe/Belgrade",
+              "Europe/Berlin",
+              "Europe/Bratislava",
+              "Europe/Brussels",
+              "Europe/Bucharest",
+              "Europe/Budapest",
+              "Europe/Busingen",
+              "Europe/Chisinau",
+              "Europe/Copenhagen",
+              "Europe/Dublin",
+              "Europe/Gibraltar",
+              "Europe/Guernsey",
+              "Europe/Helsinki",
+              "Europe/Isle_of_Man",
+              "Europe/Istanbul",
+              "Europe/Jersey",
+              "Europe/Kaliningrad",
+              "Europe/Kiev",
+              "Europe/Kirov",
+              "Europe/Lisbon",
+              "Europe/Ljubljana",
+              "Europe/London",
+              "Europe/Luxembourg",
+              "Europe/Madrid",
+              "Europe/Malta",
+              "Europe/Mariehamn",
+              "Europe/Minsk",
+              "Europe/Monaco",
+              "Europe/Moscow",
+              "Europe/Nicosia",
+              "Europe/Oslo",
+              "Europe/Paris",
+              "Europe/Podgorica",
+              "Europe/Prague",
+              "Europe/Riga",
+              "Europe/Rome",
+              "Europe/Samara",
+              "Europe/San_Marino",
+              "Europe/Sarajevo",
+              "Europe/Saratov",
+              "Europe/Simferopol",
+              "Europe/Skopje",
+              "Europe/Sofia",
+              "Europe/Stockholm",
+              "Europe/Tallinn",
+              "Europe/Tirane",
+              "Europe/Tiraspol",
+              "Europe/Ulyanovsk",
+              "Europe/Uzhgorod",
+              "Europe/Vaduz",
+              "Europe/Vatican",
+              "Europe/Vienna",
+              "Europe/Vilnius",
+              "Europe/Volgograd",
+              "Europe/Warsaw",
+              "Europe/Zagreb",
+              "Europe/Zaporozhye",
+              "Europe/Zurich",
+              "GB",
+              "GB-Eire",
+              "GMT",
+              "GMT+0",
+              "GMT-0",
+              "GMT0",
+              "Greenwich",
+              "HST",
+              "Hongkong",
+              "Iceland",
+              "Indian/Antananarivo",
+              "Indian/Chagos",
+              "Indian/Christmas",
+              "Indian/Cocos",
+              "Indian/Comoro",
+              "Indian/Kerguelen",
+              "Indian/Mahe",
+              "Indian/Maldives",
+              "Indian/Mauritius",
+              "Indian/Mayotte",
+              "Indian/Reunion",
+              "Iran",
+              "Israel",
+              "Jamaica",
+              "Japan",
+              "Kwajalein",
+              "Libya",
+              "MET",
+              "MST",
+              "MST7MDT",
+              "Mexico/BajaNorte",
+              "Mexico/BajaSur",
+              "Mexico/General",
+              "NZ",
+              "NZ-CHAT",
+              "Navajo",
+              "PRC",
+              "PST8PDT",
+              "Pacific/Apia",
+              "Pacific/Auckland",
+              "Pacific/Bougainville",
+              "Pacific/Chatham",
+              "Pacific/Chuuk",
+              "Pacific/Easter",
+              "Pacific/Efate",
+              "Pacific/Enderbury",
+              "Pacific/Fakaofo",
+              "Pacific/Fiji",
+              "Pacific/Funafuti",
+              "Pacific/Galapagos",
+              "Pacific/Gambier",
+              "Pacific/Guadalcanal",
+              "Pacific/Guam",
+              "Pacific/Honolulu",
+              "Pacific/Johnston",
+              "Pacific/Kanton",
+              "Pacific/Kiritimati",
+              "Pacific/Kosrae",
+              "Pacific/Kwajalein",
+              "Pacific/Majuro",
+              "Pacific/Marquesas",
+              "Pacific/Midway",
+              "Pacific/Nauru",
+              "Pacific/Niue",
+              "Pacific/Norfolk",
+              "Pacific/Noumea",
+              "Pacific/Pago_Pago",
+              "Pacific/Palau",
+              "Pacific/Pitcairn",
+              "Pacific/Pohnpei",
+              "Pacific/Ponape",
+              "Pacific/Port_Moresby",
+              "Pacific/Rarotonga",
+              "Pacific/Saipan",
+              "Pacific/Samoa",
+              "Pacific/Tahiti",
+              "Pacific/Tarawa",
+              "Pacific/Tongatapu",
+              "Pacific/Truk",
+              "Pacific/Wake",
+              "Pacific/Wallis",
+              "Pacific/Yap",
+              "Poland",
+              "Portugal",
+              "ROC",
+              "ROK",
+              "Singapore",
+              "Turkey",
+              "UCT",
+              "US/Alaska",
+              "US/Aleutian",
+              "US/Arizona",
+              "US/Central",
+              "US/East-Indiana",
+              "US/Eastern",
+              "US/Hawaii",
+              "US/Indiana-Starke",
+              "US/Michigan",
+              "US/Mountain",
+              "US/Pacific",
+              "US/Samoa",
+              "UTC",
+              "Universal",
+              "W-SU",
+              "WET",
               "Zulu"
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           "type": {
-            "description": "The report schedule type", 
+            "description": "The report schedule type",
             "enum": [
-              "Alert", 
+              "Alert",
               "Report"
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           "validator_config_json": {
             "$ref": "#/components/schemas/ValidatorConfigJSON"
-          }, 
+          },
           "validator_type": {
-            "description": "Determines when to trigger alert based off value from alert query. Alerts will be triggered with these validator types:\n- Not Null - When the return value is Not NULL, Empty, or 0\n- Operator - When `sql_return_value comparison_operator threshold` is True e.g. `50 <= 75`<br>Supports the comparison operators <, <=, >, >=, ==, and !=", 
+            "description": "Determines when to trigger alert based off value from alert query. Alerts will be triggered with these validator types:\n- Not Null - When the return value is Not NULL, Empty, or 0\n- Operator - When `sql_return_value comparison_operator threshold` is True e.g. `50 <= 75`<br>Supports the comparison operators <, <=, >, >=, ==, and !=",
             "enum": [
-              "not null", 
+              "not null",
               "operator"
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           "working_timeout": {
-            "description": "If an alert is staled at a working state, how long until it's state is reseted to error", 
-            "example": 3600, 
-            "format": "int32", 
-            "minimum": 1, 
+            "description": "If an alert is staled at a working state, how long until it's state is reseted to error",
+            "example": 3600,
+            "format": "int32",
+            "minimum": 1,
             "type": "integer"
           }
-        }, 
+        },
         "required": [
-          "crontab", 
-          "name", 
+          "crontab",
+          "name",
           "type"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ReportScheduleRestApi.put": {
         "properties": {
           "active": {
             "type": "boolean"
-          }, 
+          },
           "chart": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "context_markdown": {
-            "description": "Markdown description", 
-            "nullable": true, 
+            "description": "Markdown description",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "creation_method": {
-            "description": "Creation method is used to inform the frontend whether the report/alert was created in the dashboard, chart, or alerts and reports UI.", 
+            "description": "Creation method is used to inform the frontend whether the report/alert was created in the dashboard, chart, or alerts and reports UI.",
             "nullable": true
-          }, 
+          },
           "crontab": {
-            "description": "A CRON expression.[Crontab Guru](https://crontab.guru/) is a helpful resource that can help you craft a CRON expression.", 
-            "maxLength": 1000, 
-            "minLength": 1, 
+            "description": "A CRON expression.[Crontab Guru](https://crontab.guru/) is a helpful resource that can help you craft a CRON expression.",
+            "maxLength": 1000,
+            "minLength": 1,
             "type": "string"
-          }, 
+          },
           "dashboard": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "database": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "description": {
-            "description": "Use a nice description to give context to this Alert/Report", 
-            "example": "Daily sales dashboard to marketing", 
-            "nullable": true, 
+            "description": "Use a nice description to give context to this Alert/Report",
+            "example": "Daily sales dashboard to marketing",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "extra": {
             "type": "object"
-          }, 
+          },
           "force_screenshot": {
             "type": "boolean"
-          }, 
+          },
           "grace_period": {
-            "description": "Once an alert is triggered, how long, in seconds, before Superset nags you again. (in seconds)", 
-            "example": 14400, 
-            "format": "int32", 
-            "minimum": 1, 
+            "description": "Once an alert is triggered, how long, in seconds, before Superset nags you again. (in seconds)",
+            "example": 14400,
+            "format": "int32",
+            "minimum": 1,
             "type": "integer"
-          }, 
+          },
           "log_retention": {
-            "description": "How long to keep the logs around for this report (in days)", 
-            "example": 90, 
-            "format": "int32", 
-            "minimum": 1, 
+            "description": "How long to keep the logs around for this report (in days)",
+            "example": 90,
+            "format": "int32",
+            "minimum": 1,
             "type": "integer"
-          }, 
+          },
           "name": {
-            "description": "The report schedule name.", 
-            "maxLength": 150, 
-            "minLength": 1, 
+            "description": "The report schedule name.",
+            "maxLength": 150,
+            "minLength": 1,
             "type": "string"
-          }, 
+          },
           "owners": {
             "items": {
-              "description": "Owner are users ids allowed to delete or change this report. If left empty you will be one of the owners of the report.", 
-              "format": "int32", 
+              "description": "Owner are users ids allowed to delete or change this report. If left empty you will be one of the owners of the report.",
+              "format": "int32",
               "type": "integer"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "recipients": {
             "items": {
               "$ref": "#/components/schemas/ReportRecipient"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "report_format": {
             "enum": [
-              "PNG", 
-              "CSV", 
+              "PNG",
+              "CSV",
               "TEXT"
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           "sql": {
-            "description": "A SQL statement that defines whether the alert should get triggered or not. The query is expected to return either NULL or a number value.", 
-            "example": "SELECT value FROM time_series_table", 
-            "nullable": true, 
+            "description": "A SQL statement that defines whether the alert should get triggered or not. The query is expected to return either NULL or a number value.",
+            "example": "SELECT value FROM time_series_table",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "timezone": {
-            "description": "A timezone string that represents the location of the timezone.", 
+            "description": "A timezone string that represents the location of the timezone.",
             "enum": [
-              "Africa/Abidjan", 
-              "Africa/Accra", 
-              "Africa/Addis_Ababa", 
-              "Africa/Algiers", 
-              "Africa/Asmara", 
-              "Africa/Asmera", 
-              "Africa/Bamako", 
-              "Africa/Bangui", 
-              "Africa/Banjul", 
-              "Africa/Bissau", 
-              "Africa/Blantyre", 
-              "Africa/Brazzaville", 
-              "Africa/Bujumbura", 
-              "Africa/Cairo", 
-              "Africa/Casablanca", 
-              "Africa/Ceuta", 
-              "Africa/Conakry", 
-              "Africa/Dakar", 
-              "Africa/Dar_es_Salaam", 
-              "Africa/Djibouti", 
-              "Africa/Douala", 
-              "Africa/El_Aaiun", 
-              "Africa/Freetown", 
-              "Africa/Gaborone", 
-              "Africa/Harare", 
-              "Africa/Johannesburg", 
-              "Africa/Juba", 
-              "Africa/Kampala", 
-              "Africa/Khartoum", 
-              "Africa/Kigali", 
-              "Africa/Kinshasa", 
-              "Africa/Lagos", 
-              "Africa/Libreville", 
-              "Africa/Lome", 
-              "Africa/Luanda", 
-              "Africa/Lubumbashi", 
-              "Africa/Lusaka", 
-              "Africa/Malabo", 
-              "Africa/Maputo", 
-              "Africa/Maseru", 
-              "Africa/Mbabane", 
-              "Africa/Mogadishu", 
-              "Africa/Monrovia", 
-              "Africa/Nairobi", 
-              "Africa/Ndjamena", 
-              "Africa/Niamey", 
-              "Africa/Nouakchott", 
-              "Africa/Ouagadougou", 
-              "Africa/Porto-Novo", 
-              "Africa/Sao_Tome", 
-              "Africa/Timbuktu", 
-              "Africa/Tripoli", 
-              "Africa/Tunis", 
-              "Africa/Windhoek", 
-              "America/Adak", 
-              "America/Anchorage", 
-              "America/Anguilla", 
-              "America/Antigua", 
-              "America/Araguaina", 
-              "America/Argentina/Buenos_Aires", 
-              "America/Argentina/Catamarca", 
-              "America/Argentina/ComodRivadavia", 
-              "America/Argentina/Cordoba", 
-              "America/Argentina/Jujuy", 
-              "America/Argentina/La_Rioja", 
-              "America/Argentina/Mendoza", 
-              "America/Argentina/Rio_Gallegos", 
-              "America/Argentina/Salta", 
-              "America/Argentina/San_Juan", 
-              "America/Argentina/San_Luis", 
-              "America/Argentina/Tucuman", 
-              "America/Argentina/Ushuaia", 
-              "America/Aruba", 
-              "America/Asuncion", 
-              "America/Atikokan", 
-              "America/Atka", 
-              "America/Bahia", 
-              "America/Bahia_Banderas", 
-              "America/Barbados", 
-              "America/Belem", 
-              "America/Belize", 
-              "America/Blanc-Sablon", 
-              "America/Boa_Vista", 
-              "America/Bogota", 
-              "America/Boise", 
-              "America/Buenos_Aires", 
-              "America/Cambridge_Bay", 
-              "America/Campo_Grande", 
-              "America/Cancun", 
-              "America/Caracas", 
-              "America/Catamarca", 
-              "America/Cayenne", 
-              "America/Cayman", 
-              "America/Chicago", 
-              "America/Chihuahua", 
-              "America/Coral_Harbour", 
-              "America/Cordoba", 
-              "America/Costa_Rica", 
-              "America/Creston", 
-              "America/Cuiaba", 
-              "America/Curacao", 
-              "America/Danmarkshavn", 
-              "America/Dawson", 
-              "America/Dawson_Creek", 
-              "America/Denver", 
-              "America/Detroit", 
-              "America/Dominica", 
-              "America/Edmonton", 
-              "America/Eirunepe", 
-              "America/El_Salvador", 
-              "America/Ensenada", 
-              "America/Fort_Nelson", 
-              "America/Fort_Wayne", 
-              "America/Fortaleza", 
-              "America/Glace_Bay", 
-              "America/Godthab", 
-              "America/Goose_Bay", 
-              "America/Grand_Turk", 
-              "America/Grenada", 
-              "America/Guadeloupe", 
-              "America/Guatemala", 
-              "America/Guayaquil", 
-              "America/Guyana", 
-              "America/Halifax", 
-              "America/Havana", 
-              "America/Hermosillo", 
-              "America/Indiana/Indianapolis", 
-              "America/Indiana/Knox", 
-              "America/Indiana/Marengo", 
-              "America/Indiana/Petersburg", 
-              "America/Indiana/Tell_City", 
-              "America/Indiana/Vevay", 
-              "America/Indiana/Vincennes", 
-              "America/Indiana/Winamac", 
-              "America/Indianapolis", 
-              "America/Inuvik", 
-              "America/Iqaluit", 
-              "America/Jamaica", 
-              "America/Jujuy", 
-              "America/Juneau", 
-              "America/Kentucky/Louisville", 
-              "America/Kentucky/Monticello", 
-              "America/Knox_IN", 
-              "America/Kralendijk", 
-              "America/La_Paz", 
-              "America/Lima", 
-              "America/Los_Angeles", 
-              "America/Louisville", 
-              "America/Lower_Princes", 
-              "America/Maceio", 
-              "America/Managua", 
-              "America/Manaus", 
-              "America/Marigot", 
-              "America/Martinique", 
-              "America/Matamoros", 
-              "America/Mazatlan", 
-              "America/Mendoza", 
-              "America/Menominee", 
-              "America/Merida", 
-              "America/Metlakatla", 
-              "America/Mexico_City", 
-              "America/Miquelon", 
-              "America/Moncton", 
-              "America/Monterrey", 
-              "America/Montevideo", 
-              "America/Montreal", 
-              "America/Montserrat", 
-              "America/Nassau", 
-              "America/New_York", 
-              "America/Nipigon", 
-              "America/Nome", 
-              "America/Noronha", 
-              "America/North_Dakota/Beulah", 
-              "America/North_Dakota/Center", 
-              "America/North_Dakota/New_Salem", 
-              "America/Nuuk", 
-              "America/Ojinaga", 
-              "America/Panama", 
-              "America/Pangnirtung", 
-              "America/Paramaribo", 
-              "America/Phoenix", 
-              "America/Port-au-Prince", 
-              "America/Port_of_Spain", 
-              "America/Porto_Acre", 
-              "America/Porto_Velho", 
-              "America/Puerto_Rico", 
-              "America/Punta_Arenas", 
-              "America/Rainy_River", 
-              "America/Rankin_Inlet", 
-              "America/Recife", 
-              "America/Regina", 
-              "America/Resolute", 
-              "America/Rio_Branco", 
-              "America/Rosario", 
-              "America/Santa_Isabel", 
-              "America/Santarem", 
-              "America/Santiago", 
-              "America/Santo_Domingo", 
-              "America/Sao_Paulo", 
-              "America/Scoresbysund", 
-              "America/Shiprock", 
-              "America/Sitka", 
-              "America/St_Barthelemy", 
-              "America/St_Johns", 
-              "America/St_Kitts", 
-              "America/St_Lucia", 
-              "America/St_Thomas", 
-              "America/St_Vincent", 
-              "America/Swift_Current", 
-              "America/Tegucigalpa", 
-              "America/Thule", 
-              "America/Thunder_Bay", 
-              "America/Tijuana", 
-              "America/Toronto", 
-              "America/Tortola", 
-              "America/Vancouver", 
-              "America/Virgin", 
-              "America/Whitehorse", 
-              "America/Winnipeg", 
-              "America/Yakutat", 
-              "America/Yellowknife", 
-              "Antarctica/Casey", 
-              "Antarctica/Davis", 
-              "Antarctica/DumontDUrville", 
-              "Antarctica/Macquarie", 
-              "Antarctica/Mawson", 
-              "Antarctica/McMurdo", 
-              "Antarctica/Palmer", 
-              "Antarctica/Rothera", 
-              "Antarctica/South_Pole", 
-              "Antarctica/Syowa", 
-              "Antarctica/Troll", 
-              "Antarctica/Vostok", 
-              "Arctic/Longyearbyen", 
-              "Asia/Aden", 
-              "Asia/Almaty", 
-              "Asia/Amman", 
-              "Asia/Anadyr", 
-              "Asia/Aqtau", 
-              "Asia/Aqtobe", 
-              "Asia/Ashgabat", 
-              "Asia/Ashkhabad", 
-              "Asia/Atyrau", 
-              "Asia/Baghdad", 
-              "Asia/Bahrain", 
-              "Asia/Baku", 
-              "Asia/Bangkok", 
-              "Asia/Barnaul", 
-              "Asia/Beirut", 
-              "Asia/Bishkek", 
-              "Asia/Brunei", 
-              "Asia/Calcutta", 
-              "Asia/Chita", 
-              "Asia/Choibalsan", 
-              "Asia/Chongqing", 
-              "Asia/Chungking", 
-              "Asia/Colombo", 
-              "Asia/Dacca", 
-              "Asia/Damascus", 
-              "Asia/Dhaka", 
-              "Asia/Dili", 
-              "Asia/Dubai", 
-              "Asia/Dushanbe", 
-              "Asia/Famagusta", 
-              "Asia/Gaza", 
-              "Asia/Harbin", 
-              "Asia/Hebron", 
-              "Asia/Ho_Chi_Minh", 
-              "Asia/Hong_Kong", 
-              "Asia/Hovd", 
-              "Asia/Irkutsk", 
-              "Asia/Istanbul", 
-              "Asia/Jakarta", 
-              "Asia/Jayapura", 
-              "Asia/Jerusalem", 
-              "Asia/Kabul", 
-              "Asia/Kamchatka", 
-              "Asia/Karachi", 
-              "Asia/Kashgar", 
-              "Asia/Kathmandu", 
-              "Asia/Katmandu", 
-              "Asia/Khandyga", 
-              "Asia/Kolkata", 
-              "Asia/Krasnoyarsk", 
-              "Asia/Kuala_Lumpur", 
-              "Asia/Kuching", 
-              "Asia/Kuwait", 
-              "Asia/Macao", 
-              "Asia/Macau", 
-              "Asia/Magadan", 
-              "Asia/Makassar", 
-              "Asia/Manila", 
-              "Asia/Muscat", 
-              "Asia/Nicosia", 
-              "Asia/Novokuznetsk", 
-              "Asia/Novosibirsk", 
-              "Asia/Omsk", 
-              "Asia/Oral", 
-              "Asia/Phnom_Penh", 
-              "Asia/Pontianak", 
-              "Asia/Pyongyang", 
-              "Asia/Qatar", 
-              "Asia/Qostanay", 
-              "Asia/Qyzylorda", 
-              "Asia/Rangoon", 
-              "Asia/Riyadh", 
-              "Asia/Saigon", 
-              "Asia/Sakhalin", 
-              "Asia/Samarkand", 
-              "Asia/Seoul", 
-              "Asia/Shanghai", 
-              "Asia/Singapore", 
-              "Asia/Srednekolymsk", 
-              "Asia/Taipei", 
-              "Asia/Tashkent", 
-              "Asia/Tbilisi", 
-              "Asia/Tehran", 
-              "Asia/Tel_Aviv", 
-              "Asia/Thimbu", 
-              "Asia/Thimphu", 
-              "Asia/Tokyo", 
-              "Asia/Tomsk", 
-              "Asia/Ujung_Pandang", 
-              "Asia/Ulaanbaatar", 
-              "Asia/Ulan_Bator", 
-              "Asia/Urumqi", 
-              "Asia/Ust-Nera", 
-              "Asia/Vientiane", 
-              "Asia/Vladivostok", 
-              "Asia/Yakutsk", 
-              "Asia/Yangon", 
-              "Asia/Yekaterinburg", 
-              "Asia/Yerevan", 
-              "Atlantic/Azores", 
-              "Atlantic/Bermuda", 
-              "Atlantic/Canary", 
-              "Atlantic/Cape_Verde", 
-              "Atlantic/Faeroe", 
-              "Atlantic/Faroe", 
-              "Atlantic/Jan_Mayen", 
-              "Atlantic/Madeira", 
-              "Atlantic/Reykjavik", 
-              "Atlantic/South_Georgia", 
-              "Atlantic/St_Helena", 
-              "Atlantic/Stanley", 
-              "Australia/ACT", 
-              "Australia/Adelaide", 
-              "Australia/Brisbane", 
-              "Australia/Broken_Hill", 
-              "Australia/Canberra", 
-              "Australia/Currie", 
-              "Australia/Darwin", 
-              "Australia/Eucla", 
-              "Australia/Hobart", 
-              "Australia/LHI", 
-              "Australia/Lindeman", 
-              "Australia/Lord_Howe", 
-              "Australia/Melbourne", 
-              "Australia/NSW", 
-              "Australia/North", 
-              "Australia/Perth", 
-              "Australia/Queensland", 
-              "Australia/South", 
-              "Australia/Sydney", 
-              "Australia/Tasmania", 
-              "Australia/Victoria", 
-              "Australia/West", 
-              "Australia/Yancowinna", 
-              "Brazil/Acre", 
-              "Brazil/DeNoronha", 
-              "Brazil/East", 
-              "Brazil/West", 
-              "CET", 
-              "CST6CDT", 
-              "Canada/Atlantic", 
-              "Canada/Central", 
-              "Canada/Eastern", 
-              "Canada/Mountain", 
-              "Canada/Newfoundland", 
-              "Canada/Pacific", 
-              "Canada/Saskatchewan", 
-              "Canada/Yukon", 
-              "Chile/Continental", 
-              "Chile/EasterIsland", 
-              "Cuba", 
-              "EET", 
-              "EST", 
-              "EST5EDT", 
-              "Egypt", 
-              "Eire", 
-              "Etc/GMT", 
-              "Etc/GMT+0", 
-              "Etc/GMT+1", 
-              "Etc/GMT+10", 
-              "Etc/GMT+11", 
-              "Etc/GMT+12", 
-              "Etc/GMT+2", 
-              "Etc/GMT+3", 
-              "Etc/GMT+4", 
-              "Etc/GMT+5", 
-              "Etc/GMT+6", 
-              "Etc/GMT+7", 
-              "Etc/GMT+8", 
-              "Etc/GMT+9", 
-              "Etc/GMT-0", 
-              "Etc/GMT-1", 
-              "Etc/GMT-10", 
-              "Etc/GMT-11", 
-              "Etc/GMT-12", 
-              "Etc/GMT-13", 
-              "Etc/GMT-14", 
-              "Etc/GMT-2", 
-              "Etc/GMT-3", 
-              "Etc/GMT-4", 
-              "Etc/GMT-5", 
-              "Etc/GMT-6", 
-              "Etc/GMT-7", 
-              "Etc/GMT-8", 
-              "Etc/GMT-9", 
-              "Etc/GMT0", 
-              "Etc/Greenwich", 
-              "Etc/UCT", 
-              "Etc/UTC", 
-              "Etc/Universal", 
-              "Etc/Zulu", 
-              "Europe/Amsterdam", 
-              "Europe/Andorra", 
-              "Europe/Astrakhan", 
-              "Europe/Athens", 
-              "Europe/Belfast", 
-              "Europe/Belgrade", 
-              "Europe/Berlin", 
-              "Europe/Bratislava", 
-              "Europe/Brussels", 
-              "Europe/Bucharest", 
-              "Europe/Budapest", 
-              "Europe/Busingen", 
-              "Europe/Chisinau", 
-              "Europe/Copenhagen", 
-              "Europe/Dublin", 
-              "Europe/Gibraltar", 
-              "Europe/Guernsey", 
-              "Europe/Helsinki", 
-              "Europe/Isle_of_Man", 
-              "Europe/Istanbul", 
-              "Europe/Jersey", 
-              "Europe/Kaliningrad", 
-              "Europe/Kiev", 
-              "Europe/Kirov", 
-              "Europe/Lisbon", 
-              "Europe/Ljubljana", 
-              "Europe/London", 
-              "Europe/Luxembourg", 
-              "Europe/Madrid", 
-              "Europe/Malta", 
-              "Europe/Mariehamn", 
-              "Europe/Minsk", 
-              "Europe/Monaco", 
-              "Europe/Moscow", 
-              "Europe/Nicosia", 
-              "Europe/Oslo", 
-              "Europe/Paris", 
-              "Europe/Podgorica", 
-              "Europe/Prague", 
-              "Europe/Riga", 
-              "Europe/Rome", 
-              "Europe/Samara", 
-              "Europe/San_Marino", 
-              "Europe/Sarajevo", 
-              "Europe/Saratov", 
-              "Europe/Simferopol", 
-              "Europe/Skopje", 
-              "Europe/Sofia", 
-              "Europe/Stockholm", 
-              "Europe/Tallinn", 
-              "Europe/Tirane", 
-              "Europe/Tiraspol", 
-              "Europe/Ulyanovsk", 
-              "Europe/Uzhgorod", 
-              "Europe/Vaduz", 
-              "Europe/Vatican", 
-              "Europe/Vienna", 
-              "Europe/Vilnius", 
-              "Europe/Volgograd", 
-              "Europe/Warsaw", 
-              "Europe/Zagreb", 
-              "Europe/Zaporozhye", 
-              "Europe/Zurich", 
-              "GB", 
-              "GB-Eire", 
-              "GMT", 
-              "GMT+0", 
-              "GMT-0", 
-              "GMT0", 
-              "Greenwich", 
-              "HST", 
-              "Hongkong", 
-              "Iceland", 
-              "Indian/Antananarivo", 
-              "Indian/Chagos", 
-              "Indian/Christmas", 
-              "Indian/Cocos", 
-              "Indian/Comoro", 
-              "Indian/Kerguelen", 
-              "Indian/Mahe", 
-              "Indian/Maldives", 
-              "Indian/Mauritius", 
-              "Indian/Mayotte", 
-              "Indian/Reunion", 
-              "Iran", 
-              "Israel", 
-              "Jamaica", 
-              "Japan", 
-              "Kwajalein", 
-              "Libya", 
-              "MET", 
-              "MST", 
-              "MST7MDT", 
-              "Mexico/BajaNorte", 
-              "Mexico/BajaSur", 
-              "Mexico/General", 
-              "NZ", 
-              "NZ-CHAT", 
-              "Navajo", 
-              "PRC", 
-              "PST8PDT", 
-              "Pacific/Apia", 
-              "Pacific/Auckland", 
-              "Pacific/Bougainville", 
-              "Pacific/Chatham", 
-              "Pacific/Chuuk", 
-              "Pacific/Easter", 
-              "Pacific/Efate", 
-              "Pacific/Enderbury", 
-              "Pacific/Fakaofo", 
-              "Pacific/Fiji", 
-              "Pacific/Funafuti", 
-              "Pacific/Galapagos", 
-              "Pacific/Gambier", 
-              "Pacific/Guadalcanal", 
-              "Pacific/Guam", 
-              "Pacific/Honolulu", 
-              "Pacific/Johnston", 
-              "Pacific/Kanton", 
-              "Pacific/Kiritimati", 
-              "Pacific/Kosrae", 
-              "Pacific/Kwajalein", 
-              "Pacific/Majuro", 
-              "Pacific/Marquesas", 
-              "Pacific/Midway", 
-              "Pacific/Nauru", 
-              "Pacific/Niue", 
-              "Pacific/Norfolk", 
-              "Pacific/Noumea", 
-              "Pacific/Pago_Pago", 
-              "Pacific/Palau", 
-              "Pacific/Pitcairn", 
-              "Pacific/Pohnpei", 
-              "Pacific/Ponape", 
-              "Pacific/Port_Moresby", 
-              "Pacific/Rarotonga", 
-              "Pacific/Saipan", 
-              "Pacific/Samoa", 
-              "Pacific/Tahiti", 
-              "Pacific/Tarawa", 
-              "Pacific/Tongatapu", 
-              "Pacific/Truk", 
-              "Pacific/Wake", 
-              "Pacific/Wallis", 
-              "Pacific/Yap", 
-              "Poland", 
-              "Portugal", 
-              "ROC", 
-              "ROK", 
-              "Singapore", 
-              "Turkey", 
-              "UCT", 
-              "US/Alaska", 
-              "US/Aleutian", 
-              "US/Arizona", 
-              "US/Central", 
-              "US/East-Indiana", 
-              "US/Eastern", 
-              "US/Hawaii", 
-              "US/Indiana-Starke", 
-              "US/Michigan", 
-              "US/Mountain", 
-              "US/Pacific", 
-              "US/Samoa", 
-              "UTC", 
-              "Universal", 
-              "W-SU", 
-              "WET", 
+              "Africa/Abidjan",
+              "Africa/Accra",
+              "Africa/Addis_Ababa",
+              "Africa/Algiers",
+              "Africa/Asmara",
+              "Africa/Asmera",
+              "Africa/Bamako",
+              "Africa/Bangui",
+              "Africa/Banjul",
+              "Africa/Bissau",
+              "Africa/Blantyre",
+              "Africa/Brazzaville",
+              "Africa/Bujumbura",
+              "Africa/Cairo",
+              "Africa/Casablanca",
+              "Africa/Ceuta",
+              "Africa/Conakry",
+              "Africa/Dakar",
+              "Africa/Dar_es_Salaam",
+              "Africa/Djibouti",
+              "Africa/Douala",
+              "Africa/El_Aaiun",
+              "Africa/Freetown",
+              "Africa/Gaborone",
+              "Africa/Harare",
+              "Africa/Johannesburg",
+              "Africa/Juba",
+              "Africa/Kampala",
+              "Africa/Khartoum",
+              "Africa/Kigali",
+              "Africa/Kinshasa",
+              "Africa/Lagos",
+              "Africa/Libreville",
+              "Africa/Lome",
+              "Africa/Luanda",
+              "Africa/Lubumbashi",
+              "Africa/Lusaka",
+              "Africa/Malabo",
+              "Africa/Maputo",
+              "Africa/Maseru",
+              "Africa/Mbabane",
+              "Africa/Mogadishu",
+              "Africa/Monrovia",
+              "Africa/Nairobi",
+              "Africa/Ndjamena",
+              "Africa/Niamey",
+              "Africa/Nouakchott",
+              "Africa/Ouagadougou",
+              "Africa/Porto-Novo",
+              "Africa/Sao_Tome",
+              "Africa/Timbuktu",
+              "Africa/Tripoli",
+              "Africa/Tunis",
+              "Africa/Windhoek",
+              "America/Adak",
+              "America/Anchorage",
+              "America/Anguilla",
+              "America/Antigua",
+              "America/Araguaina",
+              "America/Argentina/Buenos_Aires",
+              "America/Argentina/Catamarca",
+              "America/Argentina/ComodRivadavia",
+              "America/Argentina/Cordoba",
+              "America/Argentina/Jujuy",
+              "America/Argentina/La_Rioja",
+              "America/Argentina/Mendoza",
+              "America/Argentina/Rio_Gallegos",
+              "America/Argentina/Salta",
+              "America/Argentina/San_Juan",
+              "America/Argentina/San_Luis",
+              "America/Argentina/Tucuman",
+              "America/Argentina/Ushuaia",
+              "America/Aruba",
+              "America/Asuncion",
+              "America/Atikokan",
+              "America/Atka",
+              "America/Bahia",
+              "America/Bahia_Banderas",
+              "America/Barbados",
+              "America/Belem",
+              "America/Belize",
+              "America/Blanc-Sablon",
+              "America/Boa_Vista",
+              "America/Bogota",
+              "America/Boise",
+              "America/Buenos_Aires",
+              "America/Cambridge_Bay",
+              "America/Campo_Grande",
+              "America/Cancun",
+              "America/Caracas",
+              "America/Catamarca",
+              "America/Cayenne",
+              "America/Cayman",
+              "America/Chicago",
+              "America/Chihuahua",
+              "America/Coral_Harbour",
+              "America/Cordoba",
+              "America/Costa_Rica",
+              "America/Creston",
+              "America/Cuiaba",
+              "America/Curacao",
+              "America/Danmarkshavn",
+              "America/Dawson",
+              "America/Dawson_Creek",
+              "America/Denver",
+              "America/Detroit",
+              "America/Dominica",
+              "America/Edmonton",
+              "America/Eirunepe",
+              "America/El_Salvador",
+              "America/Ensenada",
+              "America/Fort_Nelson",
+              "America/Fort_Wayne",
+              "America/Fortaleza",
+              "America/Glace_Bay",
+              "America/Godthab",
+              "America/Goose_Bay",
+              "America/Grand_Turk",
+              "America/Grenada",
+              "America/Guadeloupe",
+              "America/Guatemala",
+              "America/Guayaquil",
+              "America/Guyana",
+              "America/Halifax",
+              "America/Havana",
+              "America/Hermosillo",
+              "America/Indiana/Indianapolis",
+              "America/Indiana/Knox",
+              "America/Indiana/Marengo",
+              "America/Indiana/Petersburg",
+              "America/Indiana/Tell_City",
+              "America/Indiana/Vevay",
+              "America/Indiana/Vincennes",
+              "America/Indiana/Winamac",
+              "America/Indianapolis",
+              "America/Inuvik",
+              "America/Iqaluit",
+              "America/Jamaica",
+              "America/Jujuy",
+              "America/Juneau",
+              "America/Kentucky/Louisville",
+              "America/Kentucky/Monticello",
+              "America/Knox_IN",
+              "America/Kralendijk",
+              "America/La_Paz",
+              "America/Lima",
+              "America/Los_Angeles",
+              "America/Louisville",
+              "America/Lower_Princes",
+              "America/Maceio",
+              "America/Managua",
+              "America/Manaus",
+              "America/Marigot",
+              "America/Martinique",
+              "America/Matamoros",
+              "America/Mazatlan",
+              "America/Mendoza",
+              "America/Menominee",
+              "America/Merida",
+              "America/Metlakatla",
+              "America/Mexico_City",
+              "America/Miquelon",
+              "America/Moncton",
+              "America/Monterrey",
+              "America/Montevideo",
+              "America/Montreal",
+              "America/Montserrat",
+              "America/Nassau",
+              "America/New_York",
+              "America/Nipigon",
+              "America/Nome",
+              "America/Noronha",
+              "America/North_Dakota/Beulah",
+              "America/North_Dakota/Center",
+              "America/North_Dakota/New_Salem",
+              "America/Nuuk",
+              "America/Ojinaga",
+              "America/Panama",
+              "America/Pangnirtung",
+              "America/Paramaribo",
+              "America/Phoenix",
+              "America/Port-au-Prince",
+              "America/Port_of_Spain",
+              "America/Porto_Acre",
+              "America/Porto_Velho",
+              "America/Puerto_Rico",
+              "America/Punta_Arenas",
+              "America/Rainy_River",
+              "America/Rankin_Inlet",
+              "America/Recife",
+              "America/Regina",
+              "America/Resolute",
+              "America/Rio_Branco",
+              "America/Rosario",
+              "America/Santa_Isabel",
+              "America/Santarem",
+              "America/Santiago",
+              "America/Santo_Domingo",
+              "America/Sao_Paulo",
+              "America/Scoresbysund",
+              "America/Shiprock",
+              "America/Sitka",
+              "America/St_Barthelemy",
+              "America/St_Johns",
+              "America/St_Kitts",
+              "America/St_Lucia",
+              "America/St_Thomas",
+              "America/St_Vincent",
+              "America/Swift_Current",
+              "America/Tegucigalpa",
+              "America/Thule",
+              "America/Thunder_Bay",
+              "America/Tijuana",
+              "America/Toronto",
+              "America/Tortola",
+              "America/Vancouver",
+              "America/Virgin",
+              "America/Whitehorse",
+              "America/Winnipeg",
+              "America/Yakutat",
+              "America/Yellowknife",
+              "Antarctica/Casey",
+              "Antarctica/Davis",
+              "Antarctica/DumontDUrville",
+              "Antarctica/Macquarie",
+              "Antarctica/Mawson",
+              "Antarctica/McMurdo",
+              "Antarctica/Palmer",
+              "Antarctica/Rothera",
+              "Antarctica/South_Pole",
+              "Antarctica/Syowa",
+              "Antarctica/Troll",
+              "Antarctica/Vostok",
+              "Arctic/Longyearbyen",
+              "Asia/Aden",
+              "Asia/Almaty",
+              "Asia/Amman",
+              "Asia/Anadyr",
+              "Asia/Aqtau",
+              "Asia/Aqtobe",
+              "Asia/Ashgabat",
+              "Asia/Ashkhabad",
+              "Asia/Atyrau",
+              "Asia/Baghdad",
+              "Asia/Bahrain",
+              "Asia/Baku",
+              "Asia/Bangkok",
+              "Asia/Barnaul",
+              "Asia/Beirut",
+              "Asia/Bishkek",
+              "Asia/Brunei",
+              "Asia/Calcutta",
+              "Asia/Chita",
+              "Asia/Choibalsan",
+              "Asia/Chongqing",
+              "Asia/Chungking",
+              "Asia/Colombo",
+              "Asia/Dacca",
+              "Asia/Damascus",
+              "Asia/Dhaka",
+              "Asia/Dili",
+              "Asia/Dubai",
+              "Asia/Dushanbe",
+              "Asia/Famagusta",
+              "Asia/Gaza",
+              "Asia/Harbin",
+              "Asia/Hebron",
+              "Asia/Ho_Chi_Minh",
+              "Asia/Hong_Kong",
+              "Asia/Hovd",
+              "Asia/Irkutsk",
+              "Asia/Istanbul",
+              "Asia/Jakarta",
+              "Asia/Jayapura",
+              "Asia/Jerusalem",
+              "Asia/Kabul",
+              "Asia/Kamchatka",
+              "Asia/Karachi",
+              "Asia/Kashgar",
+              "Asia/Kathmandu",
+              "Asia/Katmandu",
+              "Asia/Khandyga",
+              "Asia/Kolkata",
+              "Asia/Krasnoyarsk",
+              "Asia/Kuala_Lumpur",
+              "Asia/Kuching",
+              "Asia/Kuwait",
+              "Asia/Macao",
+              "Asia/Macau",
+              "Asia/Magadan",
+              "Asia/Makassar",
+              "Asia/Manila",
+              "Asia/Muscat",
+              "Asia/Nicosia",
+              "Asia/Novokuznetsk",
+              "Asia/Novosibirsk",
+              "Asia/Omsk",
+              "Asia/Oral",
+              "Asia/Phnom_Penh",
+              "Asia/Pontianak",
+              "Asia/Pyongyang",
+              "Asia/Qatar",
+              "Asia/Qostanay",
+              "Asia/Qyzylorda",
+              "Asia/Rangoon",
+              "Asia/Riyadh",
+              "Asia/Saigon",
+              "Asia/Sakhalin",
+              "Asia/Samarkand",
+              "Asia/Seoul",
+              "Asia/Shanghai",
+              "Asia/Singapore",
+              "Asia/Srednekolymsk",
+              "Asia/Taipei",
+              "Asia/Tashkent",
+              "Asia/Tbilisi",
+              "Asia/Tehran",
+              "Asia/Tel_Aviv",
+              "Asia/Thimbu",
+              "Asia/Thimphu",
+              "Asia/Tokyo",
+              "Asia/Tomsk",
+              "Asia/Ujung_Pandang",
+              "Asia/Ulaanbaatar",
+              "Asia/Ulan_Bator",
+              "Asia/Urumqi",
+              "Asia/Ust-Nera",
+              "Asia/Vientiane",
+              "Asia/Vladivostok",
+              "Asia/Yakutsk",
+              "Asia/Yangon",
+              "Asia/Yekaterinburg",
+              "Asia/Yerevan",
+              "Atlantic/Azores",
+              "Atlantic/Bermuda",
+              "Atlantic/Canary",
+              "Atlantic/Cape_Verde",
+              "Atlantic/Faeroe",
+              "Atlantic/Faroe",
+              "Atlantic/Jan_Mayen",
+              "Atlantic/Madeira",
+              "Atlantic/Reykjavik",
+              "Atlantic/South_Georgia",
+              "Atlantic/St_Helena",
+              "Atlantic/Stanley",
+              "Australia/ACT",
+              "Australia/Adelaide",
+              "Australia/Brisbane",
+              "Australia/Broken_Hill",
+              "Australia/Canberra",
+              "Australia/Currie",
+              "Australia/Darwin",
+              "Australia/Eucla",
+              "Australia/Hobart",
+              "Australia/LHI",
+              "Australia/Lindeman",
+              "Australia/Lord_Howe",
+              "Australia/Melbourne",
+              "Australia/NSW",
+              "Australia/North",
+              "Australia/Perth",
+              "Australia/Queensland",
+              "Australia/South",
+              "Australia/Sydney",
+              "Australia/Tasmania",
+              "Australia/Victoria",
+              "Australia/West",
+              "Australia/Yancowinna",
+              "Brazil/Acre",
+              "Brazil/DeNoronha",
+              "Brazil/East",
+              "Brazil/West",
+              "CET",
+              "CST6CDT",
+              "Canada/Atlantic",
+              "Canada/Central",
+              "Canada/Eastern",
+              "Canada/Mountain",
+              "Canada/Newfoundland",
+              "Canada/Pacific",
+              "Canada/Saskatchewan",
+              "Canada/Yukon",
+              "Chile/Continental",
+              "Chile/EasterIsland",
+              "Cuba",
+              "EET",
+              "EST",
+              "EST5EDT",
+              "Egypt",
+              "Eire",
+              "Etc/GMT",
+              "Etc/GMT+0",
+              "Etc/GMT+1",
+              "Etc/GMT+10",
+              "Etc/GMT+11",
+              "Etc/GMT+12",
+              "Etc/GMT+2",
+              "Etc/GMT+3",
+              "Etc/GMT+4",
+              "Etc/GMT+5",
+              "Etc/GMT+6",
+              "Etc/GMT+7",
+              "Etc/GMT+8",
+              "Etc/GMT+9",
+              "Etc/GMT-0",
+              "Etc/GMT-1",
+              "Etc/GMT-10",
+              "Etc/GMT-11",
+              "Etc/GMT-12",
+              "Etc/GMT-13",
+              "Etc/GMT-14",
+              "Etc/GMT-2",
+              "Etc/GMT-3",
+              "Etc/GMT-4",
+              "Etc/GMT-5",
+              "Etc/GMT-6",
+              "Etc/GMT-7",
+              "Etc/GMT-8",
+              "Etc/GMT-9",
+              "Etc/GMT0",
+              "Etc/Greenwich",
+              "Etc/UCT",
+              "Etc/UTC",
+              "Etc/Universal",
+              "Etc/Zulu",
+              "Europe/Amsterdam",
+              "Europe/Andorra",
+              "Europe/Astrakhan",
+              "Europe/Athens",
+              "Europe/Belfast",
+              "Europe/Belgrade",
+              "Europe/Berlin",
+              "Europe/Bratislava",
+              "Europe/Brussels",
+              "Europe/Bucharest",
+              "Europe/Budapest",
+              "Europe/Busingen",
+              "Europe/Chisinau",
+              "Europe/Copenhagen",
+              "Europe/Dublin",
+              "Europe/Gibraltar",
+              "Europe/Guernsey",
+              "Europe/Helsinki",
+              "Europe/Isle_of_Man",
+              "Europe/Istanbul",
+              "Europe/Jersey",
+              "Europe/Kaliningrad",
+              "Europe/Kiev",
+              "Europe/Kirov",
+              "Europe/Lisbon",
+              "Europe/Ljubljana",
+              "Europe/London",
+              "Europe/Luxembourg",
+              "Europe/Madrid",
+              "Europe/Malta",
+              "Europe/Mariehamn",
+              "Europe/Minsk",
+              "Europe/Monaco",
+              "Europe/Moscow",
+              "Europe/Nicosia",
+              "Europe/Oslo",
+              "Europe/Paris",
+              "Europe/Podgorica",
+              "Europe/Prague",
+              "Europe/Riga",
+              "Europe/Rome",
+              "Europe/Samara",
+              "Europe/San_Marino",
+              "Europe/Sarajevo",
+              "Europe/Saratov",
+              "Europe/Simferopol",
+              "Europe/Skopje",
+              "Europe/Sofia",
+              "Europe/Stockholm",
+              "Europe/Tallinn",
+              "Europe/Tirane",
+              "Europe/Tiraspol",
+              "Europe/Ulyanovsk",
+              "Europe/Uzhgorod",
+              "Europe/Vaduz",
+              "Europe/Vatican",
+              "Europe/Vienna",
+              "Europe/Vilnius",
+              "Europe/Volgograd",
+              "Europe/Warsaw",
+              "Europe/Zagreb",
+              "Europe/Zaporozhye",
+              "Europe/Zurich",
+              "GB",
+              "GB-Eire",
+              "GMT",
+              "GMT+0",
+              "GMT-0",
+              "GMT0",
+              "Greenwich",
+              "HST",
+              "Hongkong",
+              "Iceland",
+              "Indian/Antananarivo",
+              "Indian/Chagos",
+              "Indian/Christmas",
+              "Indian/Cocos",
+              "Indian/Comoro",
+              "Indian/Kerguelen",
+              "Indian/Mahe",
+              "Indian/Maldives",
+              "Indian/Mauritius",
+              "Indian/Mayotte",
+              "Indian/Reunion",
+              "Iran",
+              "Israel",
+              "Jamaica",
+              "Japan",
+              "Kwajalein",
+              "Libya",
+              "MET",
+              "MST",
+              "MST7MDT",
+              "Mexico/BajaNorte",
+              "Mexico/BajaSur",
+              "Mexico/General",
+              "NZ",
+              "NZ-CHAT",
+              "Navajo",
+              "PRC",
+              "PST8PDT",
+              "Pacific/Apia",
+              "Pacific/Auckland",
+              "Pacific/Bougainville",
+              "Pacific/Chatham",
+              "Pacific/Chuuk",
+              "Pacific/Easter",
+              "Pacific/Efate",
+              "Pacific/Enderbury",
+              "Pacific/Fakaofo",
+              "Pacific/Fiji",
+              "Pacific/Funafuti",
+              "Pacific/Galapagos",
+              "Pacific/Gambier",
+              "Pacific/Guadalcanal",
+              "Pacific/Guam",
+              "Pacific/Honolulu",
+              "Pacific/Johnston",
+              "Pacific/Kanton",
+              "Pacific/Kiritimati",
+              "Pacific/Kosrae",
+              "Pacific/Kwajalein",
+              "Pacific/Majuro",
+              "Pacific/Marquesas",
+              "Pacific/Midway",
+              "Pacific/Nauru",
+              "Pacific/Niue",
+              "Pacific/Norfolk",
+              "Pacific/Noumea",
+              "Pacific/Pago_Pago",
+              "Pacific/Palau",
+              "Pacific/Pitcairn",
+              "Pacific/Pohnpei",
+              "Pacific/Ponape",
+              "Pacific/Port_Moresby",
+              "Pacific/Rarotonga",
+              "Pacific/Saipan",
+              "Pacific/Samoa",
+              "Pacific/Tahiti",
+              "Pacific/Tarawa",
+              "Pacific/Tongatapu",
+              "Pacific/Truk",
+              "Pacific/Wake",
+              "Pacific/Wallis",
+              "Pacific/Yap",
+              "Poland",
+              "Portugal",
+              "ROC",
+              "ROK",
+              "Singapore",
+              "Turkey",
+              "UCT",
+              "US/Alaska",
+              "US/Aleutian",
+              "US/Arizona",
+              "US/Central",
+              "US/East-Indiana",
+              "US/Eastern",
+              "US/Hawaii",
+              "US/Indiana-Starke",
+              "US/Michigan",
+              "US/Mountain",
+              "US/Pacific",
+              "US/Samoa",
+              "UTC",
+              "Universal",
+              "W-SU",
+              "WET",
               "Zulu"
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           "type": {
-            "description": "The report schedule type", 
+            "description": "The report schedule type",
             "enum": [
-              "Alert", 
+              "Alert",
               "Report"
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           "validator_config_json": {
             "$ref": "#/components/schemas/ValidatorConfigJSON"
-          }, 
+          },
           "validator_type": {
-            "description": "Determines when to trigger alert based off value from alert query. Alerts will be triggered with these validator types:\n- Not Null - When the return value is Not NULL, Empty, or 0\n- Operator - When `sql_return_value comparison_operator threshold` is True e.g. `50 <= 75`<br>Supports the comparison operators <, <=, >, >=, ==, and !=", 
+            "description": "Determines when to trigger alert based off value from alert query. Alerts will be triggered with these validator types:\n- Not Null - When the return value is Not NULL, Empty, or 0\n- Operator - When `sql_return_value comparison_operator threshold` is True e.g. `50 <= 75`<br>Supports the comparison operators <, <=, >, >=, ==, and !=",
             "enum": [
-              "not null", 
+              "not null",
               "operator"
-            ], 
-            "nullable": true, 
+            ],
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "working_timeout": {
-            "description": "If an alert is staled at a working state, how long until it's state is reseted to error", 
-            "example": 3600, 
-            "format": "int32", 
-            "minimum": 1, 
-            "nullable": true, 
+            "description": "If an alert is staled at a working state, how long until it's state is reseted to error",
+            "example": 3600,
+            "format": "int32",
+            "minimum": 1,
+            "nullable": true,
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "Resource": {
         "properties": {
           "id": {
             "type": "string"
-          }, 
+          },
           "type": {}
-        }, 
+        },
         "required": [
-          "id", 
+          "id",
           "type"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "RlsRule": {
         "properties": {
           "clause": {
             "type": "string"
-          }, 
+          },
           "dataset": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "required": [
           "clause"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "Roles": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "name": {
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "Roles1": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "name": {
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "SavedQueryRestApi.get": {
         "properties": {
           "changed_on_delta_humanized": {
             "readOnly": true
-          }, 
+          },
           "created_by": {
             "$ref": "#/components/schemas/SavedQueryRestApi.get.User"
-          }, 
+          },
           "database": {
             "$ref": "#/components/schemas/SavedQueryRestApi.get.Database"
-          }, 
+          },
           "description": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "label": {
-            "maxLength": 256, 
-            "nullable": true, 
+            "maxLength": 256,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "schema": {
-            "maxLength": 128, 
-            "nullable": true, 
+            "maxLength": 128,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "sql": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "sql_tables": {
             "readOnly": true
-          }, 
+          },
           "template_parameters": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "SavedQueryRestApi.get.Database": {
         "properties": {
           "database_name": {
-            "maxLength": 250, 
+            "maxLength": 250,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "required": [
           "database_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "SavedQueryRestApi.get.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
+          "first_name",
           "last_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "SavedQueryRestApi.get_list": {
         "properties": {
           "changed_on_delta_humanized": {
             "readOnly": true
-          }, 
+          },
           "created_by": {
             "$ref": "#/components/schemas/SavedQueryRestApi.get_list.User"
-          }, 
+          },
           "created_on": {
-            "format": "date-time", 
-            "nullable": true, 
+            "format": "date-time",
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "database": {
             "$ref": "#/components/schemas/SavedQueryRestApi.get_list.Database"
-          }, 
+          },
           "db_id": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "description": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "extra": {
             "readOnly": true
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "label": {
-            "maxLength": 256, 
-            "nullable": true, 
+            "maxLength": 256,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "last_run_delta_humanized": {
             "readOnly": true
-          }, 
+          },
           "rows": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "schema": {
-            "maxLength": 128, 
-            "nullable": true, 
+            "maxLength": 128,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "sql": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "sql_tables": {
             "readOnly": true
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "SavedQueryRestApi.get_list.Database": {
         "properties": {
           "database_name": {
-            "maxLength": 250, 
+            "maxLength": 250,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "required": [
           "database_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "SavedQueryRestApi.get_list.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "last_name": {
-            "maxLength": 64, 
+            "maxLength": 64,
             "type": "string"
           }
-        }, 
+        },
         "required": [
-          "first_name", 
+          "first_name",
           "last_name"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "SavedQueryRestApi.post": {
         "properties": {
           "db_id": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "description": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "label": {
-            "maxLength": 256, 
-            "nullable": true, 
+            "maxLength": 256,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "schema": {
-            "maxLength": 128, 
-            "nullable": true, 
+            "maxLength": 128,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "sql": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "template_parameters": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "SavedQueryRestApi.put": {
         "properties": {
           "db_id": {
-            "format": "int32", 
-            "nullable": true, 
+            "format": "int32",
+            "nullable": true,
             "type": "integer"
-          }, 
+          },
           "description": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "label": {
-            "maxLength": 256, 
-            "nullable": true, 
+            "maxLength": 256,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "schema": {
-            "maxLength": 128, 
-            "nullable": true, 
+            "maxLength": 128,
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "sql": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "template_parameters": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "SchemasResponseSchema": {
         "properties": {
           "result": {
             "items": {
-              "description": "A database schema name", 
+              "description": "A database schema name",
               "type": "string"
-            }, 
+            },
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "SelectStarResponseSchema": {
         "properties": {
           "result": {
-            "description": "SQL select star", 
+            "description": "SQL select star",
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "Slice": {
         "properties": {
           "cache_timeout": {
-            "description": "Duration (in seconds) of the caching timeout for this chart.", 
-            "format": "int32", 
+            "description": "Duration (in seconds) of the caching timeout for this chart.",
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "certification_details": {
-            "description": "Details of the certification.", 
+            "description": "Details of the certification.",
             "type": "string"
-          }, 
+          },
           "certified_by": {
-            "description": "Person or group that has certified this dashboard.", 
+            "description": "Person or group that has certified this dashboard.",
             "type": "string"
-          }, 
+          },
           "changed_on": {
-            "description": "Timestamp of the last modification.", 
+            "description": "Timestamp of the last modification.",
             "type": "string"
-          }, 
+          },
           "changed_on_humanized": {
-            "description": "Timestamp of the last modification in human readable form.", 
+            "description": "Timestamp of the last modification in human readable form.",
             "type": "string"
-          }, 
+          },
           "datasource": {
-            "description": "Datasource identifier.", 
+            "description": "Datasource identifier.",
             "type": "string"
-          }, 
+          },
           "description": {
-            "description": "Slice description.", 
+            "description": "Slice description.",
             "type": "string"
-          }, 
+          },
           "description_markeddown": {
-            "description": "Sanitized HTML version of the chart description.", 
+            "description": "Sanitized HTML version of the chart description.",
             "type": "string"
-          }, 
+          },
           "edit_url": {
-            "description": "The URL for editing the slice.", 
+            "description": "The URL for editing the slice.",
             "type": "string"
-          }, 
+          },
           "form_data": {
-            "description": "Form data associated with the slice.", 
+            "description": "Form data associated with the slice.",
             "type": "object"
-          }, 
+          },
           "is_managed_externally": {
-            "description": "If the chart is managed outside externally.", 
+            "description": "If the chart is managed outside externally.",
             "type": "boolean"
-          }, 
+          },
           "modified": {
-            "description": "Last modification in human readable form.", 
+            "description": "Last modification in human readable form.",
             "type": "string"
-          }, 
+          },
           "owners": {
-            "description": "Owners identifiers.", 
+            "description": "Owners identifiers.",
             "items": {
-              "format": "int32", 
+              "format": "int32",
               "type": "integer"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "query_context": {
-            "description": "The context associated with the query.", 
+            "description": "The context associated with the query.",
             "type": "object"
-          }, 
+          },
           "slice_id": {
-            "description": "The slice ID.", 
-            "format": "int32", 
+            "description": "The slice ID.",
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "slice_name": {
-            "description": "The slice name.", 
+            "description": "The slice name.",
             "type": "string"
-          }, 
+          },
           "slice_url": {
-            "description": "The slice URL.", 
+            "description": "The slice URL.",
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "StopQuerySchema": {
         "properties": {
           "client_id": {
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "TableExtraMetadataResponseSchema": {
         "properties": {
           "clustering": {
             "type": "object"
-          }, 
+          },
           "metadata": {
             "type": "object"
-          }, 
+          },
           "partitions": {
             "type": "object"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "TableMetadataColumnsResponse": {
         "properties": {
           "duplicates_constraint": {
             "type": "string"
-          }, 
+          },
           "keys": {
-            "description": "", 
+            "description": "",
             "items": {
               "type": "string"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "longType": {
-            "description": "The actual backend long type for the column", 
+            "description": "The actual backend long type for the column",
             "type": "string"
-          }, 
+          },
           "name": {
-            "description": "The column name", 
+            "description": "The column name",
             "type": "string"
-          }, 
+          },
           "type": {
-            "description": "The column type", 
+            "description": "The column type",
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "TableMetadataForeignKeysIndexesResponse": {
         "properties": {
           "column_names": {
             "items": {
-              "description": "A list of column names that compose the foreign key or index", 
+              "description": "A list of column names that compose the foreign key or index",
               "type": "string"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "name": {
-            "description": "The name of the foreign key or index", 
+            "description": "The name of the foreign key or index",
             "type": "string"
-          }, 
+          },
           "options": {
             "$ref": "#/components/schemas/TableMetadataOptionsResponse"
-          }, 
+          },
           "referred_columns": {
             "items": {
               "type": "string"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "referred_schema": {
             "type": "string"
-          }, 
+          },
           "referred_table": {
             "type": "string"
-          }, 
+          },
           "type": {
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "TableMetadataOptionsResponse": {
         "properties": {
           "deferrable": {
             "type": "boolean"
-          }, 
+          },
           "initially": {
             "type": "boolean"
-          }, 
+          },
           "match": {
             "type": "boolean"
-          }, 
+          },
           "ondelete": {
             "type": "boolean"
-          }, 
+          },
           "onupdate": {
             "type": "boolean"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "TableMetadataPrimaryKeyResponse": {
         "properties": {
           "column_names": {
             "items": {
-              "description": "A list of column names that compose the primary key", 
+              "description": "A list of column names that compose the primary key",
               "type": "string"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "name": {
-            "description": "The primary key index name", 
+            "description": "The primary key index name",
             "type": "string"
-          }, 
+          },
           "type": {
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "TableMetadataResponseSchema": {
         "properties": {
           "columns": {
-            "description": "A list of columns and their metadata", 
+            "description": "A list of columns and their metadata",
             "items": {
               "$ref": "#/components/schemas/TableMetadataColumnsResponse"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "foreignKeys": {
-            "description": "A list of foreign keys and their metadata", 
+            "description": "A list of foreign keys and their metadata",
             "items": {
               "$ref": "#/components/schemas/TableMetadataForeignKeysIndexesResponse"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "indexes": {
-            "description": "A list of indexes and their metadata", 
+            "description": "A list of indexes and their metadata",
             "items": {
               "$ref": "#/components/schemas/TableMetadataForeignKeysIndexesResponse"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "name": {
-            "description": "The name of the table", 
+            "description": "The name of the table",
             "type": "string"
-          }, 
+          },
           "primaryKey": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/TableMetadataPrimaryKeyResponse"
               }
-            ], 
+            ],
             "description": "Primary keys metadata"
-          }, 
+          },
           "selectStar": {
-            "description": "SQL select star", 
+            "description": "SQL select star",
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "Tables": {
         "properties": {
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "schema": {
             "type": "string"
-          }, 
+          },
           "table_name": {
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "TemporaryCachePostSchema": {
         "properties": {
           "value": {
-            "description": "Any type of JSON supported text.", 
+            "description": "Any type of JSON supported text.",
             "type": "string"
           }
-        }, 
+        },
         "required": [
           "value"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "TemporaryCachePutSchema": {
         "properties": {
           "value": {
-            "description": "Any type of JSON supported text.", 
+            "description": "Any type of JSON supported text.",
             "type": "string"
           }
-        }, 
+        },
         "required": [
           "value"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "User": {
         "properties": {
           "first_name": {
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "last_name": {
             "type": "string"
-          }, 
+          },
           "username": {
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "User1": {
         "properties": {
           "first_name": {
             "type": "string"
-          }, 
+          },
           "last_name": {
             "type": "string"
-          }, 
+          },
           "username": {
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "UserResponseSchema": {
         "properties": {
           "email": {
             "type": "string"
-          }, 
+          },
           "first_name": {
             "type": "string"
-          }, 
+          },
           "id": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "is_active": {
             "type": "boolean"
-          }, 
+          },
           "is_anonymous": {
             "type": "boolean"
-          }, 
+          },
           "last_name": {
             "type": "string"
-          }, 
+          },
           "username": {
             "type": "string"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ValidateSQLRequest": {
         "properties": {
           "schema": {
-            "nullable": true, 
+            "nullable": true,
             "type": "string"
-          }, 
+          },
           "sql": {
-            "description": "SQL statement to validate", 
+            "description": "SQL statement to validate",
             "type": "string"
-          }, 
+          },
           "template_params": {
-            "nullable": true, 
+            "nullable": true,
             "type": "object"
           }
-        }, 
+        },
         "required": [
           "sql"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "ValidateSQLResponse": {
         "properties": {
           "end_column": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "line_number": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
-          }, 
+          },
           "message": {
             "type": "string"
-          }, 
+          },
           "start_column": {
-            "format": "int32", 
+            "format": "int32",
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "ValidatorConfigJSON": {
         "properties": {
           "op": {
-            "description": "The operation to compare with a threshold to apply to the SQL output\n", 
+            "description": "The operation to compare with a threshold to apply to the SQL output\n",
             "enum": [
-              "<", 
-              "<=", 
-              ">", 
-              ">=", 
-              "==", 
+              "<",
+              "<=",
+              ">",
+              ">=",
+              "==",
               "!="
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           "threshold": {
-            "format": "float", 
+            "format": "float",
             "type": "number"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "advanced_data_type_convert_schema": {
         "properties": {
           "type": {
-            "default": "port", 
+            "default": "port",
             "type": "string"
-          }, 
+          },
           "values": {
             "items": {
               "default": "http"
-            }, 
-            "minItems": 1, 
+            },
+            "minItems": 1,
             "type": "array"
           }
-        }, 
+        },
         "required": [
-          "type", 
+          "type",
           "values"
-        ], 
+        ],
         "type": "object"
-      }, 
+      },
       "database_schemas_query_schema": {
         "properties": {
           "force": {
             "type": "boolean"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "get_delete_ids_schema": {
         "items": {
           "type": "integer"
-        }, 
+        },
         "type": "array"
-      }, 
+      },
       "get_export_ids_schema": {
         "items": {
           "type": "integer"
-        }, 
+        },
         "type": "array"
-      }, 
+      },
       "get_fav_star_ids_schema": {
         "items": {
           "type": "integer"
-        }, 
+        },
         "type": "array"
-      }, 
+      },
       "get_info_schema": {
         "properties": {
           "add_columns": {
@@ -9228,232 +9228,232 @@
               "properties": {
                 "page": {
                   "type": "integer"
-                }, 
+                },
                 "page_size": {
                   "type": "integer"
                 }
-              }, 
+              },
               "type": "object"
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           "edit_columns": {
             "additionalProperties": {
               "properties": {
                 "page": {
                   "type": "integer"
-                }, 
+                },
                 "page_size": {
                   "type": "integer"
                 }
-              }, 
+              },
               "type": "object"
-            }, 
+            },
             "type": "object"
-          }, 
+          },
           "keys": {
             "items": {
               "enum": [
-                "add_columns", 
-                "edit_columns", 
-                "filters", 
-                "permissions", 
-                "add_title", 
-                "edit_title", 
+                "add_columns",
+                "edit_columns",
+                "filters",
+                "permissions",
+                "add_title",
+                "edit_title",
                 "none"
-              ], 
+              ],
               "type": "string"
-            }, 
+            },
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "get_item_schema": {
         "properties": {
           "columns": {
             "items": {
               "type": "string"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "keys": {
             "items": {
               "enum": [
-                "show_columns", 
-                "description_columns", 
-                "label_columns", 
-                "show_title", 
+                "show_columns",
+                "description_columns",
+                "label_columns",
+                "show_title",
                 "none"
-              ], 
+              ],
               "type": "string"
-            }, 
+            },
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "get_list_schema": {
         "properties": {
           "columns": {
             "items": {
               "type": "string"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "filters": {
             "items": {
               "properties": {
                 "col": {
                   "type": "string"
-                }, 
+                },
                 "opr": {
                   "type": "string"
-                }, 
+                },
                 "value": {
                   "anyOf": [
                     {
                       "type": "number"
-                    }, 
+                    },
                     {
                       "type": "string"
-                    }, 
+                    },
                     {
                       "type": "boolean"
-                    }, 
+                    },
                     {
                       "type": "array"
                     }
                   ]
                 }
-              }, 
+              },
               "required": [
-                "col", 
-                "opr", 
+                "col",
+                "opr",
                 "value"
-              ], 
+              ],
               "type": "object"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "keys": {
             "items": {
               "enum": [
-                "list_columns", 
-                "order_columns", 
-                "label_columns", 
-                "description_columns", 
-                "list_title", 
+                "list_columns",
+                "order_columns",
+                "label_columns",
+                "description_columns",
+                "list_title",
                 "none"
-              ], 
+              ],
               "type": "string"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "order_column": {
             "type": "string"
-          }, 
+          },
           "order_direction": {
             "enum": [
-              "asc", 
+              "asc",
               "desc"
-            ], 
+            ],
             "type": "string"
-          }, 
+          },
           "page": {
             "type": "integer"
-          }, 
+          },
           "page_size": {
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "get_recent_activity_schema": {
         "properties": {
           "actions": {
             "items": {
               "type": "string"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "distinct": {
             "type": "boolean"
-          }, 
+          },
           "limit": {
             "type": "number"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "get_related_schema": {
         "properties": {
           "filter": {
             "type": "string"
-          }, 
+          },
           "include_ids": {
             "items": {
               "type": "integer"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "page": {
             "type": "integer"
-          }, 
+          },
           "page_size": {
             "type": "integer"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "screenshot_query_schema": {
         "properties": {
           "force": {
             "type": "boolean"
-          }, 
+          },
           "thumb_size": {
             "items": {
               "type": "integer"
-            }, 
+            },
             "type": "array"
-          }, 
+          },
           "window_size": {
             "items": {
               "type": "integer"
-            }, 
+            },
             "type": "array"
           }
-        }, 
+        },
         "type": "object"
-      }, 
+      },
       "thumbnail_query_schema": {
         "properties": {
           "force": {
             "type": "boolean"
           }
-        }, 
+        },
         "type": "object"
       }
-    }, 
+    },
     "securitySchemes": {
       "jwt": {
-        "bearerFormat": "JWT", 
-        "scheme": "bearer", 
+        "bearerFormat": "JWT",
+        "scheme": "bearer",
         "type": "http"
-      }, 
+      },
       "jwt_refresh": {
-        "bearerFormat": "JWT", 
-        "scheme": "bearer", 
+        "bearerFormat": "JWT",
+        "scheme": "bearer",
         "type": "http"
       }
     }
-  }, 
+  },
   "info": {
-    "description": "Superset", 
-    "title": "Superset", 
+    "description": "Superset",
+    "title": "Superset",
     "version": "v1"
-  }, 
-  "openapi": "3.0.2", 
+  },
+  "openapi": "3.0.2",
   "paths": {
     "/api/v1/advanced_data_type/convert": {
       "get": {
@@ -9465,11 +9465,11 @@
                   "$ref": "#/components/schemas/advanced_data_type_convert_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -9478,36 +9478,36 @@
                   "$ref": "#/components/schemas/AdvancedDataTypeSchema"
                 }
               }
-            }, 
+            },
             "description": "AdvancedDataTypeResponse object has been returned."
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
-        "summary": "Returns a AdvancedDataTypeResponse object populated with the passed in args.", 
+        ],
+        "summary": "Returns a AdvancedDataTypeResponse object populated with the passed in args.",
         "tags": [
           "Advanced Data Type"
         ]
       }
-    }, 
+    },
     "/api/v1/advanced_data_type/types": {
       "get": {
-        "description": "Returns a list of available advanced data types.", 
+        "description": "Returns a list of available advanced data types.",
         "responses": {
           "200": {
             "content": {
@@ -9517,39 +9517,39 @@
                     "result": {
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "a successful return of the available advanced data types has taken place."
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Advanced Data Type"
         ]
       }
-    }, 
+    },
     "/api/v1/annotation_layer/": {
       "delete": {
-        "description": "Deletes multiple annotation layers in a bulk operation.", 
+        "description": "Deletes multiple annotation layers in a bulk operation.",
         "parameters": [
           {
             "content": {
@@ -9558,11 +9558,11 @@
                   "$ref": "#/components/schemas/get_delete_ids_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -9572,37 +9572,37 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "CSS templates bulk delete"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Annotation Layers"
         ]
-      }, 
+      },
       "get": {
-        "description": "Get a list of Annotation layers, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.", 
+        "description": "Get a list of Annotation layers, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
         "parameters": [
           {
             "content": {
@@ -9611,11 +9611,11 @@
                   "$ref": "#/components/schemas/get_list_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -9623,93 +9623,93 @@
                 "schema": {
                   "properties": {
                     "count": {
-                      "description": "The total record count on the backend", 
+                      "description": "The total record count on the backend",
                       "type": "number"
-                    }, 
+                    },
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel", 
-                          "example": "A Nice description for the column", 
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "ids": {
-                      "description": "A list of item ids, useful when you don't know the column id", 
+                      "description": "A list of item ids, useful when you don't know the column id",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel", 
-                          "example": "A Nice label for the column", 
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "list_columns": {
-                      "description": "A list of columns", 
+                      "description": "A list of columns",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "list_title": {
-                      "description": "A title to render. Will be translated by babel", 
-                      "example": "List Items", 
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "List Items",
                       "type": "string"
-                    }, 
+                    },
                     "order_columns": {
-                      "description": "A list of allowed columns to sort", 
+                      "description": "A list of allowed columns to sort",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "result": {
-                      "description": "The result from the get list query", 
+                      "description": "The result from the get list query",
                       "items": {
                         "$ref": "#/components/schemas/AnnotationLayerRestApi.get_list"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Items from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Annotation Layers"
         ]
-      }, 
+      },
       "post": {
-        "description": "Create an Annotation layer", 
+        "description": "Create an Annotation layer",
         "requestBody": {
           "content": {
             "application/json": {
@@ -9717,10 +9717,10 @@
                 "$ref": "#/components/schemas/AnnotationLayerRestApi.post"
               }
             }
-          }, 
-          "description": "Annotation Layer schema", 
+          },
+          "description": "Annotation Layer schema",
           "required": true
-        }, 
+        },
         "responses": {
           "201": {
             "content": {
@@ -9729,43 +9729,43 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/AnnotationLayerRestApi.post"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Annotation added"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Annotation Layers"
         ]
       }
-    }, 
+    },
     "/api/v1/annotation_layer/_info": {
       "get": {
-        "description": "Get metadata information about this API resource", 
+        "description": "Get metadata information about this API resource",
         "parameters": [
           {
             "content": {
@@ -9774,11 +9774,11 @@
                   "$ref": "#/components/schemas/get_info_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -9787,79 +9787,79 @@
                   "properties": {
                     "add_columns": {
                       "type": "object"
-                    }, 
+                    },
                     "edit_columns": {
                       "type": "object"
-                    }, 
+                    },
                     "filters": {
                       "properties": {
                         "column_name": {
                           "items": {
                             "properties": {
                               "name": {
-                                "description": "The filter name. Will be translated by babel", 
+                                "description": "The filter name. Will be translated by babel",
                                 "type": "string"
-                              }, 
+                              },
                               "operator": {
-                                "description": "The filter operation key to use on list filters", 
+                                "description": "The filter operation key to use on list filters",
                                 "type": "string"
                               }
-                            }, 
+                            },
                             "type": "object"
-                          }, 
+                          },
                           "type": "array"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "permissions": {
-                      "description": "The user permissions for this API resource", 
+                      "description": "The user permissions for this API resource",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Annotation Layers"
         ]
       }
-    }, 
+    },
     "/api/v1/annotation_layer/related/{column_name}": {
       "get": {
         "parameters": [
           {
-            "in": "path", 
-            "name": "column_name", 
-            "required": true, 
+            "in": "path",
+            "name": "column_name",
+            "required": true,
             "schema": {
               "type": "string"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -9867,11 +9867,11 @@
                   "$ref": "#/components/schemas/get_related_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -9880,46 +9880,46 @@
                   "$ref": "#/components/schemas/RelatedResponseSchema"
                 }
               }
-            }, 
+            },
             "description": "Related column data"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Annotation Layers"
         ]
       }
-    }, 
+    },
     "/api/v1/annotation_layer/{pk}": {
       "delete": {
-        "description": "Delete Annotation layer", 
+        "description": "Delete Annotation layer",
         "parameters": [
           {
-            "description": "The annotation layer pk for this annotation", 
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "description": "The annotation layer pk for this annotation",
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -9929,43 +9929,43 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item deleted"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Annotation Layers"
         ]
-      }, 
+      },
       "get": {
-        "description": "Get an Annotation layer", 
+        "description": "Get an Annotation layer",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -9973,11 +9973,11 @@
                   "$ref": "#/components/schemas/get_item_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -9987,87 +9987,87 @@
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel", 
-                          "example": "A Nice description for the column", 
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "id": {
-                      "description": "The item id", 
+                      "description": "The item id",
                       "type": "string"
-                    }, 
+                    },
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel", 
-                          "example": "A Nice label for the column", 
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/AnnotationLayerRestApi.get"
-                    }, 
+                    },
                     "show_columns": {
-                      "description": "A list of columns", 
+                      "description": "A list of columns",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "show_title": {
-                      "description": "A title to render. Will be translated by babel", 
-                      "example": "Show Item Details", 
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "Show Item Details",
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Annotation Layers"
         ]
-      }, 
+      },
       "put": {
-        "description": "Update an Annotation layer", 
+        "description": "Update an Annotation layer",
         "parameters": [
           {
-            "description": "The annotation layer pk for this annotation", 
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "description": "The annotation layer pk for this annotation",
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -10075,10 +10075,10 @@
                 "$ref": "#/components/schemas/AnnotationLayerRestApi.put"
               }
             }
-          }, 
-          "description": "Annotation schema", 
+          },
+          "description": "Annotation schema",
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -10087,53 +10087,53 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/AnnotationLayerRestApi.put"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Annotation changed"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Annotation Layers"
         ]
       }
-    }, 
+    },
     "/api/v1/annotation_layer/{pk}/annotation/": {
       "delete": {
-        "description": "Deletes multiple annotation in a bulk operation.", 
+        "description": "Deletes multiple annotation in a bulk operation.",
         "parameters": [
           {
-            "description": "The annotation layer pk for this annotation", 
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "description": "The annotation layer pk for this annotation",
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -10141,11 +10141,11 @@
                   "$ref": "#/components/schemas/get_delete_ids_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -10155,47 +10155,47 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Annotations bulk delete"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Annotation Layers"
         ]
-      }, 
+      },
       "get": {
-        "description": "Get a list of Annotation layers, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.", 
+        "description": "Get a list of Annotation layers, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
         "parameters": [
           {
-            "description": "The annotation layer id for this annotation", 
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "description": "The annotation layer id for this annotation",
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -10203,11 +10203,11 @@
                   "$ref": "#/components/schemas/get_list_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -10215,65 +10215,65 @@
                 "schema": {
                   "properties": {
                     "count": {
-                      "description": "The total record count on the backend", 
+                      "description": "The total record count on the backend",
                       "type": "number"
-                    }, 
+                    },
                     "ids": {
-                      "description": "A list of annotation ids", 
+                      "description": "A list of annotation ids",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "result": {
-                      "description": "The result from the get list query", 
+                      "description": "The result from the get list query",
                       "items": {
                         "$ref": "#/components/schemas/AnnotationRestApi.get_list"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Items from Annotations"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Annotation Layers"
         ]
-      }, 
+      },
       "post": {
-        "description": "Create an Annotation layer", 
+        "description": "Create an Annotation layer",
         "parameters": [
           {
-            "description": "The annotation layer pk for this annotation", 
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "description": "The annotation layer pk for this annotation",
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -10281,10 +10281,10 @@
                 "$ref": "#/components/schemas/AnnotationRestApi.post"
               }
             }
-          }, 
-          "description": "Annotation schema", 
+          },
+          "description": "Annotation schema",
           "required": true
-        }, 
+        },
         "responses": {
           "201": {
             "content": {
@@ -10293,63 +10293,63 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/AnnotationRestApi.post"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Annotation added"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Annotation Layers"
         ]
       }
-    }, 
+    },
     "/api/v1/annotation_layer/{pk}/annotation/{annotation_id}": {
       "delete": {
-        "description": "Delete Annotation layer", 
+        "description": "Delete Annotation layer",
         "parameters": [
           {
-            "description": "The annotation layer pk for this annotation", 
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "description": "The annotation layer pk for this annotation",
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
-            "description": "The annotation pk for this annotation", 
-            "in": "path", 
-            "name": "annotation_id", 
-            "required": true, 
+            "description": "The annotation pk for this annotation",
+            "in": "path",
+            "name": "annotation_id",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -10359,53 +10359,53 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item deleted"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Annotation Layers"
         ]
-      }, 
+      },
       "get": {
-        "description": "Get an Annotation layer", 
+        "description": "Get an Annotation layer",
         "parameters": [
           {
-            "description": "The annotation layer pk for this annotation", 
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "description": "The annotation layer pk for this annotation",
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
-            "description": "The annotation pk", 
-            "in": "path", 
-            "name": "annotation_id", 
-            "required": true, 
+            "description": "The annotation pk",
+            "in": "path",
+            "name": "annotation_id",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -10413,11 +10413,11 @@
                   "$ref": "#/components/schemas/get_item_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -10425,66 +10425,66 @@
                 "schema": {
                   "properties": {
                     "id": {
-                      "description": "The item id", 
+                      "description": "The item id",
                       "type": "string"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/AnnotationRestApi.get"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Annotation Layers"
         ]
-      }, 
+      },
       "put": {
-        "description": "Update an Annotation layer", 
+        "description": "Update an Annotation layer",
         "parameters": [
           {
-            "description": "The annotation layer pk for this annotation", 
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "description": "The annotation layer pk for this annotation",
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
-            "description": "The annotation pk for this annotation", 
-            "in": "path", 
-            "name": "annotation_id", 
-            "required": true, 
+            "description": "The annotation pk for this annotation",
+            "in": "path",
+            "name": "annotation_id",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -10492,10 +10492,10 @@
                 "$ref": "#/components/schemas/AnnotationRestApi.put"
               }
             }
-          }, 
-          "description": "Annotation schema", 
+          },
+          "description": "Annotation schema",
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -10504,75 +10504,75 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/AnnotationRestApi.put"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Annotation changed"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Annotation Layers"
         ]
       }
-    }, 
+    },
     "/api/v1/assets/export/": {
       "get": {
-        "description": "Returns a ZIP file with all the Superset assets (databases, datasets, charts, dashboards, saved queries) as YAML files.", 
+        "description": "Returns a ZIP file with all the Superset assets (databases, datasets, charts, dashboards, saved queries) as YAML files.",
         "responses": {
           "200": {
             "content": {
               "application/zip": {
                 "schema": {
-                  "format": "binary", 
+                  "format": "binary",
                   "type": "string"
                 }
               }
-            }, 
+            },
             "description": "ZIP file"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Import/export"
         ]
       }
-    }, 
+    },
     "/api/v1/assets/import/": {
       "post": {
         "requestBody": {
@@ -10581,21 +10581,21 @@
               "schema": {
                 "properties": {
                   "bundle": {
-                    "description": "upload file (ZIP or JSON)", 
-                    "format": "binary", 
+                    "description": "upload file (ZIP or JSON)",
+                    "format": "binary",
                     "type": "string"
-                  }, 
+                  },
                   "passwords": {
-                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.", 
+                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
                     "type": "string"
                   }
-                }, 
+                },
                 "type": "object"
               }
             }
-          }, 
+          },
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -10605,49 +10605,49 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Assets import result"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Import/export"
         ]
       }
-    }, 
+    },
     "/api/v1/async_event/": {
       "get": {
-        "description": "Reads off of the Redis events stream, using the user's JWT token and optional query params for last event received.", 
+        "description": "Reads off of the Redis events stream, using the user's JWT token and optional query params for last event received.",
         "parameters": [
           {
-            "description": "Last ID received by the client", 
-            "in": "query", 
-            "name": "last_id", 
+            "description": "Last ID received by the client",
+            "in": "query",
+            "name": "last_id",
             "schema": {
               "type": "string"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -10659,60 +10659,60 @@
                         "properties": {
                           "channel_id": {
                             "type": "string"
-                          }, 
+                          },
                           "errors": {
                             "items": {
                               "type": "object"
-                            }, 
+                            },
                             "type": "array"
-                          }, 
+                          },
                           "id": {
                             "type": "string"
-                          }, 
+                          },
                           "job_id": {
                             "type": "string"
-                          }, 
+                          },
                           "result_url": {
                             "type": "string"
-                          }, 
+                          },
                           "status": {
                             "type": "string"
-                          }, 
+                          },
                           "user_id": {
                             "type": "integer"
                           }
-                        }, 
+                        },
                         "type": "object"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Async event results"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "AsyncEventsRestApi"
         ]
       }
-    }, 
+    },
     "/api/v1/available_domains/": {
       "get": {
-        "description": "Get all available domains", 
+        "description": "Get all available domains",
         "responses": {
           "200": {
             "content": {
@@ -10722,33 +10722,33 @@
                     "result": {
                       "$ref": "#/components/schemas/AvailableDomainsSchema"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "a list of available domains"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/403"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Available Domains"
         ]
       }
-    }, 
+    },
     "/api/v1/cachekey/invalidate": {
       "post": {
-        "description": "Takes a list of datasources, finds the associated cache records and invalidates them and removes the database records", 
+        "description": "Takes a list of datasources, finds the associated cache records and invalidates them and removes the database records",
         "requestBody": {
           "content": {
             "application/json": {
@@ -10756,34 +10756,34 @@
                 "$ref": "#/components/schemas/CacheInvalidationRequestSchema"
               }
             }
-          }, 
-          "description": "A list of datasources uuid or the tuples of database and datasource names", 
+          },
+          "description": "A list of datasources uuid or the tuples of database and datasource names",
           "required": true
-        }, 
+        },
         "responses": {
           "201": {
             "description": "cache was successfully invalidated"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "CacheRestApi"
         ]
       }
-    }, 
+    },
     "/api/v1/chart/": {
       "delete": {
-        "description": "Deletes multiple Charts in a bulk operation.", 
+        "description": "Deletes multiple Charts in a bulk operation.",
         "parameters": [
           {
             "content": {
@@ -10792,11 +10792,11 @@
                   "$ref": "#/components/schemas/get_delete_ids_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -10806,40 +10806,40 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Charts bulk delete"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/403"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Charts"
         ]
-      }, 
+      },
       "get": {
-        "description": "Get a list of charts, use Rison or JSON query parameters for filtering, sorting, pagination and  for selecting specific columns and metadata.", 
+        "description": "Get a list of charts, use Rison or JSON query parameters for filtering, sorting, pagination and  for selecting specific columns and metadata.",
         "parameters": [
           {
             "content": {
@@ -10848,11 +10848,11 @@
                   "$ref": "#/components/schemas/get_list_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -10860,93 +10860,93 @@
                 "schema": {
                   "properties": {
                     "count": {
-                      "description": "The total record count on the backend", 
+                      "description": "The total record count on the backend",
                       "type": "number"
-                    }, 
+                    },
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel", 
-                          "example": "A Nice description for the column", 
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "ids": {
-                      "description": "A list of item ids, useful when you don't know the column id", 
+                      "description": "A list of item ids, useful when you don't know the column id",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel", 
-                          "example": "A Nice label for the column", 
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "list_columns": {
-                      "description": "A list of columns", 
+                      "description": "A list of columns",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "list_title": {
-                      "description": "A title to render. Will be translated by babel", 
-                      "example": "List Items", 
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "List Items",
                       "type": "string"
-                    }, 
+                    },
                     "order_columns": {
-                      "description": "A list of allowed columns to sort", 
+                      "description": "A list of allowed columns to sort",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "result": {
-                      "description": "The result from the get list query", 
+                      "description": "The result from the get list query",
                       "items": {
                         "$ref": "#/components/schemas/ChartRestApi.get_list"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Items from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Charts"
         ]
-      }, 
+      },
       "post": {
-        "description": "Create a new Chart.", 
+        "description": "Create a new Chart.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -10954,10 +10954,10 @@
                 "$ref": "#/components/schemas/ChartRestApi.post"
               }
             }
-          }, 
-          "description": "Chart schema", 
+          },
+          "description": "Chart schema",
           "required": true
-        }, 
+        },
         "responses": {
           "201": {
             "content": {
@@ -10966,43 +10966,43 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/ChartRestApi.post"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Chart added"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Charts"
         ]
       }
-    }, 
+    },
     "/api/v1/chart/_info": {
       "get": {
-        "description": "Several metadata information about chart API endpoints.", 
+        "description": "Several metadata information about chart API endpoints.",
         "parameters": [
           {
             "content": {
@@ -11011,11 +11011,11 @@
                   "$ref": "#/components/schemas/get_info_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -11024,71 +11024,71 @@
                   "properties": {
                     "add_columns": {
                       "type": "object"
-                    }, 
+                    },
                     "edit_columns": {
                       "type": "object"
-                    }, 
+                    },
                     "filters": {
                       "properties": {
                         "column_name": {
                           "items": {
                             "properties": {
                               "name": {
-                                "description": "The filter name. Will be translated by babel", 
+                                "description": "The filter name. Will be translated by babel",
                                 "type": "string"
-                              }, 
+                              },
                               "operator": {
-                                "description": "The filter operation key to use on list filters", 
+                                "description": "The filter operation key to use on list filters",
                                 "type": "string"
                               }
-                            }, 
+                            },
                             "type": "object"
-                          }, 
+                          },
                           "type": "array"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "permissions": {
-                      "description": "The user permissions for this API resource", 
+                      "description": "The user permissions for this API resource",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Charts"
         ]
       }
-    }, 
+    },
     "/api/v1/chart/data": {
       "post": {
-        "description": "Takes a query context constructed in the client and returns payload data response for the given query.", 
+        "description": "Takes a query context constructed in the client and returns payload data response for the given query.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -11096,10 +11096,10 @@
                 "$ref": "#/components/schemas/ChartDataQueryContextSchema"
               }
             }
-          }, 
-          "description": "A query context consists of a datasource from which to fetch data and one or many query objects.", 
+          },
+          "description": "A query context consists of a datasource from which to fetch data and one or many query objects.",
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -11108,9 +11108,9 @@
                   "$ref": "#/components/schemas/ChartDataResponseSchema"
                 }
               }
-            }, 
+            },
             "description": "Query result"
-          }, 
+          },
           "202": {
             "content": {
               "application/json": {
@@ -11118,42 +11118,42 @@
                   "$ref": "#/components/schemas/ChartDataAsyncResponseSchema"
                 }
               }
-            }, 
+            },
             "description": "Async job details"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Charts"
         ]
       }
-    }, 
+    },
     "/api/v1/chart/data/{cache_key}": {
       "get": {
-        "description": "Takes a query context cache key and returns payload data response for the given query.", 
+        "description": "Takes a query context cache key and returns payload data response for the given query.",
         "parameters": [
           {
-            "in": "path", 
-            "name": "cache_key", 
-            "required": true, 
+            "in": "path",
+            "name": "cache_key",
+            "required": true,
             "schema": {
               "type": "string"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -11162,38 +11162,38 @@
                   "$ref": "#/components/schemas/ChartDataResponseSchema"
                 }
               }
-            }, 
+            },
             "description": "Query result"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Charts"
         ]
       }
-    }, 
+    },
     "/api/v1/chart/export/": {
       "get": {
-        "description": "Exports multiple charts and downloads them as YAML files", 
+        "description": "Exports multiple charts and downloads them as YAML files",
         "parameters": [
           {
             "content": {
@@ -11202,49 +11202,49 @@
                   "$ref": "#/components/schemas/get_export_ids_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
               "application/zip": {
                 "schema": {
-                  "format": "binary", 
+                  "format": "binary",
                   "type": "string"
                 }
               }
-            }, 
+            },
             "description": "A zip file with chart(s), dataset(s) and database(s) as YAML"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Charts"
         ]
       }
-    }, 
+    },
     "/api/v1/chart/favorite_status/": {
       "get": {
-        "description": "Check favorited dashboards for current user", 
+        "description": "Check favorited dashboards for current user",
         "parameters": [
           {
             "content": {
@@ -11253,11 +11253,11 @@
                   "$ref": "#/components/schemas/get_fav_star_ids_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -11266,32 +11266,32 @@
                   "$ref": "#/components/schemas/GetFavStarIdsSchema"
                 }
               }
-            }, 
+            },
             "description": "None"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Charts"
         ]
       }
-    }, 
+    },
     "/api/v1/chart/import/": {
       "post": {
         "requestBody": {
@@ -11300,25 +11300,25 @@
               "schema": {
                 "properties": {
                   "formData": {
-                    "description": "upload file (ZIP)", 
-                    "format": "binary", 
+                    "description": "upload file (ZIP)",
+                    "format": "binary",
                     "type": "string"
-                  }, 
+                  },
                   "overwrite": {
-                    "description": "overwrite existing charts?", 
+                    "description": "overwrite existing charts?",
                     "type": "boolean"
-                  }, 
+                  },
                   "passwords": {
-                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.", 
+                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
                     "type": "string"
                   }
-                }, 
+                },
                 "type": "object"
               }
             }
-          }, 
+          },
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -11328,48 +11328,48 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Chart import result"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Charts"
         ]
       }
-    }, 
+    },
     "/api/v1/chart/related/{column_name}": {
       "get": {
-        "description": "Get a list of all possible owners for a chart. Use `owners` has the `column_name` parameter", 
+        "description": "Get a list of all possible owners for a chart. Use `owners` has the `column_name` parameter",
         "parameters": [
           {
-            "in": "path", 
-            "name": "column_name", 
-            "required": true, 
+            "in": "path",
+            "name": "column_name",
+            "required": true,
             "schema": {
               "type": "string"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -11377,11 +11377,11 @@
                   "$ref": "#/components/schemas/get_related_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -11390,45 +11390,45 @@
                   "$ref": "#/components/schemas/RelatedResponseSchema"
                 }
               }
-            }, 
+            },
             "description": "Related column data"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Charts"
         ]
       }
-    }, 
+    },
     "/api/v1/chart/{pk}": {
       "delete": {
-        "description": "Deletes a Chart.", 
+        "description": "Deletes a Chart.",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -11438,49 +11438,49 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Chart delete"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/403"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Charts"
         ]
-      }, 
+      },
       "get": {
-        "description": "Get a chart detail information.", 
+        "description": "Get a chart detail information.",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -11488,11 +11488,11 @@
                   "$ref": "#/components/schemas/get_item_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -11502,86 +11502,86 @@
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel", 
-                          "example": "A Nice description for the column", 
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "id": {
-                      "description": "The item id", 
+                      "description": "The item id",
                       "type": "string"
-                    }, 
+                    },
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel", 
-                          "example": "A Nice label for the column", 
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/ChartRestApi.get"
-                    }, 
+                    },
                     "show_columns": {
-                      "description": "A list of columns", 
+                      "description": "A list of columns",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "show_title": {
-                      "description": "A title to render. Will be translated by babel", 
-                      "example": "Show Item Details", 
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "Show Item Details",
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Charts"
         ]
-      }, 
+      },
       "put": {
-        "description": "Changes a Chart.", 
+        "description": "Changes a Chart.",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -11589,10 +11589,10 @@
                 "$ref": "#/components/schemas/ChartRestApi.put"
               }
             }
-          }, 
-          "description": "Chart schema", 
+          },
+          "description": "Chart schema",
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -11601,58 +11601,58 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/ChartRestApi.put"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Chart changed"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/403"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Charts"
         ]
       }
-    }, 
+    },
     "/api/v1/chart/{pk}/cache_screenshot/": {
       "get": {
-        "description": "Compute and cache a screenshot.", 
+        "description": "Compute and cache a screenshot.",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -11660,11 +11660,11 @@
                   "$ref": "#/components/schemas/screenshot_query_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "202": {
             "content": {
@@ -11673,70 +11673,70 @@
                   "$ref": "#/components/schemas/ChartCacheScreenshotResponseSchema"
                 }
               }
-            }, 
+            },
             "description": "Chart async result"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Charts"
         ]
       }
-    }, 
+    },
     "/api/v1/chart/{pk}/data/": {
       "get": {
-        "description": "Takes a chart ID and uses the query context stored when the chart was saved to return payload data response.", 
+        "description": "Takes a chart ID and uses the query context stored when the chart was saved to return payload data response.",
         "parameters": [
           {
-            "description": "The chart ID", 
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "description": "The chart ID",
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
-            "description": "The format in which the data should be returned", 
-            "in": "query", 
-            "name": "format", 
+            "description": "The format in which the data should be returned",
+            "in": "query",
+            "name": "format",
             "schema": {
               "type": "string"
             }
-          }, 
+          },
           {
-            "description": "The type in which the data should be returned", 
-            "in": "query", 
-            "name": "type", 
+            "description": "The type in which the data should be returned",
+            "in": "query",
+            "name": "type",
             "schema": {
               "type": "string"
             }
-          }, 
+          },
           {
-            "description": "Should the queries be forced to load from the source", 
-            "in": "query", 
-            "name": "force", 
+            "description": "Should the queries be forced to load from the source",
+            "in": "query",
+            "name": "force",
             "schema": {
               "type": "boolean"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -11745,9 +11745,9 @@
                   "$ref": "#/components/schemas/ChartDataResponseSchema"
                 }
               }
-            }, 
+            },
             "description": "Query result"
-          }, 
+          },
           "202": {
             "content": {
               "application/json": {
@@ -11755,147 +11755,147 @@
                   "$ref": "#/components/schemas/ChartDataAsyncResponseSchema"
                 }
               }
-            }, 
+            },
             "description": "Async job details"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Charts"
         ]
       }
-    }, 
+    },
     "/api/v1/chart/{pk}/screenshot/{digest}/": {
       "get": {
-        "description": "Get a computed screenshot from cache.", 
+        "description": "Get a computed screenshot from cache.",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
-            "in": "path", 
-            "name": "digest", 
-            "required": true, 
+            "in": "path",
+            "name": "digest",
+            "required": true,
             "schema": {
               "type": "string"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
               "image/*": {
                 "schema": {
-                  "format": "binary", 
+                  "format": "binary",
                   "type": "string"
                 }
               }
-            }, 
+            },
             "description": "Chart thumbnail image"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Charts"
         ]
       }
-    }, 
+    },
     "/api/v1/chart/{pk}/thumbnail/{digest}/": {
       "get": {
-        "description": "Compute or get already computed chart thumbnail from cache.", 
+        "description": "Compute or get already computed chart thumbnail from cache.",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
-            "in": "path", 
-            "name": "digest", 
-            "required": true, 
+            "in": "path",
+            "name": "digest",
+            "required": true,
             "schema": {
               "type": "string"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
               "image/*": {
                 "schema": {
-                  "format": "binary", 
+                  "format": "binary",
                   "type": "string"
                 }
               }
-            }, 
+            },
             "description": "Chart thumbnail image"
-          }, 
+          },
           "302": {
             "description": "Redirects to the current digest"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Charts"
         ]
       }
-    }, 
+    },
     "/api/v1/css_template/": {
       "delete": {
-        "description": "Deletes multiple css templates in a bulk operation.", 
+        "description": "Deletes multiple css templates in a bulk operation.",
         "parameters": [
           {
             "content": {
@@ -11904,11 +11904,11 @@
                   "$ref": "#/components/schemas/get_delete_ids_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -11918,37 +11918,37 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "CSS templates bulk delete"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "CSS Templates"
         ]
-      }, 
+      },
       "get": {
-        "description": "Get a list of CSS templates, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.", 
+        "description": "Get a list of CSS templates, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
         "parameters": [
           {
             "content": {
@@ -11957,11 +11957,11 @@
                   "$ref": "#/components/schemas/get_list_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -11969,93 +11969,93 @@
                 "schema": {
                   "properties": {
                     "count": {
-                      "description": "The total record count on the backend", 
+                      "description": "The total record count on the backend",
                       "type": "number"
-                    }, 
+                    },
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel", 
-                          "example": "A Nice description for the column", 
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "ids": {
-                      "description": "A list of item ids, useful when you don't know the column id", 
+                      "description": "A list of item ids, useful when you don't know the column id",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel", 
-                          "example": "A Nice label for the column", 
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "list_columns": {
-                      "description": "A list of columns", 
+                      "description": "A list of columns",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "list_title": {
-                      "description": "A title to render. Will be translated by babel", 
-                      "example": "List Items", 
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "List Items",
                       "type": "string"
-                    }, 
+                    },
                     "order_columns": {
-                      "description": "A list of allowed columns to sort", 
+                      "description": "A list of allowed columns to sort",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "result": {
-                      "description": "The result from the get list query", 
+                      "description": "The result from the get list query",
                       "items": {
                         "$ref": "#/components/schemas/CssTemplateRestApi.get_list"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Items from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "CSS Templates"
         ]
-      }, 
+      },
       "post": {
-        "description": "Create a CSS template", 
+        "description": "Create a CSS template",
         "requestBody": {
           "content": {
             "application/json": {
@@ -12063,10 +12063,10 @@
                 "$ref": "#/components/schemas/CssTemplateRestApi.post"
               }
             }
-          }, 
-          "description": "Model schema", 
+          },
+          "description": "Model schema",
           "required": true
-        }, 
+        },
         "responses": {
           "201": {
             "content": {
@@ -12075,43 +12075,43 @@
                   "properties": {
                     "id": {
                       "type": "string"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/CssTemplateRestApi.post"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item inserted"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "CSS Templates"
         ]
       }
-    }, 
+    },
     "/api/v1/css_template/_info": {
       "get": {
-        "description": "Get metadata information about this API resource", 
+        "description": "Get metadata information about this API resource",
         "parameters": [
           {
             "content": {
@@ -12120,11 +12120,11 @@
                   "$ref": "#/components/schemas/get_info_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -12133,79 +12133,79 @@
                   "properties": {
                     "add_columns": {
                       "type": "object"
-                    }, 
+                    },
                     "edit_columns": {
                       "type": "object"
-                    }, 
+                    },
                     "filters": {
                       "properties": {
                         "column_name": {
                           "items": {
                             "properties": {
                               "name": {
-                                "description": "The filter name. Will be translated by babel", 
+                                "description": "The filter name. Will be translated by babel",
                                 "type": "string"
-                              }, 
+                              },
                               "operator": {
-                                "description": "The filter operation key to use on list filters", 
+                                "description": "The filter operation key to use on list filters",
                                 "type": "string"
                               }
-                            }, 
+                            },
                             "type": "object"
-                          }, 
+                          },
                           "type": "array"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "permissions": {
-                      "description": "The user permissions for this API resource", 
+                      "description": "The user permissions for this API resource",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "CSS Templates"
         ]
       }
-    }, 
+    },
     "/api/v1/css_template/related/{column_name}": {
       "get": {
         "parameters": [
           {
-            "in": "path", 
-            "name": "column_name", 
-            "required": true, 
+            "in": "path",
+            "name": "column_name",
+            "required": true,
             "schema": {
               "type": "string"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -12213,11 +12213,11 @@
                   "$ref": "#/components/schemas/get_related_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -12226,45 +12226,45 @@
                   "$ref": "#/components/schemas/RelatedResponseSchema"
                 }
               }
-            }, 
+            },
             "description": "Related column data"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "CSS Templates"
         ]
       }
-    }, 
+    },
     "/api/v1/css_template/{pk}": {
       "delete": {
-        "description": "Delete CSS template", 
+        "description": "Delete CSS template",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -12274,43 +12274,43 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item deleted"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "CSS Templates"
         ]
-      }, 
+      },
       "get": {
-        "description": "Get a CSS template", 
+        "description": "Get a CSS template",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -12318,11 +12318,11 @@
                   "$ref": "#/components/schemas/get_item_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -12332,86 +12332,86 @@
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel", 
-                          "example": "A Nice description for the column", 
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "id": {
-                      "description": "The item id", 
+                      "description": "The item id",
                       "type": "string"
-                    }, 
+                    },
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel", 
-                          "example": "A Nice label for the column", 
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/CssTemplateRestApi.get"
-                    }, 
+                    },
                     "show_columns": {
-                      "description": "A list of columns", 
+                      "description": "A list of columns",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "show_title": {
-                      "description": "A title to render. Will be translated by babel", 
-                      "example": "Show Item Details", 
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "Show Item Details",
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "CSS Templates"
         ]
-      }, 
+      },
       "put": {
-        "description": "Update a CSS template", 
+        "description": "Update a CSS template",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -12419,10 +12419,10 @@
                 "$ref": "#/components/schemas/CssTemplateRestApi.put"
               }
             }
-          }, 
-          "description": "Model schema", 
+          },
+          "description": "Model schema",
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -12432,42 +12432,42 @@
                     "result": {
                       "$ref": "#/components/schemas/CssTemplateRestApi.put"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item changed"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "CSS Templates"
         ]
       }
-    }, 
+    },
     "/api/v1/dashboard/": {
       "delete": {
-        "description": "Deletes multiple Dashboards in a bulk operation.", 
+        "description": "Deletes multiple Dashboards in a bulk operation.",
         "parameters": [
           {
             "content": {
@@ -12476,11 +12476,11 @@
                   "$ref": "#/components/schemas/get_delete_ids_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -12490,40 +12490,40 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Dashboard bulk delete"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/403"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Dashboards"
         ]
-      }, 
+      },
       "get": {
-        "description": "Get a list of dashboards, use Rison or JSON query parameters for filtering, sorting, pagination and  for selecting specific columns and metadata.", 
+        "description": "Get a list of dashboards, use Rison or JSON query parameters for filtering, sorting, pagination and  for selecting specific columns and metadata.",
         "parameters": [
           {
             "content": {
@@ -12532,11 +12532,11 @@
                   "$ref": "#/components/schemas/get_list_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -12544,93 +12544,93 @@
                 "schema": {
                   "properties": {
                     "count": {
-                      "description": "The total record count on the backend", 
+                      "description": "The total record count on the backend",
                       "type": "number"
-                    }, 
+                    },
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel", 
-                          "example": "A Nice description for the column", 
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "ids": {
-                      "description": "A list of item ids, useful when you don't know the column id", 
+                      "description": "A list of item ids, useful when you don't know the column id",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel", 
-                          "example": "A Nice label for the column", 
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "list_columns": {
-                      "description": "A list of columns", 
+                      "description": "A list of columns",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "list_title": {
-                      "description": "A title to render. Will be translated by babel", 
-                      "example": "List Items", 
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "List Items",
                       "type": "string"
-                    }, 
+                    },
                     "order_columns": {
-                      "description": "A list of allowed columns to sort", 
+                      "description": "A list of allowed columns to sort",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "result": {
-                      "description": "The result from the get list query", 
+                      "description": "The result from the get list query",
                       "items": {
                         "$ref": "#/components/schemas/DashboardRestApi.get_list"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Items from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Dashboards"
         ]
-      }, 
+      },
       "post": {
-        "description": "Create a new Dashboard.", 
+        "description": "Create a new Dashboard.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -12638,10 +12638,10 @@
                 "$ref": "#/components/schemas/DashboardRestApi.post"
               }
             }
-          }, 
-          "description": "Dashboard schema", 
+          },
+          "description": "Dashboard schema",
           "required": true
-        }, 
+        },
         "responses": {
           "201": {
             "content": {
@@ -12650,43 +12650,43 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/DashboardRestApi.post"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Dashboard added"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Dashboards"
         ]
       }
-    }, 
+    },
     "/api/v1/dashboard/_info": {
       "get": {
-        "description": "Several metadata information about dashboard API endpoints.", 
+        "description": "Several metadata information about dashboard API endpoints.",
         "parameters": [
           {
             "content": {
@@ -12695,11 +12695,11 @@
                   "$ref": "#/components/schemas/get_info_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -12708,71 +12708,71 @@
                   "properties": {
                     "add_columns": {
                       "type": "object"
-                    }, 
+                    },
                     "edit_columns": {
                       "type": "object"
-                    }, 
+                    },
                     "filters": {
                       "properties": {
                         "column_name": {
                           "items": {
                             "properties": {
                               "name": {
-                                "description": "The filter name. Will be translated by babel", 
+                                "description": "The filter name. Will be translated by babel",
                                 "type": "string"
-                              }, 
+                              },
                               "operator": {
-                                "description": "The filter operation key to use on list filters", 
+                                "description": "The filter operation key to use on list filters",
                                 "type": "string"
                               }
-                            }, 
+                            },
                             "type": "object"
-                          }, 
+                          },
                           "type": "array"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "permissions": {
-                      "description": "The user permissions for this API resource", 
+                      "description": "The user permissions for this API resource",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Dashboards"
         ]
       }
-    }, 
+    },
     "/api/v1/dashboard/export/": {
       "get": {
-        "description": "Exports multiple Dashboards and downloads them as YAML files.", 
+        "description": "Exports multiple Dashboards and downloads them as YAML files.",
         "parameters": [
           {
             "content": {
@@ -12781,11 +12781,11 @@
                   "$ref": "#/components/schemas/get_export_ids_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -12794,38 +12794,38 @@
                   "type": "string"
                 }
               }
-            }, 
+            },
             "description": "Dashboard export"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Dashboards"
         ]
       }
-    }, 
+    },
     "/api/v1/dashboard/favorite_status/": {
       "get": {
-        "description": "Check favorited dashboards for current user", 
+        "description": "Check favorited dashboards for current user",
         "parameters": [
           {
             "content": {
@@ -12834,11 +12834,11 @@
                   "$ref": "#/components/schemas/get_fav_star_ids_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -12847,32 +12847,32 @@
                   "$ref": "#/components/schemas/GetFavStarIdsSchema"
                 }
               }
-            }, 
+            },
             "description": "None"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Dashboards"
         ]
       }
-    }, 
+    },
     "/api/v1/dashboard/import/": {
       "post": {
         "requestBody": {
@@ -12881,25 +12881,25 @@
               "schema": {
                 "properties": {
                   "formData": {
-                    "description": "upload file (ZIP or JSON)", 
-                    "format": "binary", 
+                    "description": "upload file (ZIP or JSON)",
+                    "format": "binary",
                     "type": "string"
-                  }, 
+                  },
                   "overwrite": {
-                    "description": "overwrite existing dashboards?", 
+                    "description": "overwrite existing dashboards?",
                     "type": "boolean"
-                  }, 
+                  },
                   "passwords": {
-                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.", 
+                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
                     "type": "string"
                   }
-                }, 
+                },
                 "type": "object"
               }
             }
-          }, 
+          },
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -12909,49 +12909,49 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Dashboard import result"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Dashboards"
         ]
       }
-    }, 
+    },
     "/api/v1/dashboard/permalink/{key}": {
       "get": {
-        "description": "Retrives dashboard state associated with a permanent link.", 
+        "description": "Retrives dashboard state associated with a permanent link.",
         "parameters": [
           {
-            "in": "path", 
-            "name": "key", 
-            "required": true, 
+            "in": "path",
+            "name": "key",
+            "required": true,
             "schema": {
               "type": "string"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -12959,54 +12959,54 @@
                 "schema": {
                   "properties": {
                     "state": {
-                      "description": "The stored state", 
+                      "description": "The stored state",
                       "type": "object"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Returns the stored state."
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Dashboard Permanent Link"
         ]
       }
-    }, 
+    },
     "/api/v1/dashboard/related/{column_name}": {
       "get": {
-        "description": "Get a list of all possible owners for a dashboard.", 
+        "description": "Get a list of all possible owners for a dashboard.",
         "parameters": [
           {
-            "in": "path", 
-            "name": "column_name", 
-            "required": true, 
+            "in": "path",
+            "name": "column_name",
+            "required": true,
             "schema": {
               "type": "string"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -13014,11 +13014,11 @@
                   "$ref": "#/components/schemas/get_related_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -13027,46 +13027,46 @@
                   "$ref": "#/components/schemas/RelatedResponseSchema"
                 }
               }
-            }, 
+            },
             "description": "Related column data"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Dashboards"
         ]
       }
-    }, 
+    },
     "/api/v1/dashboard/{dashboard_id}/filtersets": {
       "get": {
-        "description": "Get a dashboard's list of filter sets", 
+        "description": "Get a dashboard's list of filter sets",
         "parameters": [
           {
-            "description": "The id of the dashboard", 
-            "in": "path", 
-            "name": "dashboard_id", 
-            "required": true, 
+            "description": "The id of the dashboard",
+            "in": "path",
+            "name": "dashboard_id",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -13075,72 +13075,72 @@
                   "items": {
                     "properties": {
                       "description": {
-                        "description": "A description field of the filter set", 
+                        "description": "A description field of the filter set",
                         "type": "string"
-                      }, 
+                      },
                       "json_metadata": {
-                        "description": "metadata of the filter set", 
+                        "description": "metadata of the filter set",
                         "type": "string"
-                      }, 
+                      },
                       "name": {
-                        "description": "Name of the Filter set", 
+                        "description": "Name of the Filter set",
                         "type": "string"
-                      }, 
+                      },
                       "owner_id": {
-                        "description": "A description field of the filter set", 
+                        "description": "A description field of the filter set",
                         "type": "integer"
-                      }, 
+                      },
                       "owner_type": {
-                        "description": "the Type of the owner ( Dashboard/User)", 
+                        "description": "the Type of the owner ( Dashboard/User)",
                         "type": "integer"
-                      }, 
+                      },
                       "parameters": {
                         "description": "JSON schema defining the needed parameters"
                       }
-                    }, 
+                    },
                     "type": "object"
-                  }, 
+                  },
                   "type": "array"
                 }
               }
-            }, 
+            },
             "description": "FilterSets"
-          }, 
+          },
           "302": {
             "description": "Redirects to the current digest"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "FilterSetRestApi"
         ]
-      }, 
+      },
       "post": {
-        "description": "Create a new Dashboard's Filter Set.", 
+        "description": "Create a new Dashboard's Filter Set.",
         "parameters": [
           {
-            "description": "The id of the dashboard", 
-            "in": "path", 
-            "name": "dashboard_id", 
-            "required": true, 
+            "description": "The id of the dashboard",
+            "in": "path",
+            "name": "dashboard_id",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -13148,10 +13148,10 @@
                 "$ref": "#/components/schemas/FilterSetRestApi.post"
               }
             }
-          }, 
-          "description": "Filter set schema", 
+          },
+          "description": "Filter set schema",
           "required": true
-        }, 
+        },
         "responses": {
           "201": {
             "content": {
@@ -13160,64 +13160,64 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/FilterSetRestApi.post"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Filter set added"
-          }, 
+          },
           "302": {
             "description": "Redirects to the current digest"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "FilterSetRestApi"
         ]
       }
-    }, 
+    },
     "/api/v1/dashboard/{dashboard_id}/filtersets/{pk}": {
       "delete": {
-        "description": "Deletes a Dashboard.", 
+        "description": "Deletes a Dashboard.",
         "parameters": [
           {
-            "in": "path", 
-            "name": "dashboard_id", 
-            "required": true, 
+            "in": "path",
+            "name": "dashboard_id",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -13227,58 +13227,58 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Filter set deleted"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/403"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "FilterSetRestApi"
         ]
-      }, 
+      },
       "put": {
-        "description": "Changes a Dashboard's Filter set.", 
+        "description": "Changes a Dashboard's Filter set.",
         "parameters": [
           {
-            "in": "path", 
-            "name": "dashboard_id", 
-            "required": true, 
+            "in": "path",
+            "name": "dashboard_id",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -13286,10 +13286,10 @@
                 "$ref": "#/components/schemas/FilterSetRestApi.put"
               }
             }
-          }, 
-          "description": "Filter set schema", 
+          },
+          "description": "Filter set schema",
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -13298,60 +13298,60 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/FilterSetRestApi.put"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Filter set changed"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/403"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "FilterSetRestApi"
         ]
       }
-    }, 
+    },
     "/api/v1/dashboard/{id_or_slug}": {
       "get": {
-        "description": "Get a dashboard detail information.", 
+        "description": "Get a dashboard detail information.",
         "parameters": [
           {
-            "description": "Either the id of the dashboard, or its slug", 
-            "in": "path", 
-            "name": "id_or_slug", 
-            "required": true, 
+            "description": "Either the id of the dashboard, or its slug",
+            "in": "path",
+            "name": "id_or_slug",
+            "required": true,
             "schema": {
               "type": "string"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -13361,49 +13361,49 @@
                     "result": {
                       "$ref": "#/components/schemas/DashboardGetResponseSchema"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Dashboard"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/403"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Dashboards"
         ]
       }
-    }, 
+    },
     "/api/v1/dashboard/{id_or_slug}/charts": {
       "get": {
-        "description": "Get the chart definitions for a given dashboard", 
+        "description": "Get the chart definitions for a given dashboard",
         "parameters": [
           {
-            "in": "path", 
-            "name": "id_or_slug", 
-            "required": true, 
+            "in": "path",
+            "name": "id_or_slug",
+            "required": true,
             "schema": {
               "type": "string"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -13413,53 +13413,53 @@
                     "result": {
                       "items": {
                         "$ref": "#/components/schemas/ChartEntityResponseSchema"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Dashboard chart definitions"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/403"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Dashboards"
         ]
       }
-    }, 
+    },
     "/api/v1/dashboard/{id_or_slug}/datasets": {
       "get": {
-        "description": "Returns a list of a dashboard's datasets. Each dataset includes only the information necessary to render the dashboard's charts.", 
+        "description": "Returns a list of a dashboard's datasets. Each dataset includes only the information necessary to render the dashboard's charts.",
         "parameters": [
           {
-            "description": "Either the id of the dashboard, or its slug", 
-            "in": "path", 
-            "name": "id_or_slug", 
-            "required": true, 
+            "description": "Either the id of the dashboard, or its slug",
+            "in": "path",
+            "name": "id_or_slug",
+            "required": true,
             "schema": {
               "type": "string"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -13469,53 +13469,53 @@
                     "result": {
                       "items": {
                         "$ref": "#/components/schemas/DashboardDatasetSchema"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Dashboard dataset definitions"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/403"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Dashboards"
         ]
       }
-    }, 
+    },
     "/api/v1/dashboard/{id_or_slug}/embedded": {
       "delete": {
-        "description": "Removes a dashboard's embedded configuration.", 
+        "description": "Removes a dashboard's embedded configuration.",
         "parameters": [
           {
-            "description": "The dashboard id or slug", 
-            "in": "path", 
-            "name": "id_or_slug", 
-            "required": true, 
+            "description": "The dashboard id or slug",
+            "in": "path",
+            "name": "id_or_slug",
+            "required": true,
             "schema": {
               "type": "string"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -13525,42 +13525,42 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Successfully removed the configuration"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Dashboards"
         ]
-      }, 
+      },
       "get": {
-        "description": "Returns the dashboard's embedded configuration", 
+        "description": "Returns the dashboard's embedded configuration",
         "parameters": [
           {
-            "description": "The dashboard id or slug", 
-            "in": "path", 
-            "name": "id_or_slug", 
-            "required": true, 
+            "description": "The dashboard id or slug",
+            "in": "path",
+            "name": "id_or_slug",
+            "required": true,
             "schema": {
               "type": "string"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -13570,42 +13570,42 @@
                     "result": {
                       "$ref": "#/components/schemas/EmbeddedDashboardResponseSchema"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Result contains the embedded dashboard config"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Dashboards"
         ]
-      }, 
+      },
       "post": {
-        "description": "Sets a dashboard's embedded configuration.", 
+        "description": "Sets a dashboard's embedded configuration.",
         "parameters": [
           {
-            "description": "The dashboard id or slug", 
-            "in": "path", 
-            "name": "id_or_slug", 
-            "required": true, 
+            "description": "The dashboard id or slug",
+            "in": "path",
+            "name": "id_or_slug",
+            "required": true,
             "schema": {
               "type": "string"
             }
           }
-        ], 
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -13613,10 +13613,10 @@
                 "$ref": "#/components/schemas/EmbeddedDashboardConfig"
               }
             }
-          }, 
-          "description": "The embedded configuration to set", 
+          },
+          "description": "The embedded configuration to set",
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -13626,42 +13626,42 @@
                     "result": {
                       "$ref": "#/components/schemas/EmbeddedDashboardResponseSchema"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Successfully set the configuration"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Dashboards"
         ]
-      }, 
+      },
       "put": {
-        "description": "Sets a dashboard's embedded configuration.", 
+        "description": "Sets a dashboard's embedded configuration.",
         "parameters": [
           {
-            "description": "The dashboard id or slug", 
-            "in": "path", 
-            "name": "id_or_slug", 
-            "required": true, 
+            "description": "The dashboard id or slug",
+            "in": "path",
+            "name": "id_or_slug",
+            "required": true,
             "schema": {
               "type": "string"
             }
           }
-        ], 
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -13669,10 +13669,10 @@
                 "$ref": "#/components/schemas/EmbeddedDashboardConfig"
               }
             }
-          }, 
-          "description": "The embedded configuration to set", 
+          },
+          "description": "The embedded configuration to set",
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -13682,43 +13682,43 @@
                     "result": {
                       "$ref": "#/components/schemas/EmbeddedDashboardResponseSchema"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Successfully set the configuration"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Dashboards"
         ]
       }
-    }, 
+    },
     "/api/v1/dashboard/{pk}": {
       "delete": {
-        "description": "Deletes a Dashboard.", 
+        "description": "Deletes a Dashboard.",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -13728,50 +13728,50 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Dashboard deleted"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/403"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Dashboards"
         ]
-      }, 
+      },
       "put": {
-        "description": "Changes a Dashboard.", 
+        "description": "Changes a Dashboard.",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -13779,10 +13779,10 @@
                 "$ref": "#/components/schemas/DashboardRestApi.put"
               }
             }
-          }, 
-          "description": "Dashboard schema", 
+          },
+          "description": "Dashboard schema",
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -13791,69 +13791,69 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    }, 
+                    },
                     "last_modified_time": {
                       "type": "number"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/DashboardRestApi.put"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Dashboard changed"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/403"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Dashboards"
         ]
       }
-    }, 
+    },
     "/api/v1/dashboard/{pk}/filter_state": {
       "post": {
-        "description": "Stores a new value.", 
+        "description": "Stores a new value.",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
-            "in": "query", 
-            "name": "tab_id", 
+            "in": "query",
+            "name": "tab_id",
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -13861,9 +13861,9 @@
                 "$ref": "#/components/schemas/TemporaryCachePostSchema"
               }
             }
-          }, 
+          },
           "required": true
-        }, 
+        },
         "responses": {
           "201": {
             "content": {
@@ -13871,61 +13871,61 @@
                 "schema": {
                   "properties": {
                     "key": {
-                      "description": "The key to retrieve the value.", 
+                      "description": "The key to retrieve the value.",
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "The value was stored successfully."
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Dashboard Filter State"
         ]
       }
-    }, 
+    },
     "/api/v1/dashboard/{pk}/filter_state/{key}": {
       "delete": {
-        "description": "Deletes a value.", 
+        "description": "Deletes a value.",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
-            "description": "The value key.", 
-            "in": "path", 
-            "name": "key", 
-            "required": true, 
+            "description": "The value key.",
+            "in": "path",
+            "name": "key",
+            "required": true,
             "schema": {
               "type": "string"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -13933,61 +13933,61 @@
                 "schema": {
                   "properties": {
                     "message": {
-                      "description": "The result of the operation", 
+                      "description": "The result of the operation",
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Deleted the stored value."
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Dashboard Filter State"
         ]
-      }, 
+      },
       "get": {
-        "description": "Retrives a value.", 
+        "description": "Retrives a value.",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
-            "in": "path", 
-            "name": "key", 
-            "required": true, 
+            "in": "path",
+            "name": "key",
+            "required": true,
             "schema": {
               "type": "string"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -13995,68 +13995,68 @@
                 "schema": {
                   "properties": {
                     "value": {
-                      "description": "The stored value", 
+                      "description": "The stored value",
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Returns the stored value."
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Dashboard Filter State"
         ]
-      }, 
+      },
       "put": {
-        "description": "Updates an existing value.", 
+        "description": "Updates an existing value.",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
-            "in": "path", 
-            "name": "key", 
-            "required": true, 
+            "in": "path",
+            "name": "key",
+            "required": true,
             "schema": {
               "type": "string"
             }
-          }, 
+          },
           {
-            "in": "query", 
-            "name": "tab_id", 
+            "in": "query",
+            "name": "tab_id",
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -14064,9 +14064,9 @@
                 "$ref": "#/components/schemas/TemporaryCachePutSchema"
               }
             }
-          }, 
+          },
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -14074,55 +14074,55 @@
                 "schema": {
                   "properties": {
                     "key": {
-                      "description": "The key to retrieve the value.", 
+                      "description": "The key to retrieve the value.",
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "The value was stored successfully."
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Dashboard Filter State"
         ]
       }
-    }, 
+    },
     "/api/v1/dashboard/{pk}/permalink": {
       "post": {
-        "description": "Stores a new permanent link.", 
+        "description": "Stores a new permanent link.",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "string"
             }
           }
-        ], 
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -14130,9 +14130,9 @@
                 "$ref": "#/components/schemas/DashboardPermalinkPostSchema"
               }
             }
-          }, 
+          },
           "required": true
-        }, 
+        },
         "responses": {
           "201": {
             "content": {
@@ -14140,64 +14140,64 @@
                 "schema": {
                   "properties": {
                     "key": {
-                      "description": "The key to retrieve the permanent link data.", 
+                      "description": "The key to retrieve the permanent link data.",
                       "type": "string"
-                    }, 
+                    },
                     "url": {
-                      "description": "permanent link.", 
+                      "description": "permanent link.",
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "The permanent link was stored successfully."
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Dashboard Permanent Link"
         ]
       }
-    }, 
+    },
     "/api/v1/dashboard/{pk}/thumbnail/{digest}/": {
       "get": {
-        "description": "Compute async or get already computed dashboard thumbnail from cache.", 
+        "description": "Compute async or get already computed dashboard thumbnail from cache.",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
-            "description": "A hex digest that makes this dashboard unique", 
-            "in": "path", 
-            "name": "digest", 
-            "required": true, 
+            "description": "A hex digest that makes this dashboard unique",
+            "in": "path",
+            "name": "digest",
+            "required": true,
             "schema": {
               "type": "string"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -14205,23 +14205,23 @@
                   "$ref": "#/components/schemas/thumbnail_query_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
               "image/*": {
                 "schema": {
-                  "format": "binary", 
+                  "format": "binary",
                   "type": "string"
                 }
               }
-            }, 
+            },
             "description": "Dashboard thumbnail image"
-          }, 
+          },
           "202": {
             "content": {
               "application/json": {
@@ -14230,42 +14230,42 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Thumbnail does not exist on cache, fired async to compute"
-          }, 
+          },
           "302": {
             "description": "Redirects to the current digest"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Dashboards"
         ]
       }
-    }, 
+    },
     "/api/v1/database/": {
       "get": {
-        "description": "Get a list of models", 
+        "description": "Get a list of models",
         "parameters": [
           {
             "content": {
@@ -14274,11 +14274,11 @@
                   "$ref": "#/components/schemas/get_list_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -14286,93 +14286,93 @@
                 "schema": {
                   "properties": {
                     "count": {
-                      "description": "The total record count on the backend", 
+                      "description": "The total record count on the backend",
                       "type": "number"
-                    }, 
+                    },
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel", 
-                          "example": "A Nice description for the column", 
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "ids": {
-                      "description": "A list of item ids, useful when you don't know the column id", 
+                      "description": "A list of item ids, useful when you don't know the column id",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel", 
-                          "example": "A Nice label for the column", 
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "list_columns": {
-                      "description": "A list of columns", 
+                      "description": "A list of columns",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "list_title": {
-                      "description": "A title to render. Will be translated by babel", 
-                      "example": "List Items", 
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "List Items",
                       "type": "string"
-                    }, 
+                    },
                     "order_columns": {
-                      "description": "A list of allowed columns to sort", 
+                      "description": "A list of allowed columns to sort",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "result": {
-                      "description": "The result from the get list query", 
+                      "description": "The result from the get list query",
                       "items": {
                         "$ref": "#/components/schemas/DatabaseRestApi.get_list"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Items from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Database"
         ]
-      }, 
+      },
       "post": {
-        "description": "Create a new Database.", 
+        "description": "Create a new Database.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -14380,10 +14380,10 @@
                 "$ref": "#/components/schemas/DatabaseRestApi.post"
               }
             }
-          }, 
-          "description": "Database schema", 
+          },
+          "description": "Database schema",
           "required": true
-        }, 
+        },
         "responses": {
           "201": {
             "content": {
@@ -14392,43 +14392,43 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/DatabaseRestApi.post"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Database added"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Database"
         ]
       }
-    }, 
+    },
     "/api/v1/database/_info": {
       "get": {
-        "description": "Get metadata information about this API resource", 
+        "description": "Get metadata information about this API resource",
         "parameters": [
           {
             "content": {
@@ -14437,11 +14437,11 @@
                   "$ref": "#/components/schemas/get_info_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -14450,71 +14450,71 @@
                   "properties": {
                     "add_columns": {
                       "type": "object"
-                    }, 
+                    },
                     "edit_columns": {
                       "type": "object"
-                    }, 
+                    },
                     "filters": {
                       "properties": {
                         "column_name": {
                           "items": {
                             "properties": {
                               "name": {
-                                "description": "The filter name. Will be translated by babel", 
+                                "description": "The filter name. Will be translated by babel",
                                 "type": "string"
-                              }, 
+                              },
                               "operator": {
-                                "description": "The filter operation key to use on list filters", 
+                                "description": "The filter operation key to use on list filters",
                                 "type": "string"
                               }
-                            }, 
+                            },
                             "type": "object"
-                          }, 
+                          },
                           "type": "array"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "permissions": {
-                      "description": "The user permissions for this API resource", 
+                      "description": "The user permissions for this API resource",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Database"
         ]
       }
-    }, 
+    },
     "/api/v1/database/available/": {
       "get": {
-        "description": "Get names of databases currently available", 
+        "description": "Get names of databases currently available",
         "responses": {
           "200": {
             "content": {
@@ -14523,79 +14523,79 @@
                   "items": {
                     "properties": {
                       "available_drivers": {
-                        "description": "Installed drivers for the engine", 
+                        "description": "Installed drivers for the engine",
                         "items": {
                           "type": "string"
-                        }, 
+                        },
                         "type": "array"
-                      }, 
+                      },
                       "default_driver": {
-                        "description": "Default driver for the engine", 
+                        "description": "Default driver for the engine",
                         "type": "string"
-                      }, 
+                      },
                       "engine": {
-                        "description": "Name of the SQLAlchemy engine", 
+                        "description": "Name of the SQLAlchemy engine",
                         "type": "string"
-                      }, 
+                      },
                       "engine_information": {
-                        "description": "Dict with public properties form the DB Engine", 
+                        "description": "Dict with public properties form the DB Engine",
                         "properties": {
                           "disable_ssh_tunneling": {
-                            "description": "Whether the engine supports SSH Tunnels", 
+                            "description": "Whether the engine supports SSH Tunnels",
                             "type": "boolean"
-                          }, 
+                          },
                           "supports_file_upload": {
-                            "description": "Whether the engine supports file uploads", 
+                            "description": "Whether the engine supports file uploads",
                             "type": "boolean"
                           }
-                        }, 
+                        },
                         "type": "object"
-                      }, 
+                      },
                       "name": {
-                        "description": "Name of the database", 
+                        "description": "Name of the database",
                         "type": "string"
-                      }, 
+                      },
                       "parameters": {
-                        "description": "JSON schema defining the needed parameters", 
+                        "description": "JSON schema defining the needed parameters",
                         "type": "object"
-                      }, 
+                      },
                       "preferred": {
-                        "description": "Is the database preferred?", 
+                        "description": "Is the database preferred?",
                         "type": "boolean"
-                      }, 
+                      },
                       "sqlalchemy_uri_placeholder": {
-                        "description": "Example placeholder for the SQLAlchemy URI", 
+                        "description": "Example placeholder for the SQLAlchemy URI",
                         "type": "string"
                       }
-                    }, 
+                    },
                     "type": "object"
-                  }, 
+                  },
                   "type": "array"
                 }
               }
-            }, 
+            },
             "description": "Database names"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Database"
         ]
       }
-    }, 
+    },
     "/api/v1/database/export/": {
       "get": {
-        "description": "Download database(s) and associated dataset(s) as a zip file", 
+        "description": "Download database(s) and associated dataset(s) as a zip file",
         "parameters": [
           {
             "content": {
@@ -14604,43 +14604,43 @@
                   "$ref": "#/components/schemas/get_export_ids_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
               "application/zip": {
                 "schema": {
-                  "format": "binary", 
+                  "format": "binary",
                   "type": "string"
                 }
               }
-            }, 
+            },
             "description": "A zip file with database(s) and dataset(s) as YAML"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Database"
         ]
       }
-    }, 
+    },
     "/api/v1/database/import/": {
       "post": {
         "requestBody": {
@@ -14649,25 +14649,25 @@
               "schema": {
                 "properties": {
                   "formData": {
-                    "description": "upload file (ZIP)", 
-                    "format": "binary", 
+                    "description": "upload file (ZIP)",
+                    "format": "binary",
                     "type": "string"
-                  }, 
+                  },
                   "overwrite": {
-                    "description": "overwrite existing databases?", 
+                    "description": "overwrite existing databases?",
                     "type": "boolean"
-                  }, 
+                  },
                   "passwords": {
-                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.", 
+                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
                     "type": "string"
                   }
-                }, 
+                },
                 "type": "object"
               }
             }
-          }, 
+          },
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -14677,39 +14677,39 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Database import result"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Database"
         ]
       }
-    }, 
+    },
     "/api/v1/database/test_connection/": {
       "post": {
-        "description": "Tests a database connection", 
+        "description": "Tests a database connection",
         "requestBody": {
           "content": {
             "application/json": {
@@ -14717,10 +14717,10 @@
                 "$ref": "#/components/schemas/DatabaseTestConnectionSchema"
               }
             }
-          }, 
-          "description": "Database schema", 
+          },
+          "description": "Database schema",
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -14730,36 +14730,36 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Database Test Connection"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Database"
         ]
       }
-    }, 
+    },
     "/api/v1/database/validate_parameters/": {
       "post": {
-        "description": "Validates parameters used to connect to a database", 
+        "description": "Validates parameters used to connect to a database",
         "requestBody": {
           "content": {
             "application/json": {
@@ -14767,10 +14767,10 @@
                 "$ref": "#/components/schemas/DatabaseValidateParametersSchema"
               }
             }
-          }, 
-          "description": "DB-specific parameters", 
+          },
+          "description": "DB-specific parameters",
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -14780,46 +14780,46 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Database Test Connection"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Database"
         ]
       }
-    }, 
+    },
     "/api/v1/database/{pk}": {
       "delete": {
-        "description": "Deletes a Database.", 
+        "description": "Deletes a Database.",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -14829,51 +14829,51 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Database deleted"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/403"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Database"
         ]
-      }, 
+      },
       "get": {
-        "description": "Get a database", 
+        "description": "Get a database",
         "parameters": [
           {
-            "description": "The database id", 
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "description": "The database id",
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -14882,43 +14882,43 @@
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Database"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Database"
         ]
-      }, 
+      },
       "put": {
-        "description": "Changes a Database.", 
+        "description": "Changes a Database.",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -14926,10 +14926,10 @@
                 "$ref": "#/components/schemas/DatabaseRestApi.put"
               }
             }
-          }, 
-          "description": "Database schema", 
+          },
+          "description": "Database schema",
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -14938,59 +14938,59 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/DatabaseRestApi.put"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Database changed"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/403"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Database"
         ]
       }
-    }, 
+    },
     "/api/v1/database/{pk}/function_names/": {
       "get": {
-        "description": "Get function names supported by a database", 
+        "description": "Get function names supported by a database",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -14999,42 +14999,42 @@
                   "$ref": "#/components/schemas/DatabaseFunctionNamesResponse"
                 }
               }
-            }, 
+            },
             "description": "Query result"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Database"
         ]
       }
-    }, 
+    },
     "/api/v1/database/{pk}/related_objects/": {
       "get": {
-        "description": "Get charts and dashboards count associated to a database", 
+        "description": "Get charts and dashboards count associated to a database",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -15043,42 +15043,42 @@
                   "$ref": "#/components/schemas/DatabaseRelatedObjectsResponse"
                 }
               }
-            }, 
+            },
             "description": "Query result"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Database"
         ]
       }
-    }, 
+    },
     "/api/v1/database/{pk}/schemas/": {
       "get": {
-        "description": "Get all schemas from a database", 
+        "description": "Get all schemas from a database",
         "parameters": [
           {
-            "description": "The database id", 
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "description": "The database id",
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -15086,11 +15086,11 @@
                   "$ref": "#/components/schemas/database_schemas_query_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -15099,64 +15099,64 @@
                   "$ref": "#/components/schemas/SchemasResponseSchema"
                 }
               }
-            }, 
+            },
             "description": "A List of all schemas from the database"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Database"
         ]
       }
-    }, 
+    },
     "/api/v1/database/{pk}/select_star/{table_name}/": {
       "get": {
-        "description": "Get database select star for table", 
+        "description": "Get database select star for table",
         "parameters": [
           {
-            "description": "The database id", 
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "description": "The database id",
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
-            "description": "Table name", 
-            "in": "path", 
-            "name": "table_name", 
-            "required": true, 
+            "description": "Table name",
+            "in": "path",
+            "name": "table_name",
+            "required": true,
             "schema": {
               "type": "string"
             }
-          }, 
+          },
           {
-            "description": "Table schema", 
-            "in": "path", 
-            "name": "schema_name", 
-            "required": true, 
+            "description": "Table schema",
+            "in": "path",
+            "name": "schema_name",
+            "required": true,
             "schema": {
               "type": "string"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -15165,67 +15165,67 @@
                   "$ref": "#/components/schemas/SelectStarResponseSchema"
                 }
               }
-            }, 
+            },
             "description": "SQL statement for a select star for table"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Database"
         ]
       }
-    }, 
+    },
     "/api/v1/database/{pk}/select_star/{table_name}/{schema_name}/": {
       "get": {
-        "description": "Get database select star for table", 
+        "description": "Get database select star for table",
         "parameters": [
           {
-            "description": "The database id", 
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "description": "The database id",
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
-            "description": "Table name", 
-            "in": "path", 
-            "name": "table_name", 
-            "required": true, 
+            "description": "Table name",
+            "in": "path",
+            "name": "table_name",
+            "required": true,
             "schema": {
               "type": "string"
             }
-          }, 
+          },
           {
-            "description": "Table schema", 
-            "in": "path", 
-            "name": "schema_name", 
-            "required": true, 
+            "description": "Table schema",
+            "in": "path",
+            "name": "schema_name",
+            "required": true,
             "schema": {
               "type": "string"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -15234,48 +15234,48 @@
                   "$ref": "#/components/schemas/SelectStarResponseSchema"
                 }
               }
-            }, 
+            },
             "description": "SQL statement for a select star for table"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Database"
         ]
       }
-    }, 
+    },
     "/api/v1/database/{pk}/ssh_tunnel/": {
       "delete": {
-        "description": "Deletes a SSH Tunnel.", 
+        "description": "Deletes a SSH Tunnel.",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -15285,71 +15285,71 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "SSH Tunnel deleted"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/403"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Database"
         ]
       }
-    }, 
+    },
     "/api/v1/database/{pk}/table/{table_name}/{schema_name}/": {
       "get": {
-        "description": "Get database table metadata", 
+        "description": "Get database table metadata",
         "parameters": [
           {
-            "description": "The database id", 
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "description": "The database id",
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
-            "description": "Table name", 
-            "in": "path", 
-            "name": "table_name", 
-            "required": true, 
+            "description": "Table name",
+            "in": "path",
+            "name": "table_name",
+            "required": true,
             "schema": {
               "type": "string"
             }
-          }, 
+          },
           {
-            "description": "Table schema", 
-            "in": "path", 
-            "name": "schema_name", 
-            "required": true, 
+            "description": "Table schema",
+            "in": "path",
+            "name": "schema_name",
+            "required": true,
             "schema": {
               "type": "string"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -15358,67 +15358,67 @@
                   "$ref": "#/components/schemas/TableMetadataResponseSchema"
                 }
               }
-            }, 
+            },
             "description": "Table metadata information"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Database"
         ]
       }
-    }, 
+    },
     "/api/v1/database/{pk}/table_extra/{table_name}/{schema_name}/": {
       "get": {
-        "description": "Response depends on each DB engine spec normally focused on partitions", 
+        "description": "Response depends on each DB engine spec normally focused on partitions",
         "parameters": [
           {
-            "description": "The database id", 
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "description": "The database id",
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
-            "description": "Table name", 
-            "in": "path", 
-            "name": "table_name", 
-            "required": true, 
+            "description": "Table name",
+            "in": "path",
+            "name": "table_name",
+            "required": true,
             "schema": {
               "type": "string"
             }
-          }, 
+          },
           {
-            "description": "Table schema", 
-            "in": "path", 
-            "name": "schema_name", 
-            "required": true, 
+            "description": "Table schema",
+            "in": "path",
+            "name": "schema_name",
+            "required": true,
             "schema": {
               "type": "string"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -15427,49 +15427,49 @@
                   "$ref": "#/components/schemas/TableExtraMetadataResponseSchema"
                 }
               }
-            }, 
+            },
             "description": "Table extra metadata information"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
-        "summary": "Get table extra metadata", 
+        ],
+        "summary": "Get table extra metadata",
         "tags": [
           "Database"
         ]
       }
-    }, 
+    },
     "/api/v1/database/{pk}/validate_sql/": {
       "post": {
-        "description": "Validates arbitrary SQL.", 
+        "description": "Validates arbitrary SQL.",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -15477,10 +15477,10 @@
                 "$ref": "#/components/schemas/ValidateSQLRequest"
               }
             }
-          }, 
-          "description": "Validate SQL request", 
+          },
+          "description": "Validate SQL request",
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -15488,46 +15488,46 @@
                 "schema": {
                   "properties": {
                     "result": {
-                      "description": "A List of SQL errors found on the statement", 
+                      "description": "A List of SQL errors found on the statement",
                       "items": {
                         "$ref": "#/components/schemas/ValidateSQLResponse"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Validation result"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
-        "summary": "Validates that arbitrary sql is acceptable for the given database", 
+        ],
+        "summary": "Validates that arbitrary sql is acceptable for the given database",
         "tags": [
           "Database"
         ]
       }
-    }, 
+    },
     "/api/v1/dataset/": {
       "delete": {
-        "description": "Deletes multiple Datasets in a bulk operation.", 
+        "description": "Deletes multiple Datasets in a bulk operation.",
         "parameters": [
           {
             "content": {
@@ -15536,11 +15536,11 @@
                   "$ref": "#/components/schemas/get_delete_ids_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -15550,43 +15550,43 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Dataset bulk delete"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/403"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Datasets"
         ]
-      }, 
+      },
       "get": {
-        "description": "Get a list of models", 
+        "description": "Get a list of models",
         "parameters": [
           {
             "content": {
@@ -15595,11 +15595,11 @@
                   "$ref": "#/components/schemas/get_list_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -15607,93 +15607,93 @@
                 "schema": {
                   "properties": {
                     "count": {
-                      "description": "The total record count on the backend", 
+                      "description": "The total record count on the backend",
                       "type": "number"
-                    }, 
+                    },
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel", 
-                          "example": "A Nice description for the column", 
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "ids": {
-                      "description": "A list of item ids, useful when you don't know the column id", 
+                      "description": "A list of item ids, useful when you don't know the column id",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel", 
-                          "example": "A Nice label for the column", 
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "list_columns": {
-                      "description": "A list of columns", 
+                      "description": "A list of columns",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "list_title": {
-                      "description": "A title to render. Will be translated by babel", 
-                      "example": "List Items", 
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "List Items",
                       "type": "string"
-                    }, 
+                    },
                     "order_columns": {
-                      "description": "A list of allowed columns to sort", 
+                      "description": "A list of allowed columns to sort",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "result": {
-                      "description": "The result from the get list query", 
+                      "description": "The result from the get list query",
                       "items": {
                         "$ref": "#/components/schemas/DatasetRestApi.get_list"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Items from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Datasets"
         ]
-      }, 
+      },
       "post": {
-        "description": "Create a new Dataset", 
+        "description": "Create a new Dataset",
         "requestBody": {
           "content": {
             "application/json": {
@@ -15701,10 +15701,10 @@
                 "$ref": "#/components/schemas/DatasetRestApi.post"
               }
             }
-          }, 
-          "description": "Dataset schema", 
+          },
+          "description": "Dataset schema",
           "required": true
-        }, 
+        },
         "responses": {
           "201": {
             "content": {
@@ -15713,43 +15713,43 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/DatasetRestApi.post"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Dataset added"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Datasets"
         ]
       }
-    }, 
+    },
     "/api/v1/dataset/_info": {
       "get": {
-        "description": "Get metadata information about this API resource", 
+        "description": "Get metadata information about this API resource",
         "parameters": [
           {
             "content": {
@@ -15758,11 +15758,11 @@
                   "$ref": "#/components/schemas/get_info_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -15771,79 +15771,79 @@
                   "properties": {
                     "add_columns": {
                       "type": "object"
-                    }, 
+                    },
                     "edit_columns": {
                       "type": "object"
-                    }, 
+                    },
                     "filters": {
                       "properties": {
                         "column_name": {
                           "items": {
                             "properties": {
                               "name": {
-                                "description": "The filter name. Will be translated by babel", 
+                                "description": "The filter name. Will be translated by babel",
                                 "type": "string"
-                              }, 
+                              },
                               "operator": {
-                                "description": "The filter operation key to use on list filters", 
+                                "description": "The filter operation key to use on list filters",
                                 "type": "string"
                               }
-                            }, 
+                            },
                             "type": "object"
-                          }, 
+                          },
                           "type": "array"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "permissions": {
-                      "description": "The user permissions for this API resource", 
+                      "description": "The user permissions for this API resource",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Datasets"
         ]
       }
-    }, 
+    },
     "/api/v1/dataset/distinct/{column_name}": {
       "get": {
         "parameters": [
           {
-            "in": "path", 
-            "name": "column_name", 
-            "required": true, 
+            "in": "path",
+            "name": "column_name",
+            "required": true,
             "schema": {
               "type": "string"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -15851,11 +15851,11 @@
                   "$ref": "#/components/schemas/get_related_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -15864,35 +15864,35 @@
                   "$ref": "#/components/schemas/DistincResponseSchema"
                 }
               }
-            }, 
+            },
             "description": "Distinct field data"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Datasets"
         ]
       }
-    }, 
+    },
     "/api/v1/dataset/duplicate": {
       "post": {
-        "description": "Duplicates a Dataset", 
+        "description": "Duplicates a Dataset",
         "requestBody": {
           "content": {
             "application/json": {
@@ -15900,10 +15900,10 @@
                 "$ref": "#/components/schemas/DatasetDuplicateSchema"
               }
             }
-          }, 
-          "description": "Dataset schema", 
+          },
+          "description": "Dataset schema",
           "required": true
-        }, 
+        },
         "responses": {
           "201": {
             "content": {
@@ -15912,49 +15912,49 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/DatasetDuplicateSchema"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Dataset duplicated"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/403"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Datasets"
         ]
       }
-    }, 
+    },
     "/api/v1/dataset/export/": {
       "get": {
-        "description": "Exports multiple datasets and downloads them as YAML files", 
+        "description": "Exports multiple datasets and downloads them as YAML files",
         "parameters": [
           {
             "content": {
@@ -15963,11 +15963,11 @@
                   "$ref": "#/components/schemas/get_export_ids_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -15976,32 +15976,32 @@
                   "type": "string"
                 }
               }
-            }, 
+            },
             "description": "Dataset export"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Datasets"
         ]
       }
-    }, 
+    },
     "/api/v1/dataset/import/": {
       "post": {
         "requestBody": {
@@ -16010,33 +16010,33 @@
               "schema": {
                 "properties": {
                   "formData": {
-                    "description": "upload file (ZIP or YAML)", 
-                    "format": "binary", 
+                    "description": "upload file (ZIP or YAML)",
+                    "format": "binary",
                     "type": "string"
-                  }, 
+                  },
                   "overwrite": {
-                    "description": "overwrite existing datasets?", 
+                    "description": "overwrite existing datasets?",
                     "type": "boolean"
-                  }, 
+                  },
                   "passwords": {
-                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.", 
+                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
                     "type": "string"
-                  }, 
+                  },
                   "sync_columns": {
-                    "description": "sync columns?", 
+                    "description": "sync columns?",
                     "type": "boolean"
-                  }, 
+                  },
                   "sync_metrics": {
-                    "description": "sync metrics?", 
+                    "description": "sync metrics?",
                     "type": "boolean"
                   }
-                }, 
+                },
                 "type": "object"
               }
             }
-          }, 
+          },
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -16046,47 +16046,47 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Dataset import result"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Datasets"
         ]
       }
-    }, 
+    },
     "/api/v1/dataset/related/{column_name}": {
       "get": {
         "parameters": [
           {
-            "in": "path", 
-            "name": "column_name", 
-            "required": true, 
+            "in": "path",
+            "name": "column_name",
+            "required": true,
             "schema": {
               "type": "string"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -16094,11 +16094,11 @@
                   "$ref": "#/components/schemas/get_related_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -16107,45 +16107,45 @@
                   "$ref": "#/components/schemas/RelatedResponseSchema"
                 }
               }
-            }, 
+            },
             "description": "Related column data"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Datasets"
         ]
       }
-    }, 
+    },
     "/api/v1/dataset/{pk}": {
       "delete": {
-        "description": "Deletes a Dataset", 
+        "description": "Deletes a Dataset",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -16155,49 +16155,49 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Dataset delete"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/403"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Datasets"
         ]
-      }, 
+      },
       "get": {
-        "description": "Get an item model", 
+        "description": "Get an item model",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -16205,11 +16205,11 @@
                   "$ref": "#/components/schemas/get_item_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -16219,93 +16219,93 @@
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel", 
-                          "example": "A Nice description for the column", 
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "id": {
-                      "description": "The item id", 
+                      "description": "The item id",
                       "type": "string"
-                    }, 
+                    },
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel", 
-                          "example": "A Nice label for the column", 
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/DatasetRestApi.get"
-                    }, 
+                    },
                     "show_columns": {
-                      "description": "A list of columns", 
+                      "description": "A list of columns",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "show_title": {
-                      "description": "A title to render. Will be translated by babel", 
-                      "example": "Show Item Details", 
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "Show Item Details",
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Datasets"
         ]
-      }, 
+      },
       "put": {
-        "description": "Changes a Dataset", 
+        "description": "Changes a Dataset",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
-            "in": "query", 
-            "name": "override_columns", 
+            "in": "query",
+            "name": "override_columns",
             "schema": {
               "type": "boolean"
             }
           }
-        ], 
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -16313,10 +16313,10 @@
                 "$ref": "#/components/schemas/DatasetRestApi.put"
               }
             }
-          }, 
-          "description": "Dataset schema", 
+          },
+          "description": "Dataset schema",
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -16325,69 +16325,69 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/DatasetRestApi.put"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Dataset changed"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/403"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Datasets"
         ]
       }
-    }, 
+    },
     "/api/v1/dataset/{pk}/column/{column_id}": {
       "delete": {
-        "description": "Delete a Dataset column", 
+        "description": "Delete a Dataset column",
         "parameters": [
           {
-            "description": "The dataset pk for this column", 
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "description": "The dataset pk for this column",
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
-            "description": "The column id for this dataset", 
-            "in": "path", 
-            "name": "column_id", 
-            "required": true, 
+            "description": "The column id for this dataset",
+            "in": "path",
+            "name": "column_id",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -16397,62 +16397,62 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Column deleted"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/403"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Datasets"
         ]
       }
-    }, 
+    },
     "/api/v1/dataset/{pk}/metric/{metric_id}": {
       "delete": {
-        "description": "Delete a Dataset metric", 
+        "description": "Delete a Dataset metric",
         "parameters": [
           {
-            "description": "The dataset pk for this column", 
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "description": "The dataset pk for this column",
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
-            "description": "The metric id for this dataset", 
-            "in": "path", 
-            "name": "metric_id", 
-            "required": true, 
+            "description": "The metric id for this dataset",
+            "in": "path",
+            "name": "metric_id",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -16462,52 +16462,52 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Metric deleted"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/403"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Datasets"
         ]
       }
-    }, 
+    },
     "/api/v1/dataset/{pk}/refresh": {
       "put": {
-        "description": "Refreshes and updates columns of a dataset", 
+        "description": "Refreshes and updates columns of a dataset",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -16517,52 +16517,52 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Dataset delete"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/403"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Datasets"
         ]
       }
-    }, 
+    },
     "/api/v1/dataset/{pk}/related_objects": {
       "get": {
-        "description": "Get charts and dashboards count associated to a dataset", 
+        "description": "Get charts and dashboards count associated to a dataset",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -16571,43 +16571,43 @@
                   "$ref": "#/components/schemas/DatasetRelatedObjectsResponse"
                 }
               }
-            }, 
+            },
             "description": "Query result"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Datasets"
         ]
       }
-    }, 
+    },
     "/api/v1/embedded_dashboard/{uuid}": {
       "get": {
-        "description": "Get a report schedule log", 
+        "description": "Get a report schedule log",
         "parameters": [
           {
-            "description": "The embedded configuration uuid", 
-            "in": "path", 
-            "name": "uuid", 
-            "required": true, 
+            "description": "The embedded configuration uuid",
+            "in": "path",
+            "name": "uuid",
+            "required": true,
             "schema": {
               "type": "string"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -16617,73 +16617,73 @@
                     "result": {
                       "$ref": "#/components/schemas/EmbeddedDashboardResponseSchema"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Result contains the embedded dashboard configuration"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Embedded Dashboard"
         ]
       }
-    }, 
+    },
     "/api/v1/explore/": {
       "get": {
-        "description": "Assembles Explore related information (form_data, slice, dataset)\\n in a single endpoint.<br/><br/>\\nThe information can be assembled from:<br/> - The cache using a form_data_key<br/> - The metadata database using a permalink_key<br/> - Build from scratch using dataset or slice identifiers.", 
+        "description": "Assembles Explore related information (form_data, slice, dataset)\\n in a single endpoint.<br/><br/>\\nThe information can be assembled from:<br/> - The cache using a form_data_key<br/> - The metadata database using a permalink_key<br/> - Build from scratch using dataset or slice identifiers.",
         "parameters": [
           {
-            "in": "query", 
-            "name": "form_data_key", 
+            "in": "query",
+            "name": "form_data_key",
             "schema": {
               "type": "string"
             }
-          }, 
+          },
           {
-            "in": "query", 
-            "name": "permalink_key", 
+            "in": "query",
+            "name": "permalink_key",
             "schema": {
               "type": "string"
             }
-          }, 
+          },
           {
-            "in": "query", 
-            "name": "slice_id", 
+            "in": "query",
+            "name": "slice_id",
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
-            "in": "query", 
-            "name": "datasource_id", 
+            "in": "query",
+            "name": "datasource_id",
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
-            "in": "query", 
-            "name": "datasource_type", 
+            "in": "query",
+            "name": "datasource_type",
             "schema": {
               "type": "string"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -16692,48 +16692,48 @@
                   "$ref": "#/components/schemas/ExploreContextSchema"
                 }
               }
-            }, 
+            },
             "description": "Returns the initial context."
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
-        "summary": "Assembles Explore related information (form_data, slice, dataset)\\n in a single endpoint.", 
+        ],
+        "summary": "Assembles Explore related information (form_data, slice, dataset)\\n in a single endpoint.",
         "tags": [
           "Explore"
         ]
       }
-    }, 
+    },
     "/api/v1/explore/form_data": {
       "post": {
-        "description": "Stores a new form_data.", 
+        "description": "Stores a new form_data.",
         "parameters": [
           {
-            "in": "query", 
-            "name": "tab_id", 
+            "in": "query",
+            "name": "tab_id",
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -16741,9 +16741,9 @@
                 "$ref": "#/components/schemas/FormDataPostSchema"
               }
             }
-          }, 
+          },
           "required": true
-        }, 
+        },
         "responses": {
           "201": {
             "content": {
@@ -16751,53 +16751,53 @@
                 "schema": {
                   "properties": {
                     "key": {
-                      "description": "The key to retrieve the form_data.", 
+                      "description": "The key to retrieve the form_data.",
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "The form_data was stored successfully."
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Explore Form Data"
         ]
       }
-    }, 
+    },
     "/api/v1/explore/form_data/{key}": {
       "delete": {
-        "description": "Deletes a form_data.", 
+        "description": "Deletes a form_data.",
         "parameters": [
           {
-            "description": "The form_data key.", 
-            "in": "path", 
-            "name": "key", 
-            "required": true, 
+            "description": "The form_data key.",
+            "in": "path",
+            "name": "key",
+            "required": true,
             "schema": {
               "type": "string"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -16805,53 +16805,53 @@
                 "schema": {
                   "properties": {
                     "message": {
-                      "description": "The result of the operation", 
+                      "description": "The result of the operation",
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Deleted the stored form_data."
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Explore Form Data"
         ]
-      }, 
+      },
       "get": {
-        "description": "Retrives a form_data.", 
+        "description": "Retrives a form_data.",
         "parameters": [
           {
-            "in": "path", 
-            "name": "key", 
-            "required": true, 
+            "in": "path",
+            "name": "key",
+            "required": true,
             "schema": {
               "type": "string"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -16859,60 +16859,60 @@
                 "schema": {
                   "properties": {
                     "form_data": {
-                      "description": "The stored form_data", 
+                      "description": "The stored form_data",
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Returns the stored form_data."
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Explore Form Data"
         ]
-      }, 
+      },
       "put": {
-        "description": "Updates an existing form_data.", 
+        "description": "Updates an existing form_data.",
         "parameters": [
           {
-            "in": "path", 
-            "name": "key", 
-            "required": true, 
+            "in": "path",
+            "name": "key",
+            "required": true,
             "schema": {
               "type": "string"
             }
-          }, 
+          },
           {
-            "in": "query", 
-            "name": "tab_id", 
+            "in": "query",
+            "name": "tab_id",
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -16920,9 +16920,9 @@
                 "$ref": "#/components/schemas/FormDataPutSchema"
               }
             }
-          }, 
+          },
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -16930,45 +16930,45 @@
                 "schema": {
                   "properties": {
                     "key": {
-                      "description": "The key to retrieve the form_data.", 
+                      "description": "The key to retrieve the form_data.",
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "The form_data was stored successfully."
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Explore Form Data"
         ]
       }
-    }, 
+    },
     "/api/v1/explore/permalink": {
       "post": {
-        "description": "Stores a new permanent link.", 
+        "description": "Stores a new permanent link.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -16976,9 +16976,9 @@
                 "$ref": "#/components/schemas/ExplorePermalinkPostSchema"
               }
             }
-          }, 
+          },
           "required": true
-        }, 
+        },
         "responses": {
           "201": {
             "content": {
@@ -16986,56 +16986,56 @@
                 "schema": {
                   "properties": {
                     "key": {
-                      "description": "The key to retrieve the permanent link data.", 
+                      "description": "The key to retrieve the permanent link data.",
                       "type": "string"
-                    }, 
+                    },
                     "url": {
-                      "description": "pemanent link.", 
+                      "description": "pemanent link.",
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "The permanent link was stored successfully."
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Explore Permanent Link"
         ]
       }
-    }, 
+    },
     "/api/v1/explore/permalink/{key}": {
       "get": {
-        "description": "Retrives chart state associated with a permanent link.", 
+        "description": "Retrives chart state associated with a permanent link.",
         "parameters": [
           {
-            "in": "path", 
-            "name": "key", 
-            "required": true, 
+            "in": "path",
+            "name": "key",
+            "required": true,
             "schema": {
               "type": "string"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -17043,45 +17043,45 @@
                 "schema": {
                   "properties": {
                     "state": {
-                      "description": "The stored state", 
+                      "description": "The stored state",
                       "type": "object"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Returns the stored form_data."
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Explore Permanent Link"
         ]
       }
-    }, 
+    },
     "/api/v1/log/": {
       "get": {
-        "description": "Get a list of models", 
+        "description": "Get a list of models",
         "parameters": [
           {
             "content": {
@@ -17090,11 +17090,11 @@
                   "$ref": "#/components/schemas/get_list_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -17102,91 +17102,91 @@
                 "schema": {
                   "properties": {
                     "count": {
-                      "description": "The total record count on the backend", 
+                      "description": "The total record count on the backend",
                       "type": "number"
-                    }, 
+                    },
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel", 
-                          "example": "A Nice description for the column", 
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "ids": {
-                      "description": "A list of item ids, useful when you don't know the column id", 
+                      "description": "A list of item ids, useful when you don't know the column id",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel", 
-                          "example": "A Nice label for the column", 
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "list_columns": {
-                      "description": "A list of columns", 
+                      "description": "A list of columns",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "list_title": {
-                      "description": "A title to render. Will be translated by babel", 
-                      "example": "List Items", 
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "List Items",
                       "type": "string"
-                    }, 
+                    },
                     "order_columns": {
-                      "description": "A list of allowed columns to sort", 
+                      "description": "A list of allowed columns to sort",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "result": {
-                      "description": "The result from the get list query", 
+                      "description": "The result from the get list query",
                       "items": {
                         "$ref": "#/components/schemas/LogRestApi.get_list"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Items from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "LogRestApi"
         ]
-      }, 
+      },
       "post": {
         "requestBody": {
           "content": {
@@ -17195,10 +17195,10 @@
                 "$ref": "#/components/schemas/LogRestApi.post"
               }
             }
-          }, 
-          "description": "Model schema", 
+          },
+          "description": "Model schema",
           "required": true
-        }, 
+        },
         "responses": {
           "201": {
             "content": {
@@ -17207,53 +17207,53 @@
                   "properties": {
                     "id": {
                       "type": "string"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/LogRestApi.post"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item inserted"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "LogRestApi"
         ]
       }
-    }, 
+    },
     "/api/v1/log/recent_activity/{user_id}/": {
       "get": {
-        "description": "Get recent activity data for a user", 
+        "description": "Get recent activity data for a user",
         "parameters": [
           {
-            "description": "The id of the user", 
-            "in": "path", 
-            "name": "user_id", 
-            "required": true, 
+            "description": "The id of the user",
+            "in": "path",
+            "name": "user_id",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -17261,11 +17261,11 @@
                   "$ref": "#/components/schemas/get_recent_activity_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -17274,44 +17274,44 @@
                   "$ref": "#/components/schemas/RecentActivityResponseSchema"
                 }
               }
-            }, 
+            },
             "description": "A List of recent activity objects"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "LogRestApi"
         ]
       }
-    }, 
+    },
     "/api/v1/log/{pk}": {
       "get": {
-        "description": "Get an item model", 
+        "description": "Get an item model",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -17319,11 +17319,11 @@
                   "$ref": "#/components/schemas/get_item_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -17333,78 +17333,78 @@
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel", 
-                          "example": "A Nice description for the column", 
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "id": {
-                      "description": "The item id", 
+                      "description": "The item id",
                       "type": "string"
-                    }, 
+                    },
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel", 
-                          "example": "A Nice label for the column", 
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/LogRestApi.get"
-                    }, 
+                    },
                     "show_columns": {
-                      "description": "A list of columns", 
+                      "description": "A list of columns",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "show_title": {
-                      "description": "A title to render. Will be translated by babel", 
-                      "example": "Show Item Details", 
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "Show Item Details",
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "LogRestApi"
         ]
       }
-    }, 
+    },
     "/api/v1/me/": {
       "get": {
-        "description": "Returns the user object corresponding to the agent making the request, or returns a 401 error if the user is unauthenticated.", 
+        "description": "Returns the user object corresponding to the agent making the request, or returns a 401 error if the user is unauthenticated.",
         "responses": {
           "200": {
             "content": {
@@ -17414,25 +17414,25 @@
                     "result": {
                       "$ref": "#/components/schemas/UserResponseSchema"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "The current user"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
           }
-        }, 
+        },
         "tags": [
           "Current User"
         ]
       }
-    }, 
+    },
     "/api/v1/me/roles/": {
       "get": {
-        "description": "Returns the user roles corresponding to the agent making the request, or returns a 401 error if the user is unauthenticated.", 
+        "description": "Returns the user roles corresponding to the agent making the request, or returns a 401 error if the user is unauthenticated.",
         "responses": {
           "200": {
             "content": {
@@ -17442,25 +17442,25 @@
                     "result": {
                       "$ref": "#/components/schemas/UserResponseSchema"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "The current user"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
           }
-        }, 
+        },
         "tags": [
           "Current User"
         ]
       }
-    }, 
+    },
     "/api/v1/menu/": {
       "get": {
-        "description": "Get the menu data structure. Returns a forest like structure with the menu the user has access to", 
+        "description": "Get the menu data structure. Returns a forest like structure with the menu the user has access to",
         "responses": {
           "200": {
             "content": {
@@ -17468,60 +17468,60 @@
                 "schema": {
                   "properties": {
                     "result": {
-                      "description": "Menu items in a forest like data structure", 
+                      "description": "Menu items in a forest like data structure",
                       "items": {
                         "properties": {
                           "childs": {
                             "items": {
                               "type": "object"
-                            }, 
+                            },
                             "type": "array"
-                          }, 
+                          },
                           "icon": {
-                            "description": "Icon name to show for this menu item", 
+                            "description": "Icon name to show for this menu item",
                             "type": "string"
-                          }, 
+                          },
                           "label": {
-                            "description": "Pretty name for the menu item", 
+                            "description": "Pretty name for the menu item",
                             "type": "string"
-                          }, 
+                          },
                           "name": {
-                            "description": "The internal menu item name, maps to permission_name", 
+                            "description": "The internal menu item name, maps to permission_name",
                             "type": "string"
-                          }, 
+                          },
                           "url": {
-                            "description": "The URL for the menu item", 
+                            "description": "The URL for the menu item",
                             "type": "string"
                           }
-                        }, 
+                        },
                         "type": "object"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Get menu data"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Menu"
         ]
       }
-    }, 
+    },
     "/api/v1/query/": {
       "get": {
-        "description": "Get a list of queries, use Rison or JSON query parameters for filtering, sorting, pagination and  for selecting specific columns and metadata.", 
+        "description": "Get a list of queries, use Rison or JSON query parameters for filtering, sorting, pagination and  for selecting specific columns and metadata.",
         "parameters": [
           {
             "content": {
@@ -17530,11 +17530,11 @@
                   "$ref": "#/components/schemas/get_list_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -17542,103 +17542,103 @@
                 "schema": {
                   "properties": {
                     "count": {
-                      "description": "The total record count on the backend", 
+                      "description": "The total record count on the backend",
                       "type": "number"
-                    }, 
+                    },
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel", 
-                          "example": "A Nice description for the column", 
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "ids": {
-                      "description": "A list of item ids, useful when you don't know the column id", 
+                      "description": "A list of item ids, useful when you don't know the column id",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel", 
-                          "example": "A Nice label for the column", 
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "list_columns": {
-                      "description": "A list of columns", 
+                      "description": "A list of columns",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "list_title": {
-                      "description": "A title to render. Will be translated by babel", 
-                      "example": "List Items", 
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "List Items",
                       "type": "string"
-                    }, 
+                    },
                     "order_columns": {
-                      "description": "A list of allowed columns to sort", 
+                      "description": "A list of allowed columns to sort",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "result": {
-                      "description": "The result from the get list query", 
+                      "description": "The result from the get list query",
                       "items": {
                         "$ref": "#/components/schemas/QueryRestApi.get_list"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Items from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Queries"
         ]
       }
-    }, 
+    },
     "/api/v1/query/distinct/{column_name}": {
       "get": {
         "parameters": [
           {
-            "in": "path", 
-            "name": "column_name", 
-            "required": true, 
+            "in": "path",
+            "name": "column_name",
+            "required": true,
             "schema": {
               "type": "string"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -17646,11 +17646,11 @@
                   "$ref": "#/components/schemas/get_related_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -17659,43 +17659,43 @@
                   "$ref": "#/components/schemas/DistincResponseSchema"
                 }
               }
-            }, 
+            },
             "description": "Distinct field data"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Queries"
         ]
       }
-    }, 
+    },
     "/api/v1/query/related/{column_name}": {
       "get": {
         "parameters": [
           {
-            "in": "path", 
-            "name": "column_name", 
-            "required": true, 
+            "in": "path",
+            "name": "column_name",
+            "required": true,
             "schema": {
               "type": "string"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -17703,11 +17703,11 @@
                   "$ref": "#/components/schemas/get_related_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -17716,32 +17716,32 @@
                   "$ref": "#/components/schemas/RelatedResponseSchema"
                 }
               }
-            }, 
+            },
             "description": "Related column data"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Queries"
         ]
       }
-    }, 
+    },
     "/api/v1/query/stop": {
       "post": {
         "requestBody": {
@@ -17751,10 +17751,10 @@
                 "$ref": "#/components/schemas/StopQuerySchema"
               }
             }
-          }, 
-          "description": "Stop query schema", 
+          },
+          "description": "Stop query schema",
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -17764,49 +17764,49 @@
                     "result": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Query stopped"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
-        "summary": "Manually stop a query with client_id", 
+        ],
+        "summary": "Manually stop a query with client_id",
         "tags": [
           "Queries"
         ]
       }
-    }, 
+    },
     "/api/v1/query/{pk}": {
       "get": {
-        "description": "Get query detail information.", 
+        "description": "Get query detail information.",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -17814,11 +17814,11 @@
                   "$ref": "#/components/schemas/get_item_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -17828,78 +17828,78 @@
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel", 
-                          "example": "A Nice description for the column", 
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "id": {
-                      "description": "The item id", 
+                      "description": "The item id",
                       "type": "string"
-                    }, 
+                    },
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel", 
-                          "example": "A Nice label for the column", 
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/QueryRestApi.get"
-                    }, 
+                    },
                     "show_columns": {
-                      "description": "A list of columns", 
+                      "description": "A list of columns",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "show_title": {
-                      "description": "A title to render. Will be translated by babel", 
-                      "example": "Show Item Details", 
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "Show Item Details",
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Queries"
         ]
       }
-    }, 
+    },
     "/api/v1/report/": {
       "delete": {
-        "description": "Deletes multiple report schedules in a bulk operation.", 
+        "description": "Deletes multiple report schedules in a bulk operation.",
         "parameters": [
           {
             "content": {
@@ -17908,11 +17908,11 @@
                   "$ref": "#/components/schemas/get_delete_ids_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -17922,40 +17922,40 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Report Schedule bulk delete"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/403"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Report Schedules"
         ]
-      }, 
+      },
       "get": {
-        "description": "Get a list of report schedules, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.", 
+        "description": "Get a list of report schedules, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
         "parameters": [
           {
             "content": {
@@ -17964,11 +17964,11 @@
                   "$ref": "#/components/schemas/get_list_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -17976,93 +17976,93 @@
                 "schema": {
                   "properties": {
                     "count": {
-                      "description": "The total record count on the backend", 
+                      "description": "The total record count on the backend",
                       "type": "number"
-                    }, 
+                    },
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel", 
-                          "example": "A Nice description for the column", 
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "ids": {
-                      "description": "A list of item ids, useful when you don't know the column id", 
+                      "description": "A list of item ids, useful when you don't know the column id",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel", 
-                          "example": "A Nice label for the column", 
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "list_columns": {
-                      "description": "A list of columns", 
+                      "description": "A list of columns",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "list_title": {
-                      "description": "A title to render. Will be translated by babel", 
-                      "example": "List Items", 
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "List Items",
                       "type": "string"
-                    }, 
+                    },
                     "order_columns": {
-                      "description": "A list of allowed columns to sort", 
+                      "description": "A list of allowed columns to sort",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "result": {
-                      "description": "The result from the get list query", 
+                      "description": "The result from the get list query",
                       "items": {
                         "$ref": "#/components/schemas/ReportScheduleRestApi.get_list"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Items from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Report Schedules"
         ]
-      }, 
+      },
       "post": {
-        "description": "Create a report schedule", 
+        "description": "Create a report schedule",
         "requestBody": {
           "content": {
             "application/json": {
@@ -18070,10 +18070,10 @@
                 "$ref": "#/components/schemas/ReportScheduleRestApi.post"
               }
             }
-          }, 
-          "description": "Report Schedule schema", 
+          },
+          "description": "Report Schedule schema",
           "required": true
-        }, 
+        },
         "responses": {
           "201": {
             "content": {
@@ -18082,46 +18082,46 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/ReportScheduleRestApi.post"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Report schedule added"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Report Schedules"
         ]
       }
-    }, 
+    },
     "/api/v1/report/_info": {
       "get": {
-        "description": "Get metadata information about this API resource", 
+        "description": "Get metadata information about this API resource",
         "parameters": [
           {
             "content": {
@@ -18130,11 +18130,11 @@
                   "$ref": "#/components/schemas/get_info_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -18143,79 +18143,79 @@
                   "properties": {
                     "add_columns": {
                       "type": "object"
-                    }, 
+                    },
                     "edit_columns": {
                       "type": "object"
-                    }, 
+                    },
                     "filters": {
                       "properties": {
                         "column_name": {
                           "items": {
                             "properties": {
                               "name": {
-                                "description": "The filter name. Will be translated by babel", 
+                                "description": "The filter name. Will be translated by babel",
                                 "type": "string"
-                              }, 
+                              },
                               "operator": {
-                                "description": "The filter operation key to use on list filters", 
+                                "description": "The filter operation key to use on list filters",
                                 "type": "string"
                               }
-                            }, 
+                            },
                             "type": "object"
-                          }, 
+                          },
                           "type": "array"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "permissions": {
-                      "description": "The user permissions for this API resource", 
+                      "description": "The user permissions for this API resource",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Report Schedules"
         ]
       }
-    }, 
+    },
     "/api/v1/report/related/{column_name}": {
       "get": {
         "parameters": [
           {
-            "in": "path", 
-            "name": "column_name", 
-            "required": true, 
+            "in": "path",
+            "name": "column_name",
+            "required": true,
             "schema": {
               "type": "string"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -18223,11 +18223,11 @@
                   "$ref": "#/components/schemas/get_related_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -18236,46 +18236,46 @@
                   "$ref": "#/components/schemas/RelatedResponseSchema"
                 }
               }
-            }, 
+            },
             "description": "Related column data"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Report Schedules"
         ]
       }
-    }, 
+    },
     "/api/v1/report/{pk}": {
       "delete": {
-        "description": "Delete a report schedule", 
+        "description": "Delete a report schedule",
         "parameters": [
           {
-            "description": "The report schedule pk", 
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "description": "The report schedule pk",
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -18285,46 +18285,46 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item deleted"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/403"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Report Schedules"
         ]
-      }, 
+      },
       "get": {
-        "description": "Get a report schedule", 
+        "description": "Get a report schedule",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -18332,11 +18332,11 @@
                   "$ref": "#/components/schemas/get_item_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -18346,87 +18346,87 @@
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel", 
-                          "example": "A Nice description for the column", 
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "id": {
-                      "description": "The item id", 
+                      "description": "The item id",
                       "type": "string"
-                    }, 
+                    },
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel", 
-                          "example": "A Nice label for the column", 
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/ReportScheduleRestApi.get"
-                    }, 
+                    },
                     "show_columns": {
-                      "description": "A list of columns", 
+                      "description": "A list of columns",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "show_title": {
-                      "description": "A title to render. Will be translated by babel", 
-                      "example": "Show Item Details", 
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "Show Item Details",
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Report Schedules"
         ]
-      }, 
+      },
       "put": {
-        "description": "Update a report schedule", 
+        "description": "Update a report schedule",
         "parameters": [
           {
-            "description": "The Report Schedule pk", 
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "description": "The Report Schedule pk",
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -18434,10 +18434,10 @@
                 "$ref": "#/components/schemas/ReportScheduleRestApi.put"
               }
             }
-          }, 
-          "description": "Report Schedule schema", 
+          },
+          "description": "Report Schedule schema",
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -18446,59 +18446,59 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/ReportScheduleRestApi.put"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Report Schedule changed"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/403"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Report Schedules"
         ]
       }
-    }, 
+    },
     "/api/v1/report/{pk}/log/": {
       "get": {
-        "description": "Get a list of report schedule logs, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.", 
+        "description": "Get a list of report schedule logs, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
         "parameters": [
           {
-            "description": "The report schedule id for these logs", 
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "description": "The report schedule id for these logs",
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -18506,11 +18506,11 @@
                   "$ref": "#/components/schemas/get_list_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -18518,75 +18518,75 @@
                 "schema": {
                   "properties": {
                     "count": {
-                      "description": "The total record count on the backend", 
+                      "description": "The total record count on the backend",
                       "type": "number"
-                    }, 
+                    },
                     "ids": {
-                      "description": "A list of log ids", 
+                      "description": "A list of log ids",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "result": {
-                      "description": "The result from the get list query", 
+                      "description": "The result from the get list query",
                       "items": {
                         "$ref": "#/components/schemas/ReportExecutionLogRestApi.get_list"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Items from logs"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Report Schedules"
         ]
       }
-    }, 
+    },
     "/api/v1/report/{pk}/log/{log_id}": {
       "get": {
-        "description": "Get a report schedule log", 
+        "description": "Get a report schedule log",
         "parameters": [
           {
-            "description": "The report schedule pk for log", 
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "description": "The report schedule pk for log",
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
-            "description": "The log pk", 
-            "in": "path", 
-            "name": "log_id", 
-            "required": true, 
+            "description": "The log pk",
+            "in": "path",
+            "name": "log_id",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -18594,11 +18594,11 @@
                   "$ref": "#/components/schemas/get_item_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -18606,48 +18606,48 @@
                 "schema": {
                   "properties": {
                     "id": {
-                      "description": "The log id", 
+                      "description": "The log id",
                       "type": "string"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/ReportExecutionLogRestApi.get"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item log"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Report Schedules"
         ]
       }
-    }, 
+    },
     "/api/v1/rowlevelsecurity/": {
       "delete": {
-        "description": "Deletes multiple RLS rules in a bulk operation.", 
+        "description": "Deletes multiple RLS rules in a bulk operation.",
         "parameters": [
           {
             "content": {
@@ -18656,11 +18656,11 @@
                   "$ref": "#/components/schemas/get_delete_ids_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -18670,40 +18670,40 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "RLS Rule bulk delete"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/403"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Row Level Security"
         ]
-      }, 
+      },
       "get": {
-        "description": "Get a list of models", 
+        "description": "Get a list of models",
         "parameters": [
           {
             "content": {
@@ -18712,11 +18712,11 @@
                   "$ref": "#/components/schemas/get_list_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -18724,93 +18724,93 @@
                 "schema": {
                   "properties": {
                     "count": {
-                      "description": "The total record count on the backend", 
+                      "description": "The total record count on the backend",
                       "type": "number"
-                    }, 
+                    },
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel", 
-                          "example": "A Nice description for the column", 
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "ids": {
-                      "description": "A list of item ids, useful when you don't know the column id", 
+                      "description": "A list of item ids, useful when you don't know the column id",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel", 
-                          "example": "A Nice label for the column", 
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "list_columns": {
-                      "description": "A list of columns", 
+                      "description": "A list of columns",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "list_title": {
-                      "description": "A title to render. Will be translated by babel", 
-                      "example": "List Items", 
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "List Items",
                       "type": "string"
-                    }, 
+                    },
                     "order_columns": {
-                      "description": "A list of allowed columns to sort", 
+                      "description": "A list of allowed columns to sort",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "result": {
-                      "description": "The result from the get list query", 
+                      "description": "The result from the get list query",
                       "items": {
                         "$ref": "#/components/schemas/RLSRestApi.get_list"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Items from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Row Level Security"
         ]
-      }, 
+      },
       "post": {
-        "description": "Create a new RLS Rule", 
+        "description": "Create a new RLS Rule",
         "requestBody": {
           "content": {
             "application/json": {
@@ -18818,10 +18818,10 @@
                 "$ref": "#/components/schemas/RLSRestApi.post"
               }
             }
-          }, 
-          "description": "RLS schema", 
+          },
+          "description": "RLS schema",
           "required": true
-        }, 
+        },
         "responses": {
           "201": {
             "content": {
@@ -18830,46 +18830,46 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/RLSRestApi.post"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "RLS Rule added"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Row Level Security"
         ]
       }
-    }, 
+    },
     "/api/v1/rowlevelsecurity/_info": {
       "get": {
-        "description": "Get metadata information about this API resource", 
+        "description": "Get metadata information about this API resource",
         "parameters": [
           {
             "content": {
@@ -18878,11 +18878,11 @@
                   "$ref": "#/components/schemas/get_info_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -18891,79 +18891,79 @@
                   "properties": {
                     "add_columns": {
                       "type": "object"
-                    }, 
+                    },
                     "edit_columns": {
                       "type": "object"
-                    }, 
+                    },
                     "filters": {
                       "properties": {
                         "column_name": {
                           "items": {
                             "properties": {
                               "name": {
-                                "description": "The filter name. Will be translated by babel", 
+                                "description": "The filter name. Will be translated by babel",
                                 "type": "string"
-                              }, 
+                              },
                               "operator": {
-                                "description": "The filter operation key to use on list filters", 
+                                "description": "The filter operation key to use on list filters",
                                 "type": "string"
                               }
-                            }, 
+                            },
                             "type": "object"
-                          }, 
+                          },
                           "type": "array"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "permissions": {
-                      "description": "The user permissions for this API resource", 
+                      "description": "The user permissions for this API resource",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Row Level Security"
         ]
       }
-    }, 
+    },
     "/api/v1/rowlevelsecurity/related/{column_name}": {
       "get": {
         "parameters": [
           {
-            "in": "path", 
-            "name": "column_name", 
-            "required": true, 
+            "in": "path",
+            "name": "column_name",
+            "required": true,
             "schema": {
               "type": "string"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -18971,11 +18971,11 @@
                   "$ref": "#/components/schemas/get_related_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -18984,44 +18984,44 @@
                   "$ref": "#/components/schemas/RelatedResponseSchema"
                 }
               }
-            }, 
+            },
             "description": "Related column data"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Row Level Security"
         ]
       }
-    }, 
+    },
     "/api/v1/rowlevelsecurity/{pk}": {
       "delete": {
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -19031,43 +19031,43 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item deleted"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Row Level Security"
         ]
-      }, 
+      },
       "get": {
-        "description": "Get an item model", 
+        "description": "Get an item model",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -19075,11 +19075,11 @@
                   "$ref": "#/components/schemas/get_item_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -19089,87 +19089,87 @@
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel", 
-                          "example": "A Nice description for the column", 
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "id": {
-                      "description": "The item id", 
+                      "description": "The item id",
                       "type": "string"
-                    }, 
+                    },
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel", 
-                          "example": "A Nice label for the column", 
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/RLSRestApi.get"
-                    }, 
+                    },
                     "show_columns": {
-                      "description": "A list of columns", 
+                      "description": "A list of columns",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "show_title": {
-                      "description": "A title to render. Will be translated by babel", 
-                      "example": "Show Item Details", 
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "Show Item Details",
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Row Level Security"
         ]
-      }, 
+      },
       "put": {
-        "description": "Updates an RLS Rule", 
+        "description": "Updates an RLS Rule",
         "parameters": [
           {
-            "description": "The Rule pk", 
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "description": "The Rule pk",
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -19177,10 +19177,10 @@
                 "$ref": "#/components/schemas/RLSRestApi.put"
               }
             }
-          }, 
-          "description": "RLS schema", 
+          },
+          "description": "RLS schema",
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -19189,49 +19189,49 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/RLSRestApi.put"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Rule changed"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "403": {
             "$ref": "#/components/responses/403"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Row Level Security"
         ]
       }
-    }, 
+    },
     "/api/v1/saved_query/": {
       "delete": {
-        "description": "Deletes multiple saved queries in a bulk operation.", 
+        "description": "Deletes multiple saved queries in a bulk operation.",
         "parameters": [
           {
             "content": {
@@ -19240,11 +19240,11 @@
                   "$ref": "#/components/schemas/get_delete_ids_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -19254,37 +19254,37 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Saved queries bulk delete"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Queries"
         ]
-      }, 
+      },
       "get": {
-        "description": "Get a list of saved queries, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.", 
+        "description": "Get a list of saved queries, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
         "parameters": [
           {
             "content": {
@@ -19293,11 +19293,11 @@
                   "$ref": "#/components/schemas/get_list_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -19305,93 +19305,93 @@
                 "schema": {
                   "properties": {
                     "count": {
-                      "description": "The total record count on the backend", 
+                      "description": "The total record count on the backend",
                       "type": "number"
-                    }, 
+                    },
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel", 
-                          "example": "A Nice description for the column", 
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "ids": {
-                      "description": "A list of item ids, useful when you don't know the column id", 
+                      "description": "A list of item ids, useful when you don't know the column id",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel", 
-                          "example": "A Nice label for the column", 
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "list_columns": {
-                      "description": "A list of columns", 
+                      "description": "A list of columns",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "list_title": {
-                      "description": "A title to render. Will be translated by babel", 
-                      "example": "List Items", 
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "List Items",
                       "type": "string"
-                    }, 
+                    },
                     "order_columns": {
-                      "description": "A list of allowed columns to sort", 
+                      "description": "A list of allowed columns to sort",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "result": {
-                      "description": "The result from the get list query", 
+                      "description": "The result from the get list query",
                       "items": {
                         "$ref": "#/components/schemas/SavedQueryRestApi.get_list"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Items from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Queries"
         ]
-      }, 
+      },
       "post": {
-        "description": "Create a saved query", 
+        "description": "Create a saved query",
         "requestBody": {
           "content": {
             "application/json": {
@@ -19399,10 +19399,10 @@
                 "$ref": "#/components/schemas/SavedQueryRestApi.post"
               }
             }
-          }, 
-          "description": "Model schema", 
+          },
+          "description": "Model schema",
           "required": true
-        }, 
+        },
         "responses": {
           "201": {
             "content": {
@@ -19411,43 +19411,43 @@
                   "properties": {
                     "id": {
                       "type": "string"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/SavedQueryRestApi.post"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item inserted"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Queries"
         ]
       }
-    }, 
+    },
     "/api/v1/saved_query/_info": {
       "get": {
-        "description": "Get metadata information about this API resource", 
+        "description": "Get metadata information about this API resource",
         "parameters": [
           {
             "content": {
@@ -19456,11 +19456,11 @@
                   "$ref": "#/components/schemas/get_info_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -19469,79 +19469,79 @@
                   "properties": {
                     "add_columns": {
                       "type": "object"
-                    }, 
+                    },
                     "edit_columns": {
                       "type": "object"
-                    }, 
+                    },
                     "filters": {
                       "properties": {
                         "column_name": {
                           "items": {
                             "properties": {
                               "name": {
-                                "description": "The filter name. Will be translated by babel", 
+                                "description": "The filter name. Will be translated by babel",
                                 "type": "string"
-                              }, 
+                              },
                               "operator": {
-                                "description": "The filter operation key to use on list filters", 
+                                "description": "The filter operation key to use on list filters",
                                 "type": "string"
                               }
-                            }, 
+                            },
                             "type": "object"
-                          }, 
+                          },
                           "type": "array"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "permissions": {
-                      "description": "The user permissions for this API resource", 
+                      "description": "The user permissions for this API resource",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Queries"
         ]
       }
-    }, 
+    },
     "/api/v1/saved_query/distinct/{column_name}": {
       "get": {
         "parameters": [
           {
-            "in": "path", 
-            "name": "column_name", 
-            "required": true, 
+            "in": "path",
+            "name": "column_name",
+            "required": true,
             "schema": {
               "type": "string"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -19549,11 +19549,11 @@
                   "$ref": "#/components/schemas/get_related_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -19562,35 +19562,35 @@
                   "$ref": "#/components/schemas/DistincResponseSchema"
                 }
               }
-            }, 
+            },
             "description": "Distinct field data"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Queries"
         ]
       }
-    }, 
+    },
     "/api/v1/saved_query/export/": {
       "get": {
-        "description": "Exports multiple saved queries and downloads them as YAML files", 
+        "description": "Exports multiple saved queries and downloads them as YAML files",
         "parameters": [
           {
             "content": {
@@ -19599,46 +19599,46 @@
                   "$ref": "#/components/schemas/get_export_ids_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
               "application/zip": {
                 "schema": {
-                  "format": "binary", 
+                  "format": "binary",
                   "type": "string"
                 }
               }
-            }, 
+            },
             "description": "A zip file with saved query(ies) and database(s) as YAML"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Queries"
         ]
       }
-    }, 
+    },
     "/api/v1/saved_query/import/": {
       "post": {
         "requestBody": {
@@ -19647,25 +19647,25 @@
               "schema": {
                 "properties": {
                   "formData": {
-                    "description": "upload file (ZIP)", 
-                    "format": "binary", 
+                    "description": "upload file (ZIP)",
+                    "format": "binary",
                     "type": "string"
-                  }, 
+                  },
                   "overwrite": {
-                    "description": "overwrite existing saved queries?", 
+                    "description": "overwrite existing saved queries?",
                     "type": "boolean"
-                  }, 
+                  },
                   "passwords": {
-                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.", 
+                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
                     "type": "string"
                   }
-                }, 
+                },
                 "type": "object"
               }
             }
-          }, 
+          },
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -19675,47 +19675,47 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Saved Query import result"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Queries"
         ]
       }
-    }, 
+    },
     "/api/v1/saved_query/related/{column_name}": {
       "get": {
         "parameters": [
           {
-            "in": "path", 
-            "name": "column_name", 
-            "required": true, 
+            "in": "path",
+            "name": "column_name",
+            "required": true,
             "schema": {
               "type": "string"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -19723,11 +19723,11 @@
                   "$ref": "#/components/schemas/get_related_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -19736,45 +19736,45 @@
                   "$ref": "#/components/schemas/RelatedResponseSchema"
                 }
               }
-            }, 
+            },
             "description": "Related column data"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Queries"
         ]
       }
-    }, 
+    },
     "/api/v1/saved_query/{pk}": {
       "delete": {
-        "description": "Delete saved query", 
+        "description": "Delete saved query",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -19784,43 +19784,43 @@
                     "message": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item deleted"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Queries"
         ]
-      }, 
+      },
       "get": {
-        "description": "Get a saved query", 
+        "description": "Get a saved query",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
-          }, 
+          },
           {
             "content": {
               "application/json": {
@@ -19828,11 +19828,11 @@
                   "$ref": "#/components/schemas/get_item_schema"
                 }
               }
-            }, 
-            "in": "query", 
+            },
+            "in": "query",
             "name": "q"
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -19842,86 +19842,86 @@
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel", 
-                          "example": "A Nice description for the column", 
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "id": {
-                      "description": "The item id", 
+                      "description": "The item id",
                       "type": "string"
-                    }, 
+                    },
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel", 
-                          "example": "A Nice label for the column", 
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
                           "type": "string"
                         }
-                      }, 
+                      },
                       "type": "object"
-                    }, 
+                    },
                     "result": {
                       "$ref": "#/components/schemas/SavedQueryRestApi.get"
-                    }, 
+                    },
                     "show_columns": {
-                      "description": "A list of columns", 
+                      "description": "A list of columns",
                       "items": {
                         "type": "string"
-                      }, 
+                      },
                       "type": "array"
-                    }, 
+                    },
                     "show_title": {
-                      "description": "A title to render. Will be translated by babel", 
-                      "example": "Show Item Details", 
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "Show Item Details",
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item from Model"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Queries"
         ]
-      }, 
+      },
       "put": {
-        "description": "Update a saved query", 
+        "description": "Update a saved query",
         "parameters": [
           {
-            "in": "path", 
-            "name": "pk", 
-            "required": true, 
+            "in": "path",
+            "name": "pk",
+            "required": true,
             "schema": {
               "type": "integer"
             }
           }
-        ], 
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -19929,10 +19929,10 @@
                 "$ref": "#/components/schemas/SavedQueryRestApi.put"
               }
             }
-          }, 
-          "description": "Model schema", 
+          },
+          "description": "Model schema",
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -19942,42 +19942,42 @@
                     "result": {
                       "$ref": "#/components/schemas/SavedQueryRestApi.put"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Item changed"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "422": {
             "$ref": "#/components/responses/422"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Queries"
         ]
       }
-    }, 
+    },
     "/api/v1/security/csrf_token/": {
       "get": {
-        "description": "Fetch the CSRF token", 
+        "description": "Fetch the CSRF token",
         "responses": {
           "200": {
             "content": {
@@ -19987,33 +19987,33 @@
                     "result": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Result contains the CSRF token"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Security"
         ]
       }
-    }, 
+    },
     "/api/v1/security/guest_token/": {
       "post": {
-        "description": "Fetches a guest token", 
+        "description": "Fetches a guest token",
         "requestBody": {
           "content": {
             "application/json": {
@@ -20021,10 +20021,10 @@
                 "$ref": "#/components/schemas/GuestTokenCreate"
               }
             }
-          }, 
-          "description": "Parameters for the guest token", 
+          },
+          "description": "Parameters for the guest token",
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -20034,72 +20034,72 @@
                     "token": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Result contains the guest token"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "Security"
         ]
       }
-    }, 
+    },
     "/api/v1/security/login": {
       "post": {
-        "description": "Authenticate and get a JWT access and refresh token", 
+        "description": "Authenticate and get a JWT access and refresh token",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
                 "properties": {
                   "password": {
-                    "description": "The password for authentication", 
-                    "example": "complex-password", 
+                    "description": "The password for authentication",
+                    "example": "complex-password",
                     "type": "string"
-                  }, 
+                  },
                   "provider": {
-                    "description": "Choose an authentication provider", 
+                    "description": "Choose an authentication provider",
                     "enum": [
-                      "db", 
+                      "db",
                       "ldap"
-                    ], 
-                    "example": "db", 
+                    ],
+                    "example": "db",
                     "type": "string"
-                  }, 
+                  },
                   "refresh": {
-                    "description": "If true a refresh token is provided also", 
-                    "example": true, 
+                    "description": "If true a refresh token is provided also",
+                    "example": true,
                     "type": "boolean"
-                  }, 
+                  },
                   "username": {
-                    "description": "The username for authentication", 
-                    "example": "admin", 
+                    "description": "The username for authentication",
+                    "example": "admin",
                     "type": "string"
                   }
-                }, 
+                },
                 "type": "object"
               }
             }
-          }, 
+          },
           "required": true
-        }, 
+        },
         "responses": {
           "200": {
             "content": {
@@ -20108,35 +20108,35 @@
                   "properties": {
                     "access_token": {
                       "type": "string"
-                    }, 
+                    },
                     "refresh_token": {
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Authentication Successful"
-          }, 
+          },
           "400": {
             "$ref": "#/components/responses/400"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "tags": [
           "Security"
         ]
       }
-    }, 
+    },
     "/api/v1/security/refresh": {
       "post": {
-        "description": "Use the refresh token to get a new JWT access token", 
+        "description": "Use the refresh token to get a new JWT access token",
         "responses": {
           "200": {
             "content": {
@@ -20144,46 +20144,46 @@
                 "schema": {
                   "properties": {
                     "access_token": {
-                      "description": "A new refreshed access token", 
+                      "description": "A new refreshed access token",
                       "type": "string"
                     }
-                  }, 
+                  },
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "Refresh Successful"
-          }, 
+          },
           "401": {
             "$ref": "#/components/responses/401"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt_refresh": []
           }
-        ], 
+        ],
         "tags": [
           "Security"
         ]
       }
-    }, 
+    },
     "/api/{version}/_openapi": {
       "get": {
-        "description": "Get the OpenAPI spec for a specific API version", 
+        "description": "Get the OpenAPI spec for a specific API version",
         "parameters": [
           {
-            "in": "path", 
-            "name": "version", 
-            "required": true, 
+            "in": "path",
+            "name": "version",
+            "required": true,
             "schema": {
               "type": "string"
             }
           }
-        ], 
+        ],
         "responses": {
           "200": {
             "content": {
@@ -20192,27 +20192,27 @@
                   "type": "object"
                 }
               }
-            }, 
+            },
             "description": "The OpenAPI spec"
-          }, 
+          },
           "404": {
             "$ref": "#/components/responses/404"
-          }, 
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
-        }, 
+        },
         "security": [
           {
             "jwt": []
           }
-        ], 
+        ],
         "tags": [
           "OpenApi"
         ]
       }
     }
-  }, 
+  },
   "servers": [
     {
       "url": "http://localhost:8088/"

--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -257,7 +257,7 @@
       "AnnotationLayerRestApi.get_list": {
         "properties": {
           "changed_by": {
-            "$ref": "#/components/schemas/AnnotationLayerRestApi.get_list.User1"
+            "$ref": "#/components/schemas/AnnotationLayerRestApi.get_list.User"
           },
           "changed_on": {
             "format": "date-time",
@@ -268,7 +268,7 @@
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/AnnotationLayerRestApi.get_list.User"
+            "$ref": "#/components/schemas/AnnotationLayerRestApi.get_list.User1"
           },
           "created_on": {
             "format": "date-time",
@@ -414,13 +414,13 @@
       "AnnotationRestApi.get_list": {
         "properties": {
           "changed_by": {
-            "$ref": "#/components/schemas/AnnotationRestApi.get_list.User1"
+            "$ref": "#/components/schemas/AnnotationRestApi.get_list.User"
           },
           "changed_on_delta_humanized": {
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/AnnotationRestApi.get_list.User"
+            "$ref": "#/components/schemas/AnnotationRestApi.get_list.User1"
           },
           "end_dttm": {
             "format": "date-time",
@@ -2939,13 +2939,13 @@
       "CssTemplateRestApi.get_list": {
         "properties": {
           "changed_by": {
-            "$ref": "#/components/schemas/CssTemplateRestApi.get_list.User1"
+            "$ref": "#/components/schemas/CssTemplateRestApi.get_list.User"
           },
           "changed_on_delta_humanized": {
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/CssTemplateRestApi.get_list.User"
+            "$ref": "#/components/schemas/CssTemplateRestApi.get_list.User1"
           },
           "created_on": {
             "format": "date-time",
@@ -4172,12 +4172,6 @@
       },
       "DatabaseSSHTunnel": {
         "properties": {
-          "id": {
-            "description": "SSH Tunnel ID (for updates)",
-            "format": "int32",
-            "nullable": true,
-            "type": "integer"
-          },
           "password": {
             "type": "string"
           },
@@ -5125,7 +5119,7 @@
       "DatasetRestApi.get_list": {
         "properties": {
           "changed_by": {
-            "$ref": "#/components/schemas/DatasetRestApi.get_list.User"
+            "$ref": "#/components/schemas/DatasetRestApi.get_list.User1"
           },
           "changed_by_name": {
             "readOnly": true
@@ -5168,7 +5162,7 @@
             "readOnly": true
           },
           "owners": {
-            "$ref": "#/components/schemas/DatasetRestApi.get_list.User1"
+            "$ref": "#/components/schemas/DatasetRestApi.get_list.User"
           },
           "schema": {
             "maxLength": 255,
@@ -5212,23 +5206,6 @@
             "maxLength": 64,
             "type": "string"
           },
-          "username": {
-            "maxLength": 64,
-            "type": "string"
-          }
-        },
-        "required": [
-          "first_name",
-          "username"
-        ],
-        "type": "object"
-      },
-      "DatasetRestApi.get_list.User1": {
-        "properties": {
-          "first_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
           "id": {
             "format": "int32",
             "type": "integer"
@@ -5245,6 +5222,23 @@
         "required": [
           "first_name",
           "last_name",
+          "username"
+        ],
+        "type": "object"
+      },
+      "DatasetRestApi.get_list.User1": {
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "username": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
           "username"
         ],
         "type": "object"
@@ -6166,279 +6160,6 @@
           "id": {
             "format": "int32",
             "type": "integer"
-          }
-        },
-        "type": "object"
-      },
-      "RLSRestApi.get": {
-        "properties": {
-          "clause": {
-            "description": "This is the condition that will be added to the WHERE clause. For example, to only return rows for a particular client, you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role, a base filter can be created with the clause `1 = 0` (always false).",
-            "type": "string"
-          },
-          "description": {
-            "description": "Detailed description",
-            "type": "string"
-          },
-          "filter_type": {
-            "description": "Regular filters add where clauses to queries if a user belongs to a role referenced in the filter, base filters apply filters to all queries except the roles defined in the filter, and can be used to define what users can see if no RLS filters within a filter group apply to them.",
-            "enum": [
-              "Regular",
-              "Base"
-            ],
-            "type": "string"
-          },
-          "group_key": {
-            "description": "Filters with the same group key will be ORed together within the group, while different filter groups will be ANDed together. Undefined group keys are treated as unique groups, i.e. are not grouped together. For example, if a table has three filters, of which two are for departments Finance and Marketing (group key = 'department'), and one refers to the region Europe (group key = 'region'), the filter clause would apply the filter (department = 'Finance' OR department = 'Marketing') AND (region = 'Europe').",
-            "type": "string"
-          },
-          "id": {
-            "description": "Unique if of rls filter",
-            "format": "int32",
-            "type": "integer"
-          },
-          "name": {
-            "description": "Name of rls filter",
-            "type": "string"
-          },
-          "roles": {
-            "items": {
-              "$ref": "#/components/schemas/Roles1"
-            },
-            "type": "array"
-          },
-          "tables": {
-            "items": {
-              "$ref": "#/components/schemas/Tables"
-            },
-            "type": "array"
-          }
-        },
-        "type": "object"
-      },
-      "RLSRestApi.get_list": {
-        "properties": {
-          "changed_on_delta_humanized": {
-            "readOnly": true
-          },
-          "clause": {
-            "description": "This is the condition that will be added to the WHERE clause. For example, to only return rows for a particular client, you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role, a base filter can be created with the clause `1 = 0` (always false).",
-            "type": "string"
-          },
-          "description": {
-            "description": "Detailed description",
-            "type": "string"
-          },
-          "filter_type": {
-            "description": "Regular filters add where clauses to queries if a user belongs to a role referenced in the filter, base filters apply filters to all queries except the roles defined in the filter, and can be used to define what users can see if no RLS filters within a filter group apply to them.",
-            "enum": [
-              "Regular",
-              "Base"
-            ],
-            "type": "string"
-          },
-          "group_key": {
-            "description": "Filters with the same group key will be ORed together within the group, while different filter groups will be ANDed together. Undefined group keys are treated as unique groups, i.e. are not grouped together. For example, if a table has three filters, of which two are for departments Finance and Marketing (group key = 'department'), and one refers to the region Europe (group key = 'region'), the filter clause would apply the filter (department = 'Finance' OR department = 'Marketing') AND (region = 'Europe').",
-            "type": "string"
-          },
-          "id": {
-            "description": "Unique if of rls filter",
-            "format": "int32",
-            "type": "integer"
-          },
-          "name": {
-            "description": "Name of rls filter",
-            "type": "string"
-          },
-          "roles": {
-            "items": {
-              "$ref": "#/components/schemas/Roles1"
-            },
-            "type": "array"
-          },
-          "tables": {
-            "items": {
-              "$ref": "#/components/schemas/Tables"
-            },
-            "type": "array"
-          }
-        },
-        "type": "object"
-      },
-      "RLSRestApi.post": {
-        "properties": {
-          "clause": {
-            "description": "This is the condition that will be added to the WHERE clause. For example, to only return rows for a particular client, you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role, a base filter can be created with the clause `1 = 0` (always false).",
-            "type": "string"
-          },
-          "description": {
-            "description": "Detailed description",
-            "nullable": true,
-            "type": "string"
-          },
-          "filter_type": {
-            "description": "Regular filters add where clauses to queries if a user belongs to a role referenced in the filter, base filters apply filters to all queries except the roles defined in the filter, and can be used to define what users can see if no RLS filters within a filter group apply to them.",
-            "enum": [
-              "Regular",
-              "Base"
-            ],
-            "type": "string"
-          },
-          "group_key": {
-            "description": "Filters with the same group key will be ORed together within the group, while different filter groups will be ANDed together. Undefined group keys are treated as unique groups, i.e. are not grouped together. For example, if a table has three filters, of which two are for departments Finance and Marketing (group key = 'department'), and one refers to the region Europe (group key = 'region'), the filter clause would apply the filter (department = 'Finance' OR department = 'Marketing') AND (region = 'Europe').",
-            "nullable": true,
-            "type": "string"
-          },
-          "name": {
-            "description": "Name of rls filter",
-            "maxLength": 255,
-            "minLength": 1,
-            "type": "string"
-          },
-          "roles": {
-            "description": "For regular filters, these are the roles this filter will be applied to. For base filters, these are the roles that the filter DOES NOT apply to, e.g. Admin if admin should see all data.",
-            "items": {
-              "format": "int32",
-              "type": "integer"
-            },
-            "type": "array"
-          },
-          "tables": {
-            "description": "These are the tables this filter will be applied to.",
-            "items": {
-              "format": "int32",
-              "type": "integer"
-            },
-            "minItems": 1,
-            "type": "array"
-          }
-        },
-        "required": [
-          "clause",
-          "filter_type",
-          "name",
-          "roles",
-          "tables"
-        ],
-        "type": "object"
-      },
-      "RLSRestApi.put": {
-        "properties": {
-          "clause": {
-            "description": "This is the condition that will be added to the WHERE clause. For example, to only return rows for a particular client, you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role, a base filter can be created with the clause `1 = 0` (always false).",
-            "type": "string"
-          },
-          "description": {
-            "description": "Detailed description",
-            "nullable": true,
-            "type": "string"
-          },
-          "filter_type": {
-            "description": "Regular filters add where clauses to queries if a user belongs to a role referenced in the filter, base filters apply filters to all queries except the roles defined in the filter, and can be used to define what users can see if no RLS filters within a filter group apply to them.",
-            "enum": [
-              "Regular",
-              "Base"
-            ],
-            "type": "string"
-          },
-          "group_key": {
-            "description": "Filters with the same group key will be ORed together within the group, while different filter groups will be ANDed together. Undefined group keys are treated as unique groups, i.e. are not grouped together. For example, if a table has three filters, of which two are for departments Finance and Marketing (group key = 'department'), and one refers to the region Europe (group key = 'region'), the filter clause would apply the filter (department = 'Finance' OR department = 'Marketing') AND (region = 'Europe').",
-            "nullable": true,
-            "type": "string"
-          },
-          "name": {
-            "description": "Name of rls filter",
-            "maxLength": 255,
-            "minLength": 1,
-            "type": "string"
-          },
-          "roles": {
-            "description": "For regular filters, these are the roles this filter will be applied to. For base filters, these are the roles that the filter DOES NOT apply to, e.g. Admin if admin should see all data.",
-            "items": {
-              "format": "int32",
-              "type": "integer"
-            },
-            "type": "array"
-          },
-          "tables": {
-            "description": "These are the tables this filter will be applied to.",
-            "items": {
-              "format": "int32",
-              "type": "integer"
-            },
-            "type": "array"
-          }
-        },
-        "type": "object"
-      },
-      "RecentActivity": {
-        "properties": {
-          "action": {
-            "description": "Action taken describing type of activity",
-            "type": "string"
-          },
-          "item_title": {
-            "description": "Title of item",
-            "type": "string"
-          },
-          "item_type": {
-            "description": "Type of item, e.g. slice or dashboard",
-            "type": "string"
-          },
-          "item_url": {
-            "description": "URL to item",
-            "type": "string"
-          },
-          "time": {
-            "description": "Time of activity, in epoch milliseconds",
-            "format": "float",
-            "type": "number"
-          },
-          "time_delta_humanized": {
-            "description": "Human-readable description of how long ago activity took place",
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "RecentActivityResponseSchema": {
-        "properties": {
-          "result": {
-            "description": "A list of recent activity objects",
-            "items": {
-              "$ref": "#/components/schemas/RecentActivity"
-            },
-            "type": "array"
-          }
-        },
-        "type": "object"
-      },
-      "RecentActivitySchema": {
-        "properties": {
-          "action": {
-            "description": "Action taken describing type of activity",
-            "type": "string"
-          },
-          "item_title": {
-            "description": "Title of item",
-            "type": "string"
-          },
-          "item_type": {
-            "description": "Type of item, e.g. slice or dashboard",
-            "type": "string"
-          },
-          "item_url": {
-            "description": "URL to item",
-            "type": "string"
-          },
-          "time": {
-            "description": "Time of activity, in epoch milliseconds",
-            "format": "float",
-            "type": "number"
-          },
-          "time_delta_humanized": {
-            "description": "Human-readable description of how long ago activity took place",
-            "type": "string"
           }
         },
         "type": "object"
@@ -8499,18 +8220,6 @@
         },
         "type": "object"
       },
-      "Roles1": {
-        "properties": {
-          "id": {
-            "format": "int32",
-            "type": "integer"
-          },
-          "name": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
       "SavedQueryRestApi.get": {
         "properties": {
           "changed_on_delta_humanized": {
@@ -9016,21 +8725,6 @@
         },
         "type": "object"
       },
-      "Tables": {
-        "properties": {
-          "id": {
-            "format": "int32",
-            "type": "integer"
-          },
-          "schema": {
-            "type": "string"
-          },
-          "table_name": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
       "TemporaryCachePostSchema": {
         "properties": {
           "value": {
@@ -9365,23 +9059,6 @@
           },
           "page_size": {
             "type": "integer"
-          }
-        },
-        "type": "object"
-      },
-      "get_recent_activity_schema": {
-        "properties": {
-          "actions": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "distinct": {
-            "type": "boolean"
-          },
-          "limit": {
-            "type": "number"
           }
         },
         "type": "object"
@@ -14540,10 +14217,6 @@
                       "engine_information": {
                         "description": "Dict with public properties form the DB Engine",
                         "properties": {
-                          "disable_ssh_tunneling": {
-                            "description": "Whether the engine supports SSH Tunnels",
-                            "type": "boolean"
-                          },
                           "supports_file_upload": {
                             "description": "Whether the engine supports file uploads",
                             "type": "boolean"
@@ -17241,65 +16914,6 @@
         ]
       }
     },
-    "/api/v1/log/recent_activity/{user_id}/": {
-      "get": {
-        "description": "Get recent activity data for a user",
-        "parameters": [
-          {
-            "description": "The id of the user",
-            "in": "path",
-            "name": "user_id",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/get_recent_activity_schema"
-                }
-              }
-            },
-            "in": "query",
-            "name": "q"
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RecentActivityResponseSchema"
-                }
-              }
-            },
-            "description": "A List of recent activity objects"
-          },
-          "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/404"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          }
-        ],
-        "tags": [
-          "LogRestApi"
-        ]
-      }
-    },
     "/api/v1/log/{pk}": {
       "get": {
         "description": "Get an item model",
@@ -18645,590 +18259,6 @@
         ]
       }
     },
-    "/api/v1/rowlevelsecurity/": {
-      "delete": {
-        "description": "Deletes multiple RLS rules in a bulk operation.",
-        "parameters": [
-          {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/get_delete_ids_schema"
-                }
-              }
-            },
-            "in": "query",
-            "name": "q"
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "RLS Rule bulk delete"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          }
-        ],
-        "tags": [
-          "Row Level Security"
-        ]
-      },
-      "get": {
-        "description": "Get a list of models",
-        "parameters": [
-          {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/get_list_schema"
-                }
-              }
-            },
-            "in": "query",
-            "name": "q"
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "count": {
-                      "description": "The total record count on the backend",
-                      "type": "number"
-                    },
-                    "description_columns": {
-                      "properties": {
-                        "column_name": {
-                          "description": "The description for the column name. Will be translated by babel",
-                          "example": "A Nice description for the column",
-                          "type": "string"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "ids": {
-                      "description": "A list of item ids, useful when you don't know the column id",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "label_columns": {
-                      "properties": {
-                        "column_name": {
-                          "description": "The label for the column name. Will be translated by babel",
-                          "example": "A Nice label for the column",
-                          "type": "string"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "list_columns": {
-                      "description": "A list of columns",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "list_title": {
-                      "description": "A title to render. Will be translated by babel",
-                      "example": "List Items",
-                      "type": "string"
-                    },
-                    "order_columns": {
-                      "description": "A list of allowed columns to sort",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "result": {
-                      "description": "The result from the get list query",
-                      "items": {
-                        "$ref": "#/components/schemas/RLSRestApi.get_list"
-                      },
-                      "type": "array"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Items from Model"
-          },
-          "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          }
-        ],
-        "tags": [
-          "Row Level Security"
-        ]
-      },
-      "post": {
-        "description": "Create a new RLS Rule",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RLSRestApi.post"
-              }
-            }
-          },
-          "description": "RLS schema",
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "id": {
-                      "type": "number"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/RLSRestApi.post"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "RLS Rule added"
-          },
-          "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          }
-        ],
-        "tags": [
-          "Row Level Security"
-        ]
-      }
-    },
-    "/api/v1/rowlevelsecurity/_info": {
-      "get": {
-        "description": "Get metadata information about this API resource",
-        "parameters": [
-          {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/get_info_schema"
-                }
-              }
-            },
-            "in": "query",
-            "name": "q"
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "add_columns": {
-                      "type": "object"
-                    },
-                    "edit_columns": {
-                      "type": "object"
-                    },
-                    "filters": {
-                      "properties": {
-                        "column_name": {
-                          "items": {
-                            "properties": {
-                              "name": {
-                                "description": "The filter name. Will be translated by babel",
-                                "type": "string"
-                              },
-                              "operator": {
-                                "description": "The filter operation key to use on list filters",
-                                "type": "string"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "type": "array"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "permissions": {
-                      "description": "The user permissions for this API resource",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Item from Model"
-          },
-          "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          }
-        ],
-        "tags": [
-          "Row Level Security"
-        ]
-      }
-    },
-    "/api/v1/rowlevelsecurity/related/{column_name}": {
-      "get": {
-        "parameters": [
-          {
-            "in": "path",
-            "name": "column_name",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/get_related_schema"
-                }
-              }
-            },
-            "in": "query",
-            "name": "q"
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RelatedResponseSchema"
-                }
-              }
-            },
-            "description": "Related column data"
-          },
-          "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          }
-        ],
-        "tags": [
-          "Row Level Security"
-        ]
-      }
-    },
-    "/api/v1/rowlevelsecurity/{pk}": {
-      "delete": {
-        "parameters": [
-          {
-            "in": "path",
-            "name": "pk",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Item deleted"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          }
-        ],
-        "tags": [
-          "Row Level Security"
-        ]
-      },
-      "get": {
-        "description": "Get an item model",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "pk",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/get_item_schema"
-                }
-              }
-            },
-            "in": "query",
-            "name": "q"
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "description_columns": {
-                      "properties": {
-                        "column_name": {
-                          "description": "The description for the column name. Will be translated by babel",
-                          "example": "A Nice description for the column",
-                          "type": "string"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "id": {
-                      "description": "The item id",
-                      "type": "string"
-                    },
-                    "label_columns": {
-                      "properties": {
-                        "column_name": {
-                          "description": "The label for the column name. Will be translated by babel",
-                          "example": "A Nice label for the column",
-                          "type": "string"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/RLSRestApi.get"
-                    },
-                    "show_columns": {
-                      "description": "A list of columns",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "show_title": {
-                      "description": "A title to render. Will be translated by babel",
-                      "example": "Show Item Details",
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Item from Model"
-          },
-          "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          }
-        ],
-        "tags": [
-          "Row Level Security"
-        ]
-      },
-      "put": {
-        "description": "Updates an RLS Rule",
-        "parameters": [
-          {
-            "description": "The Rule pk",
-            "in": "path",
-            "name": "pk",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RLSRestApi.put"
-              }
-            }
-          },
-          "description": "RLS schema",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "id": {
-                      "type": "number"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/RLSRestApi.put"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Rule changed"
-          },
-          "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          }
-        ],
-        "tags": [
-          "Row Level Security"
-        ]
-      }
-    },
     "/api/v1/saved_query/": {
       "delete": {
         "description": "Deletes multiple saved queries in a bulk operation.",
@@ -20215,7 +19245,7 @@
   },
   "servers": [
     {
-      "url": "http://localhost:8088/"
+      "url": "http://localhost:8088"
     }
   ]
 }

--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -136,7 +136,7 @@
             "type": "string"
           },
           "descriptionColumns": {
-            "description": "Columns to use as the description. If none are provided, all will be shown.",
+            "description": "Columns to use as the description. If none are provided,all will be shown.",
             "items": {
               "type": "string"
             },
@@ -219,7 +219,7 @@
             "type": "string"
           },
           "value": {
-            "description": "For formula annotations, this contains the formula. For other types, this is the primary key of the source object."
+            "description": "For formula annotations,this contains the formula. For other types,this is the primary key of the source object."
           },
           "width": {
             "description": "Width of annotation line",
@@ -257,7 +257,7 @@
       "AnnotationLayerRestApi.get_list": {
         "properties": {
           "changed_by": {
-            "$ref": "#/components/schemas/AnnotationLayerRestApi.get_list.User"
+            "$ref": "#/components/schemas/AnnotationLayerRestApi.get_list.User1"
           },
           "changed_on": {
             "format": "date-time",
@@ -268,7 +268,7 @@
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/AnnotationLayerRestApi.get_list.User1"
+            "$ref": "#/components/schemas/AnnotationLayerRestApi.get_list.User"
           },
           "created_on": {
             "format": "date-time",
@@ -414,13 +414,13 @@
       "AnnotationRestApi.get_list": {
         "properties": {
           "changed_by": {
-            "$ref": "#/components/schemas/AnnotationRestApi.get_list.User"
+            "$ref": "#/components/schemas/AnnotationRestApi.get_list.User1"
           },
           "changed_on_delta_humanized": {
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/AnnotationRestApi.get_list.User1"
+            "$ref": "#/components/schemas/AnnotationRestApi.get_list.User"
           },
           "end_dttm": {
             "format": "date-time",
@@ -657,7 +657,7 @@
             "type": "string"
           },
           "hasCustomLabel": {
-            "description": "When false, the label will be automatically generated based on the aggregate expression. When true, a custom label has to be specified.",
+            "description": "When false,the label will be automatically generated based on the aggregate expression. When true,a custom label has to be specified.",
             "example": true,
             "type": "boolean"
           },
@@ -666,12 +666,12 @@
             "type": "boolean"
           },
           "label": {
-            "description": "Label for the metric. Is automatically generated unless hasCustomLabel is true, in which case label must be defined.",
+            "description": "Label for the metric. Is automatically generated unless hasCustomLabel is true,in which case label must be defined.",
             "example": "Weighted observations",
             "type": "string"
           },
           "optionName": {
-            "description": "Unique identifier. Can be any string value, as long as all metrics have a unique identifier. If undefined, a random name will be generated.",
+            "description": "Unique identifier. Can be any string value,as long as all metrics have a unique identifier. If undefined,a random name will be generated.",
             "example": "metric_aec60732-fac0-4b17-b736-93f1a5c93e30",
             "type": "string"
           },
@@ -694,7 +694,7 @@
       "ChartDataAggregateOptionsSchema": {
         "properties": {
           "aggregates": {
-            "description": "The keys are the name of the aggregate column to be created, and the values specify the details of how to apply the aggregation. If an operator requires additional options, these can be passed here to be unpacked in the operator call. The following numpy operators are supported: average, argmin, argmax, cumsum, cumprod, max, mean, median, nansum, nanmin, nanmax, nanmean, nanmedian, min, percentile, prod, product, std, sum, var. Any options required by the operator can be passed to the `options` object.\n\nIn the example, a new column `first_quantile` is created based on values in the column `my_col` using the `percentile` operator with the `q=0.25` parameter.",
+            "description": "The keys are the name of the aggregate column to be created,and the values specify the details of how to apply the aggregation. If an operator requires additional options,these can be passed here to be unpacked in the operator call. The following numpy operators are supported: average,argmin,argmax,cumsum,cumprod,max,mean,median,nansum,nanmin,nanmax,nanmean,nanmedian,min,percentile,prod,product,std,sum,var. Any options required by the operator can be passed to the `options` object.\n\nIn the example,a new column `first_quantile` is created based on values in the column `my_col` using the `percentile` operator with the `q=0.25` parameter.",
             "example": {
               "first_quantile": {
                 "column": "my_col",
@@ -746,7 +746,7 @@
             "type": "array"
           },
           "metrics": {
-            "description": "Aggregate expressions. Metrics can be passed as both references to datasource metrics (strings), or ad-hoc metricswhich are defined only within the query object. See `ChartDataAdhocMetricSchema` for the structure of ad-hoc metrics. When metrics is undefined or null, the query is executed without a groupby. However, when metrics is an array (length >= 0), a groupby clause is added to the query.",
+            "description": "Aggregate expressions. Metrics can be passed as both references to datasource metrics (strings),or ad-hoc metricswhich are defined only within the query object. See `ChartDataAdhocMetricSchema` for the structure of ad-hoc metrics. When metrics is undefined or null,the query is executed without a groupby. However,when metrics is an array (length >= 0),a groupby clause is added to the query.",
             "items": {},
             "nullable": true,
             "type": "array"
@@ -933,7 +933,7 @@
             "type": "string"
           },
           "val": {
-            "description": "The value or values to compare against. Can be a string, integer, decimal, None or list, depending on the operator.",
+            "description": "The value or values to compare against. Can be a string,integer,decimal,None or list,depending on the operator.",
             "example": [
               "China",
               "France",
@@ -951,7 +951,7 @@
       "ChartDataGeodeticParseOptionsSchema": {
         "properties": {
           "altitude": {
-            "description": "Name of target column for decoded altitude. If omitted, altitude information in geodetic string is ignored.",
+            "description": "Name of target column for decoded altitude. If omitted,altitude information in geodetic string is ignored.",
             "type": "string"
           },
           "geodetic": {
@@ -1021,7 +1021,7 @@
       "ChartDataPivotOptionsSchema": {
         "properties": {
           "aggregates": {
-            "description": "The keys are the name of the aggregate column to be created, and the values specify the details of how to apply the aggregation. If an operator requires additional options, these can be passed here to be unpacked in the operator call. The following numpy operators are supported: average, argmin, argmax, cumsum, cumprod, max, mean, median, nansum, nanmin, nanmax, nanmean, nanmedian, min, percentile, prod, product, std, sum, var. Any options required by the operator can be passed to the `options` object.\n\nIn the example, a new column `first_quantile` is created based on values in the column `my_col` using the `percentile` operator with the `q=0.25` parameter.",
+            "description": "The keys are the name of the aggregate column to be created,and the values specify the details of how to apply the aggregation. If an operator requires additional options,these can be passed here to be unpacked in the operator call. The following numpy operators are supported: average,argmin,argmax,cumsum,cumprod,max,mean,median,nansum,nanmin,nanmax,nanmean,nanmedian,min,percentile,prod,product,std,sum,var. Any options required by the operator can be passed to the `options` object.\n\nIn the example,a new column `first_quantile` is created based on values in the column `my_col` using the `percentile` operator with the `q=0.25` parameter.",
             "example": {
               "first_quantile": {
                 "column": "my_col",
@@ -1092,7 +1092,7 @@
             "type": "string"
           },
           "options": {
-            "description": "Options specifying how to perform the operation. Please refer to the respective post processing operation option schemas. For example, `ChartDataPostProcessingOperationOptions` specifies the required options for the pivot operation.",
+            "description": "Options specifying how to perform the operation. Please refer to the respective post processing operation option schemas. For example,`ChartDataPostProcessingOperationOptions` specifies the required options for the pivot operation.",
             "example": {
               "aggregates": {
                 "age_mean": {
@@ -1131,7 +1131,7 @@
             "type": "number"
           },
           "monthly_seasonality": {
-            "description": "Should monthly seasonality be applied. An integer value will specify Fourier order of seasonality, `None` will automatically detect seasonality.",
+            "description": "Should monthly seasonality be applied. An integer value will specify Fourier order of seasonality,`None` will automatically detect seasonality.",
             "example": false
           },
           "periods": {
@@ -1166,11 +1166,11 @@
             "type": "string"
           },
           "weekly_seasonality": {
-            "description": "Should weekly seasonality be applied. An integer value will specify Fourier order of seasonality, `None` will automatically detect seasonality.",
+            "description": "Should weekly seasonality be applied. An integer value will specify Fourier order of seasonality,`None` will automatically detect seasonality.",
             "example": false
           },
           "yearly_seasonality": {
-            "description": "Should yearly seasonality be applied. An integer value will specify Fourier order of seasonality, `None` will automatically detect seasonality.",
+            "description": "Should yearly seasonality be applied. An integer value will specify Fourier order of seasonality,`None` will automatically detect seasonality.",
             "example": false
           }
         },
@@ -1275,12 +1275,12 @@
             "type": "string"
           },
           "granularity_sqla": {
-            "description": "Name of temporal column used for time filtering for SQL datasources. This field is deprecated, use `granularity` instead.",
+            "description": "Name of temporal column used for time filtering for SQL datasources. This field is deprecated,use `granularity` instead.",
             "nullable": true,
             "type": "string"
           },
           "groupby": {
-            "description": "Columns by which to group the query. This field is deprecated, use `columns` instead.",
+            "description": "Columns by which to group the query. This field is deprecated,use `columns` instead.",
             "items": {},
             "nullable": true,
             "type": "array"
@@ -1309,7 +1309,7 @@
             "type": "boolean"
           },
           "metrics": {
-            "description": "Aggregate expressions. Metrics can be passed as both references to datasource metrics (strings), or ad-hoc metricswhich are defined only within the query object. See `ChartDataAdhocMetricSchema` for the structure of ad-hoc metrics.",
+            "description": "Aggregate expressions. Metrics can be passed as both references to datasource metrics (strings),or ad-hoc metricswhich are defined only within the query object. See `ChartDataAdhocMetricSchema` for the structure of ad-hoc metrics.",
             "items": {},
             "nullable": true,
             "type": "array"
@@ -1320,7 +1320,7 @@
             "type": "boolean"
           },
           "orderby": {
-            "description": "Expects a list of lists where the first element is the column name which to sort by, and the second element is a boolean.",
+            "description": "Expects a list of lists where the first element is the column name which to sort by,and the second element is a boolean.",
             "example": [
               [
                 "my_col_1",
@@ -1389,7 +1389,7 @@
             "type": "array"
           },
           "time_range": {
-            "description": "A time rage, either expressed as a colon separated string `since : until` or human readable freeform. Valid formats for `since` and `until` are: \n- ISO 8601\n- X days/years/hours/day/year/weeks\n- X days/years/hours/day/year/weeks ago\n- X days/years/hours/day/year/weeks from now\n\nAdditionally, the following freeform can be used:\n\n- Last day\n- Last week\n- Last month\n- Last quarter\n- Last year\n- No filter\n- Last X seconds/minutes/hours/days/weeks/months/years\n- Next X seconds/minutes/hours/days/weeks/months/years\n",
+            "description": "A time rage,either expressed as a colon separated string `since : until` or human readable freeform. Valid formats for `since` and `until` are: \n- ISO 8601\n- X days/years/hours/day/year/weeks\n- X days/years/hours/day/year/weeks ago\n- X days/years/hours/day/year/weeks from now\n\nAdditionally,the following freeform can be used:\n\n- Last day\n- Last week\n- Last month\n- Last quarter\n- Last year\n- No filter\n- Last X seconds/minutes/hours/days/weeks/months/years\n- Next X seconds/minutes/hours/days/weeks/months/years\n",
             "example": "Last week",
             "nullable": true,
             "type": "string"
@@ -1400,13 +1400,13 @@
             "type": "string"
           },
           "timeseries_limit": {
-            "description": "Maximum row count for timeseries queries. This field is deprecated, use `series_limit` instead.Default: `0`",
+            "description": "Maximum row count for timeseries queries. This field is deprecated,use `series_limit` instead.Default: `0`",
             "format": "int32",
             "nullable": true,
             "type": "integer"
           },
           "timeseries_limit_metric": {
-            "description": "Metric used to limit timeseries queries by. This field is deprecated, use `series_limit_metric` instead.",
+            "description": "Metric used to limit timeseries queries by. This field is deprecated,use `series_limit_metric` instead.",
             "nullable": true
           },
           "url_params": {
@@ -1452,7 +1452,7 @@
             "type": "string"
           },
           "cache_timeout": {
-            "description": "Cache timeout in following order: custom timeout, datasource timeout, cache default timeout, config default cache timeout.",
+            "description": "Cache timeout in following order: custom timeout,datasource timeout,cache default timeout,config default cache timeout.",
             "format": "int32",
             "nullable": true,
             "type": "integer"
@@ -1963,7 +1963,7 @@
             "type": "string"
           },
           "query_context": {
-            "description": "The query context represents the queries that need to run in order to generate the data the visualization, and in what format the data should be returned.",
+            "description": "The query context represents the queries that need to run in order to generate the data the visualization,and in what format the data should be returned.",
             "nullable": true,
             "type": "string"
           },
@@ -2070,7 +2070,7 @@
             "type": "string"
           },
           "query_context": {
-            "description": "The query context represents the queries that need to run in order to generate the data the visualization, and in what format the data should be returned.",
+            "description": "The query context represents the queries that need to run in order to generate the data the visualization,and in what format the data should be returned.",
             "nullable": true,
             "type": "string"
           },
@@ -2148,7 +2148,7 @@
             "type": "object"
           },
           "win_type": {
-            "description": "Type of window function. See [SciPy window functions](https://docs.scipy.org/doc/scipy/reference/signal.windows.html#module-scipy.signal.windows) for more details. Some window functions require passing additional parameters to `rolling_type_options`. For instance, to use `gaussian`, the parameter `std` needs to be provided.",
+            "description": "Type of window function. See [SciPy window functions](https://docs.scipy.org/doc/scipy/reference/signal.windows.html#module-scipy.signal.windows) for more details. Some window functions require passing additional parameters to `rolling_type_options`. For instance,to use `gaussian`,the parameter `std` needs to be provided.",
             "enum": [
               "boxcar",
               "triang",
@@ -2184,7 +2184,7 @@
       "ChartDataSelectOptionsSchema": {
         "properties": {
           "columns": {
-            "description": "Columns which to select from the input data, in the desired order. If columns are renamed, the original column name should be referenced here.",
+            "description": "Columns which to select from the input data,in the desired order. If columns are renamed,the original column name should be referenced here.",
             "example": [
               "country",
               "gender",
@@ -2206,7 +2206,7 @@
             "type": "array"
           },
           "rename": {
-            "description": "columns which to rename, mapping source column to target column. For instance, `{'y': 'y2'}` will rename the column `y` to `y2`.",
+            "description": "columns which to rename,mapping source column to target column. For instance,`{'y': 'y2'}` will rename the column `y` to `y2`.",
             "example": [
               {
                 "age": "average_age"
@@ -2223,7 +2223,7 @@
       "ChartDataSortOptionsSchema": {
         "properties": {
           "aggregates": {
-            "description": "The keys are the name of the aggregate column to be created, and the values specify the details of how to apply the aggregation. If an operator requires additional options, these can be passed here to be unpacked in the operator call. The following numpy operators are supported: average, argmin, argmax, cumsum, cumprod, max, mean, median, nansum, nanmin, nanmax, nanmean, nanmedian, min, percentile, prod, product, std, sum, var. Any options required by the operator can be passed to the `options` object.\n\nIn the example, a new column `first_quantile` is created based on values in the column `my_col` using the `percentile` operator with the `q=0.25` parameter.",
+            "description": "The keys are the name of the aggregate column to be created,and the values specify the details of how to apply the aggregation. If an operator requires additional options,these can be passed here to be unpacked in the operator call. The following numpy operators are supported: average,argmin,argmax,cumsum,cumprod,max,mean,median,nansum,nanmin,nanmax,nanmean,nanmedian,min,percentile,prod,product,std,sum,var. Any options required by the operator can be passed to the `options` object.\n\nIn the example,a new column `first_quantile` is created based on values in the column `my_col` using the `percentile` operator with the `q=0.25` parameter.",
             "example": {
               "first_quantile": {
                 "column": "my_col",
@@ -2236,7 +2236,7 @@
             "type": "object"
           },
           "columns": {
-            "description": "columns by by which to sort. The key specifies the column name, value specifies if sorting in ascending order.",
+            "description": "columns by by which to sort. The key specifies the column name,value specifies if sorting in ascending order.",
             "example": {
               "country": true,
               "gender": false
@@ -2755,7 +2755,7 @@
             "type": "string"
           },
           "query_context": {
-            "description": "The query context represents the queries that need to run in order to generate the data the visualization, and in what format the data should be returned.",
+            "description": "The query context represents the queries that need to run in order to generate the data the visualization,and in what format the data should be returned.",
             "nullable": true,
             "type": "string"
           },
@@ -2862,7 +2862,7 @@
             "type": "string"
           },
           "query_context": {
-            "description": "The query context represents the queries that need to run in order to generate the data the visualization, and in what format the data should be returned.",
+            "description": "The query context represents the queries that need to run in order to generate the data the visualization,and in what format the data should be returned.",
             "nullable": true,
             "type": "string"
           },
@@ -2939,13 +2939,13 @@
       "CssTemplateRestApi.get_list": {
         "properties": {
           "changed_by": {
-            "$ref": "#/components/schemas/CssTemplateRestApi.get_list.User"
+            "$ref": "#/components/schemas/CssTemplateRestApi.get_list.User1"
           },
           "changed_on_delta_humanized": {
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/CssTemplateRestApi.get_list.User1"
+            "$ref": "#/components/schemas/CssTemplateRestApi.get_list.User"
           },
           "created_on": {
             "format": "date-time",
@@ -3960,15 +3960,15 @@
             "type": "boolean"
           },
           "allow_dml": {
-            "description": "Allow users to run non-SELECT statements (UPDATE, DELETE, CREATE, ...) in SQL Lab",
+            "description": "Allow users to run non-SELECT statements (UPDATE,DELETE,CREATE,...) in SQL Lab",
             "type": "boolean"
           },
           "allow_file_upload": {
-            "description": "Allow to upload CSV file data into this databaseIf selected, please set the schemas allowed for csv upload in Extra.",
+            "description": "Allow to upload CSV file data into this databaseIf selected,please set the schemas allowed for csv upload in Extra.",
             "type": "boolean"
           },
           "allow_run_async": {
-            "description": "Operate the database in asynchronous mode, meaning  that the queries are executed on remote workers as opposed to on the web server itself. This assumes that you have a Celery worker setup as well as a results backend. Refer to the installation docs for more information.",
+            "description": "Operate the database in asynchronous mode,meaning  that the queries are executed on remote workers as opposed to on the web server itself. This assumes that you have a Celery worker setup as well as a results backend. Refer to the installation docs for more information.",
             "type": "boolean"
           },
           "cache_timeout": {
@@ -4006,18 +4006,18 @@
             "type": "string"
           },
           "extra": {
-            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
+            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call,while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600,\"table_cache_timeout\": 600}</strong>. If unset,cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\",\"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed,just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
             "type": "string"
           },
           "force_ctas_schema": {
-            "description": "When allowing CREATE TABLE AS option in SQL Lab, this option forces the table to be created in this schema",
+            "description": "When allowing CREATE TABLE AS option in SQL Lab,this option forces the table to be created in this schema",
             "maxLength": 250,
             "minLength": 0,
             "nullable": true,
             "type": "string"
           },
           "impersonate_user": {
-            "description": "If Presto, all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled, will run the queries as service account, but impersonate the currently logged on user via hive.server2.proxy.user property.",
+            "description": "If Presto,all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled,will run the queries as service account,but impersonate the currently logged on user via hive.server2.proxy.user property.",
             "type": "boolean"
           },
           "is_managed_externally": {
@@ -4025,7 +4025,7 @@
             "type": "boolean"
           },
           "masked_encrypted_extra": {
-            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive, Presto, and BigQuery, which do not conform to the username:password syntax normally used by SQLAlchemy.</p>",
+            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive,Presto,and BigQuery,which do not conform to the username:password syntax normally used by SQLAlchemy.</p>",
             "nullable": true,
             "type": "string"
           },
@@ -4073,15 +4073,15 @@
             "type": "boolean"
           },
           "allow_dml": {
-            "description": "Allow users to run non-SELECT statements (UPDATE, DELETE, CREATE, ...) in SQL Lab",
+            "description": "Allow users to run non-SELECT statements (UPDATE,DELETE,CREATE,...) in SQL Lab",
             "type": "boolean"
           },
           "allow_file_upload": {
-            "description": "Allow to upload CSV file data into this databaseIf selected, please set the schemas allowed for csv upload in Extra.",
+            "description": "Allow to upload CSV file data into this databaseIf selected,please set the schemas allowed for csv upload in Extra.",
             "type": "boolean"
           },
           "allow_run_async": {
-            "description": "Operate the database in asynchronous mode, meaning  that the queries are executed on remote workers as opposed to on the web server itself. This assumes that you have a Celery worker setup as well as a results backend. Refer to the installation docs for more information.",
+            "description": "Operate the database in asynchronous mode,meaning  that the queries are executed on remote workers as opposed to on the web server itself. This assumes that you have a Celery worker setup as well as a results backend. Refer to the installation docs for more information.",
             "type": "boolean"
           },
           "cache_timeout": {
@@ -4120,18 +4120,18 @@
             "type": "string"
           },
           "extra": {
-            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
+            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call,while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600,\"table_cache_timeout\": 600}</strong>. If unset,cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\",\"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed,just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
             "type": "string"
           },
           "force_ctas_schema": {
-            "description": "When allowing CREATE TABLE AS option in SQL Lab, this option forces the table to be created in this schema",
+            "description": "When allowing CREATE TABLE AS option in SQL Lab,this option forces the table to be created in this schema",
             "maxLength": 250,
             "minLength": 0,
             "nullable": true,
             "type": "string"
           },
           "impersonate_user": {
-            "description": "If Presto, all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled, will run the queries as service account, but impersonate the currently logged on user via hive.server2.proxy.user property.",
+            "description": "If Presto,all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled,will run the queries as service account,but impersonate the currently logged on user via hive.server2.proxy.user property.",
             "type": "boolean"
           },
           "is_managed_externally": {
@@ -4139,7 +4139,7 @@
             "type": "boolean"
           },
           "masked_encrypted_extra": {
-            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive, Presto, and BigQuery, which do not conform to the username:password syntax normally used by SQLAlchemy.</p>",
+            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive,Presto,and BigQuery,which do not conform to the username:password syntax normally used by SQLAlchemy.</p>",
             "nullable": true,
             "type": "string"
           },
@@ -4172,6 +4172,12 @@
       },
       "DatabaseSSHTunnel": {
         "properties": {
+          "id": {
+            "description": "SSH Tunnel ID (for updates)",
+            "format": "int32",
+            "nullable": true,
+            "type": "integer"
+          },
           "password": {
             "type": "string"
           },
@@ -4218,15 +4224,15 @@
             "type": "string"
           },
           "extra": {
-            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
+            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call,while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600,\"table_cache_timeout\": 600}</strong>. If unset,cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\",\"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed,just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
             "type": "string"
           },
           "impersonate_user": {
-            "description": "If Presto, all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled, will run the queries as service account, but impersonate the currently logged on user via hive.server2.proxy.user property.",
+            "description": "If Presto,all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled,will run the queries as service account,but impersonate the currently logged on user via hive.server2.proxy.user property.",
             "type": "boolean"
           },
           "masked_encrypted_extra": {
-            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive, Presto, and BigQuery, which do not conform to the username:password syntax normally used by SQLAlchemy.</p>",
+            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive,Presto,and BigQuery,which do not conform to the username:password syntax normally used by SQLAlchemy.</p>",
             "nullable": true,
             "type": "string"
           },
@@ -4286,7 +4292,7 @@
             "type": "string"
           },
           "extra": {
-            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
+            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call,while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600,\"table_cache_timeout\": 600}</strong>. If unset,cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\",\"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed,just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
             "type": "string"
           },
           "id": {
@@ -4296,11 +4302,11 @@
             "type": "integer"
           },
           "impersonate_user": {
-            "description": "If Presto, all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled, will run the queries as service account, but impersonate the currently logged on user via hive.server2.proxy.user property.",
+            "description": "If Presto,all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled,will run the queries as service account,but impersonate the currently logged on user via hive.server2.proxy.user property.",
             "type": "boolean"
           },
           "masked_encrypted_extra": {
-            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive, Presto, and BigQuery, which do not conform to the username:password syntax normally used by SQLAlchemy.</p>",
+            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive,Presto,and BigQuery,which do not conform to the username:password syntax normally used by SQLAlchemy.</p>",
             "nullable": true,
             "type": "string"
           },
@@ -4378,7 +4384,7 @@
             "type": "boolean"
           },
           "granularity_sqla": {
-            "description": "Name of temporal column used for time filtering for SQL datasources. This field is deprecated, use `granularity` instead.",
+            "description": "Name of temporal column used for time filtering for SQL datasources. This field is deprecated,use `granularity` instead.",
             "items": {
               "items": {
                 "type": "object"
@@ -5119,7 +5125,7 @@
       "DatasetRestApi.get_list": {
         "properties": {
           "changed_by": {
-            "$ref": "#/components/schemas/DatasetRestApi.get_list.User1"
+            "$ref": "#/components/schemas/DatasetRestApi.get_list.User"
           },
           "changed_by_name": {
             "readOnly": true
@@ -5162,7 +5168,7 @@
             "readOnly": true
           },
           "owners": {
-            "$ref": "#/components/schemas/DatasetRestApi.get_list.User"
+            "$ref": "#/components/schemas/DatasetRestApi.get_list.User1"
           },
           "schema": {
             "maxLength": 255,
@@ -5206,6 +5212,23 @@
             "maxLength": 64,
             "type": "string"
           },
+          "username": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "username"
+        ],
+        "type": "object"
+      },
+      "DatasetRestApi.get_list.User1": {
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
           "id": {
             "format": "int32",
             "type": "integer"
@@ -5222,23 +5245,6 @@
         "required": [
           "first_name",
           "last_name",
-          "username"
-        ],
-        "type": "object"
-      },
-      "DatasetRestApi.get_list.User1": {
-        "properties": {
-          "first_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
-          "username": {
-            "maxLength": 64,
-            "type": "string"
-          }
-        },
-        "required": [
-          "first_name",
           "username"
         ],
         "type": "object"
@@ -6164,6 +6170,279 @@
         },
         "type": "object"
       },
+      "RLSRestApi.get": {
+        "properties": {
+          "clause": {
+            "description": "This is the condition that will be added to the WHERE clause. For example,to only return rows for a particular client,you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role,a base filter can be created with the clause `1 = 0` (always false).",
+            "type": "string"
+          },
+          "description": {
+            "description": "Detailed description",
+            "type": "string"
+          },
+          "filter_type": {
+            "description": "Regular filters add where clauses to queries if a user belongs to a role referenced in the filter,base filters apply filters to all queries except the roles defined in the filter,and can be used to define what users can see if no RLS filters within a filter group apply to them.",
+            "enum": [
+              "Regular",
+              "Base"
+            ],
+            "type": "string"
+          },
+          "group_key": {
+            "description": "Filters with the same group key will be ORed together within the group,while different filter groups will be ANDed together. Undefined group keys are treated as unique groups,i.e. are not grouped together. For example,if a table has three filters,of which two are for departments Finance and Marketing (group key = 'department'),and one refers to the region Europe (group key = 'region'),the filter clause would apply the filter (department = 'Finance' OR department = 'Marketing') AND (region = 'Europe').",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique if of rls filter",
+            "format": "int32",
+            "type": "integer"
+          },
+          "name": {
+            "description": "Name of rls filter",
+            "type": "string"
+          },
+          "roles": {
+            "items": {
+              "$ref": "#/components/schemas/Roles1"
+            },
+            "type": "array"
+          },
+          "tables": {
+            "items": {
+              "$ref": "#/components/schemas/Tables"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "RLSRestApi.get_list": {
+        "properties": {
+          "changed_on_delta_humanized": {
+            "readOnly": true
+          },
+          "clause": {
+            "description": "This is the condition that will be added to the WHERE clause. For example,to only return rows for a particular client,you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role,a base filter can be created with the clause `1 = 0` (always false).",
+            "type": "string"
+          },
+          "description": {
+            "description": "Detailed description",
+            "type": "string"
+          },
+          "filter_type": {
+            "description": "Regular filters add where clauses to queries if a user belongs to a role referenced in the filter,base filters apply filters to all queries except the roles defined in the filter,and can be used to define what users can see if no RLS filters within a filter group apply to them.",
+            "enum": [
+              "Regular",
+              "Base"
+            ],
+            "type": "string"
+          },
+          "group_key": {
+            "description": "Filters with the same group key will be ORed together within the group,while different filter groups will be ANDed together. Undefined group keys are treated as unique groups,i.e. are not grouped together. For example,if a table has three filters,of which two are for departments Finance and Marketing (group key = 'department'),and one refers to the region Europe (group key = 'region'),the filter clause would apply the filter (department = 'Finance' OR department = 'Marketing') AND (region = 'Europe').",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique if of rls filter",
+            "format": "int32",
+            "type": "integer"
+          },
+          "name": {
+            "description": "Name of rls filter",
+            "type": "string"
+          },
+          "roles": {
+            "items": {
+              "$ref": "#/components/schemas/Roles1"
+            },
+            "type": "array"
+          },
+          "tables": {
+            "items": {
+              "$ref": "#/components/schemas/Tables"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "RLSRestApi.post": {
+        "properties": {
+          "clause": {
+            "description": "This is the condition that will be added to the WHERE clause. For example,to only return rows for a particular client,you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role,a base filter can be created with the clause `1 = 0` (always false).",
+            "type": "string"
+          },
+          "description": {
+            "description": "Detailed description",
+            "nullable": true,
+            "type": "string"
+          },
+          "filter_type": {
+            "description": "Regular filters add where clauses to queries if a user belongs to a role referenced in the filter,base filters apply filters to all queries except the roles defined in the filter,and can be used to define what users can see if no RLS filters within a filter group apply to them.",
+            "enum": [
+              "Regular",
+              "Base"
+            ],
+            "type": "string"
+          },
+          "group_key": {
+            "description": "Filters with the same group key will be ORed together within the group,while different filter groups will be ANDed together. Undefined group keys are treated as unique groups,i.e. are not grouped together. For example,if a table has three filters,of which two are for departments Finance and Marketing (group key = 'department'),and one refers to the region Europe (group key = 'region'),the filter clause would apply the filter (department = 'Finance' OR department = 'Marketing') AND (region = 'Europe').",
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of rls filter",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "roles": {
+            "description": "For regular filters,these are the roles this filter will be applied to. For base filters,these are the roles that the filter DOES NOT apply to,e.g. Admin if admin should see all data.",
+            "items": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "tables": {
+            "description": "These are the tables this filter will be applied to.",
+            "items": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "clause",
+          "filter_type",
+          "name",
+          "roles",
+          "tables"
+        ],
+        "type": "object"
+      },
+      "RLSRestApi.put": {
+        "properties": {
+          "clause": {
+            "description": "This is the condition that will be added to the WHERE clause. For example,to only return rows for a particular client,you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role,a base filter can be created with the clause `1 = 0` (always false).",
+            "type": "string"
+          },
+          "description": {
+            "description": "Detailed description",
+            "nullable": true,
+            "type": "string"
+          },
+          "filter_type": {
+            "description": "Regular filters add where clauses to queries if a user belongs to a role referenced in the filter,base filters apply filters to all queries except the roles defined in the filter,and can be used to define what users can see if no RLS filters within a filter group apply to them.",
+            "enum": [
+              "Regular",
+              "Base"
+            ],
+            "type": "string"
+          },
+          "group_key": {
+            "description": "Filters with the same group key will be ORed together within the group,while different filter groups will be ANDed together. Undefined group keys are treated as unique groups,i.e. are not grouped together. For example,if a table has three filters,of which two are for departments Finance and Marketing (group key = 'department'),and one refers to the region Europe (group key = 'region'),the filter clause would apply the filter (department = 'Finance' OR department = 'Marketing') AND (region = 'Europe').",
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of rls filter",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "roles": {
+            "description": "For regular filters,these are the roles this filter will be applied to. For base filters,these are the roles that the filter DOES NOT apply to,e.g. Admin if admin should see all data.",
+            "items": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "tables": {
+            "description": "These are the tables this filter will be applied to.",
+            "items": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "RecentActivity": {
+        "properties": {
+          "action": {
+            "description": "Action taken describing type of activity",
+            "type": "string"
+          },
+          "item_title": {
+            "description": "Title of item",
+            "type": "string"
+          },
+          "item_type": {
+            "description": "Type of item,e.g. slice or dashboard",
+            "type": "string"
+          },
+          "item_url": {
+            "description": "URL to item",
+            "type": "string"
+          },
+          "time": {
+            "description": "Time of activity,in epoch milliseconds",
+            "format": "float",
+            "type": "number"
+          },
+          "time_delta_humanized": {
+            "description": "Human-readable description of how long ago activity took place",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "RecentActivityResponseSchema": {
+        "properties": {
+          "result": {
+            "description": "A list of recent activity objects",
+            "items": {
+              "$ref": "#/components/schemas/RecentActivity"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "RecentActivitySchema": {
+        "properties": {
+          "action": {
+            "description": "Action taken describing type of activity",
+            "type": "string"
+          },
+          "item_title": {
+            "description": "Title of item",
+            "type": "string"
+          },
+          "item_type": {
+            "description": "Type of item,e.g. slice or dashboard",
+            "type": "string"
+          },
+          "item_url": {
+            "description": "URL to item",
+            "type": "string"
+          },
+          "time": {
+            "description": "Time of activity,in epoch milliseconds",
+            "format": "float",
+            "type": "number"
+          },
+          "time_delta_humanized": {
+            "description": "Human-readable description of how long ago activity took place",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "RelatedResponseSchema": {
         "properties": {
           "count": {
@@ -6320,7 +6599,7 @@
             "$ref": "#/components/schemas/ReportRecipientConfigJSON"
           },
           "type": {
-            "description": "The recipient type, check spec for valid options",
+            "description": "The recipient type,check spec for valid options",
             "enum": [
               "Email",
               "Slack"
@@ -6735,7 +7014,7 @@
             "type": "string"
           },
           "creation_method": {
-            "description": "Creation method is used to inform the frontend whether the report/alert was created in the dashboard, chart, or alerts and reports UI."
+            "description": "Creation method is used to inform the frontend whether the report/alert was created in the dashboard,chart,or alerts and reports UI."
           },
           "crontab": {
             "description": "A CRON expression.[Crontab Guru](https://crontab.guru/) is a helpful resource that can help you craft a CRON expression.",
@@ -6766,7 +7045,7 @@
             "type": "boolean"
           },
           "grace_period": {
-            "description": "Once an alert is triggered, how long, in seconds, before Superset nags you again. (in seconds)",
+            "description": "Once an alert is triggered,how long,in seconds,before Superset nags you again. (in seconds)",
             "example": 14400,
             "format": "int32",
             "minimum": 1,
@@ -7433,7 +7712,7 @@
             "$ref": "#/components/schemas/ValidatorConfigJSON"
           },
           "validator_type": {
-            "description": "Determines when to trigger alert based off value from alert query. Alerts will be triggered with these validator types:\n- Not Null - When the return value is Not NULL, Empty, or 0\n- Operator - When `sql_return_value comparison_operator threshold` is True e.g. `50 <= 75`<br>Supports the comparison operators <, <=, >, >=, ==, and !=",
+            "description": "Determines when to trigger alert based off value from alert query. Alerts will be triggered with these validator types:\n- Not Null - When the return value is Not NULL,Empty,or 0\n- Operator - When `sql_return_value comparison_operator threshold` is True e.g. `50 <= 75`<br>Supports the comparison operators <,<=,>,>=,==,and !=",
             "enum": [
               "not null",
               "operator"
@@ -7441,7 +7720,7 @@
             "type": "string"
           },
           "working_timeout": {
-            "description": "If an alert is staled at a working state, how long until it's state is reseted to error",
+            "description": "If an alert is staled at a working state,how long until it's state is reseted to error",
             "example": 3600,
             "format": "int32",
             "minimum": 1,
@@ -7471,7 +7750,7 @@
             "type": "string"
           },
           "creation_method": {
-            "description": "Creation method is used to inform the frontend whether the report/alert was created in the dashboard, chart, or alerts and reports UI.",
+            "description": "Creation method is used to inform the frontend whether the report/alert was created in the dashboard,chart,or alerts and reports UI.",
             "nullable": true
           },
           "crontab": {
@@ -7502,7 +7781,7 @@
             "type": "boolean"
           },
           "grace_period": {
-            "description": "Once an alert is triggered, how long, in seconds, before Superset nags you again. (in seconds)",
+            "description": "Once an alert is triggered,how long,in seconds,before Superset nags you again. (in seconds)",
             "example": 14400,
             "format": "int32",
             "minimum": 1,
@@ -8161,7 +8440,7 @@
             "$ref": "#/components/schemas/ValidatorConfigJSON"
           },
           "validator_type": {
-            "description": "Determines when to trigger alert based off value from alert query. Alerts will be triggered with these validator types:\n- Not Null - When the return value is Not NULL, Empty, or 0\n- Operator - When `sql_return_value comparison_operator threshold` is True e.g. `50 <= 75`<br>Supports the comparison operators <, <=, >, >=, ==, and !=",
+            "description": "Determines when to trigger alert based off value from alert query. Alerts will be triggered with these validator types:\n- Not Null - When the return value is Not NULL,Empty,or 0\n- Operator - When `sql_return_value comparison_operator threshold` is True e.g. `50 <= 75`<br>Supports the comparison operators <,<=,>,>=,==,and !=",
             "enum": [
               "not null",
               "operator"
@@ -8170,7 +8449,7 @@
             "type": "string"
           },
           "working_timeout": {
-            "description": "If an alert is staled at a working state, how long until it's state is reseted to error",
+            "description": "If an alert is staled at a working state,how long until it's state is reseted to error",
             "example": 3600,
             "format": "int32",
             "minimum": 1,
@@ -8209,6 +8488,18 @@
         "type": "object"
       },
       "Roles": {
+        "properties": {
+          "id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Roles1": {
         "properties": {
           "id": {
             "format": "int32",
@@ -8725,6 +9016,21 @@
         },
         "type": "object"
       },
+      "Tables": {
+        "properties": {
+          "id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "schema": {
+            "type": "string"
+          },
+          "table_name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "TemporaryCachePostSchema": {
         "properties": {
           "value": {
@@ -9063,6 +9369,23 @@
         },
         "type": "object"
       },
+      "get_recent_activity_schema": {
+        "properties": {
+          "actions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "distinct": {
+            "type": "boolean"
+          },
+          "limit": {
+            "type": "number"
+          }
+        },
+        "type": "object"
+      },
       "get_related_schema": {
         "properties": {
           "filter": {
@@ -9279,7 +9602,7 @@
         ]
       },
       "get": {
-        "description": "Get a list of Annotation layers, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
+        "description": "Get a list of Annotation layers,use Rison or JSON query parameters for filtering,sorting,pagination and for selecting specific columns and metadata.",
         "parameters": [
           {
             "content": {
@@ -9314,7 +9637,7 @@
                       "type": "object"
                     },
                     "ids": {
-                      "description": "A list of item ids, useful when you don't know the column id",
+                      "description": "A list of item ids,useful when you don't know the column id",
                       "items": {
                         "type": "string"
                       },
@@ -9862,7 +10185,7 @@
         ]
       },
       "get": {
-        "description": "Get a list of Annotation layers, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
+        "description": "Get a list of Annotation layers,use Rison or JSON query parameters for filtering,sorting,pagination and for selecting specific columns and metadata.",
         "parameters": [
           {
             "description": "The annotation layer id for this annotation",
@@ -10217,7 +10540,7 @@
     },
     "/api/v1/assets/export/": {
       "get": {
-        "description": "Returns a ZIP file with all the Superset assets (databases, datasets, charts, dashboards, saved queries) as YAML files.",
+        "description": "Returns a ZIP file with all the Superset assets (databases,datasets,charts,dashboards,saved queries) as YAML files.",
         "responses": {
           "200": {
             "content": {
@@ -10263,7 +10586,7 @@
                     "type": "string"
                   },
                   "passwords": {
-                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
+                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`,the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
                     "type": "string"
                   }
                 },
@@ -10314,7 +10637,7 @@
     },
     "/api/v1/async_event/": {
       "get": {
-        "description": "Reads off of the Redis events stream, using the user's JWT token and optional query params for last event received.",
+        "description": "Reads off of the Redis events stream,using the user's JWT token and optional query params for last event received.",
         "parameters": [
           {
             "description": "Last ID received by the client",
@@ -10425,7 +10748,7 @@
     },
     "/api/v1/cachekey/invalidate": {
       "post": {
-        "description": "Takes a list of datasources, finds the associated cache records and invalidates them and removes the database records",
+        "description": "Takes a list of datasources,finds the associated cache records and invalidates them and removes the database records",
         "requestBody": {
           "content": {
             "application/json": {
@@ -10516,7 +10839,7 @@
         ]
       },
       "get": {
-        "description": "Get a list of charts, use Rison or JSON query parameters for filtering, sorting, pagination and  for selecting specific columns and metadata.",
+        "description": "Get a list of charts,use Rison or JSON query parameters for filtering,sorting,pagination and  for selecting specific columns and metadata.",
         "parameters": [
           {
             "content": {
@@ -10551,7 +10874,7 @@
                       "type": "object"
                     },
                     "ids": {
-                      "description": "A list of item ids, useful when you don't know the column id",
+                      "description": "A list of item ids,useful when you don't know the column id",
                       "items": {
                         "type": "string"
                       },
@@ -10894,7 +11217,7 @@
                 }
               }
             },
-            "description": "A zip file with chart(s), dataset(s) and database(s) as YAML"
+            "description": "A zip file with chart(s),dataset(s) and database(s) as YAML"
           },
           "400": {
             "$ref": "#/components/responses/400"
@@ -10986,7 +11309,7 @@
                     "type": "boolean"
                   },
                   "passwords": {
-                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
+                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`,the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
                     "type": "string"
                   }
                 },
@@ -11625,7 +11948,7 @@
         ]
       },
       "get": {
-        "description": "Get a list of CSS templates, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
+        "description": "Get a list of CSS templates,use Rison or JSON query parameters for filtering,sorting,pagination and for selecting specific columns and metadata.",
         "parameters": [
           {
             "content": {
@@ -11660,7 +11983,7 @@
                       "type": "object"
                     },
                     "ids": {
-                      "description": "A list of item ids, useful when you don't know the column id",
+                      "description": "A list of item ids,useful when you don't know the column id",
                       "items": {
                         "type": "string"
                       },
@@ -12200,7 +12523,7 @@
         ]
       },
       "get": {
-        "description": "Get a list of dashboards, use Rison or JSON query parameters for filtering, sorting, pagination and  for selecting specific columns and metadata.",
+        "description": "Get a list of dashboards,use Rison or JSON query parameters for filtering,sorting,pagination and  for selecting specific columns and metadata.",
         "parameters": [
           {
             "content": {
@@ -12235,7 +12558,7 @@
                       "type": "object"
                     },
                     "ids": {
-                      "description": "A list of item ids, useful when you don't know the column id",
+                      "description": "A list of item ids,useful when you don't know the column id",
                       "items": {
                         "type": "string"
                       },
@@ -12567,7 +12890,7 @@
                     "type": "boolean"
                   },
                   "passwords": {
-                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
+                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`,the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
                     "type": "string"
                   }
                 },
@@ -13020,7 +13343,7 @@
         "description": "Get a dashboard detail information.",
         "parameters": [
           {
-            "description": "Either the id of the dashboard, or its slug",
+            "description": "Either the id of the dashboard,or its slug",
             "in": "path",
             "name": "id_or_slug",
             "required": true,
@@ -13128,7 +13451,7 @@
         "description": "Returns a list of a dashboard's datasets. Each dataset includes only the information necessary to render the dashboard's charts.",
         "parameters": [
           {
-            "description": "Either the id of the dashboard, or its slug",
+            "description": "Either the id of the dashboard,or its slug",
             "in": "path",
             "name": "id_or_slug",
             "required": true,
@@ -13912,7 +14235,7 @@
                 }
               }
             },
-            "description": "Thumbnail does not exist on cache, fired async to compute"
+            "description": "Thumbnail does not exist on cache,fired async to compute"
           },
           "302": {
             "description": "Redirects to the current digest"
@@ -13977,7 +14300,7 @@
                       "type": "object"
                     },
                     "ids": {
-                      "description": "A list of item ids, useful when you don't know the column id",
+                      "description": "A list of item ids,useful when you don't know the column id",
                       "items": {
                         "type": "string"
                       },
@@ -14217,6 +14540,10 @@
                       "engine_information": {
                         "description": "Dict with public properties form the DB Engine",
                         "properties": {
+                          "disable_ssh_tunneling": {
+                            "description": "Whether the engine supports SSH Tunnels",
+                            "type": "boolean"
+                          },
                           "supports_file_upload": {
                             "description": "Whether the engine supports file uploads",
                             "type": "boolean"
@@ -14331,7 +14658,7 @@
                     "type": "boolean"
                   },
                   "passwords": {
-                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
+                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`,the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
                     "type": "string"
                   }
                 },
@@ -15294,7 +15621,7 @@
                       "type": "object"
                     },
                     "ids": {
-                      "description": "A list of item ids, useful when you don't know the column id",
+                      "description": "A list of item ids,useful when you don't know the column id",
                       "items": {
                         "type": "string"
                       },
@@ -15692,7 +16019,7 @@
                     "type": "boolean"
                   },
                   "passwords": {
-                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
+                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`,the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
                     "type": "string"
                   },
                   "sync_columns": {
@@ -16319,7 +16646,7 @@
     },
     "/api/v1/explore/": {
       "get": {
-        "description": "Assembles Explore related information (form_data, slice, dataset)\\n in a single endpoint.<br/><br/>\\nThe information can be assembled from:<br/> - The cache using a form_data_key<br/> - The metadata database using a permalink_key<br/> - Build from scratch using dataset or slice identifiers.",
+        "description": "Assembles Explore related information (form_data,slice,dataset)\\n in a single endpoint.<br/><br/>\\nThe information can be assembled from:<br/> - The cache using a form_data_key<br/> - The metadata database using a permalink_key<br/> - Build from scratch using dataset or slice identifiers.",
         "parameters": [
           {
             "in": "query",
@@ -16389,7 +16716,7 @@
             "jwt": []
           }
         ],
-        "summary": "Assembles Explore related information (form_data, slice, dataset)\\n in a single endpoint.",
+        "summary": "Assembles Explore related information (form_data,slice,dataset)\\n in a single endpoint.",
         "tags": [
           "Explore"
         ]
@@ -16789,7 +17116,7 @@
                       "type": "object"
                     },
                     "ids": {
-                      "description": "A list of item ids, useful when you don't know the column id",
+                      "description": "A list of item ids,useful when you don't know the column id",
                       "items": {
                         "type": "string"
                       },
@@ -16914,6 +17241,65 @@
         ]
       }
     },
+    "/api/v1/log/recent_activity/{user_id}/": {
+      "get": {
+        "description": "Get recent activity data for a user",
+        "parameters": [
+          {
+            "description": "The id of the user",
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_recent_activity_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecentActivityResponseSchema"
+                }
+              }
+            },
+            "description": "A List of recent activity objects"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "LogRestApi"
+        ]
+      }
+    },
     "/api/v1/log/{pk}": {
       "get": {
         "description": "Get an item model",
@@ -17018,7 +17404,7 @@
     },
     "/api/v1/me/": {
       "get": {
-        "description": "Returns the user object corresponding to the agent making the request, or returns a 401 error if the user is unauthenticated.",
+        "description": "Returns the user object corresponding to the agent making the request,or returns a 401 error if the user is unauthenticated.",
         "responses": {
           "200": {
             "content": {
@@ -17046,7 +17432,7 @@
     },
     "/api/v1/me/roles/": {
       "get": {
-        "description": "Returns the user roles corresponding to the agent making the request, or returns a 401 error if the user is unauthenticated.",
+        "description": "Returns the user roles corresponding to the agent making the request,or returns a 401 error if the user is unauthenticated.",
         "responses": {
           "200": {
             "content": {
@@ -17100,7 +17486,7 @@
                             "type": "string"
                           },
                           "name": {
-                            "description": "The internal menu item name, maps to permission_name",
+                            "description": "The internal menu item name,maps to permission_name",
                             "type": "string"
                           },
                           "url": {
@@ -17135,7 +17521,7 @@
     },
     "/api/v1/query/": {
       "get": {
-        "description": "Get a list of queries, use Rison or JSON query parameters for filtering, sorting, pagination and  for selecting specific columns and metadata.",
+        "description": "Get a list of queries,use Rison or JSON query parameters for filtering,sorting,pagination and  for selecting specific columns and metadata.",
         "parameters": [
           {
             "content": {
@@ -17170,7 +17556,7 @@
                       "type": "object"
                     },
                     "ids": {
-                      "description": "A list of item ids, useful when you don't know the column id",
+                      "description": "A list of item ids,useful when you don't know the column id",
                       "items": {
                         "type": "string"
                       },
@@ -17569,7 +17955,7 @@
         ]
       },
       "get": {
-        "description": "Get a list of report schedules, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
+        "description": "Get a list of report schedules,use Rison or JSON query parameters for filtering,sorting,pagination and for selecting specific columns and metadata.",
         "parameters": [
           {
             "content": {
@@ -17604,7 +17990,7 @@
                       "type": "object"
                     },
                     "ids": {
-                      "description": "A list of item ids, useful when you don't know the column id",
+                      "description": "A list of item ids,useful when you don't know the column id",
                       "items": {
                         "type": "string"
                       },
@@ -18102,7 +18488,7 @@
     },
     "/api/v1/report/{pk}/log/": {
       "get": {
-        "description": "Get a list of report schedule logs, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
+        "description": "Get a list of report schedule logs,use Rison or JSON query parameters for filtering,sorting,pagination and for selecting specific columns and metadata.",
         "parameters": [
           {
             "description": "The report schedule id for these logs",
@@ -18259,6 +18645,590 @@
         ]
       }
     },
+    "/api/v1/rowlevelsecurity/": {
+      "delete": {
+        "description": "Deletes multiple RLS rules in a bulk operation.",
+        "parameters": [
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_delete_ids_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "RLS Rule bulk delete"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Row Level Security"
+        ]
+      },
+      "get": {
+        "description": "Get a list of models",
+        "parameters": [
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_list_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "count": {
+                      "description": "The total record count on the backend",
+                      "type": "number"
+                    },
+                    "description_columns": {
+                      "properties": {
+                        "column_name": {
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "ids": {
+                      "description": "A list of item ids,useful when you don't know the column id",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "label_columns": {
+                      "properties": {
+                        "column_name": {
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "list_columns": {
+                      "description": "A list of columns",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "list_title": {
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "List Items",
+                      "type": "string"
+                    },
+                    "order_columns": {
+                      "description": "A list of allowed columns to sort",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "result": {
+                      "description": "The result from the get list query",
+                      "items": {
+                        "$ref": "#/components/schemas/RLSRestApi.get_list"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Items from Model"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Row Level Security"
+        ]
+      },
+      "post": {
+        "description": "Create a new RLS Rule",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RLSRestApi.post"
+              }
+            }
+          },
+          "description": "RLS schema",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/RLSRestApi.post"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "RLS Rule added"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Row Level Security"
+        ]
+      }
+    },
+    "/api/v1/rowlevelsecurity/_info": {
+      "get": {
+        "description": "Get metadata information about this API resource",
+        "parameters": [
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_info_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "add_columns": {
+                      "type": "object"
+                    },
+                    "edit_columns": {
+                      "type": "object"
+                    },
+                    "filters": {
+                      "properties": {
+                        "column_name": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "description": "The filter name. Will be translated by babel",
+                                "type": "string"
+                              },
+                              "operator": {
+                                "description": "The filter operation key to use on list filters",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "permissions": {
+                      "description": "The user permissions for this API resource",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Item from Model"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Row Level Security"
+        ]
+      }
+    },
+    "/api/v1/rowlevelsecurity/related/{column_name}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "column_name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_related_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RelatedResponseSchema"
+                }
+              }
+            },
+            "description": "Related column data"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Row Level Security"
+        ]
+      }
+    },
+    "/api/v1/rowlevelsecurity/{pk}": {
+      "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Item deleted"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Row Level Security"
+        ]
+      },
+      "get": {
+        "description": "Get an item model",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_item_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "description_columns": {
+                      "properties": {
+                        "column_name": {
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "id": {
+                      "description": "The item id",
+                      "type": "string"
+                    },
+                    "label_columns": {
+                      "properties": {
+                        "column_name": {
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/RLSRestApi.get"
+                    },
+                    "show_columns": {
+                      "description": "A list of columns",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "show_title": {
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "Show Item Details",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Item from Model"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Row Level Security"
+        ]
+      },
+      "put": {
+        "description": "Updates an RLS Rule",
+        "parameters": [
+          {
+            "description": "The Rule pk",
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RLSRestApi.put"
+              }
+            }
+          },
+          "description": "RLS schema",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/RLSRestApi.put"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Rule changed"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Row Level Security"
+        ]
+      }
+    },
     "/api/v1/saved_query/": {
       "delete": {
         "description": "Deletes multiple saved queries in a bulk operation.",
@@ -18314,7 +19284,7 @@
         ]
       },
       "get": {
-        "description": "Get a list of saved queries, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
+        "description": "Get a list of saved queries,use Rison or JSON query parameters for filtering,sorting,pagination and for selecting specific columns and metadata.",
         "parameters": [
           {
             "content": {
@@ -18349,7 +19319,7 @@
                       "type": "object"
                     },
                     "ids": {
-                      "description": "A list of item ids, useful when you don't know the column id",
+                      "description": "A list of item ids,useful when you don't know the column id",
                       "items": {
                         "type": "string"
                       },
@@ -18686,7 +19656,7 @@
                     "type": "boolean"
                   },
                   "passwords": {
-                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
+                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`,the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
                     "type": "string"
                   }
                 },
@@ -19245,7 +20215,7 @@
   },
   "servers": [
     {
-      "url": "http://localhost:8088"
+      "url": "http://localhost:8088/"
     }
   ]
 }

--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -9,13 +9,13 @@
                 "message": {
                   "type": "string"
                 }
-              },
+              }, 
               "type": "object"
             }
           }
-        },
+        }, 
         "description": "Bad request"
-      },
+      }, 
       "401": {
         "content": {
           "application/json": {
@@ -24,13 +24,13 @@
                 "message": {
                   "type": "string"
                 }
-              },
+              }, 
               "type": "object"
             }
           }
-        },
+        }, 
         "description": "Unauthorized"
-      },
+      }, 
       "403": {
         "content": {
           "application/json": {
@@ -39,13 +39,13 @@
                 "message": {
                   "type": "string"
                 }
-              },
+              }, 
               "type": "object"
             }
           }
-        },
+        }, 
         "description": "Forbidden"
-      },
+      }, 
       "404": {
         "content": {
           "application/json": {
@@ -54,13 +54,13 @@
                 "message": {
                   "type": "string"
                 }
-              },
+              }, 
               "type": "object"
             }
           }
-        },
+        }, 
         "description": "Not found"
-      },
+      }, 
       "422": {
         "content": {
           "application/json": {
@@ -69,13 +69,13 @@
                 "message": {
                   "type": "string"
                 }
-              },
+              }, 
               "type": "object"
             }
           }
-        },
+        }, 
         "description": "Could not process entity"
-      },
+      }, 
       "500": {
         "content": {
           "application/json": {
@@ -84,9143 +84,9143 @@
                 "message": {
                   "type": "string"
                 }
-              },
+              }, 
               "type": "object"
             }
           }
-        },
+        }, 
         "description": "Fatal error"
       }
-    },
+    }, 
     "schemas": {
       "AdvancedDataTypeSchema": {
         "properties": {
           "display_value": {
-            "description": "The string representation of the parsed values",
+            "description": "The string representation of the parsed values", 
             "type": "string"
-          },
+          }, 
           "error_message": {
             "type": "string"
-          },
+          }, 
           "valid_filter_operators": {
             "items": {
               "type": "string"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "values": {
             "items": {
-              "description": "parsed value (can be any value)",
+              "description": "parsed value (can be any value)", 
               "type": "string"
-            },
+            }, 
             "type": "array"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "AnnotationLayer": {
         "properties": {
           "annotationType": {
-            "description": "Type of annotation layer",
+            "description": "Type of annotation layer", 
             "enum": [
-              "FORMULA",
-              "INTERVAL",
-              "EVENT",
+              "FORMULA", 
+              "INTERVAL", 
+              "EVENT", 
               "TIME_SERIES"
-            ],
+            ], 
             "type": "string"
-          },
+          }, 
           "color": {
-            "description": "Layer color",
-            "nullable": true,
+            "description": "Layer color", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "descriptionColumns": {
-            "description": "Columns to use as the description. If none are provided,all will be shown.",
+            "description": "Columns to use as the description. If none are provided, all will be shown.", 
             "items": {
               "type": "string"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "hideLine": {
-            "description": "Should line be hidden. Only applies to line annotations",
-            "nullable": true,
+            "description": "Should line be hidden. Only applies to line annotations", 
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "intervalEndColumn": {
-            "description": "Column containing end of interval. Only applies to interval layers",
-            "nullable": true,
+            "description": "Column containing end of interval. Only applies to interval layers", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "name": {
-            "description": "Name of layer",
+            "description": "Name of layer", 
             "type": "string"
-          },
+          }, 
           "opacity": {
-            "description": "Opacity of layer",
+            "description": "Opacity of layer", 
             "enum": [
-              "",
-              "opacityLow",
-              "opacityMedium",
+              "", 
+              "opacityLow", 
+              "opacityMedium", 
               "opacityHigh"
-            ],
-            "nullable": true,
+            ], 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "overrides": {
             "additionalProperties": {
               "nullable": true
-            },
-            "description": "which properties should be overridable",
-            "nullable": true,
+            }, 
+            "description": "which properties should be overridable", 
+            "nullable": true, 
             "type": "object"
-          },
+          }, 
           "show": {
-            "description": "Should the layer be shown",
+            "description": "Should the layer be shown", 
             "type": "boolean"
-          },
+          }, 
           "showLabel": {
-            "description": "Should the label always be shown",
-            "nullable": true,
+            "description": "Should the label always be shown", 
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "showMarkers": {
-            "description": "Should markers be shown. Only applies to line annotations.",
+            "description": "Should markers be shown. Only applies to line annotations.", 
             "type": "boolean"
-          },
+          }, 
           "sourceType": {
-            "description": "Type of source for annotation data",
+            "description": "Type of source for annotation data", 
             "enum": [
-              "",
-              "line",
-              "NATIVE",
+              "", 
+              "line", 
+              "NATIVE", 
               "table"
-            ],
+            ], 
             "type": "string"
-          },
+          }, 
           "style": {
-            "description": "Line style. Only applies to time-series annotations",
+            "description": "Line style. Only applies to time-series annotations", 
             "enum": [
-              "dashed",
-              "dotted",
-              "solid",
+              "dashed", 
+              "dotted", 
+              "solid", 
               "longDashed"
-            ],
+            ], 
             "type": "string"
-          },
+          }, 
           "timeColumn": {
-            "description": "Column with event date or interval start date",
-            "nullable": true,
+            "description": "Column with event date or interval start date", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "titleColumn": {
-            "description": "Column with title",
-            "nullable": true,
+            "description": "Column with title", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "value": {
-            "description": "For formula annotations,this contains the formula. For other types,this is the primary key of the source object."
-          },
+            "description": "For formula annotations, this contains the formula. For other types, this is the primary key of the source object."
+          }, 
           "width": {
-            "description": "Width of annotation line",
-            "format": "float",
-            "minimum": 0,
+            "description": "Width of annotation line", 
+            "format": "float", 
+            "minimum": 0, 
             "type": "number"
           }
-        },
+        }, 
         "required": [
-          "name",
-          "show",
-          "showMarkers",
+          "name", 
+          "show", 
+          "showMarkers", 
           "value"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "AnnotationLayerRestApi.get": {
         "properties": {
           "descr": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "name": {
-            "maxLength": 250,
-            "nullable": true,
+            "maxLength": 250, 
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "AnnotationLayerRestApi.get_list": {
         "properties": {
           "changed_by": {
             "$ref": "#/components/schemas/AnnotationLayerRestApi.get_list.User1"
-          },
+          }, 
           "changed_on": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "changed_on_delta_humanized": {
             "readOnly": true
-          },
+          }, 
           "created_by": {
             "$ref": "#/components/schemas/AnnotationLayerRestApi.get_list.User"
-          },
+          }, 
           "created_on": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "descr": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "name": {
-            "maxLength": 250,
-            "nullable": true,
+            "maxLength": 250, 
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "AnnotationLayerRestApi.get_list.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
+          "first_name", 
           "last_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "AnnotationLayerRestApi.get_list.User1": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
+          "first_name", 
           "last_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "AnnotationLayerRestApi.post": {
         "properties": {
           "descr": {
-            "description": "Give a description for this annotation layer",
-            "nullable": true,
+            "description": "Give a description for this annotation layer", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "name": {
-            "description": "The annotation layer name",
-            "maxLength": 250,
-            "minLength": 1,
+            "description": "The annotation layer name", 
+            "maxLength": 250, 
+            "minLength": 1, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
           "name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "AnnotationLayerRestApi.put": {
         "properties": {
           "descr": {
-            "description": "Give a description for this annotation layer",
+            "description": "Give a description for this annotation layer", 
             "type": "string"
-          },
+          }, 
           "name": {
-            "description": "The annotation layer name",
-            "maxLength": 250,
-            "minLength": 1,
+            "description": "The annotation layer name", 
+            "maxLength": 250, 
+            "minLength": 1, 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "AnnotationRestApi.get": {
         "properties": {
           "end_dttm": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "json_metadata": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "layer": {
             "$ref": "#/components/schemas/AnnotationRestApi.get.AnnotationLayer"
-          },
+          }, 
           "long_descr": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "short_descr": {
-            "maxLength": 500,
-            "nullable": true,
+            "maxLength": 500, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "start_dttm": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
           "layer"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "AnnotationRestApi.get.AnnotationLayer": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "name": {
-            "maxLength": 250,
-            "nullable": true,
+            "maxLength": 250, 
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "AnnotationRestApi.get_list": {
         "properties": {
           "changed_by": {
             "$ref": "#/components/schemas/AnnotationRestApi.get_list.User1"
-          },
+          }, 
           "changed_on_delta_humanized": {
             "readOnly": true
-          },
+          }, 
           "created_by": {
             "$ref": "#/components/schemas/AnnotationRestApi.get_list.User"
-          },
+          }, 
           "end_dttm": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "long_descr": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "short_descr": {
-            "maxLength": 500,
-            "nullable": true,
+            "maxLength": 500, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "start_dttm": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "AnnotationRestApi.get_list.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "required": [
           "first_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "AnnotationRestApi.get_list.User1": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "required": [
           "first_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "AnnotationRestApi.post": {
         "properties": {
           "end_dttm": {
-            "description": "The annotation end date time",
-            "format": "date-time",
+            "description": "The annotation end date time", 
+            "format": "date-time", 
             "type": "string"
-          },
+          }, 
           "json_metadata": {
-            "description": "JSON metadata",
-            "nullable": true,
+            "description": "JSON metadata", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "long_descr": {
-            "description": "A long description",
-            "nullable": true,
+            "description": "A long description", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "short_descr": {
-            "description": "A short description",
-            "maxLength": 500,
-            "minLength": 1,
+            "description": "A short description", 
+            "maxLength": 500, 
+            "minLength": 1, 
             "type": "string"
-          },
+          }, 
           "start_dttm": {
-            "description": "The annotation start date time",
-            "format": "date-time",
+            "description": "The annotation start date time", 
+            "format": "date-time", 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "end_dttm",
-          "short_descr",
+          "end_dttm", 
+          "short_descr", 
           "start_dttm"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "AnnotationRestApi.put": {
         "properties": {
           "end_dttm": {
-            "description": "The annotation end date time",
-            "format": "date-time",
+            "description": "The annotation end date time", 
+            "format": "date-time", 
             "type": "string"
-          },
+          }, 
           "json_metadata": {
-            "description": "JSON metadata",
-            "nullable": true,
+            "description": "JSON metadata", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "long_descr": {
-            "description": "A long description",
-            "nullable": true,
+            "description": "A long description", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "short_descr": {
-            "description": "A short description",
-            "maxLength": 500,
-            "minLength": 1,
+            "description": "A short description", 
+            "maxLength": 500, 
+            "minLength": 1, 
             "type": "string"
-          },
+          }, 
           "start_dttm": {
-            "description": "The annotation start date time",
-            "format": "date-time",
+            "description": "The annotation start date time", 
+            "format": "date-time", 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "AvailableDomainsSchema": {
         "properties": {
           "domains": {
             "items": {
               "type": "string"
-            },
+            }, 
             "type": "array"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "CacheInvalidationRequestSchema": {
         "properties": {
           "datasource_uids": {
-            "description": "The uid of the dataset/datasource this new chart will use. A complete datasource identification needs `datasouce_uid` ",
+            "description": "The uid of the dataset/datasource this new chart will use. A complete datasource identification needs `datasouce_uid` ", 
             "items": {
               "type": "string"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "datasources": {
-            "description": "A list of the data source and database names",
+            "description": "A list of the data source and database names", 
             "items": {
               "$ref": "#/components/schemas/Datasource"
-            },
+            }, 
             "type": "array"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "CacheRestApi.get": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "CacheRestApi.get_list": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "CacheRestApi.post": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "CacheRestApi.put": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ChartCacheScreenshotResponseSchema": {
         "properties": {
           "cache_key": {
-            "description": "The cache key",
+            "description": "The cache key", 
             "type": "string"
-          },
+          }, 
           "chart_url": {
-            "description": "The url to render the chart",
+            "description": "The url to render the chart", 
             "type": "string"
-          },
+          }, 
           "image_url": {
-            "description": "The url to fetch the screenshot",
+            "description": "The url to fetch the screenshot", 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ChartDataAdhocMetricSchema": {
         "properties": {
           "aggregate": {
-            "description": "Aggregation operator. Only required for simple expression types.",
+            "description": "Aggregation operator. Only required for simple expression types.", 
             "enum": [
-              "AVG",
-              "COUNT",
-              "COUNT_DISTINCT",
-              "MAX",
-              "MIN",
+              "AVG", 
+              "COUNT", 
+              "COUNT_DISTINCT", 
+              "MAX", 
+              "MIN", 
               "SUM"
-            ],
+            ], 
             "type": "string"
-          },
+          }, 
           "column": {
             "$ref": "#/components/schemas/ChartDataColumn"
-          },
+          }, 
           "expressionType": {
-            "description": "Simple or SQL metric",
+            "description": "Simple or SQL metric", 
             "enum": [
-              "SIMPLE",
+              "SIMPLE", 
               "SQL"
-            ],
-            "example": "SQL",
+            ], 
+            "example": "SQL", 
             "type": "string"
-          },
+          }, 
           "hasCustomLabel": {
-            "description": "When false,the label will be automatically generated based on the aggregate expression. When true,a custom label has to be specified.",
-            "example": true,
+            "description": "When false, the label will be automatically generated based on the aggregate expression. When true, a custom label has to be specified.", 
+            "example": true, 
             "type": "boolean"
-          },
+          }, 
           "isExtra": {
-            "description": "Indicates if the filter has been added by a filter component as opposed to being a part of the original query.",
+            "description": "Indicates if the filter has been added by a filter component as opposed to being a part of the original query.", 
             "type": "boolean"
-          },
+          }, 
           "label": {
-            "description": "Label for the metric. Is automatically generated unless hasCustomLabel is true,in which case label must be defined.",
-            "example": "Weighted observations",
+            "description": "Label for the metric. Is automatically generated unless hasCustomLabel is true, in which case label must be defined.", 
+            "example": "Weighted observations", 
             "type": "string"
-          },
+          }, 
           "optionName": {
-            "description": "Unique identifier. Can be any string value,as long as all metrics have a unique identifier. If undefined,a random name will be generated.",
-            "example": "metric_aec60732-fac0-4b17-b736-93f1a5c93e30",
+            "description": "Unique identifier. Can be any string value, as long as all metrics have a unique identifier. If undefined, a random name will be generated.", 
+            "example": "metric_aec60732-fac0-4b17-b736-93f1a5c93e30", 
             "type": "string"
-          },
+          }, 
           "sqlExpression": {
-            "description": "The metric as defined by a SQL aggregate expression. Only required for SQL expression type.",
-            "example": "SUM(weight * observations) / SUM(weight)",
+            "description": "The metric as defined by a SQL aggregate expression. Only required for SQL expression type.", 
+            "example": "SUM(weight * observations) / SUM(weight)", 
             "type": "string"
-          },
+          }, 
           "timeGrain": {
-            "description": "Optional time grain for temporal filters",
-            "example": "PT1M",
+            "description": "Optional time grain for temporal filters", 
+            "example": "PT1M", 
             "type": "string"
           }
-        },
+        }, 
         "required": [
           "expressionType"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ChartDataAggregateOptionsSchema": {
         "properties": {
           "aggregates": {
-            "description": "The keys are the name of the aggregate column to be created,and the values specify the details of how to apply the aggregation. If an operator requires additional options,these can be passed here to be unpacked in the operator call. The following numpy operators are supported: average,argmin,argmax,cumsum,cumprod,max,mean,median,nansum,nanmin,nanmax,nanmean,nanmedian,min,percentile,prod,product,std,sum,var. Any options required by the operator can be passed to the `options` object.\n\nIn the example,a new column `first_quantile` is created based on values in the column `my_col` using the `percentile` operator with the `q=0.25` parameter.",
+            "description": "The keys are the name of the aggregate column to be created, and the values specify the details of how to apply the aggregation. If an operator requires additional options, these can be passed here to be unpacked in the operator call. The following numpy operators are supported: average, argmin, argmax, cumsum, cumprod, max, mean, median, nansum, nanmin, nanmax, nanmean, nanmedian, min, percentile, prod, product, std, sum, var. Any options required by the operator can be passed to the `options` object.\n\nIn the example, a new column `first_quantile` is created based on values in the column `my_col` using the `percentile` operator with the `q=0.25` parameter.", 
             "example": {
               "first_quantile": {
-                "column": "my_col",
-                "operator": "percentile",
+                "column": "my_col", 
+                "operator": "percentile", 
                 "options": {
                   "q": 0.25
                 }
               }
-            },
+            }, 
             "type": "object"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ChartDataAsyncResponseSchema": {
         "properties": {
           "channel_id": {
-            "description": "Unique session async channel ID",
+            "description": "Unique session async channel ID", 
             "type": "string"
-          },
+          }, 
           "job_id": {
-            "description": "Unique async job ID",
+            "description": "Unique async job ID", 
             "type": "string"
-          },
+          }, 
           "result_url": {
-            "description": "Unique result URL for fetching async query data",
+            "description": "Unique result URL for fetching async query data", 
             "type": "string"
-          },
+          }, 
           "status": {
-            "description": "Status value for async job",
+            "description": "Status value for async job", 
             "type": "string"
-          },
+          }, 
           "user_id": {
-            "description": "Requesting user ID",
-            "nullable": true,
+            "description": "Requesting user ID", 
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ChartDataBoxplotOptionsSchema": {
         "properties": {
           "groupby": {
             "items": {
-              "description": "Columns by which to group the query.",
+              "description": "Columns by which to group the query.", 
               "type": "string"
-            },
-            "nullable": true,
+            }, 
+            "nullable": true, 
             "type": "array"
-          },
+          }, 
           "metrics": {
-            "description": "Aggregate expressions. Metrics can be passed as both references to datasource metrics (strings),or ad-hoc metricswhich are defined only within the query object. See `ChartDataAdhocMetricSchema` for the structure of ad-hoc metrics. When metrics is undefined or null,the query is executed without a groupby. However,when metrics is an array (length >= 0),a groupby clause is added to the query.",
-            "items": {},
-            "nullable": true,
+            "description": "Aggregate expressions. Metrics can be passed as both references to datasource metrics (strings), or ad-hoc metricswhich are defined only within the query object. See `ChartDataAdhocMetricSchema` for the structure of ad-hoc metrics. When metrics is undefined or null, the query is executed without a groupby. However, when metrics is an array (length >= 0), a groupby clause is added to the query.", 
+            "items": {}, 
+            "nullable": true, 
             "type": "array"
-          },
+          }, 
           "percentiles": {
-            "description": "Upper and lower percentiles for percentile whisker type.",
+            "description": "Upper and lower percentiles for percentile whisker type.", 
             "example": [
-              1,
+              1, 
               99
             ]
-          },
+          }, 
           "whisker_type": {
-            "description": "Whisker type. Any numpy function will work.",
+            "description": "Whisker type. Any numpy function will work.", 
             "enum": [
-              "tukey",
-              "min/max",
+              "tukey", 
+              "min/max", 
               "percentile"
-            ],
-            "example": "tukey",
+            ], 
+            "example": "tukey", 
             "type": "string"
           }
-        },
+        }, 
         "required": [
           "whisker_type"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ChartDataColumn": {
         "properties": {
           "column_name": {
-            "description": "The name of the target column",
-            "example": "mycol",
+            "description": "The name of the target column", 
+            "example": "mycol", 
             "type": "string"
-          },
+          }, 
           "type": {
-            "description": "Type of target column",
-            "example": "BIGINT",
+            "description": "Type of target column", 
+            "example": "BIGINT", 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ChartDataContributionOptionsSchema": {
         "properties": {
           "orientation": {
-            "description": "Should cell values be calculated across the row or column.",
+            "description": "Should cell values be calculated across the row or column.", 
             "enum": [
-              "row",
+              "row", 
               "column"
-            ],
-            "example": "row",
+            ], 
+            "example": "row", 
             "type": "string"
           }
-        },
+        }, 
         "required": [
           "orientation"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ChartDataDatasource": {
         "properties": {
           "id": {
-            "description": "Datasource id",
-            "format": "int32",
+            "description": "Datasource id", 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "type": {
-            "description": "Datasource type",
+            "description": "Datasource type", 
             "enum": [
-              "sl_table",
-              "table",
-              "dataset",
-              "query",
-              "saved_query",
+              "sl_table", 
+              "table", 
+              "dataset", 
+              "query", 
+              "saved_query", 
               "view"
-            ],
+            ], 
             "type": "string"
           }
-        },
+        }, 
         "required": [
           "id"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ChartDataExtras": {
         "properties": {
           "having": {
-            "description": "HAVING clause to be added to aggregate queries using AND operator.",
+            "description": "HAVING clause to be added to aggregate queries using AND operator.", 
             "type": "string"
-          },
+          }, 
           "having_druid": {
-            "description": "HAVING filters to be added to legacy Druid datasource queries. This field is deprecated",
+            "description": "HAVING filters to be added to legacy Druid datasource queries. This field is deprecated", 
             "items": {
               "$ref": "#/components/schemas/ChartDataFilter"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "relative_end": {
-            "description": "End time for relative time deltas. Default: `config[\"DEFAULT_RELATIVE_START_TIME\"]`",
+            "description": "End time for relative time deltas. Default: `config[\"DEFAULT_RELATIVE_START_TIME\"]`", 
             "enum": [
-              "today",
+              "today", 
               "now"
-            ],
+            ], 
             "type": "string"
-          },
+          }, 
           "relative_start": {
-            "description": "Start time for relative time deltas. Default: `config[\"DEFAULT_RELATIVE_START_TIME\"]`",
+            "description": "Start time for relative time deltas. Default: `config[\"DEFAULT_RELATIVE_START_TIME\"]`", 
             "enum": [
-              "today",
+              "today", 
               "now"
-            ],
+            ], 
             "type": "string"
-          },
+          }, 
           "time_grain_sqla": {
-            "description": "To what level of granularity should the temporal column be aggregated. Supports [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) durations.",
+            "description": "To what level of granularity should the temporal column be aggregated. Supports [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) durations.", 
             "enum": [
-              "PT1S",
-              "PT5S",
-              "PT30S",
-              "PT1M",
-              "PT5M",
-              "PT10M",
-              "PT15M",
-              "PT30M",
-              "PT1H",
-              "PT6H",
-              "P1D",
-              "P1W",
-              "P1M",
-              "P3M",
-              "P1Y",
-              "1969-12-28T00:00:00Z/P1W",
-              "1969-12-29T00:00:00Z/P1W",
-              "P1W/1970-01-03T00:00:00Z",
+              "PT1S", 
+              "PT5S", 
+              "PT30S", 
+              "PT1M", 
+              "PT5M", 
+              "PT10M", 
+              "PT15M", 
+              "PT30M", 
+              "PT1H", 
+              "PT6H", 
+              "P1D", 
+              "P1W", 
+              "P1M", 
+              "P3M", 
+              "P1Y", 
+              "1969-12-28T00:00:00Z/P1W", 
+              "1969-12-29T00:00:00Z/P1W", 
+              "P1W/1970-01-03T00:00:00Z", 
               "P1W/1970-01-04T00:00:00Z"
-            ],
-            "example": "P1D",
-            "nullable": true,
+            ], 
+            "example": "P1D", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "where": {
-            "description": "WHERE clause to be added to queries using AND operator.",
+            "description": "WHERE clause to be added to queries using AND operator.", 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ChartDataFilter": {
         "properties": {
           "col": {
-            "description": "The column to filter by. Can be either a string (physical or saved expression) or an object (adhoc column)",
+            "description": "The column to filter by. Can be either a string (physical or saved expression) or an object (adhoc column)", 
             "example": "country"
-          },
+          }, 
           "grain": {
-            "description": "Optional time grain for temporal filters",
-            "example": "PT1M",
+            "description": "Optional time grain for temporal filters", 
+            "example": "PT1M", 
             "type": "string"
-          },
+          }, 
           "isExtra": {
-            "description": "Indicates if the filter has been added by a filter component as opposed to being a part of the original query.",
+            "description": "Indicates if the filter has been added by a filter component as opposed to being a part of the original query.", 
             "type": "boolean"
-          },
+          }, 
           "op": {
-            "description": "The comparison operator.",
+            "description": "The comparison operator.", 
             "enum": [
-              "==",
-              "!=",
-              ">",
-              "<",
-              ">=",
-              "<=",
-              "LIKE",
-              "ILIKE",
-              "IS NULL",
-              "IS NOT NULL",
-              "IN",
-              "NOT IN",
-              "REGEX",
-              "IS TRUE",
-              "IS FALSE",
+              "==", 
+              "!=", 
+              ">", 
+              "<", 
+              ">=", 
+              "<=", 
+              "LIKE", 
+              "ILIKE", 
+              "IS NULL", 
+              "IS NOT NULL", 
+              "IN", 
+              "NOT IN", 
+              "REGEX", 
+              "IS TRUE", 
+              "IS FALSE", 
               "TEMPORAL_RANGE"
-            ],
-            "example": "IN",
+            ], 
+            "example": "IN", 
             "type": "string"
-          },
+          }, 
           "val": {
-            "description": "The value or values to compare against. Can be a string,integer,decimal,None or list,depending on the operator.",
+            "description": "The value or values to compare against. Can be a string, integer, decimal, None or list, depending on the operator.", 
             "example": [
-              "China",
-              "France",
+              "China", 
+              "France", 
               "Japan"
-            ],
+            ], 
             "nullable": true
           }
-        },
+        }, 
         "required": [
-          "col",
+          "col", 
           "op"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ChartDataGeodeticParseOptionsSchema": {
         "properties": {
           "altitude": {
-            "description": "Name of target column for decoded altitude. If omitted,altitude information in geodetic string is ignored.",
+            "description": "Name of target column for decoded altitude. If omitted, altitude information in geodetic string is ignored.", 
             "type": "string"
-          },
+          }, 
           "geodetic": {
-            "description": "Name of source column containing geodetic point strings",
+            "description": "Name of source column containing geodetic point strings", 
             "type": "string"
-          },
+          }, 
           "latitude": {
-            "description": "Name of target column for decoded latitude",
+            "description": "Name of target column for decoded latitude", 
             "type": "string"
-          },
+          }, 
           "longitude": {
-            "description": "Name of target column for decoded longitude",
+            "description": "Name of target column for decoded longitude", 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "geodetic",
-          "latitude",
+          "geodetic", 
+          "latitude", 
           "longitude"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ChartDataGeohashDecodeOptionsSchema": {
         "properties": {
           "geohash": {
-            "description": "Name of source column containing geohash string",
+            "description": "Name of source column containing geohash string", 
             "type": "string"
-          },
+          }, 
           "latitude": {
-            "description": "Name of target column for decoded latitude",
+            "description": "Name of target column for decoded latitude", 
             "type": "string"
-          },
+          }, 
           "longitude": {
-            "description": "Name of target column for decoded longitude",
+            "description": "Name of target column for decoded longitude", 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "geohash",
-          "latitude",
+          "geohash", 
+          "latitude", 
           "longitude"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ChartDataGeohashEncodeOptionsSchema": {
         "properties": {
           "geohash": {
-            "description": "Name of target column for encoded geohash string",
+            "description": "Name of target column for encoded geohash string", 
             "type": "string"
-          },
+          }, 
           "latitude": {
-            "description": "Name of source latitude column",
+            "description": "Name of source latitude column", 
             "type": "string"
-          },
+          }, 
           "longitude": {
-            "description": "Name of source longitude column",
+            "description": "Name of source longitude column", 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "geohash",
-          "latitude",
+          "geohash", 
+          "latitude", 
           "longitude"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ChartDataPivotOptionsSchema": {
         "properties": {
           "aggregates": {
-            "description": "The keys are the name of the aggregate column to be created,and the values specify the details of how to apply the aggregation. If an operator requires additional options,these can be passed here to be unpacked in the operator call. The following numpy operators are supported: average,argmin,argmax,cumsum,cumprod,max,mean,median,nansum,nanmin,nanmax,nanmean,nanmedian,min,percentile,prod,product,std,sum,var. Any options required by the operator can be passed to the `options` object.\n\nIn the example,a new column `first_quantile` is created based on values in the column `my_col` using the `percentile` operator with the `q=0.25` parameter.",
+            "description": "The keys are the name of the aggregate column to be created, and the values specify the details of how to apply the aggregation. If an operator requires additional options, these can be passed here to be unpacked in the operator call. The following numpy operators are supported: average, argmin, argmax, cumsum, cumprod, max, mean, median, nansum, nanmin, nanmax, nanmean, nanmedian, min, percentile, prod, product, std, sum, var. Any options required by the operator can be passed to the `options` object.\n\nIn the example, a new column `first_quantile` is created based on values in the column `my_col` using the `percentile` operator with the `q=0.25` parameter.", 
             "example": {
               "first_quantile": {
-                "column": "my_col",
-                "operator": "percentile",
+                "column": "my_col", 
+                "operator": "percentile", 
                 "options": {
                   "q": 0.25
                 }
               }
-            },
+            }, 
             "type": "object"
-          },
+          }, 
           "column_fill_value": {
-            "description": "Value to replace missing pivot columns names with.",
+            "description": "Value to replace missing pivot columns names with.", 
             "type": "string"
-          },
+          }, 
           "columns": {
-            "description": "Columns to group by on the table columns",
+            "description": "Columns to group by on the table columns", 
             "items": {
               "type": "string"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "drop_missing_columns": {
-            "description": "Do not include columns whose entries are all missing (default: `true`).",
+            "description": "Do not include columns whose entries are all missing (default: `true`).", 
             "type": "boolean"
-          },
+          }, 
           "marginal_distribution_name": {
-            "description": "Name of marginal distribution row/column. (default: `All`)",
+            "description": "Name of marginal distribution row/column. (default: `All`)", 
             "type": "string"
-          },
+          }, 
           "marginal_distributions": {
-            "description": "Add totals for row/column. (default: `false`)",
+            "description": "Add totals for row/column. (default: `false`)", 
             "type": "boolean"
-          },
+          }, 
           "metric_fill_value": {
-            "description": "Value to replace missing values with in aggregate calculations.",
+            "description": "Value to replace missing values with in aggregate calculations.", 
             "type": "number"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ChartDataPostProcessingOperation": {
         "properties": {
           "operation": {
-            "description": "Post processing operation type",
+            "description": "Post processing operation type", 
             "enum": [
-              "aggregate",
-              "boxplot",
-              "compare",
-              "contribution",
-              "cum",
-              "diff",
-              "escape_separator",
-              "flatten",
-              "geodetic_parse",
-              "geohash_decode",
-              "geohash_encode",
-              "pivot",
-              "prophet",
-              "rename",
-              "resample",
-              "rolling",
-              "select",
-              "sort",
+              "aggregate", 
+              "boxplot", 
+              "compare", 
+              "contribution", 
+              "cum", 
+              "diff", 
+              "escape_separator", 
+              "flatten", 
+              "geodetic_parse", 
+              "geohash_decode", 
+              "geohash_encode", 
+              "pivot", 
+              "prophet", 
+              "rename", 
+              "resample", 
+              "rolling", 
+              "select", 
+              "sort", 
               "unescape_separator"
-            ],
-            "example": "aggregate",
+            ], 
+            "example": "aggregate", 
             "type": "string"
-          },
+          }, 
           "options": {
-            "description": "Options specifying how to perform the operation. Please refer to the respective post processing operation option schemas. For example,`ChartDataPostProcessingOperationOptions` specifies the required options for the pivot operation.",
+            "description": "Options specifying how to perform the operation. Please refer to the respective post processing operation option schemas. For example, `ChartDataPostProcessingOperationOptions` specifies the required options for the pivot operation.", 
             "example": {
               "aggregates": {
                 "age_mean": {
-                  "column": "age",
+                  "column": "age", 
                   "operator": "mean"
-                },
+                }, 
                 "age_q1": {
-                  "column": "age",
-                  "operator": "percentile",
+                  "column": "age", 
+                  "operator": "percentile", 
                   "options": {
                     "q": 0.25
                   }
                 }
-              },
+              }, 
               "groupby": [
-                "country",
+                "country", 
                 "gender"
               ]
-            },
+            }, 
             "type": "object"
           }
-        },
+        }, 
         "required": [
           "operation"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ChartDataProphetOptionsSchema": {
         "properties": {
           "confidence_interval": {
-            "description": "Width of predicted confidence interval",
-            "example": 0.8,
-            "format": "float",
-            "maximum": 1,
-            "minimum": 0,
+            "description": "Width of predicted confidence interval", 
+            "example": 0.8, 
+            "format": "float", 
+            "maximum": 1, 
+            "minimum": 0, 
             "type": "number"
-          },
+          }, 
           "monthly_seasonality": {
-            "description": "Should monthly seasonality be applied. An integer value will specify Fourier order of seasonality,`None` will automatically detect seasonality.",
+            "description": "Should monthly seasonality be applied. An integer value will specify Fourier order of seasonality, `None` will automatically detect seasonality.", 
             "example": false
-          },
+          }, 
           "periods": {
-            "example": 7,
-            "format": "int32",
+            "example": 7, 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "time_grain": {
-            "description": "Time grain used to specify time period increments in prediction. Supports [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) durations.",
+            "description": "Time grain used to specify time period increments in prediction. Supports [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) durations.", 
             "enum": [
-              "PT1S",
-              "PT5S",
-              "PT30S",
-              "PT1M",
-              "PT5M",
-              "PT10M",
-              "PT15M",
-              "PT30M",
-              "PT1H",
-              "PT6H",
-              "P1D",
-              "P1W",
-              "P1M",
-              "P3M",
-              "P1Y",
-              "1969-12-28T00:00:00Z/P1W",
-              "1969-12-29T00:00:00Z/P1W",
-              "P1W/1970-01-03T00:00:00Z",
+              "PT1S", 
+              "PT5S", 
+              "PT30S", 
+              "PT1M", 
+              "PT5M", 
+              "PT10M", 
+              "PT15M", 
+              "PT30M", 
+              "PT1H", 
+              "PT6H", 
+              "P1D", 
+              "P1W", 
+              "P1M", 
+              "P3M", 
+              "P1Y", 
+              "1969-12-28T00:00:00Z/P1W", 
+              "1969-12-29T00:00:00Z/P1W", 
+              "P1W/1970-01-03T00:00:00Z", 
               "P1W/1970-01-04T00:00:00Z"
-            ],
-            "example": "P1D",
+            ], 
+            "example": "P1D", 
             "type": "string"
-          },
+          }, 
           "weekly_seasonality": {
-            "description": "Should weekly seasonality be applied. An integer value will specify Fourier order of seasonality,`None` will automatically detect seasonality.",
+            "description": "Should weekly seasonality be applied. An integer value will specify Fourier order of seasonality, `None` will automatically detect seasonality.", 
             "example": false
-          },
+          }, 
           "yearly_seasonality": {
-            "description": "Should yearly seasonality be applied. An integer value will specify Fourier order of seasonality,`None` will automatically detect seasonality.",
+            "description": "Should yearly seasonality be applied. An integer value will specify Fourier order of seasonality, `None` will automatically detect seasonality.", 
             "example": false
           }
-        },
+        }, 
         "required": [
-          "confidence_interval",
-          "periods",
+          "confidence_interval", 
+          "periods", 
           "time_grain"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ChartDataQueryContextSchema": {
         "properties": {
           "custom_cache_timeout": {
-            "description": "Override the default cache timeout",
-            "format": "int32",
-            "nullable": true,
+            "description": "Override the default cache timeout", 
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "datasource": {
             "$ref": "#/components/schemas/ChartDataDatasource"
-          },
+          }, 
           "force": {
-            "description": "Should the queries be forced to load from the source. Default: `false`",
-            "nullable": true,
+            "description": "Should the queries be forced to load from the source. Default: `false`", 
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "form_data": {
             "nullable": true
-          },
+          }, 
           "queries": {
             "items": {
               "$ref": "#/components/schemas/ChartDataQueryObject"
-            },
+            }, 
             "type": "array"
-          },
-          "result_format": {},
+          }, 
+          "result_format": {}, 
           "result_type": {}
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ChartDataQueryObject": {
         "properties": {
           "annotation_layers": {
-            "description": "Annotation layers to apply to chart",
+            "description": "Annotation layers to apply to chart", 
             "items": {
               "$ref": "#/components/schemas/AnnotationLayer"
-            },
-            "nullable": true,
+            }, 
+            "nullable": true, 
             "type": "array"
-          },
+          }, 
           "applied_time_extras": {
-            "description": "A mapping of temporal extras that have been applied to the query",
+            "description": "A mapping of temporal extras that have been applied to the query", 
             "example": {
               "__time_range": "1 year ago : now"
-            },
-            "nullable": true,
+            }, 
+            "nullable": true, 
             "type": "object"
-          },
+          }, 
           "apply_fetch_values_predicate": {
-            "description": "Add fetch values predicate (where clause) to query if defined in datasource",
-            "nullable": true,
+            "description": "Add fetch values predicate (where clause) to query if defined in datasource", 
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "columns": {
-            "description": "Columns which to select in the query.",
-            "items": {},
-            "nullable": true,
+            "description": "Columns which to select in the query.", 
+            "items": {}, 
+            "nullable": true, 
             "type": "array"
-          },
+          }, 
           "datasource": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/ChartDataDatasource"
               }
-            ],
+            ], 
             "nullable": true
-          },
+          }, 
           "druid_time_origin": {
-            "description": "Starting point for time grain counting on legacy Druid datasources. Used to change e.g. Monday/Sunday first-day-of-week. This field is deprecated and should be passed to `extras` as `druid_time_origin`.",
-            "nullable": true,
+            "description": "Starting point for time grain counting on legacy Druid datasources. Used to change e.g. Monday/Sunday first-day-of-week. This field is deprecated and should be passed to `extras` as `druid_time_origin`.", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "extras": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/ChartDataExtras"
               }
-            ],
-            "description": "Extra parameters to add to the query.",
+            ], 
+            "description": "Extra parameters to add to the query.", 
             "nullable": true
-          },
+          }, 
           "filters": {
             "items": {
               "$ref": "#/components/schemas/ChartDataFilter"
-            },
-            "nullable": true,
+            }, 
+            "nullable": true, 
             "type": "array"
-          },
+          }, 
           "granularity": {
-            "description": "Name of temporal column used for time filtering. For legacy Druid datasources this defines the time grain.",
-            "nullable": true,
+            "description": "Name of temporal column used for time filtering. For legacy Druid datasources this defines the time grain.", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "granularity_sqla": {
-            "description": "Name of temporal column used for time filtering for SQL datasources. This field is deprecated,use `granularity` instead.",
-            "nullable": true,
+            "description": "Name of temporal column used for time filtering for SQL datasources. This field is deprecated, use `granularity` instead.", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "groupby": {
-            "description": "Columns by which to group the query. This field is deprecated,use `columns` instead.",
-            "items": {},
-            "nullable": true,
+            "description": "Columns by which to group the query. This field is deprecated, use `columns` instead.", 
+            "items": {}, 
+            "nullable": true, 
             "type": "array"
-          },
+          }, 
           "having": {
-            "description": "HAVING clause to be added to aggregate queries using AND operator. This field is deprecated and should be passed to `extras`.",
-            "nullable": true,
+            "description": "HAVING clause to be added to aggregate queries using AND operator. This field is deprecated and should be passed to `extras`.", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "having_filters": {
-            "description": "HAVING filters to be added to legacy Druid datasource queries. This field is deprecated and should be passed to `extras` as `having_druid`.",
+            "description": "HAVING filters to be added to legacy Druid datasource queries. This field is deprecated and should be passed to `extras` as `having_druid`.", 
             "items": {
               "$ref": "#/components/schemas/ChartDataFilter"
-            },
-            "nullable": true,
+            }, 
+            "nullable": true, 
             "type": "array"
-          },
+          }, 
           "is_rowcount": {
-            "description": "Should the rowcount of the actual query be returned",
-            "nullable": true,
+            "description": "Should the rowcount of the actual query be returned", 
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "is_timeseries": {
-            "description": "Is the `query_object` a timeseries.",
-            "nullable": true,
+            "description": "Is the `query_object` a timeseries.", 
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "metrics": {
-            "description": "Aggregate expressions. Metrics can be passed as both references to datasource metrics (strings),or ad-hoc metricswhich are defined only within the query object. See `ChartDataAdhocMetricSchema` for the structure of ad-hoc metrics.",
-            "items": {},
-            "nullable": true,
+            "description": "Aggregate expressions. Metrics can be passed as both references to datasource metrics (strings), or ad-hoc metricswhich are defined only within the query object. See `ChartDataAdhocMetricSchema` for the structure of ad-hoc metrics.", 
+            "items": {}, 
+            "nullable": true, 
             "type": "array"
-          },
+          }, 
           "order_desc": {
-            "description": "Reverse order. Default: `false`",
-            "nullable": true,
+            "description": "Reverse order. Default: `false`", 
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "orderby": {
-            "description": "Expects a list of lists where the first element is the column name which to sort by,and the second element is a boolean.",
+            "description": "Expects a list of lists where the first element is the column name which to sort by, and the second element is a boolean.", 
             "example": [
               [
-                "my_col_1",
+                "my_col_1", 
                 false
-              ],
+              ], 
               [
-                "my_col_2",
+                "my_col_2", 
                 true
               ]
-            ],
-            "items": {},
-            "nullable": true,
+            ], 
+            "items": {}, 
+            "nullable": true, 
             "type": "array"
-          },
+          }, 
           "post_processing": {
-            "description": "Post processing operations to be applied to the result set. Operations are applied to the result set in sequential order.",
+            "description": "Post processing operations to be applied to the result set. Operations are applied to the result set in sequential order.", 
             "items": {
               "allOf": [
                 {
                   "$ref": "#/components/schemas/ChartDataPostProcessingOperation"
                 }
-              ],
+              ], 
               "nullable": true
-            },
-            "nullable": true,
+            }, 
+            "nullable": true, 
             "type": "array"
-          },
+          }, 
           "result_type": {
             "nullable": true
-          },
+          }, 
           "row_limit": {
-            "description": "Maximum row count (0=disabled). Default: `config[\"ROW_LIMIT\"]`",
-            "format": "int32",
-            "minimum": 0,
-            "nullable": true,
+            "description": "Maximum row count (0=disabled). Default: `config[\"ROW_LIMIT\"]`", 
+            "format": "int32", 
+            "minimum": 0, 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "row_offset": {
-            "description": "Number of rows to skip. Default: `0`",
-            "format": "int32",
-            "minimum": 0,
-            "nullable": true,
+            "description": "Number of rows to skip. Default: `0`", 
+            "format": "int32", 
+            "minimum": 0, 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "series_columns": {
-            "description": "Columns to use when limiting series count. All columns must be present in the `columns` property. Requires `series_limit` and `series_limit_metric` to be set.",
-            "items": {},
-            "nullable": true,
+            "description": "Columns to use when limiting series count. All columns must be present in the `columns` property. Requires `series_limit` and `series_limit_metric` to be set.", 
+            "items": {}, 
+            "nullable": true, 
             "type": "array"
-          },
+          }, 
           "series_limit": {
-            "description": "Maximum number of series. Requires `series` and `series_limit_metric` to be set.",
-            "format": "int32",
-            "nullable": true,
+            "description": "Maximum number of series. Requires `series` and `series_limit_metric` to be set.", 
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "series_limit_metric": {
-            "description": "Metric used to limit timeseries queries by. Requires `series` and `series_limit` to be set.",
+            "description": "Metric used to limit timeseries queries by. Requires `series` and `series_limit` to be set.", 
             "nullable": true
-          },
+          }, 
           "time_offsets": {
             "items": {
               "type": "string"
-            },
-            "nullable": true,
+            }, 
+            "nullable": true, 
             "type": "array"
-          },
+          }, 
           "time_range": {
-            "description": "A time rage,either expressed as a colon separated string `since : until` or human readable freeform. Valid formats for `since` and `until` are: \n- ISO 8601\n- X days/years/hours/day/year/weeks\n- X days/years/hours/day/year/weeks ago\n- X days/years/hours/day/year/weeks from now\n\nAdditionally,the following freeform can be used:\n\n- Last day\n- Last week\n- Last month\n- Last quarter\n- Last year\n- No filter\n- Last X seconds/minutes/hours/days/weeks/months/years\n- Next X seconds/minutes/hours/days/weeks/months/years\n",
-            "example": "Last week",
-            "nullable": true,
+            "description": "A time rage, either expressed as a colon separated string `since : until` or human readable freeform. Valid formats for `since` and `until` are: \n- ISO 8601\n- X days/years/hours/day/year/weeks\n- X days/years/hours/day/year/weeks ago\n- X days/years/hours/day/year/weeks from now\n\nAdditionally, the following freeform can be used:\n\n- Last day\n- Last week\n- Last month\n- Last quarter\n- Last year\n- No filter\n- Last X seconds/minutes/hours/days/weeks/months/years\n- Next X seconds/minutes/hours/days/weeks/months/years\n", 
+            "example": "Last week", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "time_shift": {
-            "description": "A human-readable date/time string. Please refer to [parsdatetime](https://github.com/bear/parsedatetime) documentation for details on valid values.",
-            "nullable": true,
+            "description": "A human-readable date/time string. Please refer to [parsdatetime](https://github.com/bear/parsedatetime) documentation for details on valid values.", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "timeseries_limit": {
-            "description": "Maximum row count for timeseries queries. This field is deprecated,use `series_limit` instead.Default: `0`",
-            "format": "int32",
-            "nullable": true,
+            "description": "Maximum row count for timeseries queries. This field is deprecated, use `series_limit` instead.Default: `0`", 
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "timeseries_limit_metric": {
-            "description": "Metric used to limit timeseries queries by. This field is deprecated,use `series_limit_metric` instead.",
+            "description": "Metric used to limit timeseries queries by. This field is deprecated, use `series_limit_metric` instead.", 
             "nullable": true
-          },
+          }, 
           "url_params": {
             "additionalProperties": {
-              "description": "The value of the query parameter",
+              "description": "The value of the query parameter", 
               "type": "string"
-            },
-            "description": "Optional query parameters passed to a dashboard or Explore view",
-            "nullable": true,
+            }, 
+            "description": "Optional query parameters passed to a dashboard or Explore view", 
+            "nullable": true, 
             "type": "object"
-          },
+          }, 
           "where": {
-            "description": "WHERE clause to be added to queries using AND operator.This field is deprecated and should be passed to `extras`.",
-            "nullable": true,
+            "description": "WHERE clause to be added to queries using AND operator.This field is deprecated and should be passed to `extras`.", 
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ChartDataResponseResult": {
         "properties": {
           "annotation_data": {
-            "description": "All requested annotation data",
+            "description": "All requested annotation data", 
             "items": {
               "additionalProperties": {
                 "type": "string"
-              },
+              }, 
               "type": "object"
-            },
-            "nullable": true,
+            }, 
+            "nullable": true, 
             "type": "array"
-          },
+          }, 
           "applied_filters": {
-            "description": "A list with applied filters",
+            "description": "A list with applied filters", 
             "items": {
               "type": "object"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "cache_key": {
-            "description": "Unique cache key for query object",
-            "nullable": true,
+            "description": "Unique cache key for query object", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "cache_timeout": {
-            "description": "Cache timeout in following order: custom timeout,datasource timeout,cache default timeout,config default cache timeout.",
-            "format": "int32",
-            "nullable": true,
+            "description": "Cache timeout in following order: custom timeout, datasource timeout, cache default timeout, config default cache timeout.", 
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "cached_dttm": {
-            "description": "Cache timestamp",
-            "nullable": true,
+            "description": "Cache timestamp", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "colnames": {
-            "description": "A list of column names",
+            "description": "A list of column names", 
             "items": {
               "type": "string"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "coltypes": {
-            "description": "A list of generic data types of each column",
+            "description": "A list of generic data types of each column", 
             "items": {
-              "format": "int32",
+              "format": "int32", 
               "type": "integer"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "data": {
-            "description": "A list with results",
+            "description": "A list with results", 
             "items": {
               "type": "object"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "error": {
-            "description": "Error",
-            "nullable": true,
+            "description": "Error", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "from_dttm": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "is_cached": {
-            "description": "Is the result cached",
+            "description": "Is the result cached", 
             "type": "boolean"
-          },
+          }, 
           "query": {
-            "description": "The executed query statement",
+            "description": "The executed query statement", 
             "type": "string"
-          },
+          }, 
           "rejected_filters": {
-            "description": "A list with rejected filters",
+            "description": "A list with rejected filters", 
             "items": {
               "type": "object"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "rowcount": {
-            "description": "Amount of rows in result set",
-            "format": "int32",
+            "description": "Amount of rows in result set", 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "stacktrace": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "status": {
-            "description": "Status of the query",
+            "description": "Status of the query", 
             "enum": [
-              "stopped",
-              "failed",
-              "pending",
-              "running",
-              "scheduled",
-              "success",
+              "stopped", 
+              "failed", 
+              "pending", 
+              "running", 
+              "scheduled", 
+              "success", 
               "timed_out"
-            ],
+            ], 
             "type": "string"
-          },
+          }, 
           "to_dttm": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
           }
-        },
+        }, 
         "required": [
-          "cache_key",
-          "cache_timeout",
-          "cached_dttm",
-          "is_cached",
+          "cache_key", 
+          "cache_timeout", 
+          "cached_dttm", 
+          "is_cached", 
           "query"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ChartDataResponseSchema": {
         "properties": {
           "result": {
-            "description": "A list of results for each corresponding query in the request.",
+            "description": "A list of results for each corresponding query in the request.", 
             "items": {
               "$ref": "#/components/schemas/ChartDataResponseResult"
-            },
+            }, 
             "type": "array"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ChartDataRestApi.get": {
         "properties": {
           "cache_timeout": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "certification_details": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "certified_by": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "changed_on_delta_humanized": {
             "readOnly": true
-          },
+          }, 
           "dashboards": {
             "$ref": "#/components/schemas/ChartDataRestApi.get.Dashboard"
-          },
+          }, 
           "description": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "is_managed_externally": {
             "type": "boolean"
-          },
+          }, 
           "owners": {
             "$ref": "#/components/schemas/ChartDataRestApi.get.User"
-          },
+          }, 
           "params": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "query_context": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "slice_name": {
-            "maxLength": 250,
-            "nullable": true,
+            "maxLength": 250, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "thumbnail_url": {
             "readOnly": true
-          },
+          }, 
           "url": {
             "readOnly": true
-          },
+          }, 
           "viz_type": {
-            "maxLength": 250,
-            "nullable": true,
+            "maxLength": 250, 
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ChartDataRestApi.get.Dashboard": {
         "properties": {
           "dashboard_title": {
-            "maxLength": 500,
-            "nullable": true,
+            "maxLength": 500, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "json_metadata": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ChartDataRestApi.get.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "username": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
-          "last_name",
+          "first_name", 
+          "last_name", 
           "username"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ChartDataRestApi.get_list": {
         "properties": {
           "cache_timeout": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "certification_details": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "certified_by": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "changed_by": {
             "$ref": "#/components/schemas/ChartDataRestApi.get_list.User1"
-          },
+          }, 
           "changed_by_name": {
             "readOnly": true
-          },
+          }, 
           "changed_by_url": {
             "readOnly": true
-          },
+          }, 
           "changed_on_delta_humanized": {
             "readOnly": true
-          },
+          }, 
           "changed_on_utc": {
             "readOnly": true
-          },
+          }, 
           "created_by": {
             "$ref": "#/components/schemas/ChartDataRestApi.get_list.User3"
-          },
+          }, 
           "created_on_delta_humanized": {
             "readOnly": true
-          },
+          }, 
           "dashboards": {
             "$ref": "#/components/schemas/ChartDataRestApi.get_list.Dashboard"
-          },
+          }, 
           "datasource_id": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "datasource_name_text": {
             "readOnly": true
-          },
+          }, 
           "datasource_type": {
-            "maxLength": 200,
-            "nullable": true,
+            "maxLength": 200, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "datasource_url": {
             "readOnly": true
-          },
+          }, 
           "description": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "description_markeddown": {
             "readOnly": true
-          },
+          }, 
           "edit_url": {
             "readOnly": true
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "is_managed_externally": {
             "type": "boolean"
-          },
+          }, 
           "last_saved_at": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "last_saved_by": {
             "$ref": "#/components/schemas/ChartDataRestApi.get_list.User"
-          },
+          }, 
           "owners": {
             "$ref": "#/components/schemas/ChartDataRestApi.get_list.User2"
-          },
+          }, 
           "params": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "slice_name": {
-            "maxLength": 250,
-            "nullable": true,
+            "maxLength": 250, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "table": {
             "$ref": "#/components/schemas/ChartDataRestApi.get_list.SqlaTable"
-          },
+          }, 
           "thumbnail_url": {
             "readOnly": true
-          },
+          }, 
           "url": {
             "readOnly": true
-          },
+          }, 
           "viz_type": {
-            "maxLength": 250,
-            "nullable": true,
+            "maxLength": 250, 
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ChartDataRestApi.get_list.Dashboard": {
         "properties": {
           "dashboard_title": {
-            "maxLength": 500,
-            "nullable": true,
+            "maxLength": 500, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ChartDataRestApi.get_list.SqlaTable": {
         "properties": {
           "default_endpoint": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "table_name": {
-            "maxLength": 250,
+            "maxLength": 250, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
           "table_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ChartDataRestApi.get_list.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
+          "first_name", 
           "last_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ChartDataRestApi.get_list.User1": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
+          "first_name", 
           "last_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ChartDataRestApi.get_list.User2": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "username": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
-          "last_name",
+          "first_name", 
+          "last_name", 
           "username"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ChartDataRestApi.get_list.User3": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
+          "first_name", 
           "last_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ChartDataRestApi.post": {
         "properties": {
           "cache_timeout": {
-            "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.",
-            "format": "int32",
-            "nullable": true,
+            "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.", 
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "certification_details": {
-            "description": "Details of the certification",
-            "nullable": true,
+            "description": "Details of the certification", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "certified_by": {
-            "description": "Person or group that has certified this chart",
-            "nullable": true,
+            "description": "Person or group that has certified this chart", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "dashboards": {
             "items": {
-              "description": "A list of dashboards to include this new chart to.",
-              "format": "int32",
+              "description": "A list of dashboards to include this new chart to.", 
+              "format": "int32", 
               "type": "integer"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "datasource_id": {
-            "description": "The id of the dataset/datasource this new chart will use. A complete datasource identification needs `datasouce_id` and `datasource_type`.",
-            "format": "int32",
+            "description": "The id of the dataset/datasource this new chart will use. A complete datasource identification needs `datasouce_id` and `datasource_type`.", 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "datasource_name": {
-            "description": "The datasource name.",
-            "nullable": true,
+            "description": "The datasource name.", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "datasource_type": {
-            "description": "The type of dataset/datasource identified on `datasource_id`.",
+            "description": "The type of dataset/datasource identified on `datasource_id`.", 
             "enum": [
-              "sl_table",
-              "table",
-              "dataset",
-              "query",
-              "saved_query",
+              "sl_table", 
+              "table", 
+              "dataset", 
+              "query", 
+              "saved_query", 
               "view"
-            ],
+            ], 
             "type": "string"
-          },
+          }, 
           "description": {
-            "description": "A description of the chart propose.",
-            "nullable": true,
+            "description": "A description of the chart propose.", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "external_url": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "is_managed_externally": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "owners": {
             "items": {
-              "description": "Owner are users ids allowed to delete or change this chart. If left empty you will be one of the owners of the chart.",
-              "format": "int32",
+              "description": "Owner are users ids allowed to delete or change this chart. If left empty you will be one of the owners of the chart.", 
+              "format": "int32", 
               "type": "integer"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "params": {
-            "description": "Parameters are generated dynamically when clicking the save or overwrite button in the explore view. This JSON object for power users who may want to alter specific parameters.",
-            "nullable": true,
+            "description": "Parameters are generated dynamically when clicking the save or overwrite button in the explore view. This JSON object for power users who may want to alter specific parameters.", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "query_context": {
-            "description": "The query context represents the queries that need to run in order to generate the data the visualization,and in what format the data should be returned.",
-            "nullable": true,
+            "description": "The query context represents the queries that need to run in order to generate the data the visualization, and in what format the data should be returned.", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "query_context_generation": {
-            "description": "The query context generation represents whether the query_contextis user generated or not so that it does not update user modfiedstate.",
-            "nullable": true,
+            "description": "The query context generation represents whether the query_contextis user generated or not so that it does not update user modfiedstate.", 
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "slice_name": {
-            "description": "The name of the chart.",
-            "maxLength": 250,
-            "minLength": 1,
+            "description": "The name of the chart.", 
+            "maxLength": 250, 
+            "minLength": 1, 
             "type": "string"
-          },
+          }, 
           "viz_type": {
-            "description": "The type of chart visualization used.",
+            "description": "The type of chart visualization used.", 
             "example": [
-              "bar",
-              "line_multi",
-              "area",
+              "bar", 
+              "line_multi", 
+              "area", 
               "table"
-            ],
-            "maxLength": 250,
-            "minLength": 0,
+            ], 
+            "maxLength": 250, 
+            "minLength": 0, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "datasource_id",
-          "datasource_type",
+          "datasource_id", 
+          "datasource_type", 
           "slice_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ChartDataRestApi.put": {
         "properties": {
           "cache_timeout": {
-            "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.",
-            "format": "int32",
-            "nullable": true,
+            "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.", 
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "certification_details": {
-            "description": "Details of the certification",
-            "nullable": true,
+            "description": "Details of the certification", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "certified_by": {
-            "description": "Person or group that has certified this chart",
-            "nullable": true,
+            "description": "Person or group that has certified this chart", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "dashboards": {
             "items": {
-              "description": "A list of dashboards to include this new chart to.",
-              "format": "int32",
+              "description": "A list of dashboards to include this new chart to.", 
+              "format": "int32", 
               "type": "integer"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "datasource_id": {
-            "description": "The id of the dataset/datasource this new chart will use. A complete datasource identification needs `datasouce_id` and `datasource_type`.",
-            "format": "int32",
-            "nullable": true,
+            "description": "The id of the dataset/datasource this new chart will use. A complete datasource identification needs `datasouce_id` and `datasource_type`.", 
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "datasource_type": {
-            "description": "The type of dataset/datasource identified on `datasource_id`.",
+            "description": "The type of dataset/datasource identified on `datasource_id`.", 
             "enum": [
-              "sl_table",
-              "table",
-              "dataset",
-              "query",
-              "saved_query",
+              "sl_table", 
+              "table", 
+              "dataset", 
+              "query", 
+              "saved_query", 
               "view"
-            ],
-            "nullable": true,
+            ], 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "description": {
-            "description": "A description of the chart propose.",
-            "nullable": true,
+            "description": "A description of the chart propose.", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "external_url": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "is_managed_externally": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "owners": {
             "items": {
-              "description": "Owner are users ids allowed to delete or change this chart. If left empty you will be one of the owners of the chart.",
-              "format": "int32",
+              "description": "Owner are users ids allowed to delete or change this chart. If left empty you will be one of the owners of the chart.", 
+              "format": "int32", 
               "type": "integer"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "params": {
-            "description": "Parameters are generated dynamically when clicking the save or overwrite button in the explore view. This JSON object for power users who may want to alter specific parameters.",
-            "nullable": true,
+            "description": "Parameters are generated dynamically when clicking the save or overwrite button in the explore view. This JSON object for power users who may want to alter specific parameters.", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "query_context": {
-            "description": "The query context represents the queries that need to run in order to generate the data the visualization,and in what format the data should be returned.",
-            "nullable": true,
+            "description": "The query context represents the queries that need to run in order to generate the data the visualization, and in what format the data should be returned.", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "query_context_generation": {
-            "description": "The query context generation represents whether the query_contextis user generated or not so that it does not update user modfiedstate.",
-            "nullable": true,
+            "description": "The query context generation represents whether the query_contextis user generated or not so that it does not update user modfiedstate.", 
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "slice_name": {
-            "description": "The name of the chart.",
-            "maxLength": 250,
-            "minLength": 0,
-            "nullable": true,
+            "description": "The name of the chart.", 
+            "maxLength": 250, 
+            "minLength": 0, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "viz_type": {
-            "description": "The type of chart visualization used.",
+            "description": "The type of chart visualization used.", 
             "example": [
-              "bar",
-              "line_multi",
-              "area",
+              "bar", 
+              "line_multi", 
+              "area", 
               "table"
-            ],
-            "maxLength": 250,
-            "minLength": 0,
-            "nullable": true,
+            ], 
+            "maxLength": 250, 
+            "minLength": 0, 
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ChartDataRollingOptionsSchema": {
         "properties": {
           "center": {
-            "description": "Should the label be at the center of the window. Default: `false`",
-            "example": false,
+            "description": "Should the label be at the center of the window. Default: `false`", 
+            "example": false, 
             "type": "boolean"
-          },
+          }, 
           "min_periods": {
-            "description": "The minimum amount of periods required for a row to be included in the result set.",
-            "example": 7,
-            "format": "int32",
+            "description": "The minimum amount of periods required for a row to be included in the result set.", 
+            "example": 7, 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "rolling_type": {
-            "description": "Type of rolling window. Any numpy function will work.",
+            "description": "Type of rolling window. Any numpy function will work.", 
             "enum": [
-              "average",
-              "argmin",
-              "argmax",
-              "cumsum",
-              "cumprod",
-              "max",
-              "mean",
-              "median",
-              "nansum",
-              "nanmin",
-              "nanmax",
-              "nanmean",
-              "nanmedian",
-              "nanpercentile",
-              "min",
-              "percentile",
-              "prod",
-              "product",
-              "std",
-              "sum",
+              "average", 
+              "argmin", 
+              "argmax", 
+              "cumsum", 
+              "cumprod", 
+              "max", 
+              "mean", 
+              "median", 
+              "nansum", 
+              "nanmin", 
+              "nanmax", 
+              "nanmean", 
+              "nanmedian", 
+              "nanpercentile", 
+              "min", 
+              "percentile", 
+              "prod", 
+              "product", 
+              "std", 
+              "sum", 
               "var"
-            ],
-            "example": "percentile",
+            ], 
+            "example": "percentile", 
             "type": "string"
-          },
+          }, 
           "rolling_type_options": {
-            "example": {},
+            "example": {}, 
             "type": "object"
-          },
+          }, 
           "win_type": {
-            "description": "Type of window function. See [SciPy window functions](https://docs.scipy.org/doc/scipy/reference/signal.windows.html#module-scipy.signal.windows) for more details. Some window functions require passing additional parameters to `rolling_type_options`. For instance,to use `gaussian`,the parameter `std` needs to be provided.",
+            "description": "Type of window function. See [SciPy window functions](https://docs.scipy.org/doc/scipy/reference/signal.windows.html#module-scipy.signal.windows) for more details. Some window functions require passing additional parameters to `rolling_type_options`. For instance, to use `gaussian`, the parameter `std` needs to be provided.", 
             "enum": [
-              "boxcar",
-              "triang",
-              "blackman",
-              "hamming",
-              "bartlett",
-              "parzen",
-              "bohman",
-              "blackmanharris",
-              "nuttall",
-              "barthann",
-              "kaiser",
-              "gaussian",
-              "general_gaussian",
-              "slepian",
+              "boxcar", 
+              "triang", 
+              "blackman", 
+              "hamming", 
+              "bartlett", 
+              "parzen", 
+              "bohman", 
+              "blackmanharris", 
+              "nuttall", 
+              "barthann", 
+              "kaiser", 
+              "gaussian", 
+              "general_gaussian", 
+              "slepian", 
               "exponential"
-            ],
+            ], 
             "type": "string"
-          },
+          }, 
           "window": {
-            "description": "Size of the rolling window in days.",
-            "example": 7,
-            "format": "int32",
+            "description": "Size of the rolling window in days.", 
+            "example": 7, 
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "required": [
-          "rolling_type",
+          "rolling_type", 
           "window"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ChartDataSelectOptionsSchema": {
         "properties": {
           "columns": {
-            "description": "Columns which to select from the input data,in the desired order. If columns are renamed,the original column name should be referenced here.",
+            "description": "Columns which to select from the input data, in the desired order. If columns are renamed, the original column name should be referenced here.", 
             "example": [
-              "country",
-              "gender",
+              "country", 
+              "gender", 
               "age"
-            ],
+            ], 
             "items": {
               "type": "string"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "exclude": {
-            "description": "Columns to exclude from selection.",
+            "description": "Columns to exclude from selection.", 
             "example": [
               "my_temp_column"
-            ],
+            ], 
             "items": {
               "type": "string"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "rename": {
-            "description": "columns which to rename,mapping source column to target column. For instance,`{'y': 'y2'}` will rename the column `y` to `y2`.",
+            "description": "columns which to rename, mapping source column to target column. For instance, `{'y': 'y2'}` will rename the column `y` to `y2`.", 
             "example": [
               {
                 "age": "average_age"
               }
-            ],
+            ], 
             "items": {
               "type": "object"
-            },
+            }, 
             "type": "array"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ChartDataSortOptionsSchema": {
         "properties": {
           "aggregates": {
-            "description": "The keys are the name of the aggregate column to be created,and the values specify the details of how to apply the aggregation. If an operator requires additional options,these can be passed here to be unpacked in the operator call. The following numpy operators are supported: average,argmin,argmax,cumsum,cumprod,max,mean,median,nansum,nanmin,nanmax,nanmean,nanmedian,min,percentile,prod,product,std,sum,var. Any options required by the operator can be passed to the `options` object.\n\nIn the example,a new column `first_quantile` is created based on values in the column `my_col` using the `percentile` operator with the `q=0.25` parameter.",
+            "description": "The keys are the name of the aggregate column to be created, and the values specify the details of how to apply the aggregation. If an operator requires additional options, these can be passed here to be unpacked in the operator call. The following numpy operators are supported: average, argmin, argmax, cumsum, cumprod, max, mean, median, nansum, nanmin, nanmax, nanmean, nanmedian, min, percentile, prod, product, std, sum, var. Any options required by the operator can be passed to the `options` object.\n\nIn the example, a new column `first_quantile` is created based on values in the column `my_col` using the `percentile` operator with the `q=0.25` parameter.", 
             "example": {
               "first_quantile": {
-                "column": "my_col",
-                "operator": "percentile",
+                "column": "my_col", 
+                "operator": "percentile", 
                 "options": {
                   "q": 0.25
                 }
               }
-            },
+            }, 
             "type": "object"
-          },
+          }, 
           "columns": {
-            "description": "columns by by which to sort. The key specifies the column name,value specifies if sorting in ascending order.",
+            "description": "columns by by which to sort. The key specifies the column name, value specifies if sorting in ascending order.", 
             "example": {
-              "country": true,
+              "country": true, 
               "gender": false
-            },
+            }, 
             "type": "object"
           }
-        },
+        }, 
         "required": [
           "columns"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ChartEntityResponseSchema": {
         "properties": {
           "cache_timeout": {
-            "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.",
-            "format": "int32",
+            "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.", 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "certification_details": {
-            "description": "Details of the certification",
+            "description": "Details of the certification", 
             "type": "string"
-          },
+          }, 
           "certified_by": {
-            "description": "Person or group that has certified this chart",
+            "description": "Person or group that has certified this chart", 
             "type": "string"
-          },
+          }, 
           "changed_on": {
-            "description": "The ISO date that the chart was last changed.",
+            "description": "The ISO date that the chart was last changed.", 
             "type": "string"
-          },
+          }, 
           "description": {
-            "description": "A description of the chart propose.",
+            "description": "A description of the chart propose.", 
             "type": "string"
-          },
+          }, 
           "description_markeddown": {
-            "description": "Sanitized HTML version of the chart description.",
+            "description": "Sanitized HTML version of the chart description.", 
             "type": "string"
-          },
+          }, 
           "form_data": {
-            "description": "Form data from the Explore controls used to form the chart's data query.",
+            "description": "Form data from the Explore controls used to form the chart's data query.", 
             "type": "object"
-          },
+          }, 
           "id": {
-            "description": "The id of the chart.",
-            "format": "int32",
+            "description": "The id of the chart.", 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "slice_name": {
-            "description": "The name of the chart.",
+            "description": "The name of the chart.", 
             "type": "string"
-          },
+          }, 
           "slice_url": {
-            "description": "The URL of the chart.",
+            "description": "The URL of the chart.", 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ChartFavStarResponseResult": {
         "properties": {
           "id": {
-            "description": "The Chart id",
-            "format": "int32",
+            "description": "The Chart id", 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "value": {
-            "description": "The FaveStar value",
+            "description": "The FaveStar value", 
             "type": "boolean"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ChartGetDatasourceObjectDataResponse": {
         "properties": {
           "datasource_id": {
-            "description": "The datasource identifier",
-            "format": "int32",
+            "description": "The datasource identifier", 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "datasource_type": {
-            "description": "The datasource type",
-            "format": "int32",
+            "description": "The datasource type", 
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ChartGetDatasourceObjectResponse": {
         "properties": {
           "label": {
-            "description": "The name of the datasource",
+            "description": "The name of the datasource", 
             "type": "string"
-          },
+          }, 
           "value": {
             "$ref": "#/components/schemas/ChartGetDatasourceObjectDataResponse"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ChartGetDatasourceResponseSchema": {
         "properties": {
           "count": {
-            "description": "The total number of datasources",
-            "format": "int32",
+            "description": "The total number of datasources", 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "result": {
             "$ref": "#/components/schemas/ChartGetDatasourceObjectResponse"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ChartRestApi.get": {
         "properties": {
           "cache_timeout": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "certification_details": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "certified_by": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "changed_on_delta_humanized": {
             "readOnly": true
-          },
+          }, 
           "dashboards": {
             "$ref": "#/components/schemas/ChartRestApi.get.Dashboard"
-          },
+          }, 
           "description": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "is_managed_externally": {
             "type": "boolean"
-          },
+          }, 
           "owners": {
             "$ref": "#/components/schemas/ChartRestApi.get.User"
-          },
+          }, 
           "params": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "query_context": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "slice_name": {
-            "maxLength": 250,
-            "nullable": true,
+            "maxLength": 250, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "thumbnail_url": {
             "readOnly": true
-          },
+          }, 
           "url": {
             "readOnly": true
-          },
+          }, 
           "viz_type": {
-            "maxLength": 250,
-            "nullable": true,
+            "maxLength": 250, 
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ChartRestApi.get.Dashboard": {
         "properties": {
           "dashboard_title": {
-            "maxLength": 500,
-            "nullable": true,
+            "maxLength": 500, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "json_metadata": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ChartRestApi.get.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "username": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
-          "last_name",
+          "first_name", 
+          "last_name", 
           "username"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ChartRestApi.get_list": {
         "properties": {
           "cache_timeout": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "certification_details": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "certified_by": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "changed_by": {
             "$ref": "#/components/schemas/ChartRestApi.get_list.User1"
-          },
+          }, 
           "changed_by_name": {
             "readOnly": true
-          },
+          }, 
           "changed_by_url": {
             "readOnly": true
-          },
+          }, 
           "changed_on_delta_humanized": {
             "readOnly": true
-          },
+          }, 
           "changed_on_utc": {
             "readOnly": true
-          },
+          }, 
           "created_by": {
             "$ref": "#/components/schemas/ChartRestApi.get_list.User3"
-          },
+          }, 
           "created_on_delta_humanized": {
             "readOnly": true
-          },
+          }, 
           "dashboards": {
             "$ref": "#/components/schemas/ChartRestApi.get_list.Dashboard"
-          },
+          }, 
           "datasource_id": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "datasource_name_text": {
             "readOnly": true
-          },
+          }, 
           "datasource_type": {
-            "maxLength": 200,
-            "nullable": true,
+            "maxLength": 200, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "datasource_url": {
             "readOnly": true
-          },
+          }, 
           "description": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "description_markeddown": {
             "readOnly": true
-          },
+          }, 
           "edit_url": {
             "readOnly": true
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "is_managed_externally": {
             "type": "boolean"
-          },
+          }, 
           "last_saved_at": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "last_saved_by": {
             "$ref": "#/components/schemas/ChartRestApi.get_list.User"
-          },
+          }, 
           "owners": {
             "$ref": "#/components/schemas/ChartRestApi.get_list.User2"
-          },
+          }, 
           "params": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "slice_name": {
-            "maxLength": 250,
-            "nullable": true,
+            "maxLength": 250, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "table": {
             "$ref": "#/components/schemas/ChartRestApi.get_list.SqlaTable"
-          },
+          }, 
           "thumbnail_url": {
             "readOnly": true
-          },
+          }, 
           "url": {
             "readOnly": true
-          },
+          }, 
           "viz_type": {
-            "maxLength": 250,
-            "nullable": true,
+            "maxLength": 250, 
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ChartRestApi.get_list.Dashboard": {
         "properties": {
           "dashboard_title": {
-            "maxLength": 500,
-            "nullable": true,
+            "maxLength": 500, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ChartRestApi.get_list.SqlaTable": {
         "properties": {
           "default_endpoint": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "table_name": {
-            "maxLength": 250,
+            "maxLength": 250, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
           "table_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ChartRestApi.get_list.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
+          "first_name", 
           "last_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ChartRestApi.get_list.User1": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
+          "first_name", 
           "last_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ChartRestApi.get_list.User2": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "username": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
-          "last_name",
+          "first_name", 
+          "last_name", 
           "username"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ChartRestApi.get_list.User3": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
+          "first_name", 
           "last_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ChartRestApi.post": {
         "properties": {
           "cache_timeout": {
-            "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.",
-            "format": "int32",
-            "nullable": true,
+            "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.", 
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "certification_details": {
-            "description": "Details of the certification",
-            "nullable": true,
+            "description": "Details of the certification", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "certified_by": {
-            "description": "Person or group that has certified this chart",
-            "nullable": true,
+            "description": "Person or group that has certified this chart", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "dashboards": {
             "items": {
-              "description": "A list of dashboards to include this new chart to.",
-              "format": "int32",
+              "description": "A list of dashboards to include this new chart to.", 
+              "format": "int32", 
               "type": "integer"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "datasource_id": {
-            "description": "The id of the dataset/datasource this new chart will use. A complete datasource identification needs `datasouce_id` and `datasource_type`.",
-            "format": "int32",
+            "description": "The id of the dataset/datasource this new chart will use. A complete datasource identification needs `datasouce_id` and `datasource_type`.", 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "datasource_name": {
-            "description": "The datasource name.",
-            "nullable": true,
+            "description": "The datasource name.", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "datasource_type": {
-            "description": "The type of dataset/datasource identified on `datasource_id`.",
+            "description": "The type of dataset/datasource identified on `datasource_id`.", 
             "enum": [
-              "sl_table",
-              "table",
-              "dataset",
-              "query",
-              "saved_query",
+              "sl_table", 
+              "table", 
+              "dataset", 
+              "query", 
+              "saved_query", 
               "view"
-            ],
+            ], 
             "type": "string"
-          },
+          }, 
           "description": {
-            "description": "A description of the chart propose.",
-            "nullable": true,
+            "description": "A description of the chart propose.", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "external_url": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "is_managed_externally": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "owners": {
             "items": {
-              "description": "Owner are users ids allowed to delete or change this chart. If left empty you will be one of the owners of the chart.",
-              "format": "int32",
+              "description": "Owner are users ids allowed to delete or change this chart. If left empty you will be one of the owners of the chart.", 
+              "format": "int32", 
               "type": "integer"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "params": {
-            "description": "Parameters are generated dynamically when clicking the save or overwrite button in the explore view. This JSON object for power users who may want to alter specific parameters.",
-            "nullable": true,
+            "description": "Parameters are generated dynamically when clicking the save or overwrite button in the explore view. This JSON object for power users who may want to alter specific parameters.", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "query_context": {
-            "description": "The query context represents the queries that need to run in order to generate the data the visualization,and in what format the data should be returned.",
-            "nullable": true,
+            "description": "The query context represents the queries that need to run in order to generate the data the visualization, and in what format the data should be returned.", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "query_context_generation": {
-            "description": "The query context generation represents whether the query_contextis user generated or not so that it does not update user modfiedstate.",
-            "nullable": true,
+            "description": "The query context generation represents whether the query_contextis user generated or not so that it does not update user modfiedstate.", 
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "slice_name": {
-            "description": "The name of the chart.",
-            "maxLength": 250,
-            "minLength": 1,
+            "description": "The name of the chart.", 
+            "maxLength": 250, 
+            "minLength": 1, 
             "type": "string"
-          },
+          }, 
           "viz_type": {
-            "description": "The type of chart visualization used.",
+            "description": "The type of chart visualization used.", 
             "example": [
-              "bar",
-              "line_multi",
-              "area",
+              "bar", 
+              "line_multi", 
+              "area", 
               "table"
-            ],
-            "maxLength": 250,
-            "minLength": 0,
+            ], 
+            "maxLength": 250, 
+            "minLength": 0, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "datasource_id",
-          "datasource_type",
+          "datasource_id", 
+          "datasource_type", 
           "slice_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ChartRestApi.put": {
         "properties": {
           "cache_timeout": {
-            "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.",
-            "format": "int32",
-            "nullable": true,
+            "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.", 
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "certification_details": {
-            "description": "Details of the certification",
-            "nullable": true,
+            "description": "Details of the certification", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "certified_by": {
-            "description": "Person or group that has certified this chart",
-            "nullable": true,
+            "description": "Person or group that has certified this chart", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "dashboards": {
             "items": {
-              "description": "A list of dashboards to include this new chart to.",
-              "format": "int32",
+              "description": "A list of dashboards to include this new chart to.", 
+              "format": "int32", 
               "type": "integer"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "datasource_id": {
-            "description": "The id of the dataset/datasource this new chart will use. A complete datasource identification needs `datasouce_id` and `datasource_type`.",
-            "format": "int32",
-            "nullable": true,
+            "description": "The id of the dataset/datasource this new chart will use. A complete datasource identification needs `datasouce_id` and `datasource_type`.", 
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "datasource_type": {
-            "description": "The type of dataset/datasource identified on `datasource_id`.",
+            "description": "The type of dataset/datasource identified on `datasource_id`.", 
             "enum": [
-              "sl_table",
-              "table",
-              "dataset",
-              "query",
-              "saved_query",
+              "sl_table", 
+              "table", 
+              "dataset", 
+              "query", 
+              "saved_query", 
               "view"
-            ],
-            "nullable": true,
+            ], 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "description": {
-            "description": "A description of the chart propose.",
-            "nullable": true,
+            "description": "A description of the chart propose.", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "external_url": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "is_managed_externally": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "owners": {
             "items": {
-              "description": "Owner are users ids allowed to delete or change this chart. If left empty you will be one of the owners of the chart.",
-              "format": "int32",
+              "description": "Owner are users ids allowed to delete or change this chart. If left empty you will be one of the owners of the chart.", 
+              "format": "int32", 
               "type": "integer"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "params": {
-            "description": "Parameters are generated dynamically when clicking the save or overwrite button in the explore view. This JSON object for power users who may want to alter specific parameters.",
-            "nullable": true,
+            "description": "Parameters are generated dynamically when clicking the save or overwrite button in the explore view. This JSON object for power users who may want to alter specific parameters.", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "query_context": {
-            "description": "The query context represents the queries that need to run in order to generate the data the visualization,and in what format the data should be returned.",
-            "nullable": true,
+            "description": "The query context represents the queries that need to run in order to generate the data the visualization, and in what format the data should be returned.", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "query_context_generation": {
-            "description": "The query context generation represents whether the query_contextis user generated or not so that it does not update user modfiedstate.",
-            "nullable": true,
+            "description": "The query context generation represents whether the query_contextis user generated or not so that it does not update user modfiedstate.", 
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "slice_name": {
-            "description": "The name of the chart.",
-            "maxLength": 250,
-            "minLength": 0,
-            "nullable": true,
+            "description": "The name of the chart.", 
+            "maxLength": 250, 
+            "minLength": 0, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "viz_type": {
-            "description": "The type of chart visualization used.",
+            "description": "The type of chart visualization used.", 
             "example": [
-              "bar",
-              "line_multi",
-              "area",
+              "bar", 
+              "line_multi", 
+              "area", 
               "table"
-            ],
-            "maxLength": 250,
-            "minLength": 0,
-            "nullable": true,
+            ], 
+            "maxLength": 250, 
+            "minLength": 0, 
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "CssTemplateRestApi.get": {
         "properties": {
           "created_by": {
             "$ref": "#/components/schemas/CssTemplateRestApi.get.User"
-          },
+          }, 
           "css": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "template_name": {
-            "maxLength": 250,
-            "nullable": true,
+            "maxLength": 250, 
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "CssTemplateRestApi.get.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
+          "first_name", 
           "last_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "CssTemplateRestApi.get_list": {
         "properties": {
           "changed_by": {
             "$ref": "#/components/schemas/CssTemplateRestApi.get_list.User1"
-          },
+          }, 
           "changed_on_delta_humanized": {
             "readOnly": true
-          },
+          }, 
           "created_by": {
             "$ref": "#/components/schemas/CssTemplateRestApi.get_list.User"
-          },
+          }, 
           "created_on": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "css": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "template_name": {
-            "maxLength": 250,
-            "nullable": true,
+            "maxLength": 250, 
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "CssTemplateRestApi.get_list.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
+          "first_name", 
           "last_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "CssTemplateRestApi.get_list.User1": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
+          "first_name", 
           "last_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "CssTemplateRestApi.post": {
         "properties": {
           "css": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "template_name": {
-            "maxLength": 250,
-            "nullable": true,
+            "maxLength": 250, 
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "CssTemplateRestApi.put": {
         "properties": {
           "css": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "template_name": {
-            "maxLength": 250,
-            "nullable": true,
+            "maxLength": 250, 
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DashboardDatasetSchema": {
         "properties": {
           "cache_timeout": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "column_formats": {
             "type": "object"
-          },
+          }, 
           "column_types": {
             "items": {
-              "format": "int32",
+              "format": "int32", 
               "type": "integer"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "columns": {
             "items": {
               "type": "object"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "database": {
             "$ref": "#/components/schemas/Database"
-          },
+          }, 
           "datasource_name": {
             "type": "string"
-          },
+          }, 
           "default_endpoint": {
             "type": "string"
-          },
+          }, 
           "edit_url": {
             "type": "string"
-          },
+          }, 
           "fetch_values_predicate": {
             "type": "string"
-          },
+          }, 
           "filter_select": {
             "type": "boolean"
-          },
+          }, 
           "filter_select_enabled": {
             "type": "boolean"
-          },
+          }, 
           "granularity_sqla": {
             "items": {
               "items": {
                 "type": "string"
-              },
+              }, 
               "type": "array"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "health_check_message": {
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "is_sqllab_view": {
             "type": "boolean"
-          },
+          }, 
           "main_dttm_col": {
             "type": "string"
-          },
+          }, 
           "metrics": {
             "items": {
               "type": "object"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "name": {
             "type": "string"
-          },
+          }, 
           "offset": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "order_by_choices": {
             "items": {
               "items": {
                 "type": "string"
-              },
+              }, 
               "type": "array"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "owners": {
             "items": {
               "type": "object"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "params": {
             "type": "string"
-          },
+          }, 
           "perm": {
             "type": "string"
-          },
+          }, 
           "schema": {
             "type": "string"
-          },
+          }, 
           "select_star": {
             "type": "string"
-          },
+          }, 
           "sql": {
             "type": "string"
-          },
+          }, 
           "table_name": {
             "type": "string"
-          },
+          }, 
           "template_params": {
             "type": "string"
-          },
+          }, 
           "time_grain_sqla": {
             "items": {
               "items": {
                 "type": "string"
-              },
+              }, 
               "type": "array"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "type": {
             "type": "string"
-          },
+          }, 
           "uid": {
             "type": "string"
-          },
+          }, 
           "verbose_map": {
             "additionalProperties": {
               "type": "string"
-            },
+            }, 
             "type": "object"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DashboardGetResponseSchema": {
         "properties": {
           "certification_details": {
-            "description": "Details of the certification",
+            "description": "Details of the certification", 
             "type": "string"
-          },
+          }, 
           "certified_by": {
-            "description": "Person or group that has certified this dashboard",
+            "description": "Person or group that has certified this dashboard", 
             "type": "string"
-          },
+          }, 
           "changed_by": {
             "$ref": "#/components/schemas/User"
-          },
+          }, 
           "changed_by_name": {
             "type": "string"
-          },
+          }, 
           "changed_by_url": {
             "type": "string"
-          },
+          }, 
           "changed_on": {
-            "format": "date-time",
+            "format": "date-time", 
             "type": "string"
-          },
+          }, 
           "changed_on_delta_humanized": {
             "type": "string"
-          },
+          }, 
           "charts": {
             "items": {
-              "description": "The names of the dashboard's charts. Names are used for legacy reasons.",
+              "description": "The names of the dashboard's charts. Names are used for legacy reasons.", 
               "type": "string"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "css": {
-            "description": "Override CSS for the dashboard.",
+            "description": "Override CSS for the dashboard.", 
             "type": "string"
-          },
+          }, 
           "dashboard_title": {
-            "description": "A title for the dashboard.",
+            "description": "A title for the dashboard.", 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "is_managed_externally": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "json_metadata": {
-            "description": "This JSON object is generated dynamically when clicking the save or overwrite button in the dashboard view. It is exposed here for reference and for power users who may want to alter  specific parameters.",
+            "description": "This JSON object is generated dynamically when clicking the save or overwrite button in the dashboard view. It is exposed here for reference and for power users who may want to alter  specific parameters.", 
             "type": "string"
-          },
+          }, 
           "owners": {
             "items": {
               "$ref": "#/components/schemas/User"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "position_json": {
-            "description": "This json object describes the positioning of the widgets in the dashboard. It is dynamically generated when adjusting the widgets size and positions by using drag & drop in the dashboard view",
+            "description": "This json object describes the positioning of the widgets in the dashboard. It is dynamically generated when adjusting the widgets size and positions by using drag & drop in the dashboard view", 
             "type": "string"
-          },
+          }, 
           "published": {
             "type": "boolean"
-          },
+          }, 
           "roles": {
             "items": {
               "$ref": "#/components/schemas/Roles"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "slug": {
             "type": "string"
-          },
+          }, 
           "thumbnail_url": {
             "type": "string"
-          },
+          }, 
           "url": {
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DashboardPermalinkPostSchema": {
         "properties": {
           "activeTabs": {
-            "description": "Current active dashboard tabs",
+            "description": "Current active dashboard tabs", 
             "items": {
               "type": "string"
-            },
-            "nullable": true,
+            }, 
+            "nullable": true, 
             "type": "array"
-          },
+          }, 
           "anchor": {
-            "description": "Optional anchor link added to url hash",
-            "nullable": true,
+            "description": "Optional anchor link added to url hash", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "dataMask": {
-            "description": "Data mask used for native filter state",
-            "nullable": true,
+            "description": "Data mask used for native filter state", 
+            "nullable": true, 
             "type": "object"
-          },
+          }, 
           "urlParams": {
-            "description": "URL Parameters",
+            "description": "URL Parameters", 
             "items": {
-              "description": "URL Parameter key-value pair",
+              "description": "URL Parameter key-value pair", 
               "nullable": true
-            },
-            "nullable": true,
+            }, 
+            "nullable": true, 
             "type": "array"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DashboardRestApi.get": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DashboardRestApi.get_list": {
         "properties": {
           "certification_details": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "certified_by": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "changed_by": {
             "$ref": "#/components/schemas/DashboardRestApi.get_list.User"
-          },
+          }, 
           "changed_by_name": {
             "readOnly": true
-          },
+          }, 
           "changed_by_url": {
             "readOnly": true
-          },
+          }, 
           "changed_on_delta_humanized": {
             "readOnly": true
-          },
+          }, 
           "changed_on_utc": {
             "readOnly": true
-          },
+          }, 
           "created_by": {
             "$ref": "#/components/schemas/DashboardRestApi.get_list.User2"
-          },
+          }, 
           "created_on_delta_humanized": {
             "readOnly": true
-          },
+          }, 
           "css": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "dashboard_title": {
-            "maxLength": 500,
-            "nullable": true,
+            "maxLength": 500, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "is_managed_externally": {
             "type": "boolean"
-          },
+          }, 
           "json_metadata": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "owners": {
             "$ref": "#/components/schemas/DashboardRestApi.get_list.User1"
-          },
+          }, 
           "position_json": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "published": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "roles": {
             "$ref": "#/components/schemas/DashboardRestApi.get_list.Role"
-          },
+          }, 
           "slug": {
-            "maxLength": 255,
-            "nullable": true,
+            "maxLength": 255, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "status": {
             "readOnly": true
-          },
+          }, 
           "thumbnail_url": {
             "readOnly": true
-          },
+          }, 
           "url": {
             "readOnly": true
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DashboardRestApi.get_list.Role": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
           "name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "DashboardRestApi.get_list.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "username": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
-          "last_name",
+          "first_name", 
+          "last_name", 
           "username"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "DashboardRestApi.get_list.User1": {
         "properties": {
           "email": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "username": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "email",
-          "first_name",
-          "last_name",
+          "email", 
+          "first_name", 
+          "last_name", 
           "username"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "DashboardRestApi.get_list.User2": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
+          "first_name", 
           "last_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "DashboardRestApi.post": {
         "properties": {
           "certification_details": {
-            "description": "Details of the certification",
-            "nullable": true,
+            "description": "Details of the certification", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "certified_by": {
-            "description": "Person or group that has certified this dashboard",
-            "nullable": true,
+            "description": "Person or group that has certified this dashboard", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "css": {
             "type": "string"
-          },
+          }, 
           "dashboard_title": {
-            "description": "A title for the dashboard.",
-            "maxLength": 500,
-            "minLength": 0,
-            "nullable": true,
+            "description": "A title for the dashboard.", 
+            "maxLength": 500, 
+            "minLength": 0, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "external_url": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "is_managed_externally": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "json_metadata": {
-            "description": "This JSON object is generated dynamically when clicking the save or overwrite button in the dashboard view. It is exposed here for reference and for power users who may want to alter  specific parameters.",
+            "description": "This JSON object is generated dynamically when clicking the save or overwrite button in the dashboard view. It is exposed here for reference and for power users who may want to alter  specific parameters.", 
             "type": "string"
-          },
+          }, 
           "owners": {
             "items": {
-              "description": "Owner are users ids allowed to delete or change this dashboard. If left empty you will be one of the owners of the dashboard.",
-              "format": "int32",
+              "description": "Owner are users ids allowed to delete or change this dashboard. If left empty you will be one of the owners of the dashboard.", 
+              "format": "int32", 
               "type": "integer"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "position_json": {
-            "description": "This json object describes the positioning of the widgets in the dashboard. It is dynamically generated when adjusting the widgets size and positions by using drag & drop in the dashboard view",
+            "description": "This json object describes the positioning of the widgets in the dashboard. It is dynamically generated when adjusting the widgets size and positions by using drag & drop in the dashboard view", 
             "type": "string"
-          },
+          }, 
           "published": {
-            "description": "Determines whether or not this dashboard is visible in the list of all dashboards.",
+            "description": "Determines whether or not this dashboard is visible in the list of all dashboards.", 
             "type": "boolean"
-          },
+          }, 
           "roles": {
             "items": {
-              "description": "Roles is a list which defines access to the dashboard. These roles are always applied in addition to restrictions on dataset level access. If no roles defined then the dashboard is available to all roles.",
-              "format": "int32",
+              "description": "Roles is a list which defines access to the dashboard. These roles are always applied in addition to restrictions on dataset level access. If no roles defined then the dashboard is available to all roles.", 
+              "format": "int32", 
               "type": "integer"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "slug": {
-            "description": "Unique identifying part for the web address of the dashboard.",
-            "maxLength": 255,
-            "minLength": 1,
-            "nullable": true,
+            "description": "Unique identifying part for the web address of the dashboard.", 
+            "maxLength": 255, 
+            "minLength": 1, 
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DashboardRestApi.put": {
         "properties": {
           "certification_details": {
-            "description": "Details of the certification",
-            "nullable": true,
+            "description": "Details of the certification", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "certified_by": {
-            "description": "Person or group that has certified this dashboard",
-            "nullable": true,
+            "description": "Person or group that has certified this dashboard", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "css": {
-            "description": "Override CSS for the dashboard.",
-            "nullable": true,
+            "description": "Override CSS for the dashboard.", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "dashboard_title": {
-            "description": "A title for the dashboard.",
-            "maxLength": 500,
-            "minLength": 0,
-            "nullable": true,
+            "description": "A title for the dashboard.", 
+            "maxLength": 500, 
+            "minLength": 0, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "external_url": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "is_managed_externally": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "json_metadata": {
-            "description": "This JSON object is generated dynamically when clicking the save or overwrite button in the dashboard view. It is exposed here for reference and for power users who may want to alter  specific parameters.",
-            "nullable": true,
+            "description": "This JSON object is generated dynamically when clicking the save or overwrite button in the dashboard view. It is exposed here for reference and for power users who may want to alter  specific parameters.", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "owners": {
             "items": {
-              "description": "Owner are users ids allowed to delete or change this dashboard. If left empty you will be one of the owners of the dashboard.",
-              "format": "int32",
-              "nullable": true,
+              "description": "Owner are users ids allowed to delete or change this dashboard. If left empty you will be one of the owners of the dashboard.", 
+              "format": "int32", 
+              "nullable": true, 
               "type": "integer"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "position_json": {
-            "description": "This json object describes the positioning of the widgets in the dashboard. It is dynamically generated when adjusting the widgets size and positions by using drag & drop in the dashboard view",
-            "nullable": true,
+            "description": "This json object describes the positioning of the widgets in the dashboard. It is dynamically generated when adjusting the widgets size and positions by using drag & drop in the dashboard view", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "published": {
-            "description": "Determines whether or not this dashboard is visible in the list of all dashboards.",
-            "nullable": true,
+            "description": "Determines whether or not this dashboard is visible in the list of all dashboards.", 
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "roles": {
             "items": {
-              "description": "Roles is a list which defines access to the dashboard. These roles are always applied in addition to restrictions on dataset level access. If no roles defined then the dashboard is available to all roles.",
-              "format": "int32",
-              "nullable": true,
+              "description": "Roles is a list which defines access to the dashboard. These roles are always applied in addition to restrictions on dataset level access. If no roles defined then the dashboard is available to all roles.", 
+              "format": "int32", 
+              "nullable": true, 
               "type": "integer"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "slug": {
-            "description": "Unique identifying part for the web address of the dashboard.",
-            "maxLength": 255,
-            "minLength": 0,
-            "nullable": true,
+            "description": "Unique identifying part for the web address of the dashboard.", 
+            "maxLength": 255, 
+            "minLength": 0, 
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "Database": {
         "properties": {
           "allows_cost_estimate": {
             "type": "boolean"
-          },
+          }, 
           "allows_subquery": {
             "type": "boolean"
-          },
+          }, 
           "allows_virtual_table_explore": {
             "type": "boolean"
-          },
+          }, 
           "backend": {
             "type": "string"
-          },
+          }, 
           "disable_data_preview": {
             "type": "boolean"
-          },
+          }, 
           "explore_database_id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "name": {
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "Database1": {
         "properties": {
           "database_name": {
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DatabaseFunctionNamesResponse": {
         "properties": {
           "function_names": {
             "items": {
               "type": "string"
-            },
+            }, 
             "type": "array"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DatabaseRelatedChart": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "slice_name": {
             "type": "string"
-          },
+          }, 
           "viz_type": {
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DatabaseRelatedCharts": {
         "properties": {
           "count": {
-            "description": "Chart count",
-            "format": "int32",
+            "description": "Chart count", 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "result": {
-            "description": "A list of dashboards",
+            "description": "A list of dashboards", 
             "items": {
               "$ref": "#/components/schemas/DatabaseRelatedChart"
-            },
+            }, 
             "type": "array"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DatabaseRelatedDashboard": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "json_metadata": {
             "type": "object"
-          },
+          }, 
           "slug": {
             "type": "string"
-          },
+          }, 
           "title": {
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DatabaseRelatedDashboards": {
         "properties": {
           "count": {
-            "description": "Dashboard count",
-            "format": "int32",
+            "description": "Dashboard count", 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "result": {
-            "description": "A list of dashboards",
+            "description": "A list of dashboards", 
             "items": {
               "$ref": "#/components/schemas/DatabaseRelatedDashboard"
-            },
+            }, 
             "type": "array"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DatabaseRelatedObjectsResponse": {
         "properties": {
           "charts": {
             "$ref": "#/components/schemas/DatabaseRelatedCharts"
-          },
+          }, 
           "dashboards": {
             "$ref": "#/components/schemas/DatabaseRelatedDashboards"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DatabaseRestApi.get": {
         "properties": {
           "allow_ctas": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "allow_cvas": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "allow_dml": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "allow_file_upload": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "allow_run_async": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "backend": {
             "readOnly": true
-          },
+          }, 
           "cache_timeout": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "configuration_method": {
-            "maxLength": 255,
-            "nullable": true,
+            "maxLength": 255, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "database_name": {
-            "maxLength": 250,
+            "maxLength": 250, 
             "type": "string"
-          },
+          }, 
           "driver": {
             "readOnly": true
-          },
+          }, 
           "engine_information": {
             "readOnly": true
-          },
+          }, 
           "expose_in_sqllab": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "extra": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "force_ctas_schema": {
-            "maxLength": 250,
-            "nullable": true,
+            "maxLength": 250, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "impersonate_user": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "is_managed_externally": {
             "type": "boolean"
-          },
+          }, 
           "masked_encrypted_extra": {
             "readOnly": true
-          },
+          }, 
           "parameters": {
             "readOnly": true
-          },
+          }, 
           "parameters_schema": {
             "readOnly": true
-          },
+          }, 
           "server_cert": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "sqlalchemy_uri": {
-            "maxLength": 1024,
+            "maxLength": 1024, 
             "type": "string"
-          },
+          }, 
           "uuid": {
-            "format": "uuid",
-            "nullable": true,
+            "format": "uuid", 
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "database_name",
+          "database_name", 
           "sqlalchemy_uri"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "DatabaseRestApi.get_list": {
         "properties": {
           "allow_ctas": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "allow_cvas": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "allow_dml": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "allow_file_upload": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "allow_run_async": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "allows_cost_estimate": {
             "readOnly": true
-          },
+          }, 
           "allows_subquery": {
             "readOnly": true
-          },
+          }, 
           "allows_virtual_table_explore": {
             "readOnly": true
-          },
+          }, 
           "backend": {
             "readOnly": true
-          },
+          }, 
           "changed_on": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "changed_on_delta_humanized": {
             "readOnly": true
-          },
+          }, 
           "created_by": {
             "$ref": "#/components/schemas/DatabaseRestApi.get_list.User"
-          },
+          }, 
           "database_name": {
-            "maxLength": 250,
+            "maxLength": 250, 
             "type": "string"
-          },
+          }, 
           "disable_data_preview": {
             "readOnly": true
-          },
+          }, 
           "engine_information": {
             "readOnly": true
-          },
+          }, 
           "explore_database_id": {
             "readOnly": true
-          },
+          }, 
           "expose_in_sqllab": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "extra": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "force_ctas_schema": {
-            "maxLength": 250,
-            "nullable": true,
+            "maxLength": 250, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "uuid": {
-            "format": "uuid",
-            "nullable": true,
+            "format": "uuid", 
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
           "database_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "DatabaseRestApi.get_list.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
+          "first_name", 
           "last_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "DatabaseRestApi.post": {
         "properties": {
           "allow_ctas": {
-            "description": "Allow CREATE TABLE AS option in SQL Lab",
+            "description": "Allow CREATE TABLE AS option in SQL Lab", 
             "type": "boolean"
-          },
+          }, 
           "allow_cvas": {
-            "description": "Allow CREATE VIEW AS option in SQL Lab",
+            "description": "Allow CREATE VIEW AS option in SQL Lab", 
             "type": "boolean"
-          },
+          }, 
           "allow_dml": {
-            "description": "Allow users to run non-SELECT statements (UPDATE,DELETE,CREATE,...) in SQL Lab",
+            "description": "Allow users to run non-SELECT statements (UPDATE, DELETE, CREATE, ...) in SQL Lab", 
             "type": "boolean"
-          },
+          }, 
           "allow_file_upload": {
-            "description": "Allow to upload CSV file data into this databaseIf selected,please set the schemas allowed for csv upload in Extra.",
+            "description": "Allow to upload CSV file data into this databaseIf selected, please set the schemas allowed for csv upload in Extra.", 
             "type": "boolean"
-          },
+          }, 
           "allow_run_async": {
-            "description": "Operate the database in asynchronous mode,meaning  that the queries are executed on remote workers as opposed to on the web server itself. This assumes that you have a Celery worker setup as well as a results backend. Refer to the installation docs for more information.",
+            "description": "Operate the database in asynchronous mode, meaning  that the queries are executed on remote workers as opposed to on the web server itself. This assumes that you have a Celery worker setup as well as a results backend. Refer to the installation docs for more information.", 
             "type": "boolean"
-          },
+          }, 
           "cache_timeout": {
-            "description": "Duration (in seconds) of the caching timeout for charts of this database. A timeout of 0 indicates that the cache never expires. Note this defaults to the global timeout if undefined.",
-            "format": "int32",
-            "nullable": true,
+            "description": "Duration (in seconds) of the caching timeout for charts of this database. A timeout of 0 indicates that the cache never expires. Note this defaults to the global timeout if undefined.", 
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "configuration_method": {
-            "default": "sqlalchemy_form",
+            "default": "sqlalchemy_form", 
             "description": "Configuration_method is used on the frontend to inform the backend whether to explode parameters or to provide only a sqlalchemy_uri."
-          },
+          }, 
           "database_name": {
-            "description": "A database name to identify this connection.",
-            "maxLength": 250,
-            "minLength": 1,
+            "description": "A database name to identify this connection.", 
+            "maxLength": 250, 
+            "minLength": 1, 
             "type": "string"
-          },
+          }, 
           "driver": {
-            "description": "SQLAlchemy driver to use",
-            "nullable": true,
+            "description": "SQLAlchemy driver to use", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "engine": {
-            "description": "SQLAlchemy engine to use",
-            "nullable": true,
+            "description": "SQLAlchemy engine to use", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "expose_in_sqllab": {
-            "description": "Expose this database to SQLLab",
+            "description": "Expose this database to SQLLab", 
             "type": "boolean"
-          },
+          }, 
           "external_url": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "extra": {
-            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call,while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600,\"table_cache_timeout\": 600}</strong>. If unset,cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\",\"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed,just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
+            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>", 
             "type": "string"
-          },
+          }, 
           "force_ctas_schema": {
-            "description": "When allowing CREATE TABLE AS option in SQL Lab,this option forces the table to be created in this schema",
-            "maxLength": 250,
-            "minLength": 0,
-            "nullable": true,
+            "description": "When allowing CREATE TABLE AS option in SQL Lab, this option forces the table to be created in this schema", 
+            "maxLength": 250, 
+            "minLength": 0, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "impersonate_user": {
-            "description": "If Presto,all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled,will run the queries as service account,but impersonate the currently logged on user via hive.server2.proxy.user property.",
+            "description": "If Presto, all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled, will run the queries as service account, but impersonate the currently logged on user via hive.server2.proxy.user property.", 
             "type": "boolean"
-          },
+          }, 
           "is_managed_externally": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "masked_encrypted_extra": {
-            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive,Presto,and BigQuery,which do not conform to the username:password syntax normally used by SQLAlchemy.</p>",
-            "nullable": true,
+            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive, Presto, and BigQuery, which do not conform to the username:password syntax normally used by SQLAlchemy.</p>", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "parameters": {
-            "additionalProperties": {},
-            "description": "DB-specific parameters for configuration",
+            "additionalProperties": {}, 
+            "description": "DB-specific parameters for configuration", 
             "type": "object"
-          },
+          }, 
           "server_cert": {
-            "description": "<p>Optional CA_BUNDLE contents to validate HTTPS requests. Only available on certain database engines.</p>",
-            "nullable": true,
+            "description": "<p>Optional CA_BUNDLE contents to validate HTTPS requests. Only available on certain database engines.</p>", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "sqlalchemy_uri": {
-            "description": "<p>Refer to the <a href=\"https://docs.sqlalchemy.org/en/rel_1_2/core/engines.html#database-urls\">SqlAlchemy docs</a> for more information on how to structure your URI.</p>",
-            "maxLength": 1024,
-            "minLength": 1,
+            "description": "<p>Refer to the <a href=\"https://docs.sqlalchemy.org/en/rel_1_2/core/engines.html#database-urls\">SqlAlchemy docs</a> for more information on how to structure your URI.</p>", 
+            "maxLength": 1024, 
+            "minLength": 1, 
             "type": "string"
-          },
+          }, 
           "ssh_tunnel": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/DatabaseSSHTunnel"
               }
-            ],
+            ], 
             "nullable": true
-          },
+          }, 
           "uuid": {
             "type": "string"
           }
-        },
+        }, 
         "required": [
           "database_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "DatabaseRestApi.put": {
         "properties": {
           "allow_ctas": {
-            "description": "Allow CREATE TABLE AS option in SQL Lab",
+            "description": "Allow CREATE TABLE AS option in SQL Lab", 
             "type": "boolean"
-          },
+          }, 
           "allow_cvas": {
-            "description": "Allow CREATE VIEW AS option in SQL Lab",
+            "description": "Allow CREATE VIEW AS option in SQL Lab", 
             "type": "boolean"
-          },
+          }, 
           "allow_dml": {
-            "description": "Allow users to run non-SELECT statements (UPDATE,DELETE,CREATE,...) in SQL Lab",
+            "description": "Allow users to run non-SELECT statements (UPDATE, DELETE, CREATE, ...) in SQL Lab", 
             "type": "boolean"
-          },
+          }, 
           "allow_file_upload": {
-            "description": "Allow to upload CSV file data into this databaseIf selected,please set the schemas allowed for csv upload in Extra.",
+            "description": "Allow to upload CSV file data into this databaseIf selected, please set the schemas allowed for csv upload in Extra.", 
             "type": "boolean"
-          },
+          }, 
           "allow_run_async": {
-            "description": "Operate the database in asynchronous mode,meaning  that the queries are executed on remote workers as opposed to on the web server itself. This assumes that you have a Celery worker setup as well as a results backend. Refer to the installation docs for more information.",
+            "description": "Operate the database in asynchronous mode, meaning  that the queries are executed on remote workers as opposed to on the web server itself. This assumes that you have a Celery worker setup as well as a results backend. Refer to the installation docs for more information.", 
             "type": "boolean"
-          },
+          }, 
           "cache_timeout": {
-            "description": "Duration (in seconds) of the caching timeout for charts of this database. A timeout of 0 indicates that the cache never expires. Note this defaults to the global timeout if undefined.",
-            "format": "int32",
-            "nullable": true,
+            "description": "Duration (in seconds) of the caching timeout for charts of this database. A timeout of 0 indicates that the cache never expires. Note this defaults to the global timeout if undefined.", 
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "configuration_method": {
-            "default": "sqlalchemy_form",
+            "default": "sqlalchemy_form", 
             "description": "Configuration_method is used on the frontend to inform the backend whether to explode parameters or to provide only a sqlalchemy_uri."
-          },
+          }, 
           "database_name": {
-            "description": "A database name to identify this connection.",
-            "maxLength": 250,
-            "minLength": 1,
-            "nullable": true,
+            "description": "A database name to identify this connection.", 
+            "maxLength": 250, 
+            "minLength": 1, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "driver": {
-            "description": "SQLAlchemy driver to use",
-            "nullable": true,
+            "description": "SQLAlchemy driver to use", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "engine": {
-            "description": "SQLAlchemy engine to use",
-            "nullable": true,
+            "description": "SQLAlchemy engine to use", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "expose_in_sqllab": {
-            "description": "Expose this database to SQLLab",
+            "description": "Expose this database to SQLLab", 
             "type": "boolean"
-          },
+          }, 
           "external_url": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "extra": {
-            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call,while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600,\"table_cache_timeout\": 600}</strong>. If unset,cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\",\"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed,just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
+            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>", 
             "type": "string"
-          },
+          }, 
           "force_ctas_schema": {
-            "description": "When allowing CREATE TABLE AS option in SQL Lab,this option forces the table to be created in this schema",
-            "maxLength": 250,
-            "minLength": 0,
-            "nullable": true,
+            "description": "When allowing CREATE TABLE AS option in SQL Lab, this option forces the table to be created in this schema", 
+            "maxLength": 250, 
+            "minLength": 0, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "impersonate_user": {
-            "description": "If Presto,all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled,will run the queries as service account,but impersonate the currently logged on user via hive.server2.proxy.user property.",
+            "description": "If Presto, all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled, will run the queries as service account, but impersonate the currently logged on user via hive.server2.proxy.user property.", 
             "type": "boolean"
-          },
+          }, 
           "is_managed_externally": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "masked_encrypted_extra": {
-            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive,Presto,and BigQuery,which do not conform to the username:password syntax normally used by SQLAlchemy.</p>",
-            "nullable": true,
+            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive, Presto, and BigQuery, which do not conform to the username:password syntax normally used by SQLAlchemy.</p>", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "parameters": {
-            "additionalProperties": {},
-            "description": "DB-specific parameters for configuration",
+            "additionalProperties": {}, 
+            "description": "DB-specific parameters for configuration", 
             "type": "object"
-          },
+          }, 
           "server_cert": {
-            "description": "<p>Optional CA_BUNDLE contents to validate HTTPS requests. Only available on certain database engines.</p>",
-            "nullable": true,
+            "description": "<p>Optional CA_BUNDLE contents to validate HTTPS requests. Only available on certain database engines.</p>", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "sqlalchemy_uri": {
-            "description": "<p>Refer to the <a href=\"https://docs.sqlalchemy.org/en/rel_1_2/core/engines.html#database-urls\">SqlAlchemy docs</a> for more information on how to structure your URI.</p>",
-            "maxLength": 1024,
-            "minLength": 0,
+            "description": "<p>Refer to the <a href=\"https://docs.sqlalchemy.org/en/rel_1_2/core/engines.html#database-urls\">SqlAlchemy docs</a> for more information on how to structure your URI.</p>", 
+            "maxLength": 1024, 
+            "minLength": 0, 
             "type": "string"
-          },
+          }, 
           "ssh_tunnel": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/DatabaseSSHTunnel"
               }
-            ],
+            ], 
             "nullable": true
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DatabaseSSHTunnel": {
         "properties": {
           "id": {
-            "description": "SSH Tunnel ID (for updates)",
-            "format": "int32",
-            "nullable": true,
+            "description": "SSH Tunnel ID (for updates)", 
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "password": {
             "type": "string"
-          },
+          }, 
           "private_key": {
             "type": "string"
-          },
+          }, 
           "private_key_password": {
             "type": "string"
-          },
+          }, 
           "server_address": {
             "type": "string"
-          },
+          }, 
           "server_port": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "username": {
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DatabaseTestConnectionSchema": {
         "properties": {
           "configuration_method": {
-            "default": "sqlalchemy_form",
+            "default": "sqlalchemy_form", 
             "description": "Configuration_method is used on the frontend to inform the backend whether to explode parameters or to provide only a sqlalchemy_uri."
-          },
+          }, 
           "database_name": {
-            "description": "A database name to identify this connection.",
-            "maxLength": 250,
-            "minLength": 1,
-            "nullable": true,
+            "description": "A database name to identify this connection.", 
+            "maxLength": 250, 
+            "minLength": 1, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "driver": {
-            "description": "SQLAlchemy driver to use",
-            "nullable": true,
+            "description": "SQLAlchemy driver to use", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "engine": {
-            "description": "SQLAlchemy engine to use",
-            "nullable": true,
+            "description": "SQLAlchemy engine to use", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "extra": {
-            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call,while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600,\"table_cache_timeout\": 600}</strong>. If unset,cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\",\"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed,just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
+            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>", 
             "type": "string"
-          },
+          }, 
           "impersonate_user": {
-            "description": "If Presto,all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled,will run the queries as service account,but impersonate the currently logged on user via hive.server2.proxy.user property.",
+            "description": "If Presto, all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled, will run the queries as service account, but impersonate the currently logged on user via hive.server2.proxy.user property.", 
             "type": "boolean"
-          },
+          }, 
           "masked_encrypted_extra": {
-            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive,Presto,and BigQuery,which do not conform to the username:password syntax normally used by SQLAlchemy.</p>",
-            "nullable": true,
+            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive, Presto, and BigQuery, which do not conform to the username:password syntax normally used by SQLAlchemy.</p>", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "parameters": {
-            "additionalProperties": {},
-            "description": "DB-specific parameters for configuration",
+            "additionalProperties": {}, 
+            "description": "DB-specific parameters for configuration", 
             "type": "object"
-          },
+          }, 
           "server_cert": {
-            "description": "<p>Optional CA_BUNDLE contents to validate HTTPS requests. Only available on certain database engines.</p>",
-            "nullable": true,
+            "description": "<p>Optional CA_BUNDLE contents to validate HTTPS requests. Only available on certain database engines.</p>", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "sqlalchemy_uri": {
-            "description": "<p>Refer to the <a href=\"https://docs.sqlalchemy.org/en/rel_1_2/core/engines.html#database-urls\">SqlAlchemy docs</a> for more information on how to structure your URI.</p>",
-            "maxLength": 1024,
-            "minLength": 1,
+            "description": "<p>Refer to the <a href=\"https://docs.sqlalchemy.org/en/rel_1_2/core/engines.html#database-urls\">SqlAlchemy docs</a> for more information on how to structure your URI.</p>", 
+            "maxLength": 1024, 
+            "minLength": 1, 
             "type": "string"
-          },
+          }, 
           "ssh_tunnel": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/DatabaseSSHTunnel"
               }
-            ],
+            ], 
             "nullable": true
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DatabaseValidateParametersSchema": {
         "properties": {
           "catalog": {
             "additionalProperties": {
               "nullable": true
-            },
-            "description": "Gsheets specific column for managing label to sheet urls",
+            }, 
+            "description": "Gsheets specific column for managing label to sheet urls", 
             "type": "object"
-          },
+          }, 
           "configuration_method": {
             "description": "Configuration_method is used on the frontend to inform the backend whether to explode parameters or to provide only a sqlalchemy_uri."
-          },
+          }, 
           "database_name": {
-            "description": "A database name to identify this connection.",
-            "maxLength": 250,
-            "minLength": 1,
-            "nullable": true,
+            "description": "A database name to identify this connection.", 
+            "maxLength": 250, 
+            "minLength": 1, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "driver": {
-            "description": "SQLAlchemy driver to use",
-            "nullable": true,
+            "description": "SQLAlchemy driver to use", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "engine": {
-            "description": "SQLAlchemy engine to use",
+            "description": "SQLAlchemy engine to use", 
             "type": "string"
-          },
+          }, 
           "extra": {
-            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call,while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600,\"table_cache_timeout\": 600}</strong>. If unset,cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\",\"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed,just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
+            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>", 
             "type": "string"
-          },
+          }, 
           "id": {
-            "description": "Database ID (for updates)",
-            "format": "int32",
-            "nullable": true,
+            "description": "Database ID (for updates)", 
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "impersonate_user": {
-            "description": "If Presto,all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled,will run the queries as service account,but impersonate the currently logged on user via hive.server2.proxy.user property.",
+            "description": "If Presto, all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled, will run the queries as service account, but impersonate the currently logged on user via hive.server2.proxy.user property.", 
             "type": "boolean"
-          },
+          }, 
           "masked_encrypted_extra": {
-            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive,Presto,and BigQuery,which do not conform to the username:password syntax normally used by SQLAlchemy.</p>",
-            "nullable": true,
+            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive, Presto, and BigQuery, which do not conform to the username:password syntax normally used by SQLAlchemy.</p>", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "parameters": {
             "additionalProperties": {
               "nullable": true
-            },
-            "description": "DB-specific parameters for configuration",
+            }, 
+            "description": "DB-specific parameters for configuration", 
             "type": "object"
-          },
+          }, 
           "server_cert": {
-            "description": "<p>Optional CA_BUNDLE contents to validate HTTPS requests. Only available on certain database engines.</p>",
-            "nullable": true,
+            "description": "<p>Optional CA_BUNDLE contents to validate HTTPS requests. Only available on certain database engines.</p>", 
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "configuration_method",
+          "configuration_method", 
           "engine"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "Dataset": {
         "properties": {
           "cache_timeout": {
-            "description": "Duration (in seconds) of the caching timeout for this dataset.",
-            "format": "int32",
+            "description": "Duration (in seconds) of the caching timeout for this dataset.", 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "column_formats": {
-            "description": "Column formats.",
+            "description": "Column formats.", 
             "type": "object"
-          },
+          }, 
           "columns": {
-            "description": "Columns metadata.",
+            "description": "Columns metadata.", 
             "items": {
               "type": "object"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "database": {
-            "description": "Database associated with the dataset.",
+            "description": "Database associated with the dataset.", 
             "type": "object"
-          },
+          }, 
           "datasource_name": {
-            "description": "Dataset name.",
+            "description": "Dataset name.", 
             "type": "string"
-          },
+          }, 
           "default_endpoint": {
-            "description": "Default endpoint for the dataset.",
+            "description": "Default endpoint for the dataset.", 
             "type": "string"
-          },
+          }, 
           "description": {
-            "description": "Dataset description.",
+            "description": "Dataset description.", 
             "type": "string"
-          },
+          }, 
           "edit_url": {
-            "description": "The URL for editing the dataset.",
+            "description": "The URL for editing the dataset.", 
             "type": "string"
-          },
+          }, 
           "extra": {
-            "description": "JSON string containing extra configuration elements.",
+            "description": "JSON string containing extra configuration elements.", 
             "type": "object"
-          },
+          }, 
           "fetch_values_predicate": {
-            "description": "Predicate used when fetching values from the dataset.",
+            "description": "Predicate used when fetching values from the dataset.", 
             "type": "string"
-          },
+          }, 
           "filter_select": {
-            "description": "SELECT filter applied to the dataset.",
+            "description": "SELECT filter applied to the dataset.", 
             "type": "boolean"
-          },
+          }, 
           "filter_select_enabled": {
-            "description": "If the SELECT filter is enabled.",
+            "description": "If the SELECT filter is enabled.", 
             "type": "boolean"
-          },
+          }, 
           "granularity_sqla": {
-            "description": "Name of temporal column used for time filtering for SQL datasources. This field is deprecated,use `granularity` instead.",
+            "description": "Name of temporal column used for time filtering for SQL datasources. This field is deprecated, use `granularity` instead.", 
             "items": {
               "items": {
                 "type": "object"
-              },
+              }, 
               "type": "array"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "health_check_message": {
-            "description": "Health check message.",
+            "description": "Health check message.", 
             "type": "string"
-          },
+          }, 
           "id": {
-            "description": "Dataset ID.",
-            "format": "int32",
+            "description": "Dataset ID.", 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "is_sqllab_view": {
-            "description": "If the dataset is a SQL Lab view.",
+            "description": "If the dataset is a SQL Lab view.", 
             "type": "boolean"
-          },
+          }, 
           "main_dttm_col": {
-            "description": "The main temporal column.",
+            "description": "The main temporal column.", 
             "type": "string"
-          },
+          }, 
           "metrics": {
-            "description": "Dataset metrics.",
+            "description": "Dataset metrics.", 
             "items": {
               "type": "object"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "name": {
-            "description": "Dataset name.",
+            "description": "Dataset name.", 
             "type": "string"
-          },
+          }, 
           "offset": {
-            "description": "Dataset offset.",
-            "format": "int32",
+            "description": "Dataset offset.", 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "order_by_choices": {
-            "description": "List of order by columns.",
+            "description": "List of order by columns.", 
             "items": {
               "items": {
                 "type": "string"
-              },
+              }, 
               "type": "array"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "owners": {
-            "description": "List of owners identifiers",
+            "description": "List of owners identifiers", 
             "items": {
-              "format": "int32",
+              "format": "int32", 
               "type": "integer"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "params": {
-            "description": "Extra params for the dataset.",
+            "description": "Extra params for the dataset.", 
             "type": "object"
-          },
+          }, 
           "perm": {
-            "description": "Permission expression.",
+            "description": "Permission expression.", 
             "type": "string"
-          },
+          }, 
           "schema": {
-            "description": "Dataset schema.",
+            "description": "Dataset schema.", 
             "type": "string"
-          },
+          }, 
           "select_star": {
-            "description": "Select all clause.",
+            "description": "Select all clause.", 
             "type": "string"
-          },
+          }, 
           "sql": {
-            "description": "A SQL statement that defines the dataset.",
+            "description": "A SQL statement that defines the dataset.", 
             "type": "string"
-          },
+          }, 
           "table_name": {
-            "description": "The name of the table associated with the dataset.",
+            "description": "The name of the table associated with the dataset.", 
             "type": "string"
-          },
+          }, 
           "template_params": {
-            "description": "Table template params.",
+            "description": "Table template params.", 
             "type": "object"
-          },
+          }, 
           "time_grain_sqla": {
-            "description": "List of temporal granularities supported by the dataset.",
+            "description": "List of temporal granularities supported by the dataset.", 
             "items": {
               "items": {
                 "type": "string"
-              },
+              }, 
               "type": "array"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "type": {
-            "description": "Dataset type.",
+            "description": "Dataset type.", 
             "type": "string"
-          },
+          }, 
           "uid": {
-            "description": "Dataset unique identifier.",
+            "description": "Dataset unique identifier.", 
             "type": "string"
-          },
+          }, 
           "verbose_map": {
-            "description": "Mapping from raw name to verbose name.",
+            "description": "Mapping from raw name to verbose name.", 
             "type": "object"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DatasetColumnsPut": {
         "properties": {
           "advanced_data_type": {
-            "maxLength": 255,
-            "minLength": 1,
-            "nullable": true,
+            "maxLength": 255, 
+            "minLength": 1, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "column_name": {
-            "maxLength": 255,
-            "minLength": 1,
+            "maxLength": 255, 
+            "minLength": 1, 
             "type": "string"
-          },
+          }, 
           "description": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "expression": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "extra": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "filterable": {
             "type": "boolean"
-          },
+          }, 
           "groupby": {
             "type": "boolean"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "is_active": {
             "type": "boolean"
-          },
+          }, 
           "is_dttm": {
             "type": "boolean"
-          },
+          }, 
           "python_date_format": {
-            "maxLength": 255,
-            "minLength": 1,
-            "nullable": true,
+            "maxLength": 255, 
+            "minLength": 1, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "type": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "uuid": {
-            "format": "uuid",
-            "nullable": true,
+            "format": "uuid", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "verbose_name": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
           "column_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "DatasetColumnsRestApi.get": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DatasetColumnsRestApi.get_list": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DatasetColumnsRestApi.post": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DatasetColumnsRestApi.put": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DatasetDuplicateSchema": {
         "properties": {
           "base_model_id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "table_name": {
-            "maxLength": 250,
-            "minLength": 1,
+            "maxLength": 250, 
+            "minLength": 1, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "base_model_id",
+          "base_model_id", 
           "table_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "DatasetMetricRestApi.get": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DatasetMetricRestApi.get_list": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DatasetMetricRestApi.post": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DatasetMetricRestApi.put": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DatasetMetricsPut": {
         "properties": {
           "d3format": {
-            "maxLength": 128,
-            "minLength": 1,
-            "nullable": true,
+            "maxLength": 128, 
+            "minLength": 1, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "description": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "expression": {
             "type": "string"
-          },
+          }, 
           "extra": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "metric_name": {
-            "maxLength": 255,
-            "minLength": 1,
+            "maxLength": 255, 
+            "minLength": 1, 
             "type": "string"
-          },
+          }, 
           "metric_type": {
-            "maxLength": 32,
-            "minLength": 1,
-            "nullable": true,
+            "maxLength": 32, 
+            "minLength": 1, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "uuid": {
-            "format": "uuid",
-            "nullable": true,
+            "format": "uuid", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "verbose_name": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "warning_text": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "expression",
+          "expression", 
           "metric_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "DatasetRelatedChart": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "slice_name": {
             "type": "string"
-          },
+          }, 
           "viz_type": {
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DatasetRelatedCharts": {
         "properties": {
           "count": {
-            "description": "Chart count",
-            "format": "int32",
+            "description": "Chart count", 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "result": {
-            "description": "A list of dashboards",
+            "description": "A list of dashboards", 
             "items": {
               "$ref": "#/components/schemas/DatasetRelatedChart"
-            },
+            }, 
             "type": "array"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DatasetRelatedDashboard": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "json_metadata": {
             "type": "object"
-          },
+          }, 
           "slug": {
             "type": "string"
-          },
+          }, 
           "title": {
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DatasetRelatedDashboards": {
         "properties": {
           "count": {
-            "description": "Dashboard count",
-            "format": "int32",
+            "description": "Dashboard count", 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "result": {
-            "description": "A list of dashboards",
+            "description": "A list of dashboards", 
             "items": {
               "$ref": "#/components/schemas/DatasetRelatedDashboard"
-            },
+            }, 
             "type": "array"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DatasetRelatedObjectsResponse": {
         "properties": {
           "charts": {
             "$ref": "#/components/schemas/DatasetRelatedCharts"
-          },
+          }, 
           "dashboards": {
             "$ref": "#/components/schemas/DatasetRelatedDashboards"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DatasetRestApi.get": {
         "properties": {
           "cache_timeout": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "changed_by": {
             "$ref": "#/components/schemas/DatasetRestApi.get.User"
-          },
+          }, 
           "changed_on": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "changed_on_humanized": {
             "readOnly": true
-          },
+          }, 
           "columns": {
             "$ref": "#/components/schemas/DatasetRestApi.get.TableColumn"
-          },
+          }, 
           "created_by": {
             "$ref": "#/components/schemas/DatasetRestApi.get.User2"
-          },
+          }, 
           "created_on": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "created_on_humanized": {
             "readOnly": true
-          },
+          }, 
           "database": {
             "$ref": "#/components/schemas/DatasetRestApi.get.Database"
-          },
+          }, 
           "datasource_type": {
             "readOnly": true
-          },
+          }, 
           "default_endpoint": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "description": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "extra": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "fetch_values_predicate": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "filter_select_enabled": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "is_managed_externally": {
             "type": "boolean"
-          },
+          }, 
           "is_sqllab_view": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "kind": {
             "readOnly": true
-          },
+          }, 
           "main_dttm_col": {
-            "maxLength": 250,
-            "nullable": true,
+            "maxLength": 250, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "metrics": {
             "$ref": "#/components/schemas/DatasetRestApi.get.SqlMetric"
-          },
+          }, 
           "offset": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "owners": {
             "$ref": "#/components/schemas/DatasetRestApi.get.User1"
-          },
+          }, 
           "schema": {
-            "maxLength": 255,
-            "nullable": true,
+            "maxLength": 255, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "select_star": {
             "readOnly": true
-          },
+          }, 
           "sql": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "table_name": {
-            "maxLength": 250,
+            "maxLength": 250, 
             "type": "string"
-          },
+          }, 
           "template_params": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "url": {
             "readOnly": true
           }
-        },
+        }, 
         "required": [
-          "columns",
-          "database",
-          "metrics",
+          "columns", 
+          "database", 
+          "metrics", 
           "table_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "DatasetRestApi.get.Database": {
         "properties": {
           "backend": {
             "readOnly": true
-          },
+          }, 
           "database_name": {
-            "maxLength": 250,
+            "maxLength": 250, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "required": [
           "database_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "DatasetRestApi.get.SqlMetric": {
         "properties": {
           "changed_on": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "created_on": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "d3format": {
-            "maxLength": 128,
-            "nullable": true,
+            "maxLength": 128, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "description": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "expression": {
             "type": "string"
-          },
+          }, 
           "extra": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "metric_name": {
-            "maxLength": 255,
+            "maxLength": 255, 
             "type": "string"
-          },
+          }, 
           "metric_type": {
-            "maxLength": 32,
-            "nullable": true,
+            "maxLength": 32, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "verbose_name": {
-            "maxLength": 1024,
-            "nullable": true,
+            "maxLength": 1024, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "warning_text": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "expression",
+          "expression", 
           "metric_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "DatasetRestApi.get.TableColumn": {
         "properties": {
           "advanced_data_type": {
-            "maxLength": 255,
-            "nullable": true,
+            "maxLength": 255, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "changed_on": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "column_name": {
-            "maxLength": 255,
+            "maxLength": 255, 
             "type": "string"
-          },
+          }, 
           "created_on": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "description": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "expression": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "extra": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "filterable": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "groupby": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "is_active": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "is_dttm": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "python_date_format": {
-            "maxLength": 255,
-            "nullable": true,
+            "maxLength": 255, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "type": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "type_generic": {
             "readOnly": true
-          },
+          }, 
           "uuid": {
-            "format": "uuid",
-            "nullable": true,
+            "format": "uuid", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "verbose_name": {
-            "maxLength": 1024,
-            "nullable": true,
+            "maxLength": 1024, 
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
           "column_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "DatasetRestApi.get.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
+          "first_name", 
           "last_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "DatasetRestApi.get.User1": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "username": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
-          "last_name",
+          "first_name", 
+          "last_name", 
           "username"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "DatasetRestApi.get.User2": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
+          "first_name", 
           "last_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "DatasetRestApi.get_list": {
         "properties": {
           "changed_by": {
             "$ref": "#/components/schemas/DatasetRestApi.get_list.User"
-          },
+          }, 
           "changed_by_name": {
             "readOnly": true
-          },
+          }, 
           "changed_by_url": {
             "readOnly": true
-          },
+          }, 
           "changed_on_delta_humanized": {
             "readOnly": true
-          },
+          }, 
           "changed_on_utc": {
             "readOnly": true
-          },
+          }, 
           "database": {
             "$ref": "#/components/schemas/DatasetRestApi.get_list.Database"
-          },
+          }, 
           "datasource_type": {
             "readOnly": true
-          },
+          }, 
           "default_endpoint": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "description": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "explore_url": {
             "readOnly": true
-          },
+          }, 
           "extra": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "kind": {
             "readOnly": true
-          },
+          }, 
           "owners": {
             "$ref": "#/components/schemas/DatasetRestApi.get_list.User1"
-          },
+          }, 
           "schema": {
-            "maxLength": 255,
-            "nullable": true,
+            "maxLength": 255, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "sql": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "table_name": {
-            "maxLength": 250,
+            "maxLength": 250, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "database",
+          "database", 
           "table_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "DatasetRestApi.get_list.Database": {
         "properties": {
           "database_name": {
-            "maxLength": 250,
+            "maxLength": 250, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "required": [
           "database_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "DatasetRestApi.get_list.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "username": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
+          "first_name", 
           "username"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "DatasetRestApi.get_list.User1": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "username": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
-          "last_name",
+          "first_name", 
+          "last_name", 
           "username"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "DatasetRestApi.post": {
         "properties": {
           "database": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "external_url": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "is_managed_externally": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "owners": {
             "items": {
-              "format": "int32",
+              "format": "int32", 
               "type": "integer"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "schema": {
-            "maxLength": 250,
-            "minLength": 0,
+            "maxLength": 250, 
+            "minLength": 0, 
             "type": "string"
-          },
+          }, 
           "sql": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "table_name": {
-            "maxLength": 250,
-            "minLength": 1,
+            "maxLength": 250, 
+            "minLength": 1, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "database",
+          "database", 
           "table_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "DatasetRestApi.put": {
         "properties": {
           "cache_timeout": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "columns": {
             "items": {
               "$ref": "#/components/schemas/DatasetColumnsPut"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "database_id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "default_endpoint": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "description": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "external_url": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "extra": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "fetch_values_predicate": {
-            "maxLength": 1000,
-            "minLength": 0,
-            "nullable": true,
+            "maxLength": 1000, 
+            "minLength": 0, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "filter_select_enabled": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "is_managed_externally": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "is_sqllab_view": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "main_dttm_col": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "metrics": {
             "items": {
               "$ref": "#/components/schemas/DatasetMetricsPut"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "offset": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "owners": {
             "items": {
-              "format": "int32",
+              "format": "int32", 
               "type": "integer"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "schema": {
-            "maxLength": 255,
-            "minLength": 0,
-            "nullable": true,
+            "maxLength": 255, 
+            "minLength": 0, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "sql": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "table_name": {
-            "maxLength": 250,
-            "minLength": 1,
-            "nullable": true,
+            "maxLength": 250, 
+            "minLength": 1, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "template_params": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "Datasource": {
         "properties": {
           "database_name": {
-            "description": "Datasource name",
+            "description": "Datasource name", 
             "type": "string"
-          },
+          }, 
           "datasource_name": {
-            "description": "The datasource name.",
+            "description": "The datasource name.", 
             "type": "string"
-          },
+          }, 
           "datasource_type": {
-            "description": "The type of dataset/datasource identified on `datasource_id`.",
+            "description": "The type of dataset/datasource identified on `datasource_id`.", 
             "enum": [
-              "sl_table",
-              "table",
-              "dataset",
-              "query",
-              "saved_query",
+              "sl_table", 
+              "table", 
+              "dataset", 
+              "query", 
+              "saved_query", 
               "view"
-            ],
+            ], 
             "type": "string"
-          },
+          }, 
           "schema": {
-            "description": "Datasource schema",
+            "description": "Datasource schema", 
             "type": "string"
           }
-        },
+        }, 
         "required": [
           "datasource_type"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "DistincResponseSchema": {
         "properties": {
           "count": {
-            "description": "The total number of distinct values",
-            "format": "int32",
+            "description": "The total number of distinct values", 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "result": {
             "items": {
               "$ref": "#/components/schemas/DistinctResultResponse"
-            },
+            }, 
             "type": "array"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "DistinctResultResponse": {
         "properties": {
           "text": {
-            "description": "The distinct item",
+            "description": "The distinct item", 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "EmbeddedDashboardConfig": {
         "properties": {
           "allowed_domains": {
             "items": {
               "type": "string"
-            },
+            }, 
             "type": "array"
           }
-        },
+        }, 
         "required": [
           "allowed_domains"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "EmbeddedDashboardResponseSchema": {
         "properties": {
           "allowed_domains": {
             "items": {
               "type": "string"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "changed_by": {
             "$ref": "#/components/schemas/User"
-          },
+          }, 
           "changed_on": {
-            "format": "date-time",
+            "format": "date-time", 
             "type": "string"
-          },
+          }, 
           "dashboard_id": {
             "type": "string"
-          },
+          }, 
           "uuid": {
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "EmbeddedDashboardRestApi.get": {
         "properties": {
           "uuid": {
-            "format": "uuid",
+            "format": "uuid", 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "EmbeddedDashboardRestApi.get_list": {
         "properties": {
           "uuid": {
-            "format": "uuid",
+            "format": "uuid", 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "EmbeddedDashboardRestApi.post": {
         "properties": {
           "uuid": {
-            "format": "uuid",
+            "format": "uuid", 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "EmbeddedDashboardRestApi.put": {
         "properties": {
           "uuid": {
-            "format": "uuid",
+            "format": "uuid", 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ExploreContextSchema": {
         "properties": {
           "dataset": {
             "$ref": "#/components/schemas/Dataset"
-          },
+          }, 
           "form_data": {
-            "description": "Form data from the Explore controls used to form the chart's data query.",
+            "description": "Form data from the Explore controls used to form the chart's data query.", 
             "type": "object"
-          },
+          }, 
           "message": {
-            "description": "Any message related to the processed request.",
+            "description": "Any message related to the processed request.", 
             "type": "string"
-          },
+          }, 
           "slice": {
             "$ref": "#/components/schemas/Slice"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ExplorePermalinkPostSchema": {
         "properties": {
           "formData": {
-            "description": "Chart form data",
+            "description": "Chart form data", 
             "type": "object"
-          },
+          }, 
           "urlParams": {
-            "description": "URL Parameters",
+            "description": "URL Parameters", 
             "items": {
-              "description": "URL Parameter key-value pair",
+              "description": "URL Parameter key-value pair", 
               "nullable": true
-            },
-            "nullable": true,
+            }, 
+            "nullable": true, 
             "type": "array"
           }
-        },
+        }, 
         "required": [
           "formData"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "FilterSetRestApi.get": {
         "properties": {
           "dashboard_id": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "description": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "name": {
-            "maxLength": 500,
+            "maxLength": 500, 
             "type": "string"
-          },
+          }, 
           "owner_id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "owner_type": {
-            "maxLength": 255,
+            "maxLength": 255, 
             "type": "string"
-          },
+          }, 
           "params": {
             "readOnly": true
           }
-        },
+        }, 
         "required": [
-          "name",
-          "owner_id",
+          "name", 
+          "owner_id", 
           "owner_type"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "FilterSetRestApi.get_list": {
         "properties": {
           "changed_by_fk": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "changed_on": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "created_by_fk": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "created_on": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "dashboard_id": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "description": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "name": {
-            "maxLength": 500,
+            "maxLength": 500, 
             "type": "string"
-          },
+          }, 
           "owner_id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "owner_type": {
-            "maxLength": 255,
+            "maxLength": 255, 
             "type": "string"
-          },
+          }, 
           "params": {
             "readOnly": true
           }
-        },
+        }, 
         "required": [
-          "name",
-          "owner_id",
+          "name", 
+          "owner_id", 
           "owner_type"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "FilterSetRestApi.post": {
         "properties": {
           "description": {
-            "maxLength": 1000,
-            "minLength": 1,
-            "nullable": true,
+            "maxLength": 1000, 
+            "minLength": 1, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "json_metadata": {
             "type": "string"
-          },
+          }, 
           "name": {
-            "maxLength": 500,
-            "minLength": 0,
+            "maxLength": 500, 
+            "minLength": 0, 
             "type": "string"
-          },
+          }, 
           "owner_id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "owner_type": {
             "enum": [
-              "User",
+              "User", 
               "Dashboard"
-            ],
+            ], 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "json_metadata",
-          "name",
+          "json_metadata", 
+          "name", 
           "owner_type"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "FilterSetRestApi.put": {
         "properties": {
           "description": {
-            "maxLength": 1000,
-            "minLength": 1,
+            "maxLength": 1000, 
+            "minLength": 1, 
             "type": "string"
-          },
+          }, 
           "json_metadata": {
             "type": "string"
-          },
+          }, 
           "name": {
-            "maxLength": 500,
-            "minLength": 0,
+            "maxLength": 500, 
+            "minLength": 0, 
             "type": "string"
-          },
+          }, 
           "owner_type": {
             "enum": [
               "Dashboard"
-            ],
+            ], 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "FormDataPostSchema": {
         "properties": {
           "chart_id": {
-            "description": "The chart ID",
-            "format": "int32",
+            "description": "The chart ID", 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "datasource_id": {
-            "description": "The datasource ID",
-            "format": "int32",
+            "description": "The datasource ID", 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "datasource_type": {
-            "description": "The datasource type",
+            "description": "The datasource type", 
             "enum": [
-              "sl_table",
-              "table",
-              "dataset",
-              "query",
-              "saved_query",
+              "sl_table", 
+              "table", 
+              "dataset", 
+              "query", 
+              "saved_query", 
               "view"
-            ],
+            ], 
             "type": "string"
-          },
+          }, 
           "form_data": {
-            "description": "Any type of JSON supported text.",
+            "description": "Any type of JSON supported text.", 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "datasource_id",
-          "datasource_type",
+          "datasource_id", 
+          "datasource_type", 
           "form_data"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "FormDataPutSchema": {
         "properties": {
           "chart_id": {
-            "description": "The chart ID",
-            "format": "int32",
+            "description": "The chart ID", 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "datasource_id": {
-            "description": "The datasource ID",
-            "format": "int32",
+            "description": "The datasource ID", 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "datasource_type": {
-            "description": "The datasource type",
+            "description": "The datasource type", 
             "enum": [
-              "sl_table",
-              "table",
-              "dataset",
-              "query",
-              "saved_query",
+              "sl_table", 
+              "table", 
+              "dataset", 
+              "query", 
+              "saved_query", 
               "view"
-            ],
+            ], 
             "type": "string"
-          },
+          }, 
           "form_data": {
-            "description": "Any type of JSON supported text.",
+            "description": "Any type of JSON supported text.", 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "datasource_id",
-          "datasource_type",
+          "datasource_id", 
+          "datasource_type", 
           "form_data"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "GetFavStarIdsSchema": {
         "properties": {
           "result": {
-            "description": "A list of results for each corresponding chart in the request",
+            "description": "A list of results for each corresponding chart in the request", 
             "items": {
               "$ref": "#/components/schemas/ChartFavStarResponseResult"
-            },
+            }, 
             "type": "array"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "GuestTokenCreate": {
         "properties": {
           "resources": {
             "items": {
               "$ref": "#/components/schemas/Resource"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "rls": {
             "items": {
               "$ref": "#/components/schemas/RlsRule"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "user": {
             "$ref": "#/components/schemas/User1"
           }
-        },
+        }, 
         "required": [
-          "resources",
+          "resources", 
           "rls"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "LogRestApi.get": {
         "properties": {
           "action": {
-            "maxLength": 512,
-            "nullable": true,
+            "maxLength": 512, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "dashboard_id": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "dttm": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "duration_ms": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "json": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "referrer": {
-            "maxLength": 1024,
-            "nullable": true,
+            "maxLength": 1024, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "slice_id": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "user": {
             "$ref": "#/components/schemas/LogRestApi.get.User"
-          },
+          }, 
           "user_id": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "LogRestApi.get.User": {
         "properties": {
           "username": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
           "username"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "LogRestApi.get_list": {
         "properties": {
           "action": {
-            "maxLength": 512,
-            "nullable": true,
+            "maxLength": 512, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "dashboard_id": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "dttm": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "duration_ms": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "json": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "referrer": {
-            "maxLength": 1024,
-            "nullable": true,
+            "maxLength": 1024, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "slice_id": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "user": {
             "$ref": "#/components/schemas/LogRestApi.get_list.User"
-          },
+          }, 
           "user_id": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "LogRestApi.get_list.User": {
         "properties": {
           "username": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
           "username"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "LogRestApi.post": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "LogRestApi.put": {
         "properties": {
           "action": {
-            "maxLength": 512,
-            "nullable": true,
+            "maxLength": 512, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "dttm": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "json": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "user": {
             "nullable": true
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "QueryRestApi.get": {
         "properties": {
           "changed_on": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "client_id": {
-            "maxLength": 11,
+            "maxLength": 11, 
             "type": "string"
-          },
+          }, 
           "database": {
             "$ref": "#/components/schemas/QueryRestApi.get.Database"
-          },
+          }, 
           "end_result_backend_time": {
-            "nullable": true,
+            "nullable": true, 
             "type": "number"
-          },
+          }, 
           "end_time": {
-            "nullable": true,
+            "nullable": true, 
             "type": "number"
-          },
+          }, 
           "error_message": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "executed_sql": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "limit": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "progress": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "results_key": {
-            "maxLength": 64,
-            "nullable": true,
+            "maxLength": 64, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "rows": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "schema": {
-            "maxLength": 256,
-            "nullable": true,
+            "maxLength": 256, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "select_as_cta": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "select_as_cta_used": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "select_sql": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "sql": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "sql_editor_id": {
-            "maxLength": 256,
-            "nullable": true,
+            "maxLength": 256, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "start_running_time": {
-            "nullable": true,
+            "nullable": true, 
             "type": "number"
-          },
+          }, 
           "start_time": {
-            "nullable": true,
+            "nullable": true, 
             "type": "number"
-          },
+          }, 
           "status": {
-            "maxLength": 16,
-            "nullable": true,
+            "maxLength": 16, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "tab_name": {
-            "maxLength": 256,
-            "nullable": true,
+            "maxLength": 256, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "tmp_schema_name": {
-            "maxLength": 256,
-            "nullable": true,
+            "maxLength": 256, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "tmp_table_name": {
-            "maxLength": 256,
-            "nullable": true,
+            "maxLength": 256, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "tracking_url": {
             "readOnly": true
           }
-        },
+        }, 
         "required": [
-          "client_id",
+          "client_id", 
           "database"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "QueryRestApi.get.Database": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "QueryRestApi.get_list": {
         "properties": {
           "changed_on": {
-            "format": "date-time",
+            "format": "date-time", 
             "type": "string"
-          },
+          }, 
           "database": {
             "$ref": "#/components/schemas/Database1"
-          },
+          }, 
           "end_time": {
-            "format": "float",
+            "format": "float", 
             "type": "number"
-          },
+          }, 
           "executed_sql": {
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "rows": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "schema": {
             "type": "string"
-          },
+          }, 
           "sql": {
             "type": "string"
-          },
+          }, 
           "sql_tables": {
             "readOnly": true
-          },
+          }, 
           "start_time": {
-            "format": "float",
+            "format": "float", 
             "type": "number"
-          },
+          }, 
           "status": {
             "type": "string"
-          },
+          }, 
           "tab_name": {
             "type": "string"
-          },
+          }, 
           "tmp_table_name": {
             "type": "string"
-          },
+          }, 
           "tracking_url": {
             "type": "string"
-          },
+          }, 
           "user": {
             "$ref": "#/components/schemas/User"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "QueryRestApi.post": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "QueryRestApi.put": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "RLSRestApi.get": {
         "properties": {
           "clause": {
-            "description": "This is the condition that will be added to the WHERE clause. For example,to only return rows for a particular client,you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role,a base filter can be created with the clause `1 = 0` (always false).",
+            "description": "This is the condition that will be added to the WHERE clause. For example, to only return rows for a particular client, you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role, a base filter can be created with the clause `1 = 0` (always false).", 
             "type": "string"
-          },
+          }, 
           "description": {
-            "description": "Detailed description",
+            "description": "Detailed description", 
             "type": "string"
-          },
+          }, 
           "filter_type": {
-            "description": "Regular filters add where clauses to queries if a user belongs to a role referenced in the filter,base filters apply filters to all queries except the roles defined in the filter,and can be used to define what users can see if no RLS filters within a filter group apply to them.",
+            "description": "Regular filters add where clauses to queries if a user belongs to a role referenced in the filter, base filters apply filters to all queries except the roles defined in the filter, and can be used to define what users can see if no RLS filters within a filter group apply to them.", 
             "enum": [
-              "Regular",
+              "Regular", 
               "Base"
-            ],
+            ], 
             "type": "string"
-          },
+          }, 
           "group_key": {
-            "description": "Filters with the same group key will be ORed together within the group,while different filter groups will be ANDed together. Undefined group keys are treated as unique groups,i.e. are not grouped together. For example,if a table has three filters,of which two are for departments Finance and Marketing (group key = 'department'),and one refers to the region Europe (group key = 'region'),the filter clause would apply the filter (department = 'Finance' OR department = 'Marketing') AND (region = 'Europe').",
+            "description": "Filters with the same group key will be ORed together within the group, while different filter groups will be ANDed together. Undefined group keys are treated as unique groups, i.e. are not grouped together. For example, if a table has three filters, of which two are for departments Finance and Marketing (group key = 'department'), and one refers to the region Europe (group key = 'region'), the filter clause would apply the filter (department = 'Finance' OR department = 'Marketing') AND (region = 'Europe').", 
             "type": "string"
-          },
+          }, 
           "id": {
-            "description": "Unique if of rls filter",
-            "format": "int32",
+            "description": "Unique if of rls filter", 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "name": {
-            "description": "Name of rls filter",
+            "description": "Name of rls filter", 
             "type": "string"
-          },
+          }, 
           "roles": {
             "items": {
               "$ref": "#/components/schemas/Roles1"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "tables": {
             "items": {
               "$ref": "#/components/schemas/Tables"
-            },
+            }, 
             "type": "array"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "RLSRestApi.get_list": {
         "properties": {
           "changed_on_delta_humanized": {
             "readOnly": true
-          },
+          }, 
           "clause": {
-            "description": "This is the condition that will be added to the WHERE clause. For example,to only return rows for a particular client,you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role,a base filter can be created with the clause `1 = 0` (always false).",
+            "description": "This is the condition that will be added to the WHERE clause. For example, to only return rows for a particular client, you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role, a base filter can be created with the clause `1 = 0` (always false).", 
             "type": "string"
-          },
+          }, 
           "description": {
-            "description": "Detailed description",
+            "description": "Detailed description", 
             "type": "string"
-          },
+          }, 
           "filter_type": {
-            "description": "Regular filters add where clauses to queries if a user belongs to a role referenced in the filter,base filters apply filters to all queries except the roles defined in the filter,and can be used to define what users can see if no RLS filters within a filter group apply to them.",
+            "description": "Regular filters add where clauses to queries if a user belongs to a role referenced in the filter, base filters apply filters to all queries except the roles defined in the filter, and can be used to define what users can see if no RLS filters within a filter group apply to them.", 
             "enum": [
-              "Regular",
+              "Regular", 
               "Base"
-            ],
+            ], 
             "type": "string"
-          },
+          }, 
           "group_key": {
-            "description": "Filters with the same group key will be ORed together within the group,while different filter groups will be ANDed together. Undefined group keys are treated as unique groups,i.e. are not grouped together. For example,if a table has three filters,of which two are for departments Finance and Marketing (group key = 'department'),and one refers to the region Europe (group key = 'region'),the filter clause would apply the filter (department = 'Finance' OR department = 'Marketing') AND (region = 'Europe').",
+            "description": "Filters with the same group key will be ORed together within the group, while different filter groups will be ANDed together. Undefined group keys are treated as unique groups, i.e. are not grouped together. For example, if a table has three filters, of which two are for departments Finance and Marketing (group key = 'department'), and one refers to the region Europe (group key = 'region'), the filter clause would apply the filter (department = 'Finance' OR department = 'Marketing') AND (region = 'Europe').", 
             "type": "string"
-          },
+          }, 
           "id": {
-            "description": "Unique if of rls filter",
-            "format": "int32",
+            "description": "Unique if of rls filter", 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "name": {
-            "description": "Name of rls filter",
+            "description": "Name of rls filter", 
             "type": "string"
-          },
+          }, 
           "roles": {
             "items": {
               "$ref": "#/components/schemas/Roles1"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "tables": {
             "items": {
               "$ref": "#/components/schemas/Tables"
-            },
+            }, 
             "type": "array"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "RLSRestApi.post": {
         "properties": {
           "clause": {
-            "description": "This is the condition that will be added to the WHERE clause. For example,to only return rows for a particular client,you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role,a base filter can be created with the clause `1 = 0` (always false).",
+            "description": "This is the condition that will be added to the WHERE clause. For example, to only return rows for a particular client, you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role, a base filter can be created with the clause `1 = 0` (always false).", 
             "type": "string"
-          },
+          }, 
           "description": {
-            "description": "Detailed description",
-            "nullable": true,
+            "description": "Detailed description", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "filter_type": {
-            "description": "Regular filters add where clauses to queries if a user belongs to a role referenced in the filter,base filters apply filters to all queries except the roles defined in the filter,and can be used to define what users can see if no RLS filters within a filter group apply to them.",
+            "description": "Regular filters add where clauses to queries if a user belongs to a role referenced in the filter, base filters apply filters to all queries except the roles defined in the filter, and can be used to define what users can see if no RLS filters within a filter group apply to them.", 
             "enum": [
-              "Regular",
+              "Regular", 
               "Base"
-            ],
+            ], 
             "type": "string"
-          },
+          }, 
           "group_key": {
-            "description": "Filters with the same group key will be ORed together within the group,while different filter groups will be ANDed together. Undefined group keys are treated as unique groups,i.e. are not grouped together. For example,if a table has three filters,of which two are for departments Finance and Marketing (group key = 'department'),and one refers to the region Europe (group key = 'region'),the filter clause would apply the filter (department = 'Finance' OR department = 'Marketing') AND (region = 'Europe').",
-            "nullable": true,
+            "description": "Filters with the same group key will be ORed together within the group, while different filter groups will be ANDed together. Undefined group keys are treated as unique groups, i.e. are not grouped together. For example, if a table has three filters, of which two are for departments Finance and Marketing (group key = 'department'), and one refers to the region Europe (group key = 'region'), the filter clause would apply the filter (department = 'Finance' OR department = 'Marketing') AND (region = 'Europe').", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "name": {
-            "description": "Name of rls filter",
-            "maxLength": 255,
-            "minLength": 1,
+            "description": "Name of rls filter", 
+            "maxLength": 255, 
+            "minLength": 1, 
             "type": "string"
-          },
+          }, 
           "roles": {
-            "description": "For regular filters,these are the roles this filter will be applied to. For base filters,these are the roles that the filter DOES NOT apply to,e.g. Admin if admin should see all data.",
+            "description": "For regular filters, these are the roles this filter will be applied to. For base filters, these are the roles that the filter DOES NOT apply to, e.g. Admin if admin should see all data.", 
             "items": {
-              "format": "int32",
+              "format": "int32", 
               "type": "integer"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "tables": {
-            "description": "These are the tables this filter will be applied to.",
+            "description": "These are the tables this filter will be applied to.", 
             "items": {
-              "format": "int32",
+              "format": "int32", 
               "type": "integer"
-            },
-            "minItems": 1,
+            }, 
+            "minItems": 1, 
             "type": "array"
           }
-        },
+        }, 
         "required": [
-          "clause",
-          "filter_type",
-          "name",
-          "roles",
+          "clause", 
+          "filter_type", 
+          "name", 
+          "roles", 
           "tables"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "RLSRestApi.put": {
         "properties": {
           "clause": {
-            "description": "This is the condition that will be added to the WHERE clause. For example,to only return rows for a particular client,you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role,a base filter can be created with the clause `1 = 0` (always false).",
+            "description": "This is the condition that will be added to the WHERE clause. For example, to only return rows for a particular client, you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role, a base filter can be created with the clause `1 = 0` (always false).", 
             "type": "string"
-          },
+          }, 
           "description": {
-            "description": "Detailed description",
-            "nullable": true,
+            "description": "Detailed description", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "filter_type": {
-            "description": "Regular filters add where clauses to queries if a user belongs to a role referenced in the filter,base filters apply filters to all queries except the roles defined in the filter,and can be used to define what users can see if no RLS filters within a filter group apply to them.",
+            "description": "Regular filters add where clauses to queries if a user belongs to a role referenced in the filter, base filters apply filters to all queries except the roles defined in the filter, and can be used to define what users can see if no RLS filters within a filter group apply to them.", 
             "enum": [
-              "Regular",
+              "Regular", 
               "Base"
-            ],
+            ], 
             "type": "string"
-          },
+          }, 
           "group_key": {
-            "description": "Filters with the same group key will be ORed together within the group,while different filter groups will be ANDed together. Undefined group keys are treated as unique groups,i.e. are not grouped together. For example,if a table has three filters,of which two are for departments Finance and Marketing (group key = 'department'),and one refers to the region Europe (group key = 'region'),the filter clause would apply the filter (department = 'Finance' OR department = 'Marketing') AND (region = 'Europe').",
-            "nullable": true,
+            "description": "Filters with the same group key will be ORed together within the group, while different filter groups will be ANDed together. Undefined group keys are treated as unique groups, i.e. are not grouped together. For example, if a table has three filters, of which two are for departments Finance and Marketing (group key = 'department'), and one refers to the region Europe (group key = 'region'), the filter clause would apply the filter (department = 'Finance' OR department = 'Marketing') AND (region = 'Europe').", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "name": {
-            "description": "Name of rls filter",
-            "maxLength": 255,
-            "minLength": 1,
+            "description": "Name of rls filter", 
+            "maxLength": 255, 
+            "minLength": 1, 
             "type": "string"
-          },
+          }, 
           "roles": {
-            "description": "For regular filters,these are the roles this filter will be applied to. For base filters,these are the roles that the filter DOES NOT apply to,e.g. Admin if admin should see all data.",
+            "description": "For regular filters, these are the roles this filter will be applied to. For base filters, these are the roles that the filter DOES NOT apply to, e.g. Admin if admin should see all data.", 
             "items": {
-              "format": "int32",
+              "format": "int32", 
               "type": "integer"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "tables": {
-            "description": "These are the tables this filter will be applied to.",
+            "description": "These are the tables this filter will be applied to.", 
             "items": {
-              "format": "int32",
+              "format": "int32", 
               "type": "integer"
-            },
+            }, 
             "type": "array"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "RecentActivity": {
         "properties": {
           "action": {
-            "description": "Action taken describing type of activity",
+            "description": "Action taken describing type of activity", 
             "type": "string"
-          },
+          }, 
           "item_title": {
-            "description": "Title of item",
+            "description": "Title of item", 
             "type": "string"
-          },
+          }, 
           "item_type": {
-            "description": "Type of item,e.g. slice or dashboard",
+            "description": "Type of item, e.g. slice or dashboard", 
             "type": "string"
-          },
+          }, 
           "item_url": {
-            "description": "URL to item",
+            "description": "URL to item", 
             "type": "string"
-          },
+          }, 
           "time": {
-            "description": "Time of activity,in epoch milliseconds",
-            "format": "float",
+            "description": "Time of activity, in epoch milliseconds", 
+            "format": "float", 
             "type": "number"
-          },
+          }, 
           "time_delta_humanized": {
-            "description": "Human-readable description of how long ago activity took place",
+            "description": "Human-readable description of how long ago activity took place", 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "RecentActivityResponseSchema": {
         "properties": {
           "result": {
-            "description": "A list of recent activity objects",
+            "description": "A list of recent activity objects", 
             "items": {
               "$ref": "#/components/schemas/RecentActivity"
-            },
+            }, 
             "type": "array"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "RecentActivitySchema": {
         "properties": {
           "action": {
-            "description": "Action taken describing type of activity",
+            "description": "Action taken describing type of activity", 
             "type": "string"
-          },
+          }, 
           "item_title": {
-            "description": "Title of item",
+            "description": "Title of item", 
             "type": "string"
-          },
+          }, 
           "item_type": {
-            "description": "Type of item,e.g. slice or dashboard",
+            "description": "Type of item, e.g. slice or dashboard", 
             "type": "string"
-          },
+          }, 
           "item_url": {
-            "description": "URL to item",
+            "description": "URL to item", 
             "type": "string"
-          },
+          }, 
           "time": {
-            "description": "Time of activity,in epoch milliseconds",
-            "format": "float",
+            "description": "Time of activity, in epoch milliseconds", 
+            "format": "float", 
             "type": "number"
-          },
+          }, 
           "time_delta_humanized": {
-            "description": "Human-readable description of how long ago activity took place",
+            "description": "Human-readable description of how long ago activity took place", 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "RelatedResponseSchema": {
         "properties": {
           "count": {
-            "description": "The total number of related values",
-            "format": "int32",
+            "description": "The total number of related values", 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "result": {
             "items": {
               "$ref": "#/components/schemas/RelatedResultResponse"
-            },
+            }, 
             "type": "array"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "RelatedResultResponse": {
         "properties": {
           "extra": {
-            "description": "The extra metadata for related item",
+            "description": "The extra metadata for related item", 
             "type": "object"
-          },
+          }, 
           "text": {
-            "description": "The related item string representation",
+            "description": "The related item string representation", 
             "type": "string"
-          },
+          }, 
           "value": {
-            "description": "The related item identifier",
-            "format": "int32",
+            "description": "The related item identifier", 
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ReportExecutionLogRestApi.get": {
         "properties": {
           "end_dttm": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "error_message": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "scheduled_dttm": {
-            "format": "date-time",
+            "format": "date-time", 
             "type": "string"
-          },
+          }, 
           "start_dttm": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "state": {
-            "maxLength": 50,
+            "maxLength": 50, 
             "type": "string"
-          },
+          }, 
           "uuid": {
-            "format": "uuid",
-            "nullable": true,
+            "format": "uuid", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "value": {
-            "format": "float",
-            "nullable": true,
+            "format": "float", 
+            "nullable": true, 
             "type": "number"
-          },
+          }, 
           "value_row_json": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "scheduled_dttm",
+          "scheduled_dttm", 
           "state"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ReportExecutionLogRestApi.get_list": {
         "properties": {
           "end_dttm": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "error_message": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "scheduled_dttm": {
-            "format": "date-time",
+            "format": "date-time", 
             "type": "string"
-          },
+          }, 
           "start_dttm": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "state": {
-            "maxLength": 50,
+            "maxLength": 50, 
             "type": "string"
-          },
+          }, 
           "uuid": {
-            "format": "uuid",
-            "nullable": true,
+            "format": "uuid", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "value": {
-            "format": "float",
-            "nullable": true,
+            "format": "float", 
+            "nullable": true, 
             "type": "number"
-          },
+          }, 
           "value_row_json": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "scheduled_dttm",
+          "scheduled_dttm", 
           "state"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ReportExecutionLogRestApi.post": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ReportExecutionLogRestApi.put": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ReportRecipient": {
         "properties": {
           "recipient_config_json": {
             "$ref": "#/components/schemas/ReportRecipientConfigJSON"
-          },
+          }, 
           "type": {
-            "description": "The recipient type,check spec for valid options",
+            "description": "The recipient type, check spec for valid options", 
             "enum": [
-              "Email",
+              "Email", 
               "Slack"
-            ],
+            ], 
             "type": "string"
           }
-        },
+        }, 
         "required": [
           "type"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ReportRecipientConfigJSON": {
         "properties": {
           "target": {
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ReportScheduleRestApi.get": {
         "properties": {
           "active": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "chart": {
             "$ref": "#/components/schemas/ReportScheduleRestApi.get.Slice"
-          },
+          }, 
           "context_markdown": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "creation_method": {
-            "maxLength": 255,
-            "nullable": true,
+            "maxLength": 255, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "crontab": {
-            "maxLength": 1000,
+            "maxLength": 1000, 
             "type": "string"
-          },
+          }, 
           "dashboard": {
             "$ref": "#/components/schemas/ReportScheduleRestApi.get.Dashboard"
-          },
+          }, 
           "database": {
             "$ref": "#/components/schemas/ReportScheduleRestApi.get.Database"
-          },
+          }, 
           "description": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "extra": {
             "readOnly": true
-          },
+          }, 
           "force_screenshot": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "grace_period": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "last_eval_dttm": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "last_state": {
-            "maxLength": 50,
-            "nullable": true,
+            "maxLength": 50, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "last_value": {
-            "format": "float",
-            "nullable": true,
+            "format": "float", 
+            "nullable": true, 
             "type": "number"
-          },
+          }, 
           "last_value_row_json": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "log_retention": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "name": {
-            "maxLength": 150,
+            "maxLength": 150, 
             "type": "string"
-          },
+          }, 
           "owners": {
             "$ref": "#/components/schemas/ReportScheduleRestApi.get.User"
-          },
+          }, 
           "recipients": {
             "$ref": "#/components/schemas/ReportScheduleRestApi.get.ReportRecipients"
-          },
+          }, 
           "report_format": {
-            "maxLength": 50,
-            "nullable": true,
+            "maxLength": 50, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "sql": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "timezone": {
-            "maxLength": 100,
+            "maxLength": 100, 
             "type": "string"
-          },
+          }, 
           "type": {
-            "maxLength": 50,
+            "maxLength": 50, 
             "type": "string"
-          },
+          }, 
           "validator_config_json": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "validator_type": {
-            "maxLength": 100,
-            "nullable": true,
+            "maxLength": 100, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "working_timeout": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
           }
-        },
+        }, 
         "required": [
-          "crontab",
-          "name",
-          "recipients",
+          "crontab", 
+          "name", 
+          "recipients", 
           "type"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ReportScheduleRestApi.get.Dashboard": {
         "properties": {
           "dashboard_title": {
-            "maxLength": 500,
-            "nullable": true,
+            "maxLength": 500, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ReportScheduleRestApi.get.Database": {
         "properties": {
           "database_name": {
-            "maxLength": 250,
+            "maxLength": 250, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "required": [
           "database_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ReportScheduleRestApi.get.ReportRecipients": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "recipient_config_json": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "type": {
-            "maxLength": 50,
+            "maxLength": 50, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
           "type"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ReportScheduleRestApi.get.Slice": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "slice_name": {
-            "maxLength": 250,
-            "nullable": true,
+            "maxLength": 250, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "viz_type": {
-            "maxLength": 250,
-            "nullable": true,
+            "maxLength": 250, 
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ReportScheduleRestApi.get.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
+          "first_name", 
           "last_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ReportScheduleRestApi.get_list": {
         "properties": {
           "active": {
-            "nullable": true,
+            "nullable": true, 
             "type": "boolean"
-          },
+          }, 
           "changed_by": {
             "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.User"
-          },
+          }, 
           "changed_on": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "changed_on_delta_humanized": {
             "readOnly": true
-          },
+          }, 
           "chart_id": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "created_by": {
             "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.User2"
-          },
+          }, 
           "created_on": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "creation_method": {
-            "maxLength": 255,
-            "nullable": true,
+            "maxLength": 255, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "crontab": {
-            "maxLength": 1000,
+            "maxLength": 1000, 
             "type": "string"
-          },
+          }, 
           "crontab_humanized": {
             "readOnly": true
-          },
+          }, 
           "dashboard_id": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "description": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "extra": {
             "readOnly": true
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "last_eval_dttm": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "last_state": {
-            "maxLength": 50,
-            "nullable": true,
+            "maxLength": 50, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "name": {
-            "maxLength": 150,
+            "maxLength": 150, 
             "type": "string"
-          },
+          }, 
           "owners": {
             "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.User1"
-          },
+          }, 
           "recipients": {
             "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.ReportRecipients"
-          },
+          }, 
           "timezone": {
-            "maxLength": 100,
+            "maxLength": 100, 
             "type": "string"
-          },
+          }, 
           "type": {
-            "maxLength": 50,
+            "maxLength": 50, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "crontab",
-          "name",
-          "recipients",
+          "crontab", 
+          "name", 
+          "recipients", 
           "type"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ReportScheduleRestApi.get_list.ReportRecipients": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "type": {
-            "maxLength": 50,
+            "maxLength": 50, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
           "type"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ReportScheduleRestApi.get_list.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
+          "first_name", 
           "last_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ReportScheduleRestApi.get_list.User1": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
+          "first_name", 
           "last_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ReportScheduleRestApi.get_list.User2": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
+          "first_name", 
           "last_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ReportScheduleRestApi.post": {
         "properties": {
           "active": {
             "type": "boolean"
-          },
+          }, 
           "chart": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "context_markdown": {
-            "description": "Markdown description",
-            "nullable": true,
+            "description": "Markdown description", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "creation_method": {
-            "description": "Creation method is used to inform the frontend whether the report/alert was created in the dashboard,chart,or alerts and reports UI."
-          },
+            "description": "Creation method is used to inform the frontend whether the report/alert was created in the dashboard, chart, or alerts and reports UI."
+          }, 
           "crontab": {
-            "description": "A CRON expression.[Crontab Guru](https://crontab.guru/) is a helpful resource that can help you craft a CRON expression.",
-            "example": "*/5 * * * *",
-            "maxLength": 1000,
-            "minLength": 1,
+            "description": "A CRON expression.[Crontab Guru](https://crontab.guru/) is a helpful resource that can help you craft a CRON expression.", 
+            "example": "*/5 * * * *", 
+            "maxLength": 1000, 
+            "minLength": 1, 
             "type": "string"
-          },
+          }, 
           "dashboard": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "database": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "description": {
-            "description": "Use a nice description to give context to this Alert/Report",
-            "example": "Daily sales dashboard to marketing",
-            "nullable": true,
+            "description": "Use a nice description to give context to this Alert/Report", 
+            "example": "Daily sales dashboard to marketing", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "extra": {
             "type": "object"
-          },
+          }, 
           "force_screenshot": {
             "type": "boolean"
-          },
+          }, 
           "grace_period": {
-            "description": "Once an alert is triggered,how long,in seconds,before Superset nags you again. (in seconds)",
-            "example": 14400,
-            "format": "int32",
-            "minimum": 1,
+            "description": "Once an alert is triggered, how long, in seconds, before Superset nags you again. (in seconds)", 
+            "example": 14400, 
+            "format": "int32", 
+            "minimum": 1, 
             "type": "integer"
-          },
+          }, 
           "log_retention": {
-            "description": "How long to keep the logs around for this report (in days)",
-            "example": 90,
-            "format": "int32",
-            "minimum": 1,
+            "description": "How long to keep the logs around for this report (in days)", 
+            "example": 90, 
+            "format": "int32", 
+            "minimum": 1, 
             "type": "integer"
-          },
+          }, 
           "name": {
-            "description": "The report schedule name.",
-            "example": "Daily dashboard email",
-            "maxLength": 150,
-            "minLength": 1,
+            "description": "The report schedule name.", 
+            "example": "Daily dashboard email", 
+            "maxLength": 150, 
+            "minLength": 1, 
             "type": "string"
-          },
+          }, 
           "owners": {
             "items": {
-              "description": "Owner are users ids allowed to delete or change this report. If left empty you will be one of the owners of the report.",
-              "format": "int32",
+              "description": "Owner are users ids allowed to delete or change this report. If left empty you will be one of the owners of the report.", 
+              "format": "int32", 
               "type": "integer"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "recipients": {
             "items": {
               "$ref": "#/components/schemas/ReportRecipient"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "report_format": {
             "enum": [
-              "PNG",
-              "CSV",
+              "PNG", 
+              "CSV", 
               "TEXT"
-            ],
+            ], 
             "type": "string"
-          },
+          }, 
           "selected_tabs": {
             "items": {
-              "format": "int32",
+              "format": "int32", 
               "type": "integer"
-            },
-            "nullable": true,
+            }, 
+            "nullable": true, 
             "type": "array"
-          },
+          }, 
           "sql": {
-            "description": "A SQL statement that defines whether the alert should get triggered or not. The query is expected to return either NULL or a number value.",
-            "example": "SELECT value FROM time_series_table",
+            "description": "A SQL statement that defines whether the alert should get triggered or not. The query is expected to return either NULL or a number value.", 
+            "example": "SELECT value FROM time_series_table", 
             "type": "string"
-          },
+          }, 
           "timezone": {
-            "description": "A timezone string that represents the location of the timezone.",
+            "description": "A timezone string that represents the location of the timezone.", 
             "enum": [
-              "Africa/Abidjan",
-              "Africa/Accra",
-              "Africa/Addis_Ababa",
-              "Africa/Algiers",
-              "Africa/Asmara",
-              "Africa/Asmera",
-              "Africa/Bamako",
-              "Africa/Bangui",
-              "Africa/Banjul",
-              "Africa/Bissau",
-              "Africa/Blantyre",
-              "Africa/Brazzaville",
-              "Africa/Bujumbura",
-              "Africa/Cairo",
-              "Africa/Casablanca",
-              "Africa/Ceuta",
-              "Africa/Conakry",
-              "Africa/Dakar",
-              "Africa/Dar_es_Salaam",
-              "Africa/Djibouti",
-              "Africa/Douala",
-              "Africa/El_Aaiun",
-              "Africa/Freetown",
-              "Africa/Gaborone",
-              "Africa/Harare",
-              "Africa/Johannesburg",
-              "Africa/Juba",
-              "Africa/Kampala",
-              "Africa/Khartoum",
-              "Africa/Kigali",
-              "Africa/Kinshasa",
-              "Africa/Lagos",
-              "Africa/Libreville",
-              "Africa/Lome",
-              "Africa/Luanda",
-              "Africa/Lubumbashi",
-              "Africa/Lusaka",
-              "Africa/Malabo",
-              "Africa/Maputo",
-              "Africa/Maseru",
-              "Africa/Mbabane",
-              "Africa/Mogadishu",
-              "Africa/Monrovia",
-              "Africa/Nairobi",
-              "Africa/Ndjamena",
-              "Africa/Niamey",
-              "Africa/Nouakchott",
-              "Africa/Ouagadougou",
-              "Africa/Porto-Novo",
-              "Africa/Sao_Tome",
-              "Africa/Timbuktu",
-              "Africa/Tripoli",
-              "Africa/Tunis",
-              "Africa/Windhoek",
-              "America/Adak",
-              "America/Anchorage",
-              "America/Anguilla",
-              "America/Antigua",
-              "America/Araguaina",
-              "America/Argentina/Buenos_Aires",
-              "America/Argentina/Catamarca",
-              "America/Argentina/ComodRivadavia",
-              "America/Argentina/Cordoba",
-              "America/Argentina/Jujuy",
-              "America/Argentina/La_Rioja",
-              "America/Argentina/Mendoza",
-              "America/Argentina/Rio_Gallegos",
-              "America/Argentina/Salta",
-              "America/Argentina/San_Juan",
-              "America/Argentina/San_Luis",
-              "America/Argentina/Tucuman",
-              "America/Argentina/Ushuaia",
-              "America/Aruba",
-              "America/Asuncion",
-              "America/Atikokan",
-              "America/Atka",
-              "America/Bahia",
-              "America/Bahia_Banderas",
-              "America/Barbados",
-              "America/Belem",
-              "America/Belize",
-              "America/Blanc-Sablon",
-              "America/Boa_Vista",
-              "America/Bogota",
-              "America/Boise",
-              "America/Buenos_Aires",
-              "America/Cambridge_Bay",
-              "America/Campo_Grande",
-              "America/Cancun",
-              "America/Caracas",
-              "America/Catamarca",
-              "America/Cayenne",
-              "America/Cayman",
-              "America/Chicago",
-              "America/Chihuahua",
-              "America/Coral_Harbour",
-              "America/Cordoba",
-              "America/Costa_Rica",
-              "America/Creston",
-              "America/Cuiaba",
-              "America/Curacao",
-              "America/Danmarkshavn",
-              "America/Dawson",
-              "America/Dawson_Creek",
-              "America/Denver",
-              "America/Detroit",
-              "America/Dominica",
-              "America/Edmonton",
-              "America/Eirunepe",
-              "America/El_Salvador",
-              "America/Ensenada",
-              "America/Fort_Nelson",
-              "America/Fort_Wayne",
-              "America/Fortaleza",
-              "America/Glace_Bay",
-              "America/Godthab",
-              "America/Goose_Bay",
-              "America/Grand_Turk",
-              "America/Grenada",
-              "America/Guadeloupe",
-              "America/Guatemala",
-              "America/Guayaquil",
-              "America/Guyana",
-              "America/Halifax",
-              "America/Havana",
-              "America/Hermosillo",
-              "America/Indiana/Indianapolis",
-              "America/Indiana/Knox",
-              "America/Indiana/Marengo",
-              "America/Indiana/Petersburg",
-              "America/Indiana/Tell_City",
-              "America/Indiana/Vevay",
-              "America/Indiana/Vincennes",
-              "America/Indiana/Winamac",
-              "America/Indianapolis",
-              "America/Inuvik",
-              "America/Iqaluit",
-              "America/Jamaica",
-              "America/Jujuy",
-              "America/Juneau",
-              "America/Kentucky/Louisville",
-              "America/Kentucky/Monticello",
-              "America/Knox_IN",
-              "America/Kralendijk",
-              "America/La_Paz",
-              "America/Lima",
-              "America/Los_Angeles",
-              "America/Louisville",
-              "America/Lower_Princes",
-              "America/Maceio",
-              "America/Managua",
-              "America/Manaus",
-              "America/Marigot",
-              "America/Martinique",
-              "America/Matamoros",
-              "America/Mazatlan",
-              "America/Mendoza",
-              "America/Menominee",
-              "America/Merida",
-              "America/Metlakatla",
-              "America/Mexico_City",
-              "America/Miquelon",
-              "America/Moncton",
-              "America/Monterrey",
-              "America/Montevideo",
-              "America/Montreal",
-              "America/Montserrat",
-              "America/Nassau",
-              "America/New_York",
-              "America/Nipigon",
-              "America/Nome",
-              "America/Noronha",
-              "America/North_Dakota/Beulah",
-              "America/North_Dakota/Center",
-              "America/North_Dakota/New_Salem",
-              "America/Nuuk",
-              "America/Ojinaga",
-              "America/Panama",
-              "America/Pangnirtung",
-              "America/Paramaribo",
-              "America/Phoenix",
-              "America/Port-au-Prince",
-              "America/Port_of_Spain",
-              "America/Porto_Acre",
-              "America/Porto_Velho",
-              "America/Puerto_Rico",
-              "America/Punta_Arenas",
-              "America/Rainy_River",
-              "America/Rankin_Inlet",
-              "America/Recife",
-              "America/Regina",
-              "America/Resolute",
-              "America/Rio_Branco",
-              "America/Rosario",
-              "America/Santa_Isabel",
-              "America/Santarem",
-              "America/Santiago",
-              "America/Santo_Domingo",
-              "America/Sao_Paulo",
-              "America/Scoresbysund",
-              "America/Shiprock",
-              "America/Sitka",
-              "America/St_Barthelemy",
-              "America/St_Johns",
-              "America/St_Kitts",
-              "America/St_Lucia",
-              "America/St_Thomas",
-              "America/St_Vincent",
-              "America/Swift_Current",
-              "America/Tegucigalpa",
-              "America/Thule",
-              "America/Thunder_Bay",
-              "America/Tijuana",
-              "America/Toronto",
-              "America/Tortola",
-              "America/Vancouver",
-              "America/Virgin",
-              "America/Whitehorse",
-              "America/Winnipeg",
-              "America/Yakutat",
-              "America/Yellowknife",
-              "Antarctica/Casey",
-              "Antarctica/Davis",
-              "Antarctica/DumontDUrville",
-              "Antarctica/Macquarie",
-              "Antarctica/Mawson",
-              "Antarctica/McMurdo",
-              "Antarctica/Palmer",
-              "Antarctica/Rothera",
-              "Antarctica/South_Pole",
-              "Antarctica/Syowa",
-              "Antarctica/Troll",
-              "Antarctica/Vostok",
-              "Arctic/Longyearbyen",
-              "Asia/Aden",
-              "Asia/Almaty",
-              "Asia/Amman",
-              "Asia/Anadyr",
-              "Asia/Aqtau",
-              "Asia/Aqtobe",
-              "Asia/Ashgabat",
-              "Asia/Ashkhabad",
-              "Asia/Atyrau",
-              "Asia/Baghdad",
-              "Asia/Bahrain",
-              "Asia/Baku",
-              "Asia/Bangkok",
-              "Asia/Barnaul",
-              "Asia/Beirut",
-              "Asia/Bishkek",
-              "Asia/Brunei",
-              "Asia/Calcutta",
-              "Asia/Chita",
-              "Asia/Choibalsan",
-              "Asia/Chongqing",
-              "Asia/Chungking",
-              "Asia/Colombo",
-              "Asia/Dacca",
-              "Asia/Damascus",
-              "Asia/Dhaka",
-              "Asia/Dili",
-              "Asia/Dubai",
-              "Asia/Dushanbe",
-              "Asia/Famagusta",
-              "Asia/Gaza",
-              "Asia/Harbin",
-              "Asia/Hebron",
-              "Asia/Ho_Chi_Minh",
-              "Asia/Hong_Kong",
-              "Asia/Hovd",
-              "Asia/Irkutsk",
-              "Asia/Istanbul",
-              "Asia/Jakarta",
-              "Asia/Jayapura",
-              "Asia/Jerusalem",
-              "Asia/Kabul",
-              "Asia/Kamchatka",
-              "Asia/Karachi",
-              "Asia/Kashgar",
-              "Asia/Kathmandu",
-              "Asia/Katmandu",
-              "Asia/Khandyga",
-              "Asia/Kolkata",
-              "Asia/Krasnoyarsk",
-              "Asia/Kuala_Lumpur",
-              "Asia/Kuching",
-              "Asia/Kuwait",
-              "Asia/Macao",
-              "Asia/Macau",
-              "Asia/Magadan",
-              "Asia/Makassar",
-              "Asia/Manila",
-              "Asia/Muscat",
-              "Asia/Nicosia",
-              "Asia/Novokuznetsk",
-              "Asia/Novosibirsk",
-              "Asia/Omsk",
-              "Asia/Oral",
-              "Asia/Phnom_Penh",
-              "Asia/Pontianak",
-              "Asia/Pyongyang",
-              "Asia/Qatar",
-              "Asia/Qostanay",
-              "Asia/Qyzylorda",
-              "Asia/Rangoon",
-              "Asia/Riyadh",
-              "Asia/Saigon",
-              "Asia/Sakhalin",
-              "Asia/Samarkand",
-              "Asia/Seoul",
-              "Asia/Shanghai",
-              "Asia/Singapore",
-              "Asia/Srednekolymsk",
-              "Asia/Taipei",
-              "Asia/Tashkent",
-              "Asia/Tbilisi",
-              "Asia/Tehran",
-              "Asia/Tel_Aviv",
-              "Asia/Thimbu",
-              "Asia/Thimphu",
-              "Asia/Tokyo",
-              "Asia/Tomsk",
-              "Asia/Ujung_Pandang",
-              "Asia/Ulaanbaatar",
-              "Asia/Ulan_Bator",
-              "Asia/Urumqi",
-              "Asia/Ust-Nera",
-              "Asia/Vientiane",
-              "Asia/Vladivostok",
-              "Asia/Yakutsk",
-              "Asia/Yangon",
-              "Asia/Yekaterinburg",
-              "Asia/Yerevan",
-              "Atlantic/Azores",
-              "Atlantic/Bermuda",
-              "Atlantic/Canary",
-              "Atlantic/Cape_Verde",
-              "Atlantic/Faeroe",
-              "Atlantic/Faroe",
-              "Atlantic/Jan_Mayen",
-              "Atlantic/Madeira",
-              "Atlantic/Reykjavik",
-              "Atlantic/South_Georgia",
-              "Atlantic/St_Helena",
-              "Atlantic/Stanley",
-              "Australia/ACT",
-              "Australia/Adelaide",
-              "Australia/Brisbane",
-              "Australia/Broken_Hill",
-              "Australia/Canberra",
-              "Australia/Currie",
-              "Australia/Darwin",
-              "Australia/Eucla",
-              "Australia/Hobart",
-              "Australia/LHI",
-              "Australia/Lindeman",
-              "Australia/Lord_Howe",
-              "Australia/Melbourne",
-              "Australia/NSW",
-              "Australia/North",
-              "Australia/Perth",
-              "Australia/Queensland",
-              "Australia/South",
-              "Australia/Sydney",
-              "Australia/Tasmania",
-              "Australia/Victoria",
-              "Australia/West",
-              "Australia/Yancowinna",
-              "Brazil/Acre",
-              "Brazil/DeNoronha",
-              "Brazil/East",
-              "Brazil/West",
-              "CET",
-              "CST6CDT",
-              "Canada/Atlantic",
-              "Canada/Central",
-              "Canada/Eastern",
-              "Canada/Mountain",
-              "Canada/Newfoundland",
-              "Canada/Pacific",
-              "Canada/Saskatchewan",
-              "Canada/Yukon",
-              "Chile/Continental",
-              "Chile/EasterIsland",
-              "Cuba",
-              "EET",
-              "EST",
-              "EST5EDT",
-              "Egypt",
-              "Eire",
-              "Etc/GMT",
-              "Etc/GMT+0",
-              "Etc/GMT+1",
-              "Etc/GMT+10",
-              "Etc/GMT+11",
-              "Etc/GMT+12",
-              "Etc/GMT+2",
-              "Etc/GMT+3",
-              "Etc/GMT+4",
-              "Etc/GMT+5",
-              "Etc/GMT+6",
-              "Etc/GMT+7",
-              "Etc/GMT+8",
-              "Etc/GMT+9",
-              "Etc/GMT-0",
-              "Etc/GMT-1",
-              "Etc/GMT-10",
-              "Etc/GMT-11",
-              "Etc/GMT-12",
-              "Etc/GMT-13",
-              "Etc/GMT-14",
-              "Etc/GMT-2",
-              "Etc/GMT-3",
-              "Etc/GMT-4",
-              "Etc/GMT-5",
-              "Etc/GMT-6",
-              "Etc/GMT-7",
-              "Etc/GMT-8",
-              "Etc/GMT-9",
-              "Etc/GMT0",
-              "Etc/Greenwich",
-              "Etc/UCT",
-              "Etc/UTC",
-              "Etc/Universal",
-              "Etc/Zulu",
-              "Europe/Amsterdam",
-              "Europe/Andorra",
-              "Europe/Astrakhan",
-              "Europe/Athens",
-              "Europe/Belfast",
-              "Europe/Belgrade",
-              "Europe/Berlin",
-              "Europe/Bratislava",
-              "Europe/Brussels",
-              "Europe/Bucharest",
-              "Europe/Budapest",
-              "Europe/Busingen",
-              "Europe/Chisinau",
-              "Europe/Copenhagen",
-              "Europe/Dublin",
-              "Europe/Gibraltar",
-              "Europe/Guernsey",
-              "Europe/Helsinki",
-              "Europe/Isle_of_Man",
-              "Europe/Istanbul",
-              "Europe/Jersey",
-              "Europe/Kaliningrad",
-              "Europe/Kiev",
-              "Europe/Kirov",
-              "Europe/Lisbon",
-              "Europe/Ljubljana",
-              "Europe/London",
-              "Europe/Luxembourg",
-              "Europe/Madrid",
-              "Europe/Malta",
-              "Europe/Mariehamn",
-              "Europe/Minsk",
-              "Europe/Monaco",
-              "Europe/Moscow",
-              "Europe/Nicosia",
-              "Europe/Oslo",
-              "Europe/Paris",
-              "Europe/Podgorica",
-              "Europe/Prague",
-              "Europe/Riga",
-              "Europe/Rome",
-              "Europe/Samara",
-              "Europe/San_Marino",
-              "Europe/Sarajevo",
-              "Europe/Saratov",
-              "Europe/Simferopol",
-              "Europe/Skopje",
-              "Europe/Sofia",
-              "Europe/Stockholm",
-              "Europe/Tallinn",
-              "Europe/Tirane",
-              "Europe/Tiraspol",
-              "Europe/Ulyanovsk",
-              "Europe/Uzhgorod",
-              "Europe/Vaduz",
-              "Europe/Vatican",
-              "Europe/Vienna",
-              "Europe/Vilnius",
-              "Europe/Volgograd",
-              "Europe/Warsaw",
-              "Europe/Zagreb",
-              "Europe/Zaporozhye",
-              "Europe/Zurich",
-              "GB",
-              "GB-Eire",
-              "GMT",
-              "GMT+0",
-              "GMT-0",
-              "GMT0",
-              "Greenwich",
-              "HST",
-              "Hongkong",
-              "Iceland",
-              "Indian/Antananarivo",
-              "Indian/Chagos",
-              "Indian/Christmas",
-              "Indian/Cocos",
-              "Indian/Comoro",
-              "Indian/Kerguelen",
-              "Indian/Mahe",
-              "Indian/Maldives",
-              "Indian/Mauritius",
-              "Indian/Mayotte",
-              "Indian/Reunion",
-              "Iran",
-              "Israel",
-              "Jamaica",
-              "Japan",
-              "Kwajalein",
-              "Libya",
-              "MET",
-              "MST",
-              "MST7MDT",
-              "Mexico/BajaNorte",
-              "Mexico/BajaSur",
-              "Mexico/General",
-              "NZ",
-              "NZ-CHAT",
-              "Navajo",
-              "PRC",
-              "PST8PDT",
-              "Pacific/Apia",
-              "Pacific/Auckland",
-              "Pacific/Bougainville",
-              "Pacific/Chatham",
-              "Pacific/Chuuk",
-              "Pacific/Easter",
-              "Pacific/Efate",
-              "Pacific/Enderbury",
-              "Pacific/Fakaofo",
-              "Pacific/Fiji",
-              "Pacific/Funafuti",
-              "Pacific/Galapagos",
-              "Pacific/Gambier",
-              "Pacific/Guadalcanal",
-              "Pacific/Guam",
-              "Pacific/Honolulu",
-              "Pacific/Johnston",
-              "Pacific/Kanton",
-              "Pacific/Kiritimati",
-              "Pacific/Kosrae",
-              "Pacific/Kwajalein",
-              "Pacific/Majuro",
-              "Pacific/Marquesas",
-              "Pacific/Midway",
-              "Pacific/Nauru",
-              "Pacific/Niue",
-              "Pacific/Norfolk",
-              "Pacific/Noumea",
-              "Pacific/Pago_Pago",
-              "Pacific/Palau",
-              "Pacific/Pitcairn",
-              "Pacific/Pohnpei",
-              "Pacific/Ponape",
-              "Pacific/Port_Moresby",
-              "Pacific/Rarotonga",
-              "Pacific/Saipan",
-              "Pacific/Samoa",
-              "Pacific/Tahiti",
-              "Pacific/Tarawa",
-              "Pacific/Tongatapu",
-              "Pacific/Truk",
-              "Pacific/Wake",
-              "Pacific/Wallis",
-              "Pacific/Yap",
-              "Poland",
-              "Portugal",
-              "ROC",
-              "ROK",
-              "Singapore",
-              "Turkey",
-              "UCT",
-              "US/Alaska",
-              "US/Aleutian",
-              "US/Arizona",
-              "US/Central",
-              "US/East-Indiana",
-              "US/Eastern",
-              "US/Hawaii",
-              "US/Indiana-Starke",
-              "US/Michigan",
-              "US/Mountain",
-              "US/Pacific",
-              "US/Samoa",
-              "UTC",
-              "Universal",
-              "W-SU",
-              "WET",
+              "Africa/Abidjan", 
+              "Africa/Accra", 
+              "Africa/Addis_Ababa", 
+              "Africa/Algiers", 
+              "Africa/Asmara", 
+              "Africa/Asmera", 
+              "Africa/Bamako", 
+              "Africa/Bangui", 
+              "Africa/Banjul", 
+              "Africa/Bissau", 
+              "Africa/Blantyre", 
+              "Africa/Brazzaville", 
+              "Africa/Bujumbura", 
+              "Africa/Cairo", 
+              "Africa/Casablanca", 
+              "Africa/Ceuta", 
+              "Africa/Conakry", 
+              "Africa/Dakar", 
+              "Africa/Dar_es_Salaam", 
+              "Africa/Djibouti", 
+              "Africa/Douala", 
+              "Africa/El_Aaiun", 
+              "Africa/Freetown", 
+              "Africa/Gaborone", 
+              "Africa/Harare", 
+              "Africa/Johannesburg", 
+              "Africa/Juba", 
+              "Africa/Kampala", 
+              "Africa/Khartoum", 
+              "Africa/Kigali", 
+              "Africa/Kinshasa", 
+              "Africa/Lagos", 
+              "Africa/Libreville", 
+              "Africa/Lome", 
+              "Africa/Luanda", 
+              "Africa/Lubumbashi", 
+              "Africa/Lusaka", 
+              "Africa/Malabo", 
+              "Africa/Maputo", 
+              "Africa/Maseru", 
+              "Africa/Mbabane", 
+              "Africa/Mogadishu", 
+              "Africa/Monrovia", 
+              "Africa/Nairobi", 
+              "Africa/Ndjamena", 
+              "Africa/Niamey", 
+              "Africa/Nouakchott", 
+              "Africa/Ouagadougou", 
+              "Africa/Porto-Novo", 
+              "Africa/Sao_Tome", 
+              "Africa/Timbuktu", 
+              "Africa/Tripoli", 
+              "Africa/Tunis", 
+              "Africa/Windhoek", 
+              "America/Adak", 
+              "America/Anchorage", 
+              "America/Anguilla", 
+              "America/Antigua", 
+              "America/Araguaina", 
+              "America/Argentina/Buenos_Aires", 
+              "America/Argentina/Catamarca", 
+              "America/Argentina/ComodRivadavia", 
+              "America/Argentina/Cordoba", 
+              "America/Argentina/Jujuy", 
+              "America/Argentina/La_Rioja", 
+              "America/Argentina/Mendoza", 
+              "America/Argentina/Rio_Gallegos", 
+              "America/Argentina/Salta", 
+              "America/Argentina/San_Juan", 
+              "America/Argentina/San_Luis", 
+              "America/Argentina/Tucuman", 
+              "America/Argentina/Ushuaia", 
+              "America/Aruba", 
+              "America/Asuncion", 
+              "America/Atikokan", 
+              "America/Atka", 
+              "America/Bahia", 
+              "America/Bahia_Banderas", 
+              "America/Barbados", 
+              "America/Belem", 
+              "America/Belize", 
+              "America/Blanc-Sablon", 
+              "America/Boa_Vista", 
+              "America/Bogota", 
+              "America/Boise", 
+              "America/Buenos_Aires", 
+              "America/Cambridge_Bay", 
+              "America/Campo_Grande", 
+              "America/Cancun", 
+              "America/Caracas", 
+              "America/Catamarca", 
+              "America/Cayenne", 
+              "America/Cayman", 
+              "America/Chicago", 
+              "America/Chihuahua", 
+              "America/Coral_Harbour", 
+              "America/Cordoba", 
+              "America/Costa_Rica", 
+              "America/Creston", 
+              "America/Cuiaba", 
+              "America/Curacao", 
+              "America/Danmarkshavn", 
+              "America/Dawson", 
+              "America/Dawson_Creek", 
+              "America/Denver", 
+              "America/Detroit", 
+              "America/Dominica", 
+              "America/Edmonton", 
+              "America/Eirunepe", 
+              "America/El_Salvador", 
+              "America/Ensenada", 
+              "America/Fort_Nelson", 
+              "America/Fort_Wayne", 
+              "America/Fortaleza", 
+              "America/Glace_Bay", 
+              "America/Godthab", 
+              "America/Goose_Bay", 
+              "America/Grand_Turk", 
+              "America/Grenada", 
+              "America/Guadeloupe", 
+              "America/Guatemala", 
+              "America/Guayaquil", 
+              "America/Guyana", 
+              "America/Halifax", 
+              "America/Havana", 
+              "America/Hermosillo", 
+              "America/Indiana/Indianapolis", 
+              "America/Indiana/Knox", 
+              "America/Indiana/Marengo", 
+              "America/Indiana/Petersburg", 
+              "America/Indiana/Tell_City", 
+              "America/Indiana/Vevay", 
+              "America/Indiana/Vincennes", 
+              "America/Indiana/Winamac", 
+              "America/Indianapolis", 
+              "America/Inuvik", 
+              "America/Iqaluit", 
+              "America/Jamaica", 
+              "America/Jujuy", 
+              "America/Juneau", 
+              "America/Kentucky/Louisville", 
+              "America/Kentucky/Monticello", 
+              "America/Knox_IN", 
+              "America/Kralendijk", 
+              "America/La_Paz", 
+              "America/Lima", 
+              "America/Los_Angeles", 
+              "America/Louisville", 
+              "America/Lower_Princes", 
+              "America/Maceio", 
+              "America/Managua", 
+              "America/Manaus", 
+              "America/Marigot", 
+              "America/Martinique", 
+              "America/Matamoros", 
+              "America/Mazatlan", 
+              "America/Mendoza", 
+              "America/Menominee", 
+              "America/Merida", 
+              "America/Metlakatla", 
+              "America/Mexico_City", 
+              "America/Miquelon", 
+              "America/Moncton", 
+              "America/Monterrey", 
+              "America/Montevideo", 
+              "America/Montreal", 
+              "America/Montserrat", 
+              "America/Nassau", 
+              "America/New_York", 
+              "America/Nipigon", 
+              "America/Nome", 
+              "America/Noronha", 
+              "America/North_Dakota/Beulah", 
+              "America/North_Dakota/Center", 
+              "America/North_Dakota/New_Salem", 
+              "America/Nuuk", 
+              "America/Ojinaga", 
+              "America/Panama", 
+              "America/Pangnirtung", 
+              "America/Paramaribo", 
+              "America/Phoenix", 
+              "America/Port-au-Prince", 
+              "America/Port_of_Spain", 
+              "America/Porto_Acre", 
+              "America/Porto_Velho", 
+              "America/Puerto_Rico", 
+              "America/Punta_Arenas", 
+              "America/Rainy_River", 
+              "America/Rankin_Inlet", 
+              "America/Recife", 
+              "America/Regina", 
+              "America/Resolute", 
+              "America/Rio_Branco", 
+              "America/Rosario", 
+              "America/Santa_Isabel", 
+              "America/Santarem", 
+              "America/Santiago", 
+              "America/Santo_Domingo", 
+              "America/Sao_Paulo", 
+              "America/Scoresbysund", 
+              "America/Shiprock", 
+              "America/Sitka", 
+              "America/St_Barthelemy", 
+              "America/St_Johns", 
+              "America/St_Kitts", 
+              "America/St_Lucia", 
+              "America/St_Thomas", 
+              "America/St_Vincent", 
+              "America/Swift_Current", 
+              "America/Tegucigalpa", 
+              "America/Thule", 
+              "America/Thunder_Bay", 
+              "America/Tijuana", 
+              "America/Toronto", 
+              "America/Tortola", 
+              "America/Vancouver", 
+              "America/Virgin", 
+              "America/Whitehorse", 
+              "America/Winnipeg", 
+              "America/Yakutat", 
+              "America/Yellowknife", 
+              "Antarctica/Casey", 
+              "Antarctica/Davis", 
+              "Antarctica/DumontDUrville", 
+              "Antarctica/Macquarie", 
+              "Antarctica/Mawson", 
+              "Antarctica/McMurdo", 
+              "Antarctica/Palmer", 
+              "Antarctica/Rothera", 
+              "Antarctica/South_Pole", 
+              "Antarctica/Syowa", 
+              "Antarctica/Troll", 
+              "Antarctica/Vostok", 
+              "Arctic/Longyearbyen", 
+              "Asia/Aden", 
+              "Asia/Almaty", 
+              "Asia/Amman", 
+              "Asia/Anadyr", 
+              "Asia/Aqtau", 
+              "Asia/Aqtobe", 
+              "Asia/Ashgabat", 
+              "Asia/Ashkhabad", 
+              "Asia/Atyrau", 
+              "Asia/Baghdad", 
+              "Asia/Bahrain", 
+              "Asia/Baku", 
+              "Asia/Bangkok", 
+              "Asia/Barnaul", 
+              "Asia/Beirut", 
+              "Asia/Bishkek", 
+              "Asia/Brunei", 
+              "Asia/Calcutta", 
+              "Asia/Chita", 
+              "Asia/Choibalsan", 
+              "Asia/Chongqing", 
+              "Asia/Chungking", 
+              "Asia/Colombo", 
+              "Asia/Dacca", 
+              "Asia/Damascus", 
+              "Asia/Dhaka", 
+              "Asia/Dili", 
+              "Asia/Dubai", 
+              "Asia/Dushanbe", 
+              "Asia/Famagusta", 
+              "Asia/Gaza", 
+              "Asia/Harbin", 
+              "Asia/Hebron", 
+              "Asia/Ho_Chi_Minh", 
+              "Asia/Hong_Kong", 
+              "Asia/Hovd", 
+              "Asia/Irkutsk", 
+              "Asia/Istanbul", 
+              "Asia/Jakarta", 
+              "Asia/Jayapura", 
+              "Asia/Jerusalem", 
+              "Asia/Kabul", 
+              "Asia/Kamchatka", 
+              "Asia/Karachi", 
+              "Asia/Kashgar", 
+              "Asia/Kathmandu", 
+              "Asia/Katmandu", 
+              "Asia/Khandyga", 
+              "Asia/Kolkata", 
+              "Asia/Krasnoyarsk", 
+              "Asia/Kuala_Lumpur", 
+              "Asia/Kuching", 
+              "Asia/Kuwait", 
+              "Asia/Macao", 
+              "Asia/Macau", 
+              "Asia/Magadan", 
+              "Asia/Makassar", 
+              "Asia/Manila", 
+              "Asia/Muscat", 
+              "Asia/Nicosia", 
+              "Asia/Novokuznetsk", 
+              "Asia/Novosibirsk", 
+              "Asia/Omsk", 
+              "Asia/Oral", 
+              "Asia/Phnom_Penh", 
+              "Asia/Pontianak", 
+              "Asia/Pyongyang", 
+              "Asia/Qatar", 
+              "Asia/Qostanay", 
+              "Asia/Qyzylorda", 
+              "Asia/Rangoon", 
+              "Asia/Riyadh", 
+              "Asia/Saigon", 
+              "Asia/Sakhalin", 
+              "Asia/Samarkand", 
+              "Asia/Seoul", 
+              "Asia/Shanghai", 
+              "Asia/Singapore", 
+              "Asia/Srednekolymsk", 
+              "Asia/Taipei", 
+              "Asia/Tashkent", 
+              "Asia/Tbilisi", 
+              "Asia/Tehran", 
+              "Asia/Tel_Aviv", 
+              "Asia/Thimbu", 
+              "Asia/Thimphu", 
+              "Asia/Tokyo", 
+              "Asia/Tomsk", 
+              "Asia/Ujung_Pandang", 
+              "Asia/Ulaanbaatar", 
+              "Asia/Ulan_Bator", 
+              "Asia/Urumqi", 
+              "Asia/Ust-Nera", 
+              "Asia/Vientiane", 
+              "Asia/Vladivostok", 
+              "Asia/Yakutsk", 
+              "Asia/Yangon", 
+              "Asia/Yekaterinburg", 
+              "Asia/Yerevan", 
+              "Atlantic/Azores", 
+              "Atlantic/Bermuda", 
+              "Atlantic/Canary", 
+              "Atlantic/Cape_Verde", 
+              "Atlantic/Faeroe", 
+              "Atlantic/Faroe", 
+              "Atlantic/Jan_Mayen", 
+              "Atlantic/Madeira", 
+              "Atlantic/Reykjavik", 
+              "Atlantic/South_Georgia", 
+              "Atlantic/St_Helena", 
+              "Atlantic/Stanley", 
+              "Australia/ACT", 
+              "Australia/Adelaide", 
+              "Australia/Brisbane", 
+              "Australia/Broken_Hill", 
+              "Australia/Canberra", 
+              "Australia/Currie", 
+              "Australia/Darwin", 
+              "Australia/Eucla", 
+              "Australia/Hobart", 
+              "Australia/LHI", 
+              "Australia/Lindeman", 
+              "Australia/Lord_Howe", 
+              "Australia/Melbourne", 
+              "Australia/NSW", 
+              "Australia/North", 
+              "Australia/Perth", 
+              "Australia/Queensland", 
+              "Australia/South", 
+              "Australia/Sydney", 
+              "Australia/Tasmania", 
+              "Australia/Victoria", 
+              "Australia/West", 
+              "Australia/Yancowinna", 
+              "Brazil/Acre", 
+              "Brazil/DeNoronha", 
+              "Brazil/East", 
+              "Brazil/West", 
+              "CET", 
+              "CST6CDT", 
+              "Canada/Atlantic", 
+              "Canada/Central", 
+              "Canada/Eastern", 
+              "Canada/Mountain", 
+              "Canada/Newfoundland", 
+              "Canada/Pacific", 
+              "Canada/Saskatchewan", 
+              "Canada/Yukon", 
+              "Chile/Continental", 
+              "Chile/EasterIsland", 
+              "Cuba", 
+              "EET", 
+              "EST", 
+              "EST5EDT", 
+              "Egypt", 
+              "Eire", 
+              "Etc/GMT", 
+              "Etc/GMT+0", 
+              "Etc/GMT+1", 
+              "Etc/GMT+10", 
+              "Etc/GMT+11", 
+              "Etc/GMT+12", 
+              "Etc/GMT+2", 
+              "Etc/GMT+3", 
+              "Etc/GMT+4", 
+              "Etc/GMT+5", 
+              "Etc/GMT+6", 
+              "Etc/GMT+7", 
+              "Etc/GMT+8", 
+              "Etc/GMT+9", 
+              "Etc/GMT-0", 
+              "Etc/GMT-1", 
+              "Etc/GMT-10", 
+              "Etc/GMT-11", 
+              "Etc/GMT-12", 
+              "Etc/GMT-13", 
+              "Etc/GMT-14", 
+              "Etc/GMT-2", 
+              "Etc/GMT-3", 
+              "Etc/GMT-4", 
+              "Etc/GMT-5", 
+              "Etc/GMT-6", 
+              "Etc/GMT-7", 
+              "Etc/GMT-8", 
+              "Etc/GMT-9", 
+              "Etc/GMT0", 
+              "Etc/Greenwich", 
+              "Etc/UCT", 
+              "Etc/UTC", 
+              "Etc/Universal", 
+              "Etc/Zulu", 
+              "Europe/Amsterdam", 
+              "Europe/Andorra", 
+              "Europe/Astrakhan", 
+              "Europe/Athens", 
+              "Europe/Belfast", 
+              "Europe/Belgrade", 
+              "Europe/Berlin", 
+              "Europe/Bratislava", 
+              "Europe/Brussels", 
+              "Europe/Bucharest", 
+              "Europe/Budapest", 
+              "Europe/Busingen", 
+              "Europe/Chisinau", 
+              "Europe/Copenhagen", 
+              "Europe/Dublin", 
+              "Europe/Gibraltar", 
+              "Europe/Guernsey", 
+              "Europe/Helsinki", 
+              "Europe/Isle_of_Man", 
+              "Europe/Istanbul", 
+              "Europe/Jersey", 
+              "Europe/Kaliningrad", 
+              "Europe/Kiev", 
+              "Europe/Kirov", 
+              "Europe/Lisbon", 
+              "Europe/Ljubljana", 
+              "Europe/London", 
+              "Europe/Luxembourg", 
+              "Europe/Madrid", 
+              "Europe/Malta", 
+              "Europe/Mariehamn", 
+              "Europe/Minsk", 
+              "Europe/Monaco", 
+              "Europe/Moscow", 
+              "Europe/Nicosia", 
+              "Europe/Oslo", 
+              "Europe/Paris", 
+              "Europe/Podgorica", 
+              "Europe/Prague", 
+              "Europe/Riga", 
+              "Europe/Rome", 
+              "Europe/Samara", 
+              "Europe/San_Marino", 
+              "Europe/Sarajevo", 
+              "Europe/Saratov", 
+              "Europe/Simferopol", 
+              "Europe/Skopje", 
+              "Europe/Sofia", 
+              "Europe/Stockholm", 
+              "Europe/Tallinn", 
+              "Europe/Tirane", 
+              "Europe/Tiraspol", 
+              "Europe/Ulyanovsk", 
+              "Europe/Uzhgorod", 
+              "Europe/Vaduz", 
+              "Europe/Vatican", 
+              "Europe/Vienna", 
+              "Europe/Vilnius", 
+              "Europe/Volgograd", 
+              "Europe/Warsaw", 
+              "Europe/Zagreb", 
+              "Europe/Zaporozhye", 
+              "Europe/Zurich", 
+              "GB", 
+              "GB-Eire", 
+              "GMT", 
+              "GMT+0", 
+              "GMT-0", 
+              "GMT0", 
+              "Greenwich", 
+              "HST", 
+              "Hongkong", 
+              "Iceland", 
+              "Indian/Antananarivo", 
+              "Indian/Chagos", 
+              "Indian/Christmas", 
+              "Indian/Cocos", 
+              "Indian/Comoro", 
+              "Indian/Kerguelen", 
+              "Indian/Mahe", 
+              "Indian/Maldives", 
+              "Indian/Mauritius", 
+              "Indian/Mayotte", 
+              "Indian/Reunion", 
+              "Iran", 
+              "Israel", 
+              "Jamaica", 
+              "Japan", 
+              "Kwajalein", 
+              "Libya", 
+              "MET", 
+              "MST", 
+              "MST7MDT", 
+              "Mexico/BajaNorte", 
+              "Mexico/BajaSur", 
+              "Mexico/General", 
+              "NZ", 
+              "NZ-CHAT", 
+              "Navajo", 
+              "PRC", 
+              "PST8PDT", 
+              "Pacific/Apia", 
+              "Pacific/Auckland", 
+              "Pacific/Bougainville", 
+              "Pacific/Chatham", 
+              "Pacific/Chuuk", 
+              "Pacific/Easter", 
+              "Pacific/Efate", 
+              "Pacific/Enderbury", 
+              "Pacific/Fakaofo", 
+              "Pacific/Fiji", 
+              "Pacific/Funafuti", 
+              "Pacific/Galapagos", 
+              "Pacific/Gambier", 
+              "Pacific/Guadalcanal", 
+              "Pacific/Guam", 
+              "Pacific/Honolulu", 
+              "Pacific/Johnston", 
+              "Pacific/Kanton", 
+              "Pacific/Kiritimati", 
+              "Pacific/Kosrae", 
+              "Pacific/Kwajalein", 
+              "Pacific/Majuro", 
+              "Pacific/Marquesas", 
+              "Pacific/Midway", 
+              "Pacific/Nauru", 
+              "Pacific/Niue", 
+              "Pacific/Norfolk", 
+              "Pacific/Noumea", 
+              "Pacific/Pago_Pago", 
+              "Pacific/Palau", 
+              "Pacific/Pitcairn", 
+              "Pacific/Pohnpei", 
+              "Pacific/Ponape", 
+              "Pacific/Port_Moresby", 
+              "Pacific/Rarotonga", 
+              "Pacific/Saipan", 
+              "Pacific/Samoa", 
+              "Pacific/Tahiti", 
+              "Pacific/Tarawa", 
+              "Pacific/Tongatapu", 
+              "Pacific/Truk", 
+              "Pacific/Wake", 
+              "Pacific/Wallis", 
+              "Pacific/Yap", 
+              "Poland", 
+              "Portugal", 
+              "ROC", 
+              "ROK", 
+              "Singapore", 
+              "Turkey", 
+              "UCT", 
+              "US/Alaska", 
+              "US/Aleutian", 
+              "US/Arizona", 
+              "US/Central", 
+              "US/East-Indiana", 
+              "US/Eastern", 
+              "US/Hawaii", 
+              "US/Indiana-Starke", 
+              "US/Michigan", 
+              "US/Mountain", 
+              "US/Pacific", 
+              "US/Samoa", 
+              "UTC", 
+              "Universal", 
+              "W-SU", 
+              "WET", 
               "Zulu"
-            ],
+            ], 
             "type": "string"
-          },
+          }, 
           "type": {
-            "description": "The report schedule type",
+            "description": "The report schedule type", 
             "enum": [
-              "Alert",
+              "Alert", 
               "Report"
-            ],
+            ], 
             "type": "string"
-          },
+          }, 
           "validator_config_json": {
             "$ref": "#/components/schemas/ValidatorConfigJSON"
-          },
+          }, 
           "validator_type": {
-            "description": "Determines when to trigger alert based off value from alert query. Alerts will be triggered with these validator types:\n- Not Null - When the return value is Not NULL,Empty,or 0\n- Operator - When `sql_return_value comparison_operator threshold` is True e.g. `50 <= 75`<br>Supports the comparison operators <,<=,>,>=,==,and !=",
+            "description": "Determines when to trigger alert based off value from alert query. Alerts will be triggered with these validator types:\n- Not Null - When the return value is Not NULL, Empty, or 0\n- Operator - When `sql_return_value comparison_operator threshold` is True e.g. `50 <= 75`<br>Supports the comparison operators <, <=, >, >=, ==, and !=", 
             "enum": [
-              "not null",
+              "not null", 
               "operator"
-            ],
+            ], 
             "type": "string"
-          },
+          }, 
           "working_timeout": {
-            "description": "If an alert is staled at a working state,how long until it's state is reseted to error",
-            "example": 3600,
-            "format": "int32",
-            "minimum": 1,
+            "description": "If an alert is staled at a working state, how long until it's state is reseted to error", 
+            "example": 3600, 
+            "format": "int32", 
+            "minimum": 1, 
             "type": "integer"
           }
-        },
+        }, 
         "required": [
-          "crontab",
-          "name",
+          "crontab", 
+          "name", 
           "type"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ReportScheduleRestApi.put": {
         "properties": {
           "active": {
             "type": "boolean"
-          },
+          }, 
           "chart": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "context_markdown": {
-            "description": "Markdown description",
-            "nullable": true,
+            "description": "Markdown description", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "creation_method": {
-            "description": "Creation method is used to inform the frontend whether the report/alert was created in the dashboard,chart,or alerts and reports UI.",
+            "description": "Creation method is used to inform the frontend whether the report/alert was created in the dashboard, chart, or alerts and reports UI.", 
             "nullable": true
-          },
+          }, 
           "crontab": {
-            "description": "A CRON expression.[Crontab Guru](https://crontab.guru/) is a helpful resource that can help you craft a CRON expression.",
-            "maxLength": 1000,
-            "minLength": 1,
+            "description": "A CRON expression.[Crontab Guru](https://crontab.guru/) is a helpful resource that can help you craft a CRON expression.", 
+            "maxLength": 1000, 
+            "minLength": 1, 
             "type": "string"
-          },
+          }, 
           "dashboard": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "database": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "description": {
-            "description": "Use a nice description to give context to this Alert/Report",
-            "example": "Daily sales dashboard to marketing",
-            "nullable": true,
+            "description": "Use a nice description to give context to this Alert/Report", 
+            "example": "Daily sales dashboard to marketing", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "extra": {
             "type": "object"
-          },
+          }, 
           "force_screenshot": {
             "type": "boolean"
-          },
+          }, 
           "grace_period": {
-            "description": "Once an alert is triggered,how long,in seconds,before Superset nags you again. (in seconds)",
-            "example": 14400,
-            "format": "int32",
-            "minimum": 1,
+            "description": "Once an alert is triggered, how long, in seconds, before Superset nags you again. (in seconds)", 
+            "example": 14400, 
+            "format": "int32", 
+            "minimum": 1, 
             "type": "integer"
-          },
+          }, 
           "log_retention": {
-            "description": "How long to keep the logs around for this report (in days)",
-            "example": 90,
-            "format": "int32",
-            "minimum": 1,
+            "description": "How long to keep the logs around for this report (in days)", 
+            "example": 90, 
+            "format": "int32", 
+            "minimum": 1, 
             "type": "integer"
-          },
+          }, 
           "name": {
-            "description": "The report schedule name.",
-            "maxLength": 150,
-            "minLength": 1,
+            "description": "The report schedule name.", 
+            "maxLength": 150, 
+            "minLength": 1, 
             "type": "string"
-          },
+          }, 
           "owners": {
             "items": {
-              "description": "Owner are users ids allowed to delete or change this report. If left empty you will be one of the owners of the report.",
-              "format": "int32",
+              "description": "Owner are users ids allowed to delete or change this report. If left empty you will be one of the owners of the report.", 
+              "format": "int32", 
               "type": "integer"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "recipients": {
             "items": {
               "$ref": "#/components/schemas/ReportRecipient"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "report_format": {
             "enum": [
-              "PNG",
-              "CSV",
+              "PNG", 
+              "CSV", 
               "TEXT"
-            ],
+            ], 
             "type": "string"
-          },
+          }, 
           "sql": {
-            "description": "A SQL statement that defines whether the alert should get triggered or not. The query is expected to return either NULL or a number value.",
-            "example": "SELECT value FROM time_series_table",
-            "nullable": true,
+            "description": "A SQL statement that defines whether the alert should get triggered or not. The query is expected to return either NULL or a number value.", 
+            "example": "SELECT value FROM time_series_table", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "timezone": {
-            "description": "A timezone string that represents the location of the timezone.",
+            "description": "A timezone string that represents the location of the timezone.", 
             "enum": [
-              "Africa/Abidjan",
-              "Africa/Accra",
-              "Africa/Addis_Ababa",
-              "Africa/Algiers",
-              "Africa/Asmara",
-              "Africa/Asmera",
-              "Africa/Bamako",
-              "Africa/Bangui",
-              "Africa/Banjul",
-              "Africa/Bissau",
-              "Africa/Blantyre",
-              "Africa/Brazzaville",
-              "Africa/Bujumbura",
-              "Africa/Cairo",
-              "Africa/Casablanca",
-              "Africa/Ceuta",
-              "Africa/Conakry",
-              "Africa/Dakar",
-              "Africa/Dar_es_Salaam",
-              "Africa/Djibouti",
-              "Africa/Douala",
-              "Africa/El_Aaiun",
-              "Africa/Freetown",
-              "Africa/Gaborone",
-              "Africa/Harare",
-              "Africa/Johannesburg",
-              "Africa/Juba",
-              "Africa/Kampala",
-              "Africa/Khartoum",
-              "Africa/Kigali",
-              "Africa/Kinshasa",
-              "Africa/Lagos",
-              "Africa/Libreville",
-              "Africa/Lome",
-              "Africa/Luanda",
-              "Africa/Lubumbashi",
-              "Africa/Lusaka",
-              "Africa/Malabo",
-              "Africa/Maputo",
-              "Africa/Maseru",
-              "Africa/Mbabane",
-              "Africa/Mogadishu",
-              "Africa/Monrovia",
-              "Africa/Nairobi",
-              "Africa/Ndjamena",
-              "Africa/Niamey",
-              "Africa/Nouakchott",
-              "Africa/Ouagadougou",
-              "Africa/Porto-Novo",
-              "Africa/Sao_Tome",
-              "Africa/Timbuktu",
-              "Africa/Tripoli",
-              "Africa/Tunis",
-              "Africa/Windhoek",
-              "America/Adak",
-              "America/Anchorage",
-              "America/Anguilla",
-              "America/Antigua",
-              "America/Araguaina",
-              "America/Argentina/Buenos_Aires",
-              "America/Argentina/Catamarca",
-              "America/Argentina/ComodRivadavia",
-              "America/Argentina/Cordoba",
-              "America/Argentina/Jujuy",
-              "America/Argentina/La_Rioja",
-              "America/Argentina/Mendoza",
-              "America/Argentina/Rio_Gallegos",
-              "America/Argentina/Salta",
-              "America/Argentina/San_Juan",
-              "America/Argentina/San_Luis",
-              "America/Argentina/Tucuman",
-              "America/Argentina/Ushuaia",
-              "America/Aruba",
-              "America/Asuncion",
-              "America/Atikokan",
-              "America/Atka",
-              "America/Bahia",
-              "America/Bahia_Banderas",
-              "America/Barbados",
-              "America/Belem",
-              "America/Belize",
-              "America/Blanc-Sablon",
-              "America/Boa_Vista",
-              "America/Bogota",
-              "America/Boise",
-              "America/Buenos_Aires",
-              "America/Cambridge_Bay",
-              "America/Campo_Grande",
-              "America/Cancun",
-              "America/Caracas",
-              "America/Catamarca",
-              "America/Cayenne",
-              "America/Cayman",
-              "America/Chicago",
-              "America/Chihuahua",
-              "America/Coral_Harbour",
-              "America/Cordoba",
-              "America/Costa_Rica",
-              "America/Creston",
-              "America/Cuiaba",
-              "America/Curacao",
-              "America/Danmarkshavn",
-              "America/Dawson",
-              "America/Dawson_Creek",
-              "America/Denver",
-              "America/Detroit",
-              "America/Dominica",
-              "America/Edmonton",
-              "America/Eirunepe",
-              "America/El_Salvador",
-              "America/Ensenada",
-              "America/Fort_Nelson",
-              "America/Fort_Wayne",
-              "America/Fortaleza",
-              "America/Glace_Bay",
-              "America/Godthab",
-              "America/Goose_Bay",
-              "America/Grand_Turk",
-              "America/Grenada",
-              "America/Guadeloupe",
-              "America/Guatemala",
-              "America/Guayaquil",
-              "America/Guyana",
-              "America/Halifax",
-              "America/Havana",
-              "America/Hermosillo",
-              "America/Indiana/Indianapolis",
-              "America/Indiana/Knox",
-              "America/Indiana/Marengo",
-              "America/Indiana/Petersburg",
-              "America/Indiana/Tell_City",
-              "America/Indiana/Vevay",
-              "America/Indiana/Vincennes",
-              "America/Indiana/Winamac",
-              "America/Indianapolis",
-              "America/Inuvik",
-              "America/Iqaluit",
-              "America/Jamaica",
-              "America/Jujuy",
-              "America/Juneau",
-              "America/Kentucky/Louisville",
-              "America/Kentucky/Monticello",
-              "America/Knox_IN",
-              "America/Kralendijk",
-              "America/La_Paz",
-              "America/Lima",
-              "America/Los_Angeles",
-              "America/Louisville",
-              "America/Lower_Princes",
-              "America/Maceio",
-              "America/Managua",
-              "America/Manaus",
-              "America/Marigot",
-              "America/Martinique",
-              "America/Matamoros",
-              "America/Mazatlan",
-              "America/Mendoza",
-              "America/Menominee",
-              "America/Merida",
-              "America/Metlakatla",
-              "America/Mexico_City",
-              "America/Miquelon",
-              "America/Moncton",
-              "America/Monterrey",
-              "America/Montevideo",
-              "America/Montreal",
-              "America/Montserrat",
-              "America/Nassau",
-              "America/New_York",
-              "America/Nipigon",
-              "America/Nome",
-              "America/Noronha",
-              "America/North_Dakota/Beulah",
-              "America/North_Dakota/Center",
-              "America/North_Dakota/New_Salem",
-              "America/Nuuk",
-              "America/Ojinaga",
-              "America/Panama",
-              "America/Pangnirtung",
-              "America/Paramaribo",
-              "America/Phoenix",
-              "America/Port-au-Prince",
-              "America/Port_of_Spain",
-              "America/Porto_Acre",
-              "America/Porto_Velho",
-              "America/Puerto_Rico",
-              "America/Punta_Arenas",
-              "America/Rainy_River",
-              "America/Rankin_Inlet",
-              "America/Recife",
-              "America/Regina",
-              "America/Resolute",
-              "America/Rio_Branco",
-              "America/Rosario",
-              "America/Santa_Isabel",
-              "America/Santarem",
-              "America/Santiago",
-              "America/Santo_Domingo",
-              "America/Sao_Paulo",
-              "America/Scoresbysund",
-              "America/Shiprock",
-              "America/Sitka",
-              "America/St_Barthelemy",
-              "America/St_Johns",
-              "America/St_Kitts",
-              "America/St_Lucia",
-              "America/St_Thomas",
-              "America/St_Vincent",
-              "America/Swift_Current",
-              "America/Tegucigalpa",
-              "America/Thule",
-              "America/Thunder_Bay",
-              "America/Tijuana",
-              "America/Toronto",
-              "America/Tortola",
-              "America/Vancouver",
-              "America/Virgin",
-              "America/Whitehorse",
-              "America/Winnipeg",
-              "America/Yakutat",
-              "America/Yellowknife",
-              "Antarctica/Casey",
-              "Antarctica/Davis",
-              "Antarctica/DumontDUrville",
-              "Antarctica/Macquarie",
-              "Antarctica/Mawson",
-              "Antarctica/McMurdo",
-              "Antarctica/Palmer",
-              "Antarctica/Rothera",
-              "Antarctica/South_Pole",
-              "Antarctica/Syowa",
-              "Antarctica/Troll",
-              "Antarctica/Vostok",
-              "Arctic/Longyearbyen",
-              "Asia/Aden",
-              "Asia/Almaty",
-              "Asia/Amman",
-              "Asia/Anadyr",
-              "Asia/Aqtau",
-              "Asia/Aqtobe",
-              "Asia/Ashgabat",
-              "Asia/Ashkhabad",
-              "Asia/Atyrau",
-              "Asia/Baghdad",
-              "Asia/Bahrain",
-              "Asia/Baku",
-              "Asia/Bangkok",
-              "Asia/Barnaul",
-              "Asia/Beirut",
-              "Asia/Bishkek",
-              "Asia/Brunei",
-              "Asia/Calcutta",
-              "Asia/Chita",
-              "Asia/Choibalsan",
-              "Asia/Chongqing",
-              "Asia/Chungking",
-              "Asia/Colombo",
-              "Asia/Dacca",
-              "Asia/Damascus",
-              "Asia/Dhaka",
-              "Asia/Dili",
-              "Asia/Dubai",
-              "Asia/Dushanbe",
-              "Asia/Famagusta",
-              "Asia/Gaza",
-              "Asia/Harbin",
-              "Asia/Hebron",
-              "Asia/Ho_Chi_Minh",
-              "Asia/Hong_Kong",
-              "Asia/Hovd",
-              "Asia/Irkutsk",
-              "Asia/Istanbul",
-              "Asia/Jakarta",
-              "Asia/Jayapura",
-              "Asia/Jerusalem",
-              "Asia/Kabul",
-              "Asia/Kamchatka",
-              "Asia/Karachi",
-              "Asia/Kashgar",
-              "Asia/Kathmandu",
-              "Asia/Katmandu",
-              "Asia/Khandyga",
-              "Asia/Kolkata",
-              "Asia/Krasnoyarsk",
-              "Asia/Kuala_Lumpur",
-              "Asia/Kuching",
-              "Asia/Kuwait",
-              "Asia/Macao",
-              "Asia/Macau",
-              "Asia/Magadan",
-              "Asia/Makassar",
-              "Asia/Manila",
-              "Asia/Muscat",
-              "Asia/Nicosia",
-              "Asia/Novokuznetsk",
-              "Asia/Novosibirsk",
-              "Asia/Omsk",
-              "Asia/Oral",
-              "Asia/Phnom_Penh",
-              "Asia/Pontianak",
-              "Asia/Pyongyang",
-              "Asia/Qatar",
-              "Asia/Qostanay",
-              "Asia/Qyzylorda",
-              "Asia/Rangoon",
-              "Asia/Riyadh",
-              "Asia/Saigon",
-              "Asia/Sakhalin",
-              "Asia/Samarkand",
-              "Asia/Seoul",
-              "Asia/Shanghai",
-              "Asia/Singapore",
-              "Asia/Srednekolymsk",
-              "Asia/Taipei",
-              "Asia/Tashkent",
-              "Asia/Tbilisi",
-              "Asia/Tehran",
-              "Asia/Tel_Aviv",
-              "Asia/Thimbu",
-              "Asia/Thimphu",
-              "Asia/Tokyo",
-              "Asia/Tomsk",
-              "Asia/Ujung_Pandang",
-              "Asia/Ulaanbaatar",
-              "Asia/Ulan_Bator",
-              "Asia/Urumqi",
-              "Asia/Ust-Nera",
-              "Asia/Vientiane",
-              "Asia/Vladivostok",
-              "Asia/Yakutsk",
-              "Asia/Yangon",
-              "Asia/Yekaterinburg",
-              "Asia/Yerevan",
-              "Atlantic/Azores",
-              "Atlantic/Bermuda",
-              "Atlantic/Canary",
-              "Atlantic/Cape_Verde",
-              "Atlantic/Faeroe",
-              "Atlantic/Faroe",
-              "Atlantic/Jan_Mayen",
-              "Atlantic/Madeira",
-              "Atlantic/Reykjavik",
-              "Atlantic/South_Georgia",
-              "Atlantic/St_Helena",
-              "Atlantic/Stanley",
-              "Australia/ACT",
-              "Australia/Adelaide",
-              "Australia/Brisbane",
-              "Australia/Broken_Hill",
-              "Australia/Canberra",
-              "Australia/Currie",
-              "Australia/Darwin",
-              "Australia/Eucla",
-              "Australia/Hobart",
-              "Australia/LHI",
-              "Australia/Lindeman",
-              "Australia/Lord_Howe",
-              "Australia/Melbourne",
-              "Australia/NSW",
-              "Australia/North",
-              "Australia/Perth",
-              "Australia/Queensland",
-              "Australia/South",
-              "Australia/Sydney",
-              "Australia/Tasmania",
-              "Australia/Victoria",
-              "Australia/West",
-              "Australia/Yancowinna",
-              "Brazil/Acre",
-              "Brazil/DeNoronha",
-              "Brazil/East",
-              "Brazil/West",
-              "CET",
-              "CST6CDT",
-              "Canada/Atlantic",
-              "Canada/Central",
-              "Canada/Eastern",
-              "Canada/Mountain",
-              "Canada/Newfoundland",
-              "Canada/Pacific",
-              "Canada/Saskatchewan",
-              "Canada/Yukon",
-              "Chile/Continental",
-              "Chile/EasterIsland",
-              "Cuba",
-              "EET",
-              "EST",
-              "EST5EDT",
-              "Egypt",
-              "Eire",
-              "Etc/GMT",
-              "Etc/GMT+0",
-              "Etc/GMT+1",
-              "Etc/GMT+10",
-              "Etc/GMT+11",
-              "Etc/GMT+12",
-              "Etc/GMT+2",
-              "Etc/GMT+3",
-              "Etc/GMT+4",
-              "Etc/GMT+5",
-              "Etc/GMT+6",
-              "Etc/GMT+7",
-              "Etc/GMT+8",
-              "Etc/GMT+9",
-              "Etc/GMT-0",
-              "Etc/GMT-1",
-              "Etc/GMT-10",
-              "Etc/GMT-11",
-              "Etc/GMT-12",
-              "Etc/GMT-13",
-              "Etc/GMT-14",
-              "Etc/GMT-2",
-              "Etc/GMT-3",
-              "Etc/GMT-4",
-              "Etc/GMT-5",
-              "Etc/GMT-6",
-              "Etc/GMT-7",
-              "Etc/GMT-8",
-              "Etc/GMT-9",
-              "Etc/GMT0",
-              "Etc/Greenwich",
-              "Etc/UCT",
-              "Etc/UTC",
-              "Etc/Universal",
-              "Etc/Zulu",
-              "Europe/Amsterdam",
-              "Europe/Andorra",
-              "Europe/Astrakhan",
-              "Europe/Athens",
-              "Europe/Belfast",
-              "Europe/Belgrade",
-              "Europe/Berlin",
-              "Europe/Bratislava",
-              "Europe/Brussels",
-              "Europe/Bucharest",
-              "Europe/Budapest",
-              "Europe/Busingen",
-              "Europe/Chisinau",
-              "Europe/Copenhagen",
-              "Europe/Dublin",
-              "Europe/Gibraltar",
-              "Europe/Guernsey",
-              "Europe/Helsinki",
-              "Europe/Isle_of_Man",
-              "Europe/Istanbul",
-              "Europe/Jersey",
-              "Europe/Kaliningrad",
-              "Europe/Kiev",
-              "Europe/Kirov",
-              "Europe/Lisbon",
-              "Europe/Ljubljana",
-              "Europe/London",
-              "Europe/Luxembourg",
-              "Europe/Madrid",
-              "Europe/Malta",
-              "Europe/Mariehamn",
-              "Europe/Minsk",
-              "Europe/Monaco",
-              "Europe/Moscow",
-              "Europe/Nicosia",
-              "Europe/Oslo",
-              "Europe/Paris",
-              "Europe/Podgorica",
-              "Europe/Prague",
-              "Europe/Riga",
-              "Europe/Rome",
-              "Europe/Samara",
-              "Europe/San_Marino",
-              "Europe/Sarajevo",
-              "Europe/Saratov",
-              "Europe/Simferopol",
-              "Europe/Skopje",
-              "Europe/Sofia",
-              "Europe/Stockholm",
-              "Europe/Tallinn",
-              "Europe/Tirane",
-              "Europe/Tiraspol",
-              "Europe/Ulyanovsk",
-              "Europe/Uzhgorod",
-              "Europe/Vaduz",
-              "Europe/Vatican",
-              "Europe/Vienna",
-              "Europe/Vilnius",
-              "Europe/Volgograd",
-              "Europe/Warsaw",
-              "Europe/Zagreb",
-              "Europe/Zaporozhye",
-              "Europe/Zurich",
-              "GB",
-              "GB-Eire",
-              "GMT",
-              "GMT+0",
-              "GMT-0",
-              "GMT0",
-              "Greenwich",
-              "HST",
-              "Hongkong",
-              "Iceland",
-              "Indian/Antananarivo",
-              "Indian/Chagos",
-              "Indian/Christmas",
-              "Indian/Cocos",
-              "Indian/Comoro",
-              "Indian/Kerguelen",
-              "Indian/Mahe",
-              "Indian/Maldives",
-              "Indian/Mauritius",
-              "Indian/Mayotte",
-              "Indian/Reunion",
-              "Iran",
-              "Israel",
-              "Jamaica",
-              "Japan",
-              "Kwajalein",
-              "Libya",
-              "MET",
-              "MST",
-              "MST7MDT",
-              "Mexico/BajaNorte",
-              "Mexico/BajaSur",
-              "Mexico/General",
-              "NZ",
-              "NZ-CHAT",
-              "Navajo",
-              "PRC",
-              "PST8PDT",
-              "Pacific/Apia",
-              "Pacific/Auckland",
-              "Pacific/Bougainville",
-              "Pacific/Chatham",
-              "Pacific/Chuuk",
-              "Pacific/Easter",
-              "Pacific/Efate",
-              "Pacific/Enderbury",
-              "Pacific/Fakaofo",
-              "Pacific/Fiji",
-              "Pacific/Funafuti",
-              "Pacific/Galapagos",
-              "Pacific/Gambier",
-              "Pacific/Guadalcanal",
-              "Pacific/Guam",
-              "Pacific/Honolulu",
-              "Pacific/Johnston",
-              "Pacific/Kanton",
-              "Pacific/Kiritimati",
-              "Pacific/Kosrae",
-              "Pacific/Kwajalein",
-              "Pacific/Majuro",
-              "Pacific/Marquesas",
-              "Pacific/Midway",
-              "Pacific/Nauru",
-              "Pacific/Niue",
-              "Pacific/Norfolk",
-              "Pacific/Noumea",
-              "Pacific/Pago_Pago",
-              "Pacific/Palau",
-              "Pacific/Pitcairn",
-              "Pacific/Pohnpei",
-              "Pacific/Ponape",
-              "Pacific/Port_Moresby",
-              "Pacific/Rarotonga",
-              "Pacific/Saipan",
-              "Pacific/Samoa",
-              "Pacific/Tahiti",
-              "Pacific/Tarawa",
-              "Pacific/Tongatapu",
-              "Pacific/Truk",
-              "Pacific/Wake",
-              "Pacific/Wallis",
-              "Pacific/Yap",
-              "Poland",
-              "Portugal",
-              "ROC",
-              "ROK",
-              "Singapore",
-              "Turkey",
-              "UCT",
-              "US/Alaska",
-              "US/Aleutian",
-              "US/Arizona",
-              "US/Central",
-              "US/East-Indiana",
-              "US/Eastern",
-              "US/Hawaii",
-              "US/Indiana-Starke",
-              "US/Michigan",
-              "US/Mountain",
-              "US/Pacific",
-              "US/Samoa",
-              "UTC",
-              "Universal",
-              "W-SU",
-              "WET",
+              "Africa/Abidjan", 
+              "Africa/Accra", 
+              "Africa/Addis_Ababa", 
+              "Africa/Algiers", 
+              "Africa/Asmara", 
+              "Africa/Asmera", 
+              "Africa/Bamako", 
+              "Africa/Bangui", 
+              "Africa/Banjul", 
+              "Africa/Bissau", 
+              "Africa/Blantyre", 
+              "Africa/Brazzaville", 
+              "Africa/Bujumbura", 
+              "Africa/Cairo", 
+              "Africa/Casablanca", 
+              "Africa/Ceuta", 
+              "Africa/Conakry", 
+              "Africa/Dakar", 
+              "Africa/Dar_es_Salaam", 
+              "Africa/Djibouti", 
+              "Africa/Douala", 
+              "Africa/El_Aaiun", 
+              "Africa/Freetown", 
+              "Africa/Gaborone", 
+              "Africa/Harare", 
+              "Africa/Johannesburg", 
+              "Africa/Juba", 
+              "Africa/Kampala", 
+              "Africa/Khartoum", 
+              "Africa/Kigali", 
+              "Africa/Kinshasa", 
+              "Africa/Lagos", 
+              "Africa/Libreville", 
+              "Africa/Lome", 
+              "Africa/Luanda", 
+              "Africa/Lubumbashi", 
+              "Africa/Lusaka", 
+              "Africa/Malabo", 
+              "Africa/Maputo", 
+              "Africa/Maseru", 
+              "Africa/Mbabane", 
+              "Africa/Mogadishu", 
+              "Africa/Monrovia", 
+              "Africa/Nairobi", 
+              "Africa/Ndjamena", 
+              "Africa/Niamey", 
+              "Africa/Nouakchott", 
+              "Africa/Ouagadougou", 
+              "Africa/Porto-Novo", 
+              "Africa/Sao_Tome", 
+              "Africa/Timbuktu", 
+              "Africa/Tripoli", 
+              "Africa/Tunis", 
+              "Africa/Windhoek", 
+              "America/Adak", 
+              "America/Anchorage", 
+              "America/Anguilla", 
+              "America/Antigua", 
+              "America/Araguaina", 
+              "America/Argentina/Buenos_Aires", 
+              "America/Argentina/Catamarca", 
+              "America/Argentina/ComodRivadavia", 
+              "America/Argentina/Cordoba", 
+              "America/Argentina/Jujuy", 
+              "America/Argentina/La_Rioja", 
+              "America/Argentina/Mendoza", 
+              "America/Argentina/Rio_Gallegos", 
+              "America/Argentina/Salta", 
+              "America/Argentina/San_Juan", 
+              "America/Argentina/San_Luis", 
+              "America/Argentina/Tucuman", 
+              "America/Argentina/Ushuaia", 
+              "America/Aruba", 
+              "America/Asuncion", 
+              "America/Atikokan", 
+              "America/Atka", 
+              "America/Bahia", 
+              "America/Bahia_Banderas", 
+              "America/Barbados", 
+              "America/Belem", 
+              "America/Belize", 
+              "America/Blanc-Sablon", 
+              "America/Boa_Vista", 
+              "America/Bogota", 
+              "America/Boise", 
+              "America/Buenos_Aires", 
+              "America/Cambridge_Bay", 
+              "America/Campo_Grande", 
+              "America/Cancun", 
+              "America/Caracas", 
+              "America/Catamarca", 
+              "America/Cayenne", 
+              "America/Cayman", 
+              "America/Chicago", 
+              "America/Chihuahua", 
+              "America/Coral_Harbour", 
+              "America/Cordoba", 
+              "America/Costa_Rica", 
+              "America/Creston", 
+              "America/Cuiaba", 
+              "America/Curacao", 
+              "America/Danmarkshavn", 
+              "America/Dawson", 
+              "America/Dawson_Creek", 
+              "America/Denver", 
+              "America/Detroit", 
+              "America/Dominica", 
+              "America/Edmonton", 
+              "America/Eirunepe", 
+              "America/El_Salvador", 
+              "America/Ensenada", 
+              "America/Fort_Nelson", 
+              "America/Fort_Wayne", 
+              "America/Fortaleza", 
+              "America/Glace_Bay", 
+              "America/Godthab", 
+              "America/Goose_Bay", 
+              "America/Grand_Turk", 
+              "America/Grenada", 
+              "America/Guadeloupe", 
+              "America/Guatemala", 
+              "America/Guayaquil", 
+              "America/Guyana", 
+              "America/Halifax", 
+              "America/Havana", 
+              "America/Hermosillo", 
+              "America/Indiana/Indianapolis", 
+              "America/Indiana/Knox", 
+              "America/Indiana/Marengo", 
+              "America/Indiana/Petersburg", 
+              "America/Indiana/Tell_City", 
+              "America/Indiana/Vevay", 
+              "America/Indiana/Vincennes", 
+              "America/Indiana/Winamac", 
+              "America/Indianapolis", 
+              "America/Inuvik", 
+              "America/Iqaluit", 
+              "America/Jamaica", 
+              "America/Jujuy", 
+              "America/Juneau", 
+              "America/Kentucky/Louisville", 
+              "America/Kentucky/Monticello", 
+              "America/Knox_IN", 
+              "America/Kralendijk", 
+              "America/La_Paz", 
+              "America/Lima", 
+              "America/Los_Angeles", 
+              "America/Louisville", 
+              "America/Lower_Princes", 
+              "America/Maceio", 
+              "America/Managua", 
+              "America/Manaus", 
+              "America/Marigot", 
+              "America/Martinique", 
+              "America/Matamoros", 
+              "America/Mazatlan", 
+              "America/Mendoza", 
+              "America/Menominee", 
+              "America/Merida", 
+              "America/Metlakatla", 
+              "America/Mexico_City", 
+              "America/Miquelon", 
+              "America/Moncton", 
+              "America/Monterrey", 
+              "America/Montevideo", 
+              "America/Montreal", 
+              "America/Montserrat", 
+              "America/Nassau", 
+              "America/New_York", 
+              "America/Nipigon", 
+              "America/Nome", 
+              "America/Noronha", 
+              "America/North_Dakota/Beulah", 
+              "America/North_Dakota/Center", 
+              "America/North_Dakota/New_Salem", 
+              "America/Nuuk", 
+              "America/Ojinaga", 
+              "America/Panama", 
+              "America/Pangnirtung", 
+              "America/Paramaribo", 
+              "America/Phoenix", 
+              "America/Port-au-Prince", 
+              "America/Port_of_Spain", 
+              "America/Porto_Acre", 
+              "America/Porto_Velho", 
+              "America/Puerto_Rico", 
+              "America/Punta_Arenas", 
+              "America/Rainy_River", 
+              "America/Rankin_Inlet", 
+              "America/Recife", 
+              "America/Regina", 
+              "America/Resolute", 
+              "America/Rio_Branco", 
+              "America/Rosario", 
+              "America/Santa_Isabel", 
+              "America/Santarem", 
+              "America/Santiago", 
+              "America/Santo_Domingo", 
+              "America/Sao_Paulo", 
+              "America/Scoresbysund", 
+              "America/Shiprock", 
+              "America/Sitka", 
+              "America/St_Barthelemy", 
+              "America/St_Johns", 
+              "America/St_Kitts", 
+              "America/St_Lucia", 
+              "America/St_Thomas", 
+              "America/St_Vincent", 
+              "America/Swift_Current", 
+              "America/Tegucigalpa", 
+              "America/Thule", 
+              "America/Thunder_Bay", 
+              "America/Tijuana", 
+              "America/Toronto", 
+              "America/Tortola", 
+              "America/Vancouver", 
+              "America/Virgin", 
+              "America/Whitehorse", 
+              "America/Winnipeg", 
+              "America/Yakutat", 
+              "America/Yellowknife", 
+              "Antarctica/Casey", 
+              "Antarctica/Davis", 
+              "Antarctica/DumontDUrville", 
+              "Antarctica/Macquarie", 
+              "Antarctica/Mawson", 
+              "Antarctica/McMurdo", 
+              "Antarctica/Palmer", 
+              "Antarctica/Rothera", 
+              "Antarctica/South_Pole", 
+              "Antarctica/Syowa", 
+              "Antarctica/Troll", 
+              "Antarctica/Vostok", 
+              "Arctic/Longyearbyen", 
+              "Asia/Aden", 
+              "Asia/Almaty", 
+              "Asia/Amman", 
+              "Asia/Anadyr", 
+              "Asia/Aqtau", 
+              "Asia/Aqtobe", 
+              "Asia/Ashgabat", 
+              "Asia/Ashkhabad", 
+              "Asia/Atyrau", 
+              "Asia/Baghdad", 
+              "Asia/Bahrain", 
+              "Asia/Baku", 
+              "Asia/Bangkok", 
+              "Asia/Barnaul", 
+              "Asia/Beirut", 
+              "Asia/Bishkek", 
+              "Asia/Brunei", 
+              "Asia/Calcutta", 
+              "Asia/Chita", 
+              "Asia/Choibalsan", 
+              "Asia/Chongqing", 
+              "Asia/Chungking", 
+              "Asia/Colombo", 
+              "Asia/Dacca", 
+              "Asia/Damascus", 
+              "Asia/Dhaka", 
+              "Asia/Dili", 
+              "Asia/Dubai", 
+              "Asia/Dushanbe", 
+              "Asia/Famagusta", 
+              "Asia/Gaza", 
+              "Asia/Harbin", 
+              "Asia/Hebron", 
+              "Asia/Ho_Chi_Minh", 
+              "Asia/Hong_Kong", 
+              "Asia/Hovd", 
+              "Asia/Irkutsk", 
+              "Asia/Istanbul", 
+              "Asia/Jakarta", 
+              "Asia/Jayapura", 
+              "Asia/Jerusalem", 
+              "Asia/Kabul", 
+              "Asia/Kamchatka", 
+              "Asia/Karachi", 
+              "Asia/Kashgar", 
+              "Asia/Kathmandu", 
+              "Asia/Katmandu", 
+              "Asia/Khandyga", 
+              "Asia/Kolkata", 
+              "Asia/Krasnoyarsk", 
+              "Asia/Kuala_Lumpur", 
+              "Asia/Kuching", 
+              "Asia/Kuwait", 
+              "Asia/Macao", 
+              "Asia/Macau", 
+              "Asia/Magadan", 
+              "Asia/Makassar", 
+              "Asia/Manila", 
+              "Asia/Muscat", 
+              "Asia/Nicosia", 
+              "Asia/Novokuznetsk", 
+              "Asia/Novosibirsk", 
+              "Asia/Omsk", 
+              "Asia/Oral", 
+              "Asia/Phnom_Penh", 
+              "Asia/Pontianak", 
+              "Asia/Pyongyang", 
+              "Asia/Qatar", 
+              "Asia/Qostanay", 
+              "Asia/Qyzylorda", 
+              "Asia/Rangoon", 
+              "Asia/Riyadh", 
+              "Asia/Saigon", 
+              "Asia/Sakhalin", 
+              "Asia/Samarkand", 
+              "Asia/Seoul", 
+              "Asia/Shanghai", 
+              "Asia/Singapore", 
+              "Asia/Srednekolymsk", 
+              "Asia/Taipei", 
+              "Asia/Tashkent", 
+              "Asia/Tbilisi", 
+              "Asia/Tehran", 
+              "Asia/Tel_Aviv", 
+              "Asia/Thimbu", 
+              "Asia/Thimphu", 
+              "Asia/Tokyo", 
+              "Asia/Tomsk", 
+              "Asia/Ujung_Pandang", 
+              "Asia/Ulaanbaatar", 
+              "Asia/Ulan_Bator", 
+              "Asia/Urumqi", 
+              "Asia/Ust-Nera", 
+              "Asia/Vientiane", 
+              "Asia/Vladivostok", 
+              "Asia/Yakutsk", 
+              "Asia/Yangon", 
+              "Asia/Yekaterinburg", 
+              "Asia/Yerevan", 
+              "Atlantic/Azores", 
+              "Atlantic/Bermuda", 
+              "Atlantic/Canary", 
+              "Atlantic/Cape_Verde", 
+              "Atlantic/Faeroe", 
+              "Atlantic/Faroe", 
+              "Atlantic/Jan_Mayen", 
+              "Atlantic/Madeira", 
+              "Atlantic/Reykjavik", 
+              "Atlantic/South_Georgia", 
+              "Atlantic/St_Helena", 
+              "Atlantic/Stanley", 
+              "Australia/ACT", 
+              "Australia/Adelaide", 
+              "Australia/Brisbane", 
+              "Australia/Broken_Hill", 
+              "Australia/Canberra", 
+              "Australia/Currie", 
+              "Australia/Darwin", 
+              "Australia/Eucla", 
+              "Australia/Hobart", 
+              "Australia/LHI", 
+              "Australia/Lindeman", 
+              "Australia/Lord_Howe", 
+              "Australia/Melbourne", 
+              "Australia/NSW", 
+              "Australia/North", 
+              "Australia/Perth", 
+              "Australia/Queensland", 
+              "Australia/South", 
+              "Australia/Sydney", 
+              "Australia/Tasmania", 
+              "Australia/Victoria", 
+              "Australia/West", 
+              "Australia/Yancowinna", 
+              "Brazil/Acre", 
+              "Brazil/DeNoronha", 
+              "Brazil/East", 
+              "Brazil/West", 
+              "CET", 
+              "CST6CDT", 
+              "Canada/Atlantic", 
+              "Canada/Central", 
+              "Canada/Eastern", 
+              "Canada/Mountain", 
+              "Canada/Newfoundland", 
+              "Canada/Pacific", 
+              "Canada/Saskatchewan", 
+              "Canada/Yukon", 
+              "Chile/Continental", 
+              "Chile/EasterIsland", 
+              "Cuba", 
+              "EET", 
+              "EST", 
+              "EST5EDT", 
+              "Egypt", 
+              "Eire", 
+              "Etc/GMT", 
+              "Etc/GMT+0", 
+              "Etc/GMT+1", 
+              "Etc/GMT+10", 
+              "Etc/GMT+11", 
+              "Etc/GMT+12", 
+              "Etc/GMT+2", 
+              "Etc/GMT+3", 
+              "Etc/GMT+4", 
+              "Etc/GMT+5", 
+              "Etc/GMT+6", 
+              "Etc/GMT+7", 
+              "Etc/GMT+8", 
+              "Etc/GMT+9", 
+              "Etc/GMT-0", 
+              "Etc/GMT-1", 
+              "Etc/GMT-10", 
+              "Etc/GMT-11", 
+              "Etc/GMT-12", 
+              "Etc/GMT-13", 
+              "Etc/GMT-14", 
+              "Etc/GMT-2", 
+              "Etc/GMT-3", 
+              "Etc/GMT-4", 
+              "Etc/GMT-5", 
+              "Etc/GMT-6", 
+              "Etc/GMT-7", 
+              "Etc/GMT-8", 
+              "Etc/GMT-9", 
+              "Etc/GMT0", 
+              "Etc/Greenwich", 
+              "Etc/UCT", 
+              "Etc/UTC", 
+              "Etc/Universal", 
+              "Etc/Zulu", 
+              "Europe/Amsterdam", 
+              "Europe/Andorra", 
+              "Europe/Astrakhan", 
+              "Europe/Athens", 
+              "Europe/Belfast", 
+              "Europe/Belgrade", 
+              "Europe/Berlin", 
+              "Europe/Bratislava", 
+              "Europe/Brussels", 
+              "Europe/Bucharest", 
+              "Europe/Budapest", 
+              "Europe/Busingen", 
+              "Europe/Chisinau", 
+              "Europe/Copenhagen", 
+              "Europe/Dublin", 
+              "Europe/Gibraltar", 
+              "Europe/Guernsey", 
+              "Europe/Helsinki", 
+              "Europe/Isle_of_Man", 
+              "Europe/Istanbul", 
+              "Europe/Jersey", 
+              "Europe/Kaliningrad", 
+              "Europe/Kiev", 
+              "Europe/Kirov", 
+              "Europe/Lisbon", 
+              "Europe/Ljubljana", 
+              "Europe/London", 
+              "Europe/Luxembourg", 
+              "Europe/Madrid", 
+              "Europe/Malta", 
+              "Europe/Mariehamn", 
+              "Europe/Minsk", 
+              "Europe/Monaco", 
+              "Europe/Moscow", 
+              "Europe/Nicosia", 
+              "Europe/Oslo", 
+              "Europe/Paris", 
+              "Europe/Podgorica", 
+              "Europe/Prague", 
+              "Europe/Riga", 
+              "Europe/Rome", 
+              "Europe/Samara", 
+              "Europe/San_Marino", 
+              "Europe/Sarajevo", 
+              "Europe/Saratov", 
+              "Europe/Simferopol", 
+              "Europe/Skopje", 
+              "Europe/Sofia", 
+              "Europe/Stockholm", 
+              "Europe/Tallinn", 
+              "Europe/Tirane", 
+              "Europe/Tiraspol", 
+              "Europe/Ulyanovsk", 
+              "Europe/Uzhgorod", 
+              "Europe/Vaduz", 
+              "Europe/Vatican", 
+              "Europe/Vienna", 
+              "Europe/Vilnius", 
+              "Europe/Volgograd", 
+              "Europe/Warsaw", 
+              "Europe/Zagreb", 
+              "Europe/Zaporozhye", 
+              "Europe/Zurich", 
+              "GB", 
+              "GB-Eire", 
+              "GMT", 
+              "GMT+0", 
+              "GMT-0", 
+              "GMT0", 
+              "Greenwich", 
+              "HST", 
+              "Hongkong", 
+              "Iceland", 
+              "Indian/Antananarivo", 
+              "Indian/Chagos", 
+              "Indian/Christmas", 
+              "Indian/Cocos", 
+              "Indian/Comoro", 
+              "Indian/Kerguelen", 
+              "Indian/Mahe", 
+              "Indian/Maldives", 
+              "Indian/Mauritius", 
+              "Indian/Mayotte", 
+              "Indian/Reunion", 
+              "Iran", 
+              "Israel", 
+              "Jamaica", 
+              "Japan", 
+              "Kwajalein", 
+              "Libya", 
+              "MET", 
+              "MST", 
+              "MST7MDT", 
+              "Mexico/BajaNorte", 
+              "Mexico/BajaSur", 
+              "Mexico/General", 
+              "NZ", 
+              "NZ-CHAT", 
+              "Navajo", 
+              "PRC", 
+              "PST8PDT", 
+              "Pacific/Apia", 
+              "Pacific/Auckland", 
+              "Pacific/Bougainville", 
+              "Pacific/Chatham", 
+              "Pacific/Chuuk", 
+              "Pacific/Easter", 
+              "Pacific/Efate", 
+              "Pacific/Enderbury", 
+              "Pacific/Fakaofo", 
+              "Pacific/Fiji", 
+              "Pacific/Funafuti", 
+              "Pacific/Galapagos", 
+              "Pacific/Gambier", 
+              "Pacific/Guadalcanal", 
+              "Pacific/Guam", 
+              "Pacific/Honolulu", 
+              "Pacific/Johnston", 
+              "Pacific/Kanton", 
+              "Pacific/Kiritimati", 
+              "Pacific/Kosrae", 
+              "Pacific/Kwajalein", 
+              "Pacific/Majuro", 
+              "Pacific/Marquesas", 
+              "Pacific/Midway", 
+              "Pacific/Nauru", 
+              "Pacific/Niue", 
+              "Pacific/Norfolk", 
+              "Pacific/Noumea", 
+              "Pacific/Pago_Pago", 
+              "Pacific/Palau", 
+              "Pacific/Pitcairn", 
+              "Pacific/Pohnpei", 
+              "Pacific/Ponape", 
+              "Pacific/Port_Moresby", 
+              "Pacific/Rarotonga", 
+              "Pacific/Saipan", 
+              "Pacific/Samoa", 
+              "Pacific/Tahiti", 
+              "Pacific/Tarawa", 
+              "Pacific/Tongatapu", 
+              "Pacific/Truk", 
+              "Pacific/Wake", 
+              "Pacific/Wallis", 
+              "Pacific/Yap", 
+              "Poland", 
+              "Portugal", 
+              "ROC", 
+              "ROK", 
+              "Singapore", 
+              "Turkey", 
+              "UCT", 
+              "US/Alaska", 
+              "US/Aleutian", 
+              "US/Arizona", 
+              "US/Central", 
+              "US/East-Indiana", 
+              "US/Eastern", 
+              "US/Hawaii", 
+              "US/Indiana-Starke", 
+              "US/Michigan", 
+              "US/Mountain", 
+              "US/Pacific", 
+              "US/Samoa", 
+              "UTC", 
+              "Universal", 
+              "W-SU", 
+              "WET", 
               "Zulu"
-            ],
+            ], 
             "type": "string"
-          },
+          }, 
           "type": {
-            "description": "The report schedule type",
+            "description": "The report schedule type", 
             "enum": [
-              "Alert",
+              "Alert", 
               "Report"
-            ],
+            ], 
             "type": "string"
-          },
+          }, 
           "validator_config_json": {
             "$ref": "#/components/schemas/ValidatorConfigJSON"
-          },
+          }, 
           "validator_type": {
-            "description": "Determines when to trigger alert based off value from alert query. Alerts will be triggered with these validator types:\n- Not Null - When the return value is Not NULL,Empty,or 0\n- Operator - When `sql_return_value comparison_operator threshold` is True e.g. `50 <= 75`<br>Supports the comparison operators <,<=,>,>=,==,and !=",
+            "description": "Determines when to trigger alert based off value from alert query. Alerts will be triggered with these validator types:\n- Not Null - When the return value is Not NULL, Empty, or 0\n- Operator - When `sql_return_value comparison_operator threshold` is True e.g. `50 <= 75`<br>Supports the comparison operators <, <=, >, >=, ==, and !=", 
             "enum": [
-              "not null",
+              "not null", 
               "operator"
-            ],
-            "nullable": true,
+            ], 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "working_timeout": {
-            "description": "If an alert is staled at a working state,how long until it's state is reseted to error",
-            "example": 3600,
-            "format": "int32",
-            "minimum": 1,
-            "nullable": true,
+            "description": "If an alert is staled at a working state, how long until it's state is reseted to error", 
+            "example": 3600, 
+            "format": "int32", 
+            "minimum": 1, 
+            "nullable": true, 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "Resource": {
         "properties": {
           "id": {
             "type": "string"
-          },
+          }, 
           "type": {}
-        },
+        }, 
         "required": [
-          "id",
+          "id", 
           "type"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "RlsRule": {
         "properties": {
           "clause": {
             "type": "string"
-          },
+          }, 
           "dataset": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "required": [
           "clause"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "Roles": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "name": {
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "Roles1": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "name": {
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "SavedQueryRestApi.get": {
         "properties": {
           "changed_on_delta_humanized": {
             "readOnly": true
-          },
+          }, 
           "created_by": {
             "$ref": "#/components/schemas/SavedQueryRestApi.get.User"
-          },
+          }, 
           "database": {
             "$ref": "#/components/schemas/SavedQueryRestApi.get.Database"
-          },
+          }, 
           "description": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "label": {
-            "maxLength": 256,
-            "nullable": true,
+            "maxLength": 256, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "schema": {
-            "maxLength": 128,
-            "nullable": true,
+            "maxLength": 128, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "sql": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "sql_tables": {
             "readOnly": true
-          },
+          }, 
           "template_parameters": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "SavedQueryRestApi.get.Database": {
         "properties": {
           "database_name": {
-            "maxLength": 250,
+            "maxLength": 250, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "required": [
           "database_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "SavedQueryRestApi.get.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
+          "first_name", 
           "last_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "SavedQueryRestApi.get_list": {
         "properties": {
           "changed_on_delta_humanized": {
             "readOnly": true
-          },
+          }, 
           "created_by": {
             "$ref": "#/components/schemas/SavedQueryRestApi.get_list.User"
-          },
+          }, 
           "created_on": {
-            "format": "date-time",
-            "nullable": true,
+            "format": "date-time", 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "database": {
             "$ref": "#/components/schemas/SavedQueryRestApi.get_list.Database"
-          },
+          }, 
           "db_id": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "description": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "extra": {
             "readOnly": true
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "label": {
-            "maxLength": 256,
-            "nullable": true,
+            "maxLength": 256, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "last_run_delta_humanized": {
             "readOnly": true
-          },
+          }, 
           "rows": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "schema": {
-            "maxLength": 128,
-            "nullable": true,
+            "maxLength": 128, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "sql": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "sql_tables": {
             "readOnly": true
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "SavedQueryRestApi.get_list.Database": {
         "properties": {
           "database_name": {
-            "maxLength": 250,
+            "maxLength": 250, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "required": [
           "database_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "SavedQueryRestApi.get_list.User": {
         "properties": {
           "first_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "last_name": {
-            "maxLength": 64,
+            "maxLength": 64, 
             "type": "string"
           }
-        },
+        }, 
         "required": [
-          "first_name",
+          "first_name", 
           "last_name"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "SavedQueryRestApi.post": {
         "properties": {
           "db_id": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "description": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "label": {
-            "maxLength": 256,
-            "nullable": true,
+            "maxLength": 256, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "schema": {
-            "maxLength": 128,
-            "nullable": true,
+            "maxLength": 128, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "sql": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "template_parameters": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "SavedQueryRestApi.put": {
         "properties": {
           "db_id": {
-            "format": "int32",
-            "nullable": true,
+            "format": "int32", 
+            "nullable": true, 
             "type": "integer"
-          },
+          }, 
           "description": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "label": {
-            "maxLength": 256,
-            "nullable": true,
+            "maxLength": 256, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "schema": {
-            "maxLength": 128,
-            "nullable": true,
+            "maxLength": 128, 
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "sql": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "template_parameters": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "SchemasResponseSchema": {
         "properties": {
           "result": {
             "items": {
-              "description": "A database schema name",
+              "description": "A database schema name", 
               "type": "string"
-            },
+            }, 
             "type": "array"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "SelectStarResponseSchema": {
         "properties": {
           "result": {
-            "description": "SQL select star",
+            "description": "SQL select star", 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "Slice": {
         "properties": {
           "cache_timeout": {
-            "description": "Duration (in seconds) of the caching timeout for this chart.",
-            "format": "int32",
+            "description": "Duration (in seconds) of the caching timeout for this chart.", 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "certification_details": {
-            "description": "Details of the certification.",
+            "description": "Details of the certification.", 
             "type": "string"
-          },
+          }, 
           "certified_by": {
-            "description": "Person or group that has certified this dashboard.",
+            "description": "Person or group that has certified this dashboard.", 
             "type": "string"
-          },
+          }, 
           "changed_on": {
-            "description": "Timestamp of the last modification.",
+            "description": "Timestamp of the last modification.", 
             "type": "string"
-          },
+          }, 
           "changed_on_humanized": {
-            "description": "Timestamp of the last modification in human readable form.",
+            "description": "Timestamp of the last modification in human readable form.", 
             "type": "string"
-          },
+          }, 
           "datasource": {
-            "description": "Datasource identifier.",
+            "description": "Datasource identifier.", 
             "type": "string"
-          },
+          }, 
           "description": {
-            "description": "Slice description.",
+            "description": "Slice description.", 
             "type": "string"
-          },
+          }, 
           "description_markeddown": {
-            "description": "Sanitized HTML version of the chart description.",
+            "description": "Sanitized HTML version of the chart description.", 
             "type": "string"
-          },
+          }, 
           "edit_url": {
-            "description": "The URL for editing the slice.",
+            "description": "The URL for editing the slice.", 
             "type": "string"
-          },
+          }, 
           "form_data": {
-            "description": "Form data associated with the slice.",
+            "description": "Form data associated with the slice.", 
             "type": "object"
-          },
+          }, 
           "is_managed_externally": {
-            "description": "If the chart is managed outside externally.",
+            "description": "If the chart is managed outside externally.", 
             "type": "boolean"
-          },
+          }, 
           "modified": {
-            "description": "Last modification in human readable form.",
+            "description": "Last modification in human readable form.", 
             "type": "string"
-          },
+          }, 
           "owners": {
-            "description": "Owners identifiers.",
+            "description": "Owners identifiers.", 
             "items": {
-              "format": "int32",
+              "format": "int32", 
               "type": "integer"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "query_context": {
-            "description": "The context associated with the query.",
+            "description": "The context associated with the query.", 
             "type": "object"
-          },
+          }, 
           "slice_id": {
-            "description": "The slice ID.",
-            "format": "int32",
+            "description": "The slice ID.", 
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "slice_name": {
-            "description": "The slice name.",
+            "description": "The slice name.", 
             "type": "string"
-          },
+          }, 
           "slice_url": {
-            "description": "The slice URL.",
+            "description": "The slice URL.", 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "StopQuerySchema": {
         "properties": {
           "client_id": {
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "TableExtraMetadataResponseSchema": {
         "properties": {
           "clustering": {
             "type": "object"
-          },
+          }, 
           "metadata": {
             "type": "object"
-          },
+          }, 
           "partitions": {
             "type": "object"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "TableMetadataColumnsResponse": {
         "properties": {
           "duplicates_constraint": {
             "type": "string"
-          },
+          }, 
           "keys": {
-            "description": "",
+            "description": "", 
             "items": {
               "type": "string"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "longType": {
-            "description": "The actual backend long type for the column",
+            "description": "The actual backend long type for the column", 
             "type": "string"
-          },
+          }, 
           "name": {
-            "description": "The column name",
+            "description": "The column name", 
             "type": "string"
-          },
+          }, 
           "type": {
-            "description": "The column type",
+            "description": "The column type", 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "TableMetadataForeignKeysIndexesResponse": {
         "properties": {
           "column_names": {
             "items": {
-              "description": "A list of column names that compose the foreign key or index",
+              "description": "A list of column names that compose the foreign key or index", 
               "type": "string"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "name": {
-            "description": "The name of the foreign key or index",
+            "description": "The name of the foreign key or index", 
             "type": "string"
-          },
+          }, 
           "options": {
             "$ref": "#/components/schemas/TableMetadataOptionsResponse"
-          },
+          }, 
           "referred_columns": {
             "items": {
               "type": "string"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "referred_schema": {
             "type": "string"
-          },
+          }, 
           "referred_table": {
             "type": "string"
-          },
+          }, 
           "type": {
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "TableMetadataOptionsResponse": {
         "properties": {
           "deferrable": {
             "type": "boolean"
-          },
+          }, 
           "initially": {
             "type": "boolean"
-          },
+          }, 
           "match": {
             "type": "boolean"
-          },
+          }, 
           "ondelete": {
             "type": "boolean"
-          },
+          }, 
           "onupdate": {
             "type": "boolean"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "TableMetadataPrimaryKeyResponse": {
         "properties": {
           "column_names": {
             "items": {
-              "description": "A list of column names that compose the primary key",
+              "description": "A list of column names that compose the primary key", 
               "type": "string"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "name": {
-            "description": "The primary key index name",
+            "description": "The primary key index name", 
             "type": "string"
-          },
+          }, 
           "type": {
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "TableMetadataResponseSchema": {
         "properties": {
           "columns": {
-            "description": "A list of columns and their metadata",
+            "description": "A list of columns and their metadata", 
             "items": {
               "$ref": "#/components/schemas/TableMetadataColumnsResponse"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "foreignKeys": {
-            "description": "A list of foreign keys and their metadata",
+            "description": "A list of foreign keys and their metadata", 
             "items": {
               "$ref": "#/components/schemas/TableMetadataForeignKeysIndexesResponse"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "indexes": {
-            "description": "A list of indexes and their metadata",
+            "description": "A list of indexes and their metadata", 
             "items": {
               "$ref": "#/components/schemas/TableMetadataForeignKeysIndexesResponse"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "name": {
-            "description": "The name of the table",
+            "description": "The name of the table", 
             "type": "string"
-          },
+          }, 
           "primaryKey": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/TableMetadataPrimaryKeyResponse"
               }
-            ],
+            ], 
             "description": "Primary keys metadata"
-          },
+          }, 
           "selectStar": {
-            "description": "SQL select star",
+            "description": "SQL select star", 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "Tables": {
         "properties": {
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "schema": {
             "type": "string"
-          },
+          }, 
           "table_name": {
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "TemporaryCachePostSchema": {
         "properties": {
           "value": {
-            "description": "Any type of JSON supported text.",
+            "description": "Any type of JSON supported text.", 
             "type": "string"
           }
-        },
+        }, 
         "required": [
           "value"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "TemporaryCachePutSchema": {
         "properties": {
           "value": {
-            "description": "Any type of JSON supported text.",
+            "description": "Any type of JSON supported text.", 
             "type": "string"
           }
-        },
+        }, 
         "required": [
           "value"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "User": {
         "properties": {
           "first_name": {
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "last_name": {
             "type": "string"
-          },
+          }, 
           "username": {
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "User1": {
         "properties": {
           "first_name": {
             "type": "string"
-          },
+          }, 
           "last_name": {
             "type": "string"
-          },
+          }, 
           "username": {
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "UserResponseSchema": {
         "properties": {
           "email": {
             "type": "string"
-          },
+          }, 
           "first_name": {
             "type": "string"
-          },
+          }, 
           "id": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "is_active": {
             "type": "boolean"
-          },
+          }, 
           "is_anonymous": {
             "type": "boolean"
-          },
+          }, 
           "last_name": {
             "type": "string"
-          },
+          }, 
           "username": {
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ValidateSQLRequest": {
         "properties": {
           "schema": {
-            "nullable": true,
+            "nullable": true, 
             "type": "string"
-          },
+          }, 
           "sql": {
-            "description": "SQL statement to validate",
+            "description": "SQL statement to validate", 
             "type": "string"
-          },
+          }, 
           "template_params": {
-            "nullable": true,
+            "nullable": true, 
             "type": "object"
           }
-        },
+        }, 
         "required": [
           "sql"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "ValidateSQLResponse": {
         "properties": {
           "end_column": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "line_number": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
-          },
+          }, 
           "message": {
             "type": "string"
-          },
+          }, 
           "start_column": {
-            "format": "int32",
+            "format": "int32", 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "ValidatorConfigJSON": {
         "properties": {
           "op": {
-            "description": "The operation to compare with a threshold to apply to the SQL output\n",
+            "description": "The operation to compare with a threshold to apply to the SQL output\n", 
             "enum": [
-              "<",
-              "<=",
-              ">",
-              ">=",
-              "==",
+              "<", 
+              "<=", 
+              ">", 
+              ">=", 
+              "==", 
               "!="
-            ],
+            ], 
             "type": "string"
-          },
+          }, 
           "threshold": {
-            "format": "float",
+            "format": "float", 
             "type": "number"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "advanced_data_type_convert_schema": {
         "properties": {
           "type": {
-            "default": "port",
+            "default": "port", 
             "type": "string"
-          },
+          }, 
           "values": {
             "items": {
               "default": "http"
-            },
-            "minItems": 1,
+            }, 
+            "minItems": 1, 
             "type": "array"
           }
-        },
+        }, 
         "required": [
-          "type",
+          "type", 
           "values"
-        ],
+        ], 
         "type": "object"
-      },
+      }, 
       "database_schemas_query_schema": {
         "properties": {
           "force": {
             "type": "boolean"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "get_delete_ids_schema": {
         "items": {
           "type": "integer"
-        },
+        }, 
         "type": "array"
-      },
+      }, 
       "get_export_ids_schema": {
         "items": {
           "type": "integer"
-        },
+        }, 
         "type": "array"
-      },
+      }, 
       "get_fav_star_ids_schema": {
         "items": {
           "type": "integer"
-        },
+        }, 
         "type": "array"
-      },
+      }, 
       "get_info_schema": {
         "properties": {
           "add_columns": {
@@ -9228,232 +9228,232 @@
               "properties": {
                 "page": {
                   "type": "integer"
-                },
+                }, 
                 "page_size": {
                   "type": "integer"
                 }
-              },
+              }, 
               "type": "object"
-            },
+            }, 
             "type": "object"
-          },
+          }, 
           "edit_columns": {
             "additionalProperties": {
               "properties": {
                 "page": {
                   "type": "integer"
-                },
+                }, 
                 "page_size": {
                   "type": "integer"
                 }
-              },
+              }, 
               "type": "object"
-            },
+            }, 
             "type": "object"
-          },
+          }, 
           "keys": {
             "items": {
               "enum": [
-                "add_columns",
-                "edit_columns",
-                "filters",
-                "permissions",
-                "add_title",
-                "edit_title",
+                "add_columns", 
+                "edit_columns", 
+                "filters", 
+                "permissions", 
+                "add_title", 
+                "edit_title", 
                 "none"
-              ],
+              ], 
               "type": "string"
-            },
+            }, 
             "type": "array"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "get_item_schema": {
         "properties": {
           "columns": {
             "items": {
               "type": "string"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "keys": {
             "items": {
               "enum": [
-                "show_columns",
-                "description_columns",
-                "label_columns",
-                "show_title",
+                "show_columns", 
+                "description_columns", 
+                "label_columns", 
+                "show_title", 
                 "none"
-              ],
+              ], 
               "type": "string"
-            },
+            }, 
             "type": "array"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "get_list_schema": {
         "properties": {
           "columns": {
             "items": {
               "type": "string"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "filters": {
             "items": {
               "properties": {
                 "col": {
                   "type": "string"
-                },
+                }, 
                 "opr": {
                   "type": "string"
-                },
+                }, 
                 "value": {
                   "anyOf": [
                     {
                       "type": "number"
-                    },
+                    }, 
                     {
                       "type": "string"
-                    },
+                    }, 
                     {
                       "type": "boolean"
-                    },
+                    }, 
                     {
                       "type": "array"
                     }
                   ]
                 }
-              },
+              }, 
               "required": [
-                "col",
-                "opr",
+                "col", 
+                "opr", 
                 "value"
-              ],
+              ], 
               "type": "object"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "keys": {
             "items": {
               "enum": [
-                "list_columns",
-                "order_columns",
-                "label_columns",
-                "description_columns",
-                "list_title",
+                "list_columns", 
+                "order_columns", 
+                "label_columns", 
+                "description_columns", 
+                "list_title", 
                 "none"
-              ],
+              ], 
               "type": "string"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "order_column": {
             "type": "string"
-          },
+          }, 
           "order_direction": {
             "enum": [
-              "asc",
+              "asc", 
               "desc"
-            ],
+            ], 
             "type": "string"
-          },
+          }, 
           "page": {
             "type": "integer"
-          },
+          }, 
           "page_size": {
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "get_recent_activity_schema": {
         "properties": {
           "actions": {
             "items": {
               "type": "string"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "distinct": {
             "type": "boolean"
-          },
+          }, 
           "limit": {
             "type": "number"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "get_related_schema": {
         "properties": {
           "filter": {
             "type": "string"
-          },
+          }, 
           "include_ids": {
             "items": {
               "type": "integer"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "page": {
             "type": "integer"
-          },
+          }, 
           "page_size": {
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "screenshot_query_schema": {
         "properties": {
           "force": {
             "type": "boolean"
-          },
+          }, 
           "thumb_size": {
             "items": {
               "type": "integer"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "window_size": {
             "items": {
               "type": "integer"
-            },
+            }, 
             "type": "array"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "thumbnail_query_schema": {
         "properties": {
           "force": {
             "type": "boolean"
           }
-        },
+        }, 
         "type": "object"
       }
-    },
+    }, 
     "securitySchemes": {
       "jwt": {
-        "bearerFormat": "JWT",
-        "scheme": "bearer",
+        "bearerFormat": "JWT", 
+        "scheme": "bearer", 
         "type": "http"
-      },
+      }, 
       "jwt_refresh": {
-        "bearerFormat": "JWT",
-        "scheme": "bearer",
+        "bearerFormat": "JWT", 
+        "scheme": "bearer", 
         "type": "http"
       }
     }
-  },
+  }, 
   "info": {
-    "description": "Superset",
-    "title": "Superset",
+    "description": "Superset", 
+    "title": "Superset", 
     "version": "v1"
-  },
-  "openapi": "3.0.2",
+  }, 
+  "openapi": "3.0.2", 
   "paths": {
     "/api/v1/advanced_data_type/convert": {
       "get": {
@@ -9465,11 +9465,11 @@
                   "$ref": "#/components/schemas/advanced_data_type_convert_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -9478,36 +9478,36 @@
                   "$ref": "#/components/schemas/AdvancedDataTypeSchema"
                 }
               }
-            },
+            }, 
             "description": "AdvancedDataTypeResponse object has been returned."
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
-        "summary": "Returns a AdvancedDataTypeResponse object populated with the passed in args.",
+        ], 
+        "summary": "Returns a AdvancedDataTypeResponse object populated with the passed in args.", 
         "tags": [
           "Advanced Data Type"
         ]
       }
-    },
+    }, 
     "/api/v1/advanced_data_type/types": {
       "get": {
-        "description": "Returns a list of available advanced data types.",
+        "description": "Returns a list of available advanced data types.", 
         "responses": {
           "200": {
             "content": {
@@ -9517,39 +9517,39 @@
                     "result": {
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "a successful return of the available advanced data types has taken place."
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Advanced Data Type"
         ]
       }
-    },
+    }, 
     "/api/v1/annotation_layer/": {
       "delete": {
-        "description": "Deletes multiple annotation layers in a bulk operation.",
+        "description": "Deletes multiple annotation layers in a bulk operation.", 
         "parameters": [
           {
             "content": {
@@ -9558,11 +9558,11 @@
                   "$ref": "#/components/schemas/get_delete_ids_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -9572,37 +9572,37 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "CSS templates bulk delete"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Annotation Layers"
         ]
-      },
+      }, 
       "get": {
-        "description": "Get a list of Annotation layers,use Rison or JSON query parameters for filtering,sorting,pagination and for selecting specific columns and metadata.",
+        "description": "Get a list of Annotation layers, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.", 
         "parameters": [
           {
             "content": {
@@ -9611,11 +9611,11 @@
                   "$ref": "#/components/schemas/get_list_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -9623,93 +9623,93 @@
                 "schema": {
                   "properties": {
                     "count": {
-                      "description": "The total record count on the backend",
+                      "description": "The total record count on the backend", 
                       "type": "number"
-                    },
+                    }, 
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel",
-                          "example": "A Nice description for the column",
+                          "description": "The description for the column name. Will be translated by babel", 
+                          "example": "A Nice description for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "ids": {
-                      "description": "A list of item ids,useful when you don't know the column id",
+                      "description": "A list of item ids, useful when you don't know the column id", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel",
-                          "example": "A Nice label for the column",
+                          "description": "The label for the column name. Will be translated by babel", 
+                          "example": "A Nice label for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "list_columns": {
-                      "description": "A list of columns",
+                      "description": "A list of columns", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "list_title": {
-                      "description": "A title to render. Will be translated by babel",
-                      "example": "List Items",
+                      "description": "A title to render. Will be translated by babel", 
+                      "example": "List Items", 
                       "type": "string"
-                    },
+                    }, 
                     "order_columns": {
-                      "description": "A list of allowed columns to sort",
+                      "description": "A list of allowed columns to sort", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "result": {
-                      "description": "The result from the get list query",
+                      "description": "The result from the get list query", 
                       "items": {
                         "$ref": "#/components/schemas/AnnotationLayerRestApi.get_list"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Items from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Annotation Layers"
         ]
-      },
+      }, 
       "post": {
-        "description": "Create an Annotation layer",
+        "description": "Create an Annotation layer", 
         "requestBody": {
           "content": {
             "application/json": {
@@ -9717,10 +9717,10 @@
                 "$ref": "#/components/schemas/AnnotationLayerRestApi.post"
               }
             }
-          },
-          "description": "Annotation Layer schema",
+          }, 
+          "description": "Annotation Layer schema", 
           "required": true
-        },
+        }, 
         "responses": {
           "201": {
             "content": {
@@ -9729,43 +9729,43 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/AnnotationLayerRestApi.post"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Annotation added"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Annotation Layers"
         ]
       }
-    },
+    }, 
     "/api/v1/annotation_layer/_info": {
       "get": {
-        "description": "Get metadata information about this API resource",
+        "description": "Get metadata information about this API resource", 
         "parameters": [
           {
             "content": {
@@ -9774,11 +9774,11 @@
                   "$ref": "#/components/schemas/get_info_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -9787,79 +9787,79 @@
                   "properties": {
                     "add_columns": {
                       "type": "object"
-                    },
+                    }, 
                     "edit_columns": {
                       "type": "object"
-                    },
+                    }, 
                     "filters": {
                       "properties": {
                         "column_name": {
                           "items": {
                             "properties": {
                               "name": {
-                                "description": "The filter name. Will be translated by babel",
+                                "description": "The filter name. Will be translated by babel", 
                                 "type": "string"
-                              },
+                              }, 
                               "operator": {
-                                "description": "The filter operation key to use on list filters",
+                                "description": "The filter operation key to use on list filters", 
                                 "type": "string"
                               }
-                            },
+                            }, 
                             "type": "object"
-                          },
+                          }, 
                           "type": "array"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "permissions": {
-                      "description": "The user permissions for this API resource",
+                      "description": "The user permissions for this API resource", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Annotation Layers"
         ]
       }
-    },
+    }, 
     "/api/v1/annotation_layer/related/{column_name}": {
       "get": {
         "parameters": [
           {
-            "in": "path",
-            "name": "column_name",
-            "required": true,
+            "in": "path", 
+            "name": "column_name", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -9867,11 +9867,11 @@
                   "$ref": "#/components/schemas/get_related_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -9880,46 +9880,46 @@
                   "$ref": "#/components/schemas/RelatedResponseSchema"
                 }
               }
-            },
+            }, 
             "description": "Related column data"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Annotation Layers"
         ]
       }
-    },
+    }, 
     "/api/v1/annotation_layer/{pk}": {
       "delete": {
-        "description": "Delete Annotation layer",
+        "description": "Delete Annotation layer", 
         "parameters": [
           {
-            "description": "The annotation layer pk for this annotation",
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "description": "The annotation layer pk for this annotation", 
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -9929,43 +9929,43 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item deleted"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Annotation Layers"
         ]
-      },
+      }, 
       "get": {
-        "description": "Get an Annotation layer",
+        "description": "Get an Annotation layer", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -9973,11 +9973,11 @@
                   "$ref": "#/components/schemas/get_item_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -9987,87 +9987,87 @@
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel",
-                          "example": "A Nice description for the column",
+                          "description": "The description for the column name. Will be translated by babel", 
+                          "example": "A Nice description for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "id": {
-                      "description": "The item id",
+                      "description": "The item id", 
                       "type": "string"
-                    },
+                    }, 
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel",
-                          "example": "A Nice label for the column",
+                          "description": "The label for the column name. Will be translated by babel", 
+                          "example": "A Nice label for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/AnnotationLayerRestApi.get"
-                    },
+                    }, 
                     "show_columns": {
-                      "description": "A list of columns",
+                      "description": "A list of columns", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "show_title": {
-                      "description": "A title to render. Will be translated by babel",
-                      "example": "Show Item Details",
+                      "description": "A title to render. Will be translated by babel", 
+                      "example": "Show Item Details", 
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Annotation Layers"
         ]
-      },
+      }, 
       "put": {
-        "description": "Update an Annotation layer",
+        "description": "Update an Annotation layer", 
         "parameters": [
           {
-            "description": "The annotation layer pk for this annotation",
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "description": "The annotation layer pk for this annotation", 
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "requestBody": {
           "content": {
             "application/json": {
@@ -10075,10 +10075,10 @@
                 "$ref": "#/components/schemas/AnnotationLayerRestApi.put"
               }
             }
-          },
-          "description": "Annotation schema",
+          }, 
+          "description": "Annotation schema", 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -10087,53 +10087,53 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/AnnotationLayerRestApi.put"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Annotation changed"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Annotation Layers"
         ]
       }
-    },
+    }, 
     "/api/v1/annotation_layer/{pk}/annotation/": {
       "delete": {
-        "description": "Deletes multiple annotation in a bulk operation.",
+        "description": "Deletes multiple annotation in a bulk operation.", 
         "parameters": [
           {
-            "description": "The annotation layer pk for this annotation",
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "description": "The annotation layer pk for this annotation", 
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -10141,11 +10141,11 @@
                   "$ref": "#/components/schemas/get_delete_ids_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -10155,47 +10155,47 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Annotations bulk delete"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Annotation Layers"
         ]
-      },
+      }, 
       "get": {
-        "description": "Get a list of Annotation layers,use Rison or JSON query parameters for filtering,sorting,pagination and for selecting specific columns and metadata.",
+        "description": "Get a list of Annotation layers, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.", 
         "parameters": [
           {
-            "description": "The annotation layer id for this annotation",
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "description": "The annotation layer id for this annotation", 
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -10203,11 +10203,11 @@
                   "$ref": "#/components/schemas/get_list_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -10215,65 +10215,65 @@
                 "schema": {
                   "properties": {
                     "count": {
-                      "description": "The total record count on the backend",
+                      "description": "The total record count on the backend", 
                       "type": "number"
-                    },
+                    }, 
                     "ids": {
-                      "description": "A list of annotation ids",
+                      "description": "A list of annotation ids", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "result": {
-                      "description": "The result from the get list query",
+                      "description": "The result from the get list query", 
                       "items": {
                         "$ref": "#/components/schemas/AnnotationRestApi.get_list"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Items from Annotations"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Annotation Layers"
         ]
-      },
+      }, 
       "post": {
-        "description": "Create an Annotation layer",
+        "description": "Create an Annotation layer", 
         "parameters": [
           {
-            "description": "The annotation layer pk for this annotation",
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "description": "The annotation layer pk for this annotation", 
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "requestBody": {
           "content": {
             "application/json": {
@@ -10281,10 +10281,10 @@
                 "$ref": "#/components/schemas/AnnotationRestApi.post"
               }
             }
-          },
-          "description": "Annotation schema",
+          }, 
+          "description": "Annotation schema", 
           "required": true
-        },
+        }, 
         "responses": {
           "201": {
             "content": {
@@ -10293,63 +10293,63 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/AnnotationRestApi.post"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Annotation added"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Annotation Layers"
         ]
       }
-    },
+    }, 
     "/api/v1/annotation_layer/{pk}/annotation/{annotation_id}": {
       "delete": {
-        "description": "Delete Annotation layer",
+        "description": "Delete Annotation layer", 
         "parameters": [
           {
-            "description": "The annotation layer pk for this annotation",
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "description": "The annotation layer pk for this annotation", 
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
-            "description": "The annotation pk for this annotation",
-            "in": "path",
-            "name": "annotation_id",
-            "required": true,
+            "description": "The annotation pk for this annotation", 
+            "in": "path", 
+            "name": "annotation_id", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -10359,53 +10359,53 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item deleted"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Annotation Layers"
         ]
-      },
+      }, 
       "get": {
-        "description": "Get an Annotation layer",
+        "description": "Get an Annotation layer", 
         "parameters": [
           {
-            "description": "The annotation layer pk for this annotation",
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "description": "The annotation layer pk for this annotation", 
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
-            "description": "The annotation pk",
-            "in": "path",
-            "name": "annotation_id",
-            "required": true,
+            "description": "The annotation pk", 
+            "in": "path", 
+            "name": "annotation_id", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -10413,11 +10413,11 @@
                   "$ref": "#/components/schemas/get_item_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -10425,66 +10425,66 @@
                 "schema": {
                   "properties": {
                     "id": {
-                      "description": "The item id",
+                      "description": "The item id", 
                       "type": "string"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/AnnotationRestApi.get"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Annotation Layers"
         ]
-      },
+      }, 
       "put": {
-        "description": "Update an Annotation layer",
+        "description": "Update an Annotation layer", 
         "parameters": [
           {
-            "description": "The annotation layer pk for this annotation",
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "description": "The annotation layer pk for this annotation", 
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
-            "description": "The annotation pk for this annotation",
-            "in": "path",
-            "name": "annotation_id",
-            "required": true,
+            "description": "The annotation pk for this annotation", 
+            "in": "path", 
+            "name": "annotation_id", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "requestBody": {
           "content": {
             "application/json": {
@@ -10492,10 +10492,10 @@
                 "$ref": "#/components/schemas/AnnotationRestApi.put"
               }
             }
-          },
-          "description": "Annotation schema",
+          }, 
+          "description": "Annotation schema", 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -10504,75 +10504,75 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/AnnotationRestApi.put"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Annotation changed"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Annotation Layers"
         ]
       }
-    },
+    }, 
     "/api/v1/assets/export/": {
       "get": {
-        "description": "Returns a ZIP file with all the Superset assets (databases,datasets,charts,dashboards,saved queries) as YAML files.",
+        "description": "Returns a ZIP file with all the Superset assets (databases, datasets, charts, dashboards, saved queries) as YAML files.", 
         "responses": {
           "200": {
             "content": {
               "application/zip": {
                 "schema": {
-                  "format": "binary",
+                  "format": "binary", 
                   "type": "string"
                 }
               }
-            },
+            }, 
             "description": "ZIP file"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Import/export"
         ]
       }
-    },
+    }, 
     "/api/v1/assets/import/": {
       "post": {
         "requestBody": {
@@ -10581,21 +10581,21 @@
               "schema": {
                 "properties": {
                   "bundle": {
-                    "description": "upload file (ZIP or JSON)",
-                    "format": "binary",
+                    "description": "upload file (ZIP or JSON)", 
+                    "format": "binary", 
                     "type": "string"
-                  },
+                  }, 
                   "passwords": {
-                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`,the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
+                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.", 
                     "type": "string"
                   }
-                },
+                }, 
                 "type": "object"
               }
             }
-          },
+          }, 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -10605,49 +10605,49 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Assets import result"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Import/export"
         ]
       }
-    },
+    }, 
     "/api/v1/async_event/": {
       "get": {
-        "description": "Reads off of the Redis events stream,using the user's JWT token and optional query params for last event received.",
+        "description": "Reads off of the Redis events stream, using the user's JWT token and optional query params for last event received.", 
         "parameters": [
           {
-            "description": "Last ID received by the client",
-            "in": "query",
-            "name": "last_id",
+            "description": "Last ID received by the client", 
+            "in": "query", 
+            "name": "last_id", 
             "schema": {
               "type": "string"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -10659,60 +10659,60 @@
                         "properties": {
                           "channel_id": {
                             "type": "string"
-                          },
+                          }, 
                           "errors": {
                             "items": {
                               "type": "object"
-                            },
+                            }, 
                             "type": "array"
-                          },
+                          }, 
                           "id": {
                             "type": "string"
-                          },
+                          }, 
                           "job_id": {
                             "type": "string"
-                          },
+                          }, 
                           "result_url": {
                             "type": "string"
-                          },
+                          }, 
                           "status": {
                             "type": "string"
-                          },
+                          }, 
                           "user_id": {
                             "type": "integer"
                           }
-                        },
+                        }, 
                         "type": "object"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Async event results"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "AsyncEventsRestApi"
         ]
       }
-    },
+    }, 
     "/api/v1/available_domains/": {
       "get": {
-        "description": "Get all available domains",
+        "description": "Get all available domains", 
         "responses": {
           "200": {
             "content": {
@@ -10722,33 +10722,33 @@
                     "result": {
                       "$ref": "#/components/schemas/AvailableDomainsSchema"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "a list of available domains"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/403"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Available Domains"
         ]
       }
-    },
+    }, 
     "/api/v1/cachekey/invalidate": {
       "post": {
-        "description": "Takes a list of datasources,finds the associated cache records and invalidates them and removes the database records",
+        "description": "Takes a list of datasources, finds the associated cache records and invalidates them and removes the database records", 
         "requestBody": {
           "content": {
             "application/json": {
@@ -10756,34 +10756,34 @@
                 "$ref": "#/components/schemas/CacheInvalidationRequestSchema"
               }
             }
-          },
-          "description": "A list of datasources uuid or the tuples of database and datasource names",
+          }, 
+          "description": "A list of datasources uuid or the tuples of database and datasource names", 
           "required": true
-        },
+        }, 
         "responses": {
           "201": {
             "description": "cache was successfully invalidated"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "CacheRestApi"
         ]
       }
-    },
+    }, 
     "/api/v1/chart/": {
       "delete": {
-        "description": "Deletes multiple Charts in a bulk operation.",
+        "description": "Deletes multiple Charts in a bulk operation.", 
         "parameters": [
           {
             "content": {
@@ -10792,11 +10792,11 @@
                   "$ref": "#/components/schemas/get_delete_ids_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -10806,40 +10806,40 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Charts bulk delete"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/403"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Charts"
         ]
-      },
+      }, 
       "get": {
-        "description": "Get a list of charts,use Rison or JSON query parameters for filtering,sorting,pagination and  for selecting specific columns and metadata.",
+        "description": "Get a list of charts, use Rison or JSON query parameters for filtering, sorting, pagination and  for selecting specific columns and metadata.", 
         "parameters": [
           {
             "content": {
@@ -10848,11 +10848,11 @@
                   "$ref": "#/components/schemas/get_list_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -10860,93 +10860,93 @@
                 "schema": {
                   "properties": {
                     "count": {
-                      "description": "The total record count on the backend",
+                      "description": "The total record count on the backend", 
                       "type": "number"
-                    },
+                    }, 
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel",
-                          "example": "A Nice description for the column",
+                          "description": "The description for the column name. Will be translated by babel", 
+                          "example": "A Nice description for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "ids": {
-                      "description": "A list of item ids,useful when you don't know the column id",
+                      "description": "A list of item ids, useful when you don't know the column id", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel",
-                          "example": "A Nice label for the column",
+                          "description": "The label for the column name. Will be translated by babel", 
+                          "example": "A Nice label for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "list_columns": {
-                      "description": "A list of columns",
+                      "description": "A list of columns", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "list_title": {
-                      "description": "A title to render. Will be translated by babel",
-                      "example": "List Items",
+                      "description": "A title to render. Will be translated by babel", 
+                      "example": "List Items", 
                       "type": "string"
-                    },
+                    }, 
                     "order_columns": {
-                      "description": "A list of allowed columns to sort",
+                      "description": "A list of allowed columns to sort", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "result": {
-                      "description": "The result from the get list query",
+                      "description": "The result from the get list query", 
                       "items": {
                         "$ref": "#/components/schemas/ChartRestApi.get_list"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Items from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Charts"
         ]
-      },
+      }, 
       "post": {
-        "description": "Create a new Chart.",
+        "description": "Create a new Chart.", 
         "requestBody": {
           "content": {
             "application/json": {
@@ -10954,10 +10954,10 @@
                 "$ref": "#/components/schemas/ChartRestApi.post"
               }
             }
-          },
-          "description": "Chart schema",
+          }, 
+          "description": "Chart schema", 
           "required": true
-        },
+        }, 
         "responses": {
           "201": {
             "content": {
@@ -10966,43 +10966,43 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/ChartRestApi.post"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Chart added"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Charts"
         ]
       }
-    },
+    }, 
     "/api/v1/chart/_info": {
       "get": {
-        "description": "Several metadata information about chart API endpoints.",
+        "description": "Several metadata information about chart API endpoints.", 
         "parameters": [
           {
             "content": {
@@ -11011,11 +11011,11 @@
                   "$ref": "#/components/schemas/get_info_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -11024,71 +11024,71 @@
                   "properties": {
                     "add_columns": {
                       "type": "object"
-                    },
+                    }, 
                     "edit_columns": {
                       "type": "object"
-                    },
+                    }, 
                     "filters": {
                       "properties": {
                         "column_name": {
                           "items": {
                             "properties": {
                               "name": {
-                                "description": "The filter name. Will be translated by babel",
+                                "description": "The filter name. Will be translated by babel", 
                                 "type": "string"
-                              },
+                              }, 
                               "operator": {
-                                "description": "The filter operation key to use on list filters",
+                                "description": "The filter operation key to use on list filters", 
                                 "type": "string"
                               }
-                            },
+                            }, 
                             "type": "object"
-                          },
+                          }, 
                           "type": "array"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "permissions": {
-                      "description": "The user permissions for this API resource",
+                      "description": "The user permissions for this API resource", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Charts"
         ]
       }
-    },
+    }, 
     "/api/v1/chart/data": {
       "post": {
-        "description": "Takes a query context constructed in the client and returns payload data response for the given query.",
+        "description": "Takes a query context constructed in the client and returns payload data response for the given query.", 
         "requestBody": {
           "content": {
             "application/json": {
@@ -11096,10 +11096,10 @@
                 "$ref": "#/components/schemas/ChartDataQueryContextSchema"
               }
             }
-          },
-          "description": "A query context consists of a datasource from which to fetch data and one or many query objects.",
+          }, 
+          "description": "A query context consists of a datasource from which to fetch data and one or many query objects.", 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -11108,9 +11108,9 @@
                   "$ref": "#/components/schemas/ChartDataResponseSchema"
                 }
               }
-            },
+            }, 
             "description": "Query result"
-          },
+          }, 
           "202": {
             "content": {
               "application/json": {
@@ -11118,42 +11118,42 @@
                   "$ref": "#/components/schemas/ChartDataAsyncResponseSchema"
                 }
               }
-            },
+            }, 
             "description": "Async job details"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Charts"
         ]
       }
-    },
+    }, 
     "/api/v1/chart/data/{cache_key}": {
       "get": {
-        "description": "Takes a query context cache key and returns payload data response for the given query.",
+        "description": "Takes a query context cache key and returns payload data response for the given query.", 
         "parameters": [
           {
-            "in": "path",
-            "name": "cache_key",
-            "required": true,
+            "in": "path", 
+            "name": "cache_key", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -11162,38 +11162,38 @@
                   "$ref": "#/components/schemas/ChartDataResponseSchema"
                 }
               }
-            },
+            }, 
             "description": "Query result"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Charts"
         ]
       }
-    },
+    }, 
     "/api/v1/chart/export/": {
       "get": {
-        "description": "Exports multiple charts and downloads them as YAML files",
+        "description": "Exports multiple charts and downloads them as YAML files", 
         "parameters": [
           {
             "content": {
@@ -11202,49 +11202,49 @@
                   "$ref": "#/components/schemas/get_export_ids_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
               "application/zip": {
                 "schema": {
-                  "format": "binary",
+                  "format": "binary", 
                   "type": "string"
                 }
               }
-            },
-            "description": "A zip file with chart(s),dataset(s) and database(s) as YAML"
-          },
+            }, 
+            "description": "A zip file with chart(s), dataset(s) and database(s) as YAML"
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Charts"
         ]
       }
-    },
+    }, 
     "/api/v1/chart/favorite_status/": {
       "get": {
-        "description": "Check favorited dashboards for current user",
+        "description": "Check favorited dashboards for current user", 
         "parameters": [
           {
             "content": {
@@ -11253,11 +11253,11 @@
                   "$ref": "#/components/schemas/get_fav_star_ids_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -11266,32 +11266,32 @@
                   "$ref": "#/components/schemas/GetFavStarIdsSchema"
                 }
               }
-            },
+            }, 
             "description": "None"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Charts"
         ]
       }
-    },
+    }, 
     "/api/v1/chart/import/": {
       "post": {
         "requestBody": {
@@ -11300,25 +11300,25 @@
               "schema": {
                 "properties": {
                   "formData": {
-                    "description": "upload file (ZIP)",
-                    "format": "binary",
+                    "description": "upload file (ZIP)", 
+                    "format": "binary", 
                     "type": "string"
-                  },
+                  }, 
                   "overwrite": {
-                    "description": "overwrite existing charts?",
+                    "description": "overwrite existing charts?", 
                     "type": "boolean"
-                  },
+                  }, 
                   "passwords": {
-                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`,the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
+                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.", 
                     "type": "string"
                   }
-                },
+                }, 
                 "type": "object"
               }
             }
-          },
+          }, 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -11328,48 +11328,48 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Chart import result"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Charts"
         ]
       }
-    },
+    }, 
     "/api/v1/chart/related/{column_name}": {
       "get": {
-        "description": "Get a list of all possible owners for a chart. Use `owners` has the `column_name` parameter",
+        "description": "Get a list of all possible owners for a chart. Use `owners` has the `column_name` parameter", 
         "parameters": [
           {
-            "in": "path",
-            "name": "column_name",
-            "required": true,
+            "in": "path", 
+            "name": "column_name", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -11377,11 +11377,11 @@
                   "$ref": "#/components/schemas/get_related_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -11390,45 +11390,45 @@
                   "$ref": "#/components/schemas/RelatedResponseSchema"
                 }
               }
-            },
+            }, 
             "description": "Related column data"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Charts"
         ]
       }
-    },
+    }, 
     "/api/v1/chart/{pk}": {
       "delete": {
-        "description": "Deletes a Chart.",
+        "description": "Deletes a Chart.", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -11438,49 +11438,49 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Chart delete"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/403"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Charts"
         ]
-      },
+      }, 
       "get": {
-        "description": "Get a chart detail information.",
+        "description": "Get a chart detail information.", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -11488,11 +11488,11 @@
                   "$ref": "#/components/schemas/get_item_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -11502,86 +11502,86 @@
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel",
-                          "example": "A Nice description for the column",
+                          "description": "The description for the column name. Will be translated by babel", 
+                          "example": "A Nice description for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "id": {
-                      "description": "The item id",
+                      "description": "The item id", 
                       "type": "string"
-                    },
+                    }, 
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel",
-                          "example": "A Nice label for the column",
+                          "description": "The label for the column name. Will be translated by babel", 
+                          "example": "A Nice label for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/ChartRestApi.get"
-                    },
+                    }, 
                     "show_columns": {
-                      "description": "A list of columns",
+                      "description": "A list of columns", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "show_title": {
-                      "description": "A title to render. Will be translated by babel",
-                      "example": "Show Item Details",
+                      "description": "A title to render. Will be translated by babel", 
+                      "example": "Show Item Details", 
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Charts"
         ]
-      },
+      }, 
       "put": {
-        "description": "Changes a Chart.",
+        "description": "Changes a Chart.", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "requestBody": {
           "content": {
             "application/json": {
@@ -11589,10 +11589,10 @@
                 "$ref": "#/components/schemas/ChartRestApi.put"
               }
             }
-          },
-          "description": "Chart schema",
+          }, 
+          "description": "Chart schema", 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -11601,58 +11601,58 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/ChartRestApi.put"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Chart changed"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/403"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Charts"
         ]
       }
-    },
+    }, 
     "/api/v1/chart/{pk}/cache_screenshot/": {
       "get": {
-        "description": "Compute and cache a screenshot.",
+        "description": "Compute and cache a screenshot.", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -11660,11 +11660,11 @@
                   "$ref": "#/components/schemas/screenshot_query_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "202": {
             "content": {
@@ -11673,70 +11673,70 @@
                   "$ref": "#/components/schemas/ChartCacheScreenshotResponseSchema"
                 }
               }
-            },
+            }, 
             "description": "Chart async result"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Charts"
         ]
       }
-    },
+    }, 
     "/api/v1/chart/{pk}/data/": {
       "get": {
-        "description": "Takes a chart ID and uses the query context stored when the chart was saved to return payload data response.",
+        "description": "Takes a chart ID and uses the query context stored when the chart was saved to return payload data response.", 
         "parameters": [
           {
-            "description": "The chart ID",
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "description": "The chart ID", 
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
-            "description": "The format in which the data should be returned",
-            "in": "query",
-            "name": "format",
+            "description": "The format in which the data should be returned", 
+            "in": "query", 
+            "name": "format", 
             "schema": {
               "type": "string"
             }
-          },
+          }, 
           {
-            "description": "The type in which the data should be returned",
-            "in": "query",
-            "name": "type",
+            "description": "The type in which the data should be returned", 
+            "in": "query", 
+            "name": "type", 
             "schema": {
               "type": "string"
             }
-          },
+          }, 
           {
-            "description": "Should the queries be forced to load from the source",
-            "in": "query",
-            "name": "force",
+            "description": "Should the queries be forced to load from the source", 
+            "in": "query", 
+            "name": "force", 
             "schema": {
               "type": "boolean"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -11745,9 +11745,9 @@
                   "$ref": "#/components/schemas/ChartDataResponseSchema"
                 }
               }
-            },
+            }, 
             "description": "Query result"
-          },
+          }, 
           "202": {
             "content": {
               "application/json": {
@@ -11755,147 +11755,147 @@
                   "$ref": "#/components/schemas/ChartDataAsyncResponseSchema"
                 }
               }
-            },
+            }, 
             "description": "Async job details"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Charts"
         ]
       }
-    },
+    }, 
     "/api/v1/chart/{pk}/screenshot/{digest}/": {
       "get": {
-        "description": "Get a computed screenshot from cache.",
+        "description": "Get a computed screenshot from cache.", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
-            "in": "path",
-            "name": "digest",
-            "required": true,
+            "in": "path", 
+            "name": "digest", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
               "image/*": {
                 "schema": {
-                  "format": "binary",
+                  "format": "binary", 
                   "type": "string"
                 }
               }
-            },
+            }, 
             "description": "Chart thumbnail image"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Charts"
         ]
       }
-    },
+    }, 
     "/api/v1/chart/{pk}/thumbnail/{digest}/": {
       "get": {
-        "description": "Compute or get already computed chart thumbnail from cache.",
+        "description": "Compute or get already computed chart thumbnail from cache.", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
-            "in": "path",
-            "name": "digest",
-            "required": true,
+            "in": "path", 
+            "name": "digest", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
               "image/*": {
                 "schema": {
-                  "format": "binary",
+                  "format": "binary", 
                   "type": "string"
                 }
               }
-            },
+            }, 
             "description": "Chart thumbnail image"
-          },
+          }, 
           "302": {
             "description": "Redirects to the current digest"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Charts"
         ]
       }
-    },
+    }, 
     "/api/v1/css_template/": {
       "delete": {
-        "description": "Deletes multiple css templates in a bulk operation.",
+        "description": "Deletes multiple css templates in a bulk operation.", 
         "parameters": [
           {
             "content": {
@@ -11904,11 +11904,11 @@
                   "$ref": "#/components/schemas/get_delete_ids_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -11918,37 +11918,37 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "CSS templates bulk delete"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "CSS Templates"
         ]
-      },
+      }, 
       "get": {
-        "description": "Get a list of CSS templates,use Rison or JSON query parameters for filtering,sorting,pagination and for selecting specific columns and metadata.",
+        "description": "Get a list of CSS templates, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.", 
         "parameters": [
           {
             "content": {
@@ -11957,11 +11957,11 @@
                   "$ref": "#/components/schemas/get_list_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -11969,93 +11969,93 @@
                 "schema": {
                   "properties": {
                     "count": {
-                      "description": "The total record count on the backend",
+                      "description": "The total record count on the backend", 
                       "type": "number"
-                    },
+                    }, 
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel",
-                          "example": "A Nice description for the column",
+                          "description": "The description for the column name. Will be translated by babel", 
+                          "example": "A Nice description for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "ids": {
-                      "description": "A list of item ids,useful when you don't know the column id",
+                      "description": "A list of item ids, useful when you don't know the column id", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel",
-                          "example": "A Nice label for the column",
+                          "description": "The label for the column name. Will be translated by babel", 
+                          "example": "A Nice label for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "list_columns": {
-                      "description": "A list of columns",
+                      "description": "A list of columns", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "list_title": {
-                      "description": "A title to render. Will be translated by babel",
-                      "example": "List Items",
+                      "description": "A title to render. Will be translated by babel", 
+                      "example": "List Items", 
                       "type": "string"
-                    },
+                    }, 
                     "order_columns": {
-                      "description": "A list of allowed columns to sort",
+                      "description": "A list of allowed columns to sort", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "result": {
-                      "description": "The result from the get list query",
+                      "description": "The result from the get list query", 
                       "items": {
                         "$ref": "#/components/schemas/CssTemplateRestApi.get_list"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Items from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "CSS Templates"
         ]
-      },
+      }, 
       "post": {
-        "description": "Create a CSS template",
+        "description": "Create a CSS template", 
         "requestBody": {
           "content": {
             "application/json": {
@@ -12063,10 +12063,10 @@
                 "$ref": "#/components/schemas/CssTemplateRestApi.post"
               }
             }
-          },
-          "description": "Model schema",
+          }, 
+          "description": "Model schema", 
           "required": true
-        },
+        }, 
         "responses": {
           "201": {
             "content": {
@@ -12075,43 +12075,43 @@
                   "properties": {
                     "id": {
                       "type": "string"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/CssTemplateRestApi.post"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item inserted"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "CSS Templates"
         ]
       }
-    },
+    }, 
     "/api/v1/css_template/_info": {
       "get": {
-        "description": "Get metadata information about this API resource",
+        "description": "Get metadata information about this API resource", 
         "parameters": [
           {
             "content": {
@@ -12120,11 +12120,11 @@
                   "$ref": "#/components/schemas/get_info_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -12133,79 +12133,79 @@
                   "properties": {
                     "add_columns": {
                       "type": "object"
-                    },
+                    }, 
                     "edit_columns": {
                       "type": "object"
-                    },
+                    }, 
                     "filters": {
                       "properties": {
                         "column_name": {
                           "items": {
                             "properties": {
                               "name": {
-                                "description": "The filter name. Will be translated by babel",
+                                "description": "The filter name. Will be translated by babel", 
                                 "type": "string"
-                              },
+                              }, 
                               "operator": {
-                                "description": "The filter operation key to use on list filters",
+                                "description": "The filter operation key to use on list filters", 
                                 "type": "string"
                               }
-                            },
+                            }, 
                             "type": "object"
-                          },
+                          }, 
                           "type": "array"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "permissions": {
-                      "description": "The user permissions for this API resource",
+                      "description": "The user permissions for this API resource", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "CSS Templates"
         ]
       }
-    },
+    }, 
     "/api/v1/css_template/related/{column_name}": {
       "get": {
         "parameters": [
           {
-            "in": "path",
-            "name": "column_name",
-            "required": true,
+            "in": "path", 
+            "name": "column_name", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -12213,11 +12213,11 @@
                   "$ref": "#/components/schemas/get_related_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -12226,45 +12226,45 @@
                   "$ref": "#/components/schemas/RelatedResponseSchema"
                 }
               }
-            },
+            }, 
             "description": "Related column data"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "CSS Templates"
         ]
       }
-    },
+    }, 
     "/api/v1/css_template/{pk}": {
       "delete": {
-        "description": "Delete CSS template",
+        "description": "Delete CSS template", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -12274,43 +12274,43 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item deleted"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "CSS Templates"
         ]
-      },
+      }, 
       "get": {
-        "description": "Get a CSS template",
+        "description": "Get a CSS template", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -12318,11 +12318,11 @@
                   "$ref": "#/components/schemas/get_item_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -12332,86 +12332,86 @@
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel",
-                          "example": "A Nice description for the column",
+                          "description": "The description for the column name. Will be translated by babel", 
+                          "example": "A Nice description for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "id": {
-                      "description": "The item id",
+                      "description": "The item id", 
                       "type": "string"
-                    },
+                    }, 
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel",
-                          "example": "A Nice label for the column",
+                          "description": "The label for the column name. Will be translated by babel", 
+                          "example": "A Nice label for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/CssTemplateRestApi.get"
-                    },
+                    }, 
                     "show_columns": {
-                      "description": "A list of columns",
+                      "description": "A list of columns", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "show_title": {
-                      "description": "A title to render. Will be translated by babel",
-                      "example": "Show Item Details",
+                      "description": "A title to render. Will be translated by babel", 
+                      "example": "Show Item Details", 
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "CSS Templates"
         ]
-      },
+      }, 
       "put": {
-        "description": "Update a CSS template",
+        "description": "Update a CSS template", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "requestBody": {
           "content": {
             "application/json": {
@@ -12419,10 +12419,10 @@
                 "$ref": "#/components/schemas/CssTemplateRestApi.put"
               }
             }
-          },
-          "description": "Model schema",
+          }, 
+          "description": "Model schema", 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -12432,42 +12432,42 @@
                     "result": {
                       "$ref": "#/components/schemas/CssTemplateRestApi.put"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item changed"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "CSS Templates"
         ]
       }
-    },
+    }, 
     "/api/v1/dashboard/": {
       "delete": {
-        "description": "Deletes multiple Dashboards in a bulk operation.",
+        "description": "Deletes multiple Dashboards in a bulk operation.", 
         "parameters": [
           {
             "content": {
@@ -12476,11 +12476,11 @@
                   "$ref": "#/components/schemas/get_delete_ids_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -12490,40 +12490,40 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Dashboard bulk delete"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/403"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Dashboards"
         ]
-      },
+      }, 
       "get": {
-        "description": "Get a list of dashboards,use Rison or JSON query parameters for filtering,sorting,pagination and  for selecting specific columns and metadata.",
+        "description": "Get a list of dashboards, use Rison or JSON query parameters for filtering, sorting, pagination and  for selecting specific columns and metadata.", 
         "parameters": [
           {
             "content": {
@@ -12532,11 +12532,11 @@
                   "$ref": "#/components/schemas/get_list_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -12544,93 +12544,93 @@
                 "schema": {
                   "properties": {
                     "count": {
-                      "description": "The total record count on the backend",
+                      "description": "The total record count on the backend", 
                       "type": "number"
-                    },
+                    }, 
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel",
-                          "example": "A Nice description for the column",
+                          "description": "The description for the column name. Will be translated by babel", 
+                          "example": "A Nice description for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "ids": {
-                      "description": "A list of item ids,useful when you don't know the column id",
+                      "description": "A list of item ids, useful when you don't know the column id", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel",
-                          "example": "A Nice label for the column",
+                          "description": "The label for the column name. Will be translated by babel", 
+                          "example": "A Nice label for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "list_columns": {
-                      "description": "A list of columns",
+                      "description": "A list of columns", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "list_title": {
-                      "description": "A title to render. Will be translated by babel",
-                      "example": "List Items",
+                      "description": "A title to render. Will be translated by babel", 
+                      "example": "List Items", 
                       "type": "string"
-                    },
+                    }, 
                     "order_columns": {
-                      "description": "A list of allowed columns to sort",
+                      "description": "A list of allowed columns to sort", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "result": {
-                      "description": "The result from the get list query",
+                      "description": "The result from the get list query", 
                       "items": {
                         "$ref": "#/components/schemas/DashboardRestApi.get_list"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Items from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Dashboards"
         ]
-      },
+      }, 
       "post": {
-        "description": "Create a new Dashboard.",
+        "description": "Create a new Dashboard.", 
         "requestBody": {
           "content": {
             "application/json": {
@@ -12638,10 +12638,10 @@
                 "$ref": "#/components/schemas/DashboardRestApi.post"
               }
             }
-          },
-          "description": "Dashboard schema",
+          }, 
+          "description": "Dashboard schema", 
           "required": true
-        },
+        }, 
         "responses": {
           "201": {
             "content": {
@@ -12650,43 +12650,43 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/DashboardRestApi.post"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Dashboard added"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Dashboards"
         ]
       }
-    },
+    }, 
     "/api/v1/dashboard/_info": {
       "get": {
-        "description": "Several metadata information about dashboard API endpoints.",
+        "description": "Several metadata information about dashboard API endpoints.", 
         "parameters": [
           {
             "content": {
@@ -12695,11 +12695,11 @@
                   "$ref": "#/components/schemas/get_info_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -12708,71 +12708,71 @@
                   "properties": {
                     "add_columns": {
                       "type": "object"
-                    },
+                    }, 
                     "edit_columns": {
                       "type": "object"
-                    },
+                    }, 
                     "filters": {
                       "properties": {
                         "column_name": {
                           "items": {
                             "properties": {
                               "name": {
-                                "description": "The filter name. Will be translated by babel",
+                                "description": "The filter name. Will be translated by babel", 
                                 "type": "string"
-                              },
+                              }, 
                               "operator": {
-                                "description": "The filter operation key to use on list filters",
+                                "description": "The filter operation key to use on list filters", 
                                 "type": "string"
                               }
-                            },
+                            }, 
                             "type": "object"
-                          },
+                          }, 
                           "type": "array"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "permissions": {
-                      "description": "The user permissions for this API resource",
+                      "description": "The user permissions for this API resource", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Dashboards"
         ]
       }
-    },
+    }, 
     "/api/v1/dashboard/export/": {
       "get": {
-        "description": "Exports multiple Dashboards and downloads them as YAML files.",
+        "description": "Exports multiple Dashboards and downloads them as YAML files.", 
         "parameters": [
           {
             "content": {
@@ -12781,11 +12781,11 @@
                   "$ref": "#/components/schemas/get_export_ids_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -12794,38 +12794,38 @@
                   "type": "string"
                 }
               }
-            },
+            }, 
             "description": "Dashboard export"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Dashboards"
         ]
       }
-    },
+    }, 
     "/api/v1/dashboard/favorite_status/": {
       "get": {
-        "description": "Check favorited dashboards for current user",
+        "description": "Check favorited dashboards for current user", 
         "parameters": [
           {
             "content": {
@@ -12834,11 +12834,11 @@
                   "$ref": "#/components/schemas/get_fav_star_ids_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -12847,32 +12847,32 @@
                   "$ref": "#/components/schemas/GetFavStarIdsSchema"
                 }
               }
-            },
+            }, 
             "description": "None"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Dashboards"
         ]
       }
-    },
+    }, 
     "/api/v1/dashboard/import/": {
       "post": {
         "requestBody": {
@@ -12881,25 +12881,25 @@
               "schema": {
                 "properties": {
                   "formData": {
-                    "description": "upload file (ZIP or JSON)",
-                    "format": "binary",
+                    "description": "upload file (ZIP or JSON)", 
+                    "format": "binary", 
                     "type": "string"
-                  },
+                  }, 
                   "overwrite": {
-                    "description": "overwrite existing dashboards?",
+                    "description": "overwrite existing dashboards?", 
                     "type": "boolean"
-                  },
+                  }, 
                   "passwords": {
-                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`,the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
+                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.", 
                     "type": "string"
                   }
-                },
+                }, 
                 "type": "object"
               }
             }
-          },
+          }, 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -12909,49 +12909,49 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Dashboard import result"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Dashboards"
         ]
       }
-    },
+    }, 
     "/api/v1/dashboard/permalink/{key}": {
       "get": {
-        "description": "Retrives dashboard state associated with a permanent link.",
+        "description": "Retrives dashboard state associated with a permanent link.", 
         "parameters": [
           {
-            "in": "path",
-            "name": "key",
-            "required": true,
+            "in": "path", 
+            "name": "key", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -12959,54 +12959,54 @@
                 "schema": {
                   "properties": {
                     "state": {
-                      "description": "The stored state",
+                      "description": "The stored state", 
                       "type": "object"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Returns the stored state."
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Dashboard Permanent Link"
         ]
       }
-    },
+    }, 
     "/api/v1/dashboard/related/{column_name}": {
       "get": {
-        "description": "Get a list of all possible owners for a dashboard.",
+        "description": "Get a list of all possible owners for a dashboard.", 
         "parameters": [
           {
-            "in": "path",
-            "name": "column_name",
-            "required": true,
+            "in": "path", 
+            "name": "column_name", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -13014,11 +13014,11 @@
                   "$ref": "#/components/schemas/get_related_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -13027,46 +13027,46 @@
                   "$ref": "#/components/schemas/RelatedResponseSchema"
                 }
               }
-            },
+            }, 
             "description": "Related column data"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Dashboards"
         ]
       }
-    },
+    }, 
     "/api/v1/dashboard/{dashboard_id}/filtersets": {
       "get": {
-        "description": "Get a dashboard's list of filter sets",
+        "description": "Get a dashboard's list of filter sets", 
         "parameters": [
           {
-            "description": "The id of the dashboard",
-            "in": "path",
-            "name": "dashboard_id",
-            "required": true,
+            "description": "The id of the dashboard", 
+            "in": "path", 
+            "name": "dashboard_id", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -13075,72 +13075,72 @@
                   "items": {
                     "properties": {
                       "description": {
-                        "description": "A description field of the filter set",
+                        "description": "A description field of the filter set", 
                         "type": "string"
-                      },
+                      }, 
                       "json_metadata": {
-                        "description": "metadata of the filter set",
+                        "description": "metadata of the filter set", 
                         "type": "string"
-                      },
+                      }, 
                       "name": {
-                        "description": "Name of the Filter set",
+                        "description": "Name of the Filter set", 
                         "type": "string"
-                      },
+                      }, 
                       "owner_id": {
-                        "description": "A description field of the filter set",
+                        "description": "A description field of the filter set", 
                         "type": "integer"
-                      },
+                      }, 
                       "owner_type": {
-                        "description": "the Type of the owner ( Dashboard/User)",
+                        "description": "the Type of the owner ( Dashboard/User)", 
                         "type": "integer"
-                      },
+                      }, 
                       "parameters": {
                         "description": "JSON schema defining the needed parameters"
                       }
-                    },
+                    }, 
                     "type": "object"
-                  },
+                  }, 
                   "type": "array"
                 }
               }
-            },
+            }, 
             "description": "FilterSets"
-          },
+          }, 
           "302": {
             "description": "Redirects to the current digest"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "FilterSetRestApi"
         ]
-      },
+      }, 
       "post": {
-        "description": "Create a new Dashboard's Filter Set.",
+        "description": "Create a new Dashboard's Filter Set.", 
         "parameters": [
           {
-            "description": "The id of the dashboard",
-            "in": "path",
-            "name": "dashboard_id",
-            "required": true,
+            "description": "The id of the dashboard", 
+            "in": "path", 
+            "name": "dashboard_id", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "requestBody": {
           "content": {
             "application/json": {
@@ -13148,10 +13148,10 @@
                 "$ref": "#/components/schemas/FilterSetRestApi.post"
               }
             }
-          },
-          "description": "Filter set schema",
+          }, 
+          "description": "Filter set schema", 
           "required": true
-        },
+        }, 
         "responses": {
           "201": {
             "content": {
@@ -13160,64 +13160,64 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/FilterSetRestApi.post"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Filter set added"
-          },
+          }, 
           "302": {
             "description": "Redirects to the current digest"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "FilterSetRestApi"
         ]
       }
-    },
+    }, 
     "/api/v1/dashboard/{dashboard_id}/filtersets/{pk}": {
       "delete": {
-        "description": "Deletes a Dashboard.",
+        "description": "Deletes a Dashboard.", 
         "parameters": [
           {
-            "in": "path",
-            "name": "dashboard_id",
-            "required": true,
+            "in": "path", 
+            "name": "dashboard_id", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -13227,58 +13227,58 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Filter set deleted"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/403"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "FilterSetRestApi"
         ]
-      },
+      }, 
       "put": {
-        "description": "Changes a Dashboard's Filter set.",
+        "description": "Changes a Dashboard's Filter set.", 
         "parameters": [
           {
-            "in": "path",
-            "name": "dashboard_id",
-            "required": true,
+            "in": "path", 
+            "name": "dashboard_id", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "requestBody": {
           "content": {
             "application/json": {
@@ -13286,10 +13286,10 @@
                 "$ref": "#/components/schemas/FilterSetRestApi.put"
               }
             }
-          },
-          "description": "Filter set schema",
+          }, 
+          "description": "Filter set schema", 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -13298,60 +13298,60 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/FilterSetRestApi.put"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Filter set changed"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/403"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "FilterSetRestApi"
         ]
       }
-    },
+    }, 
     "/api/v1/dashboard/{id_or_slug}": {
       "get": {
-        "description": "Get a dashboard detail information.",
+        "description": "Get a dashboard detail information.", 
         "parameters": [
           {
-            "description": "Either the id of the dashboard,or its slug",
-            "in": "path",
-            "name": "id_or_slug",
-            "required": true,
+            "description": "Either the id of the dashboard, or its slug", 
+            "in": "path", 
+            "name": "id_or_slug", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -13361,49 +13361,49 @@
                     "result": {
                       "$ref": "#/components/schemas/DashboardGetResponseSchema"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Dashboard"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/403"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Dashboards"
         ]
       }
-    },
+    }, 
     "/api/v1/dashboard/{id_or_slug}/charts": {
       "get": {
-        "description": "Get the chart definitions for a given dashboard",
+        "description": "Get the chart definitions for a given dashboard", 
         "parameters": [
           {
-            "in": "path",
-            "name": "id_or_slug",
-            "required": true,
+            "in": "path", 
+            "name": "id_or_slug", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -13413,53 +13413,53 @@
                     "result": {
                       "items": {
                         "$ref": "#/components/schemas/ChartEntityResponseSchema"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Dashboard chart definitions"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/403"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Dashboards"
         ]
       }
-    },
+    }, 
     "/api/v1/dashboard/{id_or_slug}/datasets": {
       "get": {
-        "description": "Returns a list of a dashboard's datasets. Each dataset includes only the information necessary to render the dashboard's charts.",
+        "description": "Returns a list of a dashboard's datasets. Each dataset includes only the information necessary to render the dashboard's charts.", 
         "parameters": [
           {
-            "description": "Either the id of the dashboard,or its slug",
-            "in": "path",
-            "name": "id_or_slug",
-            "required": true,
+            "description": "Either the id of the dashboard, or its slug", 
+            "in": "path", 
+            "name": "id_or_slug", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -13469,53 +13469,53 @@
                     "result": {
                       "items": {
                         "$ref": "#/components/schemas/DashboardDatasetSchema"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Dashboard dataset definitions"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/403"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Dashboards"
         ]
       }
-    },
+    }, 
     "/api/v1/dashboard/{id_or_slug}/embedded": {
       "delete": {
-        "description": "Removes a dashboard's embedded configuration.",
+        "description": "Removes a dashboard's embedded configuration.", 
         "parameters": [
           {
-            "description": "The dashboard id or slug",
-            "in": "path",
-            "name": "id_or_slug",
-            "required": true,
+            "description": "The dashboard id or slug", 
+            "in": "path", 
+            "name": "id_or_slug", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -13525,42 +13525,42 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Successfully removed the configuration"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Dashboards"
         ]
-      },
+      }, 
       "get": {
-        "description": "Returns the dashboard's embedded configuration",
+        "description": "Returns the dashboard's embedded configuration", 
         "parameters": [
           {
-            "description": "The dashboard id or slug",
-            "in": "path",
-            "name": "id_or_slug",
-            "required": true,
+            "description": "The dashboard id or slug", 
+            "in": "path", 
+            "name": "id_or_slug", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -13570,42 +13570,42 @@
                     "result": {
                       "$ref": "#/components/schemas/EmbeddedDashboardResponseSchema"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Result contains the embedded dashboard config"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Dashboards"
         ]
-      },
+      }, 
       "post": {
-        "description": "Sets a dashboard's embedded configuration.",
+        "description": "Sets a dashboard's embedded configuration.", 
         "parameters": [
           {
-            "description": "The dashboard id or slug",
-            "in": "path",
-            "name": "id_or_slug",
-            "required": true,
+            "description": "The dashboard id or slug", 
+            "in": "path", 
+            "name": "id_or_slug", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
           }
-        ],
+        ], 
         "requestBody": {
           "content": {
             "application/json": {
@@ -13613,10 +13613,10 @@
                 "$ref": "#/components/schemas/EmbeddedDashboardConfig"
               }
             }
-          },
-          "description": "The embedded configuration to set",
+          }, 
+          "description": "The embedded configuration to set", 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -13626,42 +13626,42 @@
                     "result": {
                       "$ref": "#/components/schemas/EmbeddedDashboardResponseSchema"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Successfully set the configuration"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Dashboards"
         ]
-      },
+      }, 
       "put": {
-        "description": "Sets a dashboard's embedded configuration.",
+        "description": "Sets a dashboard's embedded configuration.", 
         "parameters": [
           {
-            "description": "The dashboard id or slug",
-            "in": "path",
-            "name": "id_or_slug",
-            "required": true,
+            "description": "The dashboard id or slug", 
+            "in": "path", 
+            "name": "id_or_slug", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
           }
-        ],
+        ], 
         "requestBody": {
           "content": {
             "application/json": {
@@ -13669,10 +13669,10 @@
                 "$ref": "#/components/schemas/EmbeddedDashboardConfig"
               }
             }
-          },
-          "description": "The embedded configuration to set",
+          }, 
+          "description": "The embedded configuration to set", 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -13682,43 +13682,43 @@
                     "result": {
                       "$ref": "#/components/schemas/EmbeddedDashboardResponseSchema"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Successfully set the configuration"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Dashboards"
         ]
       }
-    },
+    }, 
     "/api/v1/dashboard/{pk}": {
       "delete": {
-        "description": "Deletes a Dashboard.",
+        "description": "Deletes a Dashboard.", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -13728,50 +13728,50 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Dashboard deleted"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/403"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Dashboards"
         ]
-      },
+      }, 
       "put": {
-        "description": "Changes a Dashboard.",
+        "description": "Changes a Dashboard.", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "requestBody": {
           "content": {
             "application/json": {
@@ -13779,10 +13779,10 @@
                 "$ref": "#/components/schemas/DashboardRestApi.put"
               }
             }
-          },
-          "description": "Dashboard schema",
+          }, 
+          "description": "Dashboard schema", 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -13791,69 +13791,69 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    },
+                    }, 
                     "last_modified_time": {
                       "type": "number"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/DashboardRestApi.put"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Dashboard changed"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/403"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Dashboards"
         ]
       }
-    },
+    }, 
     "/api/v1/dashboard/{pk}/filter_state": {
       "post": {
-        "description": "Stores a new value.",
+        "description": "Stores a new value.", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
-            "in": "query",
-            "name": "tab_id",
+            "in": "query", 
+            "name": "tab_id", 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "requestBody": {
           "content": {
             "application/json": {
@@ -13861,9 +13861,9 @@
                 "$ref": "#/components/schemas/TemporaryCachePostSchema"
               }
             }
-          },
+          }, 
           "required": true
-        },
+        }, 
         "responses": {
           "201": {
             "content": {
@@ -13871,61 +13871,61 @@
                 "schema": {
                   "properties": {
                     "key": {
-                      "description": "The key to retrieve the value.",
+                      "description": "The key to retrieve the value.", 
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "The value was stored successfully."
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Dashboard Filter State"
         ]
       }
-    },
+    }, 
     "/api/v1/dashboard/{pk}/filter_state/{key}": {
       "delete": {
-        "description": "Deletes a value.",
+        "description": "Deletes a value.", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
-            "description": "The value key.",
-            "in": "path",
-            "name": "key",
-            "required": true,
+            "description": "The value key.", 
+            "in": "path", 
+            "name": "key", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -13933,61 +13933,61 @@
                 "schema": {
                   "properties": {
                     "message": {
-                      "description": "The result of the operation",
+                      "description": "The result of the operation", 
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Deleted the stored value."
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Dashboard Filter State"
         ]
-      },
+      }, 
       "get": {
-        "description": "Retrives a value.",
+        "description": "Retrives a value.", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
-            "in": "path",
-            "name": "key",
-            "required": true,
+            "in": "path", 
+            "name": "key", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -13995,68 +13995,68 @@
                 "schema": {
                   "properties": {
                     "value": {
-                      "description": "The stored value",
+                      "description": "The stored value", 
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Returns the stored value."
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Dashboard Filter State"
         ]
-      },
+      }, 
       "put": {
-        "description": "Updates an existing value.",
+        "description": "Updates an existing value.", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
-            "in": "path",
-            "name": "key",
-            "required": true,
+            "in": "path", 
+            "name": "key", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
-          },
+          }, 
           {
-            "in": "query",
-            "name": "tab_id",
+            "in": "query", 
+            "name": "tab_id", 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "requestBody": {
           "content": {
             "application/json": {
@@ -14064,9 +14064,9 @@
                 "$ref": "#/components/schemas/TemporaryCachePutSchema"
               }
             }
-          },
+          }, 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -14074,55 +14074,55 @@
                 "schema": {
                   "properties": {
                     "key": {
-                      "description": "The key to retrieve the value.",
+                      "description": "The key to retrieve the value.", 
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "The value was stored successfully."
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Dashboard Filter State"
         ]
       }
-    },
+    }, 
     "/api/v1/dashboard/{pk}/permalink": {
       "post": {
-        "description": "Stores a new permanent link.",
+        "description": "Stores a new permanent link.", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
           }
-        ],
+        ], 
         "requestBody": {
           "content": {
             "application/json": {
@@ -14130,9 +14130,9 @@
                 "$ref": "#/components/schemas/DashboardPermalinkPostSchema"
               }
             }
-          },
+          }, 
           "required": true
-        },
+        }, 
         "responses": {
           "201": {
             "content": {
@@ -14140,64 +14140,64 @@
                 "schema": {
                   "properties": {
                     "key": {
-                      "description": "The key to retrieve the permanent link data.",
+                      "description": "The key to retrieve the permanent link data.", 
                       "type": "string"
-                    },
+                    }, 
                     "url": {
-                      "description": "permanent link.",
+                      "description": "permanent link.", 
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "The permanent link was stored successfully."
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Dashboard Permanent Link"
         ]
       }
-    },
+    }, 
     "/api/v1/dashboard/{pk}/thumbnail/{digest}/": {
       "get": {
-        "description": "Compute async or get already computed dashboard thumbnail from cache.",
+        "description": "Compute async or get already computed dashboard thumbnail from cache.", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
-            "description": "A hex digest that makes this dashboard unique",
-            "in": "path",
-            "name": "digest",
-            "required": true,
+            "description": "A hex digest that makes this dashboard unique", 
+            "in": "path", 
+            "name": "digest", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -14205,23 +14205,23 @@
                   "$ref": "#/components/schemas/thumbnail_query_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
               "image/*": {
                 "schema": {
-                  "format": "binary",
+                  "format": "binary", 
                   "type": "string"
                 }
               }
-            },
+            }, 
             "description": "Dashboard thumbnail image"
-          },
+          }, 
           "202": {
             "content": {
               "application/json": {
@@ -14230,42 +14230,42 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
-            "description": "Thumbnail does not exist on cache,fired async to compute"
-          },
+            }, 
+            "description": "Thumbnail does not exist on cache, fired async to compute"
+          }, 
           "302": {
             "description": "Redirects to the current digest"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Dashboards"
         ]
       }
-    },
+    }, 
     "/api/v1/database/": {
       "get": {
-        "description": "Get a list of models",
+        "description": "Get a list of models", 
         "parameters": [
           {
             "content": {
@@ -14274,11 +14274,11 @@
                   "$ref": "#/components/schemas/get_list_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -14286,93 +14286,93 @@
                 "schema": {
                   "properties": {
                     "count": {
-                      "description": "The total record count on the backend",
+                      "description": "The total record count on the backend", 
                       "type": "number"
-                    },
+                    }, 
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel",
-                          "example": "A Nice description for the column",
+                          "description": "The description for the column name. Will be translated by babel", 
+                          "example": "A Nice description for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "ids": {
-                      "description": "A list of item ids,useful when you don't know the column id",
+                      "description": "A list of item ids, useful when you don't know the column id", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel",
-                          "example": "A Nice label for the column",
+                          "description": "The label for the column name. Will be translated by babel", 
+                          "example": "A Nice label for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "list_columns": {
-                      "description": "A list of columns",
+                      "description": "A list of columns", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "list_title": {
-                      "description": "A title to render. Will be translated by babel",
-                      "example": "List Items",
+                      "description": "A title to render. Will be translated by babel", 
+                      "example": "List Items", 
                       "type": "string"
-                    },
+                    }, 
                     "order_columns": {
-                      "description": "A list of allowed columns to sort",
+                      "description": "A list of allowed columns to sort", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "result": {
-                      "description": "The result from the get list query",
+                      "description": "The result from the get list query", 
                       "items": {
                         "$ref": "#/components/schemas/DatabaseRestApi.get_list"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Items from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Database"
         ]
-      },
+      }, 
       "post": {
-        "description": "Create a new Database.",
+        "description": "Create a new Database.", 
         "requestBody": {
           "content": {
             "application/json": {
@@ -14380,10 +14380,10 @@
                 "$ref": "#/components/schemas/DatabaseRestApi.post"
               }
             }
-          },
-          "description": "Database schema",
+          }, 
+          "description": "Database schema", 
           "required": true
-        },
+        }, 
         "responses": {
           "201": {
             "content": {
@@ -14392,43 +14392,43 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/DatabaseRestApi.post"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Database added"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Database"
         ]
       }
-    },
+    }, 
     "/api/v1/database/_info": {
       "get": {
-        "description": "Get metadata information about this API resource",
+        "description": "Get metadata information about this API resource", 
         "parameters": [
           {
             "content": {
@@ -14437,11 +14437,11 @@
                   "$ref": "#/components/schemas/get_info_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -14450,71 +14450,71 @@
                   "properties": {
                     "add_columns": {
                       "type": "object"
-                    },
+                    }, 
                     "edit_columns": {
                       "type": "object"
-                    },
+                    }, 
                     "filters": {
                       "properties": {
                         "column_name": {
                           "items": {
                             "properties": {
                               "name": {
-                                "description": "The filter name. Will be translated by babel",
+                                "description": "The filter name. Will be translated by babel", 
                                 "type": "string"
-                              },
+                              }, 
                               "operator": {
-                                "description": "The filter operation key to use on list filters",
+                                "description": "The filter operation key to use on list filters", 
                                 "type": "string"
                               }
-                            },
+                            }, 
                             "type": "object"
-                          },
+                          }, 
                           "type": "array"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "permissions": {
-                      "description": "The user permissions for this API resource",
+                      "description": "The user permissions for this API resource", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Database"
         ]
       }
-    },
+    }, 
     "/api/v1/database/available/": {
       "get": {
-        "description": "Get names of databases currently available",
+        "description": "Get names of databases currently available", 
         "responses": {
           "200": {
             "content": {
@@ -14523,79 +14523,79 @@
                   "items": {
                     "properties": {
                       "available_drivers": {
-                        "description": "Installed drivers for the engine",
+                        "description": "Installed drivers for the engine", 
                         "items": {
                           "type": "string"
-                        },
+                        }, 
                         "type": "array"
-                      },
+                      }, 
                       "default_driver": {
-                        "description": "Default driver for the engine",
+                        "description": "Default driver for the engine", 
                         "type": "string"
-                      },
+                      }, 
                       "engine": {
-                        "description": "Name of the SQLAlchemy engine",
+                        "description": "Name of the SQLAlchemy engine", 
                         "type": "string"
-                      },
+                      }, 
                       "engine_information": {
-                        "description": "Dict with public properties form the DB Engine",
+                        "description": "Dict with public properties form the DB Engine", 
                         "properties": {
                           "disable_ssh_tunneling": {
-                            "description": "Whether the engine supports SSH Tunnels",
+                            "description": "Whether the engine supports SSH Tunnels", 
                             "type": "boolean"
-                          },
+                          }, 
                           "supports_file_upload": {
-                            "description": "Whether the engine supports file uploads",
+                            "description": "Whether the engine supports file uploads", 
                             "type": "boolean"
                           }
-                        },
+                        }, 
                         "type": "object"
-                      },
+                      }, 
                       "name": {
-                        "description": "Name of the database",
+                        "description": "Name of the database", 
                         "type": "string"
-                      },
+                      }, 
                       "parameters": {
-                        "description": "JSON schema defining the needed parameters",
+                        "description": "JSON schema defining the needed parameters", 
                         "type": "object"
-                      },
+                      }, 
                       "preferred": {
-                        "description": "Is the database preferred?",
+                        "description": "Is the database preferred?", 
                         "type": "boolean"
-                      },
+                      }, 
                       "sqlalchemy_uri_placeholder": {
-                        "description": "Example placeholder for the SQLAlchemy URI",
+                        "description": "Example placeholder for the SQLAlchemy URI", 
                         "type": "string"
                       }
-                    },
+                    }, 
                     "type": "object"
-                  },
+                  }, 
                   "type": "array"
                 }
               }
-            },
+            }, 
             "description": "Database names"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Database"
         ]
       }
-    },
+    }, 
     "/api/v1/database/export/": {
       "get": {
-        "description": "Download database(s) and associated dataset(s) as a zip file",
+        "description": "Download database(s) and associated dataset(s) as a zip file", 
         "parameters": [
           {
             "content": {
@@ -14604,43 +14604,43 @@
                   "$ref": "#/components/schemas/get_export_ids_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
               "application/zip": {
                 "schema": {
-                  "format": "binary",
+                  "format": "binary", 
                   "type": "string"
                 }
               }
-            },
+            }, 
             "description": "A zip file with database(s) and dataset(s) as YAML"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Database"
         ]
       }
-    },
+    }, 
     "/api/v1/database/import/": {
       "post": {
         "requestBody": {
@@ -14649,25 +14649,25 @@
               "schema": {
                 "properties": {
                   "formData": {
-                    "description": "upload file (ZIP)",
-                    "format": "binary",
+                    "description": "upload file (ZIP)", 
+                    "format": "binary", 
                     "type": "string"
-                  },
+                  }, 
                   "overwrite": {
-                    "description": "overwrite existing databases?",
+                    "description": "overwrite existing databases?", 
                     "type": "boolean"
-                  },
+                  }, 
                   "passwords": {
-                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`,the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
+                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.", 
                     "type": "string"
                   }
-                },
+                }, 
                 "type": "object"
               }
             }
-          },
+          }, 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -14677,39 +14677,39 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Database import result"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Database"
         ]
       }
-    },
+    }, 
     "/api/v1/database/test_connection/": {
       "post": {
-        "description": "Tests a database connection",
+        "description": "Tests a database connection", 
         "requestBody": {
           "content": {
             "application/json": {
@@ -14717,10 +14717,10 @@
                 "$ref": "#/components/schemas/DatabaseTestConnectionSchema"
               }
             }
-          },
-          "description": "Database schema",
+          }, 
+          "description": "Database schema", 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -14730,36 +14730,36 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Database Test Connection"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Database"
         ]
       }
-    },
+    }, 
     "/api/v1/database/validate_parameters/": {
       "post": {
-        "description": "Validates parameters used to connect to a database",
+        "description": "Validates parameters used to connect to a database", 
         "requestBody": {
           "content": {
             "application/json": {
@@ -14767,10 +14767,10 @@
                 "$ref": "#/components/schemas/DatabaseValidateParametersSchema"
               }
             }
-          },
-          "description": "DB-specific parameters",
+          }, 
+          "description": "DB-specific parameters", 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -14780,46 +14780,46 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Database Test Connection"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Database"
         ]
       }
-    },
+    }, 
     "/api/v1/database/{pk}": {
       "delete": {
-        "description": "Deletes a Database.",
+        "description": "Deletes a Database.", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -14829,51 +14829,51 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Database deleted"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/403"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Database"
         ]
-      },
+      }, 
       "get": {
-        "description": "Get a database",
+        "description": "Get a database", 
         "parameters": [
           {
-            "description": "The database id",
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "description": "The database id", 
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -14882,43 +14882,43 @@
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Database"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Database"
         ]
-      },
+      }, 
       "put": {
-        "description": "Changes a Database.",
+        "description": "Changes a Database.", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "requestBody": {
           "content": {
             "application/json": {
@@ -14926,10 +14926,10 @@
                 "$ref": "#/components/schemas/DatabaseRestApi.put"
               }
             }
-          },
-          "description": "Database schema",
+          }, 
+          "description": "Database schema", 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -14938,59 +14938,59 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/DatabaseRestApi.put"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Database changed"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/403"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Database"
         ]
       }
-    },
+    }, 
     "/api/v1/database/{pk}/function_names/": {
       "get": {
-        "description": "Get function names supported by a database",
+        "description": "Get function names supported by a database", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -14999,42 +14999,42 @@
                   "$ref": "#/components/schemas/DatabaseFunctionNamesResponse"
                 }
               }
-            },
+            }, 
             "description": "Query result"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Database"
         ]
       }
-    },
+    }, 
     "/api/v1/database/{pk}/related_objects/": {
       "get": {
-        "description": "Get charts and dashboards count associated to a database",
+        "description": "Get charts and dashboards count associated to a database", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -15043,42 +15043,42 @@
                   "$ref": "#/components/schemas/DatabaseRelatedObjectsResponse"
                 }
               }
-            },
+            }, 
             "description": "Query result"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Database"
         ]
       }
-    },
+    }, 
     "/api/v1/database/{pk}/schemas/": {
       "get": {
-        "description": "Get all schemas from a database",
+        "description": "Get all schemas from a database", 
         "parameters": [
           {
-            "description": "The database id",
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "description": "The database id", 
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -15086,11 +15086,11 @@
                   "$ref": "#/components/schemas/database_schemas_query_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -15099,64 +15099,64 @@
                   "$ref": "#/components/schemas/SchemasResponseSchema"
                 }
               }
-            },
+            }, 
             "description": "A List of all schemas from the database"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Database"
         ]
       }
-    },
+    }, 
     "/api/v1/database/{pk}/select_star/{table_name}/": {
       "get": {
-        "description": "Get database select star for table",
+        "description": "Get database select star for table", 
         "parameters": [
           {
-            "description": "The database id",
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "description": "The database id", 
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
-            "description": "Table name",
-            "in": "path",
-            "name": "table_name",
-            "required": true,
+            "description": "Table name", 
+            "in": "path", 
+            "name": "table_name", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
-          },
+          }, 
           {
-            "description": "Table schema",
-            "in": "path",
-            "name": "schema_name",
-            "required": true,
+            "description": "Table schema", 
+            "in": "path", 
+            "name": "schema_name", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -15165,67 +15165,67 @@
                   "$ref": "#/components/schemas/SelectStarResponseSchema"
                 }
               }
-            },
+            }, 
             "description": "SQL statement for a select star for table"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Database"
         ]
       }
-    },
+    }, 
     "/api/v1/database/{pk}/select_star/{table_name}/{schema_name}/": {
       "get": {
-        "description": "Get database select star for table",
+        "description": "Get database select star for table", 
         "parameters": [
           {
-            "description": "The database id",
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "description": "The database id", 
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
-            "description": "Table name",
-            "in": "path",
-            "name": "table_name",
-            "required": true,
+            "description": "Table name", 
+            "in": "path", 
+            "name": "table_name", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
-          },
+          }, 
           {
-            "description": "Table schema",
-            "in": "path",
-            "name": "schema_name",
-            "required": true,
+            "description": "Table schema", 
+            "in": "path", 
+            "name": "schema_name", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -15234,48 +15234,48 @@
                   "$ref": "#/components/schemas/SelectStarResponseSchema"
                 }
               }
-            },
+            }, 
             "description": "SQL statement for a select star for table"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Database"
         ]
       }
-    },
+    }, 
     "/api/v1/database/{pk}/ssh_tunnel/": {
       "delete": {
-        "description": "Deletes a SSH Tunnel.",
+        "description": "Deletes a SSH Tunnel.", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -15285,71 +15285,71 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "SSH Tunnel deleted"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/403"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Database"
         ]
       }
-    },
+    }, 
     "/api/v1/database/{pk}/table/{table_name}/{schema_name}/": {
       "get": {
-        "description": "Get database table metadata",
+        "description": "Get database table metadata", 
         "parameters": [
           {
-            "description": "The database id",
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "description": "The database id", 
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
-            "description": "Table name",
-            "in": "path",
-            "name": "table_name",
-            "required": true,
+            "description": "Table name", 
+            "in": "path", 
+            "name": "table_name", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
-          },
+          }, 
           {
-            "description": "Table schema",
-            "in": "path",
-            "name": "schema_name",
-            "required": true,
+            "description": "Table schema", 
+            "in": "path", 
+            "name": "schema_name", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -15358,67 +15358,67 @@
                   "$ref": "#/components/schemas/TableMetadataResponseSchema"
                 }
               }
-            },
+            }, 
             "description": "Table metadata information"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Database"
         ]
       }
-    },
+    }, 
     "/api/v1/database/{pk}/table_extra/{table_name}/{schema_name}/": {
       "get": {
-        "description": "Response depends on each DB engine spec normally focused on partitions",
+        "description": "Response depends on each DB engine spec normally focused on partitions", 
         "parameters": [
           {
-            "description": "The database id",
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "description": "The database id", 
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
-            "description": "Table name",
-            "in": "path",
-            "name": "table_name",
-            "required": true,
+            "description": "Table name", 
+            "in": "path", 
+            "name": "table_name", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
-          },
+          }, 
           {
-            "description": "Table schema",
-            "in": "path",
-            "name": "schema_name",
-            "required": true,
+            "description": "Table schema", 
+            "in": "path", 
+            "name": "schema_name", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -15427,49 +15427,49 @@
                   "$ref": "#/components/schemas/TableExtraMetadataResponseSchema"
                 }
               }
-            },
+            }, 
             "description": "Table extra metadata information"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
-        "summary": "Get table extra metadata",
+        ], 
+        "summary": "Get table extra metadata", 
         "tags": [
           "Database"
         ]
       }
-    },
+    }, 
     "/api/v1/database/{pk}/validate_sql/": {
       "post": {
-        "description": "Validates arbitrary SQL.",
+        "description": "Validates arbitrary SQL.", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "requestBody": {
           "content": {
             "application/json": {
@@ -15477,10 +15477,10 @@
                 "$ref": "#/components/schemas/ValidateSQLRequest"
               }
             }
-          },
-          "description": "Validate SQL request",
+          }, 
+          "description": "Validate SQL request", 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -15488,46 +15488,46 @@
                 "schema": {
                   "properties": {
                     "result": {
-                      "description": "A List of SQL errors found on the statement",
+                      "description": "A List of SQL errors found on the statement", 
                       "items": {
                         "$ref": "#/components/schemas/ValidateSQLResponse"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Validation result"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
-        "summary": "Validates that arbitrary sql is acceptable for the given database",
+        ], 
+        "summary": "Validates that arbitrary sql is acceptable for the given database", 
         "tags": [
           "Database"
         ]
       }
-    },
+    }, 
     "/api/v1/dataset/": {
       "delete": {
-        "description": "Deletes multiple Datasets in a bulk operation.",
+        "description": "Deletes multiple Datasets in a bulk operation.", 
         "parameters": [
           {
             "content": {
@@ -15536,11 +15536,11 @@
                   "$ref": "#/components/schemas/get_delete_ids_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -15550,43 +15550,43 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Dataset bulk delete"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/403"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Datasets"
         ]
-      },
+      }, 
       "get": {
-        "description": "Get a list of models",
+        "description": "Get a list of models", 
         "parameters": [
           {
             "content": {
@@ -15595,11 +15595,11 @@
                   "$ref": "#/components/schemas/get_list_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -15607,93 +15607,93 @@
                 "schema": {
                   "properties": {
                     "count": {
-                      "description": "The total record count on the backend",
+                      "description": "The total record count on the backend", 
                       "type": "number"
-                    },
+                    }, 
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel",
-                          "example": "A Nice description for the column",
+                          "description": "The description for the column name. Will be translated by babel", 
+                          "example": "A Nice description for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "ids": {
-                      "description": "A list of item ids,useful when you don't know the column id",
+                      "description": "A list of item ids, useful when you don't know the column id", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel",
-                          "example": "A Nice label for the column",
+                          "description": "The label for the column name. Will be translated by babel", 
+                          "example": "A Nice label for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "list_columns": {
-                      "description": "A list of columns",
+                      "description": "A list of columns", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "list_title": {
-                      "description": "A title to render. Will be translated by babel",
-                      "example": "List Items",
+                      "description": "A title to render. Will be translated by babel", 
+                      "example": "List Items", 
                       "type": "string"
-                    },
+                    }, 
                     "order_columns": {
-                      "description": "A list of allowed columns to sort",
+                      "description": "A list of allowed columns to sort", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "result": {
-                      "description": "The result from the get list query",
+                      "description": "The result from the get list query", 
                       "items": {
                         "$ref": "#/components/schemas/DatasetRestApi.get_list"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Items from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Datasets"
         ]
-      },
+      }, 
       "post": {
-        "description": "Create a new Dataset",
+        "description": "Create a new Dataset", 
         "requestBody": {
           "content": {
             "application/json": {
@@ -15701,10 +15701,10 @@
                 "$ref": "#/components/schemas/DatasetRestApi.post"
               }
             }
-          },
-          "description": "Dataset schema",
+          }, 
+          "description": "Dataset schema", 
           "required": true
-        },
+        }, 
         "responses": {
           "201": {
             "content": {
@@ -15713,43 +15713,43 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/DatasetRestApi.post"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Dataset added"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Datasets"
         ]
       }
-    },
+    }, 
     "/api/v1/dataset/_info": {
       "get": {
-        "description": "Get metadata information about this API resource",
+        "description": "Get metadata information about this API resource", 
         "parameters": [
           {
             "content": {
@@ -15758,11 +15758,11 @@
                   "$ref": "#/components/schemas/get_info_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -15771,79 +15771,79 @@
                   "properties": {
                     "add_columns": {
                       "type": "object"
-                    },
+                    }, 
                     "edit_columns": {
                       "type": "object"
-                    },
+                    }, 
                     "filters": {
                       "properties": {
                         "column_name": {
                           "items": {
                             "properties": {
                               "name": {
-                                "description": "The filter name. Will be translated by babel",
+                                "description": "The filter name. Will be translated by babel", 
                                 "type": "string"
-                              },
+                              }, 
                               "operator": {
-                                "description": "The filter operation key to use on list filters",
+                                "description": "The filter operation key to use on list filters", 
                                 "type": "string"
                               }
-                            },
+                            }, 
                             "type": "object"
-                          },
+                          }, 
                           "type": "array"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "permissions": {
-                      "description": "The user permissions for this API resource",
+                      "description": "The user permissions for this API resource", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Datasets"
         ]
       }
-    },
+    }, 
     "/api/v1/dataset/distinct/{column_name}": {
       "get": {
         "parameters": [
           {
-            "in": "path",
-            "name": "column_name",
-            "required": true,
+            "in": "path", 
+            "name": "column_name", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -15851,11 +15851,11 @@
                   "$ref": "#/components/schemas/get_related_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -15864,35 +15864,35 @@
                   "$ref": "#/components/schemas/DistincResponseSchema"
                 }
               }
-            },
+            }, 
             "description": "Distinct field data"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Datasets"
         ]
       }
-    },
+    }, 
     "/api/v1/dataset/duplicate": {
       "post": {
-        "description": "Duplicates a Dataset",
+        "description": "Duplicates a Dataset", 
         "requestBody": {
           "content": {
             "application/json": {
@@ -15900,10 +15900,10 @@
                 "$ref": "#/components/schemas/DatasetDuplicateSchema"
               }
             }
-          },
-          "description": "Dataset schema",
+          }, 
+          "description": "Dataset schema", 
           "required": true
-        },
+        }, 
         "responses": {
           "201": {
             "content": {
@@ -15912,49 +15912,49 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/DatasetDuplicateSchema"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Dataset duplicated"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/403"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Datasets"
         ]
       }
-    },
+    }, 
     "/api/v1/dataset/export/": {
       "get": {
-        "description": "Exports multiple datasets and downloads them as YAML files",
+        "description": "Exports multiple datasets and downloads them as YAML files", 
         "parameters": [
           {
             "content": {
@@ -15963,11 +15963,11 @@
                   "$ref": "#/components/schemas/get_export_ids_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -15976,32 +15976,32 @@
                   "type": "string"
                 }
               }
-            },
+            }, 
             "description": "Dataset export"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Datasets"
         ]
       }
-    },
+    }, 
     "/api/v1/dataset/import/": {
       "post": {
         "requestBody": {
@@ -16010,33 +16010,33 @@
               "schema": {
                 "properties": {
                   "formData": {
-                    "description": "upload file (ZIP or YAML)",
-                    "format": "binary",
+                    "description": "upload file (ZIP or YAML)", 
+                    "format": "binary", 
                     "type": "string"
-                  },
+                  }, 
                   "overwrite": {
-                    "description": "overwrite existing datasets?",
+                    "description": "overwrite existing datasets?", 
                     "type": "boolean"
-                  },
+                  }, 
                   "passwords": {
-                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`,the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
+                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.", 
                     "type": "string"
-                  },
+                  }, 
                   "sync_columns": {
-                    "description": "sync columns?",
+                    "description": "sync columns?", 
                     "type": "boolean"
-                  },
+                  }, 
                   "sync_metrics": {
-                    "description": "sync metrics?",
+                    "description": "sync metrics?", 
                     "type": "boolean"
                   }
-                },
+                }, 
                 "type": "object"
               }
             }
-          },
+          }, 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -16046,47 +16046,47 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Dataset import result"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Datasets"
         ]
       }
-    },
+    }, 
     "/api/v1/dataset/related/{column_name}": {
       "get": {
         "parameters": [
           {
-            "in": "path",
-            "name": "column_name",
-            "required": true,
+            "in": "path", 
+            "name": "column_name", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -16094,11 +16094,11 @@
                   "$ref": "#/components/schemas/get_related_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -16107,45 +16107,45 @@
                   "$ref": "#/components/schemas/RelatedResponseSchema"
                 }
               }
-            },
+            }, 
             "description": "Related column data"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Datasets"
         ]
       }
-    },
+    }, 
     "/api/v1/dataset/{pk}": {
       "delete": {
-        "description": "Deletes a Dataset",
+        "description": "Deletes a Dataset", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -16155,49 +16155,49 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Dataset delete"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/403"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Datasets"
         ]
-      },
+      }, 
       "get": {
-        "description": "Get an item model",
+        "description": "Get an item model", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -16205,11 +16205,11 @@
                   "$ref": "#/components/schemas/get_item_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -16219,93 +16219,93 @@
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel",
-                          "example": "A Nice description for the column",
+                          "description": "The description for the column name. Will be translated by babel", 
+                          "example": "A Nice description for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "id": {
-                      "description": "The item id",
+                      "description": "The item id", 
                       "type": "string"
-                    },
+                    }, 
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel",
-                          "example": "A Nice label for the column",
+                          "description": "The label for the column name. Will be translated by babel", 
+                          "example": "A Nice label for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/DatasetRestApi.get"
-                    },
+                    }, 
                     "show_columns": {
-                      "description": "A list of columns",
+                      "description": "A list of columns", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "show_title": {
-                      "description": "A title to render. Will be translated by babel",
-                      "example": "Show Item Details",
+                      "description": "A title to render. Will be translated by babel", 
+                      "example": "Show Item Details", 
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Datasets"
         ]
-      },
+      }, 
       "put": {
-        "description": "Changes a Dataset",
+        "description": "Changes a Dataset", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
-            "in": "query",
-            "name": "override_columns",
+            "in": "query", 
+            "name": "override_columns", 
             "schema": {
               "type": "boolean"
             }
           }
-        ],
+        ], 
         "requestBody": {
           "content": {
             "application/json": {
@@ -16313,10 +16313,10 @@
                 "$ref": "#/components/schemas/DatasetRestApi.put"
               }
             }
-          },
-          "description": "Dataset schema",
+          }, 
+          "description": "Dataset schema", 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -16325,69 +16325,69 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/DatasetRestApi.put"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Dataset changed"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/403"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Datasets"
         ]
       }
-    },
+    }, 
     "/api/v1/dataset/{pk}/column/{column_id}": {
       "delete": {
-        "description": "Delete a Dataset column",
+        "description": "Delete a Dataset column", 
         "parameters": [
           {
-            "description": "The dataset pk for this column",
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "description": "The dataset pk for this column", 
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
-            "description": "The column id for this dataset",
-            "in": "path",
-            "name": "column_id",
-            "required": true,
+            "description": "The column id for this dataset", 
+            "in": "path", 
+            "name": "column_id", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -16397,62 +16397,62 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Column deleted"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/403"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Datasets"
         ]
       }
-    },
+    }, 
     "/api/v1/dataset/{pk}/metric/{metric_id}": {
       "delete": {
-        "description": "Delete a Dataset metric",
+        "description": "Delete a Dataset metric", 
         "parameters": [
           {
-            "description": "The dataset pk for this column",
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "description": "The dataset pk for this column", 
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
-            "description": "The metric id for this dataset",
-            "in": "path",
-            "name": "metric_id",
-            "required": true,
+            "description": "The metric id for this dataset", 
+            "in": "path", 
+            "name": "metric_id", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -16462,52 +16462,52 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Metric deleted"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/403"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Datasets"
         ]
       }
-    },
+    }, 
     "/api/v1/dataset/{pk}/refresh": {
       "put": {
-        "description": "Refreshes and updates columns of a dataset",
+        "description": "Refreshes and updates columns of a dataset", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -16517,52 +16517,52 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Dataset delete"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/403"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Datasets"
         ]
       }
-    },
+    }, 
     "/api/v1/dataset/{pk}/related_objects": {
       "get": {
-        "description": "Get charts and dashboards count associated to a dataset",
+        "description": "Get charts and dashboards count associated to a dataset", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -16571,43 +16571,43 @@
                   "$ref": "#/components/schemas/DatasetRelatedObjectsResponse"
                 }
               }
-            },
+            }, 
             "description": "Query result"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Datasets"
         ]
       }
-    },
+    }, 
     "/api/v1/embedded_dashboard/{uuid}": {
       "get": {
-        "description": "Get a report schedule log",
+        "description": "Get a report schedule log", 
         "parameters": [
           {
-            "description": "The embedded configuration uuid",
-            "in": "path",
-            "name": "uuid",
-            "required": true,
+            "description": "The embedded configuration uuid", 
+            "in": "path", 
+            "name": "uuid", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -16617,73 +16617,73 @@
                     "result": {
                       "$ref": "#/components/schemas/EmbeddedDashboardResponseSchema"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Result contains the embedded dashboard configuration"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Embedded Dashboard"
         ]
       }
-    },
+    }, 
     "/api/v1/explore/": {
       "get": {
-        "description": "Assembles Explore related information (form_data,slice,dataset)\\n in a single endpoint.<br/><br/>\\nThe information can be assembled from:<br/> - The cache using a form_data_key<br/> - The metadata database using a permalink_key<br/> - Build from scratch using dataset or slice identifiers.",
+        "description": "Assembles Explore related information (form_data, slice, dataset)\\n in a single endpoint.<br/><br/>\\nThe information can be assembled from:<br/> - The cache using a form_data_key<br/> - The metadata database using a permalink_key<br/> - Build from scratch using dataset or slice identifiers.", 
         "parameters": [
           {
-            "in": "query",
-            "name": "form_data_key",
+            "in": "query", 
+            "name": "form_data_key", 
             "schema": {
               "type": "string"
             }
-          },
+          }, 
           {
-            "in": "query",
-            "name": "permalink_key",
+            "in": "query", 
+            "name": "permalink_key", 
             "schema": {
               "type": "string"
             }
-          },
+          }, 
           {
-            "in": "query",
-            "name": "slice_id",
+            "in": "query", 
+            "name": "slice_id", 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
-            "in": "query",
-            "name": "datasource_id",
+            "in": "query", 
+            "name": "datasource_id", 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
-            "in": "query",
-            "name": "datasource_type",
+            "in": "query", 
+            "name": "datasource_type", 
             "schema": {
               "type": "string"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -16692,48 +16692,48 @@
                   "$ref": "#/components/schemas/ExploreContextSchema"
                 }
               }
-            },
+            }, 
             "description": "Returns the initial context."
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
-        "summary": "Assembles Explore related information (form_data,slice,dataset)\\n in a single endpoint.",
+        ], 
+        "summary": "Assembles Explore related information (form_data, slice, dataset)\\n in a single endpoint.", 
         "tags": [
           "Explore"
         ]
       }
-    },
+    }, 
     "/api/v1/explore/form_data": {
       "post": {
-        "description": "Stores a new form_data.",
+        "description": "Stores a new form_data.", 
         "parameters": [
           {
-            "in": "query",
-            "name": "tab_id",
+            "in": "query", 
+            "name": "tab_id", 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "requestBody": {
           "content": {
             "application/json": {
@@ -16741,9 +16741,9 @@
                 "$ref": "#/components/schemas/FormDataPostSchema"
               }
             }
-          },
+          }, 
           "required": true
-        },
+        }, 
         "responses": {
           "201": {
             "content": {
@@ -16751,53 +16751,53 @@
                 "schema": {
                   "properties": {
                     "key": {
-                      "description": "The key to retrieve the form_data.",
+                      "description": "The key to retrieve the form_data.", 
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "The form_data was stored successfully."
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Explore Form Data"
         ]
       }
-    },
+    }, 
     "/api/v1/explore/form_data/{key}": {
       "delete": {
-        "description": "Deletes a form_data.",
+        "description": "Deletes a form_data.", 
         "parameters": [
           {
-            "description": "The form_data key.",
-            "in": "path",
-            "name": "key",
-            "required": true,
+            "description": "The form_data key.", 
+            "in": "path", 
+            "name": "key", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -16805,53 +16805,53 @@
                 "schema": {
                   "properties": {
                     "message": {
-                      "description": "The result of the operation",
+                      "description": "The result of the operation", 
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Deleted the stored form_data."
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Explore Form Data"
         ]
-      },
+      }, 
       "get": {
-        "description": "Retrives a form_data.",
+        "description": "Retrives a form_data.", 
         "parameters": [
           {
-            "in": "path",
-            "name": "key",
-            "required": true,
+            "in": "path", 
+            "name": "key", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -16859,60 +16859,60 @@
                 "schema": {
                   "properties": {
                     "form_data": {
-                      "description": "The stored form_data",
+                      "description": "The stored form_data", 
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Returns the stored form_data."
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Explore Form Data"
         ]
-      },
+      }, 
       "put": {
-        "description": "Updates an existing form_data.",
+        "description": "Updates an existing form_data.", 
         "parameters": [
           {
-            "in": "path",
-            "name": "key",
-            "required": true,
+            "in": "path", 
+            "name": "key", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
-          },
+          }, 
           {
-            "in": "query",
-            "name": "tab_id",
+            "in": "query", 
+            "name": "tab_id", 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "requestBody": {
           "content": {
             "application/json": {
@@ -16920,9 +16920,9 @@
                 "$ref": "#/components/schemas/FormDataPutSchema"
               }
             }
-          },
+          }, 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -16930,45 +16930,45 @@
                 "schema": {
                   "properties": {
                     "key": {
-                      "description": "The key to retrieve the form_data.",
+                      "description": "The key to retrieve the form_data.", 
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "The form_data was stored successfully."
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Explore Form Data"
         ]
       }
-    },
+    }, 
     "/api/v1/explore/permalink": {
       "post": {
-        "description": "Stores a new permanent link.",
+        "description": "Stores a new permanent link.", 
         "requestBody": {
           "content": {
             "application/json": {
@@ -16976,9 +16976,9 @@
                 "$ref": "#/components/schemas/ExplorePermalinkPostSchema"
               }
             }
-          },
+          }, 
           "required": true
-        },
+        }, 
         "responses": {
           "201": {
             "content": {
@@ -16986,56 +16986,56 @@
                 "schema": {
                   "properties": {
                     "key": {
-                      "description": "The key to retrieve the permanent link data.",
+                      "description": "The key to retrieve the permanent link data.", 
                       "type": "string"
-                    },
+                    }, 
                     "url": {
-                      "description": "pemanent link.",
+                      "description": "pemanent link.", 
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "The permanent link was stored successfully."
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Explore Permanent Link"
         ]
       }
-    },
+    }, 
     "/api/v1/explore/permalink/{key}": {
       "get": {
-        "description": "Retrives chart state associated with a permanent link.",
+        "description": "Retrives chart state associated with a permanent link.", 
         "parameters": [
           {
-            "in": "path",
-            "name": "key",
-            "required": true,
+            "in": "path", 
+            "name": "key", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -17043,45 +17043,45 @@
                 "schema": {
                   "properties": {
                     "state": {
-                      "description": "The stored state",
+                      "description": "The stored state", 
                       "type": "object"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Returns the stored form_data."
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Explore Permanent Link"
         ]
       }
-    },
+    }, 
     "/api/v1/log/": {
       "get": {
-        "description": "Get a list of models",
+        "description": "Get a list of models", 
         "parameters": [
           {
             "content": {
@@ -17090,11 +17090,11 @@
                   "$ref": "#/components/schemas/get_list_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -17102,91 +17102,91 @@
                 "schema": {
                   "properties": {
                     "count": {
-                      "description": "The total record count on the backend",
+                      "description": "The total record count on the backend", 
                       "type": "number"
-                    },
+                    }, 
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel",
-                          "example": "A Nice description for the column",
+                          "description": "The description for the column name. Will be translated by babel", 
+                          "example": "A Nice description for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "ids": {
-                      "description": "A list of item ids,useful when you don't know the column id",
+                      "description": "A list of item ids, useful when you don't know the column id", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel",
-                          "example": "A Nice label for the column",
+                          "description": "The label for the column name. Will be translated by babel", 
+                          "example": "A Nice label for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "list_columns": {
-                      "description": "A list of columns",
+                      "description": "A list of columns", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "list_title": {
-                      "description": "A title to render. Will be translated by babel",
-                      "example": "List Items",
+                      "description": "A title to render. Will be translated by babel", 
+                      "example": "List Items", 
                       "type": "string"
-                    },
+                    }, 
                     "order_columns": {
-                      "description": "A list of allowed columns to sort",
+                      "description": "A list of allowed columns to sort", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "result": {
-                      "description": "The result from the get list query",
+                      "description": "The result from the get list query", 
                       "items": {
                         "$ref": "#/components/schemas/LogRestApi.get_list"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Items from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "LogRestApi"
         ]
-      },
+      }, 
       "post": {
         "requestBody": {
           "content": {
@@ -17195,10 +17195,10 @@
                 "$ref": "#/components/schemas/LogRestApi.post"
               }
             }
-          },
-          "description": "Model schema",
+          }, 
+          "description": "Model schema", 
           "required": true
-        },
+        }, 
         "responses": {
           "201": {
             "content": {
@@ -17207,53 +17207,53 @@
                   "properties": {
                     "id": {
                       "type": "string"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/LogRestApi.post"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item inserted"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "LogRestApi"
         ]
       }
-    },
+    }, 
     "/api/v1/log/recent_activity/{user_id}/": {
       "get": {
-        "description": "Get recent activity data for a user",
+        "description": "Get recent activity data for a user", 
         "parameters": [
           {
-            "description": "The id of the user",
-            "in": "path",
-            "name": "user_id",
-            "required": true,
+            "description": "The id of the user", 
+            "in": "path", 
+            "name": "user_id", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -17261,11 +17261,11 @@
                   "$ref": "#/components/schemas/get_recent_activity_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -17274,44 +17274,44 @@
                   "$ref": "#/components/schemas/RecentActivityResponseSchema"
                 }
               }
-            },
+            }, 
             "description": "A List of recent activity objects"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "LogRestApi"
         ]
       }
-    },
+    }, 
     "/api/v1/log/{pk}": {
       "get": {
-        "description": "Get an item model",
+        "description": "Get an item model", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -17319,11 +17319,11 @@
                   "$ref": "#/components/schemas/get_item_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -17333,78 +17333,78 @@
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel",
-                          "example": "A Nice description for the column",
+                          "description": "The description for the column name. Will be translated by babel", 
+                          "example": "A Nice description for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "id": {
-                      "description": "The item id",
+                      "description": "The item id", 
                       "type": "string"
-                    },
+                    }, 
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel",
-                          "example": "A Nice label for the column",
+                          "description": "The label for the column name. Will be translated by babel", 
+                          "example": "A Nice label for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/LogRestApi.get"
-                    },
+                    }, 
                     "show_columns": {
-                      "description": "A list of columns",
+                      "description": "A list of columns", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "show_title": {
-                      "description": "A title to render. Will be translated by babel",
-                      "example": "Show Item Details",
+                      "description": "A title to render. Will be translated by babel", 
+                      "example": "Show Item Details", 
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "LogRestApi"
         ]
       }
-    },
+    }, 
     "/api/v1/me/": {
       "get": {
-        "description": "Returns the user object corresponding to the agent making the request,or returns a 401 error if the user is unauthenticated.",
+        "description": "Returns the user object corresponding to the agent making the request, or returns a 401 error if the user is unauthenticated.", 
         "responses": {
           "200": {
             "content": {
@@ -17414,25 +17414,25 @@
                     "result": {
                       "$ref": "#/components/schemas/UserResponseSchema"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "The current user"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
           }
-        },
+        }, 
         "tags": [
           "Current User"
         ]
       }
-    },
+    }, 
     "/api/v1/me/roles/": {
       "get": {
-        "description": "Returns the user roles corresponding to the agent making the request,or returns a 401 error if the user is unauthenticated.",
+        "description": "Returns the user roles corresponding to the agent making the request, or returns a 401 error if the user is unauthenticated.", 
         "responses": {
           "200": {
             "content": {
@@ -17442,25 +17442,25 @@
                     "result": {
                       "$ref": "#/components/schemas/UserResponseSchema"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "The current user"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
           }
-        },
+        }, 
         "tags": [
           "Current User"
         ]
       }
-    },
+    }, 
     "/api/v1/menu/": {
       "get": {
-        "description": "Get the menu data structure. Returns a forest like structure with the menu the user has access to",
+        "description": "Get the menu data structure. Returns a forest like structure with the menu the user has access to", 
         "responses": {
           "200": {
             "content": {
@@ -17468,60 +17468,60 @@
                 "schema": {
                   "properties": {
                     "result": {
-                      "description": "Menu items in a forest like data structure",
+                      "description": "Menu items in a forest like data structure", 
                       "items": {
                         "properties": {
                           "childs": {
                             "items": {
                               "type": "object"
-                            },
+                            }, 
                             "type": "array"
-                          },
+                          }, 
                           "icon": {
-                            "description": "Icon name to show for this menu item",
+                            "description": "Icon name to show for this menu item", 
                             "type": "string"
-                          },
+                          }, 
                           "label": {
-                            "description": "Pretty name for the menu item",
+                            "description": "Pretty name for the menu item", 
                             "type": "string"
-                          },
+                          }, 
                           "name": {
-                            "description": "The internal menu item name,maps to permission_name",
+                            "description": "The internal menu item name, maps to permission_name", 
                             "type": "string"
-                          },
+                          }, 
                           "url": {
-                            "description": "The URL for the menu item",
+                            "description": "The URL for the menu item", 
                             "type": "string"
                           }
-                        },
+                        }, 
                         "type": "object"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Get menu data"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Menu"
         ]
       }
-    },
+    }, 
     "/api/v1/query/": {
       "get": {
-        "description": "Get a list of queries,use Rison or JSON query parameters for filtering,sorting,pagination and  for selecting specific columns and metadata.",
+        "description": "Get a list of queries, use Rison or JSON query parameters for filtering, sorting, pagination and  for selecting specific columns and metadata.", 
         "parameters": [
           {
             "content": {
@@ -17530,11 +17530,11 @@
                   "$ref": "#/components/schemas/get_list_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -17542,103 +17542,103 @@
                 "schema": {
                   "properties": {
                     "count": {
-                      "description": "The total record count on the backend",
+                      "description": "The total record count on the backend", 
                       "type": "number"
-                    },
+                    }, 
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel",
-                          "example": "A Nice description for the column",
+                          "description": "The description for the column name. Will be translated by babel", 
+                          "example": "A Nice description for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "ids": {
-                      "description": "A list of item ids,useful when you don't know the column id",
+                      "description": "A list of item ids, useful when you don't know the column id", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel",
-                          "example": "A Nice label for the column",
+                          "description": "The label for the column name. Will be translated by babel", 
+                          "example": "A Nice label for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "list_columns": {
-                      "description": "A list of columns",
+                      "description": "A list of columns", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "list_title": {
-                      "description": "A title to render. Will be translated by babel",
-                      "example": "List Items",
+                      "description": "A title to render. Will be translated by babel", 
+                      "example": "List Items", 
                       "type": "string"
-                    },
+                    }, 
                     "order_columns": {
-                      "description": "A list of allowed columns to sort",
+                      "description": "A list of allowed columns to sort", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "result": {
-                      "description": "The result from the get list query",
+                      "description": "The result from the get list query", 
                       "items": {
                         "$ref": "#/components/schemas/QueryRestApi.get_list"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Items from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Queries"
         ]
       }
-    },
+    }, 
     "/api/v1/query/distinct/{column_name}": {
       "get": {
         "parameters": [
           {
-            "in": "path",
-            "name": "column_name",
-            "required": true,
+            "in": "path", 
+            "name": "column_name", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -17646,11 +17646,11 @@
                   "$ref": "#/components/schemas/get_related_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -17659,43 +17659,43 @@
                   "$ref": "#/components/schemas/DistincResponseSchema"
                 }
               }
-            },
+            }, 
             "description": "Distinct field data"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Queries"
         ]
       }
-    },
+    }, 
     "/api/v1/query/related/{column_name}": {
       "get": {
         "parameters": [
           {
-            "in": "path",
-            "name": "column_name",
-            "required": true,
+            "in": "path", 
+            "name": "column_name", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -17703,11 +17703,11 @@
                   "$ref": "#/components/schemas/get_related_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -17716,32 +17716,32 @@
                   "$ref": "#/components/schemas/RelatedResponseSchema"
                 }
               }
-            },
+            }, 
             "description": "Related column data"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Queries"
         ]
       }
-    },
+    }, 
     "/api/v1/query/stop": {
       "post": {
         "requestBody": {
@@ -17751,10 +17751,10 @@
                 "$ref": "#/components/schemas/StopQuerySchema"
               }
             }
-          },
-          "description": "Stop query schema",
+          }, 
+          "description": "Stop query schema", 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -17764,49 +17764,49 @@
                     "result": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Query stopped"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
-        "summary": "Manually stop a query with client_id",
+        ], 
+        "summary": "Manually stop a query with client_id", 
         "tags": [
           "Queries"
         ]
       }
-    },
+    }, 
     "/api/v1/query/{pk}": {
       "get": {
-        "description": "Get query detail information.",
+        "description": "Get query detail information.", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -17814,11 +17814,11 @@
                   "$ref": "#/components/schemas/get_item_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -17828,78 +17828,78 @@
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel",
-                          "example": "A Nice description for the column",
+                          "description": "The description for the column name. Will be translated by babel", 
+                          "example": "A Nice description for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "id": {
-                      "description": "The item id",
+                      "description": "The item id", 
                       "type": "string"
-                    },
+                    }, 
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel",
-                          "example": "A Nice label for the column",
+                          "description": "The label for the column name. Will be translated by babel", 
+                          "example": "A Nice label for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/QueryRestApi.get"
-                    },
+                    }, 
                     "show_columns": {
-                      "description": "A list of columns",
+                      "description": "A list of columns", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "show_title": {
-                      "description": "A title to render. Will be translated by babel",
-                      "example": "Show Item Details",
+                      "description": "A title to render. Will be translated by babel", 
+                      "example": "Show Item Details", 
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Queries"
         ]
       }
-    },
+    }, 
     "/api/v1/report/": {
       "delete": {
-        "description": "Deletes multiple report schedules in a bulk operation.",
+        "description": "Deletes multiple report schedules in a bulk operation.", 
         "parameters": [
           {
             "content": {
@@ -17908,11 +17908,11 @@
                   "$ref": "#/components/schemas/get_delete_ids_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -17922,40 +17922,40 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Report Schedule bulk delete"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/403"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Report Schedules"
         ]
-      },
+      }, 
       "get": {
-        "description": "Get a list of report schedules,use Rison or JSON query parameters for filtering,sorting,pagination and for selecting specific columns and metadata.",
+        "description": "Get a list of report schedules, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.", 
         "parameters": [
           {
             "content": {
@@ -17964,11 +17964,11 @@
                   "$ref": "#/components/schemas/get_list_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -17976,93 +17976,93 @@
                 "schema": {
                   "properties": {
                     "count": {
-                      "description": "The total record count on the backend",
+                      "description": "The total record count on the backend", 
                       "type": "number"
-                    },
+                    }, 
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel",
-                          "example": "A Nice description for the column",
+                          "description": "The description for the column name. Will be translated by babel", 
+                          "example": "A Nice description for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "ids": {
-                      "description": "A list of item ids,useful when you don't know the column id",
+                      "description": "A list of item ids, useful when you don't know the column id", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel",
-                          "example": "A Nice label for the column",
+                          "description": "The label for the column name. Will be translated by babel", 
+                          "example": "A Nice label for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "list_columns": {
-                      "description": "A list of columns",
+                      "description": "A list of columns", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "list_title": {
-                      "description": "A title to render. Will be translated by babel",
-                      "example": "List Items",
+                      "description": "A title to render. Will be translated by babel", 
+                      "example": "List Items", 
                       "type": "string"
-                    },
+                    }, 
                     "order_columns": {
-                      "description": "A list of allowed columns to sort",
+                      "description": "A list of allowed columns to sort", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "result": {
-                      "description": "The result from the get list query",
+                      "description": "The result from the get list query", 
                       "items": {
                         "$ref": "#/components/schemas/ReportScheduleRestApi.get_list"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Items from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Report Schedules"
         ]
-      },
+      }, 
       "post": {
-        "description": "Create a report schedule",
+        "description": "Create a report schedule", 
         "requestBody": {
           "content": {
             "application/json": {
@@ -18070,10 +18070,10 @@
                 "$ref": "#/components/schemas/ReportScheduleRestApi.post"
               }
             }
-          },
-          "description": "Report Schedule schema",
+          }, 
+          "description": "Report Schedule schema", 
           "required": true
-        },
+        }, 
         "responses": {
           "201": {
             "content": {
@@ -18082,46 +18082,46 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/ReportScheduleRestApi.post"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Report schedule added"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Report Schedules"
         ]
       }
-    },
+    }, 
     "/api/v1/report/_info": {
       "get": {
-        "description": "Get metadata information about this API resource",
+        "description": "Get metadata information about this API resource", 
         "parameters": [
           {
             "content": {
@@ -18130,11 +18130,11 @@
                   "$ref": "#/components/schemas/get_info_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -18143,79 +18143,79 @@
                   "properties": {
                     "add_columns": {
                       "type": "object"
-                    },
+                    }, 
                     "edit_columns": {
                       "type": "object"
-                    },
+                    }, 
                     "filters": {
                       "properties": {
                         "column_name": {
                           "items": {
                             "properties": {
                               "name": {
-                                "description": "The filter name. Will be translated by babel",
+                                "description": "The filter name. Will be translated by babel", 
                                 "type": "string"
-                              },
+                              }, 
                               "operator": {
-                                "description": "The filter operation key to use on list filters",
+                                "description": "The filter operation key to use on list filters", 
                                 "type": "string"
                               }
-                            },
+                            }, 
                             "type": "object"
-                          },
+                          }, 
                           "type": "array"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "permissions": {
-                      "description": "The user permissions for this API resource",
+                      "description": "The user permissions for this API resource", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Report Schedules"
         ]
       }
-    },
+    }, 
     "/api/v1/report/related/{column_name}": {
       "get": {
         "parameters": [
           {
-            "in": "path",
-            "name": "column_name",
-            "required": true,
+            "in": "path", 
+            "name": "column_name", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -18223,11 +18223,11 @@
                   "$ref": "#/components/schemas/get_related_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -18236,46 +18236,46 @@
                   "$ref": "#/components/schemas/RelatedResponseSchema"
                 }
               }
-            },
+            }, 
             "description": "Related column data"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Report Schedules"
         ]
       }
-    },
+    }, 
     "/api/v1/report/{pk}": {
       "delete": {
-        "description": "Delete a report schedule",
+        "description": "Delete a report schedule", 
         "parameters": [
           {
-            "description": "The report schedule pk",
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "description": "The report schedule pk", 
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -18285,46 +18285,46 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item deleted"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/403"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Report Schedules"
         ]
-      },
+      }, 
       "get": {
-        "description": "Get a report schedule",
+        "description": "Get a report schedule", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -18332,11 +18332,11 @@
                   "$ref": "#/components/schemas/get_item_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -18346,87 +18346,87 @@
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel",
-                          "example": "A Nice description for the column",
+                          "description": "The description for the column name. Will be translated by babel", 
+                          "example": "A Nice description for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "id": {
-                      "description": "The item id",
+                      "description": "The item id", 
                       "type": "string"
-                    },
+                    }, 
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel",
-                          "example": "A Nice label for the column",
+                          "description": "The label for the column name. Will be translated by babel", 
+                          "example": "A Nice label for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/ReportScheduleRestApi.get"
-                    },
+                    }, 
                     "show_columns": {
-                      "description": "A list of columns",
+                      "description": "A list of columns", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "show_title": {
-                      "description": "A title to render. Will be translated by babel",
-                      "example": "Show Item Details",
+                      "description": "A title to render. Will be translated by babel", 
+                      "example": "Show Item Details", 
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Report Schedules"
         ]
-      },
+      }, 
       "put": {
-        "description": "Update a report schedule",
+        "description": "Update a report schedule", 
         "parameters": [
           {
-            "description": "The Report Schedule pk",
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "description": "The Report Schedule pk", 
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "requestBody": {
           "content": {
             "application/json": {
@@ -18434,10 +18434,10 @@
                 "$ref": "#/components/schemas/ReportScheduleRestApi.put"
               }
             }
-          },
-          "description": "Report Schedule schema",
+          }, 
+          "description": "Report Schedule schema", 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -18446,59 +18446,59 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/ReportScheduleRestApi.put"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Report Schedule changed"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/403"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Report Schedules"
         ]
       }
-    },
+    }, 
     "/api/v1/report/{pk}/log/": {
       "get": {
-        "description": "Get a list of report schedule logs,use Rison or JSON query parameters for filtering,sorting,pagination and for selecting specific columns and metadata.",
+        "description": "Get a list of report schedule logs, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.", 
         "parameters": [
           {
-            "description": "The report schedule id for these logs",
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "description": "The report schedule id for these logs", 
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -18506,11 +18506,11 @@
                   "$ref": "#/components/schemas/get_list_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -18518,75 +18518,75 @@
                 "schema": {
                   "properties": {
                     "count": {
-                      "description": "The total record count on the backend",
+                      "description": "The total record count on the backend", 
                       "type": "number"
-                    },
+                    }, 
                     "ids": {
-                      "description": "A list of log ids",
+                      "description": "A list of log ids", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "result": {
-                      "description": "The result from the get list query",
+                      "description": "The result from the get list query", 
                       "items": {
                         "$ref": "#/components/schemas/ReportExecutionLogRestApi.get_list"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Items from logs"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Report Schedules"
         ]
       }
-    },
+    }, 
     "/api/v1/report/{pk}/log/{log_id}": {
       "get": {
-        "description": "Get a report schedule log",
+        "description": "Get a report schedule log", 
         "parameters": [
           {
-            "description": "The report schedule pk for log",
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "description": "The report schedule pk for log", 
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
-            "description": "The log pk",
-            "in": "path",
-            "name": "log_id",
-            "required": true,
+            "description": "The log pk", 
+            "in": "path", 
+            "name": "log_id", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -18594,11 +18594,11 @@
                   "$ref": "#/components/schemas/get_item_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -18606,48 +18606,48 @@
                 "schema": {
                   "properties": {
                     "id": {
-                      "description": "The log id",
+                      "description": "The log id", 
                       "type": "string"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/ReportExecutionLogRestApi.get"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item log"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Report Schedules"
         ]
       }
-    },
+    }, 
     "/api/v1/rowlevelsecurity/": {
       "delete": {
-        "description": "Deletes multiple RLS rules in a bulk operation.",
+        "description": "Deletes multiple RLS rules in a bulk operation.", 
         "parameters": [
           {
             "content": {
@@ -18656,11 +18656,11 @@
                   "$ref": "#/components/schemas/get_delete_ids_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -18670,40 +18670,40 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "RLS Rule bulk delete"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/403"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Row Level Security"
         ]
-      },
+      }, 
       "get": {
-        "description": "Get a list of models",
+        "description": "Get a list of models", 
         "parameters": [
           {
             "content": {
@@ -18712,11 +18712,11 @@
                   "$ref": "#/components/schemas/get_list_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -18724,93 +18724,93 @@
                 "schema": {
                   "properties": {
                     "count": {
-                      "description": "The total record count on the backend",
+                      "description": "The total record count on the backend", 
                       "type": "number"
-                    },
+                    }, 
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel",
-                          "example": "A Nice description for the column",
+                          "description": "The description for the column name. Will be translated by babel", 
+                          "example": "A Nice description for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "ids": {
-                      "description": "A list of item ids,useful when you don't know the column id",
+                      "description": "A list of item ids, useful when you don't know the column id", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel",
-                          "example": "A Nice label for the column",
+                          "description": "The label for the column name. Will be translated by babel", 
+                          "example": "A Nice label for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "list_columns": {
-                      "description": "A list of columns",
+                      "description": "A list of columns", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "list_title": {
-                      "description": "A title to render. Will be translated by babel",
-                      "example": "List Items",
+                      "description": "A title to render. Will be translated by babel", 
+                      "example": "List Items", 
                       "type": "string"
-                    },
+                    }, 
                     "order_columns": {
-                      "description": "A list of allowed columns to sort",
+                      "description": "A list of allowed columns to sort", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "result": {
-                      "description": "The result from the get list query",
+                      "description": "The result from the get list query", 
                       "items": {
                         "$ref": "#/components/schemas/RLSRestApi.get_list"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Items from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Row Level Security"
         ]
-      },
+      }, 
       "post": {
-        "description": "Create a new RLS Rule",
+        "description": "Create a new RLS Rule", 
         "requestBody": {
           "content": {
             "application/json": {
@@ -18818,10 +18818,10 @@
                 "$ref": "#/components/schemas/RLSRestApi.post"
               }
             }
-          },
-          "description": "RLS schema",
+          }, 
+          "description": "RLS schema", 
           "required": true
-        },
+        }, 
         "responses": {
           "201": {
             "content": {
@@ -18830,46 +18830,46 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/RLSRestApi.post"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "RLS Rule added"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Row Level Security"
         ]
       }
-    },
+    }, 
     "/api/v1/rowlevelsecurity/_info": {
       "get": {
-        "description": "Get metadata information about this API resource",
+        "description": "Get metadata information about this API resource", 
         "parameters": [
           {
             "content": {
@@ -18878,11 +18878,11 @@
                   "$ref": "#/components/schemas/get_info_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -18891,79 +18891,79 @@
                   "properties": {
                     "add_columns": {
                       "type": "object"
-                    },
+                    }, 
                     "edit_columns": {
                       "type": "object"
-                    },
+                    }, 
                     "filters": {
                       "properties": {
                         "column_name": {
                           "items": {
                             "properties": {
                               "name": {
-                                "description": "The filter name. Will be translated by babel",
+                                "description": "The filter name. Will be translated by babel", 
                                 "type": "string"
-                              },
+                              }, 
                               "operator": {
-                                "description": "The filter operation key to use on list filters",
+                                "description": "The filter operation key to use on list filters", 
                                 "type": "string"
                               }
-                            },
+                            }, 
                             "type": "object"
-                          },
+                          }, 
                           "type": "array"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "permissions": {
-                      "description": "The user permissions for this API resource",
+                      "description": "The user permissions for this API resource", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Row Level Security"
         ]
       }
-    },
+    }, 
     "/api/v1/rowlevelsecurity/related/{column_name}": {
       "get": {
         "parameters": [
           {
-            "in": "path",
-            "name": "column_name",
-            "required": true,
+            "in": "path", 
+            "name": "column_name", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -18971,11 +18971,11 @@
                   "$ref": "#/components/schemas/get_related_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -18984,44 +18984,44 @@
                   "$ref": "#/components/schemas/RelatedResponseSchema"
                 }
               }
-            },
+            }, 
             "description": "Related column data"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Row Level Security"
         ]
       }
-    },
+    }, 
     "/api/v1/rowlevelsecurity/{pk}": {
       "delete": {
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -19031,43 +19031,43 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item deleted"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Row Level Security"
         ]
-      },
+      }, 
       "get": {
-        "description": "Get an item model",
+        "description": "Get an item model", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -19075,11 +19075,11 @@
                   "$ref": "#/components/schemas/get_item_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -19089,87 +19089,87 @@
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel",
-                          "example": "A Nice description for the column",
+                          "description": "The description for the column name. Will be translated by babel", 
+                          "example": "A Nice description for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "id": {
-                      "description": "The item id",
+                      "description": "The item id", 
                       "type": "string"
-                    },
+                    }, 
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel",
-                          "example": "A Nice label for the column",
+                          "description": "The label for the column name. Will be translated by babel", 
+                          "example": "A Nice label for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/RLSRestApi.get"
-                    },
+                    }, 
                     "show_columns": {
-                      "description": "A list of columns",
+                      "description": "A list of columns", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "show_title": {
-                      "description": "A title to render. Will be translated by babel",
-                      "example": "Show Item Details",
+                      "description": "A title to render. Will be translated by babel", 
+                      "example": "Show Item Details", 
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Row Level Security"
         ]
-      },
+      }, 
       "put": {
-        "description": "Updates an RLS Rule",
+        "description": "Updates an RLS Rule", 
         "parameters": [
           {
-            "description": "The Rule pk",
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "description": "The Rule pk", 
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "requestBody": {
           "content": {
             "application/json": {
@@ -19177,10 +19177,10 @@
                 "$ref": "#/components/schemas/RLSRestApi.put"
               }
             }
-          },
-          "description": "RLS schema",
+          }, 
+          "description": "RLS schema", 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -19189,49 +19189,49 @@
                   "properties": {
                     "id": {
                       "type": "number"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/RLSRestApi.put"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Rule changed"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "403": {
             "$ref": "#/components/responses/403"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Row Level Security"
         ]
       }
-    },
+    }, 
     "/api/v1/saved_query/": {
       "delete": {
-        "description": "Deletes multiple saved queries in a bulk operation.",
+        "description": "Deletes multiple saved queries in a bulk operation.", 
         "parameters": [
           {
             "content": {
@@ -19240,11 +19240,11 @@
                   "$ref": "#/components/schemas/get_delete_ids_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -19254,37 +19254,37 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Saved queries bulk delete"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Queries"
         ]
-      },
+      }, 
       "get": {
-        "description": "Get a list of saved queries,use Rison or JSON query parameters for filtering,sorting,pagination and for selecting specific columns and metadata.",
+        "description": "Get a list of saved queries, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.", 
         "parameters": [
           {
             "content": {
@@ -19293,11 +19293,11 @@
                   "$ref": "#/components/schemas/get_list_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -19305,93 +19305,93 @@
                 "schema": {
                   "properties": {
                     "count": {
-                      "description": "The total record count on the backend",
+                      "description": "The total record count on the backend", 
                       "type": "number"
-                    },
+                    }, 
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel",
-                          "example": "A Nice description for the column",
+                          "description": "The description for the column name. Will be translated by babel", 
+                          "example": "A Nice description for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "ids": {
-                      "description": "A list of item ids,useful when you don't know the column id",
+                      "description": "A list of item ids, useful when you don't know the column id", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel",
-                          "example": "A Nice label for the column",
+                          "description": "The label for the column name. Will be translated by babel", 
+                          "example": "A Nice label for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "list_columns": {
-                      "description": "A list of columns",
+                      "description": "A list of columns", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "list_title": {
-                      "description": "A title to render. Will be translated by babel",
-                      "example": "List Items",
+                      "description": "A title to render. Will be translated by babel", 
+                      "example": "List Items", 
                       "type": "string"
-                    },
+                    }, 
                     "order_columns": {
-                      "description": "A list of allowed columns to sort",
+                      "description": "A list of allowed columns to sort", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "result": {
-                      "description": "The result from the get list query",
+                      "description": "The result from the get list query", 
                       "items": {
                         "$ref": "#/components/schemas/SavedQueryRestApi.get_list"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Items from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Queries"
         ]
-      },
+      }, 
       "post": {
-        "description": "Create a saved query",
+        "description": "Create a saved query", 
         "requestBody": {
           "content": {
             "application/json": {
@@ -19399,10 +19399,10 @@
                 "$ref": "#/components/schemas/SavedQueryRestApi.post"
               }
             }
-          },
-          "description": "Model schema",
+          }, 
+          "description": "Model schema", 
           "required": true
-        },
+        }, 
         "responses": {
           "201": {
             "content": {
@@ -19411,43 +19411,43 @@
                   "properties": {
                     "id": {
                       "type": "string"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/SavedQueryRestApi.post"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item inserted"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Queries"
         ]
       }
-    },
+    }, 
     "/api/v1/saved_query/_info": {
       "get": {
-        "description": "Get metadata information about this API resource",
+        "description": "Get metadata information about this API resource", 
         "parameters": [
           {
             "content": {
@@ -19456,11 +19456,11 @@
                   "$ref": "#/components/schemas/get_info_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -19469,79 +19469,79 @@
                   "properties": {
                     "add_columns": {
                       "type": "object"
-                    },
+                    }, 
                     "edit_columns": {
                       "type": "object"
-                    },
+                    }, 
                     "filters": {
                       "properties": {
                         "column_name": {
                           "items": {
                             "properties": {
                               "name": {
-                                "description": "The filter name. Will be translated by babel",
+                                "description": "The filter name. Will be translated by babel", 
                                 "type": "string"
-                              },
+                              }, 
                               "operator": {
-                                "description": "The filter operation key to use on list filters",
+                                "description": "The filter operation key to use on list filters", 
                                 "type": "string"
                               }
-                            },
+                            }, 
                             "type": "object"
-                          },
+                          }, 
                           "type": "array"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "permissions": {
-                      "description": "The user permissions for this API resource",
+                      "description": "The user permissions for this API resource", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Queries"
         ]
       }
-    },
+    }, 
     "/api/v1/saved_query/distinct/{column_name}": {
       "get": {
         "parameters": [
           {
-            "in": "path",
-            "name": "column_name",
-            "required": true,
+            "in": "path", 
+            "name": "column_name", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -19549,11 +19549,11 @@
                   "$ref": "#/components/schemas/get_related_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -19562,35 +19562,35 @@
                   "$ref": "#/components/schemas/DistincResponseSchema"
                 }
               }
-            },
+            }, 
             "description": "Distinct field data"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Queries"
         ]
       }
-    },
+    }, 
     "/api/v1/saved_query/export/": {
       "get": {
-        "description": "Exports multiple saved queries and downloads them as YAML files",
+        "description": "Exports multiple saved queries and downloads them as YAML files", 
         "parameters": [
           {
             "content": {
@@ -19599,46 +19599,46 @@
                   "$ref": "#/components/schemas/get_export_ids_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
               "application/zip": {
                 "schema": {
-                  "format": "binary",
+                  "format": "binary", 
                   "type": "string"
                 }
               }
-            },
+            }, 
             "description": "A zip file with saved query(ies) and database(s) as YAML"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Queries"
         ]
       }
-    },
+    }, 
     "/api/v1/saved_query/import/": {
       "post": {
         "requestBody": {
@@ -19647,25 +19647,25 @@
               "schema": {
                 "properties": {
                   "formData": {
-                    "description": "upload file (ZIP)",
-                    "format": "binary",
+                    "description": "upload file (ZIP)", 
+                    "format": "binary", 
                     "type": "string"
-                  },
+                  }, 
                   "overwrite": {
-                    "description": "overwrite existing saved queries?",
+                    "description": "overwrite existing saved queries?", 
                     "type": "boolean"
-                  },
+                  }, 
                   "passwords": {
-                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`,the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
+                    "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.", 
                     "type": "string"
                   }
-                },
+                }, 
                 "type": "object"
               }
             }
-          },
+          }, 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -19675,47 +19675,47 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Saved Query import result"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Queries"
         ]
       }
-    },
+    }, 
     "/api/v1/saved_query/related/{column_name}": {
       "get": {
         "parameters": [
           {
-            "in": "path",
-            "name": "column_name",
-            "required": true,
+            "in": "path", 
+            "name": "column_name", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -19723,11 +19723,11 @@
                   "$ref": "#/components/schemas/get_related_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -19736,45 +19736,45 @@
                   "$ref": "#/components/schemas/RelatedResponseSchema"
                 }
               }
-            },
+            }, 
             "description": "Related column data"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Queries"
         ]
       }
-    },
+    }, 
     "/api/v1/saved_query/{pk}": {
       "delete": {
-        "description": "Delete saved query",
+        "description": "Delete saved query", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -19784,43 +19784,43 @@
                     "message": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item deleted"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Queries"
         ]
-      },
+      }, 
       "get": {
-        "description": "Get a saved query",
+        "description": "Get a saved query", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
-          },
+          }, 
           {
             "content": {
               "application/json": {
@@ -19828,11 +19828,11 @@
                   "$ref": "#/components/schemas/get_item_schema"
                 }
               }
-            },
-            "in": "query",
+            }, 
+            "in": "query", 
             "name": "q"
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -19842,86 +19842,86 @@
                     "description_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The description for the column name. Will be translated by babel",
-                          "example": "A Nice description for the column",
+                          "description": "The description for the column name. Will be translated by babel", 
+                          "example": "A Nice description for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "id": {
-                      "description": "The item id",
+                      "description": "The item id", 
                       "type": "string"
-                    },
+                    }, 
                     "label_columns": {
                       "properties": {
                         "column_name": {
-                          "description": "The label for the column name. Will be translated by babel",
-                          "example": "A Nice label for the column",
+                          "description": "The label for the column name. Will be translated by babel", 
+                          "example": "A Nice label for the column", 
                           "type": "string"
                         }
-                      },
+                      }, 
                       "type": "object"
-                    },
+                    }, 
                     "result": {
                       "$ref": "#/components/schemas/SavedQueryRestApi.get"
-                    },
+                    }, 
                     "show_columns": {
-                      "description": "A list of columns",
+                      "description": "A list of columns", 
                       "items": {
                         "type": "string"
-                      },
+                      }, 
                       "type": "array"
-                    },
+                    }, 
                     "show_title": {
-                      "description": "A title to render. Will be translated by babel",
-                      "example": "Show Item Details",
+                      "description": "A title to render. Will be translated by babel", 
+                      "example": "Show Item Details", 
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item from Model"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Queries"
         ]
-      },
+      }, 
       "put": {
-        "description": "Update a saved query",
+        "description": "Update a saved query", 
         "parameters": [
           {
-            "in": "path",
-            "name": "pk",
-            "required": true,
+            "in": "path", 
+            "name": "pk", 
+            "required": true, 
             "schema": {
               "type": "integer"
             }
           }
-        ],
+        ], 
         "requestBody": {
           "content": {
             "application/json": {
@@ -19929,10 +19929,10 @@
                 "$ref": "#/components/schemas/SavedQueryRestApi.put"
               }
             }
-          },
-          "description": "Model schema",
+          }, 
+          "description": "Model schema", 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -19942,42 +19942,42 @@
                     "result": {
                       "$ref": "#/components/schemas/SavedQueryRestApi.put"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Item changed"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "422": {
             "$ref": "#/components/responses/422"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Queries"
         ]
       }
-    },
+    }, 
     "/api/v1/security/csrf_token/": {
       "get": {
-        "description": "Fetch the CSRF token",
+        "description": "Fetch the CSRF token", 
         "responses": {
           "200": {
             "content": {
@@ -19987,33 +19987,33 @@
                     "result": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Result contains the CSRF token"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Security"
         ]
       }
-    },
+    }, 
     "/api/v1/security/guest_token/": {
       "post": {
-        "description": "Fetches a guest token",
+        "description": "Fetches a guest token", 
         "requestBody": {
           "content": {
             "application/json": {
@@ -20021,10 +20021,10 @@
                 "$ref": "#/components/schemas/GuestTokenCreate"
               }
             }
-          },
-          "description": "Parameters for the guest token",
+          }, 
+          "description": "Parameters for the guest token", 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -20034,72 +20034,72 @@
                     "token": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Result contains the guest token"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "Security"
         ]
       }
-    },
+    }, 
     "/api/v1/security/login": {
       "post": {
-        "description": "Authenticate and get a JWT access and refresh token",
+        "description": "Authenticate and get a JWT access and refresh token", 
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
                 "properties": {
                   "password": {
-                    "description": "The password for authentication",
-                    "example": "complex-password",
+                    "description": "The password for authentication", 
+                    "example": "complex-password", 
                     "type": "string"
-                  },
+                  }, 
                   "provider": {
-                    "description": "Choose an authentication provider",
+                    "description": "Choose an authentication provider", 
                     "enum": [
-                      "db",
+                      "db", 
                       "ldap"
-                    ],
-                    "example": "db",
+                    ], 
+                    "example": "db", 
                     "type": "string"
-                  },
+                  }, 
                   "refresh": {
-                    "description": "If true a refresh token is provided also",
-                    "example": true,
+                    "description": "If true a refresh token is provided also", 
+                    "example": true, 
                     "type": "boolean"
-                  },
+                  }, 
                   "username": {
-                    "description": "The username for authentication",
-                    "example": "admin",
+                    "description": "The username for authentication", 
+                    "example": "admin", 
                     "type": "string"
                   }
-                },
+                }, 
                 "type": "object"
               }
             }
-          },
+          }, 
           "required": true
-        },
+        }, 
         "responses": {
           "200": {
             "content": {
@@ -20108,35 +20108,35 @@
                   "properties": {
                     "access_token": {
                       "type": "string"
-                    },
+                    }, 
                     "refresh_token": {
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Authentication Successful"
-          },
+          }, 
           "400": {
             "$ref": "#/components/responses/400"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "tags": [
           "Security"
         ]
       }
-    },
+    }, 
     "/api/v1/security/refresh": {
       "post": {
-        "description": "Use the refresh token to get a new JWT access token",
+        "description": "Use the refresh token to get a new JWT access token", 
         "responses": {
           "200": {
             "content": {
@@ -20144,46 +20144,46 @@
                 "schema": {
                   "properties": {
                     "access_token": {
-                      "description": "A new refreshed access token",
+                      "description": "A new refreshed access token", 
                       "type": "string"
                     }
-                  },
+                  }, 
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "Refresh Successful"
-          },
+          }, 
           "401": {
             "$ref": "#/components/responses/401"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt_refresh": []
           }
-        ],
+        ], 
         "tags": [
           "Security"
         ]
       }
-    },
+    }, 
     "/api/{version}/_openapi": {
       "get": {
-        "description": "Get the OpenAPI spec for a specific API version",
+        "description": "Get the OpenAPI spec for a specific API version", 
         "parameters": [
           {
-            "in": "path",
-            "name": "version",
-            "required": true,
+            "in": "path", 
+            "name": "version", 
+            "required": true, 
             "schema": {
               "type": "string"
             }
           }
-        ],
+        ], 
         "responses": {
           "200": {
             "content": {
@@ -20192,27 +20192,27 @@
                   "type": "object"
                 }
               }
-            },
+            }, 
             "description": "The OpenAPI spec"
-          },
+          }, 
           "404": {
             "$ref": "#/components/responses/404"
-          },
+          }, 
           "500": {
             "$ref": "#/components/responses/500"
           }
-        },
+        }, 
         "security": [
           {
             "jwt": []
           }
-        ],
+        ], 
         "tags": [
           "OpenApi"
         ]
       }
     }
-  },
+  }, 
   "servers": [
     {
       "url": "http://localhost:8088/"

--- a/superset-frontend/src/profile/components/RecentActivity.tsx
+++ b/superset-frontend/src/profile/components/RecentActivity.tsx
@@ -18,9 +18,10 @@
  */
 import React from 'react';
 import moment from 'moment';
+import rison from 'rison';
 
 import TableLoader from '../../components/TableLoader';
-import { Activity } from '../types';
+import { ActivityResult } from '../types';
 import { BootstrapUser } from '../../types/bootstrapTypes';
 
 interface RecentActivityProps {
@@ -29,8 +30,8 @@ interface RecentActivityProps {
 
 export default function RecentActivity({ user }: RecentActivityProps) {
   const rowLimit = 50;
-  const mutator = function (data: Activity[]) {
-    return data
+  const mutator = function (data: ActivityResult) {
+    return data.result
       .filter(row => row.action === 'dashboard' || row.action === 'explore')
       .map(row => ({
         name: <a href={row.item_url}>{row.item_title}</a>,
@@ -39,13 +40,14 @@ export default function RecentActivity({ user }: RecentActivityProps) {
         _time: row.time,
       }));
   };
+  const params = rison.encode({ limit: rowLimit });
   return (
     <div>
       <TableLoader
         className="table-condensed"
         mutator={mutator}
         sortable
-        dataEndpoint={`/superset/recent_activity/${user?.userId}/?limit=${rowLimit}`}
+        dataEndpoint={`/api/v1/log/recent_activity/${user?.userId}/?q=${params}`}
       />
     </div>
   );

--- a/superset-frontend/src/profile/components/RecentActivity.tsx
+++ b/superset-frontend/src/profile/components/RecentActivity.tsx
@@ -40,7 +40,7 @@ export default function RecentActivity({ user }: RecentActivityProps) {
         _time: row.time,
       }));
   };
-  const params = rison.encode({ limit: rowLimit });
+  const params = rison.encode({ page_size: rowLimit });
   return (
     <div>
       <TableLoader

--- a/superset-frontend/src/profile/types.ts
+++ b/superset-frontend/src/profile/types.ts
@@ -32,3 +32,7 @@ export type Activity = {
   item_url: string;
   time: number;
 };
+
+export type ActivityResult = {
+  result: Activity[];
+};

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -197,7 +197,7 @@ export const getRecentAcitivtyObjs = (
     return Promise.all(newBatch)
       .then(([chartRes, dashboardRes]) => {
         res.other = [...chartRes.json.result, ...dashboardRes.json.result];
-        res.viewed = recentsRes.json;
+        res.viewed = recentsRes.json.result;
         return res;
       })
       .catch(errMsg =>

--- a/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/ActivityTable.tsx
@@ -38,7 +38,7 @@ import EmptyState from './EmptyState';
 import { WelcomeTable } from './types';
 
 /**
- * Return result from /superset/recent_activity/{user_id}
+ * Return result from /api/v1/log/recent_activity/{user_id}/
  */
 interface RecentActivity {
   action: string;

--- a/superset-frontend/src/views/CRUD/welcome/Welcome.test.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/Welcome.test.tsx
@@ -43,7 +43,7 @@ const dashboardFavoriteStatusEndpoint =
   'glob:*/api/v1/dashboard/favorite_status?*';
 const savedQueryEndpoint = 'glob:*/api/v1/saved_query/?*';
 const savedQueryInfoEndpoint = 'glob:*/api/v1/saved_query/_info?*';
-const recentActivityEndpoint = 'glob:*/superset/recent_activity/*';
+const recentActivityEndpoint = 'glob:*/api/v1/log/recent_activity/*';
 
 fetchMock.get(chartsEndpoint, {
   result: [
@@ -142,7 +142,7 @@ describe('Welcome with sql role', () => {
   it('calls api methods in parallel on page load', () => {
     const chartCall = fetchMock.calls(/chart\/\?q/);
     const savedQueryCall = fetchMock.calls(/saved_query\/\?q/);
-    const recentCall = fetchMock.calls(/superset\/recent_activity\/*/);
+    const recentCall = fetchMock.calls(/api\/v1\/log\/recent_activity\/*/);
     const dashboardCall = fetchMock.calls(/dashboard\/\?q/);
     expect(chartCall).toHaveLength(2);
     expect(recentCall).toHaveLength(1);
@@ -186,7 +186,7 @@ describe('Welcome without sql role', () => {
   it('calls api methods in parallel on page load', () => {
     const chartCall = fetchMock.calls(/chart\/\?q/);
     const savedQueryCall = fetchMock.calls(/saved_query\/\?q/);
-    const recentCall = fetchMock.calls(/superset\/recent_activity\/*/);
+    const recentCall = fetchMock.calls(/api\/v1\/log\/recent_activity\/*/);
     const dashboardCall = fetchMock.calls(/dashboard\/\?q/);
     expect(chartCall).toHaveLength(2);
     expect(recentCall).toHaveLength(1);

--- a/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
@@ -166,7 +166,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
   const canAccessSqlLab = canUserAccessSqlLab(user);
   const userid = user.userId;
   const id = userid!.toString(); // confident that user is not a guest user
-  const params = rison.encode({ limit: 6 });
+  const params = rison.encode({ page_size: 6 });
   const recent = `/api/v1/log/recent_activity/${user.userId}/?q=${params}`;
   const [activeChild, setActiveChild] = useState('Loading');
   const userKey = dangerouslyGetItemDoNotUse(id, null);

--- a/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
+++ b/superset-frontend/src/views/CRUD/welcome/Welcome.tsx
@@ -23,6 +23,7 @@ import {
   styled,
   t,
 } from '@superset-ui/core';
+import rison from 'rison';
 import Collapse from 'src/components/Collapse';
 import { User } from 'src/types/bootstrapTypes';
 import { reject } from 'lodash';
@@ -165,7 +166,8 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
   const canAccessSqlLab = canUserAccessSqlLab(user);
   const userid = user.userId;
   const id = userid!.toString(); // confident that user is not a guest user
-  const recent = `/superset/recent_activity/${user.userId}/?limit=6`;
+  const params = rison.encode({ limit: 6 });
+  const recent = `/api/v1/log/recent_activity/${user.userId}/?q=${params}`;
   const [activeChild, setActiveChild] = useState('Loading');
   const userKey = dangerouslyGetItemDoNotUse(id, null);
   let defaultChecked = false;

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -20,7 +20,7 @@ import json
 import logging
 from collections import defaultdict
 from functools import partial
-from typing import Any, Callable, Dict, List, Set, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union
 
 import sqlalchemy as sqla
 from flask_appbuilder import Model
@@ -176,6 +176,11 @@ class Dashboard(Model, AuditMixinNullable, ImportExportMixin):
     @property
     def url(self) -> str:
         return f"/superset/dashboard/{self.slug or self.id}/"
+
+    @staticmethod
+    def get_url(id_: int, slug: Optional[str] = None) -> str:
+        # To be able to generate URL's without instanciating a Dashboard object
+        return f"/superset/dashboard/{slug or id_}/"
 
     @property
     def datasources(self) -> Set[BaseDatasource]:

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -288,7 +288,9 @@ class Slice(  # pylint: disable=too-many-public-methods
         return self.build_explore_url(self.id, base_url, overrides)
 
     @staticmethod
-    def build_explore_url(id_: int, base_url: str = "/explore", overrides: Optional[Dict[str, Any]] = None) -> str:
+    def build_explore_url(
+        id_: int, base_url: str = "/explore", overrides: Optional[Dict[str, Any]] = None
+    ) -> str:
         overrides = overrides or {}
         form_data = {"slice_id": id_}
         form_data.update(overrides)

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -285,11 +285,15 @@ class Slice(  # pylint: disable=too-many-public-methods
         base_url: str = "/explore",
         overrides: Optional[Dict[str, Any]] = None,
     ) -> str:
+        return self.build_explore_url(self.id, base_url, overrides)
+
+    @staticmethod
+    def build_explore_url(id_: int, base_url: str = "/explore", overrides: Optional[Dict[str, Any]] = None) -> str:
         overrides = overrides or {}
-        form_data = {"slice_id": self.id}
+        form_data = {"slice_id": id_}
         form_data.update(overrides)
         params = parse.quote(json.dumps(form_data))
-        return f"{base_url}/?slice_id={self.id}&form_data={params}"
+        return f"{base_url}/?slice_id={id_}&form_data={params}"
 
     @property
     def slice_url(self) -> str:

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -155,6 +155,7 @@ from superset.views.base import (
     json_success,
     validate_sqlatable,
 )
+from superset.views.log.dao import LogDAO
 from superset.views.sql_lab.schemas import SqlJsonPayloadSchema
 from superset.views.utils import (
     _deserialize_results_payload,
@@ -1438,6 +1439,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @has_access_api
     @event_logger.log_this
     @expose("/recent_activity/<int:user_id>/", methods=["GET"])
+    @deprecated()
     def recent_activity(  # pylint: disable=too-many-locals
         self, user_id: int
     ) -> FlaskResponse:
@@ -1452,96 +1454,8 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         # whether to get distinct subjects
         distinct = request.args.get("distinct") != "false"
 
-        has_subject_title = or_(
-            and_(
-                Dashboard.dashboard_title is not None,
-                Dashboard.dashboard_title != "",
-            ),
-            and_(Slice.slice_name is not None, Slice.slice_name != ""),
-        )
+        payload = LogDAO.get_recent_activity(user_id, limit, actions, distinct)
 
-        if distinct:
-            one_year_ago = datetime.today() - timedelta(days=365)
-            subqry = (
-                db.session.query(
-                    Log.dashboard_id,
-                    Log.slice_id,
-                    Log.action,
-                    func.max(Log.dttm).label("dttm"),
-                )
-                .group_by(Log.dashboard_id, Log.slice_id, Log.action)
-                .filter(
-                    and_(
-                        Log.action.in_(actions),
-                        Log.user_id == user_id,
-                        # limit to one year of data to improve performance
-                        Log.dttm > one_year_ago,
-                        or_(Log.dashboard_id.isnot(None), Log.slice_id.isnot(None)),
-                    )
-                )
-                .subquery()
-            )
-            qry = (
-                db.session.query(
-                    subqry,
-                    Dashboard.slug.label("dashboard_slug"),
-                    Dashboard.dashboard_title,
-                    Slice.slice_name,
-                )
-                .outerjoin(Dashboard, Dashboard.id == subqry.c.dashboard_id)
-                .outerjoin(
-                    Slice,
-                    Slice.id == subqry.c.slice_id,
-                )
-                .filter(has_subject_title)
-                .order_by(subqry.c.dttm.desc())
-                .limit(limit)
-            )
-        else:
-            qry = (
-                db.session.query(
-                    Log.dttm,
-                    Log.action,
-                    Log.dashboard_id,
-                    Log.slice_id,
-                    Dashboard.slug.label("dashboard_slug"),
-                    Dashboard.dashboard_title,
-                    Slice.slice_name,
-                )
-                .outerjoin(Dashboard, Dashboard.id == Log.dashboard_id)
-                .outerjoin(Slice, Slice.id == Log.slice_id)
-                .filter(has_subject_title)
-                .order_by(Log.dttm.desc())
-                .limit(limit)
-            )
-
-        payload = []
-        for log in qry.all():
-            item_url = None
-            item_title = None
-            item_type = None
-            if log.dashboard_id:
-                item_type = "dashboard"
-                item_url = Dashboard(id=log.dashboard_id, slug=log.dashboard_slug).url
-                item_title = log.dashboard_title
-            elif log.slice_id:
-                slc = Slice(id=log.slice_id, slice_name=log.slice_name)
-                item_type = "slice"
-                item_url = slc.slice_url
-                item_title = slc.chart
-
-            payload.append(
-                {
-                    "action": log.action,
-                    "item_type": item_type,
-                    "item_url": item_url,
-                    "item_title": item_title,
-                    "time": log.dttm,
-                    "time_delta_humanized": humanize.naturaltime(
-                        datetime.now() - log.dttm
-                    ),
-                }
-            )
         return json_success(json.dumps(payload, default=utils.json_int_dttm_ser))
 
     @api

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -20,12 +20,11 @@ from __future__ import annotations
 import logging
 import re
 from contextlib import closing
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any, Callable, cast, Dict, List, Optional, Union
 from urllib import parse
 
 import backoff
-import humanize
 import pandas as pd
 import simplejson as json
 from flask import abort, flash, g, redirect, render_template, request, Response
@@ -41,7 +40,6 @@ from flask_babel import gettext as __, lazy_gettext as _
 from sqlalchemy import and_, or_
 from sqlalchemy.exc import DBAPIError, NoSuchModuleError, SQLAlchemyError
 from sqlalchemy.orm.session import Session
-from sqlalchemy.sql import functions as func
 
 from superset import (
     app,
@@ -98,7 +96,7 @@ from superset.explore.permalink.commands.get import GetExplorePermalinkCommand
 from superset.explore.permalink.exceptions import ExplorePermalinkGetFailedError
 from superset.extensions import async_query_manager, cache_manager
 from superset.jinja_context import get_template_processor
-from superset.models.core import Database, FavStar, Log
+from superset.models.core import Database, FavStar
 from superset.models.dashboard import Dashboard
 from superset.models.datasource_access_request import DatasourceAccessRequest
 from superset.models.slice import Slice
@@ -1440,7 +1438,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @event_logger.log_this
     @expose("/recent_activity/<int:user_id>/", methods=["GET"])
     @deprecated()
-    def recent_activity(  # pylint: disable=too-many-locals
+    def recent_activity(
         self, user_id: int
     ) -> FlaskResponse:
         """Recent activity (actions) for a given user"""

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1450,7 +1450,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         # whether to get distinct subjects
         distinct = request.args.get("distinct") != "false"
 
-        payload = LogDAO.get_recent_activity(user_id, limit, actions, distinct)
+        payload = LogDAO.get_recent_activity(user_id, actions, distinct, 0, limit)
 
         return json_success(json.dumps(payload, default=utils.json_int_dttm_ser))
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1438,9 +1438,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @event_logger.log_this
     @expose("/recent_activity/<int:user_id>/", methods=["GET"])
     @deprecated()
-    def recent_activity(
-        self, user_id: int
-    ) -> FlaskResponse:
+    def recent_activity(self, user_id: int) -> FlaskResponse:
         """Recent activity (actions) for a given user"""
         error_obj = self.get_user_activity_access_error(user_id)
         if error_obj:

--- a/superset/views/log/api.py
+++ b/superset/views/log/api.py
@@ -21,9 +21,9 @@ from flask_appbuilder.api import expose, protect, rison, safe
 from flask_appbuilder.hooks import before_request
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 
+import superset.models.core as models
 from superset import event_logger, security_manager
 from superset.exceptions import SupersetSecurityException
-import superset.models.core as models
 from superset.superset_typing import FlaskResponse
 from superset.views.base_api import BaseSupersetModelRestApi, statsd_metrics
 from superset.views.log.dao import LogDAO

--- a/superset/views/log/api.py
+++ b/superset/views/log/api.py
@@ -56,6 +56,7 @@ class LogRestApi(LogMixin, BaseSupersetModelRestApi):
         "referrer",
     ]
     show_columns = list_columns
+    page_size = 20
     apispec_parameter_schemas = {
         "get_recent_activity_schema": get_recent_activity_schema,
     }
@@ -127,11 +128,12 @@ class LogRestApi(LogMixin, BaseSupersetModelRestApi):
         error_obj = self.get_user_activity_access_error(user_id)
         if error_obj:
             return error_obj
+        
+        args = kwargs["rison"]
+        page, page_size = self._sanitize_page_args(*self._handle_page_args(args))
+        actions = args.get("actions", ["explore", "dashboard"])
+        distinct = args.get("distinct", True)
 
-        limit = kwargs["rison"].get("limit", 100)
-        actions = kwargs["rison"].get("actions", ["explore", "dashboard"])
-        distinct = kwargs["rison"].get("distinct", True)
-
-        payload = LogDAO.get_recent_activity(user_id, limit, actions, distinct)
+        payload = LogDAO.get_recent_activity(user_id, actions, distinct, page, page_size)
 
         return self.response(200, result=payload)

--- a/superset/views/log/api.py
+++ b/superset/views/log/api.py
@@ -128,12 +128,14 @@ class LogRestApi(LogMixin, BaseSupersetModelRestApi):
         error_obj = self.get_user_activity_access_error(user_id)
         if error_obj:
             return error_obj
-        
+
         args = kwargs["rison"]
         page, page_size = self._sanitize_page_args(*self._handle_page_args(args))
         actions = args.get("actions", ["explore", "dashboard"])
         distinct = args.get("distinct", True)
 
-        payload = LogDAO.get_recent_activity(user_id, actions, distinct, page, page_size)
+        payload = LogDAO.get_recent_activity(
+            user_id, actions, distinct, page, page_size
+        )
 
         return self.response(200, result=payload)

--- a/superset/views/log/api.py
+++ b/superset/views/log/api.py
@@ -120,7 +120,7 @@ class LogRestApi(LogMixin, BaseSupersetModelRestApi):
             401:
               $ref: '#/components/responses/401'
             403:
-              $ref: '#/components/responses/404'
+              $ref: '#/components/responses/403'
             500:
               $ref: '#/components/responses/500'
         """

--- a/superset/views/log/api.py
+++ b/superset/views/log/api.py
@@ -27,7 +27,11 @@ import superset.models.core as models
 from superset.superset_typing import FlaskResponse
 from superset.views.base_api import BaseSupersetModelRestApi, statsd_metrics
 from superset.views.log.dao import LogDAO
-from superset.views.log.schemas import get_recent_activity_schema, RecentActivityResponseSchema, RecentActivitySchema
+from superset.views.log.schemas import (
+    get_recent_activity_schema,
+    RecentActivityResponseSchema,
+    RecentActivitySchema,
+)
 
 from ...constants import MODEL_API_RW_METHOD_PERMISSION_MAP
 from . import LogMixin
@@ -55,7 +59,10 @@ class LogRestApi(LogMixin, BaseSupersetModelRestApi):
     apispec_parameter_schemas = {
         "get_recent_activity_schema": get_recent_activity_schema,
     }
-    openapi_spec_component_schemas = (RecentActivityResponseSchema, RecentActivitySchema)
+    openapi_spec_component_schemas = (
+        RecentActivityResponseSchema,
+        RecentActivitySchema,
+    )
 
     @staticmethod
     def is_enabled() -> bool:
@@ -126,5 +133,5 @@ class LogRestApi(LogMixin, BaseSupersetModelRestApi):
         distinct = kwargs["rison"].get("distinct", True)
 
         payload = LogDAO.get_recent_activity(user_id, limit, actions, distinct)
-        
+
         return self.response(200, result=payload)

--- a/superset/views/log/api.py
+++ b/superset/views/log/api.py
@@ -14,12 +14,20 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Any, Optional
+
 from flask import current_app as app
+from flask_appbuilder.api import expose, protect, rison, safe
 from flask_appbuilder.hooks import before_request
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 
+from superset import event_logger, security_manager
+from superset.exceptions import SupersetSecurityException
 import superset.models.core as models
-from superset.views.base_api import BaseSupersetModelRestApi
+from superset.superset_typing import FlaskResponse
+from superset.views.base_api import BaseSupersetModelRestApi, statsd_metrics
+from superset.views.log.dao import LogDAO
+from superset.views.log.schemas import get_recent_activity_schema, RecentActivityResponseSchema, RecentActivitySchema
 
 from ...constants import MODEL_API_RW_METHOD_PERMISSION_MAP
 from . import LogMixin
@@ -27,7 +35,7 @@ from . import LogMixin
 
 class LogRestApi(LogMixin, BaseSupersetModelRestApi):
     datamodel = SQLAInterface(models.Log)
-    include_route_methods = {"get_list", "get", "post"}
+    include_route_methods = {"get_list", "get", "post", "recent_activity"}
     class_permission_name = "Log"
     method_permission_name = MODEL_API_RW_METHOD_PERMISSION_MAP
     resource_name = "log"
@@ -44,13 +52,79 @@ class LogRestApi(LogMixin, BaseSupersetModelRestApi):
         "referrer",
     ]
     show_columns = list_columns
+    apispec_parameter_schemas = {
+        "get_recent_activity_schema": get_recent_activity_schema,
+    }
+    openapi_spec_component_schemas = (RecentActivityResponseSchema, RecentActivitySchema)
 
     @staticmethod
     def is_enabled() -> bool:
         return app.config["FAB_ADD_SECURITY_VIEWS"] and app.config["SUPERSET_LOG_VIEW"]
 
-    @before_request
+    @before_request(only=["get_list", "get", "post"])
     def ensure_enabled(self) -> None:
         if not self.is_enabled():
             return self.response_404()
         return None
+
+    def get_user_activity_access_error(self, user_id: int) -> Optional[FlaskResponse]:
+        try:
+            security_manager.raise_for_user_activity_access(user_id)
+        except SupersetSecurityException as ex:
+            return self.response(403, message=ex.message)
+        return None
+
+    @expose("/recent_activity/<int:user_id>/", methods=["GET"])
+    @protect()
+    @safe
+    @statsd_metrics
+    @rison(get_recent_activity_schema)
+    @event_logger.log_this_with_context(
+        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
+        f".recent_activity",
+        log_to_statsd=False,
+    )
+    def recent_activity(self, user_id: int, **kwargs: Any) -> FlaskResponse:
+        """Get recent activity data for a user
+        ---
+        get:
+          description: Get recent activity data for a user
+          parameters:
+          - in: path
+            schema:
+              type: integer
+            name: user_id
+            description: The id of the user
+          - in: query
+            name: q
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/get_recent_activity_schema'
+          responses:
+            200:
+              description: A List of recent activity objects
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/RecentActivityResponseSchema"
+            400:
+              $ref: '#/components/responses/400'
+            401:
+              $ref: '#/components/responses/401'
+            403:
+              $ref: '#/components/responses/404'
+            500:
+              $ref: '#/components/responses/500'
+        """
+        error_obj = self.get_user_activity_access_error(user_id)
+        if error_obj:
+            return error_obj
+
+        limit = kwargs["rison"].get("limit", 100)
+        actions = kwargs["rison"].get("actions", ["explore", "dashboard"])
+        distinct = kwargs["rison"].get("distinct", True)
+
+        payload = LogDAO.get_recent_activity(user_id, limit, actions, distinct)
+        
+        return self.response(200, result=payload)

--- a/superset/views/log/api.py
+++ b/superset/views/log/api.py
@@ -95,7 +95,7 @@ class LogRestApi(LogMixin, BaseSupersetModelRestApi):
         """Get recent activity data for a user
         ---
         get:
-          description: Get recent activity data for a user
+          summary: Get recent activity data for a user
           parameters:
           - in: path
             schema:

--- a/superset/views/log/dao.py
+++ b/superset/views/log/dao.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 from datetime import datetime, timedelta
-from typing import List
+from typing import Any, Dict, List
 
 import humanize
 from sqlalchemy import and_, or_
@@ -35,7 +35,7 @@ class LogDAO(BaseDAO):
     @staticmethod
     def get_recent_activity(
         user_id: int, limit: int, actions: List[str], distinct: bool
-    ) -> List[dict]:
+    ) -> List[Dict[str, Any]]:
         has_subject_title = or_(
             and_(
                 Dashboard.dashboard_title is not None,

--- a/superset/views/log/dao.py
+++ b/superset/views/log/dao.py
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 from datetime import datetime, timedelta
 from typing import List
 

--- a/superset/views/log/dao.py
+++ b/superset/views/log/dao.py
@@ -34,7 +34,7 @@ class LogDAO(BaseDAO):
 
     @staticmethod
     def get_recent_activity(
-        user_id: int, limit: int, actions: List[str], distinct: bool
+        user_id: int, actions: List[str], distinct: bool, page: int, page_size: int
     ) -> List[Dict[str, Any]]:
         has_subject_title = or_(
             and_(
@@ -79,7 +79,8 @@ class LogDAO(BaseDAO):
                 )
                 .filter(has_subject_title)
                 .order_by(subqry.c.dttm.desc())
-                .limit(limit)
+                .limit(page_size)
+                .offset(page * page_size)
             )
         else:
             qry = (
@@ -97,7 +98,8 @@ class LogDAO(BaseDAO):
                 .filter(has_subject_title)
                 .filter(Log.action.in_(actions), Log.user_id == user_id)
                 .order_by(Log.dttm.desc())
-                .limit(limit)
+                .limit(page_size)
+                .offset(page * page_size)
             )
 
         payload = []

--- a/superset/views/log/dao.py
+++ b/superset/views/log/dao.py
@@ -107,13 +107,12 @@ class LogDAO(BaseDAO):
             item_type = None
             if log.dashboard_id:
                 item_type = "dashboard"
-                item_url = Dashboard(id=log.dashboard_id, slug=log.dashboard_slug).url
+                item_url = Dashboard.get_url(log.dashboard_id, log.dashboard_slug)
                 item_title = log.dashboard_title
             elif log.slice_id:
-                slc = Slice(id=log.slice_id, slice_name=log.slice_name)
                 item_type = "slice"
-                item_url = slc.slice_url
-                item_title = slc.chart
+                item_url = Slice.build_explore_url(log.slice_id)
+                item_title = log.slice_name or "<empty>"
 
             payload.append(
                 {

--- a/superset/views/log/dao.py
+++ b/superset/views/log/dao.py
@@ -13,7 +13,6 @@ from superset.models.slice import Slice
 from superset.utils.dates import datetime_to_epoch
 
 
-
 class LogDAO(BaseDAO):
     model_cls = Log
 

--- a/superset/views/log/schemas.py
+++ b/superset/views/log/schemas.py
@@ -25,6 +25,7 @@ get_recent_activity_schema = {
     },
 }
 
+
 class RecentActivitySchema(Schema):
     action = fields.String(description="Action taken describing type of activity")
     item_type = fields.String(description="Type of item, e.g. slice or dashboard")

--- a/superset/views/log/schemas.py
+++ b/superset/views/log/schemas.py
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from marshmallow import fields, Schema
+
+get_recent_activity_schema = {
+    "type": "object",
+    "properties": {
+        "limit": {"type": "number"},
+        "actions": {"type": "array", "items": {"type": "string"}},
+        "distinct": {"type": "boolean"},
+    },
+}
+
+class RecentActivitySchema(Schema):
+    action = fields.String(description="Action taken describing type of activity")
+    item_type = fields.String(description="Type of item, e.g. slice or dashboard")
+    item_url = fields.String(description="URL to item")
+    item_title = fields.String(description="Title of item")
+    time = fields.Float(description="Time of activity, in epoch milliseconds")
+    time_delta_humanized = fields.String(
+        description="Human-readable description of how long ago activity took place"
+    )
+
+
+class RecentActivityResponseSchema(Schema):
+    result = fields.List(
+        fields.Nested(RecentActivitySchema),
+        description="A list of recent activity objects",
+    )

--- a/superset/views/log/schemas.py
+++ b/superset/views/log/schemas.py
@@ -19,7 +19,8 @@ from marshmallow import fields, Schema
 get_recent_activity_schema = {
     "type": "object",
     "properties": {
-        "limit": {"type": "number"},
+        "page": {"type": "number"},
+        "page_size": {"type": "number"},
         "actions": {"type": "array", "items": {"type": "string"}},
         "distinct": {"type": "boolean"},
     },

--- a/tests/integration_tests/dashboard_tests.py
+++ b/tests/integration_tests/dashboard_tests.py
@@ -541,7 +541,7 @@ class TestDashboard(SupersetTestCase):
         dash.owners = [admin_user]
         dash.slices = []
         dash.published = False
-        db.session.merge(dash)
+        db.session.add(dash)
         db.session.commit()
 
         # list dashboards as a gamma user

--- a/tests/integration_tests/dashboard_tests.py
+++ b/tests/integration_tests/dashboard_tests.py
@@ -547,6 +547,10 @@ class TestDashboard(SupersetTestCase):
         # list dashboards as a gamma user
         self.login(gamma_user.username)
         resp = self.get_resp("/api/v1/dashboard/")
+
+        db.session.delete(dash)
+        db.session.commit()
+
         self.assertNotIn(f"/superset/dashboard/{slug}/", resp)
 
 

--- a/tests/integration_tests/dashboard_tests.py
+++ b/tests/integration_tests/dashboard_tests.py
@@ -510,8 +510,8 @@ class TestDashboard(SupersetTestCase):
         regular_dash.dashboard_title = "A Plain Ol Dashboard"
         regular_dash.slug = regular_dash_slug
 
-        db.session.merge(favorite_dash)
-        db.session.merge(regular_dash)
+        db.session.add(favorite_dash)
+        db.session.add(regular_dash)
         db.session.commit()
 
         dash = db.session.query(Dashboard).filter_by(slug=fav_dash_slug).first()
@@ -521,12 +521,18 @@ class TestDashboard(SupersetTestCase):
         favorites.class_name = "Dashboard"
         favorites.user_id = user.id
 
-        db.session.merge(favorites)
+        db.session.add(favorites)
         db.session.commit()
 
         self.login(user.username)
 
         resp = self.get_resp("/api/v1/dashboard/")
+
+        db.session.delete(favorites)
+        db.session.delete(regular_dash)
+        db.session.delete(favorite_dash)
+        db.session.commit()
+
         self.assertIn(f"/superset/dashboard/{fav_dash_slug}/", resp)
 
     def test_user_can_not_view_unpublished_dash(self):

--- a/tests/integration_tests/dashboard_tests.py
+++ b/tests/integration_tests/dashboard_tests.py
@@ -487,13 +487,18 @@ class TestDashboard(SupersetTestCase):
         hidden_dash.slices = []
         hidden_dash.owners = []
 
-        db.session.merge(dash)
-        db.session.merge(hidden_dash)
+        db.session.add(dash)
+        db.session.add(hidden_dash)
         db.session.commit()
 
         self.login(user.username)
 
         resp = self.get_resp("/api/v1/dashboard/")
+
+        db.session.delete(dash)
+        db.session.delete(hidden_dash)
+        db.session.commit()
+
         self.assertIn(f"/superset/dashboard/{my_dash_slug}/", resp)
         self.assertNotIn(f"/superset/dashboard/{not_my_dash_slug}/", resp)
 

--- a/tests/integration_tests/dashboard_utils.py
+++ b/tests/integration_tests/dashboard_utils.py
@@ -80,8 +80,9 @@ def create_dashboard(
     slug: str, title: str, position: str, slices: List[Slice]
 ) -> Dashboard:
     dash = db.session.query(Dashboard).filter_by(slug=slug).one_or_none()
-    if not dash:
-        dash = Dashboard()
+    if dash:
+        return dash
+    dash = Dashboard()
     dash.dashboard_title = title
     if position is not None:
         js = position
@@ -90,7 +91,7 @@ def create_dashboard(
     dash.slug = slug
     if slices is not None:
         dash.slices = slices
-    db.session.merge(dash)
+    db.session.add(dash)
     db.session.commit()
 
     return dash

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -756,7 +756,7 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
         rv = self.get_assert_metric(uri, "get_list")
         self.assertEqual(rv.status_code, 200)
         data = json.loads(rv.data.decode("utf-8"))
-        self.assertEqual(data["count"], 5)
+        self.assertEqual(data["count"], 4)
 
     @pytest.mark.usefixtures("create_created_by_gamma_dashboards")
     def test_get_dashboards_created_by_me(self):

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -756,7 +756,7 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
         rv = self.get_assert_metric(uri, "get_list")
         self.assertEqual(rv.status_code, 200)
         data = json.loads(rv.data.decode("utf-8"))
-        self.assertEqual(data["count"], 4)
+        self.assertEqual(data["count"], 0)
 
     @pytest.mark.usefixtures("create_created_by_gamma_dashboards")
     def test_get_dashboards_created_by_me(self):

--- a/tests/integration_tests/dashboards/security/security_dataset_tests.py
+++ b/tests/integration_tests/dashboards/security/security_dataset_tests.py
@@ -137,8 +137,8 @@ class TestDashboardDatasetSecurity(DashboardTestCase):
         regular_dash.dashboard_title = "A Plain Ol Dashboard"
         regular_dash.slug = regular_dash_slug
 
-        db.session.merge(favorite_dash)
-        db.session.merge(regular_dash)
+        db.session.add(favorite_dash)
+        db.session.add(regular_dash)
         db.session.commit()
 
         dash = db.session.query(Dashboard).filter_by(slug=fav_dash_slug).first()
@@ -148,13 +148,19 @@ class TestDashboardDatasetSecurity(DashboardTestCase):
         favorites.class_name = "Dashboard"
         favorites.user_id = user.id
 
-        db.session.merge(favorites)
+        db.session.add(favorites)
         db.session.commit()
 
         self.login(user.username)
 
         # act
         get_dashboards_response = self.get_resp(DASHBOARDS_API_URL)
+
+        # cleanup
+        db.session.delete(favorites)
+        db.session.delete(favorite_dash)
+        db.session.delete(regular_dash)
+        db.session.commit()
 
         # assert
         self.assertIn(f"/superset/dashboard/{fav_dash_slug}/", get_dashboards_response)

--- a/tests/integration_tests/log_api_tests.py
+++ b/tests/integration_tests/log_api_tests.py
@@ -17,6 +17,7 @@
 # isort:skip_file
 """Unit tests for Superset"""
 import json
+import time
 from typing import Optional
 from unittest.mock import ANY
 
@@ -264,7 +265,9 @@ class TestLogApi(SupersetTestCase):
         dash2 = create_dashboard("dash2_slug", "dash2_title", "{}", [])
         dash3 = create_dashboard("dash3_slug", "dash3_title", "{}", [])
         log = self.insert_log("dashboard", admin_user, dashboard_id=dash.id)
+        time.sleep(0.01)
         log2 = self.insert_log("dashboard", admin_user, dashboard_id=dash2.id)
+        time.sleep(0.01)
         log3 = self.insert_log("dashboard", admin_user, dashboard_id=dash3.id)
 
         arguments = {"page": 0, "page_size": 2}

--- a/tests/integration_tests/log_api_tests.py
+++ b/tests/integration_tests/log_api_tests.py
@@ -21,6 +21,7 @@ import time
 from typing import Optional
 from unittest.mock import ANY
 
+from flask_appbuilder.security.sqla.models import User
 import prison
 from unittest.mock import patch
 

--- a/tests/integration_tests/log_api_tests.py
+++ b/tests/integration_tests/log_api_tests.py
@@ -47,6 +47,7 @@ EXPECTED_COLUMNS = [
 
 
 class TestLogApi(SupersetTestCase):
+    maxDiff = None
     def insert_log(
         self,
         action: str,
@@ -189,6 +190,7 @@ class TestLogApi(SupersetTestCase):
 
         db.session.delete(log1)
         db.session.delete(log2)
+        db.session.delete(dash)
         db.session.commit()
 
         self.assertEqual(
@@ -227,6 +229,9 @@ class TestLogApi(SupersetTestCase):
         db.session.delete(log)
         db.session.delete(log2)
         db.session.delete(log3)
+        db.session.delete(dash)
+        db.session.delete(dash2)
+        db.session.delete(dash3)
         db.session.commit()
 
         self.assertEqual(rv.status_code, 200)
@@ -249,6 +254,7 @@ class TestLogApi(SupersetTestCase):
 
         db.session.delete(log)
         db.session.delete(log2)
+        db.session.delete(dash)
         db.session.commit()
 
         self.assertEqual(rv.status_code, 200)
@@ -271,6 +277,7 @@ class TestLogApi(SupersetTestCase):
 
         db.session.delete(log)
         db.session.delete(log2)
+        db.session.delete(dash)
         db.session.commit()
         self.assertEqual(rv.status_code, 200)
         response = json.loads(rv.data.decode("utf-8"))

--- a/tests/integration_tests/log_api_tests.py
+++ b/tests/integration_tests/log_api_tests.py
@@ -189,16 +189,21 @@ class TestLogApi(SupersetTestCase):
 
         self.assertEqual(rv.status_code, 200)
         response = json.loads(rv.data.decode("utf-8"))
-        self.assertEqual(response, {
-            "result": [{
-                "action": "dashboard",
-                "item_type": "dashboard",
-                "item_url": "/superset/dashboard/dash_slug/",
-                "item_title": "dash_title",
-                "time": ANY,
-                "time_delta_humanized": ANY,
-            }]
-        })
+        self.assertEqual(
+            response,
+            {
+                "result": [
+                    {
+                        "action": "dashboard",
+                        "item_type": "dashboard",
+                        "item_url": "/superset/dashboard/dash_slug/",
+                        "item_title": "dash_title",
+                        "time": ANY,
+                        "time_delta_humanized": ANY,
+                    }
+                ]
+            },
+        )
 
     def test_get_recent_activity_limit(self):
         """

--- a/tests/integration_tests/log_api_tests.py
+++ b/tests/integration_tests/log_api_tests.py
@@ -266,6 +266,8 @@ class TestLogApi(SupersetTestCase):
         """
         Log API: Test recent activity when distinct is false
         """
+        db.session.query(Log).delete(synchronize_session=False)
+        db.session.commit()
         admin_user = self.get_user("admin")
         self.login(username="admin")
         dash = create_dashboard("dash_slug", "dash_title", "{}", [])
@@ -282,6 +284,4 @@ class TestLogApi(SupersetTestCase):
         db.session.commit()
         self.assertEqual(rv.status_code, 200)
         response = json.loads(rv.data.decode("utf-8"))
-        print(response["result"])
-        self.assertEqual(response["result"], {"a": 1})  # debugging
         self.assertEqual(len(response["result"]), 2)

--- a/tests/integration_tests/log_api_tests.py
+++ b/tests/integration_tests/log_api_tests.py
@@ -47,8 +47,6 @@ EXPECTED_COLUMNS = [
 
 
 class TestLogApi(SupersetTestCase):
-    maxDiff = None
-
     def insert_log(
         self,
         action: str,

--- a/tests/integration_tests/log_api_tests.py
+++ b/tests/integration_tests/log_api_tests.py
@@ -47,7 +47,6 @@ EXPECTED_COLUMNS = [
 
 
 class TestLogApi(SupersetTestCase):
-    maxDiff = None
     def insert_log(
         self,
         action: str,

--- a/tests/integration_tests/log_api_tests.py
+++ b/tests/integration_tests/log_api_tests.py
@@ -109,6 +109,8 @@ class TestLogApi(SupersetTestCase):
         self.login(username="alpha")
         rv = self.client.get(uri)
         self.assertEqual(rv.status_code, 403)
+        db.session.delete(log)
+        db.session.commit()
 
     def test_get_item(self):
         """
@@ -212,8 +214,8 @@ class TestLogApi(SupersetTestCase):
         admin_user = self.get_user("admin")
         self.login(username="admin")
         dash = create_dashboard("dash_slug", "dash_title", "{}", [])
-        dash2 = create_dashboard("dash_slug2", "dash_title2", "{}", [])
-        dash3 = create_dashboard("dash_slug3", "dash_title3", "{}", [])
+        dash2 = create_dashboard("dash2_slug", "dash2_title", "{}", [])
+        dash3 = create_dashboard("dash3_slug", "dash3_title", "{}", [])
         log = self.insert_log("dashboard", admin_user, dashboard_id=dash.id)
         log2 = self.insert_log("dashboard", admin_user, dashboard_id=dash2.id)
         log3 = self.insert_log("dashboard", admin_user, dashboard_id=dash3.id)

--- a/tests/integration_tests/log_api_tests.py
+++ b/tests/integration_tests/log_api_tests.py
@@ -266,9 +266,9 @@ class TestLogApi(SupersetTestCase):
         dash2 = create_dashboard("dash2_slug", "dash2_title", "{}", [])
         dash3 = create_dashboard("dash3_slug", "dash3_title", "{}", [])
         log = self.insert_log("dashboard", admin_user, dashboard_id=dash.id)
-        time.sleep(0.01)
+        time.sleep(0.05)
         log2 = self.insert_log("dashboard", admin_user, dashboard_id=dash2.id)
-        time.sleep(0.01)
+        time.sleep(0.05)
         log3 = self.insert_log("dashboard", admin_user, dashboard_id=dash3.id)
 
         arguments = {"page": 0, "page_size": 2}

--- a/tests/integration_tests/log_api_tests.py
+++ b/tests/integration_tests/log_api_tests.py
@@ -282,5 +282,6 @@ class TestLogApi(SupersetTestCase):
         db.session.commit()
         self.assertEqual(rv.status_code, 200)
         response = json.loads(rv.data.decode("utf-8"))
-        self.assertEqual(response["result"], {})  # debugging
+        print(response["result"])
+        self.assertEqual(response["result"], {"a": 1})  # debugging
         self.assertEqual(len(response["result"]), 2)

--- a/tests/integration_tests/log_api_tests.py
+++ b/tests/integration_tests/log_api_tests.py
@@ -282,4 +282,5 @@ class TestLogApi(SupersetTestCase):
         db.session.commit()
         self.assertEqual(rv.status_code, 200)
         response = json.loads(rv.data.decode("utf-8"))
+        self.assertEqual(response["result"], {})  # debugging
         self.assertEqual(len(response["result"]), 2)

--- a/tests/integration_tests/log_api_tests.py
+++ b/tests/integration_tests/log_api_tests.py
@@ -182,13 +182,13 @@ class TestLogApi(SupersetTestCase):
 
         uri = f"api/v1/log/recent_activity/{admin_user.id}/"
         rv = self.client.get(uri)
+        self.assertEqual(rv.status_code, 200)
+        response = json.loads(rv.data.decode("utf-8"))
 
         db.session.delete(log1)
         db.session.delete(log2)
         db.session.commit()
 
-        self.assertEqual(rv.status_code, 200)
-        response = json.loads(rv.data.decode("utf-8"))
         self.assertEqual(
             response,
             {

--- a/tests/integration_tests/log_api_tests.py
+++ b/tests/integration_tests/log_api_tests.py
@@ -21,7 +21,6 @@ from typing import Optional
 from unittest.mock import ANY
 
 import prison
-from flask_appbuilder.security.sqla.models import User
 from unittest.mock import patch
 
 from superset import db
@@ -293,7 +292,7 @@ class TestLogApi(SupersetTestCase):
                         "item_title": "dash2_title",
                         "time": ANY,
                         "time_delta_humanized": ANY,
-                    }
+                    },
                 ]
             },
         )

--- a/tests/integration_tests/log_api_tests.py
+++ b/tests/integration_tests/log_api_tests.py
@@ -16,8 +16,8 @@
 # under the License.
 # isort:skip_file
 """Unit tests for Superset"""
+from datetime import datetime, timedelta
 import json
-import time
 from typing import Optional
 from unittest.mock import ANY
 
@@ -266,10 +266,13 @@ class TestLogApi(SupersetTestCase):
         dash2 = create_dashboard("dash2_slug", "dash2_title", "{}", [])
         dash3 = create_dashboard("dash3_slug", "dash3_title", "{}", [])
         log = self.insert_log("dashboard", admin_user, dashboard_id=dash.id)
-        time.sleep(0.05)
         log2 = self.insert_log("dashboard", admin_user, dashboard_id=dash2.id)
-        time.sleep(0.05)
         log3 = self.insert_log("dashboard", admin_user, dashboard_id=dash3.id)
+
+        now = datetime.now()
+        log3.dttm = now
+        log2.dttm = now - timedelta(days=1)
+        log.dttm = now - timedelta(days=2)
 
         arguments = {"page": 0, "page_size": 2}
         uri = f"api/v1/log/recent_activity/{admin_user.id}/?q={prison.dumps(arguments)}"

--- a/tests/integration_tests/log_api_tests.py
+++ b/tests/integration_tests/log_api_tests.py
@@ -47,6 +47,7 @@ EXPECTED_COLUMNS = [
 
 
 class TestLogApi(SupersetTestCase):
+    maxDiff = None
     def insert_log(
         self,
         action: str,

--- a/tests/integration_tests/log_api_tests.py
+++ b/tests/integration_tests/log_api_tests.py
@@ -48,6 +48,7 @@ EXPECTED_COLUMNS = [
 
 class TestLogApi(SupersetTestCase):
     maxDiff = None
+
     def insert_log(
         self,
         action: str,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Introduces a new endpoint to replace the deprecated one:
* `/api/v1/log/recent_activity/<user_id>/`

It is pretty much the same as the old one, except that it uses rison, has test coverage, and openapi yaml/schemas.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
