### PR TITLE
fix: better logic to extract errors on databricks

### DIFF
--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -218,12 +218,15 @@ class DatabricksNativeEngineSpec(DatabricksODBCEngineSpec, BasicParametersMixin)
         raw_message = cls._extract_error_message(ex)
 
         context = context or {}
+        # access_token isn't currently parseable from the
+        # databricks error response, but adding it in here
+        # for reference if their error message changes
         context = {
-            "host": context["hostname"],
-            "access_token": context["password"],
-            "port": context["port"],
-            "username": context["username"],
-            "database": context["database"],
+            "host": context.get("hostname"),
+            "access_token": context.get("password"),
+            "port": context.get("port"),
+            "username": context.get("username"),
+            "database": context.get("database"),
         }
         for regex, (message, error_type, extra) in cls.custom_errors.items():
             match = regex.search(raw_message)


### PR DESCRIPTION
### SUMMARY
Small fix to handle null values for context params for databricks. This error happens for example in sql lab when a bad query is written and the error is parsed. The error just says "hostname" when that's not the root cause of the issue. Note that databricks doesn't currently have any custom error messages.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:
![SQL_Lab_Databricks_return__hostname__for_error_message_when_the_error_is_not_about_hostname___Shortcut](https://user-images.githubusercontent.com/5186919/213570735-e447ebdb-cdff-4f53-b5b1-0439073ba735.png)

After (better error message):
![_DEV__Superset](https://user-images.githubusercontent.com/5186919/213570909-ba095052-1249-4e2d-ad2a-86cd0285f49c.png)


### TESTING INSTRUCTIONS
run a query in sqlab with a bad column name

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
