### PR TITLE
chore(dashboard): Log events for download as image

### DIFF
--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
@@ -68,6 +68,7 @@ const createProps = () => ({
   lastModifiedTime: 0,
   isDropdownVisible: true,
   dataMask: {},
+  logEvent: jest.fn(),
 });
 const editModeOnProps = {
   ...createProps(),

--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx
@@ -36,6 +36,7 @@ import getDashboardUrl from 'src/dashboard/util/getDashboardUrl';
 import { getActiveFilters } from 'src/dashboard/util/activeDashboardFilters';
 import { getUrlParam } from 'src/utils/urlUtils';
 import { FILTER_BOX_MIGRATION_STATES } from 'src/explore/constants';
+import { LOG_ACTIONS_DASHBOARD_DOWNLOAD_AS_IMAGE } from 'src/logger/LogUtils';
 
 const propTypes = {
   addSuccessToast: PropTypes.func.isRequired,
@@ -65,6 +66,7 @@ const propTypes = {
   onSave: PropTypes.func.isRequired,
   showPropertiesModal: PropTypes.func.isRequired,
   manageEmbedded: PropTypes.func.isRequired,
+  logEvent: PropTypes.func,
   refreshLimit: PropTypes.number,
   refreshWarning: PropTypes.string,
   lastModifiedTime: PropTypes.number.isRequired,
@@ -182,6 +184,7 @@ class HeaderActionsDropdown extends React.PureComponent {
         )(domEvent).then(() => {
           menu.style.visibility = 'visible';
         });
+        this.props.logEvent?.(LOG_ACTIONS_DASHBOARD_DOWNLOAD_AS_IMAGE);
         break;
       }
       case MENU_KEYS.TOGGLE_FULLSCREEN: {

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -464,6 +464,7 @@ class Header extends React.PureComponent {
       setRefreshFrequency,
       lastModifiedTime,
       filterboxMigrationState,
+      logEvent,
     } = this.props;
 
     const userCanEdit =
@@ -679,6 +680,7 @@ class Header extends React.PureComponent {
               filterboxMigrationState={filterboxMigrationState}
               isDropdownVisible={this.state.isDropdownVisible}
               setIsDropdownVisible={this.setIsDropdownVisible}
+              logEvent={logEvent}
             />
           }
           showFaveStar={user?.userId && dashboardInfo?.id}

--- a/superset-frontend/src/dashboard/components/SliceHeader/SliceHeader.test.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeader/SliceHeader.test.tsx
@@ -156,6 +156,7 @@ const createProps = (overrides: any = {}) => ({
   toggleExpandSlice: jest.fn(),
   forceRefresh: jest.fn(),
   logExploreChart: jest.fn(),
+  logEvent: jest.fn(),
   exportCSV: jest.fn(),
   formData: { slice_id: 1, datasource: '58__table' },
   width: 100,

--- a/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
@@ -133,6 +133,7 @@ const SliceHeader: FC<SliceHeaderProps> = ({
   updateSliceName = () => ({}),
   toggleExpandSlice = () => ({}),
   logExploreChart = () => ({}),
+  logEvent,
   exportCSV = () => ({}),
   editMode = false,
   annotationQuery = {},
@@ -271,6 +272,7 @@ const SliceHeader: FC<SliceHeaderProps> = ({
                 toggleExpandSlice={toggleExpandSlice}
                 forceRefresh={forceRefresh}
                 logExploreChart={logExploreChart}
+                logEvent={logEvent}
                 exportCSV={exportCSV}
                 exportFullCSV={exportFullCSV}
                 supersetCanExplore={supersetCanExplore}

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
@@ -47,6 +47,7 @@ const createProps = (viz_type = 'sunburst') =>
     forceRefresh: jest.fn(),
     handleToggleFullSize: jest.fn(),
     toggleExpandSlice: jest.fn(),
+    logEvent: jest.fn(),
     slice: {
       slice_id: 371,
       slice_url: '/explore/?form_data=%7B%22slice_id%22%3A%20371%7D',

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -54,6 +54,7 @@ import ViewQueryModal from 'src/explore/components/controls/ViewQueryModal';
 import { ResultsPaneOnDashboard } from 'src/explore/components/DataTablesPane';
 import Modal from 'src/components/Modal';
 import { DrillDetailMenuItems } from 'src/components/Chart/DrillDetail';
+import { LOG_ACTIONS_CHART_DOWNLOAD_AS_IMAGE } from 'src/logger/LogUtils';
 
 const MENU_KEYS = {
   CROSS_FILTER_SCOPING: 'cross_filter_scoping',
@@ -137,6 +138,7 @@ export interface SliceHeaderControlsProps {
 
   forceRefresh: (sliceId: number, dashboardId: number) => void;
   logExploreChart?: (sliceId: number) => void;
+  logEvent?: (eventName: string, eventData?: object) => void;
   toggleExpandSlice?: (sliceId: number) => void;
   exportCSV?: (sliceId: number) => void;
   exportFullCSV?: (sliceId: number) => void;
@@ -320,6 +322,9 @@ class SliceHeaderControls extends React.PureComponent<
           // @ts-ignore
         )(domEvent).then(() => {
           menu.style.visibility = 'visible';
+        });
+        this.props.logEvent?.(LOG_ACTIONS_CHART_DOWNLOAD_AS_IMAGE, {
+          chartId: this.props.slice.slice_id,
         });
         break;
       }

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -408,6 +408,7 @@ class Chart extends React.Component {
       postTransformProps,
       datasetsStatus,
       isInView,
+      logEvent,
     } = this.props;
 
     const { width } = this.state;
@@ -457,6 +458,7 @@ class Chart extends React.Component {
           editMode={editMode}
           annotationQuery={chart.annotationQuery}
           logExploreChart={this.logExploreChart}
+          logEvent={logEvent}
           onExploreChart={this.onExploreChart}
           exportCSV={this.exportCSV}
           exportFullCSV={this.exportFullCSV}

--- a/superset-frontend/src/logger/LogUtils.ts
+++ b/superset-frontend/src/logger/LogUtils.ts
@@ -47,6 +47,9 @@ export const LOG_ACTIONS_DATASET_CREATION_SUCCESS = 'dataset_creation_success';
 export const LOG_ACTIONS_SPA_NAVIGATION = 'spa_navigation';
 export const LOG_ACTIONS_CONFIRM_OVERWRITE_DASHBOARD_METADATA =
   'confirm_overwrite_dashboard_metadata';
+export const LOG_ACTIONS_DASHBOARD_DOWNLOAD_AS_IMAGE =
+  'dashboard_download_as_image';
+export const LOG_ACTIONS_CHART_DOWNLOAD_AS_IMAGE = 'chart_download_as_image';
 
 // Log event types --------------------------------------------------------------
 export const LOG_EVENT_TYPE_TIMING = new Set([
@@ -67,6 +70,8 @@ export const LOG_EVENT_TYPE_USER = new Set([
   LOG_ACTIONS_PERIODIC_RENDER_DASHBOARD,
   LOG_ACTIONS_MOUNT_EXPLORER,
   LOG_ACTIONS_CONFIRM_OVERWRITE_DASHBOARD_METADATA,
+  LOG_ACTIONS_DASHBOARD_DOWNLOAD_AS_IMAGE,
+  LOG_ACTIONS_CHART_DOWNLOAD_AS_IMAGE,
 ]);
 
 export const LOG_EVENT_DATASET_TYPE_DATASET_CREATION = [


### PR DESCRIPTION
### SUMMARY
This commit adds the logger for "download as image" link on both dashboard menu and chart menu.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

- Dashboard

<img width="569" alt="Screenshot 2023-01-19 at 2 56 03 PM" src="https://user-images.githubusercontent.com/1392866/213581992-387f02e1-aa7a-44ae-861c-2ed05ddfd148.png">

- Chart
<img width="567" alt="Screenshot 2023-01-19 at 3 02 14 PM" src="https://user-images.githubusercontent.com/1392866/213581954-c9710279-0f53-4e31-8f06-5c50adffd3f1.png">

### TESTING INSTRUCTIONS
- Open a dashboard
- click dropdown menu > "Download as image"
- Check the network tab for the logging event

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @ktmud @john-bodley 