### PR TITLE
feat(ssh_tunnel): Add feature flag to SSH Tunnel API

### DIFF
--- a/superset/databases/ssh_tunnel/commands/delete.py
+++ b/superset/databases/ssh_tunnel/commands/delete.py
@@ -19,10 +19,12 @@ from typing import Optional
 
 from flask_appbuilder.models.sqla import Model
 
+from superset import is_feature_enabled
 from superset.commands.base import BaseCommand
 from superset.dao.exceptions import DAODeleteFailedError
 from superset.databases.ssh_tunnel.commands.exceptions import (
     SSHTunnelDeleteFailedError,
+    SSHTunnelingNotEnabledError,
     SSHTunnelNotFoundError,
 )
 from superset.databases.ssh_tunnel.dao import SSHTunnelDAO
@@ -37,6 +39,8 @@ class DeleteSSHTunnelCommand(BaseCommand):
         self._model: Optional[SSHTunnel] = None
 
     def run(self) -> Model:
+        if not is_feature_enabled("SSH_TUNNELING"):
+            raise SSHTunnelingNotEnabledError()
         self.validate()
         try:
             ssh_tunnel = SSHTunnelDAO.delete(self._model)

--- a/superset/databases/ssh_tunnel/commands/exceptions.py
+++ b/superset/databases/ssh_tunnel/commands/exceptions.py
@@ -46,6 +46,11 @@ class SSHTunnelCreateFailedError(CommandException):
     message = _("Creating SSH Tunnel failed for an unknown reason")
 
 
+class SSHTunnelingNotEnabledError(CommandException):
+    status = 400
+    message = _("SSH Tunneling is not enabled")
+
+
 class SSHTunnelRequiredFieldValidationError(ValidationError):
     def __init__(self, field_name: str) -> None:
         super().__init__(

--- a/tests/integration_tests/databases/ssh_tunnel/commands/commands_tests.py
+++ b/tests/integration_tests/databases/ssh_tunnel/commands/commands_tests.py
@@ -67,8 +67,10 @@ class TestUpdateSSHTunnelCommand(SupersetTestCase):
 
 class TestDeleteSSHTunnelCommand(SupersetTestCase):
     @mock.patch("superset.utils.core.g")
-    def test_delete_ssh_tunnel_not_found(self, mock_g):
+    @mock.patch("superset.databases.ssh_tunnel.commands.delete.is_feature_enabled")
+    def test_delete_ssh_tunnel_not_found(self, mock_g, mock_delete_is_feature_enabled):
         mock_g.user = security_manager.find_user("admin")
+        mock_delete_is_feature_enabled.return_value = True
         # We have not created a SSH Tunnel yet so id = 1 is invalid
         command = DeleteSSHTunnelCommand(1)
         with pytest.raises(SSHTunnelNotFoundError) as excinfo:

--- a/tests/unit_tests/databases/api_test.py
+++ b/tests/unit_tests/databases/api_test.py
@@ -241,6 +241,10 @@ def test_delete_ssh_tunnel(
         # mock the lookup so that we don't need to include the driver
         mocker.patch("sqlalchemy.engine.URL.get_driver_name", return_value="gsheets")
         mocker.patch("superset.utils.log.DBEventLogger.log")
+        mocker.patch(
+            "superset.databases.ssh_tunnel.commands.delete.is_feature_enabled",
+            return_value=True,
+        )
 
         # Create our SSHTunnel
         tunnel = SSHTunnel(
@@ -313,6 +317,10 @@ def test_delete_ssh_tunnel_not_found(
         # mock the lookup so that we don't need to include the driver
         mocker.patch("sqlalchemy.engine.URL.get_driver_name", return_value="gsheets")
         mocker.patch("superset.utils.log.DBEventLogger.log")
+        mocker.patch(
+            "superset.databases.ssh_tunnel.commands.delete.is_feature_enabled",
+            return_value=True,
+        )
 
         # Create our SSHTunnel
         tunnel = SSHTunnel(

--- a/tests/unit_tests/databases/ssh_tunnel/commands/delete_test.py
+++ b/tests/unit_tests/databases/ssh_tunnel/commands/delete_test.py
@@ -18,6 +18,7 @@
 from typing import Iterator
 
 import pytest
+from pytest_mock import MockFixture
 from sqlalchemy.orm.session import Session
 
 
@@ -50,7 +51,9 @@ def session_with_data(session: Session) -> Iterator[Session]:
     session.rollback()
 
 
-def test_delete_ssh_tunnel_command(session_with_data: Session) -> None:
+def test_delete_ssh_tunnel_command(
+    mocker: MockFixture, session_with_data: Session
+) -> None:
     from superset.databases.dao import DatabaseDAO
     from superset.databases.ssh_tunnel.commands.delete import DeleteSSHTunnelCommand
     from superset.databases.ssh_tunnel.models import SSHTunnel
@@ -60,9 +63,11 @@ def test_delete_ssh_tunnel_command(session_with_data: Session) -> None:
     assert result
     assert isinstance(result, SSHTunnel)
     assert 1 == result.database_id
-
+    mocker.patch(
+        "superset.databases.ssh_tunnel.commands.delete.is_feature_enabled",
+        return_value=True,
+    )
     DeleteSSHTunnelCommand(1).run()
-
     result = DatabaseDAO.get_ssh_tunnel(1)
 
     assert result is None


### PR DESCRIPTION
### SUMMARY
Need to make sure we block any API request to our endpoints that use SSH Tunnels if the feature flag is not enabled. Also, we are updating the tests and adding a new one for the new exception if the flag is disabled.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [X] Introduces new feature or API
- [ ] Removes existing feature or API
