### PR TITLE
feat: export/import `allow_dml` flag

### DIFF
--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -683,6 +683,7 @@ class ImportV1DatabaseSchema(Schema):
     allow_run_async = fields.Boolean()
     allow_ctas = fields.Boolean()
     allow_cvas = fields.Boolean()
+    allow_dml = fields.Boolean(required=False)
     allow_csv_upload = fields.Boolean()
     extra = fields.Nested(ImportV1DatabaseExtraSchema)
     uuid = fields.UUID(required=True)

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -168,6 +168,7 @@ class Database(
         "allow_run_async",
         "allow_ctas",
         "allow_cvas",
+        "allow_dml",
         "allow_file_upload",
         "extra",
     ]

--- a/tests/integration_tests/databases/commands_tests.py
+++ b/tests/integration_tests/databases/commands_tests.py
@@ -159,6 +159,7 @@ class TestExportDatabasesCommand(SupersetTestCase):
                 "allow_csv_upload": True,
                 "allow_ctas": True,
                 "allow_cvas": True,
+                "allow_dml": True,
                 "allow_run_async": False,
                 "cache_timeout": None,
                 "database_name": "examples",
@@ -362,6 +363,7 @@ class TestExportDatabasesCommand(SupersetTestCase):
             "allow_run_async",
             "allow_ctas",
             "allow_cvas",
+            "allow_dml",
             "allow_csv_upload",
             "extra",
             "uuid",
@@ -405,6 +407,7 @@ class TestImportDatabasesCommand(SupersetTestCase):
         assert database.allow_file_upload
         assert database.allow_ctas
         assert database.allow_cvas
+        assert database.allow_dml
         assert not database.allow_run_async
         assert database.cache_timeout is None
         assert database.database_name == "imported_database"
@@ -440,6 +443,7 @@ class TestImportDatabasesCommand(SupersetTestCase):
         assert database.allow_file_upload
         assert database.allow_ctas
         assert database.allow_cvas
+        assert database.allow_dml
         assert not database.allow_run_async
         assert database.cache_timeout is None
         assert database.database_name == "imported_database"

--- a/tests/integration_tests/fixtures/importexport.py
+++ b/tests/integration_tests/fixtures/importexport.py
@@ -350,6 +350,7 @@ database_config: Dict[str, Any] = {
     "allow_csv_upload": True,
     "allow_ctas": True,
     "allow_cvas": True,
+    "allow_dml": True,
     "allow_run_async": False,
     "cache_timeout": None,
     "database_name": "imported_database",

--- a/tests/unit_tests/databases/commands/importers/v1/import_test.py
+++ b/tests/unit_tests/databases/commands/importers/v1/import_test.py
@@ -41,11 +41,21 @@ def test_import_database(session: Session) -> None:
     assert database.allow_run_async is False
     assert database.allow_ctas is True
     assert database.allow_cvas is True
+    assert database.allow_dml is True
     assert database.allow_file_upload is True
     assert database.extra == "{}"
     assert database.uuid == "b8a1ccd3-779d-4ab7-8ad8-9ab119d7fe89"
     assert database.is_managed_externally is False
     assert database.external_url is None
+
+    # ``allow_dml`` was initially not exported; the import should work if the field is
+    # missing
+    config = copy.deepcopy(database_config)
+    del config["allow_dml"]
+    session.delete(database)
+    session.flush()
+    database = import_database(session, config)
+    assert database.allow_dml is False
 
 
 def test_import_database_managed_externally(session: Session) -> None:

--- a/tests/unit_tests/datasets/commands/export_test.py
+++ b/tests/unit_tests/datasets/commands/export_test.py
@@ -194,6 +194,7 @@ expose_in_sqllab: true
 allow_run_async: false
 allow_ctas: false
 allow_cvas: false
+allow_dml: false
 allow_file_upload: false
 extra:
   metadata_params: {{}}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When exporting a database, include the `allow_dml` field.

When importing use the field if present. If not, default to false.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
