### PR TITLE
fix: allow CSV upload in Other db

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -809,6 +809,9 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
           database_name,
           configuration_method: CONFIGURATION_METHOD.SQLALCHEMY_URI,
           engine: undefined,
+          engine_information: {
+            supports_file_upload: true,
+          },
         },
       });
     } else {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The "Other" database should have CSV uploads showing up as an option.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

![Screenshot 2023-01-20 at 11-34-31 Superset](https://user-images.githubusercontent.com/1534870/213756498-f89ac786-aaf3-4fd3-b236-d3fb9052183b.png)

After:

![Screenshot 2023-01-20 at 12-51-10 Superset](https://user-images.githubusercontent.com/1534870/213756513-99b2ae68-f5d4-4fdc-bc05-39abb1770213.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
