### PR TITLE
fix(sqllab): type error on renderBigIntStr

### DIFF
--- a/superset-frontend/src/components/FilterableTable/FilterableTable.test.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.test.tsx
@@ -21,7 +21,7 @@ import { ReactWrapper } from 'enzyme';
 import { styledMount as mount } from 'spec/helpers/theming';
 import FilterableTable, {
   MAX_COLUMNS_FOR_TABLE,
-  renderBigIntStrToNumber,
+  convertBigIntStrToNumber,
 } from 'src/components/FilterableTable';
 import { render, screen } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
@@ -334,17 +334,17 @@ describe('FilterableTable sorting - RTL', () => {
 });
 
 test('renders bigInt value in a number format', () => {
-  expect(renderBigIntStrToNumber('123')).toBe('123');
-  expect(renderBigIntStrToNumber('some string value')).toBe(
+  expect(convertBigIntStrToNumber('123')).toBe('123');
+  expect(convertBigIntStrToNumber('some string value')).toBe(
     'some string value',
   );
-  expect(renderBigIntStrToNumber('{ a: 123 }')).toBe('{ a: 123 }');
-  expect(renderBigIntStrToNumber('"Not a Number"')).toBe('"Not a Number"');
+  expect(convertBigIntStrToNumber('{ a: 123 }')).toBe('{ a: 123 }');
+  expect(convertBigIntStrToNumber('"Not a Number"')).toBe('"Not a Number"');
   // trim quotes for bigint string format
-  expect(renderBigIntStrToNumber('"-12345678901234567890"')).toBe(
+  expect(convertBigIntStrToNumber('"-12345678901234567890"')).toBe(
     '-12345678901234567890',
   );
-  expect(renderBigIntStrToNumber('"12345678901234567890"')).toBe(
+  expect(convertBigIntStrToNumber('"12345678901234567890"')).toBe(
     '12345678901234567890',
   );
 });

--- a/superset-frontend/src/components/FilterableTable/index.tsx
+++ b/superset-frontend/src/components/FilterableTable/index.tsx
@@ -63,11 +63,15 @@ function safeJsonObjectParse(
   }
 }
 
-export function renderBigIntStrToNumber(value: string | number) {
+export function convertBigIntStrToNumber(value: string | number) {
   if (typeof value === 'string' && /^"-?\d+"$/.test(value)) {
-    return <>{value.substring(1, value.length - 1)}</>;
+    return value.substring(1, value.length - 1);
   }
-  return <>{value}</>;
+  return value;
+}
+
+function renderBigIntStrToNumber(value: string | number) {
+  return <>{convertBigIntStrToNumber(value)}</>;
 }
 
 const GRID_POSITION_ADJUSTMENT = 4;

--- a/superset-frontend/src/components/FilterableTable/index.tsx
+++ b/superset-frontend/src/components/FilterableTable/index.tsx
@@ -63,11 +63,11 @@ function safeJsonObjectParse(
   }
 }
 
-export function renderBigIntStrToNumber(value: string) {
+export function renderBigIntStrToNumber(value: string | number) {
   if (typeof value === 'string' && /^"-?\d+"$/.test(value)) {
-    return value.substring(1, value.length - 1);
+    return <>{value.substring(1, value.length - 1)}</>;
   }
-  return value;
+  return <>{value}</>;
 }
 
 const GRID_POSITION_ADJUSTMENT = 4;


### PR DESCRIPTION
### SUMMARY
As titled, this commit fixes the type error on `renderBigIntStrToNumber`


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

- Before

```
Type '(value: string) => string' is not assignable to type '(displayValue: string | number, rawValue?: string | number | boolean | null | undefined, ...keyPath: (string | number)[]) => Element'.
```

- After

N/A

### TESTING INSTRUCTIONS

npm run type

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @ktmud 