### PR TITLE
fix: Handles disabled options on Select All

### DIFF
--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -45,6 +45,8 @@ import {
   getSuffixIcon,
   SELECT_ALL_VALUE,
   selectAllOption,
+  mapValues,
+  mapOptions,
 } from './utils';
 import { SelectOptionsType, SelectProps } from './types';
 import {
@@ -415,20 +417,8 @@ const Select = forwardRef(
         ) {
           // send all options to onchange if all are not currently there
           if (!selectAllMode) {
-            newValues = labelInValue
-              ? selectAllEligible.map(opt => ({
-                  key: opt.value,
-                  value: opt.value,
-                  label: opt.label,
-                }))
-              : selectAllEligible.map(opt => opt.value);
-            newOptions = fullSelectOptions.map(opt => ({
-              children: opt.label,
-              key: opt.value,
-              value: opt.value,
-              label: opt.label,
-              disabled: opt.disabled,
-            }));
+            newValues = mapValues(selectAllEligible, labelInValue);
+            newOptions = mapOptions(selectAllEligible);
           } else {
             newValues = ensureIsArray(values).filter(
               (val: any) => getValue(val) !== SELECT_ALL_VALUE,
@@ -438,8 +428,11 @@ const Select = forwardRef(
           ensureIsArray(values).length === selectAllEligible.length &&
           selectAllMode
         ) {
-          newValues = [];
-          newValues = [];
+          const array = selectAllEligible.filter(
+            option => hasOption(option.value, selectValue) && option.disabled,
+          );
+          newValues = mapValues(array, labelInValue);
+          newOptions = mapOptions(array);
         }
       }
       onChange?.(newValues, newOptions);

--- a/superset-frontend/src/components/Select/utils.tsx
+++ b/superset-frontend/src/components/Select/utils.tsx
@@ -204,3 +204,21 @@ export const renderSelectOptions = (options: SelectOptionsType) =>
       </Option>
     );
   });
+
+export const mapValues = (values: SelectOptionsType, labelInValue: boolean) =>
+  labelInValue
+    ? values.map(opt => ({
+        key: opt.value,
+        value: opt.value,
+        label: opt.label,
+      }))
+    : values.map(opt => opt.value);
+
+export const mapOptions = (values: SelectOptionsType) =>
+  values.map(opt => ({
+    children: opt.label,
+    key: opt.value,
+    value: opt.value,
+    label: opt.label,
+    disabled: opt.disabled,
+  }));


### PR DESCRIPTION
### SUMMARY
Updates `Select` to correctly handle disabled options on Select All.

Follow-up of https://github.com/apache/superset/pull/22084

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/214135879-d4502cc7-3e8a-4543-883d-4637b07d7ad0.mov

### TESTING INSTRUCTIONS
- Select All should count only disabled options that are selected initially.
- Select All should NOT count disabled options that are unselected.
- Select All shouldn't change the original state of disabled options.
- Clear All should preserve disabled options that are selected initially.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
