### PR TITLE
chore: Update typing for `Table` component

### DIFF
--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
@@ -42,11 +42,7 @@ import NullCell from 'src/components/Table/cell-renderers/NullCell';
 import TimeCell from 'src/components/Table/cell-renderers/TimeCell';
 import { EmptyStateMedium } from 'src/components/EmptyState';
 import { getDatasourceSamples } from 'src/components/Chart/chartAction';
-import Table, {
-  ColumnsType,
-  TablePaginationConfig,
-  TableSize,
-} from 'src/components/Table';
+import Table, { ColumnsType, TableSize } from 'src/components/Table';
 import MetadataBar, {
   ContentType,
   MetadataType,
@@ -302,7 +298,7 @@ export default function DrillDetailPane({
           recordCount={resultsPage?.total}
           usePagination
           loading={isLoading}
-          onChange={(pagination: TablePaginationConfig) =>
+          onChange={pagination =>
             setPageIndex(pagination.current ? pagination.current - 1 : 0)
           }
           resizable

--- a/superset-frontend/src/components/Table/Table.stories.tsx
+++ b/superset-frontend/src/components/Table/Table.stories.tsx
@@ -24,8 +24,8 @@ import {
   TableSize,
   SUPERSET_TABLE_COLUMN,
   ColumnsType,
-  OnChangeFunction,
   ETableAction,
+  OnChangeFunction,
 } from './index';
 import { numericalSort, alphabeticalSort } from './sorters';
 import ButtonCell from './cell-renderers/ButtonCell';
@@ -404,7 +404,7 @@ export const ServerPagination: ComponentStory<typeof Table> = args => {
   const [data, setData] = useState(generateData(0, 5));
   const [loading, setLoading] = useState(false);
 
-  const handleChange: OnChangeFunction = (
+  const handleChange: OnChangeFunction<BasicData> = (
     pagination,
     filters,
     sorter,
@@ -610,7 +610,7 @@ const shoppingData: ShoppingData[] = [
   },
 ];
 
-export const HeaderRenderers: ComponentStory<typeof Table> = args => {
+export const HeaderRenderers: ComponentStory<typeof Table> = () => {
   const [orderDateFormatting, setOrderDateFormatting] = useState('formatted');
   const [priceLocale, setPriceLocale] = useState(LocaleCode.en_US);
   const shoppingColumns: ColumnsType<ShoppingData> = [
@@ -672,7 +672,7 @@ export const HeaderRenderers: ComponentStory<typeof Table> = args => {
   ];
 
   return (
-    <Table
+    <Table<ShoppingData>
       data={shoppingData}
       columns={shoppingColumns}
       size={TableSize.SMALL}

--- a/superset-frontend/src/components/Table/Table.stories.tsx
+++ b/superset-frontend/src/components/Table/Table.stories.tsx
@@ -24,8 +24,8 @@ import {
   TableSize,
   SUPERSET_TABLE_COLUMN,
   ColumnsType,
-  ETableAction,
   OnChangeFunction,
+  ETableAction,
 } from './index';
 import { numericalSort, alphabeticalSort } from './sorters';
 import ButtonCell from './cell-renderers/ButtonCell';

--- a/superset-frontend/src/components/Table/VirtualTable.tsx
+++ b/superset-frontend/src/components/Table/VirtualTable.tsx
@@ -16,17 +16,24 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Table as AntTable } from 'antd';
+
+import AntTable, {
+  TablePaginationConfig,
+  TableProps as AntTableProps,
+} from 'antd/lib/table';
 import classNames from 'classnames';
 import { useResizeDetector } from 'react-resize-detector';
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { VariableSizeGrid as Grid } from 'react-window';
-import { StyledComponent } from '@emotion/styled';
 import { useTheme, styled } from '@superset-ui/core';
-import { TablePaginationConfig } from 'antd/lib/table';
-import { TableProps, TableSize, ETableAction } from './index';
 
-const StyledCell: StyledComponent<any> = styled('div')<any>(
+import { TableSize, ETableAction } from './index';
+
+interface VirtualTableProps<RecordType> extends AntTableProps<RecordType> {
+  height?: number;
+}
+
+const StyledCell = styled('div')<{ height?: number }>(
   ({ theme, height }) => `
   white-space: nowrap;
   overflow: hidden;
@@ -40,7 +47,7 @@ const StyledCell: StyledComponent<any> = styled('div')<any>(
 `,
 );
 
-const StyledTable: StyledComponent<any> = styled(AntTable)<any>(
+const StyledTable = styled(AntTable)<{ height?: number }>(
   ({ theme }) => `
     th.ant-table-cell {
       font-weight: ${theme.typography.weights.bold};
@@ -61,7 +68,9 @@ const StyledTable: StyledComponent<any> = styled(AntTable)<any>(
 const SMALL = 39;
 const MIDDLE = 47;
 
-const VirtualTable = (props: TableProps) => {
+const VirtualTable = <RecordType extends object>(
+  props: VirtualTableProps<RecordType>,
+) => {
   const { columns, pagination, onChange, height, scroll, size } = props;
   const [tableWidth, setTableWidth] = useState<number>(0);
   const onResize = useCallback((width: number) => {

--- a/superset-frontend/src/components/Table/index.tsx
+++ b/superset-frontend/src/components/Table/index.tsx
@@ -135,6 +135,10 @@ export interface TableProps<RecordType> {
    * Invoked when the tables sorting, paging, or filtering is changed.
    */
   onChange?: AntTableProps<RecordType>['onChange'];
+  /**
+   * Returns props that should be applied to each row component.
+   */
+  onRow?: AntTableProps<RecordType>['onRow'];
 }
 
 export enum TableSize {
@@ -246,6 +250,7 @@ export function Table<RecordType extends object>(
     virtualize = false,
     onChange = noop,
     recordCount,
+    onRow,
   } = props;
 
   const wrapperRef = useRef<HTMLDivElement | null>(null);
@@ -375,6 +380,7 @@ export function Table<RecordType extends object>(
     locale: mergedLocale,
     showSorterTooltip: false,
     onChange,
+    onRow,
     theme,
     height: bodyHeight,
   };

--- a/superset-frontend/src/components/Table/index.tsx
+++ b/superset-frontend/src/components/Table/index.tsx
@@ -17,33 +17,19 @@
  * under the License.
  */
 import React, { useState, useEffect, useRef, ReactElement } from 'react';
-import { Table as AntTable, ConfigProvider } from 'antd';
-import {
+import AntTable, {
   ColumnType,
-  ColumnGroupType,
+  ColumnsType,
   TableProps as AntTableProps,
-} from 'antd/es/table';
-import { PaginationProps } from 'antd/es/pagination';
-import { Key } from 'antd/lib/table/interface';
-import { t, useTheme, logging } from '@superset-ui/core';
+} from 'antd/lib/table';
+import ConfigProvider from 'antd/lib/config-provider';
+import { PaginationProps } from 'antd/lib/pagination';
+import { t, useTheme, logging, styled } from '@superset-ui/core';
 import Loading from 'src/components/Loading';
-import styled, { StyledComponent } from '@emotion/styled';
 import InteractiveTableUtils from './utils/InteractiveTableUtils';
 import VirtualTable from './VirtualTable';
 
 export const SUPERSET_TABLE_COLUMN = 'superset/table-column';
-export interface TableDataType {
-  key: React.Key;
-}
-
-export interface TablePaginationConfig extends PaginationProps {
-  extra?: object;
-}
-
-export type ColumnsType<RecordType = unknown> = (
-  | ColumnGroupType<RecordType>
-  | ColumnType<RecordType>
-)[];
 
 export enum SelectionType {
   'DISABLED' = 'disabled',
@@ -51,35 +37,12 @@ export enum SelectionType {
   'MULTI' = 'multi',
 }
 
-export interface Locale {
-  /**
-   * Text contained within the Table UI.
-   */
-  filterTitle: string;
-  filterConfirm: string;
-  filterReset: string;
-  filterEmptyText: string;
-  filterCheckall: string;
-  filterSearchPlaceholder: string;
-  emptyText: string;
-  selectAll: string;
-  selectInvert: string;
-  selectNone: string;
-  selectionAll: string;
-  sortTitle: string;
-  expand: string;
-  collapse: string;
-  triggerDesc: string;
-  triggerAsc: string;
-  cancelSort: string;
-}
-
 export type SortOrder = 'descend' | 'ascend' | null;
 export interface SorterResult<RecordType> {
   column?: ColumnType<RecordType>;
   order?: SortOrder;
-  field?: Key | Key[];
-  columnKey?: Key;
+  field?: React.Key | React.Key[];
+  columnKey?: React.Key;
 }
 
 export enum ETableAction {
@@ -88,19 +51,7 @@ export enum ETableAction {
   FILTER = 'filter',
 }
 
-export interface TableCurrentDataSource<RecordType> {
-  currentDataSource: RecordType[];
-  action: ETableAction;
-}
-
-export type OnChangeFunction = (
-  pagination: TablePaginationConfig,
-  filters: Record<string, (Key | boolean)[] | null>,
-  sorter: SorterResult<any> | SorterResult<any>[],
-  extra: TableCurrentDataSource<any>,
-) => void;
-
-export interface TableProps extends AntTableProps<TableProps> {
+export interface TableProps<RecordType> {
   /**
    * Data that will populate the each row and map to the column key.
    */
@@ -108,7 +59,7 @@ export interface TableProps extends AntTableProps<TableProps> {
   /**
    * Table column definitions.
    */
-  columns: ColumnsType<any>;
+  columns: ColumnsType<RecordType>;
   /**
    * Array of row keys to represent list of selected rows.
    */
@@ -165,7 +116,7 @@ export interface TableProps extends AntTableProps<TableProps> {
   /**
    * Enables setting the text displayed in various components and tooltips within the Table UI.
    */
-  locale?: Locale;
+  locale?: Partial<AntTableProps<RecordType>['locale']>;
   /**
    * Restricts the visible height of the table and allows for internal scrolling within the table
    * when the number of rows exceeds the visible space.
@@ -183,15 +134,7 @@ export interface TableProps extends AntTableProps<TableProps> {
   /**
    * Invoked when the tables sorting, paging, or filtering is changed.
    */
-  onChange?: OnChangeFunction;
-}
-
-interface IPaginationOptions {
-  hideOnSinglePage: boolean;
-  pageSize: number;
-  pageSizeOptions: string[];
-  onShowSizeChange: Function;
-  total?: number;
+  onChange?: AntTableProps<RecordType>['onChange'];
 }
 
 export enum TableSize {
@@ -199,12 +142,16 @@ export enum TableSize {
   MIDDLE = 'middle',
 }
 
+export { ColumnsType };
+export type OnChangeFunction<RecordType> =
+  AntTableProps<RecordType>['onChange'];
+
 const defaultRowSelection: React.Key[] = [];
 
 const PAGINATION_HEIGHT = 40;
 const HEADER_HEIGHT = 68;
 
-const StyledTable: StyledComponent<any> = styled(AntTable)<any>(
+const StyledTable = styled(AntTable)<{ height?: number }>(
   ({ theme, height }) => `
     .ant-table-body {
       overflow: auto;
@@ -231,11 +178,9 @@ const StyledTable: StyledComponent<any> = styled(AntTable)<any>(
     .ant-pagination-item-active {
       border-color: ${theme.colors.primary.base};
     }
-  }
-`,
+  `,
 );
-
-const StyledVirtualTable: StyledComponent<any> = styled(VirtualTable)<any>(
+const StyledVirtualTable = styled(VirtualTable)(
   ({ theme }) => `
   .virtual-table .ant-table-container:before,
   .virtual-table .ant-table-container:after {
@@ -277,7 +222,9 @@ selectionMap[SelectionType.MULTI] = 'checkbox';
 selectionMap[SelectionType.SINGLE] = 'radio';
 selectionMap[SelectionType.DISABLED] = null;
 
-export function Table(props: TableProps) {
+export function Table<RecordType extends object>(
+  props: TableProps<RecordType>,
+) {
   const {
     data,
     columns,
@@ -304,7 +251,9 @@ export function Table(props: TableProps) {
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const [derivedColumns, setDerivedColumns] = useState(columns);
   const [pageSize, setPageSize] = useState(defaultPageSize);
-  const [mergedLocale, setMergedLocale] = useState({ ...defaultLocale });
+  const [mergedLocale, setMergedLocale] = useState<
+    Required<AntTableProps<RecordType>>['locale']
+  >({ ...defaultLocale });
   const [selectedRowKeys, setSelectedRowKeys] =
     useState<React.Key[]>(selectedRows);
   const interactiveTableUtils = useRef<InteractiveTableUtils | null>(null);
@@ -387,7 +336,7 @@ export function Table(props: TableProps) {
 
   const theme = useTheme();
 
-  const paginationSettings: IPaginationOptions | false = usePagination
+  const paginationSettings: PaginationProps | false = usePagination
     ? {
         hideOnSinglePage: true,
         pageSize,
@@ -420,7 +369,7 @@ export function Table(props: TableProps) {
     loading: { spinning: loading ?? false, indicator: <Loading /> },
     hasData: hideData ? false : data,
     columns: derivedColumns,
-    dataSource: hideData ? [undefined] : data,
+    dataSource: hideData ? undefined : data,
     size,
     pagination: paginationSettings,
     locale: mergedLocale,

--- a/superset-frontend/src/components/Table/index.tsx
+++ b/superset-frontend/src/components/Table/index.tsx
@@ -73,7 +73,7 @@ export interface TableProps<RecordType> {
    */
   size: TableSize;
   /**
-   * Adjusts the padding around elements for different amounts of spacing between elements.
+   * Controls if table rows are selectable and if multiple select is supported.
    */
   selectionType?: SelectionType;
   /*

--- a/superset-frontend/src/components/Table/index.tsx
+++ b/superset-frontend/src/components/Table/index.tsx
@@ -18,7 +18,6 @@
  */
 import React, { useState, useEffect, useRef, ReactElement } from 'react';
 import AntTable, {
-  ColumnType,
   ColumnsType,
   TableProps as AntTableProps,
 } from 'antd/lib/table';
@@ -38,12 +37,6 @@ export enum SelectionType {
 }
 
 export type SortOrder = 'descend' | 'ascend' | null;
-export interface SorterResult<RecordType> {
-  column?: ColumnType<RecordType>;
-  order?: SortOrder;
-  field?: React.Key | React.Key[];
-  columnKey?: React.Key;
-}
 
 export enum ETableAction {
   PAGINATE = 'paginate',
@@ -51,11 +44,20 @@ export enum ETableAction {
   FILTER = 'filter',
 }
 
+export { ColumnsType };
+export type OnChangeFunction<RecordType> =
+  AntTableProps<RecordType>['onChange'];
+
+export enum TableSize {
+  SMALL = 'small',
+  MIDDLE = 'middle',
+}
+
 export interface TableProps<RecordType> {
   /**
    * Data that will populate the each row and map to the column key.
    */
-  data: object[];
+  data: RecordType[];
   /**
    * Table column definitions.
    */
@@ -67,7 +69,7 @@ export interface TableProps<RecordType> {
   /**
    * Callback function invoked when a row is selected by user.
    */
-  handleRowSelection?: Function;
+  handleRowSelection?: (newSelectedRowKeys: React.Key[]) => void;
   /**
    * Controls the size of the table.
    */
@@ -134,21 +136,12 @@ export interface TableProps<RecordType> {
   /**
    * Invoked when the tables sorting, paging, or filtering is changed.
    */
-  onChange?: AntTableProps<RecordType>['onChange'];
+  onChange?: OnChangeFunction<RecordType>;
   /**
    * Returns props that should be applied to each row component.
    */
   onRow?: AntTableProps<RecordType>['onRow'];
 }
-
-export enum TableSize {
-  SMALL = 'small',
-  MIDDLE = 'middle',
-}
-
-export { ColumnsType };
-export type OnChangeFunction<RecordType> =
-  AntTableProps<RecordType>['onChange'];
 
 const defaultRowSelection: React.Key[] = [];
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR resolves some typing and props issues in the Table component:
- Removes some unused type/interface definitions and type annotations
- Imports some types directly from AntD rather than redefining them
- Removes uses of `any`
- Makes the `Table` component type and its corresponding `TableProps` interface generic, requiring the `RecordType` type variable.  This makes `Table` more compatible with the AntD components/types it extends.
- Stops `TableProps` from inheriting from its AntD counterpart.  Our `Table` component only knows how to handle a subset of the properties in the AntD `TableProps`, but it currently accepts every prop defined in AntD `TableProps`.
- Fixes support for the `onRow` prop, which is described in Storybook but isn't currently working.
- Updates imports so we're only importing things that are exposed in `antd/lib/table`, `antd/lib/config-provider`, and `antd/lib/pagination`
- Fixes the jsdoc for the `selectionType` prop

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- There should be no user-facing changes
- Check that Storybook "Actions" tab now registers actions

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
