### PR TITLE
fix(cache): remove unused webserver config & handle trailing slashes

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -154,10 +154,6 @@ FILTER_SELECT_ROW_LIMIT = 10000
 # values may be "Last day", "Last week", "<ISO date> : now", etc.
 DEFAULT_TIME_FILTER = NO_TIME_RANGE
 
-SUPERSET_WEBSERVER_PROTOCOL = "http"
-SUPERSET_WEBSERVER_ADDRESS = "0.0.0.0"
-SUPERSET_WEBSERVER_PORT = 8088
-
 # This is an important setting, and should be lower than your
 # [load balancer / proxy / envoy / kong / ...] timeout settings.
 # You should also make sure to configure your WSGI server

--- a/superset/tasks/cache.py
+++ b/superset/tasks/cache.py
@@ -32,6 +32,7 @@ from superset.models.slice import Slice
 from superset.tags.models import Tag, TaggedObject
 from superset.utils.date_parser import parse_human_datetime
 from superset.utils.machine_auth import MachineAuthProvider
+from superset.utils.urls import get_url_path
 
 logger = get_task_logger(__name__)
 logger.setLevel(logging.INFO)
@@ -233,8 +234,7 @@ def fetch_url(data: str, headers: dict[str, str]) -> dict[str, str]:
     """
     result = {}
     try:
-        baseurl = app.config["WEBDRIVER_BASEURL"]
-        url = f"{baseurl}api/v1/chart/warm_up_cache"
+        url = get_url_path("Superset.warm_up_cache")
         logger.info("Fetching %s with payload %s", url, data)
         req = request.Request(
             url, data=bytes(data, "utf-8"), headers=headers, method="PUT"

--- a/tests/integration_tests/superset_test_config.py
+++ b/tests/integration_tests/superset_test_config.py
@@ -36,7 +36,6 @@ SQLALCHEMY_DATABASE_URI = "sqlite:///" + os.path.join(
     DATA_DIR, "unittests.integration_tests.db"
 )
 DEBUG = False
-SUPERSET_WEBSERVER_PORT = 8081
 SILENCE_FAB = False
 # Allowing SQLALCHEMY_DATABASE_URI and SQLALCHEMY_EXAMPLES_URI to be defined as an env vars for
 # continuous integration

--- a/tests/integration_tests/superset_test_config_thumbnails.py
+++ b/tests/integration_tests/superset_test_config_thumbnails.py
@@ -24,7 +24,6 @@ SQLALCHEMY_DATABASE_URI = "sqlite:///" + os.path.join(
     DATA_DIR, "unittests.integration_tests.db"
 )
 DEBUG = True
-SUPERSET_WEBSERVER_PORT = 8081
 
 # Allowing SQLALCHEMY_DATABASE_URI to be defined as an env var for
 # continuous integration

--- a/tests/integration_tests/tasks/test_cache.py
+++ b/tests/integration_tests/tasks/test_cache.py
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from unittest import mock
+
+import pytest
+
+from tests.integration_tests.test_app import app
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "http://base-url",
+        "http://base-url/",
+    ],
+    ids=["Without trailing slash", "With trailing slash"],
+)
+@mock.patch("superset.tasks.cache.request.Request")
+@mock.patch("superset.tasks.cache.request.urlopen")
+def test_fetch_url(mock_urlopen, mock_request_cls, base_url):
+    from superset.tasks.cache import fetch_url
+
+    mock_request = mock.MagicMock()
+    mock_request_cls.return_value = mock_request
+
+    mock_urlopen.return_value = mock.MagicMock()
+    mock_urlopen.return_value.code = 200
+
+    app.config["WEBDRIVER_BASEURL"] = base_url
+    headers = {"key": "value"}
+    data = "data"
+    data_encoded = b"data"
+
+    result = fetch_url(data, headers)
+
+    assert data == result["success"]
+    mock_request_cls.assert_called_once_with(
+        "http://base-url/superset/warm_up_cache/",
+        data=data_encoded,
+        headers=headers,
+        method="PUT",
+    )
+    # assert the same Request object is used
+    mock_urlopen.assert_called_once_with(mock_request, timeout=mock.ANY)


### PR DESCRIPTION
### SUMMARY

Values for `WEBDRIVER_BASEURL` must end with a slash for the cache warmup to work. Our mdx files sometimes show example values without a trailing slash, which is quite confusing. We can adapt the `fetch_url` task to handle either case (trailing or non-trailing slash) by using our existing util function `get_url_path(...)`.

Related to this (`WEBDRIVER_BASEURL`): We stopped using `SUPERSET_WEBSERVER_PROTOCOL`, `SUPERSET_WEBSERVER_ADDRESS`, `SUPERSET_WEBSERVER_PORT` with https://github.com/apache/superset/pull/21076. I'm removing the keys from the base config as there does not seem to be any immediate need for them: We already have `WEBDRIVER_BASEURL` (and the `_USER_FRIENDLY` variant), which are in use all over the project.

### TESTING

Added an integration test to ensure the URL is generated correctly.

Full-text search for the deleted config keys :)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
