### PR TITLE
fix(sqllab): ignore schema validate while loading

### DIFF
--- a/superset-frontend/src/SqlLab/hooks/useQueryEditor/index.ts
+++ b/superset-frontend/src/SqlLab/hooks/useQueryEditor/index.ts
@@ -59,7 +59,12 @@ export default function useQueryEditor<T extends keyof QueryEditor>(
     [schemaOptions],
   );
 
-  if ('schema' in queryEditor && schema && !schemaOptionsMap.has(schema)) {
+  if (
+    'schema' in queryEditor &&
+    schemaOptions &&
+    schema &&
+    !schemaOptionsMap.has(schema)
+  ) {
     delete queryEditor.schema;
   }
 

--- a/superset-frontend/src/SqlLab/hooks/useQueryEditor/useQueryEditor.test.ts
+++ b/superset-frontend/src/SqlLab/hooks/useQueryEditor/useQueryEditor.test.ts
@@ -116,3 +116,28 @@ test('skips the deprecated schema option', () => {
   expect(result.current.schema).not.toEqual(defaultQueryEditor.schema);
   expect(result.current.schema).toBeUndefined();
 });
+
+test('skips the deprecated schema option before loaded', () => {
+  const { result } = renderHook(
+    () => useQueryEditor(defaultQueryEditor.id, ['schema']),
+    {
+      wrapper: createWrapper({
+        useRedux: true,
+        store: mockStore({
+          ...initialState,
+          sqlLab: {
+            ...initialState.sqlLab,
+            queryEditors: [
+              {
+                id: defaultQueryEditor.id,
+                schema: defaultQueryEditor.schema,
+              },
+            ],
+          },
+        }),
+      }),
+    },
+  );
+  expect(result.current.schema).toEqual(defaultQueryEditor.schema);
+  expect(result.current.schema).not.toBeUndefined();
+});


### PR DESCRIPTION
### SUMMARY
This commit fixes the side effect of #22695.

The initial selected schema option has gone because the schema validator checks the existence with the empty schemaOptions before loaded.
This commit skips the validation before loaded.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://user-images.githubusercontent.com/1392866/214704441-f2cc74f0-8c84-41b1-ab6b-c6ad442548a0.mov

After:

https://user-images.githubusercontent.com/1392866/214704435-c7b557dd-c575-46dd-aa3f-9dcd03e45095.mov

### TESTING INSTRUCTIONS
disable "SQLLAB_BACKEND_PERSISTENCE"
select a schema and open a new tab
check the schema preassigned from the above the schema selection


### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
