### PR TITLE
fix(sqllab): reverts #22695

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -128,22 +128,10 @@ export function getUpToDateQuery(rootState, queryEditor, key) {
     sqlLab: { unsavedQueryEditor },
   } = rootState;
   const id = key ?? queryEditor.id;
-  const updatedQueryEditor = {
+  return {
     ...queryEditor,
     ...(id === unsavedQueryEditor.id && unsavedQueryEditor),
   };
-
-  if (
-    'schema' in updatedQueryEditor &&
-    !updatedQueryEditor.schemaOptions?.find(
-      ({ value }) => value === updatedQueryEditor.schema,
-    )
-  ) {
-    // remove the deprecated schema option
-    delete updatedQueryEditor.schema;
-  }
-
-  return updatedQueryEditor;
 }
 
 export function resetState() {

--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.js
@@ -316,54 +316,6 @@ describe('async actions', () => {
     });
   });
 
-  describe('getUpToDateQuery', () => {
-    const id = 'randomidvalue2';
-    const unsavedQueryEditor = {
-      id,
-      sql: 'some query here',
-      schemaOptions: [{ value: 'testSchema' }, { value: 'schema2' }],
-    };
-
-    it('returns payload with the updated queryEditor', () => {
-      const queryEditor = {
-        id,
-        name: 'Dummy query editor',
-        schema: 'testSchema',
-      };
-      const state = {
-        sqlLab: {
-          tabHistory: [id],
-          queryEditors: [queryEditor],
-          unsavedQueryEditor,
-        },
-      };
-      expect(actions.getUpToDateQuery(state, queryEditor)).toEqual({
-        ...queryEditor,
-        ...unsavedQueryEditor,
-      });
-    });
-
-    it('ignores the deprecated schema option', () => {
-      const queryEditor = {
-        id,
-        name: 'Dummy query editor',
-        schema: 'oldSchema',
-      };
-      const state = {
-        sqlLab: {
-          tabHistory: [id],
-          queryEditors: [queryEditor],
-          unsavedQueryEditor,
-        },
-      };
-      expect(actions.getUpToDateQuery(state, queryEditor)).toEqual({
-        ...queryEditor,
-        ...unsavedQueryEditor,
-        schema: undefined,
-      });
-    });
-  });
-
   describe('postStopQuery', () => {
     const stopQueryEndpoint = 'glob:*/api/v1/query/stop';
     fetchMock.post(stopQueryEndpoint, {});

--- a/superset-frontend/src/SqlLab/components/ShareSqlLabQuery/ShareSqlLabQuery.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ShareSqlLabQuery/ShareSqlLabQuery.test.tsx
@@ -43,7 +43,6 @@ const mockQueryEditor = {
   autorun: false,
   sql: 'SELECT * FROM ...',
   remoteId: 999,
-  schemaOptions: [{ value: 'query_schema' }, { value: 'query_schema_updated' }],
 };
 const disabled = {
   id: 'disabledEditorId',
@@ -83,7 +82,6 @@ const standardProviderWithUnsaved: React.FC = ({ children }) => (
         ...initialState,
         sqlLab: {
           ...initialState.sqlLab,
-          queryEditors: [mockQueryEditor],
           unsavedQueryEditor,
         },
       })}
@@ -125,7 +123,7 @@ describe('ShareSqlLabQuery', () => {
         });
       });
       const button = screen.getByRole('button');
-      const { id, remoteId, schemaOptions, ...expected } = mockQueryEditor;
+      const { id, remoteId, ...expected } = mockQueryEditor;
       const storeQuerySpy = jest.spyOn(utils, 'storeQuery');
       userEvent.click(button);
       expect(storeQuerySpy.mock.calls).toHaveLength(1);

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
@@ -117,6 +117,7 @@ const SqlEditorLeftBar = ({
 }: SqlEditorLeftBarProps) => {
   const dispatch = useDispatch();
   const queryEditor = useQueryEditor(queryEditorId, ['dbId', 'schema']);
+
   const [emptyResultsWithSearch, setEmptyResultsWithSearch] = useState(false);
   const [userSelectedDb, setUserSelected] = useState<DatabaseObject | null>(
     null,

--- a/superset-frontend/src/SqlLab/hooks/useQueryEditor/index.ts
+++ b/superset-frontend/src/SqlLab/hooks/useQueryEditor/index.ts
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useMemo } from 'react';
 import pick from 'lodash/pick';
 import { shallowEqual, useSelector } from 'react-redux';
 import { SqlLabRootState, QueryEditor } from 'src/SqlLab/types';
@@ -25,10 +24,7 @@ export default function useQueryEditor<T extends keyof QueryEditor>(
   sqlEditorId: string,
   attributes: ReadonlyArray<T>,
 ) {
-  const queryEditor = useSelector<
-    SqlLabRootState,
-    Pick<QueryEditor, T | 'id' | 'schema'>
-  >(
+  return useSelector<SqlLabRootState, Pick<QueryEditor, T | 'id'>>(
     ({ sqlLab: { unsavedQueryEditor, queryEditors } }) =>
       pick(
         {
@@ -36,32 +32,7 @@ export default function useQueryEditor<T extends keyof QueryEditor>(
           ...(sqlEditorId === unsavedQueryEditor.id && unsavedQueryEditor),
         },
         ['id'].concat(attributes),
-      ) as Pick<QueryEditor, T | 'id' | 'schema'>,
+      ) as Pick<QueryEditor, T | 'id'>,
     shallowEqual,
   );
-  const { schema, schemaOptions } = useSelector<
-    SqlLabRootState,
-    Pick<QueryEditor, 'schema' | 'schemaOptions'>
-  >(
-    ({ sqlLab: { unsavedQueryEditor, queryEditors } }) =>
-      pick(
-        {
-          ...queryEditors.find(({ id }) => id === sqlEditorId),
-          ...(sqlEditorId === unsavedQueryEditor.id && unsavedQueryEditor),
-        },
-        ['schema', 'schemaOptions'],
-      ) as Pick<QueryEditor, T | 'schema' | 'schemaOptions'>,
-    shallowEqual,
-  );
-
-  const schemaOptionsMap = useMemo(
-    () => new Set(schemaOptions?.map(({ value }) => value)),
-    [schemaOptions],
-  );
-
-  if ('schema' in queryEditor && schema && !schemaOptionsMap.has(schema)) {
-    delete queryEditor.schema;
-  }
-
-  return queryEditor as Pick<QueryEditor, T | 'id'>;
 }

--- a/superset-frontend/src/SqlLab/hooks/useQueryEditor/useQueryEditor.test.ts
+++ b/superset-frontend/src/SqlLab/hooks/useQueryEditor/useQueryEditor.test.ts
@@ -70,7 +70,7 @@ test('includes id implicitly', () => {
 test('returns updated values from unsaved change', () => {
   const expectedSql = 'SELECT updated_column\nFROM updated_table\nWHERE';
   const { result } = renderHook(
-    () => useQueryEditor(defaultQueryEditor.id, ['id', 'sql', 'schema']),
+    () => useQueryEditor(defaultQueryEditor.id, ['id', 'sql']),
     {
       wrapper: createWrapper({
         useRedux: true,
@@ -88,31 +88,5 @@ test('returns updated values from unsaved change', () => {
     },
   );
   expect(result.current.id).toEqual(defaultQueryEditor.id);
-  expect(result.current.schema).toEqual(defaultQueryEditor.schema);
   expect(result.current.sql).toEqual(expectedSql);
-});
-
-test('skips the deprecated schema option', () => {
-  const expectedSql = 'SELECT updated_column\nFROM updated_table\nWHERE';
-  const { result } = renderHook(
-    () => useQueryEditor(defaultQueryEditor.id, ['schema']),
-    {
-      wrapper: createWrapper({
-        useRedux: true,
-        store: mockStore({
-          ...initialState,
-          sqlLab: {
-            ...initialState.sqlLab,
-            unsavedQueryEditor: {
-              id: defaultQueryEditor.id,
-              sql: expectedSql,
-              schema: 'deprecated schema',
-            },
-          },
-        }),
-      }),
-    },
-  );
-  expect(result.current.schema).not.toEqual(defaultQueryEditor.schema);
-  expect(result.current.schema).toBeUndefined();
 });

--- a/superset-frontend/src/SqlLab/types.ts
+++ b/superset-frontend/src/SqlLab/types.ts
@@ -35,7 +35,7 @@ export interface QueryEditor {
   id: string;
   dbId?: number;
   name: string;
-  schema?: string;
+  schema: string;
   autorun: boolean;
   sql: string;
   remoteId: number | null;


### PR DESCRIPTION
### SUMMARY
This reverts commit d591cc80820c57c54e0e1f7e269527af2ac3c37b.


The initial selected schema option has gone because the schema validator checks the existence with the empty schemaOptions before loaded.
This commit reverts #22695 and will create new PR for appropriate solution.
Before:

https://user-images.githubusercontent.com/1392866/214704441-f2cc74f0-8c84-41b1-ab6b-c6ad442548a0.mov

After:

https://user-images.githubusercontent.com/1392866/214704435-c7b557dd-c575-46dd-aa3f-9dcd03e45095.mov

### TESTING INSTRUCTIONS
disable "SQLLAB_BACKEND_PERSISTENCE"
select a schema and open a new tab
check the schema preassigned from the above the schema selection

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
