### PR TITLE
fix(explore): Fix the test on AnnotationLayer

### DIFF
--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
@@ -334,7 +334,7 @@ class AnnotationLayer extends React.PureComponent {
                     ...x,
                     data: {
                       ...x.data,
-                      groupby: x.data.groupby.map(column =>
+                      groupby: x.data.groupby?.map(column =>
                         getColumnLabel(column),
                       ),
                     },


### PR DESCRIPTION
### SUMMARY
This commit fixes the test regression due to #22453

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

- Before

```
/home/runner/work/superset/superset/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.test.tsx:159
  expect(await _testingLibrary.screen.findByText('Chart')).toBeInTheDocument();
```

- After

None

### TESTING INSTRUCTIONS
CI

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
