### PR TITLE
fix: edit pyarrow stringify to better handle emojis and accents

### DIFF
--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -70,9 +70,14 @@ def stringify_values(array: NDArray[Any]) -> NDArray[Any]:
         for obj in it:
             if na_obj := pd.isna(obj):
                 # pandas <NA> type cannot be converted to string
-                obj[na_obj] = None  # type: ignore
+                obj[na_obj] = None
             else:
-                obj[...] = stringify(obj)  # type: ignore
+                try:
+                    # for simple string conversions
+                    # this handles odd character types better
+                    obj[...] = obj.astype(str)
+                except ValueError:
+                    obj[...] = stringify(obj)
 
     return result
 

--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -70,14 +70,14 @@ def stringify_values(array: NDArray[Any]) -> NDArray[Any]:
         for obj in it:
             if na_obj := pd.isna(obj):
                 # pandas <NA> type cannot be converted to string
-                obj[na_obj] = None
+                obj[na_obj] = None  # type: ignore
             else:
                 try:
                     # for simple string conversions
                     # this handles odd character types better
-                    obj[...] = obj.astype(str)
+                    obj[...] = obj.astype(str)  # type: ignore
                 except ValueError:
-                    obj[...] = stringify(obj)
+                    obj[...] = stringify(obj)  # type: ignore
 
     return result
 

--- a/superset/utils/pandas_postprocessing/boxplot.py
+++ b/superset/utils/pandas_postprocessing/boxplot.py
@@ -57,10 +57,10 @@ def boxplot(
     """
 
     def quartile1(series: Series) -> float:
-        return np.nanpercentile(series, 25, interpolation="midpoint")
+        return np.nanpercentile(series, 25, method="midpoint")
 
     def quartile3(series: Series) -> float:
-        return np.nanpercentile(series, 75, interpolation="midpoint")
+        return np.nanpercentile(series, 75, method="midpoint")
 
     if whisker_type == PostProcessingBoxplotWhiskerType.TUKEY:
 
@@ -99,8 +99,8 @@ def boxplot(
             return np.nanpercentile(series, low)
 
     else:
-        whisker_high = np.max
-        whisker_low = np.min
+        whisker_high = np.max  # type: ignore
+        whisker_low = np.min  # type: ignore
 
     def outliers(series: Series) -> Set[float]:
         above = series[series > whisker_high(series)]

--- a/superset/utils/pandas_postprocessing/boxplot.py
+++ b/superset/utils/pandas_postprocessing/boxplot.py
@@ -57,10 +57,10 @@ def boxplot(
     """
 
     def quartile1(series: Series) -> float:
-        return np.nanpercentile(series, 25, interpolation="midpoint")  # type: ignore
+        return np.nanpercentile(series, 25, interpolation="midpoint")
 
     def quartile3(series: Series) -> float:
-        return np.nanpercentile(series, 75, interpolation="midpoint")  # type: ignore
+        return np.nanpercentile(series, 75, interpolation="midpoint")
 
     if whisker_type == PostProcessingBoxplotWhiskerType.TUKEY:
 
@@ -99,8 +99,8 @@ def boxplot(
             return np.nanpercentile(series, low)
 
     else:
-        whisker_high = np.max  # type: ignore
-        whisker_low = np.min  # type: ignore
+        whisker_high = np.max
+        whisker_low = np.min
 
     def outliers(series: Series) -> Set[float]:
         above = series[series > whisker_high(series)]

--- a/superset/utils/pandas_postprocessing/flatten.py
+++ b/superset/utils/pandas_postprocessing/flatten.py
@@ -85,7 +85,7 @@ def flatten(
         _columns = []
         for series in df.columns.to_flat_index():
             _cells = []
-            for cell in series if is_sequence(series) else [series]:  # type: ignore
+            for cell in series if is_sequence(series) else [series]:
                 if pd.notnull(cell):
                     # every cell should be converted to string and escape comma
                     _cells.append(escape_separator(str(cell)))

--- a/superset/utils/pandas_postprocessing/flatten.py
+++ b/superset/utils/pandas_postprocessing/flatten.py
@@ -85,7 +85,7 @@ def flatten(
         _columns = []
         for series in df.columns.to_flat_index():
             _cells = []
-            for cell in series if is_sequence(series) else [series]:
+            for cell in series if is_sequence(series) else [series]:  # type: ignore
                 if pd.notnull(cell):
                     # every cell should be converted to string and escape comma
                     _cells.append(escape_separator(str(cell)))

--- a/tests/integration_tests/result_set_tests.py
+++ b/tests/integration_tests/result_set_tests.py
@@ -169,13 +169,13 @@ class TestSupersetResultSet(SupersetTestCase):
                     "id": 4,
                     "dict_arr": '[{"table_name": "unicode_test", "database_id": 1}]',
                     "num_arr": "[1, 2, 3]",
-                    "map_col": '{"chart_name": "scatter"}',
+                    "map_col": "{'chart_name': 'scatter'}",
                 },
                 {
                     "id": 3,
                     "dict_arr": '[{"table_name": "birth_names", "database_id": 1}]',
                     "num_arr": "[4, 5, 6]",
-                    "map_col": '{"chart_name": "plot"}',
+                    "map_col": "{'chart_name': 'plot'}",
                 },
             ],
         )

--- a/tests/unit_tests/dataframe_test.py
+++ b/tests/unit_tests/dataframe_test.py
@@ -55,7 +55,87 @@ def test_df_to_records_NaT_type() -> None:
 
     assert df_to_records(df) == [
         {"date": None},
-        {"date": '"2023-01-06T20:50:31.749000+00:00"'},
+        {"date": "2023-01-06 20:50:31.749000+00:00"},
+    ]
+
+
+def test_df_to_records_mixed_emoji_type() -> None:
+    from superset.db_engine_specs import BaseEngineSpec
+    from superset.result_set import SupersetResultSet
+
+    data = [
+        ("What's up?", "This is a string text", 1),
+        ("What's up?", "This is a string with an 😍 added", 2),
+        ("What's up?", NaT, 3),
+        ("What's up?", "Last emoji 😁", 4),
+    ]
+
+    cursor_descr: DbapiDescription = [
+        ("question", "varchar", None, None, None, None, False),
+        ("response", "varchar", None, None, None, None, False),
+        ("count", "integer", None, None, None, None, False),
+    ]
+
+    results = SupersetResultSet(data, cursor_descr, BaseEngineSpec)
+    df = results.to_pandas_df()
+
+    assert df_to_records(df) == [
+        {"question": "What's up?", "response": "This is a string text", "count": 1},
+        {
+            "question": "What's up?",
+            "response": "This is a string with an 😍 added",
+            "count": 2,
+        },
+        {
+            "question": "What's up?",
+            "response": None,
+            "count": 3,
+        },
+        {
+            "question": "What's up?",
+            "response": "Last emoji 😁",
+            "count": 4,
+        },
+    ]
+
+
+def test_df_to_records_mixed_accent_type() -> None:
+    from superset.db_engine_specs import BaseEngineSpec
+    from superset.result_set import SupersetResultSet
+
+    data = [
+        ("What's up?", "This is a string text", 1),
+        ("What's up?", "This is a string with áccent", 2),
+        ("What's up?", NaT, 3),
+        ("What's up?", "móre áccent", 4),
+    ]
+
+    cursor_descr: DbapiDescription = [
+        ("question", "varchar", None, None, None, None, False),
+        ("response", "varchar", None, None, None, None, False),
+        ("count", "integer", None, None, None, None, False),
+    ]
+
+    results = SupersetResultSet(data, cursor_descr, BaseEngineSpec)
+    df = results.to_pandas_df()
+
+    assert df_to_records(df) == [
+        {"question": "What's up?", "response": "This is a string text", "count": 1},
+        {
+            "question": "What's up?",
+            "response": "This is a string with áccent",
+            "count": 2,
+        },
+        {
+            "question": "What's up?",
+            "response": None,
+            "count": 3,
+        },
+        {
+            "question": "What's up?",
+            "response": "móre áccent",
+            "count": 4,
+        },
     ]
 
 

--- a/tests/unit_tests/result_set_test.py
+++ b/tests/unit_tests/result_set_test.py
@@ -98,10 +98,10 @@ def test_stringify_with_null_integers():
 
     expected = np.array(
         [
-            array(['"foo"', '"foo"', '"foo"'], dtype=object),
-            array(['"bar"', '"bar"', '"bar"'], dtype=object),
+            array(["foo", "foo", "foo"], dtype=object),
+            array(["bar", "bar", "bar"], dtype=object),
             array([None, None, None], dtype=object),
-            array([None, "true", None], dtype=object),
+            array([None, "True", None], dtype=object),
         ]
     )
 
@@ -132,10 +132,10 @@ def test_stringify_with_null_timestamps():
 
     expected = np.array(
         [
-            array(['"foo"', '"foo"', '"foo"'], dtype=object),
-            array(['"bar"', '"bar"', '"bar"'], dtype=object),
+            array(["foo", "foo", "foo"], dtype=object),
+            array(["bar", "bar", "bar"], dtype=object),
             array([None, None, None], dtype=object),
-            array([None, "true", None], dtype=object),
+            array([None, "True", None], dtype=object),
         ]
     )
 


### PR DESCRIPTION
### SUMMARY
similar to https://github.com/apache/superset/pull/22628, pyathena values for emojis and accents when there are null values are not being parsed correctly. This changes the stringify function to use a built in pandas method, which solves the issues. 

This PR also fixes some numpy typing errors that are unrelated to this bug, but were failing CI.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="496" alt="Clipboard 2023-25-01 at 7 45 12 PM" src="https://user-images.githubusercontent.com/5186919/214982632-c45a5926-5053-4dcb-9eb4-c048e00d30ee.png">

<img width="504" alt="Clipboard 2023-25-01 at 7 55 39 PM" src="https://user-images.githubusercontent.com/5186919/214982642-88976dda-b032-4639-bf4f-d2dac07bbdb9.png">


After:
emojis with nulls
![_DEV__Superset](https://user-images.githubusercontent.com/5186919/214982460-a44c86a1-5877-424e-8ee7-d8abd04b49f5.png)

accents with nulls
![_DEV__Superset](https://user-images.githubusercontent.com/5186919/214982489-f8dd3d5b-c294-4a04-835a-d2d48c627696.png)


### TESTING INSTRUCTIONS
run a query in pyathena with the pandas connector for a table that has a mix of nulls and accents and/or emojis in the same column

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
