### PR TITLE
fix(explore): unable to update linked charts

### DIFF
--- a/superset/charts/commands/update.py
+++ b/superset/charts/commands/update.py
@@ -105,7 +105,10 @@ class UpdateChartCommand(UpdateMixin, BaseCommand):
 
         # Validate/Populate dashboards only if it's a list
         if dashboard_ids is not None:
-            dashboards = DashboardDAO.find_by_ids(dashboard_ids, skip_base_filter=True)
+            dashboards = DashboardDAO.find_by_ids(
+                dashboard_ids,
+                skip_base_filter=True,
+            )
             if len(dashboards) != len(dashboard_ids):
                 exceptions.append(DashboardsNotFoundValidationError())
             self._properties["dashboards"] = dashboards

--- a/superset/charts/commands/update.py
+++ b/superset/charts/commands/update.py
@@ -105,7 +105,7 @@ class UpdateChartCommand(UpdateMixin, BaseCommand):
 
         # Validate/Populate dashboards only if it's a list
         if dashboard_ids is not None:
-            dashboards = DashboardDAO.find_by_ids(dashboard_ids)
+            dashboards = DashboardDAO.find_by_ids(dashboard_ids, skip_base_filter=True)
             if len(dashboards) != len(dashboard_ids):
                 exceptions.append(DashboardsNotFoundValidationError())
             self._properties["dashboards"] = dashboards

--- a/superset/dao/base.py
+++ b/superset/dao/base.py
@@ -73,16 +73,22 @@ class BaseDAO:
             return None
 
     @classmethod
-    def find_by_ids(cls, model_ids: Union[List[str], List[int]]) -> List[Model]:
+    def find_by_ids(
+        cls,
+        model_ids: Union[List[str], List[int]],
+        session: Session = None,
+        skip_base_filter: bool = False,
+    ) -> List[Model]:
         """
         Find a List of models by a list of ids, if defined applies `base_filter`
         """
         id_col = getattr(cls.model_cls, cls.id_column_name, None)
         if id_col is None:
             return []
-        query = db.session.query(cls.model_cls).filter(id_col.in_(model_ids))
-        if cls.base_filter:
-            data_model = SQLAInterface(cls.model_cls, db.session)
+        session = session or db.session
+        query = session.query(cls.model_cls).filter(id_col.in_(model_ids))
+        if cls.base_filter and not skip_base_filter:
+            data_model = SQLAInterface(cls.model_cls, session)
             query = cls.base_filter(  # pylint: disable=not-callable
                 cls.id_column_name, data_model
             ).apply(query, None)

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -692,6 +692,61 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         db.session.delete(user_alpha2)
         db.session.commit()
 
+    def test_update_chart_linked_with_not_owned_dashboard(self):
+        """
+        Chart API: Test update chart which is linked to not owned dashboard
+        """
+        user_alpha1 = self.create_user(
+            "alpha1", "password", "Alpha", email="alpha1@superset.org"
+        )
+        user_alpha2 = self.create_user(
+            "alpha2", "password", "Alpha", email="alpha2@superset.org"
+        )
+        chart = self.insert_chart("title", [user_alpha1.id], 1)
+
+        original_dashboard = Dashboard()
+        original_dashboard.dashboard_title = "Original Dashboard"
+        original_dashboard.slug = "slug"
+        original_dashboard.owners = [user_alpha1]
+        original_dashboard.slices = [chart]
+        original_dashboard.published = False
+        db.session.add(original_dashboard)
+
+        new_dashboard = Dashboard()
+        new_dashboard.dashboard_title = "Cloned Dashboard"
+        new_dashboard.slug = "new_slug"
+        new_dashboard.owners = [user_alpha2]
+        new_dashboard.slices = [chart]
+        new_dashboard.published = False
+        db.session.add(new_dashboard)
+
+        self.login(username="alpha1", password="password")
+        chart_data_with_invalid_dashboard = {
+            "slice_name": "title1_changed",
+            "dashboards": [original_dashboard.id, 0],
+        }
+        chart_data = {
+            "slice_name": "title1_changed",
+            "dashboards": [original_dashboard.id, new_dashboard.id],
+        }
+        uri = f"api/v1/chart/{chart.id}"
+
+        rv = self.put_assert_metric(uri, chart_data_with_invalid_dashboard, "put")
+        self.assertEqual(rv.status_code, 422)
+        response = json.loads(rv.data.decode("utf-8"))
+        expected_response = {"message": {"dashboards": ["Dashboards do not exist"]}}
+        self.assertEqual(response, expected_response)
+
+        rv = self.put_assert_metric(uri, chart_data, "put")
+        self.assertEqual(rv.status_code, 200)
+
+        db.session.delete(chart)
+        db.session.delete(original_dashboard)
+        db.session.delete(new_dashboard)
+        db.session.delete(user_alpha1)
+        db.session.delete(user_alpha2)
+        db.session.commit()
+
     def test_update_chart_validate_datasource(self):
         """
         Chart API: Test update validate datasource

--- a/tests/unit_tests/datasets/dao/dao_tests.py
+++ b/tests/unit_tests/datasets/dao/dao_tests.py
@@ -71,3 +71,29 @@ def test_datasource_find_by_id_skip_base_filter_not_found(
         skip_base_filter=True,
     )
     assert result is None
+
+def test_datasource_find_by_ids_skip_base_filter(session_with_data: Session) -> None:
+    from superset.connectors.sqla.models import SqlaTable
+    from superset.datasets.dao import DatasetDAO
+
+    result = DatasetDAO.find_by_ids(
+        [1, 125326326],
+        session=session_with_data,
+        skip_base_filter=True,
+    )
+
+    assert result
+    assert [1] == map(lambda x: x.id, result)
+    assert ["my_sqla_table"] == map(lambda x: x.table_name, result)
+    assert isinstance(result[0], SqlaTable)
+
+def test_datasource_find_by_ids_skip_base_filter(session_with_data: Session) -> None:
+    from superset.datasets.dao import DatasetDAO
+
+    result = DatasetDAO.find_by_ids(
+        [125326326, 125326326125326326],
+        session=session_with_data,
+        skip_base_filter=True,
+    )
+
+    assert len(result) == 0

--- a/tests/unit_tests/datasets/dao/dao_tests.py
+++ b/tests/unit_tests/datasets/dao/dao_tests.py
@@ -83,8 +83,8 @@ def test_datasource_find_by_ids_skip_base_filter(session_with_data: Session) -> 
     )
 
     assert result
-    assert [1] == map(lambda x: x.id, result)
-    assert ["my_sqla_table"] == map(lambda x: x.table_name, result)
+    assert [1] == list(map(lambda x: x.id, result))
+    assert ["my_sqla_table"] == list(map(lambda x: x.table_name, result))
     assert isinstance(result[0], SqlaTable)
 
 def test_datasource_find_by_ids_skip_base_filter_not_found(session_with_data: Session) -> None:

--- a/tests/unit_tests/datasets/dao/dao_tests.py
+++ b/tests/unit_tests/datasets/dao/dao_tests.py
@@ -72,6 +72,7 @@ def test_datasource_find_by_id_skip_base_filter_not_found(
     )
     assert result is None
 
+
 def test_datasource_find_by_ids_skip_base_filter(session_with_data: Session) -> None:
     from superset.connectors.sqla.models import SqlaTable
     from superset.datasets.dao import DatasetDAO
@@ -87,7 +88,10 @@ def test_datasource_find_by_ids_skip_base_filter(session_with_data: Session) -> 
     assert ["my_sqla_table"] == list(map(lambda x: x.table_name, result))
     assert isinstance(result[0], SqlaTable)
 
-def test_datasource_find_by_ids_skip_base_filter_not_found(session_with_data: Session) -> None:
+
+def test_datasource_find_by_ids_skip_base_filter_not_found(
+    session_with_data: Session,
+) -> None:
     from superset.datasets.dao import DatasetDAO
 
     result = DatasetDAO.find_by_ids(

--- a/tests/unit_tests/datasets/dao/dao_tests.py
+++ b/tests/unit_tests/datasets/dao/dao_tests.py
@@ -87,7 +87,7 @@ def test_datasource_find_by_ids_skip_base_filter(session_with_data: Session) -> 
     assert ["my_sqla_table"] == map(lambda x: x.table_name, result)
     assert isinstance(result[0], SqlaTable)
 
-def test_datasource_find_by_ids_skip_base_filter(session_with_data: Session) -> None:
+def test_datasource_find_by_ids_skip_base_filter_not_found(session_with_data: Session) -> None:
     from superset.datasets.dao import DatasetDAO
 
     result = DatasetDAO.find_by_ids(


### PR DESCRIPTION
### SUMMARY
When any random user clones a dashboard without clone charts, the original owner of the chart cannot update the chart.

<img width="806" alt="Notification_Center" src="https://user-images.githubusercontent.com/1392866/215570499-d3960798-7f11-4d4b-8e29-95170747e5ba.png">

> For example, create a chart and link to two dashboards owned by different users. Set the dashboard who owned by the secondary owner to draft. Update the chart by the primary owner.
> Please see the [test spec](https://github.com/apache/superset/pull/22896/files#diff-8b0aeaa2773ac70adc8318be6818e75848e8da5f6ee05838dda7c92c2ad29ed4R707-R732) for this example

It's caused by the #21497 which starts passing the linked `dashboards` ids and the following validation logic triggered.

https://github.com/apache/superset/blob/7bd2afd724799be2d5ca3edb90c5b95a56609211/superset/charts/commands/update.py#L107-L110

The main problem is base `find_by_ids` applies `base_filter` which excludes the dashboard without ownership under draft status. (see the following logs)

```
superset_app           | SELECT dashboards.uuid AS dashboards_uuid, dashboards.created_on AS dashboards_created_on, dashboards.changed_on AS dashboards_changed_on, dashboards.id AS dashboards_id, dashboards.dashboard_title AS dashboards_dashboard_title, dashboards.position_json AS dashboards_position_json, dashboards.description AS dashboards_description, dashboards.css AS dashboards_css, dashboards.certified_by AS dashboards_certified_by, dashboards.certification_details AS dashboards_certification_details, dashboards.json_metadata AS dashboards_json_metadata, dashboards.slug AS dashboards_slug, dashboards.published AS dashboards_published, dashboards.is_managed_externally AS dashboards_is_managed_externally, dashboards.external_url AS dashboards_external_url, dashboards.created_by_fk AS dashboards_created_by_fk, dashboards.changed_by_fk AS dashboards_changed_by_fk
superset_app           | FROM dashboards
superset_app           | WHERE dashboards.id IN (__[POSTCOMPILE_id_1]) AND (dashboards.id IN (SELECT dashboards.id
superset_app           | FROM dashboards JOIN dashboard_user AS dashboard_user_1 ON dashboards.id = dashboard_user_1.dashboard_id JOIN ab_user ON ab_user.id = dashboard_user_1.user_id
superset_app           | WHERE ab_user.id = %(id_2)s) OR dashboards.id IN (SELECT dashboards.id
superset_app           | FROM dashboards LEFT OUTER JOIN (dashboard_slices AS dashboard_slices_1 JOIN slices ON slices.id = dashboard_slices_1.slice_id) ON dashboards.id = dashboard_slices_1.dashboard_id
superset_app           | WHERE dashboards.published IS true AND true) OR dashboards.id IN (SELECT favstar.obj_id
superset_app           | FROM favstar
superset_app           | WHERE favstar.user_id = %(user_id_1)s AND favstar.class_name = %(class_name_1)s))
```

Since the `DashboardsNotFoundValidation` checks the existence, this commit adds the `skip_base_filter` option on find_by_ids as `find_by_id` has and use the option for DashboardsNotFoundValidation.

https://github.com/apache/superset/blob/7bd2afd724799be2d5ca3edb90c5b95a56609211/superset/dao/base.py#L56-L63

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

- Before

https://user-images.githubusercontent.com/1392866/215229495-51c51f7b-0e46-4577-8e7d-7686274c86fa.mov

- After:

https://user-images.githubusercontent.com/1392866/215229482-acf97753-3589-4e92-8eb0-9e347ce7b297.mov


### TESTING INSTRUCTIONS

1. Create a dashboard and a chart
2. Login with a different user
3. Clone the above dashboard without duplicates charts
4. Login with the original user and edit chart

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @ktmud @john-bodley 