### PR TITLE
fix: fix warning in ssh tunnel

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -63,7 +63,7 @@ import {
   ExtraJson,
 } from 'src/views/CRUD/data/database/types';
 import Loading from 'src/components/Loading';
-import { omit } from 'lodash';
+import { pick } from 'lodash';
 import ExtraOptions from './ExtraOptions';
 import SqlAlchemyForm from './SqlAlchemyForm';
 import DatabaseConnectionForm from './DatabaseConnectionForm';
@@ -373,12 +373,25 @@ export function dbReducer(
           [action.payload.name]: action.payload.value,
         },
       };
-    case ActionType.setSSHTunnelLoginMethod:
+    case ActionType.setSSHTunnelLoginMethod: {
+      let ssh_tunnel = {};
+      if (trimmedState?.ssh_tunnel) {
+        // remove any attributes that are considered sensitive
+        ssh_tunnel = pick(trimmedState.ssh_tunnel, [
+          'id',
+          'server_address',
+          'server_port',
+          'username',
+        ]);
+      }
       if (action.payload.login_method === AuthType.privateKey) {
         return {
           ...trimmedState,
           ssh_tunnel: {
-            ...omit(trimmedState?.ssh_tunnel, ['password']),
+            private_key: trimmedState?.ssh_tunnel?.private_key,
+            private_key_password:
+              trimmedState?.ssh_tunnel?.private_key_password,
+            ...ssh_tunnel,
           },
         };
       }
@@ -386,16 +399,15 @@ export function dbReducer(
         return {
           ...trimmedState,
           ssh_tunnel: {
-            ...omit(trimmedState?.ssh_tunnel, [
-              'private_key',
-              'private_key_password',
-            ]),
+            password: trimmedState?.ssh_tunnel?.password,
+            ...ssh_tunnel,
           },
         };
       }
       return {
         ...trimmedState,
       };
+    }
     case ActionType.removeSSHTunnelConfig:
       return {
         ...trimmedState,

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -63,6 +63,7 @@ import {
   ExtraJson,
 } from 'src/views/CRUD/data/database/types';
 import Loading from 'src/components/Loading';
+import { omit } from 'lodash';
 import ExtraOptions from './ExtraOptions';
 import SqlAlchemyForm from './SqlAlchemyForm';
 import DatabaseConnectionForm from './DatabaseConnectionForm';
@@ -374,21 +375,21 @@ export function dbReducer(
       };
     case ActionType.setSSHTunnelLoginMethod:
       if (action.payload.login_method === AuthType.privateKey) {
-        const { password, ...rest } = trimmedState?.ssh_tunnel ?? {};
         return {
           ...trimmedState,
           ssh_tunnel: {
-            ...rest,
+            ...omit(trimmedState?.ssh_tunnel, ['password']),
           },
         };
       }
       if (action.payload.login_method === AuthType.password) {
-        const { private_key, private_key_password, ...rest } =
-          trimmedState?.ssh_tunnel ?? {};
         return {
           ...trimmedState,
           ssh_tunnel: {
-            ...rest,
+            ...omit(trimmedState?.ssh_tunnel, [
+              'private_key',
+              'private_key_password',
+            ]),
           },
         };
       }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

There was a warning where we were deconstructing an object for password and private_key but then not using those variables. The reason behind the deconstruction was so as to not pass those values into the return object. Reformatted using lodash. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
