### PR TITLE
test: Clean up AdhocFilterOption test warnings

### DIFF
--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterOption/AdhocFilterOption.test.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterOption/AdhocFilterOption.test.tsx
@@ -19,13 +19,34 @@
 import React from 'react';
 import { render, screen, waitFor } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
-import { HTML5Backend } from 'react-dnd-html5-backend';
-import { DndProvider } from 'react-dnd';
 import AdhocFilter, {
   EXPRESSION_TYPES,
   CLAUSES,
 } from 'src/explore/components/controls/FilterControl/AdhocFilter';
 import AdhocFilterOption, { AdhocFilterOptionProps } from '.';
+
+jest.mock('src/components/Icons/Icon', () => ({
+  __esModule: true,
+  default: ({
+    fileName,
+    role,
+    iconColor,
+    ...rest
+  }: {
+    fileName: string;
+    role: string;
+    iconColor: string;
+  }) => (
+    <span
+      role={role ?? 'img'}
+      aria-label={fileName.replace('_', '-')}
+      // @ts-ignore
+      iconcolor={iconColor ?? 'green'}
+      {...rest}
+    />
+  ),
+  StyledIcon: () => <span />,
+}));
 
 const simpleAdhocFilter = new AdhocFilter({
   expressionType: EXPRESSION_TYPES.SIMPLE,
@@ -56,36 +77,37 @@ const mockedProps = {
 };
 
 const setup = (props: AdhocFilterOptionProps) => (
-  <DndProvider backend={HTML5Backend}>
-    <AdhocFilterOption {...props} />
-  </DndProvider>
+  <AdhocFilterOption {...props} />
 );
 
 test('should render', async () => {
-  const { container } = render(setup(mockedProps));
+  const { container } = render(setup(mockedProps), {
+    useDnd: true,
+    useRedux: true,
+  });
   await waitFor(() => expect(container).toBeInTheDocument());
 });
 
 test('should render the control label', async () => {
-  render(setup(mockedProps));
+  render(setup(mockedProps), { useDnd: true, useRedux: true });
   expect(await screen.findByText('value > 10')).toBeInTheDocument();
 });
 
 test('should render the remove button', async () => {
-  render(setup(mockedProps));
+  render(setup(mockedProps), { useDnd: true, useRedux: true });
   const removeBtn = await screen.findByRole('button');
   expect(removeBtn).toBeInTheDocument();
 });
 
 test('should render the right caret', async () => {
-  render(setup(mockedProps));
+  render(setup(mockedProps), { useDnd: true, useRedux: true });
   expect(
     await screen.findByRole('img', { name: 'caret-right' }),
   ).toBeInTheDocument();
 });
 
 test('should render the Popover on clicking the right caret', async () => {
-  render(setup(mockedProps));
+  render(setup(mockedProps), { useDnd: true, useRedux: true });
   const rightCaret = await screen.findByRole('img', { name: 'caret-right' });
   userEvent.click(rightCaret);
   expect(screen.getByRole('tooltip')).toBeInTheDocument();

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterOption/AdhocFilterOption.test.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterOption/AdhocFilterOption.test.tsx
@@ -27,23 +27,8 @@ import AdhocFilterOption, { AdhocFilterOptionProps } from '.';
 
 jest.mock('src/components/Icons/Icon', () => ({
   __esModule: true,
-  default: ({
-    fileName,
-    role,
-    iconColor,
-    ...rest
-  }: {
-    fileName: string;
-    role: string;
-    iconColor: string;
-  }) => (
-    <span
-      role={role ?? 'img'}
-      aria-label={fileName.replace('_', '-')}
-      // @ts-ignore
-      iconcolor={iconColor ?? 'green'}
-      {...rest}
-    />
+  default: ({ fileName, role }: { fileName: string; role: string }) => (
+    <span role={role ?? 'img'} aria-label={fileName.replace('_', '-')} />
   ),
   StyledIcon: () => <span />,
 }));


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes 5 warnings in `superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterOption/AdhocFilterOption.test.tsx`. There was one act error and the other four were because the tests needed a redux provider. I also changed the tests to use `useDnd` from Superset's test helper's `render` function instead of wrapping the provider in the setup function.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- cd into `superset-frontend`
- run `npm run test superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterOption/AdhocFilterOption.test.tsx`
- Observe that only one warning is left in the test.
  - There were 6 warnings initially

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
