### PR TITLE
fix: Time range filter applied on a dashboard is not persisting to the chart explore

### DIFF
--- a/superset-frontend/src/explore/controlUtils/getFormDataFromDashboardContext.test.ts
+++ b/superset-frontend/src/explore/controlUtils/getFormDataFromDashboardContext.test.ts
@@ -48,6 +48,14 @@ const getExploreFormData = (overrides: JsonObject = {}) => ({
       sqlExpression: "city = 'Warsaw'",
       filterOptionName: '567',
     },
+    {
+      clause: 'WHERE' as const,
+      expressionType: 'SIMPLE' as const,
+      operator: 'TEMPORAL_RANGE' as const,
+      subject: 'ds',
+      comparator: 'No filter',
+      filterOptionName: '678',
+    },
   ],
   adhoc_filters_b: [
     {
@@ -157,6 +165,14 @@ const getExpectedResultFormData = (overrides: JsonObject = {}) => ({
       comparator: null,
       sqlExpression: "city = 'Warsaw'",
       filterOptionName: '567',
+    },
+    {
+      clause: 'WHERE',
+      expressionType: 'SIMPLE',
+      operator: 'TEMPORAL_RANGE',
+      subject: 'ds',
+      comparator: 'Last month',
+      filterOptionName: expect.any(String),
     },
     {
       clause: 'WHERE',
@@ -279,7 +295,7 @@ const getExpectedResultFormData = (overrides: JsonObject = {}) => ({
   ...overrides,
 });
 
-it('merges dashboard context form data with explore form data', () => {
+test('merges dashboard context form data with explore form data', () => {
   const fullFormData = getFormDataWithDashboardContext(
     getExploreFormData(),
     getDashboardFormData(),


### PR DESCRIPTION
### SUMMARY
Filters applied to the dashboard are carried over to the chart explore when accessing a chart from the dashboard. However, this is not happening for time range filters in case `GENERIC_CHART_AXES` is enabled. This PR fixes this issue.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/215803952-17043a56-0bfc-48c0-9f70-5403f86af68e.mov

https://user-images.githubusercontent.com/70410625/215804010-a31c51fc-cda7-4b31-8d85-a9c69f30801b.mov

### TESTING INSTRUCTIONS
- Make sure that GENERIC_CHART_AXES is enabled.
- Access your Workspace.
- Create a chart and save it to a dashboard.
- Apply a time range filter on the dashboard.
- Access the chart from the dashboard
- Check that the filter is carried over

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
