### PR TITLE
fix: Trino - handle proper exception type in get_create_view

### DIFF
--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -272,3 +272,13 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
         return {
             requests_exceptions.ConnectionError: SupersetDBAPIConnectionError,
         }
+    
+    @classmethod
+    def get_create_view(
+        cls, database: "Database", schema: Optional[str], table: str
+    ) -> Optional[str]:
+        from trino.exceptions import TrinoUserError
+        try:
+            return super(cls, cls).get_create_view(database, schema, table)
+        except TrinoUserError:
+            return None


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

TrinoEngineSpec inherits PrestoBaseEngineSpec while the underlying sqlalchemy engine is throwing a different exception type if the table is not a view.

```
Traceback (most recent call last):
  File "/opt/superset/lib/python3.9/site-packages/flask_appbuilder/api/__init__.py", line 109, in wraps
    return f(self, *args, **kwargs)
  File "/opt/superset/lib/python3.9/site-packages/superset/views/base_api.py", line 113, in wraps
    raise ex
  File "/opt/superset/lib/python3.9/site-packages/superset/views/base_api.py", line 110, in wraps
    duration, response = time_function(f, self, *args, **kwargs)
  File "/opt/superset/lib/python3.9/site-packages/superset/utils/core.py", line 1524, in time_function
    response = func(*args, **kwargs)
  File "/opt/superset/lib/python3.9/site-packages/superset/utils/log.py", line 245, in wrapper
    value = f(*args, **kwargs)
  File "/opt/superset/lib/python3.9/site-packages/superset/databases/api.py", line 601, in table_extra_metadata
    payload = database.db_engine_spec.extra_table_metadata(
  File "/opt/superset/lib/python3.9/site-packages/superset/db_engine_specs/presto.py", line 927, in extra_table_metadata
    Any, cls.get_create_view(database, schema_name, table_name)
  File "/opt/superset/lib/python3.9/site-packages/superset/db_engine_specs/presto.py", line 951, in get_create_view
    cls.execute(cursor, sql)
  File "/opt/superset/lib/python3.9/site-packages/superset/db_engine_specs/base.py", line 1261, in execute
    raise cls.get_dbapi_mapped_exception(ex)
  File "/opt/superset/lib/python3.9/site-packages/superset/db_engine_specs/base.py", line 1259, in execute
    cursor.execute(query)
  File "/opt/superset/lib/python3.9/site-packages/trino/dbapi.py", line 439, in execute
    result = self._query.execute()
  File "/opt/superset/lib/python3.9/site-packages/trino/client.py", line 765, in execute
    self._result.rows += self.fetch()
  File "/opt/superset/lib/python3.9/site-packages/trino/client.py", line 780, in fetch
    status = self._request.process(response)
  File "/opt/superset/lib/python3.9/site-packages/trino/client.py", line 581, in process
    raise self._process_error(response["error"], response.get("id"))
trino.exceptions.TrinoUserError: TrinoUserError(type=USER_ERROR, name=NOT_SUPPORTED, message="line 1:1: Relation 'asdf' is a table, not a view", query_id=20230131_110859_18306_tzku9)
```

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Open "SQL Lab" with Trino connection and browse up to some specific table.
While the table info is loaded well, the error is shown to the user in the bottom right corner.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
