### PR TITLE
fix: Could not remove metrics in Explore

### DIFF
--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricOption.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricOption.jsx
@@ -47,8 +47,7 @@ class AdhocMetricOption extends React.PureComponent {
     this.onRemoveMetric = this.onRemoveMetric.bind(this);
   }
 
-  onRemoveMetric(e) {
-    e.stopPropagation();
+  onRemoveMetric() {
     this.props.onRemoveMetric(this.props.index);
   }
 


### PR DESCRIPTION
### SUMMARY

This PR https://github.com/apache/superset/issues/22707 moved the `stopPropagation` event downstream but wasn't removed upstream causing a bug with removing metrics.

### BEFORE

https://user-images.githubusercontent.com/60598000/216051640-e7c1309e-bd7e-4a08-b155-616dc7b7dca7.mov

### TESTING INSTRUCTIONS
- Run query in SQL lab and create chart OR create a chart from a dataset
- Add metric
- Try to delete it via clicking "x"
- The metric should be deleted successfully

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
