### PR TITLE
fix(native-filters): Ensure that time range filter loses focus after closing modal

### DIFF
--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -248,27 +248,28 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
   function onSave() {
     onChange(timeRangeValue);
     setShow(false);
+    onClosePopover();
   }
 
   function onOpen() {
     setTimeRangeValue(value);
     setFrame(guessedFrame);
     setShow(true);
+    onOpenPopover();
   }
 
   function onHide() {
     setTimeRangeValue(value);
     setFrame(guessedFrame);
     setShow(false);
+    onClosePopover();
   }
 
   const toggleOverlay = () => {
     if (show) {
       onHide();
-      onClosePopover();
     } else {
       onOpen();
-      onOpenPopover();
     }
   };
 

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/tests/DateFilterLabel.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/tests/DateFilterLabel.test.tsx
@@ -31,23 +31,25 @@ import { DATE_FILTER_TEST_KEY } from '../utils';
 
 const mockStore = configureStore([thunk]);
 
+const defaultProps = {
+  onChange: jest.fn(),
+  onClosePopover: jest.fn(),
+  onOpenPopover: jest.fn(),
+};
+
 function setup(
-  props: Omit<DateFilterControlProps, 'name'>,
+  props: Omit<DateFilterControlProps, 'name'> = defaultProps,
   store: any = mockStore({}),
 ) {
   return (
     <Provider store={store}>
-      <DateFilterLabel
-        name="time_range"
-        onChange={props.onChange}
-        overlayStyle={props.overlayStyle}
-      />
+      <DateFilterLabel name="time_range" {...props} />
     </Provider>
   );
 }
 
 test('DateFilter with default props', () => {
-  render(setup({ onChange: () => {} }));
+  render(setup());
   // label
   expect(screen.getByText(NO_TIME_RANGE)).toBeInTheDocument();
 
@@ -58,7 +60,7 @@ test('DateFilter with default props', () => {
   ).toBeInTheDocument();
 });
 
-test('DateFilter shoule be applied the overlayStyle props', () => {
+test('DateFilter should be applied the overlayStyle props', () => {
   render(setup({ onChange: () => {}, overlayStyle: 'Modal' }));
   // should be Modal as overlay
   userEvent.click(screen.getByText(NO_TIME_RANGE));
@@ -67,10 +69,10 @@ test('DateFilter shoule be applied the overlayStyle props', () => {
   ).toBeInTheDocument();
 });
 
-test('DateFilter shoule be applied the global config time_filter from the store', () => {
+test('DateFilter should be applied the global config time_filter from the store', () => {
   render(
     setup(
-      { onChange: () => {} },
+      defaultProps,
       mockStore({
         common: { conf: { DEFAULT_TIME_FILTER: 'Last week' } },
       }),
@@ -83,4 +85,24 @@ test('DateFilter shoule be applied the global config time_filter from the store'
   expect(
     screen.getByTestId(DATE_FILTER_TEST_KEY.commonFrame),
   ).toBeInTheDocument();
+});
+
+test('Open and close popover', () => {
+  render(setup());
+
+  // click "Cancel"
+  userEvent.click(screen.getByText(NO_TIME_RANGE));
+  expect(defaultProps.onOpenPopover).toHaveBeenCalled();
+  expect(screen.getByText('Edit time range')).toBeInTheDocument();
+  userEvent.click(screen.getByText('CANCEL'));
+  expect(defaultProps.onClosePopover).toHaveBeenCalled();
+  expect(screen.queryByText('Edit time range')).not.toBeInTheDocument();
+
+  // click "Apply"
+  userEvent.click(screen.getByText(NO_TIME_RANGE));
+  expect(defaultProps.onOpenPopover).toHaveBeenCalled();
+  expect(screen.getByText('Edit time range')).toBeInTheDocument();
+  userEvent.click(screen.getByText('APPLY'));
+  expect(defaultProps.onClosePopover).toHaveBeenCalled();
+  expect(screen.queryByText('Edit time range')).not.toBeInTheDocument();
 });

--- a/superset-frontend/src/filters/components/Time/TimeFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Time/TimeFilterPlugin.tsx
@@ -97,7 +97,11 @@ export default function TimeFilterPlugin(props: PluginFilterTimeProps) {
           name="time_range"
           onChange={handleTimeRangeChange}
           onOpenPopover={() => setFilterActive(true)}
-          onClosePopover={() => setFilterActive(false)}
+          onClosePopover={() => {
+            setFilterActive(false);
+            unsetHoveredFilter();
+            unsetFocusedFilter();
+          }}
           isOverflowingFilterBar={isOverflowingFilterBar}
         />
       </ControlContainer>


### PR DESCRIPTION
### SUMMARY
When user applied a time range native filter, the filter would not call "unfocus" action (in Chrome) or "unhover" action (in Safari) which caused the charts not in scope of that filter to stay greyed out.
This PR fixes that behaviour by manually calling those actions after clicking "Save" or "Cancel" buttons in the time range modal.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/15073128/216053067-b16c17fd-aad2-4c64-aa26-1502e56890e9.mov

After:

https://user-images.githubusercontent.com/15073128/216053089-413e25a8-75ef-48d2-ae84-eaa2b14ee41c.mov

### TESTING INSTRUCTIONS
1. Add 2 charts compatible with time filters to a dashboard
2. Add a time range filter that has only 1 of added charts in scope
3. Set the filter and close the modal
4. Verify that both charts are not greyed out

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
