### PR TITLE
fix: Remove button is broken for metrics on Explore

### DIFF
--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl/index.jsx
@@ -121,7 +121,10 @@ class AdhocFilterControl extends React.Component {
         sections={this.props.sections}
         operators={this.props.operators}
         datasource={this.props.datasource}
-        onRemoveFilter={() => this.onRemoveFilter(index)}
+        onRemoveFilter={e => {
+          e.stopPropagation();
+          this.onRemoveFilter(index);
+        }}
         onMoveLabel={this.moveLabel}
         onDropLabel={() => this.props.onChange(this.state.values)}
         partitionColumn={this.state.partitionColumn}
@@ -195,6 +198,7 @@ class AdhocFilterControl extends React.Component {
   onRemoveFilter(index) {
     const { confirmDeletion } = this.props;
     const { values } = this.state;
+    const { removeFilter } = this;
     if (confirmDeletion) {
       const { confirmationText, confirmationTitle, triggerCondition } =
         confirmDeletion;
@@ -203,7 +207,7 @@ class AdhocFilterControl extends React.Component {
           title: confirmationTitle,
           content: confirmationText,
           onOk() {
-            this.removeFilter(index);
+            removeFilter(index);
           },
         });
         return;

--- a/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
+++ b/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
@@ -308,10 +308,7 @@ export const OptionControlLabel = ({
       <CloseContainer
         role="button"
         data-test="remove-control-button"
-        onClick={e => {
-          e.stopPropagation();
-          onRemove();
-        }}
+        onClick={onRemove}
       >
         <Icons.XSmall iconColor={theme.colors.grayscale.light1} />
       </CloseContainer>


### PR DESCRIPTION
### SUMMARY
#22707 introduced many improvements to Generic X-axis but unfortunately also introduced [this](https://github.com/apache/superset/issues/22898) bug when removing a metric. This PR fixes the referred bug.

Fixes https://github.com/apache/superset/issues/22898

### TESTING INSTRUCTIONS
Check the original issue for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
