### PR TITLE
fix(native-filters): Don't include description icon in truncation calc

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
@@ -49,7 +49,8 @@ const VerticalFilterControlTitle = styled.h4`
 const HorizontalFilterControlTitle = styled(VerticalFilterControlTitle)`
   font-weight: ${({ theme }) => theme.typography.weights.normal};
   color: ${({ theme }) => theme.colors.grayscale.base};
-  ${truncationCSS}
+  max-width: ${({ theme }) => theme.gridUnit * 15}px;
+  ${truncationCSS};
 `;
 
 const HorizontalOverflowFilterControlTitle = styled(
@@ -68,7 +69,6 @@ const VerticalFilterControlTitleBox = styled.div`
 
 const HorizontalFilterControlTitleBox = styled(VerticalFilterControlTitleBox)`
   margin-bottom: unset;
-  max-width: ${({ theme }) => theme.gridUnit * 15}px;
 `;
 
 const HorizontalOverflowFilterControlTitleBox = styled(


### PR DESCRIPTION
### SUMMARY
In the horizontal native filters bar, the filter name's max width is 60px. However, the description and "is required" icon shouldn't be included in those 60 pixels. This PR fixes that behaviour.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="293" alt="image" src="https://user-images.githubusercontent.com/15073128/216067411-23cb3662-ddb2-40aa-9810-3340f89674a1.png">

After:
<img width="316" alt="image" src="https://user-images.githubusercontent.com/15073128/216067481-922609d3-1566-413f-9549-6286d257b0a6.png">


### TESTING INSTRUCTIONS
1. Enable horizontal filter bar
2. Add a filter with a name that's a bit shorter than 60 pixels and verify that it doesn't truncate
3. Add description
4. Verify that description icon is visible and title is still not truncated
5. Change the name to something linger the 60px and verify that it's truncated

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @kasiazjc 