### PR TITLE
fix(datasets): Fix property selection on JSON response

### DIFF
--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/LeftPanel.test.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/LeftPanel.test.tsx
@@ -138,7 +138,7 @@ fetchMock.get(schemasEndpoint, {
 
 fetchMock.get(tablesEndpoint, {
   tableLength: 3,
-  options: [
+  result: [
     { value: 'Sheet1', type: 'table', extra: null },
     { value: 'Sheet2', type: 'table', extra: null },
     { value: 'Sheet3', type: 'table', extra: null },

--- a/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/AddDataset/LeftPanel/index.tsx
@@ -190,7 +190,7 @@ export default function LeftPanel({
     (url: string) => {
       SupersetClient.get({ url })
         .then(({ json }) => {
-          const options: TableOption[] = json.options.map((table: Table) => {
+          const options: TableOption[] = json.result.map((table: Table) => {
             const option: TableOption = {
               value: table.value,
               label: <TableOption table={table} />,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes a small bug introduced in https://github.com/apache/superset/pull/22835 that is causing database table fetch to fail with a `TypeError: Cannot read properties of undefined (reading 'map')` error.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![localhost_9000_dataset_add_ (1)](https://user-images.githubusercontent.com/13007381/216116830-735ad4d8-fc5e-451d-9160-c2bec265b9ce.png)

After:
![localhost_9000_dataset_add_](https://user-images.githubusercontent.com/13007381/216116853-c3f56c6b-d831-4843-8818-32ef740c60c2.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Open the new Add Dataset flow and ensure that you can select a DB and schema and see tables appear.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
