### PR TITLE
fix(explore): Time comparison in Mixed Chart in GENERIC_CHART_AXES not working

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/buildQuery.ts
@@ -67,11 +67,8 @@ export default function buildQuery(formData: QueryFormData) {
         fd,
         queryObject,
       )
-        ? timeComparePivotOperator(fd, queryObject)
-        : pivotOperator(fd, {
-            ...queryObject,
-            columns: fd.groupby,
-          });
+        ? timeComparePivotOperator(fd, baseQueryObject)
+        : pivotOperator(fd, baseQueryObject);
 
       const tmpQueryObject = {
         ...queryObject,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/buildQuery.ts
@@ -67,8 +67,8 @@ export default function buildQuery(formData: QueryFormData) {
         fd,
         queryObject,
       )
-        ? timeComparePivotOperator(fd, baseQueryObject)
-        : pivotOperator(fd, baseQueryObject);
+        ? timeComparePivotOperator(fd, { ...queryObject, columns: fd.groupby })
+        : pivotOperator(fd, { ...queryObject, columns: fd.groupby });
 
       const tmpQueryObject = {
         ...queryObject,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/buildQuery.test.ts
@@ -198,6 +198,21 @@ test('should compile AA in query A', () => {
   // time comparison
   expect(query.time_offsets).toEqual(['1 years ago']);
 
+  // pivot
+  expect(
+    query.post_processing?.find(operator => operator?.operation === 'pivot'),
+  ).toEqual({
+    operation: 'pivot',
+    options: {
+      index: ['__timestamp'],
+      columns: ['foo'],
+      drop_missing_columns: false,
+      aggregates: {
+        'sum(sales)': { operator: 'mean' },
+        'sum(sales)__1 years ago': { operator: 'mean' },
+      },
+    },
+  });
   // cumsum
   expect(
     // prettier-ignore
@@ -384,20 +399,14 @@ test('should convert a queryObject with x-axis although FF is disabled', () => {
 });
 
 test("shouldn't convert a queryObject with axis although FF is enabled", () => {
-  let windowSpy: any;
-
-  beforeAll(() => {
+  const windowSpy = jest
+    .spyOn(window, 'window', 'get')
     // @ts-ignore
-    windowSpy = jest.spyOn(window, 'window', 'get').mockImplementation(() => ({
+    .mockImplementation(() => ({
       featureFlags: {
         GENERIC_CHART_AXES: true,
       },
     }));
-  });
-
-  afterAll(() => {
-    windowSpy.mockRestore();
-  });
 
   const { queries } = buildQuery(formDataMixedChart);
   expect(queries[0]).toEqual(
@@ -468,4 +477,40 @@ test("shouldn't convert a queryObject with axis although FF is enabled", () => {
       ],
     }),
   );
+
+  windowSpy.mockRestore();
+});
+
+test('ensure correct pivot columns with GENERIC_CHART_AXES enabled', () => {
+  const windowSpy = jest
+    .spyOn(window, 'window', 'get')
+    // @ts-ignore
+    .mockImplementation(() => ({
+      featureFlags: {
+        GENERIC_CHART_AXES: true,
+      },
+    }));
+
+  const query = buildQuery({ ...formDataMixedChartWithAA, x_axis: 'ds' })
+    .queries[0];
+
+  expect(query.time_offsets).toEqual(['1 years ago']);
+
+  // pivot
+  expect(
+    query.post_processing?.find(operator => operator?.operation === 'pivot'),
+  ).toEqual({
+    operation: 'pivot',
+    options: {
+      index: ['ds'],
+      columns: ['foo'],
+      drop_missing_columns: false,
+      aggregates: {
+        'sum(sales)': { operator: 'mean' },
+        'sum(sales)__1 years ago': { operator: 'mean' },
+      },
+    },
+  });
+
+  windowSpy.mockRestore();
 });


### PR DESCRIPTION
### SUMMARY
In Mixed Chart with GENERIC_CHART_AXES we were setting the pivot columns incorrectly. That resulted in time comparison advanced analytics not working correctly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="856" alt="image" src="https://user-images.githubusercontent.com/15073128/216156176-a9c1ee2e-8537-477c-8aeb-5593d86e4b85.png">

<img width="1484" alt="image" src="https://user-images.githubusercontent.com/15073128/216156062-c9dae26d-f6c2-4ccb-aa09-49300d70f580.png">


After:

<img width="836" alt="image" src="https://user-images.githubusercontent.com/15073128/216155831-bd91a4e8-676a-4810-906a-ecbc695d11d4.png">

<img width="1485" alt="image" src="https://user-images.githubusercontent.com/15073128/216155932-0811108c-c584-49d5-a278-e0f63dd5c48f.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
