### PR TITLE
fix: Make cte_alias a property of db engine spec

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -89,7 +89,7 @@ from superset.connectors.sqla.utils import (
     validate_adhoc_subquery,
 )
 from superset.datasets.models import Dataset as NewDataset
-from superset.db_engine_specs.base import BaseEngineSpec, CTE_ALIAS, TimestampExpression
+from superset.db_engine_specs.base import BaseEngineSpec, TimestampExpression
 from superset.exceptions import (
     AdvancedDataTypeResponseError,
     DatasetInvalidPermissionEvaluationException,
@@ -904,7 +904,7 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
 
         cte = self.db_engine_spec.get_cte_query(from_sql)
         from_clause = (
-            table(CTE_ALIAS)
+            table(self.db_engine_spec.cte_alias)
             if cte
             else TextAsFrom(self.text(from_sql), []).alias(VIRTUAL_TABLE_ALIAS)
         )

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -85,10 +85,6 @@ ColumnTypeMapping = Tuple[
 
 logger = logging.getLogger()
 
-
-CTE_ALIAS = "__cte"
-
-
 class TimeGrain(NamedTuple):
     name: str  # TODO: redundant field, remove
     label: str
@@ -344,6 +340,8 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     # If True, then it will allow  in subquery ,
     # if False it will allow as regular CTE
     allows_cte_in_subquery = True
+    # Define alias for CTE
+    cte_alias = "__cte"
     # Whether allow LIMIT clause in the SQL
     # If True, then the database engine is allowed for LIMIT clause
     # If False, then the database engine is allowed for TOP clause
@@ -887,7 +885,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
 
             # extract rest of the SQLs after CTE
             remainder = "".join(str(token) for token in stmt.tokens[idx:]).strip()
-            return f"WITH {token.value},\n{CTE_ALIAS} AS (\n{remainder}\n)"
+            return f"WITH {token.value},\n{cls.cte_alias} AS (\n{remainder}\n)"
 
         return None
 

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -85,6 +85,7 @@ ColumnTypeMapping = Tuple[
 
 logger = logging.getLogger()
 
+
 class TimeGrain(NamedTuple):
     name: str  # TODO: redundant field, remove
     label: str

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -98,7 +98,6 @@ if TYPE_CHECKING:
 config = app.config
 logger = logging.getLogger(__name__)
 
-CTE_ALIAS = "__cte"
 VIRTUAL_TABLE_ALIAS = "virtual_table"
 ADVANCED_DATA_TYPES = config["ADVANCED_DATA_TYPES"]
 
@@ -1046,7 +1045,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
 
         cte = self.db_engine_spec.get_cte_query(from_sql)
         from_clause = (
-            sa.table(CTE_ALIAS)
+            sa.table(self.db_engine_spec.cte_alias)
             if cte
             else TextAsFrom(self.text(from_sql), []).alias(VIRTUAL_TABLE_ALIAS)
         )


### PR DESCRIPTION
### SUMMARY
In existing code, there is a consensus that the cte alias should be '__cte'.

However, there are a few problems.
1. cte_alias is defined in multiple places in the code, both in [base.py](https://github.com/apache/superset/blob/b410dbb5dd510f1ed1dce6b2d0e114dda263eedb/superset/db_engine_specs/base.py#L89) and [helpers.py](https://github.com/apache/superset/blob/b410dbb5dd510f1ed1dce6b2d0e114dda263eedb/superset/models/helpers.py#L101)
2. Developers of DB engine specs cannot specify their own cte_alias.

My fix:
1. Change base.py and make cte_alias an attribute of BaseEngineSpec
2. Make all other usages of cte_alias refre back to the engine spec.

This will solve the outlined problems because
1. All changes to CTE_ALIAS will now be automatically propagated
2.  Developers can now overwrite cte_alias in their db_engine_spec

### TESTING INSTRUCTIONS
Create chart from dataset that has a CTE

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
- [X] Has associated issue: Fixes #22946
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
