### PR TITLE
fix(sqllab): Invalid schema fetch by deprecated value

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/SqlEditorLeftBar.test.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/SqlEditorLeftBar.test.jsx
@@ -41,15 +41,24 @@ const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
 const store = mockStore(initialState);
 
-fetchMock.get('glob:*/api/v1/database/*/schemas/?*', { result: [] });
-fetchMock.get('glob:*/api/v1/database/*/tables/*', {
-  count: 1,
-  result: [
-    {
-      label: 'ab_user',
-      value: 'ab_user',
-    },
-  ],
+beforeEach(() => {
+  fetchMock.get('glob:*/api/v1/database/*/schemas/?*', {
+    result: ['main', 'new_schema'],
+  });
+  fetchMock.get('glob:*/api/v1/database/**', { result: [] });
+  fetchMock.get('glob:*/api/v1/database/*/tables/*', {
+    count: 1,
+    result: [
+      {
+        label: 'ab_user',
+        value: 'ab_user',
+      },
+    ],
+  });
+});
+
+afterEach(() => {
+  fetchMock.restore();
 });
 
 const renderAndWait = (props, store) =>
@@ -110,8 +119,9 @@ test('should toggle the table when the header is clicked', async () => {
   userEvent.click(header);
 
   await waitFor(() => {
-    expect(store.getActions()).toHaveLength(4);
-    expect(store.getActions()[3].type).toEqual('COLLAPSE_TABLE');
+    expect(store.getActions()[store.getActions().length - 1].type).toEqual(
+      'COLLAPSE_TABLE',
+    );
   });
 });
 
@@ -129,14 +139,55 @@ test('When changing database the table list must be updated', async () => {
         database_name: 'new_db',
         backend: 'postgresql',
       }}
-      queryEditor={{ ...mockedProps.queryEditor, schema: 'new_schema' }}
+      queryEditorId={defaultQueryEditor.id}
       tables={[{ ...mockedProps.tables[0], dbId: 2, name: 'new_table' }]}
     />,
     {
       useRedux: true,
-      initialState,
+      store: mockStore({
+        ...initialState,
+        sqlLab: {
+          ...initialState.sqlLab,
+          unsavedQueryEditor: {
+            id: defaultQueryEditor.id,
+            schema: 'new_schema',
+          },
+        },
+      }),
     },
   );
   expect(await screen.findByText(/new_db/i)).toBeInTheDocument();
   expect(await screen.findByText(/new_table/i)).toBeInTheDocument();
+});
+
+test('ignore schema api when current schema is deprecated', async () => {
+  const invalidSchemaName = 'None';
+  const { rerender } = await renderAndWait(
+    mockedProps,
+    mockStore({
+      ...initialState,
+      sqlLab: {
+        ...initialState.sqlLab,
+        unsavedQueryEditor: {
+          id: defaultQueryEditor.id,
+          schema: invalidSchemaName,
+        },
+      },
+    }),
+  );
+
+  expect(await screen.findByText(/Database/i)).toBeInTheDocument();
+  expect(screen.queryByText(/None/i)).toBeInTheDocument();
+  expect(fetchMock.calls()).not.toContainEqual(
+    expect.arrayContaining([
+      expect.stringContaining(
+        `/tables/${mockedProps.database.id}/${invalidSchemaName}/`,
+      ),
+    ]),
+  );
+  rerender();
+  // Deselect the deprecated schema selection
+  await waitFor(() =>
+    expect(screen.queryByText(/None/i)).not.toBeInTheDocument(),
+  );
 });

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/SqlEditorLeftBar.test.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/SqlEditorLeftBar.test.jsx
@@ -42,10 +42,11 @@ const mockStore = configureStore(middlewares);
 const store = mockStore(initialState);
 
 beforeEach(() => {
+  fetchMock.get('glob:*/api/v1/database/?*', { result: [] });
   fetchMock.get('glob:*/api/v1/database/*/schemas/?*', {
+    count: 2,
     result: ['main', 'new_schema'],
   });
-  fetchMock.get('glob:*/api/v1/database/**', { result: [] });
   fetchMock.get('glob:*/api/v1/database/*/tables/*', {
     count: 1,
     result: [

--- a/superset-frontend/src/components/TableSelector/TableSelector.test.tsx
+++ b/superset-frontend/src/components/TableSelector/TableSelector.test.tsx
@@ -19,12 +19,11 @@
 
 import React from 'react';
 import { render, screen, waitFor, within } from 'spec/helpers/testing-library';
-import { SupersetClient } from '@superset-ui/core';
+import { queryClient } from 'src/views/QueryProvider';
+import fetchMock from 'fetch-mock';
 import { act } from 'react-dom/test-utils';
 import userEvent from '@testing-library/user-event';
 import TableSelector, { TableSelectorMultiple } from '.';
-
-const SupersetClientGet = jest.spyOn(SupersetClient, 'get');
 
 const createProps = (props = {}) => ({
   database: {
@@ -37,37 +36,43 @@ const createProps = (props = {}) => ({
   ...props,
 });
 
-afterEach(() => {
-  jest.clearAllMocks();
-});
-
-const getSchemaMockFunction = async () =>
+const getSchemaMockFunction = () =>
   ({
-    json: {
-      result: ['schema_a', 'schema_b'],
-    },
+    result: ['schema_a', 'schema_b'],
   } as any);
 
-const getTableMockFunction = async () =>
+const getTableMockFunction = () =>
   ({
-    json: {
-      count: 4,
-      result: [
-        { label: 'table_a', value: 'table_a' },
-        { label: 'table_b', value: 'table_b' },
-        { label: 'table_c', value: 'table_c' },
-        { label: 'table_d', value: 'table_d' },
-      ],
-    },
+    count: 4,
+    result: [
+      { label: 'table_a', value: 'table_a' },
+      { label: 'table_b', value: 'table_b' },
+      { label: 'table_c', value: 'table_c' },
+      { label: 'table_d', value: 'table_d' },
+    ],
   } as any);
+
+const databaseApiRoute = 'glob:*/api/v1/database/?*';
+const schemaApiRoute = 'glob:*/api/v1/database/*/schemas/?*';
+const tablesApiRoute = 'glob:*/api/v1/database/*/tables/*';
 
 const getSelectItemContainer = (select: HTMLElement) =>
   select.parentElement?.parentElement?.getElementsByClassName(
     'ant-select-selection-item',
   );
 
+beforeEach(() => {
+  queryClient.clear();
+  fetchMock.get(databaseApiRoute, { result: [] });
+});
+
+afterEach(() => {
+  fetchMock.reset();
+});
+
 test('renders with default props', async () => {
-  SupersetClientGet.mockImplementation(getTableMockFunction);
+  fetchMock.get(schemaApiRoute, { result: [] });
+  fetchMock.get(tablesApiRoute, getTableMockFunction());
 
   const props = createProps();
   render(<TableSelector {...props} />, { useRedux: true });
@@ -88,7 +93,8 @@ test('renders with default props', async () => {
 });
 
 test('renders table options', async () => {
-  SupersetClientGet.mockImplementation(getTableMockFunction);
+  fetchMock.get(schemaApiRoute, { result: ['test_schema'] });
+  fetchMock.get(tablesApiRoute, getTableMockFunction());
 
   const props = createProps();
   render(<TableSelector {...props} />, { useRedux: true });
@@ -105,7 +111,8 @@ test('renders table options', async () => {
 });
 
 test('renders disabled without schema', async () => {
-  SupersetClientGet.mockImplementation(getTableMockFunction);
+  fetchMock.get(schemaApiRoute, { result: [] });
+  fetchMock.get(tablesApiRoute, getTableMockFunction());
 
   const props = createProps();
   render(<TableSelector {...props} schema={undefined} />, { useRedux: true });
@@ -118,7 +125,7 @@ test('renders disabled without schema', async () => {
 });
 
 test('table options are notified after schema selection', async () => {
-  SupersetClientGet.mockImplementation(getSchemaMockFunction);
+  fetchMock.get(schemaApiRoute, getSchemaMockFunction());
 
   const callback = jest.fn();
   const props = createProps({
@@ -142,7 +149,7 @@ test('table options are notified after schema selection', async () => {
     await screen.findByRole('option', { name: 'schema_b' }),
   ).toBeInTheDocument();
 
-  SupersetClientGet.mockImplementation(getTableMockFunction);
+  fetchMock.get(tablesApiRoute, getTableMockFunction());
 
   act(() => {
     userEvent.click(screen.getAllByText('schema_a')[1]);
@@ -159,7 +166,8 @@ test('table options are notified after schema selection', async () => {
 });
 
 test('table select retain value if not in SQL Lab mode', async () => {
-  SupersetClientGet.mockImplementation(getTableMockFunction);
+  fetchMock.get(schemaApiRoute, { result: ['test_schema'] });
+  fetchMock.get(tablesApiRoute, getTableMockFunction());
 
   const callback = jest.fn();
   const props = createProps({
@@ -182,7 +190,7 @@ test('table select retain value if not in SQL Lab mode', async () => {
     await screen.findByRole('option', { name: 'table_a' }),
   ).toBeInTheDocument();
 
-  act(() => {
+  await waitFor(() => {
     userEvent.click(screen.getAllByText('table_a')[1]);
   });
 
@@ -199,7 +207,8 @@ test('table select retain value if not in SQL Lab mode', async () => {
 });
 
 test('table multi select retain all the values selected', async () => {
-  SupersetClientGet.mockImplementation(getTableMockFunction);
+  fetchMock.get(schemaApiRoute, { result: ['test_schema'] });
+  fetchMock.get(tablesApiRoute, getTableMockFunction());
 
   const callback = jest.fn();
   const props = createProps({
@@ -217,23 +226,19 @@ test('table multi select retain all the values selected', async () => {
 
   userEvent.click(tableSelect);
 
-  act(() => {
-    const item = screen.getAllByText('table_b');
+  await waitFor(async () => {
+    const item = await screen.findAllByText('table_b');
     userEvent.click(item[item.length - 1]);
   });
 
-  act(() => {
-    const item = screen.getAllByText('table_c');
+  await waitFor(async () => {
+    const item = await screen.findAllByText('table_c');
     userEvent.click(item[item.length - 1]);
   });
 
-  expect(screen.getByRole('option', { name: 'table_b' })).toHaveAttribute(
-    'aria-selected',
-    'true',
-  );
+  const selection1 = await screen.findByRole('option', { name: 'table_b' });
+  expect(selection1).toHaveAttribute('aria-selected', 'true');
 
-  expect(screen.getByRole('option', { name: 'table_c' })).toHaveAttribute(
-    'aria-selected',
-    'true',
-  );
+  const selection2 = await screen.findByRole('option', { name: 'table_c' });
+  expect(selection2).toHaveAttribute('aria-selected', 'true');
 });

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -275,26 +275,6 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
     internalTableChange(value);
   };
 
-  function renderDatabaseSelector() {
-    return (
-      <DatabaseSelector
-        db={database}
-        emptyState={emptyState}
-        formMode={formMode}
-        getDbList={getDbList}
-        handleError={handleError}
-        onDbChange={readOnly ? undefined : internalDbChange}
-        onEmptyResults={onEmptyResults}
-        onSchemaChange={readOnly ? undefined : internalSchemaChange}
-        onSchemasLoad={onSchemasLoad}
-        schema={currentSchema}
-        sqlLabMode={sqlLabMode}
-        isDatabaseSelectEnabled={isDatabaseSelectEnabled && !readOnly}
-        readOnly={readOnly}
-      />
-    );
-  }
-
   const handleFilterOption = useMemo(
     () => (search: string, option: TableOption) => {
       const searchValue = search.trim().toLowerCase();
@@ -346,7 +326,21 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
 
   return (
     <TableSelectorWrapper>
-      {renderDatabaseSelector()}
+      <DatabaseSelector
+        db={database}
+        emptyState={emptyState}
+        formMode={formMode}
+        getDbList={getDbList}
+        handleError={handleError}
+        onDbChange={readOnly ? undefined : internalDbChange}
+        onEmptyResults={onEmptyResults}
+        onSchemaChange={readOnly ? undefined : internalSchemaChange}
+        onSchemasLoad={onSchemasLoad}
+        schema={currentSchema}
+        sqlLabMode={sqlLabMode}
+        isDatabaseSelectEnabled={isDatabaseSelectEnabled && !readOnly}
+        readOnly={readOnly}
+      />
       {sqlLabMode && !formMode && <div className="divider" />}
       {renderTableSelect()}
     </TableSelectorWrapper>

--- a/superset-frontend/src/hooks/apiResources/index.ts
+++ b/superset-frontend/src/hooks/apiResources/index.ts
@@ -29,3 +29,4 @@ export {
 export * from './charts';
 export * from './dashboards';
 export * from './tables';
+export * from './schemas';

--- a/superset-frontend/src/hooks/apiResources/schemas.test.ts
+++ b/superset-frontend/src/hooks/apiResources/schemas.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import rison from 'rison';
+import fetchMock from 'fetch-mock';
+import { act, renderHook } from '@testing-library/react-hooks';
+import QueryProvider, { queryClient } from 'src/views/QueryProvider';
+import { useSchemas } from './schemas';
+
+const fakeApiResult = {
+  result: ['test schema 1', 'test schema b'],
+};
+
+const expectedResult = fakeApiResult.result.map((value: string) => ({
+  value,
+  label: value,
+  title: value,
+}));
+
+describe('useSchemas hook', () => {
+  beforeEach(() => {
+    queryClient.clear();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    fetchMock.reset();
+    jest.useRealTimers();
+  });
+
+  test('returns api response mapping json result', async () => {
+    const expectDbId = 'db1';
+    const forceRefresh = false;
+    const schemaApiRoute = `glob:*/api/v1/database/${expectDbId}/schemas/*`;
+    fetchMock.get(schemaApiRoute, fakeApiResult);
+    const { result } = renderHook(
+      () =>
+        useSchemas({
+          dbId: expectDbId,
+        }),
+      {
+        wrapper: QueryProvider,
+      },
+    );
+    await act(async () => {
+      jest.runAllTimers();
+    });
+    expect(fetchMock.calls(schemaApiRoute).length).toBe(1);
+    expect(
+      fetchMock.calls(
+        `end:/api/v1/database/${expectDbId}/schemas/?q=${rison.encode({
+          force: forceRefresh,
+        })}`,
+      ).length,
+    ).toBe(1);
+    expect(result.current.data).toEqual(expectedResult);
+    await act(async () => {
+      result.current.refetch();
+    });
+    expect(fetchMock.calls(schemaApiRoute).length).toBe(2);
+    expect(
+      fetchMock.calls(
+        `end:/api/v1/database/${expectDbId}/schemas/?q=${rison.encode({
+          force: true,
+        })}`,
+      ).length,
+    ).toBe(1);
+    expect(result.current.data).toEqual(expectedResult);
+  });
+
+  test('returns cached data without api request', async () => {
+    const expectDbId = 'db1';
+    const schemaApiRoute = `glob:*/api/v1/database/${expectDbId}/schemas/*`;
+    fetchMock.get(schemaApiRoute, fakeApiResult);
+    const { result, rerender } = renderHook(
+      () =>
+        useSchemas({
+          dbId: expectDbId,
+        }),
+      {
+        wrapper: QueryProvider,
+      },
+    );
+    await act(async () => {
+      jest.runAllTimers();
+    });
+    expect(fetchMock.calls(schemaApiRoute).length).toBe(1);
+    rerender();
+    expect(fetchMock.calls(schemaApiRoute).length).toBe(1);
+    expect(result.current.data).toEqual(expectedResult);
+  });
+
+  it('returns refreshed data after expires', async () => {
+    const expectDbId = 'db1';
+    const schemaApiRoute = `glob:*/api/v1/database/${expectDbId}/schemas/*`;
+    fetchMock.get(schemaApiRoute, fakeApiResult);
+    const { result, rerender } = renderHook(
+      () =>
+        useSchemas({
+          dbId: expectDbId,
+        }),
+      {
+        wrapper: QueryProvider,
+      },
+    );
+    await act(async () => {
+      jest.runAllTimers();
+    });
+    expect(fetchMock.calls(schemaApiRoute).length).toBe(1);
+    rerender();
+    await act(async () => {
+      jest.runAllTimers();
+    });
+    expect(fetchMock.calls(schemaApiRoute).length).toBe(1);
+    queryClient.clear();
+    rerender();
+    await act(async () => {
+      jest.runAllTimers();
+    });
+    expect(fetchMock.calls(schemaApiRoute).length).toBe(2);
+    expect(result.current.data).toEqual(expectedResult);
+  });
+});

--- a/superset-frontend/src/hooks/apiResources/schemas.ts
+++ b/superset-frontend/src/hooks/apiResources/schemas.ts
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useRef } from 'react';
+import { useQuery, UseQueryOptions } from 'react-query';
+import rison from 'rison';
+import { SupersetClient } from '@superset-ui/core';
+
+export type FetchSchemasQueryParams = {
+  dbId?: string | number;
+  forceRefresh?: boolean;
+};
+
+type QueryData = {
+  json: { result: string[] };
+  response: Response;
+};
+
+export type SchemaOption = {
+  value: string;
+  label: string;
+  title: string;
+};
+
+export function fetchSchemas({ dbId, forceRefresh }: FetchSchemasQueryParams) {
+  const queryParams = rison.encode({ force: forceRefresh });
+  // TODO: Would be nice to add pagination in a follow-up. Needs endpoint changes.
+  const endpoint = `/api/v1/database/${dbId}/schemas/?q=${queryParams}`;
+  return SupersetClient.get({ endpoint }) as Promise<QueryData>;
+}
+
+type Params = FetchSchemasQueryParams &
+  Pick<UseQueryOptions<SchemaOption[]>, 'onSuccess' | 'onError'>;
+
+export function useSchemas(options: Params) {
+  const { dbId, onSuccess, onError } = options || {};
+  const forceRefreshRef = useRef(false);
+  const params = { dbId };
+  const result = useQuery<QueryData, Error, SchemaOption[]>(
+    ['schemas', { dbId }],
+    () => fetchSchemas({ ...params, forceRefresh: forceRefreshRef.current }),
+    {
+      select: ({ json }) =>
+        json.result.map((value: string) => ({
+          value,
+          label: value,
+          title: value,
+        })),
+      enabled: Boolean(dbId),
+      onSuccess,
+      onError,
+      onSettled: () => {
+        forceRefreshRef.current = false;
+      },
+    },
+  );
+
+  return {
+    ...result,
+    refetch: () => {
+      forceRefreshRef.current = true;
+      return result.refetch();
+    },
+  };
+}

--- a/superset-frontend/src/hooks/apiResources/tables.test.ts
+++ b/superset-frontend/src/hooks/apiResources/tables.test.ts
@@ -16,78 +16,76 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import rison from 'rison';
+import fetchMock from 'fetch-mock';
 import { act, renderHook } from '@testing-library/react-hooks';
-import { SupersetClient } from '@superset-ui/core';
 import QueryProvider, { queryClient } from 'src/views/QueryProvider';
 import { useTables } from './tables';
 
 const fakeApiResult = {
-  json: {
-    count: 2,
-    result: [
-      {
-        id: 1,
-        name: 'fake api result1',
-        label: 'fake api label1',
-      },
-      {
-        id: 2,
-        name: 'fake api result2',
-        label: 'fake api label2',
-      },
-    ],
-  },
+  count: 2,
+  result: [
+    {
+      id: 1,
+      name: 'fake api result1',
+      label: 'fake api label1',
+    },
+    {
+      id: 2,
+      name: 'fake api result2',
+      label: 'fake api label2',
+    },
+  ],
 };
 
 const fakeHasMoreApiResult = {
-  json: {
-    count: 4,
-    result: [
-      {
-        id: 1,
-        name: 'fake api result1',
-        label: 'fake api label1',
-      },
-      {
-        id: 2,
-        name: 'fake api result2',
-        label: 'fake api label2',
-      },
-    ],
-  },
+  count: 4,
+  result: [
+    {
+      id: 1,
+      name: 'fake api result1',
+      label: 'fake api label1',
+    },
+    {
+      id: 2,
+      name: 'fake api result2',
+      label: 'fake api label2',
+    },
+  ],
 };
 
+const fakeSchemaApiResult = ['schema1', 'schema2'];
+
 const expectedData = {
-  options: [...fakeApiResult.json.result],
+  options: fakeApiResult.result,
   hasMore: false,
 };
 
 const expectedHasMoreData = {
-  options: [...fakeHasMoreApiResult.json.result],
+  options: fakeHasMoreApiResult.result,
   hasMore: true,
 };
 
-jest.mock('@superset-ui/core', () => ({
-  SupersetClient: {
-    get: jest.fn().mockResolvedValue(fakeApiResult),
-  },
-}));
-
 describe('useTables hook', () => {
   beforeEach(() => {
-    (SupersetClient.get as jest.Mock).mockClear();
     queryClient.clear();
     jest.useFakeTimers();
   });
 
   afterEach(() => {
+    fetchMock.reset();
     jest.useRealTimers();
   });
 
-  it('returns api response mapping json options', async () => {
+  test('returns api response mapping json options', async () => {
     const expectDbId = 'db1';
-    const expectedSchema = 'schemaA';
-    const forceRefresh = false;
+    const expectedSchema = 'schema1';
+    const schemaApiRoute = `glob:*/api/v1/database/${expectDbId}/schemas/*`;
+    const tableApiRoute = `glob:*/api/v1/database/${expectDbId}/tables/?q=*`;
+    fetchMock.get(tableApiRoute, fakeApiResult);
+    fetchMock.get(schemaApiRoute, {
+      result: fakeSchemaApiResult,
+    });
     const { result } = renderHook(
       () =>
         useTables({
@@ -101,29 +99,73 @@ describe('useTables hook', () => {
     await act(async () => {
       jest.runAllTimers();
     });
-    expect(SupersetClient.get).toHaveBeenCalledTimes(1);
-    expect(SupersetClient.get).toHaveBeenCalledWith({
-      endpoint: `/api/v1/database/${expectDbId}/tables/?q=(force:!${
-        forceRefresh ? 't' : 'f'
-      },schema_name:${expectedSchema})`,
-    });
+    expect(fetchMock.calls(schemaApiRoute).length).toBe(1);
+    expect(
+      fetchMock.calls(
+        `end:api/v1/database/${expectDbId}/tables/?q=${rison.encode({
+          force: false,
+          schema_name: expectedSchema,
+        })}`,
+      ).length,
+    ).toBe(1);
     expect(result.current.data).toEqual(expectedData);
     await act(async () => {
       result.current.refetch();
     });
-    expect(SupersetClient.get).toHaveBeenCalledTimes(2);
-    expect(SupersetClient.get).toHaveBeenCalledWith({
-      endpoint: `/api/v1/database/${expectDbId}/tables/?q=(force:!t,schema_name:${expectedSchema})`,
-    });
+    expect(fetchMock.calls(schemaApiRoute).length).toBe(1);
+    expect(
+      fetchMock.calls(
+        `end:api/v1/database/${expectDbId}/tables/?q=${rison.encode({
+          force: true,
+          schema_name: expectedSchema,
+        })}`,
+      ).length,
+    ).toBe(1);
     expect(result.current.data).toEqual(expectedData);
   });
 
-  it('returns hasMore when total is larger than result size', async () => {
-    (SupersetClient.get as jest.Mock).mockResolvedValueOnce(
-      fakeHasMoreApiResult,
-    );
+  test('skips the deprecated schema option', async () => {
     const expectDbId = 'db1';
-    const expectedSchema = 'schemaA';
+    const unexpectedSchema = 'invalid schema';
+    const schemaApiRoute = `glob:*/api/v1/database/${expectDbId}/schemas/*`;
+    const tableApiRoute = `glob:*/api/v1/database/${expectDbId}/tables/?q=*`;
+    fetchMock.get(tableApiRoute, fakeApiResult);
+    fetchMock.get(schemaApiRoute, {
+      result: fakeSchemaApiResult,
+    });
+    const { result } = renderHook(
+      () =>
+        useTables({
+          dbId: expectDbId,
+          schema: unexpectedSchema,
+        }),
+      {
+        wrapper: QueryProvider,
+      },
+    );
+    await act(async () => {
+      jest.runAllTimers();
+    });
+    expect(fetchMock.calls(schemaApiRoute).length).toBe(1);
+    expect(result.current.data).toEqual(undefined);
+    expect(
+      fetchMock.calls(
+        `end:api/v1/database/${expectDbId}/tables/?q=${rison.encode({
+          force: false,
+          schema_name: unexpectedSchema,
+        })}`,
+      ).length,
+    ).toBe(0);
+  });
+
+  test('returns hasMore when total is larger than result size', async () => {
+    const expectDbId = 'db1';
+    const expectedSchema = 'schema2';
+    const tableApiRoute = `glob:*/api/v1/database/${expectDbId}/tables/?q=*`;
+    fetchMock.get(tableApiRoute, fakeHasMoreApiResult);
+    fetchMock.get(`glob:*/api/v1/database/${expectDbId}/schemas/*`, {
+      result: fakeSchemaApiResult,
+    });
     const { result } = renderHook(
       () =>
         useTables({
@@ -137,13 +179,18 @@ describe('useTables hook', () => {
     await act(async () => {
       jest.runAllTimers();
     });
-    expect(SupersetClient.get).toHaveBeenCalledTimes(1);
+    expect(fetchMock.calls(tableApiRoute).length).toBe(1);
     expect(result.current.data).toEqual(expectedHasMoreData);
   });
 
-  it('returns cached data without api request', async () => {
+  test('returns cached data without api request', async () => {
     const expectDbId = 'db1';
-    const expectedSchema = 'schemaA';
+    const expectedSchema = 'schema1';
+    const tableApiRoute = `glob:*/api/v1/database/${expectDbId}/tables/?q=*`;
+    fetchMock.get(tableApiRoute, fakeApiResult);
+    fetchMock.get(`glob:*/api/v1/database/${expectDbId}/schemas/*`, {
+      result: fakeSchemaApiResult,
+    });
     const { result, rerender } = renderHook(
       () =>
         useTables({
@@ -157,15 +204,20 @@ describe('useTables hook', () => {
     await act(async () => {
       jest.runAllTimers();
     });
-    expect(SupersetClient.get).toHaveBeenCalledTimes(1);
+    expect(fetchMock.calls(tableApiRoute).length).toBe(1);
     rerender();
-    expect(SupersetClient.get).toHaveBeenCalledTimes(1);
+    expect(fetchMock.calls(tableApiRoute).length).toBe(1);
     expect(result.current.data).toEqual(expectedData);
   });
 
-  it('returns refreshed data after expires', async () => {
+  test('returns refreshed data after expires', async () => {
     const expectDbId = 'db1';
-    const expectedSchema = 'schemaA';
+    const expectedSchema = 'schema1';
+    const tableApiRoute = `glob:*/api/v1/database/${expectDbId}/tables/?q=*`;
+    fetchMock.get(tableApiRoute, fakeApiResult);
+    fetchMock.get(`glob:*/api/v1/database/${expectDbId}/schemas/*`, {
+      result: fakeSchemaApiResult,
+    });
     const { result, rerender } = renderHook(
       () =>
         useTables({
@@ -179,18 +231,18 @@ describe('useTables hook', () => {
     await act(async () => {
       jest.runAllTimers();
     });
-    expect(SupersetClient.get).toHaveBeenCalledTimes(1);
+    expect(fetchMock.calls(tableApiRoute).length).toBe(1);
     rerender();
     await act(async () => {
       jest.runAllTimers();
     });
-    expect(SupersetClient.get).toHaveBeenCalledTimes(1);
+    expect(fetchMock.calls(tableApiRoute).length).toBe(1);
     queryClient.clear();
     rerender();
     await act(async () => {
       jest.runAllTimers();
     });
-    expect(SupersetClient.get).toHaveBeenCalledTimes(2);
+    expect(fetchMock.calls(tableApiRoute).length).toBe(2);
     expect(result.current.data).toEqual(expectedData);
   });
 });


### PR DESCRIPTION
### SUMMARY
Alternative solution of #22695 (reverted due to regression)

When a selected schema option in a old saved tab has been deprecated, it would fail to query since the selected schema is no longer existed.
This commit adds the validation logic for the current selected schema option and then reset the schema option if no longer existed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

After: Schema option changes from None -> Empty (Initial selected deprecated option without api fetch. And then reset the deprecated option)

https://user-images.githubusercontent.com/1392866/216437216-468645f9-734b-4c72-9ae5-b8658b8c5bb5.mov

Before:

<img width="415" alt="Screenshot_2023-01-09_at_3_55_57_PM" src="https://user-images.githubusercontent.com/1392866/211938201-af50da2a-3a5b-4fec-b479-e15e98eb2060.png">

<img width="900" alt="Superset-2" src="https://user-images.githubusercontent.com/1392866/211938150-e2d3d9a7-1566-4787-ab9e-cde8a645de16.png">

### TESTING INSTRUCTIONS

- Select a schema from the list and then close
- delete the above selected schema
- reopen the sqllab and check the error

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @ktmud 