### PR TITLE
test: Clean up SelectAsyncControl test warnings

### DIFF
--- a/superset-frontend/src/explore/components/controls/SelectAsyncControl/SelectAsyncControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/SelectAsyncControl/SelectAsyncControl.test.tsx
@@ -65,17 +65,17 @@ beforeEach(() => {
   jest.resetAllMocks();
 });
 
-test('Should render', () => {
+test('Should render', async () => {
   const props = createProps();
   render(<SelectAsyncControl {...props} />, { useRedux: true });
-  expect(screen.getByTestId('select-test')).toBeInTheDocument();
+  expect(await screen.findByTestId('select-test')).toBeInTheDocument();
 });
 
-test('Should send correct props to Select component - value props', () => {
+test('Should send correct props to Select component - value props', async () => {
   const props = createProps();
   render(<SelectAsyncControl {...props} />, { useRedux: true });
 
-  expect(screen.getByTestId('select-test')).toHaveAttribute(
+  expect(await screen.findByTestId('select-test')).toHaveAttribute(
     'data-value',
     JSON.stringify(props.value),
   );
@@ -89,20 +89,20 @@ test('Should send correct props to Select component - value props', () => {
   );
 });
 
-test('Should send correct props to Select component - function onChange multi:true', () => {
+test('Should send correct props to Select component - function onChange multi:true', async () => {
   const props = createProps();
   render(<SelectAsyncControl {...props} />, { useRedux: true });
   expect(props.onChange).toBeCalledTimes(0);
-  userEvent.click(screen.getByText('onChange'));
+  userEvent.click(await screen.findByText('onChange'));
   expect(props.onChange).toBeCalledTimes(1);
 });
 
-test('Should send correct props to Select component - function onChange multi:false', () => {
+test('Should send correct props to Select component - function onChange multi:false', async () => {
   const props = createProps();
   render(<SelectAsyncControl {...{ ...props, multi: false }} />, {
     useRedux: true,
   });
   expect(props.onChange).toBeCalledTimes(0);
-  userEvent.click(screen.getByText('onChange'));
+  userEvent.click(await screen.findByText('onChange'));
   expect(props.onChange).toBeCalledTimes(1);
 });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes 5 warnings in `superset-frontend/src/explore/components/controls/SelectAsyncControl/SelectAsyncControl.test.tsx`. There were 4 act errors and one "Can't perform a React state update on an unmounted component" warning.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- cd into `superset-frontend`
- run `npm run test superset-frontend/src/explore/components/controls/SelectAsyncControl/SelectAsyncControl.test.tsx`
- Observe that only one warning is left in the test.
  - There were 6 warnings initially

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
