### PR TITLE
test: Convert DatasetList test from jsx to tsx

### DIFF
--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetList.test.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetList.test.tsx
@@ -84,7 +84,7 @@ fetchMock.get(databaseEndpoint, {
   result: [],
 });
 
-async function mountAndWait(props) {
+async function mountAndWait(props: {}) {
   const mounted = mount(
     <Provider store={store}>
       <DatasetList {...props} user={mockUser} />
@@ -97,7 +97,7 @@ async function mountAndWait(props) {
 
 describe('DatasetList', () => {
   const mockedProps = {};
-  let wrapper;
+  let wrapper: any;
 
   beforeAll(async () => {
     wrapper = await mountAndWait(mockedProps);
@@ -255,7 +255,10 @@ describe('RTL', () => {
     return mounted;
   }
 
-  let isFeatureEnabledMock;
+  let isFeatureEnabledMock: jest.SpyInstance<
+    boolean,
+    [feature: featureFlags.FeatureFlag]
+  >;
   beforeEach(async () => {
     isFeatureEnabledMock = jest
       .spyOn(featureFlags, 'isFeatureEnabled')


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR converts the DatasetList test from jsx to tsx.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- cd into `superset-frontend`
- run `npm run test superset-frontend/src/views/CRUD/data/dataset/DatasetList.test.tsx`
- Observe that the test still passes post-conversion

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
