### PR TITLE
chore: Remove dependency warnings from SqlEditorLeftBar/index.tsx

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
@@ -210,35 +210,50 @@ const SqlEditorLeftBar = ({
   const shouldShowReset = window.location.search === '?reset=1';
   const tableMetaDataHeight = height - 130; // 130 is the height of the selects above
 
-  const handleSchemaChange = useCallback((schema: string) => {
-    if (queryEditor) {
-      dispatch(queryEditorSetSchema(queryEditor, schema));
-    }
-  }, []);
+  const handleSchemaChange = useCallback(
+    (schema: string) => {
+      if (queryEditor) {
+        dispatch(queryEditorSetSchema(queryEditor, schema));
+      }
+    },
+    [dispatch, queryEditor],
+  );
 
-  const handleTablesLoad = useCallback((options: Array<any>) => {
-    if (queryEditor) {
-      dispatch(queryEditorSetTableOptions(queryEditor, options));
-    }
-  }, []);
+  const handleTablesLoad = useCallback(
+    (options: Array<any>) => {
+      if (queryEditor) {
+        dispatch(queryEditorSetTableOptions(queryEditor, options));
+      }
+    },
+    [dispatch, queryEditor],
+  );
 
-  const handleSchemasLoad = useCallback((options: Array<any>) => {
-    if (queryEditor) {
-      dispatch(queryEditorSetSchemaOptions(queryEditor, options));
-    }
-  }, []);
+  const handleSchemasLoad = useCallback(
+    (options: Array<any>) => {
+      if (queryEditor) {
+        dispatch(queryEditorSetSchemaOptions(queryEditor, options));
+      }
+    },
+    [dispatch, queryEditor],
+  );
 
-  const handleDbList = useCallback((result: DatabaseObject) => {
-    dispatch(setDatabases(result));
-  }, []);
+  const handleDbList = useCallback(
+    (result: DatabaseObject) => {
+      dispatch(setDatabases(result));
+    },
+    [dispatch],
+  );
 
-  const handleError = useCallback((message: string) => {
-    dispatch(addDangerToast(message));
-  }, []);
+  const handleError = useCallback(
+    (message: string) => {
+      dispatch(addDangerToast(message));
+    },
+    [dispatch],
+  );
 
   const handleResetState = useCallback(() => {
     dispatch(resetState());
-  }, []);
+  }, [dispatch]);
 
   return (
     <LeftBarStyles data-test="sql-editor-left-bar">


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR removes all dependency warnings from `SqlEditorLeftBar/index.tsx` by passing any needed dependencies into dependency arrays with warnings.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- cd into `superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx`
- Observe that there are no warnings in the file

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
