### PR TITLE
docs(alerts & reports): clarify nature of "-dev" labeled container images

### DIFF
--- a/docs/docs/installation/alerts-reports.mdx
+++ b/docs/docs/installation/alerts-reports.mdx
@@ -43,6 +43,8 @@ All you need to do is add the required config variables described in this guide 
 If you are running a non-dev docker image, e.g., a stable release like `apache/superset:2.0.1`, that image does not include a headless browser.  Only the `superset_worker` container needs this headless browser to browse to the target chart or dashboard.
 You can either install and configure the headless browser - see "Custom Dockerfile" section below - or when deploying via `docker-compose`, modify your `docker-compose.yml` file to use a dev image for the worker container and a stable release image for the `superset_app` container.
 
+*Note*: In this context, a "dev image" is the same application software as its corresponding non-dev image, just bundled with additional tools.  So an image like `2.0.1-dev` is identical to `2.0.1` when it comes to stability, functionality, and running in production.  The actual "in-development" versions of Superset - cutting-edge and unstable - are not tagged with version numbers on Docker Hub and will display version `0.0.0-dev` within the Superset UI.
+
 #### Slack integration
 
 To send alerts and reports to Slack channels, you need to create a new Slack Application on your workspace.


### PR DESCRIPTION
Add a sentence clarifying that images like `2.0.1-dev` are not unstable images, they are just 2.0.1 bundled with tools.  Addresses a point of user confusion surfaced via Slack.