### PR TITLE
fix: Form data was not being passed to save/update slice

### DIFF
--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -198,6 +198,8 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
         );
       }
 
+      const { url_params, ...formData } = this.props.form_data || {};
+
       let dashboard: DashboardGetResponse | null = null;
       if (this.state.newDashboardName || this.state.saveToDashboardId) {
         let saveToDashboardId = this.state.saveToDashboardId || null;
@@ -216,13 +218,12 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
           sliceDashboards = sliceDashboards.includes(dashboard.id)
             ? sliceDashboards
             : [...sliceDashboards, dashboard.id];
-          const { url_params, ...formData } = this.props.form_data || {};
-          this.props.actions.setFormData({
-            ...formData,
-            dashboards: sliceDashboards,
-          });
+          formData.dashboards = sliceDashboards;
         }
       }
+
+      // Sets the form data
+      this.props.actions.setFormData({ ...formData });
 
       //  Update or create slice
       let value: { id: number };


### PR DESCRIPTION
### SUMMARY
https://github.com/apache/superset/pull/20965 refactored `SaveModal` and stored the `form_data` in Redux. Actions that were dependent on the `form_data` were updated to query Redux instead of receiving it via params. The problem left by the refactoring was that `setFormData` was not being consistently called and dependent actions such as `createSlice` and `updateSlice` were not receiving the latest `form_data` object. This PR fixes this problem.

### TESTING INSTRUCTIONS
1 - Create a new chart
2 - Add some controls
3 - Make sure the form_data received by SaveModal has all the modified values

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
