### PR TITLE
fix(sqllab): clean unwanted scrollbar

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -179,7 +179,7 @@ const StyledSqlEditor = styled.div`
       border-top: 1px solid ${theme.colors.grayscale.light2};
       border-bottom: 1px solid ${theme.colors.grayscale.light2};
       width: 3%;
-      margin: ${theme.gridUnit}px 47%;
+      margin: ${SQL_EDITOR_GUTTER_MARGIN}px 47%;
     }
 
     .gutter.gutter-vertical {


### PR DESCRIPTION
### SUMMARY

_Regression by #22474_

When `.gutter` style migrated to emotion, the margin size has been updated incorrectly.
(`margin: 3px 47%;` to `margin: ${theme.gridUnit}px 47%;` [theme.gridUnit: 4])

As a result, a unwanted scrollbar in sqllab editor has been shown due to the unmatched margin size.

This commit updates the `.gutter` margin matching with the constant.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

-Before:

<img width="1170" alt="Superset_and_Inbox__1_963__-_justin_park_airbnb_com_-_Airbnb_com_Mail" src="https://user-images.githubusercontent.com/1392866/216682518-1517a90b-7430-4e0f-bee6-bc4cdaaa6c38.png">

- After:

<img width="1164" alt="Screenshot 2023-02-03 at 10 37 15 AM" src="https://user-images.githubusercontent.com/1392866/216682575-f6611539-55a1-4318-8ac4-c4f7d339e1ec.png">

### TESTING INSTRUCTIONS
Go to sqllab and check the scrollbar on editor panel

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @kgabryje @ktmud 