### PR TITLE
fix(migrations): Flask-Migrate output is not logged during alembic migrations #17991

### DIFF
--- a/superset/migrations/alembic.ini
+++ b/superset/migrations/alembic.ini
@@ -28,7 +28,7 @@ file_template = %%(year)d-%%(month).2d-%%(day).2d_%%(hour).2d-%%(minute).2d_%%(r
 
 # Logging configuration
 [loggers]
-keys = root,sqlalchemy,alembic
+keys = root,sqlalchemy,alembic,flask_migrate
 
 [handlers]
 keys = console
@@ -60,3 +60,8 @@ formatter = generic
 [formatter_generic]
 format = %(levelname)-5.5s [%(name)s] %(message)s
 datefmt = %H:%M:%S
+
+[logger_flask_migrate]
+level = DEBUG
+handlers =
+qualname = flask_migrate


### PR DESCRIPTION
### SUMMARY
As noted in many issues, alembic migrations aren't logged when doing upgrades in Helm which makes debugging a failing `superset-init-db` job impossible. 

This change comes from issue #17991 and a related issue in the flask migrate repository [here](https://github.com/miguelgrinberg/Flask-Migrate/issues/434)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
No flask_migrate error logs to show the issue as to why `superset-init-db` fails. It would look exactly like the after screenshot below with no `ERROR [flask_migrate] Error: Can't locate revision identified by 'f3c2d8ec8595'` line.

After:
Logs include flask_migrate error message.
<img width="989" alt="Screen Shot 2023-02-03 at 3 36 36 PM" src="https://user-images.githubusercontent.com/28707707/216705888-3c788d10-fa89-43f7-bf60-5ae842bdd733.png">

### TESTING INSTRUCTIONS

1. Deploy a version of superset on kubernetes using helm
2. Upgrade this helm installation to a version of superset that has migrations 
3. See logs occurring. Without this change, no flask_migrate logs are included

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #17991 #19836 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
