### PR TITLE
refactor: rename digest param to cache_key in chart API (screenshot m…

### DIFF
--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -582,7 +582,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
 
         return trigger_celery()
 
-    @expose("/<pk>/screenshot/<digest>/", methods=["GET"])
+    @expose("/<pk>/screenshot/<cache_key>/", methods=["GET"])
     @protect()
     @safe
     @statsd_metrics
@@ -590,7 +590,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.screenshot",
         log_to_statsd=False,
     )
-    def screenshot(self, pk: int, digest: str) -> WerkzeugResponse:
+    def screenshot(self, pk: int, cache_key: str) -> WerkzeugResponse:
         """Get Chart screenshot
         ---
         get:
@@ -603,7 +603,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
           - in: path
             schema:
               type: string
-            name: digest
+            name: cache_key
           responses:
             200:
               description: Chart thumbnail image
@@ -628,7 +628,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
             return self.response_404()
 
         # fetch the chart screenshot using the current user and cache if set
-        img = ChartScreenshot.get_from_cache_key(thumbnail_cache, digest)
+        img = ChartScreenshot.get_from_cache_key(thumbnail_cache, cache_key)
         if img:
             return Response(
                 FileWrapper(img), mimetype="image/png", direct_passthrough=True


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
The ```screenshot``` method in the ```charts API``` has the ```digest``` parameter as one of its parameters. This parameter should be called ```cache_key``` because a screenshot is retrieved from the cache using the cache key within the method. The name ```digest``` can be misleading (you might think it could be the ```digest``` property of the Slice object).

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
