### PR TITLE
fix(ssh_tunnel): Fix bug on database edition for databases with ssh tunnels

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.test.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.test.tsx
@@ -1510,6 +1510,27 @@ describe('DatabaseModal', () => {
       expect(allowFileUploadText).not.toBeInTheDocument();
       expect(schemasForFileUploadText).not.toBeInTheDocument();
     });
+
+    it('if the SSH Tunneling toggle is not displayed, nothing should get displayed', async () => {
+      const SSHTunnelingToggle = screen.queryByTestId('ssh-tunnel-switch');
+      expect(SSHTunnelingToggle).not.toBeInTheDocument();
+      const SSHTunnelServerAddressInput = screen.queryByTestId(
+        'ssh-tunnel-server_address-input',
+      );
+      expect(SSHTunnelServerAddressInput).not.toBeInTheDocument();
+      const SSHTunnelServerPortInput = screen.queryByTestId(
+        'ssh-tunnel-server_port-input',
+      );
+      expect(SSHTunnelServerPortInput).not.toBeInTheDocument();
+      const SSHTunnelUsernameInput = screen.queryByTestId(
+        'ssh-tunnel-username-input',
+      );
+      expect(SSHTunnelUsernameInput).not.toBeInTheDocument();
+      const SSHTunnelPasswordInput = screen.queryByTestId(
+        'ssh-tunnel-password-input',
+      );
+      expect(SSHTunnelPasswordInput).not.toBeInTheDocument();
+    });
   });
 
   describe('DatabaseModal w errors as objects', () => {

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -1157,7 +1157,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
     if (db && isSSHTunneling) {
       setUseSSHTunneling(!isEmpty(db?.ssh_tunnel));
     }
-  }, [db]);
+  }, [db, isSSHTunneling]);
 
   const onDbImport = async (info: UploadChangeParam) => {
     setImportingErrorMessage('');

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -1154,7 +1154,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
   }, [passwordsNeeded]);
 
   useEffect(() => {
-    if (db) {
+    if (db && isSSHTunneling) {
       setUseSSHTunneling(!isEmpty(db?.ssh_tunnel));
     }
   }, [db]);


### PR DESCRIPTION
### SUMMARY

-  If the `SSH_TUNNELING` feature flag is `OFF` no `SSH Tunnel Switch` or the rest of the form fields must be visible in the DatabaseModal, however, that's not happening when editing a DB. Add test that check that if no switch is in the document, then the rest of fields must not be in the document.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1050" alt="Screenshot 2023-02-06 at 19 52 58" src="https://user-images.githubusercontent.com/38889534/217106895-87350b63-eb2e-4114-ae28-bfd1df58937a.png">

After:
<img width="1050" alt="Screenshot 2023-02-06 at 19 53 36" src="https://user-images.githubusercontent.com/38889534/217106876-fdc06aec-7a3e-4aa1-bdd5-5576e244c07a.png">


### TESTING INSTRUCTIONS
1. Make sure your SSH_TUNNELING flag is OFF
2. Open the edit modal on a DB that has SSH Tunnel attached to it
3. The `SSH Tunnel` switch must not be visible
4. The rest of SSH Tunnel form fields must not be visible 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
