### PR TITLE
fix(sqllab): regression of clearQueryResults

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet/ResultSet.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/ResultSet.test.tsx
@@ -148,6 +148,31 @@ describe('ResultSet', () => {
     expect(alert).toHaveTextContent('The query returned no data');
   });
 
+  test('should clear query results', async () => {
+    const props = {
+      ...mockedProps,
+      query: { ...mockedProps.query, cached: false },
+    };
+    const store = mockStore({
+      ...initialState,
+      sqlLab: {
+        ...initialState.sqlLab,
+        queries: {
+          [props.query.id]: props.query,
+        },
+      },
+    });
+    await waitFor(() => {
+      setup(props, store);
+    });
+
+    expect(store.getActions()).toContainEqual(
+      expect.objectContaining({
+        type: 'CLEAR_QUERY_RESULTS',
+      }),
+    );
+  });
+
   test('should call reRunQuery if timed out', async () => {
     const store = mockStore(initialState);
     const propsWithError = {

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -167,7 +167,7 @@ const ResultSet = ({
 
   const prevQuery = usePrevious(query);
   useEffect(() => {
-    if (cache && query.cached && query?.results?.data?.length > 0) {
+    if (cache && !query.cached && query?.results?.data?.length > 0) {
       setCachedData(query.results.data);
       dispatch(clearQueryResults(query));
     }


### PR DESCRIPTION
### SUMMARY
This PR fixes a bug introduced by (https://github.com/apache/superset/pull/21186) that caused increasing local storage size dramatically (which makes the space limitation warning frequently). This is because the [migration logic](https://github.com/apache/superset/pull/21186/files#diff-407b1e72d7f4462c85eca33d215cd9981b18db050f649dfaaac5748a262d09b8R163) flip to `query.cached` from `!nextProps.query.cached` so `clearQueryResults()` never triggered.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
- After:
<img width="701" alt="Superset-3" src="https://user-images.githubusercontent.com/1392866/217110237-fcb9fb1a-403b-410d-90cd-2f4a0bfdb18b.png">

<img width="466" alt="Superset-2" src="https://user-images.githubusercontent.com/1392866/217110245-2a1bd0e7-062f-4625-b42f-97b75232a4b2.png">

- Before:
<img width="703" alt="Superset-4" src="https://user-images.githubusercontent.com/1392866/217110272-d121c50c-eeab-466b-8362-20c55ad34df3.png">

<img width="489" alt="Superset" src="https://user-images.githubusercontent.com/1392866/217110301-f450ca78-27d7-42d8-a772-ff071a52e958.png">

### TESTING INSTRUCTIONS
Go to SqlLab
Run a query and check the localStorage of sqlLab > queries > results > data

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
