### PR TITLE
chore: refactor SliceAdder for react 17 and react 18

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -191,6 +191,7 @@
     "react-transition-group": "^2.5.3",
     "react-ultimate-pagination": "^1.3.0",
     "react-virtualized": "9.19.1",
+    "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
     "redux": "^4.0.5",
     "redux-localstorage": "^0.4.1",

--- a/superset-frontend/src/dashboard/components/SliceAdder.jsx
+++ b/superset-frontend/src/dashboard/components/SliceAdder.jsx
@@ -19,7 +19,8 @@
 /* eslint-env browser */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { List, AutoSizer } from 'react-virtualized';
+import AutoSizer from 'react-virtualized-auto-sizer';
+import { FixedSizeList as List } from 'react-window';
 import { createFilter } from 'react-search-input';
 import {
   t,
@@ -333,13 +334,14 @@ class SliceAdder extends React.Component {
                 <List
                   width={width}
                   height={height}
-                  rowCount={this.state.filteredSlices.length}
-                  rowHeight={DEFAULT_CELL_HEIGHT}
-                  rowRenderer={this.rowRenderer}
+                  itemCount={this.state.filteredSlices.length}
+                  itemSize={DEFAULT_CELL_HEIGHT}
                   searchTerm={this.state.searchTerm}
                   sortBy={this.state.sortBy}
                   selectedSliceIds={this.props.selectedSliceIds}
-                />
+                >
+                  {this.rowRenderer}
+                </List>
               )}
             </AutoSizer>
           </ChartList>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- react-virtualized does not support for react 17 and react 18. This PR is refactoring SliceAdder to get rid of the react-virtualized by using react-window

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![sliceAdder](https://user-images.githubusercontent.com/5705598/217116529-c34d1bb6-3aea-49df-8c8d-272ded5158e3.gif)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
