### PR TITLE
fix(explore): Enable saving metric after changing title

### DIFF
--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/AdhocMetricEditPopover.test.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/AdhocMetricEditPopover.test.tsx
@@ -162,6 +162,16 @@ test('Clicking on "Save" should call onChange and onClose for new metric', () =>
   expect(props.onClose).toBeCalledTimes(1);
 });
 
+test('Clicking on "Save" should call onChange and onClose for new title', () => {
+  const props = createProps();
+  render(<AdhocMetricEditPopover {...props} isLabelModified />);
+  expect(props.onChange).toBeCalledTimes(0);
+  expect(props.onClose).toBeCalledTimes(0);
+  userEvent.click(screen.getByRole('button', { name: 'Save' }));
+  expect(props.onChange).toBeCalledTimes(1);
+  expect(props.onClose).toBeCalledTimes(1);
+});
+
 test('Should switch to tab:Simple', () => {
   const props = createProps();
   props.getCurrentTab.mockImplementation(tab => {

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
@@ -62,6 +62,7 @@ const propTypes = {
   savedMetric: savedMetricType,
   datasource: PropTypes.object,
   isNewMetric: PropTypes.bool,
+  isLabelModified: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -299,6 +300,7 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
       onResize,
       datasource,
       isNewMetric,
+      isLabelModified,
       ...popoverProps
     } = this.props;
     const { adhocMetric, savedMetric } = this.state;
@@ -345,6 +347,7 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
 
     const stateIsValid = adhocMetric.isValid() || savedMetric?.metric_name;
     const hasUnsavedChanges =
+      isLabelModified ||
       isNewMetric ||
       !adhocMetric.equals(propsAdhocMetric) ||
       (!(

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger.tsx
@@ -225,6 +225,10 @@ class AdhocMetricPopoverTrigger extends React.PureComponent<
           getCurrentTab={this.getCurrentTab}
           getCurrentLabel={this.getCurrentLabel}
           isNewMetric={this.props.isNew}
+          isLabelModified={
+            this.state.labelModified &&
+            adhocMetricLabel !== this.state.title.label
+          }
         />
       </ExplorePopoverContent>
     );


### PR DESCRIPTION

### SUMMARY
When user added an adhoc metric with a custom title, saved it, and then tried to only change the title, the "Save" button remained greyed out. This PR fixes that bug.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="374" alt="image" src="https://user-images.githubusercontent.com/15073128/217261790-512686ac-ea3c-445c-8082-480c7ddb14a1.png">

After:

<img width="376" alt="image" src="https://user-images.githubusercontent.com/15073128/217261738-cb02b323-d7bc-491b-999b-524c4937f5e7.png">


### TESTING INSTRUCTIONS
1. Create an adhoc metric, give it a custom name and save
2. Open the adhoc metric popover to edit the created metric
3. Change only the title
4. "Save" button should be enabled

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
