### PR TITLE
fix: Time Column on Generic X-axis

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/query/buildQueryContext.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/buildQueryContext.ts
@@ -20,16 +20,11 @@
 import buildQueryObject from './buildQueryObject';
 import DatasourceKey from './DatasourceKey';
 import { QueryFieldAliases, QueryFormData } from './types/QueryFormData';
-import {
-  BinaryQueryObjectFilterClause,
-  QueryContext,
-  QueryObject,
-} from './types/Query';
+import { QueryContext, QueryObject } from './types/Query';
 import { SetDataMaskHook } from '../chart';
 import { JsonObject } from '../connection';
 import { normalizeTimeColumn } from './normalizeTimeColumn';
-import { hasGenericChartAxes, isXAxisSet } from './getXAxis';
-import { ensureIsArray } from '../utils';
+import { isXAxisSet } from './getXAxis';
 
 const WRAP_IN_ARRAY = (baseQueryObject: QueryObject) => [baseQueryObject];
 
@@ -59,14 +54,6 @@ export default function buildQueryContext(
     if (Array.isArray(query.post_processing)) {
       // eslint-disable-next-line no-param-reassign
       query.post_processing = query.post_processing.filter(Boolean);
-    }
-    if (hasGenericChartAxes && query.time_range) {
-      // eslint-disable-next-line no-param-reassign
-      query.filters = ensureIsArray(query.filters).map(flt =>
-        flt?.op === 'TEMPORAL_RANGE'
-          ? ({ ...flt, val: query.time_range } as BinaryQueryObjectFilterClause)
-          : flt,
-      );
     }
   });
   if (isXAxisSet(formData)) {

--- a/superset-frontend/packages/superset-ui-core/test/query/buildQueryContext.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/buildQueryContext.test.ts
@@ -164,41 +164,4 @@ describe('buildQueryContext', () => {
     expect(spyNormalizeTimeColumn).not.toBeCalled();
     spyNormalizeTimeColumn.mockRestore();
   });
-  it('should orverride time filter if GENERIC_CHART_AXES is enabled', () => {
-    Object.defineProperty(getXAxisModule, 'hasGenericChartAxes', {
-      value: true,
-    });
-
-    const queryContext = buildQueryContext(
-      {
-        datasource: '5__table',
-        viz_type: 'table',
-      },
-      () => [
-        {
-          filters: [
-            {
-              col: 'col1',
-              op: 'TEMPORAL_RANGE',
-              val: '2001 : 2002',
-            },
-            {
-              col: 'col2',
-              op: 'IN',
-              val: ['a', 'b'],
-            },
-          ],
-          time_range: '1990 : 1991',
-        },
-      ],
-    );
-    expect(queryContext.queries[0].filters).toEqual([
-      { col: 'col1', op: 'TEMPORAL_RANGE', val: '1990 : 1991' },
-      {
-        col: 'col2',
-        op: 'IN',
-        val: ['a', 'b'],
-      },
-    ]);
-  });
 });

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -198,7 +198,8 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
         );
       }
 
-      const { url_params, ...formData } = this.props.form_data || {};
+      const formData = this.props.form_data || {};
+      delete formData.url_params;
 
       let dashboard: DashboardGetResponse | null = null;
       if (this.state.newDashboardName || this.state.saveToDashboardId) {

--- a/superset/common/query_context_factory.py
+++ b/superset/common/query_context_factory.py
@@ -151,7 +151,7 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
             if not filter_to_remove:
                 filter_to_remove = next(
                     (
-                        filter
+                        filter["col"]
                         for filter in query_object.filter
                         if filter["op"] == "TEMPORAL_RANGE"
                     ),
@@ -165,7 +165,7 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
                 query_object.filter = [
                     filter
                     for filter in query_object.filter
-                    if filter["col"] != filter_to_remove["col"]
+                    if filter["col"] != filter_to_remove
                 ]
 
     def _apply_filters(self, query_object: QueryObject):

--- a/superset/common/query_context_factory.py
+++ b/superset/common/query_context_factory.py
@@ -26,7 +26,6 @@ from superset.common.query_object import QueryObject
 from superset.common.query_object_factory import QueryObjectFactory
 from superset.datasource.dao import DatasourceDAO
 from superset.models.slice import Slice
-from superset.superset_typing import AdhocColumn
 from superset.utils.core import DatasourceDict, DatasourceType
 
 if TYPE_CHECKING:
@@ -162,8 +161,9 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
                         # Use the first temporal filter
                         filter_to_remove = temporal_filters[0]
 
-            # Removes the temporal filter which may be an x-axis or another temporal filter.
-            # A new filter based on the value of the granularity will be added later in the code.
+            # Removes the temporal filter which may be an x-axis or
+            # another temporal filter. A new filter based on the value of
+            # the granularity will be added later in the code.
             # In practice, this is replacing the previous default temporal filter.
             if filter_to_remove:
                 query_object.filter = [
@@ -174,6 +174,6 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
 
     def _apply_filters(self, query_object: QueryObject):
         if query_object.time_range:
-            for filter in query_object.filter:
-                if filter["op"] == "TEMPORAL_RANGE":
-                    filter["val"] = query_object.time_range
+            for filter_object in query_object.filter:
+                if filter_object["op"] == "TEMPORAL_RANGE":
+                    filter_object["val"] = query_object.time_range

--- a/superset/common/query_context_factory.py
+++ b/superset/common/query_context_factory.py
@@ -26,7 +26,6 @@ from superset.common.query_object import QueryObject
 from superset.common.query_object_factory import QueryObjectFactory
 from superset.datasource.dao import DatasourceDAO
 from superset.models.slice import Slice
-from superset.superset_typing import AdhocColumn
 from superset.utils.core import DatasourceDict, DatasourceType
 
 if TYPE_CHECKING:
@@ -136,13 +135,16 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
                         column
                         for column in query_object.columns
                         if column == x_axis
-                        or (type(column) is dict and column["sqlExpression"] == x_axis)
+                        or (
+                            isinstance(column, dict)
+                            and column["sqlExpression"] == x_axis
+                        )
                     ),
                     None,
                 )
                 # Replaces x-axis column values with granularity
                 if x_axis_column:
-                    if type(x_axis_column) is dict:
+                    if isinstance(x_axis_column, dict):
                         x_axis_column["sqlExpression"] = granularity
                         x_axis_column["label"] = granularity
                     else:

--- a/superset/common/query_context_factory.py
+++ b/superset/common/query_context_factory.py
@@ -22,9 +22,11 @@ from superset import app, db
 from superset.charts.dao import ChartDAO
 from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
 from superset.common.query_context import QueryContext
+from superset.common.query_object import QueryObject
 from superset.common.query_object_factory import QueryObjectFactory
 from superset.datasource.dao import DatasourceDAO
 from superset.models.slice import Slice
+from superset.superset_typing import AdhocColumn
 from superset.utils.core import DatasourceDict, DatasourceType
 
 if TYPE_CHECKING:
@@ -65,8 +67,12 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
         result_type = result_type or ChartDataResultType.FULL
         result_format = result_format or ChartDataResultFormat.JSON
         queries_ = [
-            self._query_object_factory.create(
-                result_type, datasource=datasource, **query_obj
+            self._process_query_object(
+                datasource_model_instance,
+                form_data,
+                self._query_object_factory.create(
+                    result_type, datasource=datasource, **query_obj
+                ),
             )
             for query_obj in queries
         ]
@@ -90,7 +96,6 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
 
     # pylint: disable=no-self-use
     def _convert_to_model(self, datasource: DatasourceDict) -> BaseDatasource:
-
         return DatasourceDAO.get_datasource(
             session=db.session,
             datasource_type=DatasourceType(datasource["type"]),
@@ -99,3 +104,54 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
 
     def _get_slice(self, slice_id: Any) -> Optional[Slice]:
         return ChartDAO.find_by_id(slice_id)
+
+    def _process_query_object(
+        self,
+        datasource: BaseDatasource,
+        form_data: Dict[str, Any],
+        query_object: QueryObject,
+    ) -> QueryObject:
+        self._apply_granularity(query_object, form_data, datasource)
+        self._apply_filters(query_object)
+        return query_object
+
+    def _apply_granularity(
+        self,
+        query_object: QueryObject,
+        form_data: Dict[str, Any],
+        datasource: BaseDatasource,
+    ):
+        temporal_columns = {
+            column.column_name for column in datasource.columns if column.is_temporal
+        }
+        granularity = query_object.granularity
+        x_axis = form_data.get("x_axis")
+        if granularity and x_axis in temporal_columns:
+            x_axis_column = next(
+                (
+                    column
+                    for column in query_object.columns
+                    if column["sqlExpression"] == x_axis
+                ),
+                None,
+            )
+            if x_axis_column:
+                x_axis_column["sqlExpression"] = granularity
+                x_axis_column["label"] = granularity
+                query_object.granularity = None
+                for post_processing in query_object.post_processing:
+                    if post_processing.get("operation") == "pivot":
+                        post_processing["options"]["index"] = [granularity]
+
+            x_axis_filter = x_axis and next(
+                (filter for filter in query_object.filter if filter["col"] == x_axis),
+                None,
+            )
+            if x_axis_filter:
+                x_axis_filter["col"] = granularity
+
+    def _apply_filters(self, query_object: QueryObject):
+        if query_object.time_range:
+            for filter in query_object.filter:
+                if filter["op"] == "TEMPORAL_RANGE":
+                    filter["val"] = query_object.time_range

--- a/superset/common/query_context_factory.py
+++ b/superset/common/query_context_factory.py
@@ -121,7 +121,9 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
         datasource: BaseDatasource,
     ) -> None:
         temporal_columns = {
-            column.column_name for column in datasource.columns if column.is_temporal
+            column.column_name
+            for column in datasource.columns
+            if (column["is_dttm"] if isinstance(column, dict) else column.is_dttm)
         }
         granularity = query_object.granularity
         x_axis = form_data and form_data.get("x_axis")


### PR DESCRIPTION
### SUMMARY
Fixes Time Column filters when `GENERIC_CHART_AXES` is enabled. Specifically:
- If a time column is applied and the x-axis is temporal, replace the x-axis and its associated filter with the time column
- If a time column is applied and the x-axis is NOT temporal, replace the first temporal filter with the time column if the time column is not already in the filters
- Moves to the server side the behavior of applying a time range to all temporal filters

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/217339766-c752a47c-7826-4a20-81ef-6ed76426772f.mov

https://user-images.githubusercontent.com/70410625/217339914-a0147934-0caf-4f48-ac15-27be684bd81a.mov

### TESTING INSTRUCTIONS
- Make sure the above rules work as intended
- Make sure different combinations of Time Range and Time column work as intended

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
