### PR TITLE
fix(dashboard): Chart's empty state not centered

### DIFF
--- a/superset-frontend/src/components/Chart/Chart.jsx
+++ b/superset-frontend/src/components/Chart/Chart.jsx
@@ -109,6 +109,10 @@ const Styles = styled.div`
   }
 
   .slice_container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+
     height: ${p => p.height}px;
 
     .pivot_table tbody tr {


### PR DESCRIPTION
### SUMMARY
This pr fixes chart's empty state on dashboard vertical alignment - was aligned to the top, should be entered.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="522" alt="image" src="https://user-images.githubusercontent.com/15073128/217308768-5b5070ab-8a94-4944-b0d0-c49269373d57.png">

After:

<img width="611" alt="image" src="https://user-images.githubusercontent.com/15073128/217308665-5c155030-651b-4477-a2c2-8e8035c19124.png">


### TESTING INSTRUCTIONS
Add some filters to trigger empty state in chart on dashboard, verify that empty state placeholder is centred.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


CC @kasiazjc 