### PR TITLE
chore(tests): Cypress optimizations to help with fails

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/load.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/load.test.ts
@@ -45,6 +45,6 @@ describe('Dashboard load', () => {
   it('should send log data', () => {
     interceptLog();
     cy.visit(WORLD_HEALTH_DASHBOARD);
-    cy.wait('@logs');
+    cy.wait('@logs', { timeout: 15000 });
   });
 });

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
@@ -235,7 +235,7 @@ function openMoreFilters(intercetFilterState = true) {
   }
 }
 
-describe.only('Horizontal FilterBar', () => {
+describe('Horizontal FilterBar', () => {
   it('should go from vertical to horizontal and the opposite', () => {
     visitDashboard();
     openVerticalFilterBar();

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
@@ -235,7 +235,7 @@ function openMoreFilters(intercetFilterState = true) {
   }
 }
 
-describe('Horizontal FilterBar', () => {
+describe.only('Horizontal FilterBar', () => {
   it('should go from vertical to horizontal and the opposite', () => {
     visitDashboard();
     openVerticalFilterBar();
@@ -283,7 +283,7 @@ describe('Horizontal FilterBar', () => {
     cy.getBySel('form-item-value').should('have.length', 3);
     cy.viewport(768, 1024);
     cy.getBySel('form-item-value').should('have.length', 0);
-    openMoreFilters();
+    openMoreFilters(false);
     cy.getBySel('form-item-value').should('have.length', 3);
 
     cy.getBySel('filter-bar').click();


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR makes two small tweaks to flaky/failing tests:
- `dashboard/nativeFilters.test.ts:should show "more filters" on window resizing up and down`: stopped `openMoreFilters` from waiting for the `postFilterState` request, as this was sometimes happening before the wait was started causing flakes/fails.
- `dashboard/load.test.ts:should send log data`: increased the wait time from the 10s default to 15s, as I think the dashboard taking longer than 10s to load was causing this wait to timeout.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
