### PR TITLE
fix: dataset import error message

### DIFF
--- a/superset/commands/importers/v1/__init__.py
+++ b/superset/commands/importers/v1/__init__.py
@@ -67,6 +67,9 @@ class ImportModelsCommand(BaseCommand):
         try:
             self._import(db.session, self._configs, self.overwrite)
             db.session.commit()
+        except CommandException as ex:
+            db.session.rollback()
+            raise ex
         except Exception as ex:
             db.session.rollback()
             raise self.import_error() from ex

--- a/superset/datasets/commands/exceptions.py
+++ b/superset/datasets/commands/exceptions.py
@@ -193,5 +193,5 @@ class DatasetDuplicateFailedError(CreateFailedError):
     message = _("Dataset could not be duplicated.")
 
 
-class DatasetForbiddenDataURI(ForbiddenError):
+class DatasetForbiddenDataURI(ImportFailedError):
     message = _("Data URI is not allowed.")


### PR DESCRIPTION
### SUMMARY
When a not allowed data URI exists on the import zip, the error message is generic and does not help the user.

#### Before:
<img width="757" alt="Screenshot 2023-02-07 at 18 01 59" src="https://user-images.githubusercontent.com/4025227/217409718-97f011f6-c2ed-4d9a-a73b-dba93b202094.png">

#### After:
<img width="755" alt="Screenshot 2023-02-07 at 18 04 53" src="https://user-images.githubusercontent.com/4025227/217410074-d3b61a2f-d1c9-4187-a713-0a6c531db637.png">


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
