### PR TITLE
chore: Migrate /superset/schemas_access_for_file_upload to v1

### DIFF
--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -1223,6 +1223,7 @@
             "example": false
           },
           "periods": {
+            "description": "Time periods (in units of `time_grain`) to predict into the future",
             "example": 7,
             "format": "int32",
             "type": "integer"
@@ -1578,6 +1579,7 @@
             "type": "string"
           },
           "from_dttm": {
+            "description": "Start timestamp of time range",
             "format": "int32",
             "nullable": true,
             "type": "integer"
@@ -1603,6 +1605,7 @@
             "type": "integer"
           },
           "stacktrace": {
+            "description": "Stacktrace if there was an error",
             "nullable": true,
             "type": "string"
           },
@@ -1620,6 +1623,7 @@
             "type": "string"
           },
           "to_dttm": {
+            "description": "End timestamp of time range",
             "format": "int32",
             "nullable": true,
             "type": "integer"
@@ -1830,10 +1834,10 @@
             "type": "string"
           },
           "last_saved_by": {
-            "$ref": "#/components/schemas/ChartDataRestApi.get_list.User3"
+            "$ref": "#/components/schemas/ChartDataRestApi.get_list.User1"
           },
           "owners": {
-            "$ref": "#/components/schemas/ChartDataRestApi.get_list.User1"
+            "$ref": "#/components/schemas/ChartDataRestApi.get_list.User3"
           },
           "params": {
             "nullable": true,
@@ -1921,16 +1925,11 @@
           "last_name": {
             "maxLength": 64,
             "type": "string"
-          },
-          "username": {
-            "maxLength": 64,
-            "type": "string"
           }
         },
         "required": [
           "first_name",
-          "last_name",
-          "username"
+          "last_name"
         ],
         "type": "object"
       },
@@ -1968,11 +1967,16 @@
           "last_name": {
             "maxLength": 64,
             "type": "string"
+          },
+          "username": {
+            "maxLength": 64,
+            "type": "string"
           }
         },
         "required": [
           "first_name",
-          "last_name"
+          "last_name",
+          "username"
         ],
         "type": "object"
       },
@@ -2232,6 +2236,7 @@
             "type": "string"
           },
           "rolling_type_options": {
+            "description": "Optional options to pass to rolling method. Needed for e.g. quantile operation.",
             "example": {},
             "type": "object"
           },
@@ -2622,10 +2627,10 @@
             "type": "string"
           },
           "last_saved_by": {
-            "$ref": "#/components/schemas/ChartRestApi.get_list.User3"
+            "$ref": "#/components/schemas/ChartRestApi.get_list.User1"
           },
           "owners": {
-            "$ref": "#/components/schemas/ChartRestApi.get_list.User1"
+            "$ref": "#/components/schemas/ChartRestApi.get_list.User3"
           },
           "params": {
             "nullable": true,
@@ -2713,16 +2718,11 @@
           "last_name": {
             "maxLength": 64,
             "type": "string"
-          },
-          "username": {
-            "maxLength": 64,
-            "type": "string"
           }
         },
         "required": [
           "first_name",
-          "last_name",
-          "username"
+          "last_name"
         ],
         "type": "object"
       },
@@ -2760,11 +2760,16 @@
           "last_name": {
             "maxLength": 64,
             "type": "string"
+          },
+          "username": {
+            "maxLength": 64,
+            "type": "string"
           }
         },
         "required": [
           "first_name",
-          "last_name"
+          "last_name",
+          "username"
         ],
         "type": "object"
       },
@@ -3415,7 +3420,7 @@
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/DashboardRestApi.get_list.User2"
+            "$ref": "#/components/schemas/DashboardRestApi.get_list.User1"
           },
           "created_on_delta_humanized": {
             "readOnly": true
@@ -3441,7 +3446,7 @@
             "type": "string"
           },
           "owners": {
-            "$ref": "#/components/schemas/DashboardRestApi.get_list.User1"
+            "$ref": "#/components/schemas/DashboardRestApi.get_list.User2"
           },
           "position_json": {
             "nullable": true,
@@ -3515,6 +3520,27 @@
       },
       "DashboardRestApi.get_list.User1": {
         "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "id": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "last_name"
+        ],
+        "type": "object"
+      },
+      "DashboardRestApi.get_list.User2": {
+        "properties": {
           "email": {
             "maxLength": 64,
             "type": "string"
@@ -3541,27 +3567,6 @@
           "first_name",
           "last_name",
           "username"
-        ],
-        "type": "object"
-      },
-      "DashboardRestApi.get_list.User2": {
-        "properties": {
-          "first_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
-          "id": {
-            "format": "int32",
-            "type": "integer"
-          },
-          "last_name": {
-            "maxLength": 64,
-            "type": "string"
-          }
-        },
-        "required": [
-          "first_name",
-          "last_name"
         ],
         "type": "object"
       },
@@ -4288,6 +4293,18 @@
         },
         "type": "object"
       },
+      "DatabaseSchemaAccessForFileUploadResponse": {
+        "properties": {
+          "schemas": {
+            "description": "The list of schemas allowed for the database to upload information",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
       "DatabaseTablesResponse": {
         "properties": {
           "extra": {
@@ -4912,7 +4929,7 @@
             "$ref": "#/components/schemas/DatasetRestApi.get.TableColumn"
           },
           "created_by": {
-            "$ref": "#/components/schemas/DatasetRestApi.get.User2"
+            "$ref": "#/components/schemas/DatasetRestApi.get.User1"
           },
           "created_on": {
             "format": "date-time",
@@ -4976,7 +4993,7 @@
             "type": "integer"
           },
           "owners": {
-            "$ref": "#/components/schemas/DatasetRestApi.get.User1"
+            "$ref": "#/components/schemas/DatasetRestApi.get.User2"
           },
           "schema": {
             "maxLength": 255,
@@ -5190,6 +5207,23 @@
             "maxLength": 64,
             "type": "string"
           },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "last_name"
+        ],
+        "type": "object"
+      },
+      "DatasetRestApi.get.User2": {
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
           "id": {
             "format": "int32",
             "type": "integer"
@@ -5207,23 +5241,6 @@
           "first_name",
           "last_name",
           "username"
-        ],
-        "type": "object"
-      },
-      "DatasetRestApi.get.User2": {
-        "properties": {
-          "first_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
-          "last_name": {
-            "maxLength": 64,
-            "type": "string"
-          }
-        },
-        "required": [
-          "first_name",
-          "last_name"
         ],
         "type": "object"
       },
@@ -6966,7 +6983,7 @@
             "type": "integer"
           },
           "created_by": {
-            "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.User2"
+            "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.User1"
           },
           "created_on": {
             "format": "date-time",
@@ -7016,7 +7033,7 @@
             "type": "string"
           },
           "owners": {
-            "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.User1"
+            "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.User2"
           },
           "recipients": {
             "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.ReportRecipients"
@@ -7077,10 +7094,6 @@
             "maxLength": 64,
             "type": "string"
           },
-          "id": {
-            "format": "int32",
-            "type": "integer"
-          },
           "last_name": {
             "maxLength": 64,
             "type": "string"
@@ -7097,6 +7110,10 @@
           "first_name": {
             "maxLength": 64,
             "type": "string"
+          },
+          "id": {
+            "format": "int32",
+            "type": "integer"
           },
           "last_name": {
             "maxLength": 64,
@@ -15243,6 +15260,50 @@
             "jwt": []
           }
         ],
+        "tags": [
+          "Database"
+        ]
+      }
+    },
+    "/api/v1/database/{pk}/schemas_access_for_file_upload/": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatabaseSchemaAccessForFileUploadResponse"
+                }
+              }
+            },
+            "description": "The list of the database schemas where to upload information"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "The list of the database schemas where to upload information",
         "tags": [
           "Database"
         ]

--- a/superset/constants.py
+++ b/superset/constants.py
@@ -143,6 +143,7 @@ MODEL_API_RW_METHOD_PERMISSION_MAP = {
     "delete_ssh_tunnel": "write",
     "get_updated_since": "read",
     "stop_query": "read",
+    "schemas_access_for_file_upload": "read",
 }
 
 EXTRA_FORM_DATA_APPEND_KEYS = {

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -740,3 +740,10 @@ def encrypted_field_properties(self, field: Any, **_) -> Dict[str, Any]:  # type
         if self.openapi_version.major > 2:
             ret["x-encrypted-extra"] = True
     return ret
+
+
+class DatabaseSchemaAccessForFileUploadResponse(Schema):
+    schemas = fields.List(
+        fields.String(),
+        description="The list of schemas allowed for the database to upload information",
+    )

--- a/superset/templates/superset/form_view/database_schemas_selector.html
+++ b/superset/templates/superset/form_view/database_schemas_selector.html
@@ -32,12 +32,11 @@ under the License.
   function update_schemas_allowed_for_csv_upload(db_id) {
     $.ajax({
       method: "GET",
-      url: "/superset/schemas_access_for_file_upload",
-      data: {db_id: db_id},
+      url: `/api/v1/database/${db_id}/schemas_access_for_file_upload/`,
       dataType: 'json',
       contentType: "application/json; charset=utf-8"
     }).done(function (data) {
-      change_schema_field_in_formview(data)
+      change_schema_field_in_formview(data ? data.schemas : [])
     }).fail(function (error) {
       var errorMsg = error.responseJSON.error;
       alert("ERROR: " + errorMsg);

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2734,6 +2734,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @has_access_api
     @event_logger.log_this
     @expose("/schemas_access_for_file_upload")
+    @deprecated()
     def schemas_access_for_file_upload(self) -> FlaskResponse:
         """
         This method exposes an API endpoint to

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -3171,3 +3171,45 @@ class TestDatabaseApi(SupersetTestCase):
             return
         self.assertEqual(rv.status_code, 422)
         self.assertIn("Kaboom!", response["errors"][0]["message"])
+
+    @mock.patch(
+        "superset.security.SupersetSecurityManager.get_schemas_accessible_by_user"
+    )
+    @mock.patch("superset.security.SupersetSecurityManager.can_access_database")
+    @mock.patch("superset.security.SupersetSecurityManager.can_access_all_datasources")
+    def test_schemas_access_for_csv_upload_not_found_endpoint(
+        self,
+        mock_can_access_all_datasources,
+        mock_can_access_database,
+        mock_schemas_accessible,
+    ):
+        self.login(username="admin")
+        self.create_fake_db()
+        mock_can_access_all_datasources.return_value = False
+        mock_can_access_database.return_value = False
+        mock_schemas_accessible.return_value = ["this_schema_is_allowed_too"]
+        rv = self.client.get(f"/api/v1/database/120ff/schemas_access_for_file_upload")
+        self.assertEqual(rv.status_code, 404)
+        self.delete_fake_db()
+
+    @mock.patch(
+        "superset.security.SupersetSecurityManager.get_schemas_accessible_by_user"
+    )
+    @mock.patch("superset.security.SupersetSecurityManager.can_access_database")
+    @mock.patch("superset.security.SupersetSecurityManager.can_access_all_datasources")
+    def test_schemas_access_for_csv_upload_endpoint(
+        self,
+        mock_can_access_all_datasources,
+        mock_can_access_database,
+        mock_schemas_accessible,
+    ):
+        self.login(username="admin")
+        dbobj = self.create_fake_db()
+        mock_can_access_all_datasources.return_value = False
+        mock_can_access_database.return_value = False
+        mock_schemas_accessible.return_value = ["this_schema_is_allowed_too"]
+        data = self.get_json_resp(
+            url=f"/api/v1/database/{dbobj.id}/schemas_access_for_file_upload"
+        )
+        assert data == {"schemas": ["this_schema_is_allowed_too"]}
+        self.delete_fake_db()


### PR DESCRIPTION
### SUMMARY
Continuing the effort on deprecating all /superset/ REST API endpoints
Deprecates `/superset/schemas_access_for_file_upload` for `/api/v1/database/{id}/schemas_access_for_file_upload`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
