### PR TITLE
feat(sqllab): Add event logger

### DIFF
--- a/superset-frontend/src/SqlLab/App.jsx
+++ b/superset-frontend/src/SqlLab/App.jsx
@@ -31,6 +31,7 @@ import {
 } from 'src/featureFlags';
 import setupExtensions from 'src/setup/setupExtensions';
 import getBootstrapData from 'src/utils/getBootstrapData';
+import logger from 'src/middleware/loggerMiddleware';
 import getInitialState from './reducers/getInitialState';
 import rootReducer from './reducers/index';
 import { initEnhancer } from '../reduxUtils';
@@ -116,7 +117,7 @@ const store = createStore(
   rootReducer,
   initialState,
   compose(
-    applyMiddleware(thunkMiddleware),
+    applyMiddleware(thunkMiddleware, logger),
     initEnhancer(
       !isFeatureEnabled(FeatureFlag.SQLLAB_BACKEND_PERSISTENCE),
       sqlLabPersistStateConfig,

--- a/superset-frontend/src/logger/LogUtils.ts
+++ b/superset-frontend/src/logger/LogUtils.ts
@@ -50,6 +50,8 @@ export const LOG_ACTIONS_CONFIRM_OVERWRITE_DASHBOARD_METADATA =
 export const LOG_ACTIONS_DASHBOARD_DOWNLOAD_AS_IMAGE =
   'dashboard_download_as_image';
 export const LOG_ACTIONS_CHART_DOWNLOAD_AS_IMAGE = 'chart_download_as_image';
+export const LOG_ACTIONS_SQLLAB_WARN_LOCAL_STORAGE_USAGE =
+  'sqllab_warn_local_storage_usage';
 
 // Log event types --------------------------------------------------------------
 export const LOG_EVENT_TYPE_TIMING = new Set([

--- a/superset-frontend/src/middleware/loggerMiddleware.js
+++ b/superset-frontend/src/middleware/loggerMiddleware.js
@@ -96,7 +96,8 @@ const loggerMiddleware = store => next => action => {
     );
     logMetadata = {
       source: 'sqlLab',
-      source_id: editor?.dbId,
+      source_id: editor?.id,
+      db_id: editor?.dbId,
       schema: editor?.schema,
     };
   }

--- a/superset-frontend/src/middleware/loggerMiddleware.js
+++ b/superset-frontend/src/middleware/loggerMiddleware.js
@@ -72,7 +72,7 @@ const loggerMiddleware = store => next => action => {
     return next(action);
   }
 
-  const { dashboardInfo, explore, impressionId, dashboardLayout } =
+  const { dashboardInfo, explore, impressionId, dashboardLayout, sqlLab } =
     store.getState();
   let logMetadata = {
     impression_id: impressionId,
@@ -89,6 +89,13 @@ const loggerMiddleware = store => next => action => {
       source: 'explore',
       source_id: explore.slice ? explore.slice.slice_id : 0,
       ...logMetadata,
+    };
+  } else if (sqlLab) {
+    logMetadata = {
+      source: 'sqlLab',
+      source_id: sqlLab.queryEditors.find(
+        ({ id }) => id === sqlLab.tabHistory.slice(-1)[0],
+      )?.dbId,
     };
   }
 

--- a/superset-frontend/src/middleware/loggerMiddleware.js
+++ b/superset-frontend/src/middleware/loggerMiddleware.js
@@ -91,11 +91,13 @@ const loggerMiddleware = store => next => action => {
       ...logMetadata,
     };
   } else if (sqlLab) {
+    const editor = sqlLab.queryEditors.find(
+      ({ id }) => id === sqlLab.tabHistory.slice(-1)[0],
+    );
     logMetadata = {
       source: 'sqlLab',
-      source_id: sqlLab.queryEditors.find(
-        ({ id }) => id === sqlLab.tabHistory.slice(-1)[0],
-      )?.dbId,
+      source_id: editor?.dbId,
+      schema: editor?.schema,
     };
   }
 


### PR DESCRIPTION
### SUMMARY
This commit adds the event logger on SqlLab to measure future user interaction and performance.
This commit logs the `sqllab_warn_local_storage_usage` to measure the frequency of the storage limitation warning.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

- After
<img width="493" alt="Screenshot_2023-02-08_at_3_04_54_PM" src="https://user-images.githubusercontent.com/1392866/217676844-29995496-f435-4e85-ba23-4f591777a0ab.png">

### TESTING INSTRUCTIONS
check chrome network tab

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
