### PR TITLE
chore: Removes icon warnings from tests

### DIFF
--- a/superset-frontend/spec/helpers/shim.tsx
+++ b/superset-frontend/spec/helpers/shim.tsx
@@ -89,4 +89,34 @@ jest.mock('react-markdown', () => (props: any) => <>{props.children}</>);
 jest.mock('rehype-sanitize', () => () => jest.fn());
 jest.mock('rehype-raw', () => () => jest.fn());
 
+// Mocks the Icon component due to its async nature
+// Tests should override this when needed
+jest.mock('src/components/Icons/Icon', () => ({
+  __esModule: true,
+  default: ({
+    fileName,
+    role,
+    'aria-label': ariaLabel,
+    ...rest
+  }: {
+    fileName: string;
+    role: string;
+    'aria-label': React.AriaAttributes['aria-label'];
+  }) => (
+    <span
+      role={role ?? 'img'}
+      aria-label={ariaLabel || fileName.replace('_', '-')}
+      {...rest}
+    />
+  ),
+  StyledIcon: ({
+    role,
+    'aria-label': ariaLabel,
+    ...rest
+  }: {
+    role: string;
+    'aria-label': React.AriaAttributes['aria-label'];
+  }) => <span role={role ?? 'img'} aria-label={ariaLabel} {...rest} />,
+}));
+
 process.env.WEBPACK_MODE = 'test';

--- a/superset-frontend/src/SqlLab/components/QueryLimitSelect/QueryLimitSelect.test.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryLimitSelect/QueryLimitSelect.test.tsx
@@ -42,9 +42,6 @@ jest.mock('src/components/Select/Select', () => () => (
 jest.mock('src/components/Select/AsyncSelect', () => () => (
   <div data-test="mock-deprecated-async-select" />
 ));
-jest.mock('src/components/Icons/Icon', () => () => (
-  <div data-test="mock-icons-icon" />
-));
 
 const defaultQueryLimit = 100;
 

--- a/superset-frontend/src/components/AlteredSliceTag/AlteredSliceTag.test.jsx
+++ b/superset-frontend/src/components/AlteredSliceTag/AlteredSliceTag.test.jsx
@@ -33,8 +33,6 @@ import {
   fakePluginControls,
 } from './AlteredSliceTagMocks';
 
-jest.mock('src/components/Icons/Icon', () => () => <span />);
-
 const getTableWrapperFromModalBody = modalBody =>
   modalBody.find(TableView).find(TableCollection);
 

--- a/superset-frontend/src/components/Datasource/DatasourceEditor.test.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceEditor.test.jsx
@@ -24,18 +24,6 @@ import DatasourceEditor from 'src/components/Datasource/DatasourceEditor';
 import mockDatasource from 'spec/fixtures/mockDatasource';
 import * as featureFlags from 'src/featureFlags';
 
-jest.mock('src/components/Icons/Icon', () => ({
-  __esModule: true,
-  default: ({ fileName, role, ...rest }) => (
-    <span
-      role={role ?? 'img'}
-      aria-label={fileName.replace('_', '-')}
-      {...rest}
-    />
-  ),
-  StyledIcon: () => <span />,
-}));
-
 const props = {
   datasource: mockDatasource['7__table'],
   addSuccessToast: () => {},

--- a/superset-frontend/src/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/superset-frontend/src/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -20,8 +20,6 @@ import React from 'react';
 import { render, screen } from 'spec/helpers/testing-library';
 import ErrorBoundary from '.';
 
-jest.mock('src/components/Icons/Icon', () => () => <span />);
-
 const mockedProps = {
   children: <span>Error children</span>,
   onError: () => null,

--- a/superset-frontend/src/components/ListView/ListView.test.jsx
+++ b/superset-frontend/src/components/ListView/ListView.test.jsx
@@ -35,12 +35,6 @@ import Pagination from 'src/components/Pagination/Wrapper';
 
 import waitForComponentToPaint from 'spec/helpers/waitForComponentToPaint';
 
-jest.mock('src/components/Icons/Icon', () => ({
-  __esModule: true,
-  default: () => <span />,
-  StyledIcon: () => <span />,
-}));
-
 function makeMockLocation(query) {
   const queryStr = encodeURIComponent(query);
   return {

--- a/superset-frontend/src/components/MessageToasts/Toast.test.jsx
+++ b/superset-frontend/src/components/MessageToasts/Toast.test.jsx
@@ -23,8 +23,6 @@ import Toast from 'src/components/MessageToasts/Toast';
 import { act } from 'react-dom/test-utils';
 import mockMessageToasts from './mockMessageToasts';
 
-jest.mock('src/components/Icons/Icon', () => () => <span />);
-
 const props = {
   toast: mockMessageToasts[0],
   onCloseToast() {},

--- a/superset-frontend/src/components/PageHeaderWithActions/PageHeaderWithActions.test.tsx
+++ b/superset-frontend/src/components/PageHeaderWithActions/PageHeaderWithActions.test.tsx
@@ -23,8 +23,6 @@ import userEvent from '@testing-library/user-event';
 import { PageHeaderWithActions, PageHeaderWithActionsProps } from './index';
 import { Menu } from '../Menu';
 
-jest.mock('src/components/Icons/Icon', () => () => <span />);
-
 const defaultProps: PageHeaderWithActionsProps = {
   editableTitleProps: {
     title: 'Test title',

--- a/superset-frontend/src/components/ReportModal/HeaderReportDropdown/index.test.tsx
+++ b/superset-frontend/src/components/ReportModal/HeaderReportDropdown/index.test.tsx
@@ -24,12 +24,6 @@ import HeaderReportDropdown, { HeaderReportProps } from '.';
 
 let isFeatureEnabledMock: jest.MockInstance<boolean, [string]>;
 
-jest.mock('src/components/Icons/Icon', () => ({
-  __esModule: true,
-  default: () => <span />,
-  StyledIcon: () => <span />,
-}));
-
 const createProps = () => ({
   dashboardId: 1,
   useTextMenu: false,

--- a/superset-frontend/src/components/ReportModal/ReportModal.test.tsx
+++ b/superset-frontend/src/components/ReportModal/ReportModal.test.tsx
@@ -33,12 +33,6 @@ fetchMock.get(REPORT_ENDPOINT, {});
 
 const NOOP = () => {};
 
-jest.mock('src/components/Icons/Icon', () => ({
-  __esModule: true,
-  default: () => <span />,
-  StyledIcon: () => <span />,
-}));
-
 const defaultProps = {
   addDangerToast: NOOP,
   addSuccessToast: NOOP,

--- a/superset-frontend/src/components/Select/AsyncSelect.tsx
+++ b/superset-frontend/src/components/Select/AsyncSelect.tsx
@@ -511,9 +511,9 @@ const AsyncSelect = forwardRef(
           suffixIcon={getSuffixIcon(isLoading, showSearch, isDropdownVisible)}
           menuItemSelectedIcon={
             invertSelection ? (
-              <StyledStopOutlined iconSize="m" />
+              <StyledStopOutlined iconSize="m" aria-label="stop" />
             ) : (
-              <StyledCheckOutlined iconSize="m" />
+              <StyledCheckOutlined iconSize="m" aria-label="check" />
             )
           }
           oneLine={oneLine}

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -486,9 +486,9 @@ const Select = forwardRef(
           )}
           menuItemSelectedIcon={
             invertSelection ? (
-              <StyledStopOutlined iconSize="m" />
+              <StyledStopOutlined iconSize="m" aria-label="stop" />
             ) : (
-              <StyledCheckOutlined iconSize="m" />
+              <StyledCheckOutlined iconSize="m" aria-label="check" />
             )
           }
           oneLine={oneLine}

--- a/superset-frontend/src/components/TableView/TableView.test.tsx
+++ b/superset-frontend/src/components/TableView/TableView.test.tsx
@@ -44,8 +44,6 @@ const mockedProps: TableViewProps = {
   pageSize: 1,
 };
 
-jest.mock('src/components/Icons/Icon', () => () => <span />);
-
 test('should render', () => {
   const { container } = render(<TableView {...mockedProps} />);
   expect(container).toBeInTheDocument();

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
@@ -49,9 +49,6 @@ jest.mock('src/featureFlags');
 jest.mock('src/components/ResizableSidebar/useStoredSidebarWidth');
 
 // mock following dependant components to fix the prop warnings
-jest.mock('src/components/Icons/Icon', () => () => (
-  <div data-test="mock-icon" />
-));
 jest.mock('src/components/DeprecatedSelect/WindowedSelect', () => () => (
   <div data-test="mock-windowed-select" />
 ));

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
@@ -27,25 +27,6 @@ import DatasourceControl from '.';
 
 const SupersetClientGet = jest.spyOn(SupersetClient, 'get');
 
-jest.mock('src/components/Icons/Icon', () => ({
-  __esModule: true,
-  default: ({
-    fileName,
-    role,
-    ...rest
-  }: {
-    fileName: string;
-    role: string;
-  }) => (
-    <span
-      role={role ?? 'img'}
-      aria-label={fileName.replace('_', '-')}
-      {...rest}
-    />
-  ),
-  StyledIcon: () => <span />,
-}));
-
 const createProps = (overrides: JsonObject = {}) => ({
   hovered: false,
   type: 'DatasourceControl',

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.test.tsx
@@ -30,14 +30,6 @@ import { DndMetricSelect } from 'src/explore/components/controls/DndColumnSelect
 import { AGGREGATES } from 'src/explore/constants';
 import { EXPRESSION_TYPES } from '../MetricControl/AdhocMetric';
 
-jest.mock('src/components/Icons/Icon', () => ({
-  __esModule: true,
-  default: ({ fileName }: { fileName: string }) => (
-    <span role="img" aria-label={fileName.replace('_', '-')} />
-  ),
-  StyledIcon: () => <span />,
-}));
-
 const defaultProps = {
   savedMetrics: [
     {

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterOption/AdhocFilterOption.test.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterOption/AdhocFilterOption.test.tsx
@@ -25,14 +25,6 @@ import AdhocFilter, {
 } from 'src/explore/components/controls/FilterControl/AdhocFilter';
 import AdhocFilterOption, { AdhocFilterOptionProps } from '.';
 
-jest.mock('src/components/Icons/Icon', () => ({
-  __esModule: true,
-  default: ({ fileName, role }: { fileName: string; role: string }) => (
-    <span role={role ?? 'img'} aria-label={fileName.replace('_', '-')} />
-  ),
-  StyledIcon: () => <span />,
-}));
-
 const simpleAdhocFilter = new AdhocFilter({
   expressionType: EXPRESSION_TYPES.SIMPLE,
   subject: 'value',

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/FastVizSwitcher.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/FastVizSwitcher.tsx
@@ -213,7 +213,9 @@ export const FastVizSwitcher = React.memo(
       ) {
         vizTiles.unshift({
           name: currentSelection,
-          icon: <Icons.MonitorOutlined {...antdIconProps} />,
+          icon: (
+            <Icons.MonitorOutlined {...antdIconProps} aria-label="monitor" />
+          ),
         });
       }
       if (
@@ -224,7 +226,12 @@ export const FastVizSwitcher = React.memo(
       ) {
         vizTiles.unshift({
           name: currentViz,
-          icon: <Icons.CheckSquareOutlined {...antdIconProps} />,
+          icon: (
+            <Icons.CheckSquareOutlined
+              {...antdIconProps}
+              aria-label="check-square"
+            />
+          ),
         });
       }
       return vizTiles;

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseList.test.jsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseList.test.jsx
@@ -64,14 +64,6 @@ jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
 }));
 
-jest.mock('src/components/Icons/Icon', () => ({
-  __esModule: true,
-  default: ({ fileName, role }) => (
-    <span role={role ?? 'img'} aria-label={fileName.replace('_', '-')} />
-  ),
-  StyledIcon: () => <span />,
-}));
-
 fetchMock.get(databasesInfoEndpoint, {
   permissions: ['can_write'],
 });

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.test.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.test.tsx
@@ -45,25 +45,6 @@ jest.mock('@superset-ui/core', () => ({
   isFeatureEnabled: () => true,
 }));
 
-jest.mock('src/components/Icons/Icon', () => ({
-  __esModule: true,
-  default: ({
-    fileName,
-    role,
-    ...rest
-  }: {
-    fileName: string;
-    role: string;
-  }) => (
-    <span
-      role={role ?? 'img'}
-      aria-label={fileName.replace('_', '-')}
-      {...rest}
-    />
-  ),
-  StyledIcon: () => <span />,
-}));
-
 const mockHistoryPush = jest.fn();
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),

--- a/superset-frontend/src/views/CRUD/data/query/QueryList.test.tsx
+++ b/superset-frontend/src/views/CRUD/data/query/QueryList.test.tsx
@@ -35,14 +35,6 @@ import SyntaxHighlighter from 'react-syntax-highlighter/dist/cjs/light';
 import SubMenu from 'src/views/components/SubMenu';
 import { QueryState } from '@superset-ui/core';
 
-jest.mock('src/components/Icons/Icon', () => ({
-  __esModule: true,
-  default: ({ fileName, role }: { fileName: string; role: string }) => (
-    <span role={role ?? 'img'} aria-label={fileName.replace('_', '-')} />
-  ),
-  StyledIcon: () => <span />,
-}));
-
 // store needed for withToasts
 const mockStore = configureStore([thunk]);
 const store = mockStore({});


### PR DESCRIPTION
### SUMMARY
Thanks to the great work done by @lyndsiWilliams removing the test warnings, I was able to identify a common pattern in the use of icons by test files. This PR takes advantage of this pattern and globally mocks the `Icons` component to remove the following warning from tests:

```
console.error
      Warning: An update to Icon inside a test was not wrapped in act(...).
```

### TESTING INSTRUCTIONS
1 - Execute all tests
2 - All tests should pass with no referred warning

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
