### PR TITLE
chore(style): make brand icon max width customizable

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/style/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/style/index.tsx
@@ -161,6 +161,7 @@ const defaultTheme = {
   },
   transitionTiming: 0.3,
   gridUnit: 4,
+  brandIconMaxWidth: 37,
 };
 
 export type SupersetTheme = typeof defaultTheme;

--- a/superset-frontend/src/views/components/Menu.tsx
+++ b/superset-frontend/src/views/components/Menu.tsx
@@ -62,7 +62,7 @@ const StyledHeader = styled.header`
         padding: ${theme.gridUnit}px ${theme.gridUnit * 2}px ${
     theme.gridUnit
   }px ${theme.gridUnit * 4}px;
-        max-width: ${theme.gridUnit * 37}px;
+        max-width: ${theme.gridUnit * theme.brandIconMaxWidth}px;
         img {
           height: 100%;
           object-fit: contain;


### PR DESCRIPTION
### SUMMARY
Currently the brand icon can at maximum be 37 grid units wide, making it impossible to feature wider icons. This moves the default max width into the theme object so it can be overridden.

### AFTER
With this change, adding the following to your `superset_config.py` would render a wider logo:
```python
THEME_OVERRIDES = {
    "brandIconMaxWidth": 65,
}
```
![image](https://user-images.githubusercontent.com/33317356/218982771-7f0d9532-ec7e-435d-9173-eb87492f14e9.png)

### BEFORE
Previously, the logo would get squished if it exceeded the default max width:
![image](https://user-images.githubusercontent.com/33317356/218983171-ef8fa0b6-4354-4079-9301-06ef850ebb5e.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
