### PR TITLE
fix: css template permissions for gamma role

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -164,6 +164,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
     GAMMA_READ_ONLY_MODEL_VIEWS = {
         "Dataset",
         "Datasource",
+        "CssTemplate",
     } | READ_ONLY_MODEL_VIEWS
 
     ADMIN_ONLY_VIEW_MENUS = {

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -1490,6 +1490,7 @@ class TestRolePermission(SupersetTestCase):
     def test_gamma_permissions_basic(self):
         self.assert_can_gamma(get_perm_tuples("Gamma"))
         self.assert_cannot_alpha(get_perm_tuples("Gamma"))
+        self.assert_cannot_gamma(get_perm_tuples("Gamma"))
 
     @pytest.mark.usefixtures("public_role_like_gamma")
     def test_public_permissions_basic(self):

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -1328,13 +1328,26 @@ class TestRolePermission(SupersetTestCase):
     def assert_can_menu(self, view_menu, permissions_set):
         self.assertIn(("menu_access", view_menu), permissions_set)
 
+    def assert_cannot_menu(self, view_menu, permissions_set):
+        self.assertNotIn(("menu_access", view_menu), permissions_set)
+
+    def assert_cannot_gamma(self, perm_set):
+        self.assert_cannot_write("CssTemplate", perm_set)
+        self.assert_cannot_menu("CSS Templates", perm_set)
+        self.assert_cannot_menu("Manage", perm_set)
+        self.assert_cannot_menu("Queries", perm_set)
+        self.assert_cannot_menu("Import dashboards", perm_set)
+        self.assert_cannot_menu("Upload a CSV", perm_set)
+        self.assert_cannot_menu("ReportSchedule", perm_set)
+        self.assert_cannot_menu("Alerts & Report", perm_set)
+
     def assert_can_gamma(self, perm_set):
+        self.assert_can_read("CssTemplate", perm_set)
         self.assert_can_read("Dataset", perm_set)
 
         # make sure that user can create slices and dashboards
         self.assert_can_all("Dashboard", perm_set)
         self.assert_can_all("Chart", perm_set)
-
         self.assertIn(("can_add_slices", "Superset"), perm_set)
         self.assertIn(("can_copy_dash", "Superset"), perm_set)
         self.assertIn(("can_created_dashboards", "Superset"), perm_set)


### PR DESCRIPTION
### SUMMARY

Fixes Gamma role css template permissions to be read only

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
