### PR TITLE
fix(sqllab): Persisting tab state for saved query 

### DIFF
--- a/superset/views/sql_lab/views.py
+++ b/superset/views/sql_lab/views.py
@@ -152,6 +152,8 @@ class TabStateView(BaseSupersetView):
             sql=query_editor.get("sql", "SELECT ..."),
             query_limit=query_editor.get("queryLimit"),
             hide_left_bar=query_editor.get("hideLeftBar"),
+            saved_query_id=query_editor.get("remoteId"),
+            template_params=query_editor.get("templateParams"),
         )
         (
             db.session.query(TabState)


### PR DESCRIPTION
### SUMMARY
When we have multiple tabs opened for saved query, the most recent tab will only have the link preserved while all the other tabs will lose the linkage between saved  queries.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/44616979/219140783-abe75215-4de6-41d1-93d4-12a124cd3823.mov

After:


https://user-images.githubusercontent.com/44616979/219141567-66d4c57d-bfc2-4aee-b7ab-69283000f810.mov



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
