### PR TITLE
fix: dict bug on QueryContextFactory

### DIFF
--- a/superset/common/query_context_factory.py
+++ b/superset/common/query_context_factory.py
@@ -121,7 +121,7 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
         datasource: BaseDatasource,
     ) -> None:
         temporal_columns = {
-            column.column_name
+            column["column_name"] if isinstance(column, dict) else column.column_name
             for column in datasource.columns
             if (column["is_dttm"] if isinstance(column, dict) else column.is_dttm)
         }


### PR DESCRIPTION
### SUMMARY
Fixes minor bug from #23021 

**DB engine Error**
'dict' object has no attribute 'column_name'
This may be triggered by:Issue 1011 - Superset encountered an unexpected error.

```
  File "/app/superset/common/query_context_factory.py", line 123, in _apply_granularity
    temporal_columns = {
  File "/app/superset/common/query_context_factory.py", line 124, in <setcomp>
    column.column_name
AttributeError: 'dict' object has no attribute 'column_name'
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://user-images.githubusercontent.com/81631424/219262267-a867caff-7d43-4da0-81c8-58760df81e95.png)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [v ] Has associated issue: #23021 