### PR TITLE
fix: missing __init__ on module sqllab commands

### DIFF
--- a/superset/sqllab/api.py
+++ b/superset/sqllab/api.py
@@ -121,9 +121,7 @@ class SqlLabRestApi(BaseSupersetApi):
         """
         result = SqlResultExportCommand(client_id=client_id).run()
 
-        query = result.get("query")
-        data = result.get("data")
-        row_count = result.get("count")
+        query, data, row_count = result["query"], result["data"], result["count"]
 
         quoted_csv_name = parse.quote(query.name)
         response = CsvResponse(
@@ -292,7 +290,7 @@ class SqlLabRestApi(BaseSupersetApi):
             SqlQueryRenderImpl(get_template_processor),
             sql_json_executor,
             execution_context_convertor,
-            config.get("SQLLAB_CTAS_NO_LIMIT"),
+            config["SQLLAB_CTAS_NO_LIMIT"],
             log_params,
         )
 

--- a/superset/sqllab/commands/__init__.py
+++ b/superset/sqllab/commands/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/superset/sqllab/commands/export.py
+++ b/superset/sqllab/commands/export.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=too-few-public-methods, too-many-arguments
 from __future__ import annotations
 
 import logging

--- a/superset/sqllab/commands/export.py
+++ b/superset/sqllab/commands/export.py
@@ -20,7 +20,7 @@ import logging
 from typing import Any, cast, List, TypedDict
 
 import pandas as pd
-from flask_babel import gettext as __, lazy_gettext as _
+from flask_babel import gettext as __
 
 from superset import app, db, results_backend, results_backend_use_msgpack
 from superset.commands.base import BaseCommand
@@ -30,7 +30,6 @@ from superset.models.sql_lab import Query
 from superset.sql_parse import ParsedQuery
 from superset.sqllab.limiting_factor import LimitingFactor
 from superset.utils import core as utils, csv
-from superset.utils.dates import now_as_float
 from superset.views.utils import _deserialize_results_payload
 
 config = app.config
@@ -73,7 +72,7 @@ class SqlResultExportCommand(BaseCommand):
 
         try:
             self._query.raise_for_access()
-        except SupersetSecurityException:
+        except SupersetSecurityException as ex:
             raise SupersetErrorException(
                 SupersetError(
                     message=__("Cannot access the query"),
@@ -81,7 +80,7 @@ class SqlResultExportCommand(BaseCommand):
                     level=ErrorLevel.ERROR,
                 ),
                 status=403,
-            )
+            ) from ex
 
     def run(
         self,

--- a/superset/sqllab/commands/results.py
+++ b/superset/sqllab/commands/results.py
@@ -14,13 +14,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=too-few-public-methods, too-many-arguments
 from __future__ import annotations
 
 import logging
 from typing import Any, cast, Dict, Optional
 
-from flask_babel import gettext as __, lazy_gettext as _
+from flask_babel import gettext as __
 
 from superset import app, db, results_backend, results_backend_use_msgpack
 from superset.commands.base import BaseCommand

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2363,7 +2363,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             SqlQueryRenderImpl(get_template_processor),
             sql_json_executor,
             execution_context_convertor,
-            config.get("SQLLAB_CTAS_NO_LIMIT"),
+            config["SQLLAB_CTAS_NO_LIMIT"],
             log_params,
         )
 

--- a/tests/integration_tests/sql_lab/commands_tests.py
+++ b/tests/integration_tests/sql_lab/commands_tests.py
@@ -104,13 +104,9 @@ class TestSqlResultExportCommand(SupersetTestCase):
         get_df_mock.return_value = pd.DataFrame({"foo": [1, 2, 3]})
         result = command.run()
 
-        data = result.get("data")
-        count = result.get("count")
-        query = result.get("query")
-
-        assert data == "foo\n1\n2\n3\n"
-        assert count == 3
-        assert query.client_id == "test"
+        assert result["data"] == "foo\n1\n2\n3\n"
+        assert result["count"] == 3
+        assert result["query"].client_id == "test"
 
     @pytest.mark.usefixtures("create_database_and_query")
     @patch("superset.models.sql_lab.Query.raise_for_access", lambda _: None)
@@ -126,13 +122,9 @@ class TestSqlResultExportCommand(SupersetTestCase):
         get_df_mock.return_value = pd.DataFrame({"foo": [1, 2, 3]})
         result = command.run()
 
-        data = result.get("data")
-        count = result.get("count")
-        query = result.get("query")
-
-        assert data == "foo\n1\n2\n"
-        assert count == 2
-        assert query.client_id == "test"
+        assert result["data"] == "foo\n1\n2\n"
+        assert result["count"] == 2
+        assert result["query"].client_id == "test"
 
     @pytest.mark.usefixtures("create_database_and_query")
     @patch("superset.models.sql_lab.Query.raise_for_access", lambda _: None)
@@ -152,13 +144,9 @@ class TestSqlResultExportCommand(SupersetTestCase):
 
         result = command.run()
 
-        data = result.get("data")
-        count = result.get("count")
-        query = result.get("query")
-
-        assert data == "foo\n1\n"
-        assert count == 1
-        assert query.client_id == "test"
+        assert result["data"] == "foo\n1\n"
+        assert result["count"] == 1
+        assert result["query"].client_id == "test"
 
     @pytest.mark.usefixtures("create_database_and_query")
     @patch("superset.models.sql_lab.Query.raise_for_access", lambda _: None)
@@ -179,13 +167,9 @@ class TestSqlResultExportCommand(SupersetTestCase):
 
         result = command.run()
 
-        data = result.get("data")
-        count = result.get("count")
-        query = result.get("query")
-
-        assert data == "foo\n0\n1\n2\n3\n4\n"
-        assert count == 5
-        assert query.client_id == "test"
+        assert result["data"] == "foo\n0\n1\n2\n3\n4\n"
+        assert result["count"] == 5
+        assert result["query"].client_id == "test"
 
 
 class TestSqlExecutionResultsCommand(SupersetTestCase):
@@ -217,9 +201,8 @@ class TestSqlExecutionResultsCommand(SupersetTestCase):
             db.session.commit()
 
     @patch("superset.sqllab.commands.results.results_backend_use_msgpack", False)
+    @patch("superset.sqllab.commands.results.results_backend", None)
     def test_validation_no_results_backend(self) -> None:
-        results.results_backend = None
-
         command = results.SqlExecutionResultsCommand("test", 1000)
 
         with pytest.raises(SupersetErrorException) as ex_info:
@@ -306,5 +289,5 @@ class TestSqlExecutionResultsCommand(SupersetTestCase):
         result = command.run()
 
         assert result.get("status") == "success"
-        assert result.get("query").get("rows") == 104
+        assert result["query"].get("rows") == 104
         assert result.get("data") == data


### PR DESCRIPTION
### SUMMARY

Missing `__init__.py` on module and lint fixes

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
