### PR TITLE
chore(sqla): Address performance tradeoff with eager loading

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -234,7 +234,6 @@ class TableColumn(Model, BaseColumn, CertificationMixin):
     table: Mapped["SqlaTable"] = relationship(
         "SqlaTable",
         back_populates="columns",
-        lazy="joined",  # Eager loading for efficient parent referencing with selectin.
     )
     is_dttm = Column(Boolean, default=False)
     expression = Column(MediumText())
@@ -449,7 +448,6 @@ class SqlMetric(Model, BaseMetric, CertificationMixin):
     table: Mapped["SqlaTable"] = relationship(
         "SqlaTable",
         back_populates="metrics",
-        lazy="joined",  # Eager loading for efficient parent referencing with selectin.
     )
     expression = Column(MediumText(), nullable=False)
     extra = Column(Text)
@@ -551,13 +549,11 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
         TableColumn,
         back_populates="table",
         cascade="all, delete-orphan",
-        lazy="selectin",  # Only non-eager loading that works with bidirectional joined.
     )
     metrics: Mapped[List[SqlMetric]] = relationship(
         SqlMetric,
         back_populates="table",
         cascade="all, delete-orphan",
-        lazy="selectin",  # Only non-eager loading that works with bidirectional joined.
     )
     metric_class = SqlMetric
     column_class = TableColumn


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

https://github.com/apache/superset/pull/22413 introduced logic for eager loading of the columns/metrics (as well as their back references) for a dataset, however the eagerness comes at a cost, i.e., the RESTful API GET `/api/v1/explore` endpoint is less performant given that all when fetching a slice or dataset the columns/metrics relationships are eagerly loaded.

This PR provides a tradeoff where we lazily load the columns/metrics relationships which negatively impacts the `/api/v1/dataset` endpoint but speeds up the `/api/v1/explore` endpoint (the later is used significantly more than the former).  The TL;DR is the current behavior was hyper optimized for one use case which negatively impacted other workflows.

The proposed behavior works best in the general sense and is more akin to how objects were lazy loaded prior to https://github.com/apache/superset/pull/22413 though facets of the existing performance improvements—by not leveraging the `joined` [relationship](https://docs.sqlalchemy.org/en/14/orm/relationship_api.html#sqlalchemy.orm.relationship)—remain. As we further refactor the API we can rethink said logic. 

Specifically for Airbnb's uber dataset the results are:

| Endpoint               | Current | Proposed |
| ----------------  | -------- | --------- |
| `/api/v1/dataset` | ~ 7 s      | ~ 26 s†     | 
| `/api/v1/explore` | ~ 16 s    | ~ 5 s         |

† Note even though this is slower it is significantly faster than prior to https://github.com/apache/superset/pull/22413 which used to time out. Furthermore a significantly cost is in the (now) lazy loading of the back references, i.e., `metric.table` which likely could be refactored in code.  

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI and local performance testing.
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
