### PR TITLE
chore: add execution_id to any available report logs

### DIFF
--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -719,9 +719,11 @@ class AsyncExecuteReportScheduleCommand(BaseCommand):
                 user = security_manager.find_user(username)
                 with override_user(user):
                     logger.info(
-                        "Running report schedule %s as user %s",
-                        self._execution_id,
+                        "Running report schedule as user %s",
                         username,
+                        extra={
+                            "execution_id": self._execution_id,
+                        },
                     )
                     ReportScheduleStateMachine(
                         session, self._execution_id, self._model, self._scheduled_dttm
@@ -736,9 +738,9 @@ class AsyncExecuteReportScheduleCommand(BaseCommand):
     ) -> None:
         # Validate/populate model exists
         logger.info(
-            "session is validated: id %s, executionid: %s",
+            "session is validated: id %s",
             self._model_id,
-            self._execution_id,
+            extra={"execution_id": self._execution_id},
         )
         self._model = (
             session.query(ReportSchedule).filter_by(id=self._model_id).one_or_none()

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -187,6 +187,7 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
     def send(self) -> None:
         subject = self._get_subject()
         content = self._get_content()
+        execution_id = content.header_data and content.header_data.get("execution_id")
         to = self._get_to()
         try:
             send_email_smtp(
@@ -203,7 +204,8 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
                 header_data=content.header_data,
             )
             logger.info(
-                "Report sent to email, notification content is %s", content.header_data
+                "Report sent to email. Execution_id is %s",
+                execution_id,
             )
         except SupersetErrorsException as ex:
             raise NotificationError(

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -204,8 +204,8 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
                 header_data=content.header_data,
             )
             logger.info(
-                "Report sent to email. Execution_id is %s",
-                execution_id,
+                "Report sent to email",
+                extra={"execution_id": execution_id},
             )
         except SupersetErrorsException as ex:
             raise NotificationError(

--- a/superset/reports/notifications/slack.py
+++ b/superset/reports/notifications/slack.py
@@ -181,8 +181,8 @@ Error: %(text)s
             else:
                 client.chat_postMessage(channel=channel, text=body)
             logger.info(
-                "Report sent to slack. Execution id is %s",
-                self._content.header_data["execution_id"],
+                "Report sent to slack",
+                extra={"execution_id": self._content.header_data["execution_id"]},
             )
         except (
             BotUserAccessError,

--- a/superset/reports/notifications/slack.py
+++ b/superset/reports/notifications/slack.py
@@ -180,7 +180,10 @@ Error: %(text)s
                     )
             else:
                 client.chat_postMessage(channel=channel, text=body)
-            logger.info("Report sent to slack")
+            logger.info(
+                "Report sent to slack. Execution id is %s",
+                self._content.header_data["execution_id"],
+            )
         except (
             BotUserAccessError,
             SlackRequestError,

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -202,6 +202,7 @@ class HeaderDataType(TypedDict):
     notification_source: Optional[str]
     chart_id: Optional[int]
     dashboard_id: Optional[int]
+    execution_id: uuid.UUID
 
 
 class DatasourceDict(TypedDict):

--- a/superset/utils/screenshots.py
+++ b/superset/utils/screenshots.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import logging
 from io import BytesIO
-from typing import cast, Optional, TYPE_CHECKING, TypedDict, Union
+from typing import Optional, TYPE_CHECKING, TypedDict, Union
 from uuid import UUID
 
 from flask import current_app
@@ -219,13 +219,15 @@ class ChartScreenshot(BaseScreenshot):
     thumbnail_type: str = "chart"
     element: str = "chart-container"
 
-    def __init__(self, url: str, digest: str, *args: ScreenshotDetails):
+    def __init__(
+        self, url: str, digest: str, options: Optional[ScreenshotDetails] = None
+    ):
         # Chart reports and thumbnails are in standalone="true" mode
         url = modify_url_query(
             url,
             standalone=ChartStandaloneMode.HIDE_NAV.value,
         )
-        options = cast(ScreenshotDetails, {*args})
+        options = options or {}
         super().__init__(url, digest, options.get("execution_id"))
         self.window_size = options.get("window_size") or (800, 600)
         self.thumb_size = options.get("thumb_size") or (800, 600)
@@ -235,14 +237,16 @@ class DashboardScreenshot(BaseScreenshot):
     thumbnail_type: str = "dashboard"
     element: str = "standalone"
 
-    def __init__(self, url: str, digest: str, *args: ScreenshotDetails):
+    def __init__(
+        self, url: str, digest: str, options: Optional[ScreenshotDetails] = None
+    ):
         # per the element above, dashboard screenshots
         # should always capture in standalone
         url = modify_url_query(
             url,
             standalone=DashboardStandaloneMode.REPORT.value,
         )
-        options = cast(ScreenshotDetails, {*args})
+        options = options or {}
         super().__init__(url, digest, options.get("execution_id"))
         self.window_size = options.get("window_size") or (1600, 1200)
         self.thumb_size = options.get("thumb_size") or (800, 600)

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -202,11 +202,11 @@ class WebDriverProxy:
             ]
             logger.debug("Wait %i seconds for chart animation", selenium_animation_wait)
             sleep(selenium_animation_wait)
-            logger.info(
-                "Taking a PNG screenshot of url %s as user %s with execution_id: %s",
+            logger.debug(
+                "Taking a PNG screenshot of url %s as user %s",
                 url,
                 user.username,
-                execution_id,
+                extra={"execution_id": execution_id},
             )
 
             if current_app.config["SCREENSHOT_REPLACE_UNEXPECTED_ERRORS"]:

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -21,6 +21,7 @@ import logging
 from enum import Enum
 from time import sleep
 from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
+from uuid import UUID
 
 from flask import current_app
 from selenium.common.exceptions import (
@@ -165,7 +166,11 @@ class WebDriverProxy:
             pass
 
     def get_screenshot(
-        self, url: str, element_name: str, user: User
+        self,
+        url: str,
+        element_name: str,
+        user: User,
+        execution_id: Optional[UUID] = None,
     ) -> Optional[bytes]:
         driver = self.auth(user)
         driver.set_window_size(*self._window)
@@ -174,7 +179,6 @@ class WebDriverProxy:
         selenium_headstart = current_app.config["SCREENSHOT_SELENIUM_HEADSTART"]
         logger.debug("Sleeping for %i seconds", selenium_headstart)
         sleep(selenium_headstart)
-
         try:
             logger.debug("Wait for the presence of %s", element_name)
             element = WebDriverWait(driver, self._screenshot_locate_wait).until(
@@ -198,10 +202,11 @@ class WebDriverProxy:
             ]
             logger.debug("Wait %i seconds for chart animation", selenium_animation_wait)
             sleep(selenium_animation_wait)
-            logger.debug(
-                "Taking a PNG screenshot of url %s as user %s",
+            logger.info(
+                "Taking a PNG screenshot of url %s as user %s with execution_id: %s",
                 url,
                 user.username,
+                execution_id,
             )
 
             if current_app.config["SCREENSHOT_REPLACE_UNEXPECTED_ERRORS"]:

--- a/tests/integration_tests/thumbnails_tests.py
+++ b/tests/integration_tests/thumbnails_tests.py
@@ -19,6 +19,7 @@
 
 import json
 import urllib.request
+import uuid
 from io import BytesIO
 from typing import Tuple
 from unittest import skipUnless
@@ -210,12 +211,16 @@ class TestWebDriverProxy(SupersetTestCase):
             app.config["THUMBNAIL_SELENIUM_USER"]
         )
         url = get_url_path("Superset.slice", slice_id=1, standalone="true")
-        webdriver.get_screenshot(url=url, element_name="chart-container", user=user)
-        logger_mock.info.assert_called_with(
-            "Taking a PNG screenshot of url %s as user %s with execution_id: %s",
+        webdriver.get_screenshot(
+            url=url,
+            element_name="chart-container",
+            user=user,
+        )
+        logger_mock.debug.assert_called_with(
+            "Taking a PNG screenshot of url %s as user %s",
             "http://0.0.0.0:8081/superset/slice/1/?standalone=true",
             "admin",
-            None,
+            extra={"execution_id": None},
         )
 
     @patch("superset.utils.webdriver.WebDriverWait")
@@ -229,14 +234,18 @@ class TestWebDriverProxy(SupersetTestCase):
             app.config["THUMBNAIL_SELENIUM_USER"]
         )
         url = get_url_path("Superset.slice", slice_id=1, standalone="true")
+        execution_id = uuid.uuid4()
         webdriver.get_screenshot(
-            url=url, element_name="chart-container", user=user, execution_id="12345"
+            url=url,
+            element_name="chart-container",
+            user=user,
+            execution_id=execution_id,
         )
-        logger_mock.info.assert_called_with(
-            "Taking a PNG screenshot of url %s as user %s with execution_id: %s",
+        logger_mock.debug.assert_called_with(
+            "Taking a PNG screenshot of url %s as user %s",
             "http://0.0.0.0:8081/superset/slice/1/?standalone=true",
             "admin",
-            "12345",
+            extra={"execution_id": execution_id},
         )
 
 

--- a/tests/unit_tests/notifications/email_tests.py
+++ b/tests/unit_tests/notifications/email_tests.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import uuid
+
 import pandas as pd
 
 
@@ -41,6 +43,7 @@ def test_render_description_with_html() -> None:
             "notification_source": None,
             "chart_id": None,
             "dashboard_id": None,
+            "execution_id": uuid.uuid4(),
         },
     )
     email_body = (

--- a/tests/unit_tests/notifications/slack_tests.py
+++ b/tests/unit_tests/notifications/slack_tests.py
@@ -1,0 +1,84 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+
+@patch("superset.reports.notifications.slack.logger")
+def test_send_slack(
+    logger_mock: MagicMock,
+) -> None:
+    # `superset.models.helpers`, a dependency of following imports,
+    # requires app context
+    from superset.reports.models import ReportRecipients, ReportRecipientType
+    from superset.reports.notifications.base import NotificationContent
+    from superset.reports.notifications.slack import SlackNotification, WebClient
+
+    execution_id = uuid.uuid4()
+    content = NotificationContent(
+        name="test alert",
+        embedded_data=pd.DataFrame(
+            {
+                "A": [1, 2, 3],
+                "B": [4, 5, 6],
+                "C": ["111", "222", '<a href="http://www.example.com">333</a>'],
+            }
+        ),
+        description='<p>This is <a href="#">a test</a> alert</p><br />',
+        header_data={
+            "notification_format": "PNG",
+            "notification_type": "Alert",
+            "owners": [1],
+            "notification_source": None,
+            "chart_id": None,
+            "dashboard_id": None,
+            "execution_id": execution_id,
+        },
+    )
+    with patch.object(
+        WebClient, "chat_postMessage", return_value=True
+    ) as chat_post_message_mock:
+
+        SlackNotification(
+            recipient=ReportRecipients(
+                type=ReportRecipientType.SLACK,
+                recipient_config_json='{"target": "some_channel"}',
+            ),
+            content=content,
+        ).send()
+        logger_mock.info.assert_called_with(
+            "Report sent to slack", extra={"execution_id": execution_id}
+        )
+        chat_post_message_mock.assert_called_with(
+            channel="some_channel",
+            text="""*test alert*
+
+<p>This is <a href="#">a test</a> alert</p><br />
+
+<None|Explore in Superset>
+
+```
+|    |   A |   B | C                                        |
+|---:|----:|----:|:-----------------------------------------|
+|  0 |   1 |   4 | 111                                      |
+|  1 |   2 |   5 | 222                                      |
+|  2 |   3 |   6 | <a href="http://www.example.com">333</a> |
+```
+""",
+        )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
To improve logging, we're looking to be able to search for an execution ID to tie together logs from the entire alert/report Celery job. To do this, I have added an execution_id to the Screenshot classes (dashboard and chart), the slack and email send methods and the webdriver screenshot method. The report task is already passing the execution id through to the commands, etc, so I also passed the celery execution id through the thumbnail generation to the screenshot logs as well.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
