### PR TITLE
fix(rbac): show objects accessible by database access perm

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -44,6 +44,8 @@ assists people when migrating to a new version.
 
 ### Other
 
+- [23118](https://github.com/apache/superset/pull/23118): Previously the "database access on <database>" permission granted access to all datasets on the underlying database, but they didn't show up on the list views. Now all dashboards, charts and datasets that are accessible via this permission will also show up on their respective list views.
+
 ## 2.0.1
 
 - [21895](https://github.com/apache/superset/pull/21895): Markdown components had their security increased by adhering to the same sanitization process enforced by Github. This means that some HTML elements found in markdowns are not allowed anymore due to the security risks they impose. If you're deploying Superset in a trusted environment and wish to use some of the blocked elements, then you can use the HTML_SANITIZATION_SCHEMA_EXTENSIONS configuration to extend the default sanitization schema. There's also the option to disable HTML sanitization using the HTML_SANITIZATION configuration but we do not recommend this approach because of the security risks. Given the provided configurations, we don't view the improved sanitization as a breaking change but as a security patch.

--- a/superset/charts/dao.py
+++ b/superset/charts/dao.py
@@ -20,7 +20,7 @@ from typing import List, Optional, TYPE_CHECKING
 
 from sqlalchemy.exc import SQLAlchemyError
 
-from superset.charts.filters import ChartDaoFilter
+from superset.charts.filters import ChartFilter
 from superset.dao.base import BaseDAO
 from superset.extensions import db
 from superset.models.core import FavStar, FavStarClassName
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 
 class ChartDAO(BaseDAO):
     model_cls = Slice
-    base_filter = ChartDaoFilter
+    base_filter = ChartFilter
 
     @staticmethod
     def bulk_delete(models: Optional[List[Slice]], commit: bool = True) -> None:

--- a/superset/charts/dao.py
+++ b/superset/charts/dao.py
@@ -20,7 +20,7 @@ from typing import List, Optional, TYPE_CHECKING
 
 from sqlalchemy.exc import SQLAlchemyError
 
-from superset.charts.filters import ChartFilter
+from superset.charts.filters import ChartDaoFilter
 from superset.dao.base import BaseDAO
 from superset.extensions import db
 from superset.models.core import FavStar, FavStarClassName
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 
 class ChartDAO(BaseDAO):
     model_cls = Slice
-    base_filter = ChartFilter
+    base_filter = ChartDaoFilter
 
     @staticmethod
     def bulk_delete(models: Optional[List[Slice]], commit: bool = True) -> None:

--- a/superset/dashboards/filters.py
+++ b/superset/dashboards/filters.py
@@ -110,7 +110,7 @@ class DashboardAccessFilter(BaseFilter):  # pylint: disable=too-few-public-metho
     """
 
     def apply(self, query: Query, value: Any) -> Query:
-        if security_manager.can_access_all_datasources():
+        if security_manager.is_admin():
             return query
 
         is_rbac_disabled_filter = []
@@ -127,7 +127,10 @@ class DashboardAccessFilter(BaseFilter):  # pylint: disable=too-few-public-metho
                 and_(
                     Dashboard.published.is_(True),
                     *is_rbac_disabled_filter,
-                    get_dataset_access_filters(Slice),
+                    get_dataset_access_filters(
+                        Slice,
+                        security_manager.can_access_all_datasources(),
+                    ),
                 )
             )
         )

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -99,7 +99,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-DATABASE_PERM_REGEX = re.compile(r"\[\w+\]\.\(id\:(\d+)\)")
+DATABASE_PERM_REGEX = re.compile(r"^\[.+\]\.\(id\:(\d+)\)$")
 
 
 class DatabaseAndSchema(NamedTuple):

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -99,7 +99,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-DATABASE_PERM_REGEX = re.compile(r"^\[.+\]\.\(id\:(\d+)\)$")
+DATABASE_PERM_REGEX = re.compile(r"^\[.+\]\.\(id\:(?P<id>\d+)\)$")
 
 
 class DatabaseAndSchema(NamedTuple):
@@ -608,7 +608,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         """
         perms = self.user_view_menu_names("database_access")
         return [
-            int(match[1])
+            int(match.group("id"))
             for perm in perms
             if (match := DATABASE_PERM_REGEX.match(perm))
         ]

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -84,6 +84,7 @@ from superset.utils.core import (
     get_user_id,
     RowLevelSecurityFilterType,
 )
+from superset.utils.filters import get_dataset_access_filters
 from superset.utils.urls import get_url_host
 
 if TYPE_CHECKING:
@@ -527,8 +528,6 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         :returns: The list of datasources
         """
 
-        user_perms = self.user_view_menu_names("datasource_access")
-        schema_perms = self.user_view_menu_names("schema_access")
         user_datasources = set()
 
         # pylint: disable=import-outside-toplevel
@@ -536,12 +535,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
 
         user_datasources.update(
             self.get_session.query(SqlaTable)
-            .filter(
-                or_(
-                    SqlaTable.perm.in_(user_perms),
-                    SqlaTable.schema_perm.in_(schema_perms),
-                )
-            )
+            .filter(get_dataset_access_filters(SqlaTable))
             .all()
         )
 
@@ -606,7 +600,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             return {s.name for s in view_menu_names}
         return set()
 
-    def get_databases_accessible_by_user(self):
+    def get_accessible_databases(self) -> List[int]:
         """
         Return the list of databases accessible by the user.
 

--- a/superset/utils/filters.py
+++ b/superset/utils/filters.py
@@ -14,13 +14,17 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Any, Type
 
 from flask_appbuilder import Model
 from sqlalchemy import or_
 from sqlalchemy.sql.elements import BooleanClauseList
 
 
-def get_dataset_access_filters(base_model: Model) -> BooleanClauseList:
+def get_dataset_access_filters(
+    base_model: Type[Model],
+    *args: Any,
+) -> BooleanClauseList:
     # pylint: disable=import-outside-toplevel
     from superset import security_manager
     from superset.connectors.sqla.models import Database
@@ -33,4 +37,5 @@ def get_dataset_access_filters(base_model: Model) -> BooleanClauseList:
         Database.id.in_(database_ids),
         base_model.perm.in_(perms),
         base_model.schema_perm.in_(schema_perms),
+        *args,
     )

--- a/superset/utils/filters.py
+++ b/superset/utils/filters.py
@@ -14,18 +14,23 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Any
 
-from sqlalchemy.orm.query import Query
-
-from superset import security_manager
-from superset.utils.filters import get_dataset_access_filters
-from superset.views.base import BaseFilter
+from flask_appbuilder import Model
+from sqlalchemy import or_
+from sqlalchemy.sql.elements import BooleanClauseList
 
 
-class SliceFilter(BaseFilter):  # pylint: disable=too-few-public-methods
-    def apply(self, query: Query, value: Any) -> Query:
-        if security_manager.can_access_all_datasources():
-            return query
+def get_dataset_access_filters(base_model: Model) -> BooleanClauseList:
+    # pylint: disable=import-outside-toplevel
+    from superset import security_manager
+    from superset.connectors.sqla.models import Database
 
-        return query.filter(get_dataset_access_filters(self.model))
+    database_ids = security_manager.get_accessible_databases()
+    perms = security_manager.user_view_menu_names("datasource_access")
+    schema_perms = security_manager.user_view_menu_names("schema_access")
+
+    return or_(
+        Database.id.in_(database_ids),
+        base_model.perm.in_(perms),
+        base_model.schema_perm.in_(schema_perms),
+    )

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -46,7 +46,7 @@ from flask_jwt_extended.exceptions import NoAuthorizationError
 from flask_wtf.csrf import CSRFError
 from flask_wtf.form import FlaskForm
 from pkg_resources import resource_filename
-from sqlalchemy import exc, or_
+from sqlalchemy import exc
 from sqlalchemy.orm import Query
 from werkzeug.exceptions import HTTPException
 from wtforms import Form
@@ -78,7 +78,7 @@ from superset.reports.models import ReportRecipientType
 from superset.superset_typing import FlaskResponse
 from superset.translations.utils import get_language_pack
 from superset.utils import core as utils
-from superset.utils.core import get_user_id
+from superset.utils.filters import get_dataset_access_filters
 
 from .utils import bootstrap_user_data
 
@@ -674,16 +674,7 @@ class DatasourceFilter(BaseFilter):  # pylint: disable=too-few-public-methods
             models.Database,
             models.Database.id == self.model.database_id,
         )
-        database_perms = security_manager.get_databases_accessible_by_user()
-        datasource_perms = security_manager.user_view_menu_names("datasource_access")
-        schema_perms = security_manager.user_view_menu_names("schema_access")
-        return query.filter(
-            or_(
-                self.model.database_id.in_(database_perms),
-                self.model.perm.in_(datasource_perms),
-                self.model.schema_perm.in_(schema_perms),
-            )
-        )
+        return query.filter(get_dataset_access_filters(self.model))
 
 
 class CsvResponse(Response):

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -239,28 +239,44 @@ class TestDatasetApi(SupersetTestCase):
         response = json.loads(rv.data.decode("utf-8"))
         assert response["result"] == []
 
-    def test_get_dataset_list_gamma_owned(self):
+    def test_get_dataset_list_gamma_has_database_access(self):
         """
-        Dataset API: Test get dataset list owned by gamma
+        Dataset API: Test get dataset list with database access
         """
-        if backend() == "sqlite":
-            return
-
-        main_db = get_main_database()
-        owned_dataset = self.insert_dataset(
-            "ab_user", [self.get_user("gamma").id], main_db
-        )
 
         self.login(username="gamma")
+
+        # create new dataset
+        main_db = get_main_database()
+        dataset = self.insert_dataset("ab_user", [], main_db)
+
+        # make sure dataset is not visible due to missing perms
+        uri = "api/v1/dataset/"
+        rv = self.get_assert_metric(uri, "get_list")
+        assert rv.status_code == 200
+        response = json.loads(rv.data.decode("utf-8"))
+
+        assert response["count"] == 0
+
+        # give database access to main db
+        main_db_pvm = security_manager.find_permission_view_menu(
+            "database_access", main_db.perm
+        )
+        gamma_role = security_manager.find_role("Gamma")
+        gamma_role.permissions.append(main_db_pvm)
+        db.session.commit()
+
+        # make sure dataset is now visible
         uri = "api/v1/dataset/"
         rv = self.get_assert_metric(uri, "get_list")
         assert rv.status_code == 200
         response = json.loads(rv.data.decode("utf-8"))
 
         assert response["count"] == 1
-        assert response["result"][0]["table_name"] == "ab_user"
 
-        db.session.delete(owned_dataset)
+        # revert gamma permission
+        gamma_role.permissions.remove(main_db_pvm)
+        db.session.delete(dataset)
         db.session.commit()
 
     def test_get_dataset_related_database_gamma(self):

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -2272,6 +2272,8 @@ class TestDatasetApi(SupersetTestCase):
         assert len(new_dataset.columns) == 2
         assert new_dataset.columns[0].column_name == "id"
         assert new_dataset.columns[1].column_name == "name"
+        db.session.delete(new_dataset)
+        db.session.commit()
 
     @pytest.mark.usefixtures("create_datasets")
     def test_duplicate_physical_dataset(self):

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -272,7 +272,8 @@ class TestDatasetApi(SupersetTestCase):
         assert rv.status_code == 200
         response = json.loads(rv.data.decode("utf-8"))
 
-        assert response["count"] == 1
+        tables = {tbl["table_name"] for tbl in response["result"]}
+        assert tables == {"ab_user"}
 
         # revert gamma permission
         gamma_role.permissions.remove(main_db_pvm)

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -243,6 +243,8 @@ class TestDatasetApi(SupersetTestCase):
         """
         Dataset API: Test get dataset list with database access
         """
+        if backend() == "sqlite":
+            return
 
         self.login(username="gamma")
 


### PR DESCRIPTION
### SUMMARY
Currently giving a user "database access on ..." does indeed give access to all dashboards, charts and datasets on that database, but they don't show up on the list views. This fixes that. Other changes:
- Similar logic existed in multiple places across the codebase, some of which were missing recently introduced permission logic. To DRY it up, we introduce a new util that generates the necessary filter clauses and use that in all places where we need to filter by accessible datasets.
- The fairly recent PR #20135 introduced logic to display datasets that the user owns. While it's important to show datasets that are owned, the logic introduced in that PR is no longer necessary after this change, as users will now see all owned datasets, as long as they can access them. Therefore the added logic is removed and the integration test is replaced by a test that ensures that the correct datasets are visible with the correct roles/perms.

### TESTING INSTRUCTIONS
1. Add a database "X"
2. Create a role "Y" with the "database access on X" permission
3. Add a dataset from the database, create a chart from it and also create + publish a dashboard from it.
4. Create a user with roles "Gamma" and "Y"
5. Login with that user and notice that the newly added dataset + chart + dashboard is now shown on the listview.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #20208
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
