### PR TITLE
fix(ci): explicity set yaml Loader

### DIFF
--- a/superset/examples/utils.py
+++ b/superset/examples/utils.py
@@ -86,7 +86,7 @@ def load_configs_from_directory(
 
     # removing "type" from the metadata allows us to import any exported model
     # from the unzipped directory directly
-    metadata = yaml.load(contents.get(METADATA_FILE_NAME, "{}"), Loader=None)
+    metadata = yaml.load(contents.get(METADATA_FILE_NAME, "{}"), Loader=yaml.Loader)
     if "type" in metadata:
         del metadata["type"]
     contents[METADATA_FILE_NAME] = yaml.dump(metadata)


### PR DESCRIPTION
### SUMMARY
Yet another "new stub" failure causing errors on CI (see: https://github.com/python/typeshed/pull/9752):
<img width="1099" alt="image" src="https://user-images.githubusercontent.com/33317356/220116703-394fbbde-5a55-4b32-86fa-94c209e1f225.png">

It appears this is incorrect, as it seems to default to `Loader`, but no point in waiting for it to be fixed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
