### PR TITLE
feat(dashboard): Add cross filter from context menu

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/chart/types/Base.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/types/Base.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { ExtraFormData } from '../../query';
+import { BinaryQueryObjectFilterClause, ExtraFormData } from '../../query';
 import { JsonObject } from '../..';
 
 export type HandlerFunction = (...args: unknown[]) => void;
@@ -31,6 +31,14 @@ export enum Behavior {
    * when dimensions are right-clicked on.
    */
   DRILL_TO_DETAIL = 'DRILL_TO_DETAIL',
+}
+
+export interface ContextMenuFilters {
+  crossFilter?: {
+    dataMask: DataMask;
+    isCurrentValueSelected?: boolean;
+  };
+  drillToDetail?: BinaryQueryObjectFilterClause[];
 }
 
 export enum AppSection {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberViz.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberViz.tsx
@@ -220,8 +220,8 @@ class BigNumberVis extends React.PureComponent<BigNumberVizProps> {
           const { data } = eventParams;
           if (data) {
             const pointerEvent = eventParams.event.event;
-            const filters: BinaryQueryObjectFilterClause[] = [];
-            filters.push({
+            const drillToDetailFilters: BinaryQueryObjectFilterClause[] = [];
+            drillToDetailFilters.push({
               col: this.props.formData?.granularitySqla,
               grain: this.props.formData?.timeGrainSqla,
               op: '==',
@@ -231,7 +231,7 @@ class BigNumberVis extends React.PureComponent<BigNumberVizProps> {
             this.props.onContextMenu(
               pointerEvent.clientX,
               pointerEvent.clientY,
-              filters,
+              { drillToDetail: drillToDetailFilters },
             );
           }
         }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/types.ts
@@ -19,8 +19,8 @@
 
 import { EChartsCoreOption } from 'echarts';
 import {
-  BinaryQueryObjectFilterClause,
   ChartDataResponseResult,
+  ContextMenuFilters,
   DataRecordValue,
   NumberFormatter,
   QueryFormData,
@@ -89,7 +89,7 @@ export type BigNumberVizProps = {
   onContextMenu?: (
     clientX: number,
     clientY: number,
-    filters?: BinaryQueryObjectFilterClause[],
+    filters?: ContextMenuFilters,
   ) => void;
   xValueFormatter?: TimeFormatter;
   formData?: BigNumberWithTrendlineFormData;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/EchartsBoxPlot.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/EchartsBoxPlot.tsx
@@ -16,60 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useCallback } from 'react';
+import React from 'react';
 import Echart from '../components/Echart';
 import { allEventHandlers } from '../utils/eventHandlers';
 import { BoxPlotChartTransformedProps } from './types';
 
 export default function EchartsBoxPlot(props: BoxPlotChartTransformedProps) {
-  const {
-    height,
-    width,
-    echartOptions,
-    setDataMask,
-    labelMap,
-    groupby,
-    selectedValues,
-    refs,
-    emitCrossFilters,
-  } = props;
-  const handleChange = useCallback(
-    (values: string[]) => {
-      if (!emitCrossFilters) {
-        return;
-      }
+  const { height, width, echartOptions, selectedValues, refs } = props;
 
-      const groupbyValues = values.map(value => labelMap[value]);
-
-      setDataMask({
-        extraFormData: {
-          filters:
-            values.length === 0
-              ? []
-              : groupby.map((col, idx) => {
-                  const val = groupbyValues.map(v => v[idx]);
-                  if (val === null || val === undefined)
-                    return {
-                      col,
-                      op: 'IS NULL',
-                    };
-                  return {
-                    col,
-                    op: 'IN',
-                    val: val as (string | number | boolean)[],
-                  };
-                }),
-        },
-        filterState: {
-          value: groupbyValues.length ? groupbyValues : null,
-          selectedValues: values.length ? values : null,
-        },
-      });
-    },
-    [groupby, labelMap, setDataMask, selectedValues],
-  );
-
-  const eventHandlers = allEventHandlers(props, handleChange);
+  const eventHandlers = allEventHandlers(props);
 
   return (
     <Echart

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/EchartsFunnel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/EchartsFunnel.tsx
@@ -16,60 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useCallback } from 'react';
+import React from 'react';
 import { FunnelChartTransformedProps } from './types';
 import Echart from '../components/Echart';
 import { allEventHandlers } from '../utils/eventHandlers';
 
 export default function EchartsFunnel(props: FunnelChartTransformedProps) {
-  const {
-    height,
-    width,
-    echartOptions,
-    setDataMask,
-    labelMap,
-    groupby,
-    selectedValues,
-    emitCrossFilters,
-    refs,
-  } = props;
-  const handleChange = useCallback(
-    (values: string[]) => {
-      if (!emitCrossFilters) {
-        return;
-      }
+  const { height, width, echartOptions, selectedValues, refs } = props;
 
-      const groupbyValues = values.map(value => labelMap[value]);
-
-      setDataMask({
-        extraFormData: {
-          filters:
-            values.length === 0
-              ? []
-              : groupby.map((col, idx) => {
-                  const val = groupbyValues.map(v => v[idx]);
-                  if (val === null || val === undefined)
-                    return {
-                      col,
-                      op: 'IS NULL',
-                    };
-                  return {
-                    col,
-                    op: 'IN',
-                    val: val as (string | number | boolean)[],
-                  };
-                }),
-        },
-        filterState: {
-          value: groupbyValues.length ? groupbyValues : null,
-          selectedValues: values.length ? values : null,
-        },
-      });
-    },
-    [groupby, labelMap, setDataMask, selectedValues],
-  );
-
-  const eventHandlers = allEventHandlers(props, handleChange);
+  const eventHandlers = allEventHandlers(props);
 
   return (
     <Echart

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Gauge/EchartsGauge.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Gauge/EchartsGauge.tsx
@@ -16,60 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useCallback } from 'react';
+import React from 'react';
 import { GaugeChartTransformedProps } from './types';
 import Echart from '../components/Echart';
 import { allEventHandlers } from '../utils/eventHandlers';
 
 export default function EchartsGauge(props: GaugeChartTransformedProps) {
-  const {
-    height,
-    width,
-    echartOptions,
-    setDataMask,
-    labelMap,
-    groupby,
-    selectedValues,
-    emitCrossFilters,
-    refs,
-  } = props;
-  const handleChange = useCallback(
-    (values: string[]) => {
-      if (!emitCrossFilters) {
-        return;
-      }
+  const { height, width, echartOptions, selectedValues, refs } = props;
 
-      const groupbyValues = values.map(value => labelMap[value]);
-
-      setDataMask({
-        extraFormData: {
-          filters:
-            values.length === 0
-              ? []
-              : groupby.map((col, idx) => {
-                  const val = groupbyValues.map(v => v[idx]);
-                  if (val === null || val === undefined)
-                    return {
-                      col,
-                      op: 'IS NULL',
-                    };
-                  return {
-                    col,
-                    op: 'IN',
-                    val: val as (string | number | boolean)[],
-                  };
-                }),
-        },
-        filterState: {
-          value: groupbyValues.length ? groupbyValues : null,
-          selectedValues: values.length ? values : null,
-        },
-      });
-    },
-    [groupby, labelMap, setDataMask, selectedValues],
-  );
-
-  const eventHandlers = allEventHandlers(props, handleChange);
+  const eventHandlers = allEventHandlers(props);
 
   return (
     <Echart

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Radar/EchartsRadar.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Radar/EchartsRadar.tsx
@@ -16,60 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useCallback } from 'react';
+import React from 'react';
 import { RadarChartTransformedProps } from './types';
 import Echart from '../components/Echart';
 import { allEventHandlers } from '../utils/eventHandlers';
 
 export default function EchartsRadar(props: RadarChartTransformedProps) {
-  const {
-    height,
-    width,
-    echartOptions,
-    setDataMask,
-    labelMap,
-    groupby,
-    selectedValues,
-    emitCrossFilters,
-    refs,
-  } = props;
-  const handleChange = useCallback(
-    (values: string[]) => {
-      if (!emitCrossFilters) {
-        return;
-      }
-
-      const groupbyValues = values.map(value => labelMap[value]);
-
-      setDataMask({
-        extraFormData: {
-          filters:
-            values.length === 0
-              ? []
-              : groupby.map((col, idx) => {
-                  const val = groupbyValues.map(v => v[idx]);
-                  if (val === null || val === undefined)
-                    return {
-                      col,
-                      op: 'IS NULL',
-                    };
-                  return {
-                    col,
-                    op: 'IN',
-                    val: val as (string | number | boolean)[],
-                  };
-                }),
-        },
-        filterState: {
-          value: groupbyValues.length ? groupbyValues : null,
-          selectedValues: values.length ? values : null,
-        },
-      });
-    },
-    [groupby, labelMap, setDataMask, selectedValues],
-  );
-
-  const eventHandlers = allEventHandlers(props, handleChange);
+  const { height, width, echartOptions, selectedValues, refs } = props;
+  const eventHandlers = allEventHandlers(props);
 
   return (
     <Echart

--- a/superset-frontend/plugins/plugin-chart-echarts/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/types.ts
@@ -18,9 +18,9 @@
  */
 import React, { RefObject } from 'react';
 import {
-  BinaryQueryObjectFilterClause,
   ChartDataResponseResult,
   ChartProps,
+  ContextMenuFilters,
   FilterState,
   HandlerFunction,
   PlainObject,
@@ -124,7 +124,7 @@ export interface BaseTransformedProps<F> {
   onContextMenu?: (
     clientX: number,
     clientY: number,
-    filters?: BinaryQueryObjectFilterClause[],
+    filters?: ContextMenuFilters,
   ) => void;
   setDataMask?: SetDataMaskHook;
   filterState?: FilterState;
@@ -146,7 +146,7 @@ export type ContextMenuTransformedProps = {
   onContextMenu?: (
     clientX: number,
     clientY: number,
-    filters?: BinaryQueryObjectFilterClause[],
+    filters?: ContextMenuFilters,
   ) => void;
   setDataMask?: SetDataMaskHook;
 };

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -279,6 +279,70 @@ export default function PivotTableChart(props: PivotTableProps) {
     [groupbyColumnsRaw, groupbyRowsRaw, setDataMask],
   );
 
+  const getCrossFilterDataMask = useCallback(
+    (value: { [key: string]: string }) => {
+      const isActiveFilterValue = (key: string, val: DataRecordValue) =>
+        !!selectedFilters && selectedFilters[key]?.includes(val);
+
+      if (!value) {
+        return undefined;
+      }
+
+      const [key, val] = Object.entries(value)[0];
+      let values = { ...selectedFilters };
+      if (isActiveFilterValue(key, val)) {
+        values = {};
+      } else {
+        values = { [key]: [val] };
+      }
+
+      const filterKeys = Object.keys(values);
+      const groupby = [...groupbyRowsRaw, ...groupbyColumnsRaw];
+      return {
+        dataMask: {
+          extraFormData: {
+            filters:
+              filterKeys.length === 0
+                ? undefined
+                : filterKeys.map(key => {
+                    const val = values?.[key];
+                    const col =
+                      groupby.find(item => {
+                        if (isPhysicalColumn(item)) {
+                          return item === key;
+                        }
+                        if (isAdhocColumn(item)) {
+                          return item.label === key;
+                        }
+                        return false;
+                      }) ?? '';
+                    if (val === null || val === undefined)
+                      return {
+                        col,
+                        op: 'IS NULL' as const,
+                      };
+                    return {
+                      col,
+                      op: 'IN' as const,
+                      val: val as (string | number | boolean)[],
+                    };
+                  }),
+          },
+          filterState: {
+            value:
+              values && Object.keys(values).length
+                ? Object.values(values)
+                : null,
+            selectedFilters:
+              values && Object.keys(values).length ? values : null,
+          },
+        },
+        isCurrentValueSelected: isActiveFilterValue(key, val),
+      };
+    },
+    [groupbyColumnsRaw, groupbyRowsRaw, selectedFilters],
+  );
+
   const toggleFilter = useCallback(
     (
       e: MouseEvent,
@@ -369,18 +433,19 @@ export default function PivotTableChart(props: PivotTableProps) {
       e: MouseEvent,
       colKey: (string | number | boolean)[] | undefined,
       rowKey: (string | number | boolean)[] | undefined,
+      dataPoint: { [key: string]: string },
     ) => {
       if (onContextMenu) {
         e.preventDefault();
         e.stopPropagation();
-        const filters: BinaryQueryObjectFilterClause[] = [];
+        const drillToDetailFilters: BinaryQueryObjectFilterClause[] = [];
         if (colKey && colKey.length > 1) {
           colKey.forEach((val, i) => {
             const col = cols[i];
             const formatter = dateFormatters[col];
             const formattedVal = formatter?.(val as number) || String(val);
             if (i > 0) {
-              filters.push({
+              drillToDetailFilters.push({
                 col,
                 op: '==',
                 val,
@@ -395,7 +460,7 @@ export default function PivotTableChart(props: PivotTableProps) {
             const col = rows[i];
             const formatter = dateFormatters[col];
             const formattedVal = formatter?.(val as number) || String(val);
-            filters.push({
+            drillToDetailFilters.push({
               col,
               op: '==',
               val,
@@ -404,7 +469,10 @@ export default function PivotTableChart(props: PivotTableProps) {
             });
           });
         }
-        onContextMenu(e.clientX, e.clientY, filters);
+        onContextMenu(e.clientX, e.clientY, {
+          drillToDetail: drillToDetailFilters,
+          crossFilter: getCrossFilterDataMask(dataPoint),
+        });
       }
     },
     [cols, dateFormatters, onContextMenu, rows, timeGrainSqla],

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.jsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.jsx
@@ -393,6 +393,7 @@ export class TableRenderer extends React.Component {
     // Iterate through columns. Jump over duplicate values.
     let i = 0;
     while (i < visibleColKeys.length) {
+      let handleContextMenu;
       const colKey = visibleColKeys[i];
       const colSpan = attrIdx < colKey.length ? colAttrSpans[i][attrIdx] : 1;
       let colLabelClass = 'pvtColLabel';
@@ -402,6 +403,10 @@ export class TableRenderer extends React.Component {
           !omittedHighlightHeaderGroups.includes(colAttrs[attrIdx])
         ) {
           colLabelClass += ' hoverable';
+          handleContextMenu = e =>
+            this.props.onContextMenu(e, colKey, undefined, {
+              [attrName]: colKey[attrIdx],
+            });
         }
         if (
           highlightedHeaderCells &&
@@ -434,6 +439,7 @@ export class TableRenderer extends React.Component {
               attrIdx,
               this.props.tableOptions.clickColumnHeaderCallback,
             )}
+            onContextMenu={handleContextMenu}
           >
             {displayHeaderCell(
               needToggle,
@@ -590,12 +596,17 @@ export class TableRenderer extends React.Component {
 
     const colIncrSpan = colAttrs.length !== 0 ? 1 : 0;
     const attrValueCells = rowKey.map((r, i) => {
+      let handleContextMenu;
       let valueCellClassName = 'pvtRowLabel';
       if (
         highlightHeaderCellsOnHover &&
         !omittedHighlightHeaderGroups.includes(rowAttrs[i])
       ) {
         valueCellClassName += ' hoverable';
+        handleContextMenu = e =>
+          this.props.onContextMenu(e, undefined, rowKey, {
+            [rowAttrs[i]]: r,
+          });
       }
       if (
         highlightedHeaderCells &&
@@ -631,6 +642,7 @@ export class TableRenderer extends React.Component {
               i,
               this.props.tableOptions.clickRowHeaderCallback,
             )}
+            onContextMenu={handleContextMenu}
           >
             {displayHeaderCell(
               needRowToggle,

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/types.ts
@@ -26,8 +26,8 @@ import {
   NumberFormatter,
   QueryFormMetric,
   QueryFormColumn,
-  BinaryQueryObjectFilterClause,
   TimeGranularity,
+  ContextMenuFilters,
 } from '@superset-ui/core';
 import { ColorFormatters } from '@superset-ui/chart-controls';
 
@@ -77,7 +77,7 @@ interface PivotTableCustomizeProps {
   onContextMenu?: (
     clientX: number,
     clientY: number,
-    filters?: BinaryQueryObjectFilterClause[],
+    filters?: ContextMenuFilters,
   ) => void;
   timeGrainSqla?: TimeGranularity;
 }

--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
@@ -23,7 +23,6 @@ import React, {
   HTMLProps,
   MutableRefObject,
   CSSProperties,
-  MouseEvent,
 } from 'react';
 import {
   useTable,
@@ -67,7 +66,6 @@ export interface DataTableProps<D extends object> extends TableOptions<D> {
   rowCount: number;
   wrapperRef?: MutableRefObject<HTMLDivElement>;
   onColumnOrderChange: () => void;
-  onContextMenu?: (value: D, clientX: number, clientY: number) => void;
 }
 
 export interface RenderHTMLCellProps extends HTMLProps<HTMLTableCellElement> {
@@ -100,7 +98,6 @@ export default typedMemo(function DataTable<D extends object>({
   serverPagination,
   wrapperRef: userWrapperRef,
   onColumnOrderChange,
-  onContextMenu,
   ...moreUseTableOptions
 }: DataTableProps<D>): JSX.Element {
   const tableHooks: PluginHook<D>[] = [
@@ -273,21 +270,7 @@ export default typedMemo(function DataTable<D extends object>({
             prepareRow(row);
             const { key: rowKey, ...rowProps } = row.getRowProps();
             return (
-              <tr
-                key={rowKey || row.id}
-                {...rowProps}
-                onContextMenu={(e: MouseEvent) => {
-                  if (onContextMenu) {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    onContextMenu(
-                      row.original,
-                      e.nativeEvent.clientX,
-                      e.nativeEvent.clientY,
-                    );
-                  }
-                }}
-              >
+              <tr key={rowKey || row.id} {...rowProps}>
                 {row.cells.map(cell =>
                   cell.render('Cell', { key: cell.column.id }),
                 )}

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -365,7 +365,11 @@ export default function TableChart<D extends DataRecord = DataRecord>(
     onContextMenu && !isRawRecords
       ? (
           value: D,
-          cellPoint: { key: string; value: DataRecordValue },
+          cellPoint: {
+            key: string;
+            value: DataRecordValue;
+            isMetric?: boolean;
+          },
           clientX: number,
           clientY: number,
         ) => {
@@ -383,7 +387,9 @@ export default function TableChart<D extends DataRecord = DataRecord>(
           });
           onContextMenu(clientX, clientY, {
             drillToDetail: drillToDetailFilters,
-            crossFilter: getCrossFilterDataMask(cellPoint.key, cellPoint.value),
+            crossFilter: cellPoint.isMetric
+              ? undefined
+              : getCrossFilterDataMask(cellPoint.key, cellPoint.value),
           });
         }
       : undefined;
@@ -423,7 +429,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
         getValueRange(key, alignPositiveNegative);
 
       let className = '';
-      if (emitCrossFilters) {
+      if (emitCrossFilters && !isMetric) {
         className += ' dt-is-filter';
       }
 
@@ -486,7 +492,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
             // show raw number in title in case of numeric values
             title: typeof value === 'number' ? String(value) : undefined,
             onClick:
-              emitCrossFilters && !valueRange
+              emitCrossFilters && !valueRange && !isMetric
                 ? () => toggleFilter(key, value)
                 : undefined,
             onContextMenu: (e: MouseEvent) => {
@@ -495,7 +501,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
                 e.stopPropagation();
                 handleContextMenu(
                   row.original,
-                  { key, value },
+                  { key, value, isMetric },
                   e.nativeEvent.clientX,
                   e.nativeEvent.clientY,
                 );

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -22,11 +22,13 @@ import React, {
   useLayoutEffect,
   useMemo,
   useState,
+  MouseEvent,
 } from 'react';
 import {
   ColumnInstance,
   ColumnWithLooseAccessor,
   DefaultSortTypes,
+  Row,
 } from 'react-table';
 import { extent as d3Extent, max as d3Max } from 'd3-array';
 import { FaSort } from '@react-icons/all-files/fa/FaSort';
@@ -241,57 +243,6 @@ export default function TableChart<D extends DataRecord = DataRecord>(
   // keep track of whether column order changed, so that column widths can too
   const [columnOrderToggle, setColumnOrderToggle] = useState(false);
 
-  const handleChange = useCallback(
-    (filters: { [x: string]: DataRecordValue[] }) => {
-      if (!emitCrossFilters) {
-        return;
-      }
-
-      const groupBy = Object.keys(filters);
-      const groupByValues = Object.values(filters);
-      const labelElements: string[] = [];
-      groupBy.forEach(col => {
-        const isTimestamp = col === DTTM_ALIAS;
-        const filterValues = ensureIsArray(filters?.[col]);
-        if (filterValues.length) {
-          const valueLabels = filterValues.map(value =>
-            isTimestamp ? timestampFormatter(value) : value,
-          );
-          labelElements.push(`${valueLabels.join(', ')}`);
-        }
-      });
-      setDataMask({
-        extraFormData: {
-          filters:
-            groupBy.length === 0
-              ? []
-              : groupBy.map(col => {
-                  const val = ensureIsArray(filters?.[col]);
-                  if (!val.length)
-                    return {
-                      col,
-                      op: 'IS NULL',
-                    };
-                  return {
-                    col,
-                    op: 'IN',
-                    val: val.map(el =>
-                      el instanceof Date ? el.getTime() : el!,
-                    ),
-                    grain: col === DTTM_ALIAS ? timeGrain : undefined,
-                  };
-                }),
-        },
-        filterState: {
-          label: labelElements.join(', '),
-          value: groupByValues.length ? groupByValues : null,
-          filters: filters && Object.keys(filters).length ? filters : null,
-        },
-      });
-    },
-    [emitCrossFilters, setDataMask],
-  );
-
   // only take relevant page size options
   const pageSizeOptions = useMemo(() => {
     const getServerPagination = (n: number) => n <= rowCount;
@@ -322,25 +273,80 @@ export default function TableChart<D extends DataRecord = DataRecord>(
     [filters],
   );
 
+  const getCrossFilterDataMask = (key: string, value: DataRecordValue) => {
+    let updatedFilters = { ...(filters || {}) };
+    if (filters && isActiveFilterValue(key, value)) {
+      updatedFilters = {};
+    } else {
+      updatedFilters = {
+        [key]: [value],
+      };
+    }
+    if (
+      Array.isArray(updatedFilters[key]) &&
+      updatedFilters[key].length === 0
+    ) {
+      delete updatedFilters[key];
+    }
+
+    const groupBy = Object.keys(updatedFilters);
+    const groupByValues = Object.values(updatedFilters);
+    const labelElements: string[] = [];
+    groupBy.forEach(col => {
+      const isTimestamp = col === DTTM_ALIAS;
+      const filterValues = ensureIsArray(updatedFilters?.[col]);
+      if (filterValues.length) {
+        const valueLabels = filterValues.map(value =>
+          isTimestamp ? timestampFormatter(value) : value,
+        );
+        labelElements.push(`${valueLabels.join(', ')}`);
+      }
+    });
+
+    return {
+      dataMask: {
+        extraFormData: {
+          filters:
+            groupBy.length === 0
+              ? []
+              : groupBy.map(col => {
+                  const val = ensureIsArray(updatedFilters?.[col]);
+                  if (!val.length)
+                    return {
+                      col,
+                      op: 'IS NULL' as const,
+                    };
+                  return {
+                    col,
+                    op: 'IN' as const,
+                    val: val.map(el =>
+                      el instanceof Date ? el.getTime() : el!,
+                    ),
+                    grain: col === DTTM_ALIAS ? timeGrain : undefined,
+                  };
+                }),
+        },
+        filterState: {
+          label: labelElements.join(', '),
+          value: groupByValues.length ? groupByValues : null,
+          filters:
+            updatedFilters && Object.keys(updatedFilters).length
+              ? updatedFilters
+              : null,
+        },
+      },
+      isCurrentValueSelected: isActiveFilterValue(key, value),
+    };
+  };
+
   const toggleFilter = useCallback(
     function toggleFilter(key: string, val: DataRecordValue) {
-      let updatedFilters = { ...(filters || {}) };
-      if (filters && isActiveFilterValue(key, val)) {
-        updatedFilters = {};
-      } else {
-        updatedFilters = {
-          [key]: [val],
-        };
+      if (!emitCrossFilters) {
+        return;
       }
-      if (
-        Array.isArray(updatedFilters[key]) &&
-        updatedFilters[key].length === 0
-      ) {
-        delete updatedFilters[key];
-      }
-      handleChange(updatedFilters);
+      setDataMask(getCrossFilterDataMask(key, val).dataMask);
     },
-    [filters, handleChange, isActiveFilterValue],
+    [emitCrossFilters, getCrossFilterDataMask, setDataMask],
   );
 
   const getSharedStyle = (column: DataColumnMeta): CSSProperties => {
@@ -354,6 +360,33 @@ export default function TableChart<D extends DataRecord = DataRecord>(
       textAlign,
     };
   };
+
+  const handleContextMenu =
+    onContextMenu && !isRawRecords
+      ? (
+          value: D,
+          cellPoint: { key: string; value: DataRecordValue },
+          clientX: number,
+          clientY: number,
+        ) => {
+          const drillToDetailFilters: BinaryQueryObjectFilterClause[] = [];
+          columnsMeta.forEach(col => {
+            if (!col.isMetric) {
+              const dataRecordValue = value[col.key];
+              drillToDetailFilters.push({
+                col: col.key,
+                op: '==',
+                val: dataRecordValue as string | number | boolean,
+                formattedVal: formatColumnValue(col, dataRecordValue)[1],
+              });
+            }
+          });
+          onContextMenu(clientX, clientY, {
+            drillToDetail: drillToDetailFilters,
+            crossFilter: getCrossFilterDataMask(cellPoint.key, cellPoint.value),
+          });
+        }
+      : undefined;
 
   const getColumnConfigs = useCallback(
     (column: DataColumnMeta, i: number): ColumnWithLooseAccessor<D> => {
@@ -400,7 +433,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
         // typing is incorrect in current version of `@types/react-table`
         // so we ask TS not to check.
         accessor: ((datum: D) => datum[key]) as never,
-        Cell: ({ value }: { value: DataRecordValue }) => {
+        Cell: ({ value, row }: { value: DataRecordValue; row: Row<D> }) => {
           const [isHtml, text] = formatColumnValue(column, value);
           const html = isHtml ? { __html: text } : undefined;
 
@@ -456,6 +489,18 @@ export default function TableChart<D extends DataRecord = DataRecord>(
               emitCrossFilters && !valueRange
                 ? () => toggleFilter(key, value)
                 : undefined,
+            onContextMenu: (e: MouseEvent) => {
+              if (handleContextMenu) {
+                e.preventDefault();
+                e.stopPropagation();
+                handleContextMenu(
+                  row.original,
+                  { key, value },
+                  e.nativeEvent.clientX,
+                  e.nativeEvent.clientY,
+                );
+              }
+            },
             className: [
               className,
               value == null ? 'dt-is-null' : '',
@@ -621,25 +666,6 @@ export default function TableChart<D extends DataRecord = DataRecord>(
 
   const { width: widthFromState, height: heightFromState } = tableSize;
 
-  const handleContextMenu =
-    onContextMenu && !isRawRecords
-      ? (value: D, clientX: number, clientY: number) => {
-          const filters: BinaryQueryObjectFilterClause[] = [];
-          columnsMeta.forEach(col => {
-            if (!col.isMetric) {
-              const dataRecordValue = value[col.key];
-              filters.push({
-                col: col.key,
-                op: '==',
-                val: dataRecordValue as string | number | boolean,
-                formattedVal: formatColumnValue(col, dataRecordValue)[1],
-              });
-            }
-          });
-          onContextMenu(clientX, clientY, filters);
-        }
-      : undefined;
-
   return (
     <Styles>
       <DataTable<D>
@@ -662,7 +688,6 @@ export default function TableChart<D extends DataRecord = DataRecord>(
         selectPageSize={pageSize !== null && SelectPageSize}
         // not in use in Superset, but needed for unit tests
         sticky={sticky}
-        onContextMenu={handleContextMenu}
       />
     </Styles>
   );

--- a/superset-frontend/plugins/plugin-chart-table/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/types.ts
@@ -30,7 +30,7 @@ import {
   ChartDataResponseResult,
   QueryFormData,
   SetDataMaskHook,
-  BinaryQueryObjectFilterClause,
+  ContextMenuFilters,
 } from '@superset-ui/core';
 import { ColorFormatters, ColumnConfig } from '@superset-ui/chart-controls';
 
@@ -114,7 +114,7 @@ export interface TableChartTransformedProps<D extends DataRecord = DataRecord> {
   onContextMenu?: (
     clientX: number,
     clientY: number,
-    filters?: BinaryQueryObjectFilterClause[],
+    filters?: ContextMenuFilters,
   ) => void;
 }
 

--- a/superset-frontend/src/components/Chart/ChartRenderer.jsx
+++ b/superset-frontend/src/components/Chart/ChartRenderer.jsx
@@ -87,7 +87,8 @@ class ChartRenderer extends React.Component {
     this.state = {
       showContextMenu:
         props.source === ChartSource.Dashboard &&
-        isFeatureEnabled(FeatureFlag.DRILL_TO_DETAIL),
+        (isFeatureEnabled(FeatureFlag.DRILL_TO_DETAIL) ||
+          isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS)),
       inContextMenu: false,
     };
     this.hasQueryResponseChange = false;

--- a/superset-frontend/src/components/Chart/DisabledMenuItemTooltip.tsx
+++ b/superset-frontend/src/components/Chart/DisabledMenuItemTooltip.tsx
@@ -16,24 +16,33 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
-import { PieChartTransformedProps } from './types';
-import Echart from '../components/Echart';
-import { allEventHandlers } from '../utils/eventHandlers';
 
-export default function EchartsPie(props: PieChartTransformedProps) {
-  const { height, width, echartOptions, selectedValues, refs } = props;
+import React, { ReactNode } from 'react';
+import { css, SupersetTheme } from '@superset-ui/core';
+import Icons from 'src/components/Icons';
+import { Tooltip } from 'src/components/Tooltip';
 
-  const eventHandlers = allEventHandlers(props);
-
-  return (
-    <Echart
-      refs={refs}
-      height={height}
-      width={width}
-      echartOptions={echartOptions}
-      eventHandlers={eventHandlers}
-      selectedValues={selectedValues}
+export const MenuItemTooltip = ({
+  title,
+  color,
+}: {
+  title: ReactNode;
+  color?: string;
+}) => (
+  <Tooltip title={title} placement="top">
+    <Icons.InfoCircleOutlined
+      data-test="tooltip-trigger"
+      css={(theme: SupersetTheme) => css`
+        color: ${color || theme.colors.text.label};
+        margin-left: ${theme.gridUnit * 2}px;
+        &.anticon {
+          font-size: unset;
+          .anticon {
+            line-height: unset;
+            vertical-align: unset;
+          }
+        }
+      `}
     />
-  );
-}
+  </Tooltip>
+);

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailMenuItems.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailMenuItems.tsx
@@ -27,36 +27,15 @@ import {
   getChartMetadataRegistry,
   QueryFormData,
   styled,
-  SupersetTheme,
   t,
 } from '@superset-ui/core';
 import { Menu } from 'src/components/Menu';
-import Icons from 'src/components/Icons';
-import { Tooltip } from 'src/components/Tooltip';
 import DrillDetailModal from './DrillDetailModal';
 import { getMenuAdjustedY, MENU_ITEM_HEIGHT } from '../utils';
+import { MenuItemTooltip } from '../DisabledMenuItemTooltip';
 
 const MENU_PADDING = 4;
 const DRILL_TO_DETAIL_TEXT = t('Drill to detail by');
-
-const DisabledMenuItemTooltip = ({ title }: { title: ReactNode }) => (
-  <Tooltip title={title} placement="top">
-    <Icons.InfoCircleOutlined
-      data-test="tooltip-trigger"
-      css={(theme: SupersetTheme) => css`
-        color: ${theme.colors.text.label};
-        margin-left: ${theme.gridUnit * 2}px;
-        &.anticon {
-          font-size: unset;
-          .anticon {
-            line-height: unset;
-            vertical-align: unset;
-          }
-        }
-      `}
-    />
-  </Tooltip>
-);
 
 const DisabledMenuItem = ({ children, ...props }: { children: ReactNode }) => (
   <Menu.Item disabled {...props}>
@@ -141,7 +120,7 @@ const DrillDetailMenuItems = ({
     drillToDetailMenuItem = (
       <DisabledMenuItem {...props} key="drill-detail-no-aggregations">
         {t('Drill to detail')}
-        <DisabledMenuItemTooltip
+        <MenuItemTooltip
           title={t(
             'Drill to detail is disabled because this chart does not group data by dimension value.',
           )}
@@ -165,7 +144,7 @@ const DrillDetailMenuItems = ({
     drillToDetailByMenuItem = (
       <DisabledMenuItem {...props} key="drill-detail-by-chart-not-supported">
         {DRILL_TO_DETAIL_TEXT}
-        <DisabledMenuItemTooltip
+        <MenuItemTooltip
           title={t(
             'Drill to detail by value is not yet supported for this chart type.',
           )}
@@ -228,7 +207,7 @@ const DrillDetailMenuItems = ({
     drillToDetailByMenuItem = (
       <DisabledMenuItem {...props} key="drill-detail-by-select-aggregation">
         {DRILL_TO_DETAIL_TEXT}
-        <DisabledMenuItemTooltip
+        <MenuItemTooltip
           title={t(
             'Right-click on a dimension value to drill to detail by that value.',
           )}


### PR DESCRIPTION
### SUMMARY
Enable selecting/deselecing cross-filter from chart's context menu.

Enabled charts: World Map, all Echarts, Pivot Table, Table

"Add cross-filter" context menu option will be visible, but disabled if:
- dashboard has cross-filtering disabled
- chart does not support cross-filtering
- clicked data point does not support cross-filtering (e.g. empty space on chart)

"Add cross-filter" context menu option will not be displayed if `DASHBOARD_CROSS_FILTERS` feature flag is disabled.


If user right-clicks on series that's not emitting a cross-filter, a "Add cross-filter" option will be displayed.
If user right-clicks on series that's currently emitting a cross-filter, a "Remove cross-filter" option will be displayed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/15073128/220665986-95da1b4e-9554-4e1e-ad84-6ce5ac0d71fc.mov


### TESTING INSTRUCTIONS
Test the cross filtering feature on all charts that support it (compatible charts listed above)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
