### PR TITLE
chore: Remove the ability to add filter-box charts when DASHBOARD_NATIVE_FILTERS feature is enabled

### DIFF
--- a/superset-frontend/src/dashboard/actions/sliceEntities.js
+++ b/superset-frontend/src/dashboard/actions/sliceEntities.js
@@ -22,6 +22,7 @@ import rison from 'rison';
 
 import { addDangerToast } from 'src/components/MessageToasts/actions';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
+import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 
 export const SET_ALL_SLICES = 'SET_ALL_SLICES';
 const FETCH_SLICES_PAGE_SIZE = 200;
@@ -55,6 +56,16 @@ export function fetchSlices(
   const additional_filters = filter_value
     ? [{ col: 'slice_name', opr: 'chart_all_text', value: filter_value }]
     : [];
+
+  if (isFeatureEnabled(FeatureFlag.DASHBOARD_NATIVE_FILTERS)) {
+    additional_filters.push({
+      col: 'viz_type',
+      opr: 'neq',
+      value: 'filter_box',
+    });
+  }
+
+  isFeatureEnabled(FeatureFlag.DASHBOARD_NATIVE_FILTERS);
 
   const cloneSlices = { ...slices };
 

--- a/superset-frontend/src/dashboard/actions/sliceEntities.js
+++ b/superset-frontend/src/dashboard/actions/sliceEntities.js
@@ -65,8 +65,6 @@ export function fetchSlices(
     });
   }
 
-  isFeatureEnabled(FeatureFlag.DASHBOARD_NATIVE_FILTERS);
-
   const cloneSlices = { ...slices };
 
   return SupersetClient.get({

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -41,6 +41,7 @@ import { Select } from 'src/components';
 import Loading from 'src/components/Loading';
 import { setSaveChartModalVisibility } from 'src/explore/actions/saveModalActions';
 import { SaveActionType } from 'src/explore/types';
+import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 
 // Session storage key for recent dashboard
 const SK_DASHBOARD_ID = 'save_chart_recent_dashboard';
@@ -69,6 +70,7 @@ type SaveModalState = {
   action: SaveActionType;
   isLoading: boolean;
   saveStatus?: string | null;
+  vizType?: string;
 };
 
 export const StyledModal = styled(Modal)`
@@ -92,6 +94,7 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
       alert: null,
       action: this.canOverwriteSlice() ? 'overwrite' : 'saveas',
       isLoading: false,
+      vizType: props.form_data?.viz_type,
     };
     this.onDashboardSelectChange = this.onDashboardSelectChange.bind(this);
     this.onSliceNameChange = this.onSliceNameChange.bind(this);
@@ -339,27 +342,32 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
             />
           </FormItem>
         )}
-        <FormItem
-          label={t('Add to dashboard')}
-          data-test="save-chart-modal-select-dashboard-form"
-        >
-          <Select
-            allowClear
-            allowNewOptions
-            ariaLabel={t('Select a dashboard')}
-            options={this.props.dashboards}
-            onChange={this.onDashboardSelectChange}
-            value={dashboardSelectValue || undefined}
-            placeholder={
-              <div>
-                <b>{t('Select')}</b>
-                {t(' a dashboard OR ')}
-                <b>{t('create')}</b>
-                {t(' a new one')}
-              </div>
-            }
-          />
-        </FormItem>
+        {!(
+          isFeatureEnabled(FeatureFlag.DASHBOARD_NATIVE_FILTERS) &&
+          this.state.vizType === 'filter_box'
+        ) && (
+          <FormItem
+            label={t('Add to dashboard')}
+            data-test="save-chart-modal-select-dashboard-form"
+          >
+            <Select
+              allowClear
+              allowNewOptions
+              ariaLabel={t('Select a dashboard')}
+              options={this.props.dashboards}
+              onChange={this.onDashboardSelectChange}
+              value={dashboardSelectValue || undefined}
+              placeholder={
+                <div>
+                  <b>{t('Select')}</b>
+                  {t(' a dashboard OR ')}
+                  <b>{t('create')}</b>
+                  {t(' a new one')}
+                </div>
+              }
+            />
+          </FormItem>
+        )}
       </Form>
     );
   };
@@ -376,7 +384,9 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
           !this.state.newSliceName ||
           (!this.state.saveToDashboardId && !this.state.newDashboardName) ||
           (this.props.datasource?.type !== DatasourceType.Table &&
-            !this.state.datasetName)
+            !this.state.datasetName) ||
+          (isFeatureEnabled(FeatureFlag.DASHBOARD_NATIVE_FILTERS) &&
+            this.state.vizType === 'filter_box')
         }
         onClick={() => this.saveOrOverwrite(true)}
       >

--- a/superset-frontend/src/pages/ChartCreation/index.tsx
+++ b/superset-frontend/src/pages/ChartCreation/index.tsx
@@ -33,6 +33,7 @@ import Button from 'src/components/Button';
 import { AsyncSelect, Steps } from 'src/components';
 import { Tooltip } from 'src/components/Tooltip';
 import withToasts from 'src/components/MessageToasts/withToasts';
+import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 
 import VizTypeGallery, {
   MAX_ADVISABLE_VIZ_GALLERY_WIDTH,
@@ -65,6 +66,13 @@ const ELEMENTS_EXCEPT_VIZ_GALLERY = ESTIMATED_NAV_HEIGHT + 250;
 
 const bootstrapData = getBootstrapData();
 const denyList: string[] = bootstrapData.common.conf.VIZ_TYPE_DENYLIST || [];
+
+if (
+  isFeatureEnabled(FeatureFlag.DASHBOARD_NATIVE_FILTERS) &&
+  !('filter_box' in denyList)
+) {
+  denyList.push('filter_box');
+}
 
 const StyledContainer = styled.div`
   ${({ theme }) => `


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR addresses recommendation #&#x2060;4 in https://github.com/apache/superset/issues/14383, i.e., it prevents:

1. A new filter-box visualization type chart being created; 
2. An existing filter-box visualization type being added to a dashboard (either via the edit dashboard or save chart workflow)

if the `DASHBOARD_NATIVE_FILTERS` filter flag is enabled. 

Note the export/import dashboard workflow has not been augmented from a preservation standpoint, i.e., filter-boxes can still be imported when they're part of the exported dashboard. Finally, per SIP-64,

> ... dashboard cannot regress to having both native and legacy filters.

the goal is to prevent an existing dashboard from regressing once native filters are enabled whereas the export/import workflow creates a new dashboard, i.e., it's exempt from the problematic workflows.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### CREATE 

##### BEFORE

<img width="978" alt="Screenshot 2023-02-22 at 10 56 03 AM" src="https://user-images.githubusercontent.com/4567245/220468823-93aae6a0-2a65-44b1-9771-7acf43e924a2.png">

##### AFTER

<img width="976" alt="Screenshot 2023-02-22 at 10 50 37 AM" src="https://user-images.githubusercontent.com/4567245/220469054-33ecd515-a638-4691-82a8-c954eaf56b95.png">

#### ADD (EXPLORER)

##### BEFORE

<img width="537" alt="Screenshot 2023-02-22 at 10 56 18 AM" src="https://user-images.githubusercontent.com/4567245/220468813-79e773e7-acfd-4af4-951b-202334cfa387.png">

##### AFTER 

<img width="539" alt="Screenshot 2023-02-22 at 10 48 16 AM" src="https://user-images.githubusercontent.com/4567245/220469061-98b244f2-a5ad-4815-99e9-3be1b168cc4d.png">

#### ADD (DASHBOARD)

##### BEFORE

<img width="334" alt="Screenshot 2023-02-22 at 10 55 44 AM" src="https://user-images.githubusercontent.com/4567245/220468829-95cf821f-914e-4e32-bb4a-f05b0f53a8b2.png">

##### AFTER

Note any existing filter-box in the dashboard is still shown.

<img width="334" alt="Screenshot 2023-02-22 at 10 51 04 AM" src="https://user-images.githubusercontent.com/4567245/220469050-b4449685-ec3a-4ee2-930e-829d3f9c0604.png">

### TESTING INSTRUCTIONS

Regrettably there doesn't seem to be any unit tests for any of these workflows and thus only manual testing was undertaken.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/14383
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
