### PR TITLE
fix(cache): coerce schema_cache_timeout to None

### DIFF
--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -551,7 +551,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         try:
             schemas = database.get_all_schema_names(
                 cache=database.schema_cache_enabled,
-                cache_timeout=database.schema_cache_timeout,
+                cache_timeout=database.schema_cache_timeout or None,
                 force=kwargs["rison"].get("force", False),
             )
             schemas = security_manager.get_schemas_accessible_by_user(database, schemas)


### PR DESCRIPTION
### SUMMARY

Fixes #21827

When a database is created `schema_cache_timeout`  property is set to empty string by default inside `extra_json` (or at least this is the case for older versions). This leads to the following error when calling `get_all_schema_names` which exptects an optional integer. This PR fixes this error.

```
redis.exceptions.ResponseError: value is not an integer or out of range
```

Additionally, these params don't seem to be used in `get_all_schema_names`. So maybe the best course is to remove them all together.

### TESTING INSTRUCTIONS
Without this, the SQL Lab shows an error when fetching schemas
