### PR TITLE
fix(dataset): Respect columns configuration when duplicating datasets

### DIFF
--- a/superset/datasets/commands/duplicate.py
+++ b/superset/datasets/commands/duplicate.py
@@ -50,44 +50,43 @@ class DuplicateDatasetCommand(CreateMixin, BaseCommand):
     def run(self) -> Model:
         self.validate()
         try:
-            if self._base_model and self._database:
-                table_name = self._properties["table_name"]
-                owners = self._properties["owners"]
-                table = SqlaTable(table_name=table_name, owners=owners)
-                table.database = self._database
-                table.schema = self._base_model.schema
-                table.template_params = self._base_model.template_params
-                table.is_sqllab_view = True
-                table.sql = ParsedQuery(self._base_model.sql).stripped()
-                db.session.add(table)
-                cols = []
-                for config_ in self._base_model.columns:
-                    column_name = config_.column_name
-                    col = TableColumn(
-                        column_name=column_name,
-                        verbose_name=config_.verbose_name,
-                        expression=config_.expression,
-                        filterable=config_.filterable,
-                        groupby=config_.groupby,
-                        is_dttm=config_.is_dttm,
-                        type=config_.type,
-                        description=config_.description,
-                    )
-                    cols.append(col)
-                table.columns = cols
-                mets = []
-                for config_ in self._base_model.metrics:
-                    metric_name = config_.metric_name
-                    met = SqlMetric(
-                        metric_name=metric_name,
-                        verbose_name=config_.verbose_name,
-                        expression=config_.expression,
-                        metric_type=config_.metric_type,
-                        description=config_.description,
-                    )
-                    mets.append(met)
-                table.metrics = mets
-                db.session.commit()
+            table_name = self._properties["table_name"]
+            owners = self._properties["owners"]
+            table = SqlaTable(table_name=table_name, owners=owners)
+            table.database = self._database  # type: ignore
+            table.schema = self._base_model.schema  # type: ignore
+            table.template_params = self._base_model.template_params  # type: ignore
+            table.is_sqllab_view = True
+            table.sql = ParsedQuery(self._base_model.sql).stripped()  # type: ignore
+            db.session.add(table)
+            cols = []
+            for config_ in self._base_model.columns:  # type: ignore
+                column_name = config_.column_name
+                col = TableColumn(
+                    column_name=column_name,
+                    verbose_name=config_.verbose_name,
+                    expression=config_.expression,
+                    filterable=config_.filterable,
+                    groupby=config_.groupby,
+                    is_dttm=config_.is_dttm,
+                    type=config_.type,
+                    description=config_.description,
+                )
+                cols.append(col)
+            table.columns = cols
+            mets = []
+            for config_ in self._base_model.metrics:  # type: ignore
+                metric_name = config_.metric_name
+                met = SqlMetric(
+                    metric_name=metric_name,
+                    verbose_name=config_.verbose_name,
+                    expression=config_.expression,
+                    metric_type=config_.metric_type,
+                    description=config_.description,
+                )
+                mets.append(met)
+            table.metrics = mets
+            db.session.commit()
         except (SQLAlchemyError, DAOCreateFailedError) as ex:
             logger.warning(ex, exc_info=True)
             db.session.rollback()

--- a/superset/datasets/commands/duplicate.py
+++ b/superset/datasets/commands/duplicate.py
@@ -49,18 +49,20 @@ class DuplicateDatasetCommand(CreateMixin, BaseCommand):
 
     def run(self) -> Model:
         self.validate()
+        assert self._database is not None
+        assert self._base_model is not None
         try:
             table_name = self._properties["table_name"]
             owners = self._properties["owners"]
             table = SqlaTable(table_name=table_name, owners=owners)
-            table.database = self._database  # type: ignore
-            table.schema = self._base_model.schema  # type: ignore
-            table.template_params = self._base_model.template_params  # type: ignore
+            table.database = self._database
+            table.schema = self._base_model.schema
+            table.template_params = self._base_model.template_params
             table.is_sqllab_view = True
-            table.sql = ParsedQuery(self._base_model.sql).stripped()  # type: ignore
+            table.sql = ParsedQuery(self._base_model.sql).stripped()
             db.session.add(table)
             cols = []
-            for config_ in self._base_model.columns:  # type: ignore
+            for config_ in self._base_model.columns:
                 column_name = config_.column_name
                 col = TableColumn(
                     column_name=column_name,
@@ -75,7 +77,7 @@ class DuplicateDatasetCommand(CreateMixin, BaseCommand):
                 cols.append(col)
             table.columns = cols
             mets = []
-            for config_ in self._base_model.metrics:  # type: ignore
+            for config_ in self._base_model.metrics:
                 metric_name = config_.metric_name
                 met = SqlMetric(
                     metric_name=metric_name,


### PR DESCRIPTION
### SUMMARY

When duplicating datasets, we currently are forcing columns on the new dataset to have `groupby` and `filreable` set to `True` even if the user marked those as false in the base dataset. With this changes we are fixing that. Also did a small refactor in how we raise exceptions so they are all in the `validate` method and using existing exceptions.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![error](https://user-images.githubusercontent.com/38889534/221206730-04342723-704e-4c88-a8e4-4d9d1249551e.gif)


After:
![test](https://user-images.githubusercontent.com/38889534/221206798-6242c12c-5bca-46d7-a718-22000edae1fe.gif)


### TESTING INSTRUCTIONS
1. Create a Virtual dataset
2. Create a `calculated column` in your new dataset
3. Check `isFilterable` for the new column and save the changes
4. Open the new dataset for edition and uncheck `isFilterable` so it is False
5. Duplicate the dataset
6. The new dataset must have `isFilterable` unchecked

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
