### PR TITLE
fix(dashboard): Cross-filters not working properly for new dashboards

### DIFF
--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -313,7 +313,6 @@ export function saveDashboardRequest(data, id, saveType) {
       // syncing with the backend transformations of the metadata
       if (updatedDashboard.json_metadata) {
         const metadata = JSON.parse(updatedDashboard.json_metadata);
-        console.log('onUpdateSuccess dashboardState', metadata);
         dispatch(
           dashboardInfoChanged({
             metadata,
@@ -372,7 +371,6 @@ export function saveDashboardRequest(data, id, saveType) {
       if (isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS)) {
         chartConfiguration = handleChartConfiguration();
       }
-      console.log('dash save', { chartConfiguration });
       const updatedDashboard =
         saveType === SAVE_TYPE_OVERWRITE_CONFIRMED
           ? data

--- a/superset-frontend/src/dashboard/actions/hydrate.js
+++ b/superset-frontend/src/dashboard/actions/hydrate.js
@@ -16,9 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-/* eslint-disable camelcase */
-import { Behavior, getChartMetadataRegistry } from '@superset-ui/core';
-
 import { chart } from 'src/components/Chart/chartReducer';
 import { initSliceEntities } from 'src/dashboard/reducers/sliceEntities';
 import { getInitialState as getInitialNativeFilterState } from 'src/dashboard/reducers/nativeFilters';
@@ -26,7 +23,10 @@ import { applyDefaultFormData } from 'src/explore/store';
 import { buildActiveFilters } from 'src/dashboard/util/activeDashboardFilters';
 import { findPermission } from 'src/utils/findPermission';
 import { canUserEditDashboard } from 'src/dashboard/util/permissionUtils';
-import { isCrossFiltersEnabled } from 'src/dashboard/util/crossFilters';
+import {
+  getCrossFiltersConfiguration,
+  isCrossFiltersEnabled,
+} from 'src/dashboard/util/crossFilters';
 import {
   DASHBOARD_FILTER_SCOPE_GLOBAL,
   dashboardFilter,
@@ -56,7 +56,6 @@ import { FeatureFlag, isFeatureEnabled } from '../../featureFlags';
 import extractUrlParams from '../util/extractUrlParams';
 import getNativeFilterConfig from '../util/filterboxMigrationHelper';
 import { updateColorSchema } from './dashboardInfo';
-import { getChartIdsInFilterScope } from '../util/getChartIdsInFilterScope';
 import updateComponentParentsList from '../util/updateComponentParentsList';
 import { FilterBarOrientation } from '../types';
 
@@ -133,7 +132,7 @@ export const hydrateDashboard =
 
     charts.forEach(slice => {
       const key = slice.slice_id;
-      const form_data = {
+      const formData = {
         ...slice.form_data,
         url_params: {
           ...slice.form_data.url_params,
@@ -143,7 +142,7 @@ export const hydrateDashboard =
       chartQueries[key] = {
         ...chart,
         id: key,
-        form_data: applyDefaultFormData(form_data),
+        form_data: applyDefaultFormData(formData),
       };
 
       slices[key] = {
@@ -343,54 +342,11 @@ export const hydrateDashboard =
         ].includes(filterboxMigrationState));
 
     if (isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS)) {
-      // If user just added cross filter to dashboard it's not saving it scope on server,
-      // so we tweak it until user will update scope and will save it in server
-      Object.values(dashboardLayout.present).forEach(layoutItem => {
-        const chartId = layoutItem.meta?.chartId;
-        const behaviors =
-          (
-            getChartMetadataRegistry().get(
-              chartQueries[chartId]?.form_data?.viz_type,
-            ) ?? {}
-          )?.behaviors ?? [];
-
-        if (!metadata.chart_configuration) {
-          metadata.chart_configuration = {};
-        }
-        if (behaviors.includes(Behavior.INTERACTIVE_CHART)) {
-          if (!metadata.chart_configuration[chartId]) {
-            metadata.chart_configuration[chartId] = {
-              id: chartId,
-              crossFilters: {
-                scope: {
-                  rootPath: [DASHBOARD_ROOT_ID],
-                  excluded: [chartId], // By default it doesn't affects itself
-                },
-              },
-            };
-          }
-          metadata.chart_configuration[chartId].crossFilters.chartsInScope =
-            getChartIdsInFilterScope(
-              metadata.chart_configuration[chartId].crossFilters.scope,
-              chartQueries,
-              dashboardLayout.present,
-            );
-        }
-        if (
-          behaviors.includes(Behavior.INTERACTIVE_CHART) &&
-          !metadata.chart_configuration[chartId]
-        ) {
-          metadata.chart_configuration[chartId] = {
-            id: chartId,
-            crossFilters: {
-              scope: {
-                rootPath: [DASHBOARD_ROOT_ID],
-                excluded: [chartId], // By default it doesn't affects itself
-              },
-            },
-          };
-        }
-      });
+      metadata.chart_configuration = getCrossFiltersConfiguration(
+        dashboardLayout.present,
+        metadata.chart_configuration,
+        chartQueries,
+      );
     }
 
     const { roles } = user;

--- a/superset-frontend/src/dashboard/util/crossFilters.test.ts
+++ b/superset-frontend/src/dashboard/util/crossFilters.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import sinon from 'sinon';
+import { Behavior, FeatureFlag } from '@superset-ui/core';
+import * as core from '@superset-ui/core';
+import { getCrossFiltersConfiguration } from './crossFilters';
+
+const DASHBOARD_LAYOUT = {
+  'CHART-1': {
+    children: [],
+    id: 'CHART-1',
+    meta: {
+      chartId: 1,
+      sliceName: 'Test chart 1',
+      height: 1,
+      width: 1,
+      uuid: '1',
+    },
+    parents: ['ROOT_ID', 'GRID_ID', 'ROW-6XUMf1rV76'],
+    type: 'CHART',
+  },
+  'CHART-2': {
+    children: [],
+    id: 'CHART-2',
+    meta: {
+      chartId: 2,
+      sliceName: 'Test chart 2',
+      height: 1,
+      width: 1,
+      uuid: '2',
+    },
+    parents: ['ROOT_ID', 'GRID_ID', 'ROW-6XUMf1rV76'],
+    type: 'CHART',
+  },
+};
+
+const CHARTS = {
+  '1': {
+    id: 1,
+    form_data: {
+      datasource: '2__table',
+      viz_type: 'echarts_timeseries_line',
+      slice_id: 1,
+    },
+    chartAlert: null,
+    chartStatus: 'rendered' as const,
+    chartUpdateEndTime: 0,
+    chartUpdateStartTime: 0,
+    lastRendered: 0,
+    latestQueryFormData: {},
+    sliceFormData: {
+      datasource: '2__table',
+      viz_type: 'echarts_timeseries_line',
+    },
+    queryController: null,
+    queriesResponse: [{}],
+    triggerQuery: false,
+  },
+  '2': {
+    id: 2,
+    form_data: {
+      datasource: '2__table',
+      viz_type: 'echarts_timeseries_line',
+      slice_id: 2,
+    },
+    chartAlert: null,
+    chartStatus: 'rendered' as const,
+    chartUpdateEndTime: 0,
+    chartUpdateStartTime: 0,
+    lastRendered: 0,
+    latestQueryFormData: {},
+    sliceFormData: {
+      datasource: '2__table',
+      viz_type: 'echarts_timeseries_line',
+    },
+    queryController: null,
+    queriesResponse: [{}],
+    triggerQuery: false,
+  },
+};
+
+const INITIAL_CHART_CONFIG = {
+  '1': {
+    id: 1,
+    crossFilters: {
+      scope: {
+        rootPath: ['ROOT_ID'],
+        excluded: [1],
+      },
+      chartsInScope: [2],
+    },
+  },
+};
+
+test('Generate correct cross filters configuration without initial configuration', () => {
+  // @ts-ignore
+  global.featureFlags = {
+    [FeatureFlag.DASHBOARD_CROSS_FILTERS]: true,
+  };
+  const metadataRegistryStub = sinon
+    .stub(core, 'getChartMetadataRegistry')
+    .callsFake(() => ({
+      // @ts-ignore
+      get: () => ({
+        behaviors: [Behavior.INTERACTIVE_CHART],
+      }),
+    }));
+  expect(
+    getCrossFiltersConfiguration(DASHBOARD_LAYOUT, undefined, CHARTS),
+  ).toEqual({
+    '1': {
+      id: 1,
+      crossFilters: {
+        scope: {
+          rootPath: ['ROOT_ID'],
+          excluded: [1],
+        },
+        chartsInScope: [2],
+      },
+    },
+    '2': {
+      id: 2,
+      crossFilters: {
+        scope: {
+          rootPath: ['ROOT_ID'],
+          excluded: [2],
+        },
+        chartsInScope: [1],
+      },
+    },
+  });
+  metadataRegistryStub.restore();
+});
+
+test('Generate correct cross filters configuration with initial configuration', () => {
+  // @ts-ignore
+  global.featureFlags = {
+    [FeatureFlag.DASHBOARD_CROSS_FILTERS]: true,
+  };
+  const metadataRegistryStub = sinon
+    .stub(core, 'getChartMetadataRegistry')
+    .callsFake(() => ({
+      // @ts-ignore
+      get: () => ({
+        behaviors: [Behavior.INTERACTIVE_CHART],
+      }),
+    }));
+  expect(
+    getCrossFiltersConfiguration(
+      DASHBOARD_LAYOUT,
+      INITIAL_CHART_CONFIG,
+      CHARTS,
+    ),
+  ).toEqual({
+    '1': {
+      id: 1,
+      crossFilters: {
+        scope: {
+          rootPath: ['ROOT_ID'],
+          excluded: [1],
+        },
+        chartsInScope: [2],
+      },
+    },
+    '2': {
+      id: 2,
+      crossFilters: {
+        scope: {
+          rootPath: ['ROOT_ID'],
+          excluded: [2],
+        },
+        chartsInScope: [1],
+      },
+    },
+  });
+  metadataRegistryStub.restore();
+});
+
+test('Return undefined if DASHBOARD_CROSS_FILTERS feature flag is disabled', () => {
+  // @ts-ignore
+  global.featureFlags = {
+    [FeatureFlag.DASHBOARD_CROSS_FILTERS]: false,
+  };
+  expect(
+    getCrossFiltersConfiguration(
+      DASHBOARD_LAYOUT,
+      INITIAL_CHART_CONFIG,
+      CHARTS,
+    ),
+  ).toEqual(undefined);
+});

--- a/superset-frontend/src/dashboard/util/crossFilters.ts
+++ b/superset-frontend/src/dashboard/util/crossFilters.ts
@@ -21,6 +21,7 @@ import {
   Behavior,
   FeatureFlag,
   getChartMetadataRegistry,
+  isDefined,
   isFeatureEnabled,
 } from '@superset-ui/core';
 import { DASHBOARD_ROOT_ID } from './constants';
@@ -36,7 +37,7 @@ export const isCrossFiltersEnabled = (
 export const getCrossFiltersConfiguration = (
   dashboardLayout: DashboardLayout,
   initialConfig: DashboardInfo['metadata']['chart_configuration'] = {},
-  chartQueries: ChartsState,
+  charts: ChartsState,
 ) => {
   if (!isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS)) {
     return undefined;
@@ -46,11 +47,15 @@ export const getCrossFiltersConfiguration = (
   const chartConfiguration = {};
   Object.values(dashboardLayout).forEach(layoutItem => {
     const chartId = layoutItem.meta?.chartId;
+
+    if (!isDefined(chartId)) {
+      return;
+    }
+
     const behaviors =
       (
-        getChartMetadataRegistry().get(
-          chartQueries[chartId]?.form_data?.viz_type,
-        ) ?? {}
+        getChartMetadataRegistry().get(charts[chartId]?.form_data?.viz_type) ??
+        {}
       )?.behaviors ?? [];
 
     if (behaviors.includes(Behavior.INTERACTIVE_CHART)) {
@@ -71,7 +76,7 @@ export const getCrossFiltersConfiguration = (
       chartConfiguration[chartId].crossFilters.chartsInScope =
         getChartIdsInFilterScope(
           chartConfiguration[chartId].crossFilters.scope,
-          chartQueries,
+          charts,
           dashboardLayout,
         );
     }

--- a/superset-frontend/src/dashboard/util/crossFilters.ts
+++ b/superset-frontend/src/dashboard/util/crossFilters.ts
@@ -35,7 +35,7 @@ export const isCrossFiltersEnabled = (
 
 export const getCrossFiltersConfiguration = (
   dashboardLayout: DashboardLayout,
-  initialConfig: DashboardInfo['metadata']['chart_configuration'],
+  initialConfig: DashboardInfo['metadata']['chart_configuration'] = {},
   chartQueries: ChartsState,
 ) => {
   if (!isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS)) {


### PR DESCRIPTION
### SUMMARY
When user created a new dashboard or added a chart to an existing dashboard, the cross filters would not work properly until the page was refreshed (and hydrate dashboard was triggered). The reason for that is that the cross filters configuration for each chart was created only on dashboard hydration, but not on dashboard save. This PR fixes that behaviour.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/15073128/221249185-7b7a4e96-49c5-4ff3-a264-c3069f8a1586.mov

After:

https://user-images.githubusercontent.com/15073128/221249247-d0e43da0-2eb9-4d58-b2ff-d40962775f06.mov


### TESTING INSTRUCTIONS
1. Open a dashboard and click Edit
2. Add a chart to the dashboard and save
3. Apply cross-filter on some other chart
4. Verify that the newly added chart is getting filtered by the cross-filter

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
