### PR TITLE
fix(ssh_tunnel): Display SSHTunnel Switch when editing a DB that was created with the Dynamic Form

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -1532,6 +1532,69 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
     </StyledBtns>
   );
 
+  const renderDatabaseConnectionForm = () => (
+    <>
+      <DatabaseConnectionForm
+        isEditMode={isEditMode}
+        db={db as DatabaseObject}
+        sslForced={sslForced}
+        dbModel={dbModel}
+        onAddTableCatalog={() => {
+          setDB({ type: ActionType.addTableCatalogSheet });
+        }}
+        onQueryChange={({ target }: { target: HTMLInputElement }) =>
+          onChange(ActionType.queryChange, {
+            name: target.name,
+            value: target.value,
+          })
+        }
+        onExtraInputChange={({ target }: { target: HTMLInputElement }) =>
+          onChange(ActionType.extraInputChange, {
+            name: target.name,
+            value: target.value,
+          })
+        }
+        onRemoveTableCatalog={(idx: number) => {
+          setDB({
+            type: ActionType.removeTableCatalogSheet,
+            payload: { indexToDelete: idx },
+          });
+        }}
+        onParametersChange={({ target }: { target: HTMLInputElement }) =>
+          onChange(ActionType.parametersChange, {
+            type: target.type,
+            name: target.name,
+            checked: target.checked,
+            value: target.value,
+          })
+        }
+        onChange={({ target }: { target: HTMLInputElement }) =>
+          onChange(ActionType.textChange, {
+            name: target.name,
+            value: target.value,
+          })
+        }
+        getValidation={() => getValidation(db)}
+        validationErrors={validationErrors}
+        getPlaceholder={getPlaceholder}
+      />
+      <SSHTunnelContainer>
+        <SSHTunnelSwitchComponent
+          isEditMode={isEditMode}
+          dbFetched={dbFetched}
+          disableSSHTunnelingForEngine={disableSSHTunnelingForEngine}
+          useSSHTunneling={useSSHTunneling}
+          setUseSSHTunneling={setUseSSHTunneling}
+          setDB={setDB}
+          isSSHTunneling={isSSHTunneling}
+        />
+      </SSHTunnelContainer>
+      {useSSHTunneling && (
+        <SSHTunnelContainer>{renderSSHTunnelForm()}</SSHTunnelContainer>
+      )}
+    </>
+  );
+
   const renderFinishState = () => {
     if (!editNewDb) {
       return (
@@ -1568,51 +1631,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
         />
       );
     }
-    return (
-      <DatabaseConnectionForm
-        isEditMode
-        sslForced={sslForced}
-        dbModel={dbModel}
-        db={db as DatabaseObject}
-        onParametersChange={({ target }: { target: HTMLInputElement }) =>
-          onChange(ActionType.parametersChange, {
-            type: target.type,
-            name: target.name,
-            checked: target.checked,
-            value: target.value,
-          })
-        }
-        onExtraInputChange={({ target }: { target: HTMLInputElement }) =>
-          onChange(ActionType.extraInputChange, {
-            name: target.name,
-            value: target.value,
-          })
-        }
-        onChange={({ target }: { target: HTMLInputElement }) =>
-          onChange(ActionType.textChange, {
-            name: target.name,
-            value: target.value,
-          })
-        }
-        onQueryChange={({ target }: { target: HTMLInputElement }) =>
-          onChange(ActionType.queryChange, {
-            name: target.name,
-            value: target.value,
-          })
-        }
-        onAddTableCatalog={() =>
-          setDB({ type: ActionType.addTableCatalogSheet })
-        }
-        onRemoveTableCatalog={(idx: number) =>
-          setDB({
-            type: ActionType.removeTableCatalogSheet,
-            payload: { indexToDelete: idx },
-          })
-        }
-        getValidation={() => getValidation(db)}
-        validationErrors={validationErrors}
-      />
-    );
+    return renderDatabaseConnectionForm();
   };
 
   if (
@@ -1758,49 +1777,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
               )}
             </StyledAlignment>
           ) : (
-            <DatabaseConnectionForm
-              isEditMode
-              sslForced={sslForced}
-              dbModel={dbModel}
-              db={db as DatabaseObject}
-              onParametersChange={({ target }: { target: HTMLInputElement }) =>
-                onChange(ActionType.parametersChange, {
-                  type: target.type,
-                  name: target.name,
-                  checked: target.checked,
-                  value: target.value,
-                })
-              }
-              onExtraInputChange={({ target }: { target: HTMLInputElement }) =>
-                onChange(ActionType.extraInputChange, {
-                  name: target.name,
-                  value: target.value,
-                })
-              }
-              onChange={({ target }: { target: HTMLInputElement }) =>
-                onChange(ActionType.textChange, {
-                  name: target.name,
-                  value: target.value,
-                })
-              }
-              onQueryChange={({ target }: { target: HTMLInputElement }) =>
-                onChange(ActionType.queryChange, {
-                  name: target.name,
-                  value: target.value,
-                })
-              }
-              onAddTableCatalog={() =>
-                setDB({ type: ActionType.addTableCatalogSheet })
-              }
-              onRemoveTableCatalog={(idx: number) =>
-                setDB({
-                  type: ActionType.removeTableCatalogSheet,
-                  payload: { indexToDelete: idx },
-                })
-              }
-              getValidation={() => getValidation(db)}
-              validationErrors={validationErrors}
-            />
+            renderDatabaseConnectionForm()
           )}
           {!isEditMode && (
             <StyledAlertMargin>
@@ -1950,73 +1927,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
                   dbModel={dbModel}
                 />
                 {hasAlert && renderStepTwoAlert()}
-                <DatabaseConnectionForm
-                  db={db}
-                  sslForced={sslForced}
-                  dbModel={dbModel}
-                  onAddTableCatalog={() => {
-                    setDB({ type: ActionType.addTableCatalogSheet });
-                  }}
-                  onQueryChange={({ target }: { target: HTMLInputElement }) =>
-                    onChange(ActionType.queryChange, {
-                      name: target.name,
-                      value: target.value,
-                    })
-                  }
-                  onExtraInputChange={({
-                    target,
-                  }: {
-                    target: HTMLInputElement;
-                  }) =>
-                    onChange(ActionType.extraInputChange, {
-                      name: target.name,
-                      value: target.value,
-                    })
-                  }
-                  onRemoveTableCatalog={(idx: number) => {
-                    setDB({
-                      type: ActionType.removeTableCatalogSheet,
-                      payload: { indexToDelete: idx },
-                    });
-                  }}
-                  onParametersChange={({
-                    target,
-                  }: {
-                    target: HTMLInputElement;
-                  }) =>
-                    onChange(ActionType.parametersChange, {
-                      type: target.type,
-                      name: target.name,
-                      checked: target.checked,
-                      value: target.value,
-                    })
-                  }
-                  onChange={({ target }: { target: HTMLInputElement }) =>
-                    onChange(ActionType.textChange, {
-                      name: target.name,
-                      value: target.value,
-                    })
-                  }
-                  getValidation={() => getValidation(db)}
-                  validationErrors={validationErrors}
-                  getPlaceholder={getPlaceholder}
-                />
-                <SSHTunnelContainer>
-                  <SSHTunnelSwitchComponent
-                    isEditMode={isEditMode}
-                    dbFetched={dbFetched}
-                    disableSSHTunnelingForEngine={disableSSHTunnelingForEngine}
-                    useSSHTunneling={useSSHTunneling}
-                    setUseSSHTunneling={setUseSSHTunneling}
-                    setDB={setDB}
-                    isSSHTunneling={isSSHTunneling}
-                  />
-                </SSHTunnelContainer>
-                {useSSHTunneling && (
-                  <SSHTunnelContainer>
-                    {renderSSHTunnelForm()}
-                  </SSHTunnelContainer>
-                )}
+                {renderDatabaseConnectionForm()}
                 <div css={(theme: SupersetTheme) => infoTooltip(theme)}>
                   {dbModel.engine !== Engines.GSheet && (
                     <>


### PR DESCRIPTION
### SUMMARY

Right now when editing a Database you created using the `Dynamic Form` you won't see the `SSH Tunnel` toggle, so you  you won't be able to add the tunnel after creating the DB this way.

This is happening because we forgot to add the switch component into one of the three places we are rendering the `Dynamic Form (<DatabaseConnectionForm>)` in our `DatabaseModal`.

So, now we are consolidating all those repetitive code into one single method and reusing it when needed thus avoiding such things in the future.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![error](https://user-images.githubusercontent.com/38889534/221266276-a36a134c-9364-4872-9ba8-840dd54666c0.gif)

After:
![test](https://user-images.githubusercontent.com/38889534/221266339-3889d76c-1f45-4a38-a2a5-a6d9d60dfe22.gif)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
