### PR TITLE
fix(sshtunnel): argument params to properly setting `server_port`

### DIFF
--- a/superset/extensions/ssh.py
+++ b/superset/extensions/ssh.py
@@ -51,8 +51,7 @@ class SSHManager:
     ) -> SSHTunnelForwarder:
         url = make_url_safe(sqlalchemy_database_uri)
         params = {
-            "ssh_address_or_host": ssh_tunnel.server_address,
-            "ssh_port": ssh_tunnel.server_port,
+            "ssh_address_or_host": (ssh_tunnel.server_address, ssh_tunnel.server_port),
             "ssh_username": ssh_tunnel.username,
             "remote_bind_address": (url.host, url.port),  # bind_port, bind_host
             "local_bind_address": (self.local_bind_address,),


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Using configuration for tuple to set service_host + server_port. Realized there was an upstream issue with the lib properly setting the port before establishing the connection. Will submit upstream fix later but want to unblock superset users being able to set the port properly.
```
with sshtunnel.open_tunnel(
    ssh_address_or_host=(SERVER, SERVER_PORT),
    ssh_username=SSH_USER,
    ssh_pkey=private_key,
    remote_bind_address=(remote_host, remote_port),
    local_bind_address=("127.0.0.1",),
    # debug_level='TRACE',
) as server:
   # establish connection...
```
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
