### PR TITLE
fix: permission checks on import

### DIFF
--- a/superset/charts/commands/importers/v1/utils.py
+++ b/superset/charts/commands/importers/v1/utils.py
@@ -21,17 +21,24 @@ from typing import Any, Dict
 from flask import g
 from sqlalchemy.orm import Session
 
+from superset import security_manager
+from superset.commands.exceptions import ImportFailedError
 from superset.models.slice import Slice
 
 
 def import_chart(
     session: Session, config: Dict[str, Any], overwrite: bool = False
 ) -> Slice:
+    can_write = security_manager.can_access("can_write", "Chart")
     existing = session.query(Slice).filter_by(uuid=config["uuid"]).first()
     if existing:
-        if not overwrite:
+        if not overwrite or not can_write:
             return existing
         config["id"] = existing.id
+    elif not can_write:
+        raise ImportFailedError(
+            "Chart doesn't exist and user doesn't have permission to create charts"
+        )
 
     # TODO (betodealmeida): move this logic to import_from_dict
     config["params"] = json.dumps(config["params"])

--- a/superset/charts/commands/importers/v1/utils.py
+++ b/superset/charts/commands/importers/v1/utils.py
@@ -31,6 +31,8 @@ def import_chart(
 ) -> Slice:
     can_write = security_manager.can_access("can_write", "Chart")
     existing = session.query(Slice).filter_by(uuid=config["uuid"]).first()
+    print("BETO")
+    print(can_write, existing)
     if existing:
         if not overwrite or not can_write:
             return existing

--- a/superset/charts/commands/importers/v1/utils.py
+++ b/superset/charts/commands/importers/v1/utils.py
@@ -31,8 +31,6 @@ def import_chart(
 ) -> Slice:
     can_write = security_manager.can_access("can_write", "Chart")
     existing = session.query(Slice).filter_by(uuid=config["uuid"]).first()
-    print("BETO")
-    print(can_write, existing)
     if existing:
         if not overwrite or not can_write:
             return existing

--- a/superset/cli/examples.py
+++ b/superset/cli/examples.py
@@ -20,7 +20,6 @@ import click
 from flask.cli import with_appcontext
 
 import superset.utils.database as database_utils
-from superset import security_manager
 
 logger = logging.getLogger(__name__)
 
@@ -114,8 +113,4 @@ def load_examples(
     force: bool = False,
 ) -> None:
     """Loads a set of Slices and Dashboards and a supporting dataset"""
-    # pylint: disable=import-outside-toplevel
-    from superset.utils.core import override_user
-
-    with override_user(security_manager.find_user(username="admin")):
-        load_examples_run(load_test_data, load_big_data, only_metadata, force)
+    load_examples_run(load_test_data, load_big_data, only_metadata, force)

--- a/superset/cli/examples.py
+++ b/superset/cli/examples.py
@@ -20,6 +20,7 @@ import click
 from flask.cli import with_appcontext
 
 import superset.utils.database as database_utils
+from superset import security_manager
 
 logger = logging.getLogger(__name__)
 
@@ -113,4 +114,8 @@ def load_examples(
     force: bool = False,
 ) -> None:
     """Loads a set of Slices and Dashboards and a supporting dataset"""
-    load_examples_run(load_test_data, load_big_data, only_metadata, force)
+    # pylint: disable=import-outside-toplevel
+    from superset.utils.core import override_user
+
+    with override_user(security_manager.find_user(username="admin")):
+        load_examples_run(load_test_data, load_big_data, only_metadata, force)

--- a/superset/commands/importers/v1/examples.py
+++ b/superset/commands/importers/v1/examples.py
@@ -133,12 +133,18 @@ class ImportExamplesCommand(ImportModelsCommand):
                     config["schema"] = get_example_default_schema()
 
                 dataset = import_dataset(
-                    session, config, overwrite=overwrite, force_data=force_data
+                    session,
+                    config,
+                    overwrite=overwrite,
+                    force_data=force_data,
                 )
 
                 try:
                     dataset = import_dataset(
-                        session, config, overwrite=overwrite, force_data=force_data
+                        session,
+                        config,
+                        overwrite=overwrite,
+                        force_data=force_data,
                     )
                 except MultipleResultsFound:
                     # Multiple result can be found for datasets. There was a bug in

--- a/superset/commands/importers/v1/examples.py
+++ b/superset/commands/importers/v1/examples.py
@@ -16,12 +16,14 @@
 # under the License.
 from typing import Any, Dict, List, Set, Tuple
 
+from flask import current_app
+from flask_login import login_user
 from marshmallow import Schema
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import MultipleResultsFound
 from sqlalchemy.sql import select
 
-from superset import db
+from superset import db, security_manager
 from superset.charts.commands.importers.v1 import ImportChartsCommand
 from superset.charts.commands.importers.v1.utils import import_chart
 from superset.charts.schemas import ImportV1ChartSchema
@@ -67,13 +69,24 @@ class ImportExamplesCommand(ImportModelsCommand):
     def run(self) -> None:
         self.validate()
 
-        # rollback to prevent partial imports
-        try:
-            self._import(db.session, self._configs, self.overwrite, self.force_data)
-            db.session.commit()
-        except Exception as ex:
-            db.session.rollback()
-            raise self.import_error() from ex
+        # login as the admin so we have the correct permissions to import everything
+        admin = security_manager.find_user("admin")
+        with current_app.app_context():
+            with current_app.test_request_context("/login"):
+                login_user(admin)
+
+                # rollback to prevent partial imports
+                try:
+                    self._import(
+                        db.session,
+                        self._configs,
+                        self.overwrite,
+                        self.force_data,
+                    )
+                    db.session.commit()
+                except Exception as ex:
+                    db.session.rollback()
+                    raise self.import_error() from ex
 
     @classmethod
     def _get_uuids(cls) -> Set[str]:

--- a/superset/commands/importers/v1/examples.py
+++ b/superset/commands/importers/v1/examples.py
@@ -21,7 +21,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import MultipleResultsFound
 from sqlalchemy.sql import select
 
-from superset import db
+from superset import db, security_manager
 from superset.charts.commands.importers.v1 import ImportChartsCommand
 from superset.charts.commands.importers.v1.utils import import_chart
 from superset.charts.schemas import ImportV1ChartSchema
@@ -42,7 +42,7 @@ from superset.datasets.commands.importers.v1 import ImportDatasetsCommand
 from superset.datasets.commands.importers.v1.utils import import_dataset
 from superset.datasets.schemas import ImportV1DatasetSchema
 from superset.models.dashboard import dashboard_slices
-from superset.utils.core import get_example_default_schema
+from superset.utils.core import get_example_default_schema, override_user
 from superset.utils.database import get_example_database
 
 
@@ -69,12 +69,13 @@ class ImportExamplesCommand(ImportModelsCommand):
 
         # rollback to prevent partial imports
         try:
-            self._import(
-                db.session,
-                self._configs,
-                self.overwrite,
-                self.force_data,
-            )
+            with override_user(security_manager.find_user(username="admin")):
+                self._import(
+                    db.session,
+                    self._configs,
+                    self.overwrite,
+                    self.force_data,
+                )
             db.session.commit()
         except Exception as ex:
             db.session.rollback()
@@ -123,13 +124,6 @@ class ImportExamplesCommand(ImportModelsCommand):
                 # set schema
                 if config["schema"] is None:
                     config["schema"] = get_example_default_schema()
-
-                dataset = import_dataset(
-                    session,
-                    config,
-                    overwrite=overwrite,
-                    force_data=force_data,
-                )
 
                 try:
                     dataset = import_dataset(

--- a/superset/dashboards/commands/importers/v1/utils.py
+++ b/superset/dashboards/commands/importers/v1/utils.py
@@ -22,6 +22,8 @@ from typing import Any, Dict, Set
 from flask import g
 from sqlalchemy.orm import Session
 
+from superset import security_manager
+from superset.commands.exceptions import ImportFailedError
 from superset.models.dashboard import Dashboard
 
 logger = logging.getLogger(__name__)
@@ -146,11 +148,16 @@ def update_id_refs(  # pylint: disable=too-many-locals
 def import_dashboard(
     session: Session, config: Dict[str, Any], overwrite: bool = False
 ) -> Dashboard:
+    can_write = security_manager.can_access("can_write", "Dashboard")
     existing = session.query(Dashboard).filter_by(uuid=config["uuid"]).first()
     if existing:
-        if not overwrite:
+        if not overwrite or not can_write:
             return existing
         config["id"] = existing.id
+    elif not can_write:
+        raise ImportFailedError(
+            "Dashboard doesn't exist and user doesn't have permission to create dashboard"
+        )
 
     # TODO (betodealmeida): move this logic to import_from_dict
     config = config.copy()

--- a/superset/dashboards/commands/importers/v1/utils.py
+++ b/superset/dashboards/commands/importers/v1/utils.py
@@ -156,7 +156,8 @@ def import_dashboard(
         config["id"] = existing.id
     elif not can_write:
         raise ImportFailedError(
-            "Dashboard doesn't exist and user doesn't have permission to create dashboard"
+            "Dashboard doesn't exist and user doesn't "
+            "have permission to create dashboards"
         )
 
     # TODO (betodealmeida): move this logic to import_from_dict

--- a/superset/datasets/commands/importers/v1/utils.py
+++ b/superset/datasets/commands/importers/v1/utils.py
@@ -29,8 +29,8 @@ from sqlalchemy.orm.exc import MultipleResultsFound
 from sqlalchemy.sql.visitors import VisitableType
 
 from superset import security_manager
-from superset.connectors.sqla.models import SqlaTable
 from superset.commands.exceptions import ImportFailedError
+from superset.connectors.sqla.models import SqlaTable
 from superset.datasets.commands.exceptions import DatasetForbiddenDataURI
 from superset.models.core import Database
 

--- a/superset/datasets/commands/importers/v1/utils.py
+++ b/superset/datasets/commands/importers/v1/utils.py
@@ -28,7 +28,9 @@ from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import MultipleResultsFound
 from sqlalchemy.sql.visitors import VisitableType
 
+from superset import security_manager
 from superset.connectors.sqla.models import SqlaTable
+from superset.commands.exceptions import ImportFailedError
 from superset.datasets.commands.exceptions import DatasetForbiddenDataURI
 from superset.models.core import Database
 
@@ -104,11 +106,16 @@ def import_dataset(
     overwrite: bool = False,
     force_data: bool = False,
 ) -> SqlaTable:
+    can_write = security_manager.can_access("can_write", "Dataset")
     existing = session.query(SqlaTable).filter_by(uuid=config["uuid"]).first()
     if existing:
-        if not overwrite:
+        if not overwrite or not can_write:
             return existing
         config["id"] = existing.id
+    elif not can_write:
+        raise ImportFailedError(
+            "Dataset doesn't exist and user doesn't have permission to create datasets"
+        )
 
     # TODO (betodealmeida): move this logic to import_from_dict
     config = config.copy()

--- a/superset/examples/utils.py
+++ b/superset/examples/utils.py
@@ -92,7 +92,9 @@ def load_configs_from_directory(
     contents[METADATA_FILE_NAME] = yaml.dump(metadata)
 
     command = ImportExamplesCommand(
-        contents, overwrite=overwrite, force_data=force_data
+        contents,
+        overwrite=overwrite,
+        force_data=force_data,
     )
     try:
         command.run()

--- a/tests/integration_tests/charts/commands_tests.py
+++ b/tests/integration_tests/charts/commands_tests.py
@@ -164,9 +164,10 @@ class TestExportChartsCommand(SupersetTestCase):
 
 class TestImportChartsCommand(SupersetTestCase):
     @patch("superset.charts.commands.importers.v1.utils.g")
-    def test_import_v1_chart(self, mock_g):
+    @patch("superset.security.manager.g")
+    def test_import_v1_chart(self, sm_g, utils_g):
         """Test that we can import a chart"""
-        mock_g.user = security_manager.find_user("admin")
+        admin = sm_g.user = utils_g.user = security_manager.find_user("admin")
         contents = {
             "metadata.yaml": yaml.safe_dump(chart_metadata_config),
             "databases/imported_database.yaml": yaml.safe_dump(database_config),
@@ -227,7 +228,7 @@ class TestImportChartsCommand(SupersetTestCase):
         assert database.database_name == "imported_database"
         assert chart.table.database == database
 
-        assert chart.owners == [mock_g.user]
+        assert chart.owners == [admin]
 
         chart.owners = []
         dataset.owners = []
@@ -237,8 +238,10 @@ class TestImportChartsCommand(SupersetTestCase):
         db.session.delete(database)
         db.session.commit()
 
-    def test_import_v1_chart_multiple(self):
+    @patch("superset.security.manager.g")
+    def test_import_v1_chart_multiple(self, sm_g):
         """Test that a chart can be imported multiple times"""
+        sm_g.user = security_manager.find_user("admin")
         contents = {
             "metadata.yaml": yaml.safe_dump(chart_metadata_config),
             "databases/imported_database.yaml": yaml.safe_dump(database_config),

--- a/tests/integration_tests/dashboards/commands_tests.py
+++ b/tests/integration_tests/dashboards/commands_tests.py
@@ -485,9 +485,10 @@ class TestImportDashboardsCommand(SupersetTestCase):
         db.session.commit()
 
     @patch("superset.dashboards.commands.importers.v1.utils.g")
-    def test_import_v1_dashboard(self, mock_g):
+    @patch("superset.security.manager.g")
+    def test_import_v1_dashboard(self, sm_g, utils_g):
         """Test that we can import a dashboard"""
-        mock_g.user = security_manager.find_user("admin")
+        admin = sm_g.user = utils_g.user = security_manager.find_user("admin")
         contents = {
             "metadata.yaml": yaml.safe_dump(dashboard_metadata_config),
             "databases/imported_database.yaml": yaml.safe_dump(database_config),
@@ -567,7 +568,7 @@ class TestImportDashboardsCommand(SupersetTestCase):
         database = dataset.database
         assert str(database.uuid) == database_config["uuid"]
 
-        assert dashboard.owners == [mock_g.user]
+        assert dashboard.owners == [admin]
 
         dashboard.owners = []
         chart.owners = []
@@ -579,8 +580,11 @@ class TestImportDashboardsCommand(SupersetTestCase):
         db.session.delete(database)
         db.session.commit()
 
-    def test_import_v1_dashboard_multiple(self):
+    @patch("superset.security.manager.g")
+    def test_import_v1_dashboard_multiple(self, mock_g):
         """Test that a dashboard can be imported multiple times"""
+        mock_g.user = security_manager.find_user("admin")
+
         num_dashboards = db.session.query(Dashboard).count()
 
         contents = {

--- a/tests/integration_tests/databases/commands_tests.py
+++ b/tests/integration_tests/databases/commands_tests.py
@@ -75,10 +75,8 @@ from tests.integration_tests.fixtures.importexport import (
 
 
 class TestCreateDatabaseCommand(SupersetTestCase):
-    @mock.patch(
-        "superset.databases.commands.test_connection.event_logger.log_with_context"
-    )
-    @mock.patch("superset.utils.core.g")
+    @patch("superset.databases.commands.test_connection.event_logger.log_with_context")
+    @patch("superset.utils.core.g")
     def test_create_duplicate_error(self, mock_g, mock_logger):
         example_db = get_example_database()
         mock_g.user = security_manager.find_user("admin")
@@ -96,10 +94,8 @@ class TestCreateDatabaseCommand(SupersetTestCase):
             "DatabaseRequiredFieldValidationError"
         )
 
-    @mock.patch(
-        "superset.databases.commands.test_connection.event_logger.log_with_context"
-    )
-    @mock.patch("superset.utils.core.g")
+    @patch("superset.databases.commands.test_connection.event_logger.log_with_context")
+    @patch("superset.utils.core.g")
     def test_multiple_error_logging(self, mock_g, mock_logger):
         mock_g.user = security_manager.find_user("admin")
         command = CreateDatabaseCommand({})
@@ -401,8 +397,11 @@ class TestExportDatabasesCommand(SupersetTestCase):
 
 
 class TestImportDatabasesCommand(SupersetTestCase):
-    def test_import_v1_database(self):
+    @patch("superset.security.manager.g")
+    def test_import_v1_database(self, mock_g):
         """Test that a database can be imported"""
+        mock_g.user = security_manager.find_user("admin")
+
         contents = {
             "metadata.yaml": yaml.safe_dump(database_metadata_config),
             "databases/imported_database.yaml": yaml.safe_dump(database_config),
@@ -427,7 +426,8 @@ class TestImportDatabasesCommand(SupersetTestCase):
         db.session.delete(database)
         db.session.commit()
 
-    def test_import_v1_database_broken_csv_fields(self):
+    @patch("superset.security.manager.g")
+    def test_import_v1_database_broken_csv_fields(self, mock_g):
         """
         Test that a database can be imported with broken schema.
 
@@ -435,6 +435,8 @@ class TestImportDatabasesCommand(SupersetTestCase):
         the V1 schema. This test ensures that we can import databases that were
         exported with the broken schema.
         """
+        mock_g.user = security_manager.find_user("admin")
+
         broken_config = database_config.copy()
         broken_config["allow_file_upload"] = broken_config.pop("allow_csv_upload")
         broken_config["extra"] = {"schemas_allowed_for_file_upload": ["upload"]}
@@ -463,8 +465,11 @@ class TestImportDatabasesCommand(SupersetTestCase):
         db.session.delete(database)
         db.session.commit()
 
-    def test_import_v1_database_multiple(self):
+    @patch("superset.security.manager.g")
+    def test_import_v1_database_multiple(self, mock_g):
         """Test that a database can be imported multiple times"""
+        mock_g.user = security_manager.find_user("admin")
+
         num_databases = db.session.query(Database).count()
 
         contents = {
@@ -504,8 +509,11 @@ class TestImportDatabasesCommand(SupersetTestCase):
         db.session.delete(database)
         db.session.commit()
 
-    def test_import_v1_database_with_dataset(self):
+    @patch("superset.security.manager.g")
+    def test_import_v1_database_with_dataset(self, mock_g):
         """Test that a database can be imported with datasets"""
+        mock_g.user = security_manager.find_user("admin")
+
         contents = {
             "databases/imported_database.yaml": yaml.safe_dump(database_config),
             "datasets/imported_dataset.yaml": yaml.safe_dump(dataset_config),
@@ -524,8 +532,11 @@ class TestImportDatabasesCommand(SupersetTestCase):
         db.session.delete(database)
         db.session.commit()
 
-    def test_import_v1_database_with_dataset_multiple(self):
+    @patch("superset.security.manager.g")
+    def test_import_v1_database_with_dataset_multiple(self, mock_g):
         """Test that a database can be imported multiple times w/o changing datasets"""
+        mock_g.user = security_manager.find_user("admin")
+
         contents = {
             "databases/imported_database.yaml": yaml.safe_dump(database_config),
             "datasets/imported_dataset.yaml": yaml.safe_dump(dataset_config),
@@ -629,7 +640,7 @@ class TestImportDatabasesCommand(SupersetTestCase):
             }
         }
 
-    @mock.patch("superset.databases.schemas.is_feature_enabled")
+    @patch("superset.databases.schemas.is_feature_enabled")
     def test_import_v1_database_masked_ssh_tunnel_password(
         self, mock_schema_is_feature_enabled
     ):
@@ -650,7 +661,7 @@ class TestImportDatabasesCommand(SupersetTestCase):
             }
         }
 
-    @mock.patch("superset.databases.schemas.is_feature_enabled")
+    @patch("superset.databases.schemas.is_feature_enabled")
     def test_import_v1_database_masked_ssh_tunnel_private_key_and_password(
         self, mock_schema_is_feature_enabled
     ):
@@ -674,11 +685,15 @@ class TestImportDatabasesCommand(SupersetTestCase):
             }
         }
 
-    @mock.patch("superset.databases.schemas.is_feature_enabled")
+    @patch("superset.databases.schemas.is_feature_enabled")
+    @patch("superset.security.manager.g")
     def test_import_v1_database_with_ssh_tunnel_password(
-        self, mock_schema_is_feature_enabled
+        self,
+        mock_g,
+        mock_schema_is_feature_enabled,
     ):
         """Test that a database with ssh_tunnel password can be imported"""
+        mock_g.user = security_manager.find_user("admin")
         mock_schema_is_feature_enabled.return_value = True
         masked_database_config = database_with_ssh_tunnel_config_password.copy()
         masked_database_config["ssh_tunnel"]["password"] = "TEST"
@@ -713,11 +728,16 @@ class TestImportDatabasesCommand(SupersetTestCase):
         db.session.delete(database)
         db.session.commit()
 
-    @mock.patch("superset.databases.schemas.is_feature_enabled")
+    @patch("superset.databases.schemas.is_feature_enabled")
+    @patch("superset.security.manager.g")
     def test_import_v1_database_with_ssh_tunnel_private_key_and_password(
-        self, mock_schema_is_feature_enabled
+        self,
+        mock_g,
+        mock_schema_is_feature_enabled,
     ):
         """Test that a database with ssh_tunnel private_key and private_key_password can be imported"""
+        mock_g.user = security_manager.find_user("admin")
+
         mock_schema_is_feature_enabled.return_value = True
         masked_database_config = database_with_ssh_tunnel_config_private_key.copy()
         masked_database_config["ssh_tunnel"]["private_key"] = "TestPrivateKey"
@@ -754,7 +774,7 @@ class TestImportDatabasesCommand(SupersetTestCase):
         db.session.delete(database)
         db.session.commit()
 
-    @mock.patch("superset.databases.schemas.is_feature_enabled")
+    @patch("superset.databases.schemas.is_feature_enabled")
     def test_import_v1_database_masked_ssh_tunnel_no_credentials(
         self, mock_schema_is_feature_enabled
     ):
@@ -770,7 +790,7 @@ class TestImportDatabasesCommand(SupersetTestCase):
             command.run()
         assert str(excinfo.value) == "Must provide credentials for the SSH Tunnel"
 
-    @mock.patch("superset.databases.schemas.is_feature_enabled")
+    @patch("superset.databases.schemas.is_feature_enabled")
     def test_import_v1_database_masked_ssh_tunnel_multiple_credentials(
         self, mock_schema_is_feature_enabled
     ):
@@ -788,7 +808,7 @@ class TestImportDatabasesCommand(SupersetTestCase):
             str(excinfo.value) == "Cannot have multiple credentials for the SSH Tunnel"
         )
 
-    @mock.patch("superset.databases.schemas.is_feature_enabled")
+    @patch("superset.databases.schemas.is_feature_enabled")
     def test_import_v1_database_masked_ssh_tunnel_only_priv_key_psswd(
         self, mock_schema_is_feature_enabled
     ):
@@ -839,11 +859,9 @@ class TestImportDatabasesCommand(SupersetTestCase):
 
 
 class TestTestConnectionDatabaseCommand(SupersetTestCase):
-    @mock.patch("superset.databases.dao.Database._get_sqla_engine")
-    @mock.patch(
-        "superset.databases.commands.test_connection.event_logger.log_with_context"
-    )
-    @mock.patch("superset.utils.core.g")
+    @patch("superset.databases.dao.Database._get_sqla_engine")
+    @patch("superset.databases.commands.test_connection.event_logger.log_with_context")
+    @patch("superset.utils.core.g")
     def test_connection_db_exception(
         self, mock_g, mock_event_logger, mock_get_sqla_engine
     ):
@@ -862,11 +880,9 @@ class TestTestConnectionDatabaseCommand(SupersetTestCase):
             )
         mock_event_logger.assert_called()
 
-    @mock.patch("superset.databases.dao.Database._get_sqla_engine")
-    @mock.patch(
-        "superset.databases.commands.test_connection.event_logger.log_with_context"
-    )
-    @mock.patch("superset.utils.core.g")
+    @patch("superset.databases.dao.Database._get_sqla_engine")
+    @patch("superset.databases.commands.test_connection.event_logger.log_with_context")
+    @patch("superset.utils.core.g")
     def test_connection_do_ping_exception(
         self, mock_g, mock_event_logger, mock_get_sqla_engine
     ):
@@ -887,11 +903,9 @@ class TestTestConnectionDatabaseCommand(SupersetTestCase):
             == SupersetErrorType.GENERIC_DB_ENGINE_ERROR
         )
 
-    @mock.patch("superset.databases.commands.test_connection.func_timeout")
-    @mock.patch(
-        "superset.databases.commands.test_connection.event_logger.log_with_context"
-    )
-    @mock.patch("superset.utils.core.g")
+    @patch("superset.databases.commands.test_connection.func_timeout")
+    @patch("superset.databases.commands.test_connection.event_logger.log_with_context")
+    @patch("superset.utils.core.g")
     def test_connection_do_ping_timeout(
         self, mock_g, mock_event_logger, mock_func_timeout
     ):
@@ -911,11 +925,9 @@ class TestTestConnectionDatabaseCommand(SupersetTestCase):
             == SupersetErrorType.CONNECTION_DATABASE_TIMEOUT
         )
 
-    @mock.patch("superset.databases.dao.Database._get_sqla_engine")
-    @mock.patch(
-        "superset.databases.commands.test_connection.event_logger.log_with_context"
-    )
-    @mock.patch("superset.utils.core.g")
+    @patch("superset.databases.dao.Database._get_sqla_engine")
+    @patch("superset.databases.commands.test_connection.event_logger.log_with_context")
+    @patch("superset.utils.core.g")
     def test_connection_superset_security_connection(
         self, mock_g, mock_event_logger, mock_get_sqla_engine
     ):
@@ -936,11 +948,9 @@ class TestTestConnectionDatabaseCommand(SupersetTestCase):
 
         mock_event_logger.assert_called()
 
-    @mock.patch("superset.databases.dao.Database._get_sqla_engine")
-    @mock.patch(
-        "superset.databases.commands.test_connection.event_logger.log_with_context"
-    )
-    @mock.patch("superset.utils.core.g")
+    @patch("superset.databases.dao.Database._get_sqla_engine")
+    @patch("superset.databases.commands.test_connection.event_logger.log_with_context")
+    @patch("superset.utils.core.g")
     def test_connection_db_api_exc(
         self, mock_g, mock_event_logger, mock_get_sqla_engine
     ):
@@ -963,9 +973,9 @@ class TestTestConnectionDatabaseCommand(SupersetTestCase):
         mock_event_logger.assert_called()
 
 
-@mock.patch("superset.db_engine_specs.base.is_hostname_valid")
-@mock.patch("superset.db_engine_specs.base.is_port_open")
-@mock.patch("superset.databases.commands.validate.DatabaseDAO")
+@patch("superset.db_engine_specs.base.is_hostname_valid")
+@patch("superset.db_engine_specs.base.is_port_open")
+@patch("superset.databases.commands.validate.DatabaseDAO")
 def test_validate(DatabaseDAO, is_port_open, is_hostname_valid, app_context):
     """
     Test parameter validation.
@@ -988,8 +998,8 @@ def test_validate(DatabaseDAO, is_port_open, is_hostname_valid, app_context):
     command.run()
 
 
-@mock.patch("superset.db_engine_specs.base.is_hostname_valid")
-@mock.patch("superset.db_engine_specs.base.is_port_open")
+@patch("superset.db_engine_specs.base.is_hostname_valid")
+@patch("superset.db_engine_specs.base.is_port_open")
 def test_validate_partial(is_port_open, is_hostname_valid, app_context):
     """
     Test parameter validation when only some parameters are present.
@@ -1029,7 +1039,7 @@ def test_validate_partial(is_port_open, is_hostname_valid, app_context):
     ]
 
 
-@mock.patch("superset.db_engine_specs.base.is_hostname_valid")
+@patch("superset.db_engine_specs.base.is_hostname_valid")
 def test_validate_partial_invalid_hostname(is_hostname_valid, app_context):
     """
     Test parameter validation when only some parameters are present.
@@ -1083,7 +1093,7 @@ def test_validate_partial_invalid_hostname(is_hostname_valid, app_context):
 
 
 class TestTablesDatabaseCommand(SupersetTestCase):
-    @mock.patch("superset.databases.dao.DatabaseDAO.find_by_id")
+    @patch("superset.databases.dao.DatabaseDAO.find_by_id")
     def test_database_tables_list_with_unknown_database(self, mock_find_by_id):
         mock_find_by_id.return_value = None
         command = TablesDatabaseCommand(1, "test", False)
@@ -1092,9 +1102,9 @@ class TestTablesDatabaseCommand(SupersetTestCase):
             command.run()
             assert str(excinfo.value) == ("Database not found.")
 
-    @mock.patch("superset.databases.dao.DatabaseDAO.find_by_id")
-    @mock.patch("superset.security.manager.SupersetSecurityManager.can_access_database")
-    @mock.patch("superset.utils.core.g")
+    @patch("superset.databases.dao.DatabaseDAO.find_by_id")
+    @patch("superset.security.manager.SupersetSecurityManager.can_access_database")
+    @patch("superset.utils.core.g")
     def test_database_tables_superset_exception(
         self, mock_g, mock_can_access_database, mock_find_by_id
     ):
@@ -1111,9 +1121,9 @@ class TestTablesDatabaseCommand(SupersetTestCase):
             command.run()
             assert str(excinfo.value) == "Test Error"
 
-    @mock.patch("superset.databases.dao.DatabaseDAO.find_by_id")
-    @mock.patch("superset.security.manager.SupersetSecurityManager.can_access_database")
-    @mock.patch("superset.utils.core.g")
+    @patch("superset.databases.dao.DatabaseDAO.find_by_id")
+    @patch("superset.security.manager.SupersetSecurityManager.can_access_database")
+    @patch("superset.utils.core.g")
     def test_database_tables_exception(
         self, mock_g, mock_can_access_database, mock_find_by_id
     ):
@@ -1130,9 +1140,9 @@ class TestTablesDatabaseCommand(SupersetTestCase):
                 == "Unexpected error occurred, please check your logs for details"
             )
 
-    @mock.patch("superset.databases.dao.DatabaseDAO.find_by_id")
-    @mock.patch("superset.security.manager.SupersetSecurityManager.can_access_database")
-    @mock.patch("superset.utils.core.g")
+    @patch("superset.databases.dao.DatabaseDAO.find_by_id")
+    @patch("superset.security.manager.SupersetSecurityManager.can_access_database")
+    @patch("superset.utils.core.g")
     def test_database_tables_list_tables(
         self, mock_g, mock_can_access_database, mock_find_by_id
     ):

--- a/tests/integration_tests/datasets/commands_tests.py
+++ b/tests/integration_tests/datasets/commands_tests.py
@@ -327,10 +327,11 @@ class TestImportDatasetsCommand(SupersetTestCase):
         db.session.commit()
 
     @patch("superset.datasets.commands.importers.v1.utils.g")
+    @patch("superset.security.manager.g")
     @pytest.mark.usefixtures("load_energy_table_with_slice")
-    def test_import_v1_dataset(self, mock_g):
+    def test_import_v1_dataset(self, sm_g, utils_g):
         """Test that we can import a dataset"""
-        mock_g.user = security_manager.find_user("admin")
+        admin = sm_g.user = utils_g.user = security_manager.find_user("admin")
         contents = {
             "metadata.yaml": yaml.safe_dump(dataset_metadata_config),
             "databases/imported_database.yaml": yaml.safe_dump(database_config),
@@ -360,7 +361,7 @@ class TestImportDatasetsCommand(SupersetTestCase):
         )
 
         # user should be included as one of the owners
-        assert dataset.owners == [mock_g.user]
+        assert dataset.owners == [admin]
 
         # database is also imported
         assert str(dataset.database.uuid) == "b8a1ccd3-779d-4ab7-8ad8-9ab119d7fe89"
@@ -395,8 +396,11 @@ class TestImportDatasetsCommand(SupersetTestCase):
         db.session.delete(dataset.database)
         db.session.commit()
 
-    def test_import_v1_dataset_multiple(self):
+    @patch("superset.security.manager.g")
+    def test_import_v1_dataset_multiple(self, mock_g):
         """Test that a dataset can be imported multiple times"""
+        mock_g.user = security_manager.find_user("admin")
+
         contents = {
             "metadata.yaml": yaml.safe_dump(dataset_metadata_config),
             "databases/imported_database.yaml": yaml.safe_dump(database_config),
@@ -483,8 +487,11 @@ class TestImportDatasetsCommand(SupersetTestCase):
             }
         }
 
-    def test_import_v1_dataset_existing_database(self):
+    @patch("superset.security.manager.g")
+    def test_import_v1_dataset_existing_database(self, mock_g):
         """Test that a dataset can be imported when the database already exists"""
+        mock_g.user = security_manager.find_user("admin")
+
         # first import database...
         contents = {
             "metadata.yaml": yaml.safe_dump(database_metadata_config),

--- a/tests/integration_tests/queries/saved_queries/commands_tests.py
+++ b/tests/integration_tests/queries/saved_queries/commands_tests.py
@@ -142,8 +142,11 @@ class TestExportSavedQueriesCommand(SupersetTestCase):
 
 
 class TestImportSavedQueriesCommand(SupersetTestCase):
-    def test_import_v1_saved_queries(self):
+    @patch("superset.security.manager.g")
+    def test_import_v1_saved_queries(self, mock_g):
         """Test that we can import a saved query"""
+        mock_g.user = security_manager.find_user("admin")
+
         contents = {
             "metadata.yaml": yaml.safe_dump(saved_queries_metadata_config),
             "databases/imported_database.yaml": yaml.safe_dump(database_config),
@@ -169,8 +172,11 @@ class TestImportSavedQueriesCommand(SupersetTestCase):
         db.session.delete(database)
         db.session.commit()
 
-    def test_import_v1_saved_queries_multiple(self):
+    @patch("superset.security.manager.g")
+    def test_import_v1_saved_queries_multiple(self, mock_g):
         """Test that a saved query can be imported multiple times"""
+        mock_g.user = security_manager.find_user("admin")
+
         contents = {
             "metadata.yaml": yaml.safe_dump(saved_queries_metadata_config),
             "databases/imported_database.yaml": yaml.safe_dump(database_config),

--- a/tests/unit_tests/charts/commands/importers/v1/import_test.py
+++ b/tests/unit_tests/charts/commands/importers/v1/import_test.py
@@ -18,18 +18,25 @@
 
 import copy
 
+import pytest
+from pytest_mock import MockFixture
 from sqlalchemy.orm.session import Session
 
+from superset.commands.exceptions import ImportFailedError
 
-def test_import_chart(session: Session) -> None:
+
+def test_import_chart(mocker: MockFixture, session: Session) -> None:
     """
     Test importing a chart.
     """
+    from superset import security_manager
     from superset.charts.commands.importers.v1.utils import import_chart
     from superset.connectors.sqla.models import SqlaTable
     from superset.models.core import Database
     from superset.models.slice import Slice
     from tests.integration_tests.fixtures.importexport import chart_config
+
+    mocker.patch.object(security_manager, "can_access", return_value=True)
 
     engine = session.get_bind()
     Slice.metadata.create_all(engine)  # pylint: disable=no-member
@@ -45,15 +52,18 @@ def test_import_chart(session: Session) -> None:
     assert chart.external_url is None
 
 
-def test_import_chart_managed_externally(session: Session) -> None:
+def test_import_chart_managed_externally(mocker: MockFixture, session: Session) -> None:
     """
     Test importing a chart that is managed externally.
     """
+    from superset import security_manager
     from superset.charts.commands.importers.v1.utils import import_chart
     from superset.connectors.sqla.models import SqlaTable
     from superset.models.core import Database
     from superset.models.slice import Slice
     from tests.integration_tests.fixtures.importexport import chart_config
+
+    mocker.patch.object(security_manager, "can_access", return_value=True)
 
     engine = session.get_bind()
     Slice.metadata.create_all(engine)  # pylint: disable=no-member
@@ -67,3 +77,34 @@ def test_import_chart_managed_externally(session: Session) -> None:
     chart = import_chart(session, config)
     assert chart.is_managed_externally is True
     assert chart.external_url == "https://example.org/my_chart"
+
+
+def test_import_chart_without_permission(
+    mocker: MockFixture,
+    session: Session,
+) -> None:
+    """
+    Test importing a chart when a user doesn't have permissions to create.
+    """
+    from superset import security_manager
+    from superset.charts.commands.importers.v1.utils import import_chart
+    from superset.connectors.sqla.models import SqlaTable
+    from superset.models.core import Database
+    from superset.models.slice import Slice
+    from tests.integration_tests.fixtures.importexport import chart_config
+
+    mocker.patch.object(security_manager, "can_access", return_value=False)
+
+    engine = session.get_bind()
+    Slice.metadata.create_all(engine)  # pylint: disable=no-member
+
+    config = copy.deepcopy(chart_config)
+    config["datasource_id"] = 1
+    config["datasource_type"] = "table"
+
+    with pytest.raises(ImportFailedError) as excinfo:
+        import_chart(session, config)
+    assert (
+        str(excinfo.value)
+        == "Chart doesn't exist and user doesn't have permission to create charts"
+    )

--- a/tests/unit_tests/commands/importers/v1/assets_test.py
+++ b/tests/unit_tests/commands/importers/v1/assets_test.py
@@ -17,6 +17,7 @@
 
 import copy
 
+from pytest_mock import MockFixture
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql import select
 
@@ -30,13 +31,16 @@ from tests.unit_tests.fixtures.assets_configs import (
 )
 
 
-def test_import_new_assets(session: Session) -> None:
+def test_import_new_assets(mocker: MockFixture, session: Session) -> None:
     """
     Test that all new assets are imported correctly.
     """
+    from superset import security_manager
     from superset.commands.importers.v1.assets import ImportAssetsCommand
     from superset.models.dashboard import dashboard_slices
     from superset.models.slice import Slice
+
+    mocker.patch.object(security_manager, "can_access", return_value=True)
 
     engine = session.get_bind()
     Slice.metadata.create_all(engine)  # pylint: disable=no-member
@@ -59,13 +63,16 @@ def test_import_new_assets(session: Session) -> None:
     assert len(dashboard_ids) == expected_number_of_dashboards
 
 
-def test_import_adds_dashboard_charts(session: Session) -> None:
+def test_import_adds_dashboard_charts(mocker: MockFixture, session: Session) -> None:
     """
     Test that existing dashboards are updated with new charts.
     """
+    from superset import security_manager
     from superset.commands.importers.v1.assets import ImportAssetsCommand
     from superset.models.dashboard import dashboard_slices
     from superset.models.slice import Slice
+
+    mocker.patch.object(security_manager, "can_access", return_value=True)
 
     engine = session.get_bind()
     Slice.metadata.create_all(engine)  # pylint: disable=no-member
@@ -95,13 +102,16 @@ def test_import_adds_dashboard_charts(session: Session) -> None:
     assert len(dashboard_ids) == expected_number_of_dashboards
 
 
-def test_import_removes_dashboard_charts(session: Session) -> None:
+def test_import_removes_dashboard_charts(mocker: MockFixture, session: Session) -> None:
     """
     Test that existing dashboards are updated without old charts.
     """
+    from superset import security_manager
     from superset.commands.importers.v1.assets import ImportAssetsCommand
     from superset.models.dashboard import dashboard_slices
     from superset.models.slice import Slice
+
+    mocker.patch.object(security_manager, "can_access", return_value=True)
 
     engine = session.get_bind()
     Slice.metadata.create_all(engine)  # pylint: disable=no-member

--- a/tests/unit_tests/dashboards/commands/importers/v1/import_test.py
+++ b/tests/unit_tests/dashboards/commands/importers/v1/import_test.py
@@ -18,18 +18,25 @@
 
 import copy
 
+import pytest
+from pytest_mock import MockFixture
 from sqlalchemy.orm.session import Session
 
+from superset.commands.exceptions import ImportFailedError
 
-def test_import_dashboard(session: Session) -> None:
+
+def test_import_dashboard(mocker: MockFixture, session: Session) -> None:
     """
     Test importing a dashboard.
     """
+    from superset import security_manager
     from superset.connectors.sqla.models import SqlaTable
     from superset.dashboards.commands.importers.v1.utils import import_dashboard
     from superset.models.core import Database
     from superset.models.slice import Slice
     from tests.integration_tests.fixtures.importexport import dashboard_config
+
+    mocker.patch.object(security_manager, "can_access", return_value=True)
 
     engine = session.get_bind()
     Slice.metadata.create_all(engine)  # pylint: disable=no-member
@@ -43,15 +50,21 @@ def test_import_dashboard(session: Session) -> None:
     assert dashboard.external_url is None
 
 
-def test_import_dashboard_managed_externally(session: Session) -> None:
+def test_import_dashboard_managed_externally(
+    mocker: MockFixture,
+    session: Session,
+) -> None:
     """
     Test importing a dashboard that is managed externally.
     """
+    from superset import security_manager
     from superset.connectors.sqla.models import SqlaTable
     from superset.dashboards.commands.importers.v1.utils import import_dashboard
     from superset.models.core import Database
     from superset.models.slice import Slice
     from tests.integration_tests.fixtures.importexport import dashboard_config
+
+    mocker.patch.object(security_manager, "can_access", return_value=True)
 
     engine = session.get_bind()
     Slice.metadata.create_all(engine)  # pylint: disable=no-member
@@ -63,3 +76,32 @@ def test_import_dashboard_managed_externally(session: Session) -> None:
     dashboard = import_dashboard(session, config)
     assert dashboard.is_managed_externally is True
     assert dashboard.external_url == "https://example.org/my_dashboard"
+
+
+def test_import_dashboard_without_permission(
+    mocker: MockFixture,
+    session: Session,
+) -> None:
+    """
+    Test importing a dashboard when a user doesn't have permissions to create.
+    """
+    from superset import security_manager
+    from superset.connectors.sqla.models import SqlaTable
+    from superset.dashboards.commands.importers.v1.utils import import_dashboard
+    from superset.models.core import Database
+    from superset.models.slice import Slice
+    from tests.integration_tests.fixtures.importexport import dashboard_config
+
+    mocker.patch.object(security_manager, "can_access", return_value=False)
+
+    engine = session.get_bind()
+    Slice.metadata.create_all(engine)  # pylint: disable=no-member
+
+    config = copy.deepcopy(dashboard_config)
+
+    with pytest.raises(ImportFailedError) as excinfo:
+        import_dashboard(session, config)
+    assert (
+        str(excinfo.value)
+        == "Dashboard doesn't exist and user doesn't have permission to create dashboards"
+    )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When importing assets (databases, datasets, charts, dashboards), ensure that the user has the proper permissions to create the assets. Otherwise a user who can only create charts is able to import a chart and have a dataset and databases added.

@eschutho, @dpgaspar said it would be nice if we could include this in 2.1.0, not sure if there's still time.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Updated and added unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
