### PR TITLE
fix(docs): Change postgres to postgresql in brew install command

### DIFF
--- a/docs/docs/installation/installing-superset-from-scratch.mdx
+++ b/docs/docs/installation/installing-superset-from-scratch.mdx
@@ -61,7 +61,7 @@ We don't recommend using the system installed Python. Instead, first install the
 [homebrew](https://brew.sh/) manager and then run the following commands:
 
 ```
-brew install readline pkg-config libffi openssl mysql postgres
+brew install readline pkg-config libffi openssl mysql postgresql
 ```
 
 You should install a recent version of Python (the official docker image uses 3.8.16). We'd recommend using a Python version manager like [pyenv](https://github.com/pyenv/pyenv) (and also [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv)).


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR changes `postgres` to `postgresql` in the brew install command under the Mac OS X dependencies section of the "Installing Superset from Scratch" docs here: https://superset.apache.org/docs/installation/installing-superset-from-scratch/

For reference, here are the postgres docs with the brew command: https://wiki.postgresql.org/wiki/Homebrew

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- cd into `docs/`
- Run `npm install` and `npm start` to run the docs locally
- Navigate to the "Installing Superset from Scratch" page at the Mac OS X dependencies section
- Observe that the `postgres` part of the `brew install` command is now `postgresql`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
