### PR TITLE
test: Remove test playgrounds

### DIFF
--- a/superset-frontend/src/components/Datasource/DatasourceEditor.test.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceEditor.test.jsx
@@ -107,7 +107,6 @@ describe('DatasourceEditor', () => {
     });
 
     userEvent.click(getToggles[0]);
-    screen.logTestingPlaygroundURL();
     const deleteButtons = screen.getAllByRole('button', {
       name: /delete item/i,
     });

--- a/superset-frontend/src/dashboard/components/RefreshIntervalModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/RefreshIntervalModal.test.tsx
@@ -219,7 +219,6 @@ describe('RefreshIntervalModal - RTL', () => {
     await openRefreshIntervalModal();
     await displayOptions();
 
-    screen.logTestingPlaygroundURL();
     // Select a new interval and click save
     userEvent.click(screen.getByText(/10 seconds/i));
     userEvent.click(screen.getByRole('button', { name: /save/i }));


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I found a couple of test playgrounds that were left in the code, this PR removes them.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- cd into `superset-frontend`
- Run each test with these commands and observe no test playground in the terminal:
  - `npm test superset-frontend/src/components/Datasource/DatasourceEditor.test.jsx`
  - `npm test superset-frontend/src/dashboard/components/RefreshIntervalModal.test.tsx`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
