### PR TITLE
fix(dashboard): Page crashing when cross filter applied on adhoc column

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilterTag.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilterTag.test.tsx
@@ -20,10 +20,14 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { render, screen } from 'spec/helpers/testing-library';
 import { FilterBarOrientation } from 'src/dashboard/types';
-import { IndicatorStatus } from '../../selectors';
+import { CrossFilterIndicator, IndicatorStatus } from '../../selectors';
 import CrossFilterTag from './CrossFilterTag';
 
-const mockedProps = {
+const mockedProps: {
+  filter: CrossFilterIndicator;
+  orientation: FilterBarOrientation;
+  removeCrossFilter: (filterId: number) => void;
+} = {
   filter: {
     name: 'test',
     emitterId: 1,
@@ -44,6 +48,19 @@ const setup = (props: typeof mockedProps) =>
 test('CrossFilterTag should render', () => {
   const { container } = setup(mockedProps);
   expect(container).toBeInTheDocument();
+});
+
+test('CrossFilterTag with adhoc column should render', () => {
+  const props = { ...mockedProps };
+  props.filter.column = {
+    label: 'My column',
+    sqlExpression: 'country_name',
+    expressionType: 'SQL',
+  };
+  const { container } = setup(mockedProps);
+  expect(container).toBeInTheDocument();
+  expect(screen.getByText('My column')).toBeInTheDocument();
+  expect(screen.getByText('Italy')).toBeInTheDocument();
 });
 
 test('Column and value should be visible', () => {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilterTag.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilterTag.test.tsx
@@ -51,13 +51,19 @@ test('CrossFilterTag should render', () => {
 });
 
 test('CrossFilterTag with adhoc column should render', () => {
-  const props = { ...mockedProps };
-  props.filter.column = {
-    label: 'My column',
-    sqlExpression: 'country_name',
-    expressionType: 'SQL',
+  const props = {
+    ...mockedProps,
+    filter: {
+      ...mockedProps.filter,
+      column: {
+        label: 'My column',
+        sqlExpression: 'country_name',
+        expressionType: 'SQL' as const,
+      },
+    },
   };
-  const { container } = setup(mockedProps);
+
+  const { container } = setup(props);
   expect(container).toBeInTheDocument();
   expect(screen.getByText('My column')).toBeInTheDocument();
   expect(screen.getByText('Italy')).toBeInTheDocument();

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilterTag.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilterTag.tsx
@@ -18,7 +18,7 @@
  */
 
 import React from 'react';
-import { styled, css, useTheme } from '@superset-ui/core';
+import { styled, css, useTheme, getColumnLabel } from '@superset-ui/core';
 import { CrossFilterIndicator } from 'src/dashboard/components/nativeFilters/selectors';
 import { Tag } from 'src/components';
 import { Tooltip } from 'src/components/Tooltip';
@@ -62,6 +62,7 @@ const CrossFilterTag = (props: {
     useCSSTextTruncation<HTMLSpanElement>();
   const [valueRef, valueIsTruncated] = useCSSTextTruncation<HTMLSpanElement>();
 
+  const columnLabel = getColumnLabel(filter.column ?? '');
   return (
     <StyledTag
       css={css`
@@ -76,9 +77,9 @@ const CrossFilterTag = (props: {
       closable
       onClose={() => removeCrossFilter(filter.emitterId)}
     >
-      <Tooltip title={columnIsTruncated ? filter.column : null}>
+      <Tooltip title={columnIsTruncated ? columnLabel : null}>
         <StyledCrossFilterColumn ref={columnRef}>
-          {filter.column}
+          {columnLabel}
         </StyledCrossFilterColumn>
       </Tooltip>
       <Tooltip title={valueIsTruncated ? filter.value : null}>

--- a/superset-frontend/src/dashboard/components/nativeFilters/selectors.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/selectors.ts
@@ -26,6 +26,7 @@ import {
   isFeatureEnabled,
   NativeFilterType,
   NO_TIME_RANGE,
+  QueryFormColumn,
 } from '@superset-ui/core';
 import { TIME_FILTER_MAP } from 'src/explore/constants';
 import { getChartIdsInFilterBoxScope } from 'src/dashboard/util/activeDashboardFilters';
@@ -151,7 +152,7 @@ const getRejectedColumns = (chart: any): Set<string> =>
   );
 
 export type Indicator = {
-  column?: string;
+  column?: QueryFormColumn;
   name: string;
   value?: any;
   status?: IndicatorStatus;


### PR DESCRIPTION

### SUMMARY
When user applied a cross filter on an adhoc column, the dashboard page would crash because the cross filter tag expected a string for a column and received an object instead.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before:

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/15073128/221585002-1c2d70af-44a5-46b4-b5e0-98071e604d03.png">

after:

<img width="522" alt="image" src="https://user-images.githubusercontent.com/15073128/221585106-cc10f37a-cb0b-4c37-8b0c-309fd561e6ca.png">


### TESTING INSTRUCTIONS
1. Add a chart with dimension created with adhoc column
2. Apply a cross filter on that dimension
3. Verify that a cross filter tag in filter bar is displayed correctly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
