### PR TITLE
fix: add disallowed query params for engines specs

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1737,7 +1737,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         if existing_disallowed := cls.disallow_uri_query_params.intersection(
             sqlalchemy_uri.query
         ):
-            raise ValueError("Disallowed query parameter(s) %s", existing_disallowed)
+            raise ValueError(f"Forbidden query parameter(s): {existing_disallowed}")
 
 
 # schema for adding a database by providing parameters instead of the

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -354,6 +354,8 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     # This set will give the keywords for data limit statements
     # to consider for the engines with TOP SQL parsing
     top_keywords: Set[str] = {"TOP"}
+    # A set of disallowed connection query parameters
+    disallow_connection_query_params: Set[str] = set()
 
     force_column_alias_quotes = False
     arraysize = 0
@@ -1723,6 +1725,19 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
             "supports_file_upload": cls.supports_file_upload,
             "disable_ssh_tunneling": cls.disable_ssh_tunneling,
         }
+
+    @classmethod
+    def validate_database_uri(cls, sqlalchemy_uri: URL) -> None:
+        """
+        Validates a database SQLAlchemy URI per engine spec.
+        Use this to implement a final validation for unwanted connection configuration
+
+        :param sqlalchemy_uri:
+        """
+        for query_param in sqlalchemy_uri.query.keys():
+            if query_param in cls.disallow_connection_query_params:
+                raise ValueError("Disallowed query parameter")
+        return
 
 
 # schema for adding a database by providing parameters instead of the

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1734,9 +1734,10 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
 
         :param sqlalchemy_uri:
         """
-        for query_param in sqlalchemy_uri.query.keys():
-            if query_param in cls.disallow_uri_query_params:
-                raise ValueError("Disallowed query parameter")
+        if existing_disallowed := cls.disallow_uri_query_params.intersection(
+            sqlalchemy_uri.query
+        ):
+            raise ValueError("Disallowed query parameter(s) %s", existing_disallowed)
 
 
 # schema for adding a database by providing parameters instead of the

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1737,7 +1737,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         if existing_disallowed := cls.disallow_uri_query_params.intersection(
             sqlalchemy_uri.query
         ):
-            raise ValueError("Disallowed query parameter(s) %s", existing_disallowed)
+            raise ValueError("Forbidden query parameter(s): %s", existing_disallowed)
 
 
 # schema for adding a database by providing parameters instead of the

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -355,7 +355,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     # to consider for the engines with TOP SQL parsing
     top_keywords: Set[str] = {"TOP"}
     # A set of disallowed connection query parameters
-    disallow_connection_query_params: Set[str] = set()
+    disallow_uri_query_params: Set[str] = set()
 
     force_column_alias_quotes = False
     arraysize = 0
@@ -1735,9 +1735,8 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         :param sqlalchemy_uri:
         """
         for query_param in sqlalchemy_uri.query.keys():
-            if query_param in cls.disallow_connection_query_params:
+            if query_param in cls.disallow_uri_query_params:
                 raise ValueError("Disallowed query parameter")
-        return
 
 
 # schema for adding a database by providing parameters instead of the

--- a/superset/db_engine_specs/mysql.py
+++ b/superset/db_engine_specs/mysql.py
@@ -35,11 +35,7 @@ from sqlalchemy.dialects.mysql import (
 )
 from sqlalchemy.engine.url import URL
 
-from superset.db_engine_specs.base import (
-    BaseEngineSpec,
-    BasicParametersMixin,
-    BasicParametersSchema,
-)
+from superset.db_engine_specs.base import BaseEngineSpec, BasicParametersMixin
 from superset.errors import SupersetErrorType
 from superset.models.sql_lab import Query
 from superset.utils.core import GenericDataType
@@ -177,7 +173,7 @@ class MySQLEngineSpec(BaseEngineSpec, BasicParametersMixin):
             {},
         ),
     }
-    disallow_connection_query_params = {"local_infile"}
+    disallow_uri_query_params = {"local_infile"}
 
     @classmethod
     def convert_dttm(

--- a/superset/db_engine_specs/mysql.py
+++ b/superset/db_engine_specs/mysql.py
@@ -35,7 +35,11 @@ from sqlalchemy.dialects.mysql import (
 )
 from sqlalchemy.engine.url import URL
 
-from superset.db_engine_specs.base import BaseEngineSpec, BasicParametersMixin
+from superset.db_engine_specs.base import (
+    BaseEngineSpec,
+    BasicParametersMixin,
+    BasicParametersSchema,
+)
 from superset.errors import SupersetErrorType
 from superset.models.sql_lab import Query
 from superset.utils.core import GenericDataType
@@ -173,6 +177,7 @@ class MySQLEngineSpec(BaseEngineSpec, BasicParametersMixin):
             {},
         ),
     }
+    disallow_connection_query_params = {"local_infile"}
 
     @classmethod
     def convert_dttm(

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -424,6 +424,8 @@ class Database(
         sqlalchemy_url = make_url_safe(
             sqlalchemy_uri if sqlalchemy_uri else self.sqlalchemy_uri_decrypted
         )
+        self.db_engine_spec.validate_database_uri(sqlalchemy_url)
+
         sqlalchemy_url = self.db_engine_spec.adjust_database_uri(sqlalchemy_url, schema)
         effective_username = self.get_effective_user(sqlalchemy_url)
         # If using MySQL or Presto for example, will set url.username

--- a/tests/unit_tests/db_engine_specs/test_mysql.py
+++ b/tests/unit_tests/db_engine_specs/test_mysql.py
@@ -33,6 +33,7 @@ from sqlalchemy.dialects.mysql import (
     TINYINT,
     TINYTEXT,
 )
+from sqlalchemy.engine.url import make_url
 
 from superset.utils.core import GenericDataType
 from tests.unit_tests.db_engine_specs.utils import (
@@ -97,6 +98,25 @@ def test_convert_dttm(
     from superset.db_engine_specs.mysql import MySQLEngineSpec as spec
 
     assert_convert_dttm(spec, target_type, expected_result, dttm)
+
+
+@pytest.mark.parametrize(
+    "sqlalchemy_uri,error",
+    [
+        ("mysql://user:password@host/db1?local_infile=1", True),
+        ("mysql://user:password@host/db1?local_infile=0", True),
+        ("mysql://user:password@host/db1", False),
+    ],
+)
+def test_validate_database_uri(sqlalchemy_uri: str, error: bool) -> None:
+    from superset.db_engine_specs.mysql import MySQLEngineSpec
+
+    url = make_url(sqlalchemy_uri)
+    if error:
+        with pytest.raises(ValueError):
+            MySQLEngineSpec.validate_database_uri(url)
+        return
+    MySQLEngineSpec.validate_database_uri(url)
 
 
 @patch("sqlalchemy.engine.Engine.connect")


### PR DESCRIPTION
### SUMMARY

Adding a final validation for disallowing query parameters on specific database engines

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
