### PR TITLE
fix(dashboard): Don't show cross filters checkbox to users without write permissions

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBarSettings/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBarSettings/index.tsx
@@ -144,7 +144,7 @@ const FilterBarSettings = () => {
   );
   const menuItems: DropDownSelectableProps['menuItems'] = [];
 
-  if (isCrossFiltersFeatureEnabled) {
+  if (isCrossFiltersFeatureEnabled && canEdit) {
     menuItems.unshift({
       key: crossFiltersMenuKey,
       label: crossFiltersMenuItem,


### PR DESCRIPTION
### SUMMARY
Users without edit permission for a dashboard could still see the checkbox for enabling/disabling cross filters. Clicking on it would trigger a 403 error.
This PR disables showing the checkbox to users without write permissions to current dashboard

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Open a dashboard that you don't have a write access to
2. Verify that you can't see a "Enable cross-filtering" checkbox

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: https://github.com/apache/superset/issues/23220
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
