### PR TITLE
fix: Video Game Sales dashboard default filters

### DIFF
--- a/superset/examples/configs/dashboards/Video_Game_Sales.yaml
+++ b/superset/examples/configs/dashboards/Video_Game_Sales.yaml
@@ -366,7 +366,7 @@ metadata:
   timed_refresh_immune_slices: []
   expanded_slices: {}
   refresh_frequency: 0
-  default_filters: '{"3547": {"Platform": ["PS", "PS2", "PS3", "XB", "X360"], "__time_range":
+  default_filters: '{"3547": {"platform": ["PS", "PS2", "PS3", "XB", "X360"], "__time_range":
     "No filter"}}'
   color_scheme: supersetColors
   filter_scopes:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Whilst spelunking around with filters I realized that the default filters were not being applied to the "Video Games Sales" dashboard. The root cause was there was a typo in the filter scope. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE

<img width="450" alt="Screenshot 2023-03-01 at 12 08 18 PM" src="https://user-images.githubusercontent.com/4567245/222004101-239fcbcf-4005-49ae-ab81-7683dd4d6135.png">

#### AFTER

<img width="448" alt="Screenshot 2023-03-01 at 12 13 08 PM" src="https://user-images.githubusercontent.com/4567245/222004268-3597f35d-189b-436c-8acd-23b1bfd91e34.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
