### PR TITLE
fix: customize tab on heatmap chart is blank

### DIFF
--- a/superset-frontend/src/explore/components/ControlPanelsContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.test.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { render, screen } from 'spec/helpers/testing-library';
 import {
   DatasourceType,
@@ -104,5 +105,43 @@ describe('ControlPanelsContainer', () => {
     expect(
       await screen.findAllByTestId('collapsible-control-panel-header'),
     ).toHaveLength(4);
+    expect(screen.getByRole('tab', { name: /customize/i })).toBeInTheDocument();
+    userEvent.click(screen.getByRole('tab', { name: /customize/i }));
+    expect(
+      await screen.findAllByTestId('collapsible-control-panel-header'),
+    ).toHaveLength(5);
+  });
+
+  test('renders ControlPanelSections no Customize Tab', async () => {
+    getChartControlPanelRegistry().registerValue('table', {
+      controlPanelSections: [
+        {
+          label: t('GROUP BY'),
+          description: t(
+            'Use this section if you want a query that aggregates',
+          ),
+          expanded: true,
+          controlSetRows: [
+            ['groupby'],
+            ['metrics'],
+            ['percent_metrics'],
+            ['timeseries_limit_metric', 'row_limit'],
+            ['include_time', 'order_desc'],
+          ],
+        },
+        {
+          label: t('Options'),
+          expanded: true,
+          controlSetRows: [],
+        },
+      ],
+    });
+    render(<ControlPanelsContainer {...getDefaultProps()} />, {
+      useRedux: true,
+    });
+    expect(screen.queryByText(/customize/i)).not.toBeInTheDocument();
+    expect(
+      await screen.findAllByTestId('collapsible-control-panel-header'),
+    ).toHaveLength(2);
   });
 });

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -235,7 +235,7 @@ function getState(
       )
     ) {
       querySections.push(section);
-    } else {
+    } else if (section.controlSetRows.length > 0) {
       customizeSections.push(section);
     }
   });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- To fix the issue with a blank "Customize" tab on the Heatmap chart https://github.com/apache/superset/discussions/23164#discussioncomment-5126401

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
<img width="1776" alt="Screenshot 2023-02-28 at 4 11 12 PM" src="https://user-images.githubusercontent.com/5705598/222011949-fa4837a0-4e28-4c9a-bece-645d9fa8b7f8.png">
After:
<img width="1789" alt="Screenshot 2023-02-28 at 4 00 12 PM" src="https://user-images.githubusercontent.com/5705598/222011982-c6aea188-6ab1-420f-9793-46a4bdb2a706.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
