### PR TITLE
chore: add full uuid to report crud view

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,6 +20,10 @@ jobs:
         run: |
           if [ -n "${{ (secrets.DOCKERHUB_USER != '' && secrets.DOCKERHUB_TOKEN != '') || '' }}" ]; then
             echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+            echo "has secrets!"
+          else
+            echo "has-secrets=0" >> "$GITHUB_OUTPUT"
+            echo "no secrets!"
           fi
 
   docker-build:

--- a/superset-frontend/src/pages/ExecutionLogList/index.tsx
+++ b/superset-frontend/src/pages/ExecutionLogList/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { css, styled, t } from '@superset-ui/core';
+import { css, styled, t, SupersetTheme } from '@superset-ui/core';
 import moment from 'moment';
 import React, { useEffect, useMemo } from 'react';
 import { Link, useParams } from 'react-router-dom';
@@ -103,10 +103,18 @@ function ExecutionLog({ addDangerToast, isReportEnabled }: ExecutionLogProps) {
           row: {
             original: { uuid: executionId },
           },
-        }: any) => (executionId ? executionId.slice(0, 6) : 'none'),
+        }: any) => (
+          <div
+            css={(theme: SupersetTheme) => ({
+              fontFamily: theme.typography.families.monospace,
+            })}
+          >
+            {executionId}
+          </div>
+        ),
         accessor: 'uuid',
         Header: t('Execution ID'),
-        size: 'xs',
+        size: 's',
         disableSortBy: true,
       },
       {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Small change to print the entire UUID on the alert/report execution logs when using the id to cross-check in system logs

### BEFORE
![_DEV__Superset](https://user-images.githubusercontent.com/5186919/222018126-48c9fc4f-806f-4ffd-b9b9-4bc78e88a776.png)


### AFTER
![_DEV__Superset](https://user-images.githubusercontent.com/5186919/222018151-106a5ba8-2882-4df0-a2c6-73dbc3dc55a9.png)



### TESTING INSTRUCTIONS
View execution logs for alerts or reports

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
