### PR TITLE
fix(dao): use explicit id filter

### DIFF
--- a/superset/dao/base.py
+++ b/superset/dao/base.py
@@ -65,9 +65,9 @@ class BaseDAO:
             query = cls.base_filter(  # pylint: disable=not-callable
                 cls.id_column_name, data_model
             ).apply(query, None)
-        id_filter = {cls.id_column_name: model_id}
+        id_column = getattr(cls.model_cls, cls.id_column_name)
         try:
-            return query.filter_by(**id_filter).one_or_none()
+            return query.filter(id_column == model_id).one_or_none()
         except StatementError:
             # can happen if int is passed instead of a string or similar
             return None


### PR DESCRIPTION
### SUMMARY
#23118 caused a regression that made the `BaseDAO` unable to find objects if the base query contained joins to other tables. This is because the filter was often ambiguous, as the id column is the same on all tables. Interestingly this regression was not caught because we didn't have an integration test that tested updates for non-admin users that didn't have the "all_datasource_access" perm.

This PR does the following:
- Changes the filter in `BaseDao` to filter specifically by the `id_column_name` of the `model_cls`
- Updates the non-admin chart update API integration tests to use the `gamma_no_csv` user instead of `alpha`. Previously this test didn't catch the regression, because Alpha users short circuit the base filters due to having "all_datasource_access". By using the `gamma_no_csv` user with explicit access to the examples dataset, we can ensure that the full base filter is being applied, and catches a potential regression. With these changes, this test failed on master branch.

### AFTER
Now updating the chart works as expected:

https://user-images.githubusercontent.com/33317356/222098227-ae8b67dc-2555-4c2b-852f-197fdc17e091.mp4

### BEFORE
Previously, the chart was not found:

https://user-images.githubusercontent.com/33317356/222098288-f8a00379-cfcc-4011-a212-2f5424c25a30.mp4

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
