### PR TITLE
fix(dashboard): Cross-filter search icon in filter bar

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilter.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilter.tsx
@@ -21,7 +21,7 @@ import React, { useCallback } from 'react';
 import { css, useTheme } from '@superset-ui/core';
 import { CrossFilterIndicator } from 'src/dashboard/components/nativeFilters/selectors';
 import { useDispatch } from 'react-redux';
-import { setFocusedNativeFilter } from 'src/dashboard/actions/nativeFilters';
+import { setDirectPathToChild } from 'src/dashboard/actions/dashboardState';
 import { FilterBarOrientation } from 'src/dashboard/types';
 import { updateDataMask } from 'src/dataMask/actions';
 import CrossFilterTag from './CrossFilterTag';
@@ -39,7 +39,7 @@ const CrossFilter = (props: {
   const handleHighlightFilterSource = useCallback(
     (path?: string[]) => {
       if (path) {
-        dispatch(setFocusedNativeFilter(path[0]));
+        dispatch(setDirectPathToChild(path));
       }
     },
     [dispatch],


### PR DESCRIPTION
### SUMMARY
Before, clicking the search icon in FilterBar to highlight cross-filter's source chart would grey out the whole dashboard and make it unclickable. This PR fixes that behaviour 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
