### PR TITLE
feat: Jinja template to translate contents dynamically

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -126,6 +126,7 @@ setup(
         "wtforms>=2.3.3, <2.4",
         "wtforms-json",
         "xlsxwriter>=3.0.7, <3.1",
+        "translate == 3.6.1",
     ],
     extras_require={
         "athena": ["pyathena[pandas]>=2, <3"],

--- a/superset/config.py
+++ b/superset/config.py
@@ -377,6 +377,23 @@ LANGUAGES = {
 LANGUAGES = {}
 
 # ---------------------------------------------------
+# Jinja translation function: `translate`
+# ---------------------------------------------------
+# Available providers for translation:
+#   - mymemory, microsoft, deepl, libre
+
+TRANSLATION_PROVIDER: str = "mymemory"
+# TRANSLATION_SECRET_ACCESS_KEY: str = os.getenv("MY_SECRET")
+
+# uncomment `PROVIDER_CREDENTIALS_DICT` and use a `secret_access_key`
+# to get your provider oAuth token
+# PROVIDER_CREDENTIALS_DICT = {}
+# PROVIDER_CREDENTIALS_DICT = {
+#   "secret_access_key": "os.getenv('YOUR_VERY_SECRET_KEY')",
+#   # "pro": True # for: DeepL’s pro API,
+# }
+
+# ---------------------------------------------------
 # Feature flags
 # ---------------------------------------------------
 # Feature flags that are set by default go here. Their values can be
@@ -1583,7 +1600,7 @@ elif importlib.util.find_spec("superset_config") and not is_test():
     try:
         # pylint: disable=import-error,wildcard-import,unused-wildcard-import
         import superset_config
-        from superset_config import *  # type: ignore
+        from superset_config import *
 
         print(f"Loaded your LOCAL configuration at [{superset_config.__file__}]")
     except Exception:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

#### Problematic to solve:
To manage translation for dimensions, we need to create various calculated dimensions for each language.
If you want your dashboard to be translated in 5 languages, let's say because your organisation is present in 5 countries. So in this case you may create 5 calculated dimensions (for each column) that corresponds to the number of translations. And you need to create 1 dashboard / language using the appropriate translated column.
The total number of translation is the product of `distinct values count for all columns x languages`

#### Feature description
This PR introduce a new function to Jinja context that allows translation ability for features with the least effort.
The used library is `translate == 3.6.1`, it's quite simple as it calls api of translation services such as : `deepl`, `mymemory`, `microsoft` or also `libre translate`. This brings the ability to translate and have all in 1 dashboard and reduce number of calculated columns.

### BEFORE

to handle translations for SQL we have to handle it value by value, so we create as many custom dimensions as the number of languages that we want to handle

```SQL
SELECT 
    CASE 
     WHEN value = 'Good morning' THEN 'Bonjour'
     WHEN value = 'Good evening' THEN 'Bonsoir'
     ELSE 'No translation found'
    END AS greeting_fr
```

### AFTER
Things could get much simpler, by creating 1 custom dimension or write it directly inside your dataset SQL query.

```SQL
SELECT {{translate(value, 'fr')}} AS greeting_fr
```
or
```SQL
SELECT {{translate(value, from_language='en', to_language='fr', add_to_cache_keys=True, escape_result=True)}} AS greeting_fr
```

### TESTING INSTRUCTIONS

1. Set `"ENABLE_TEMPLATE_PROCESSING": True` on the config
2. Optional: set `TRANSLATION_PROVIDER` to one of the available providers `deepl`, `mymemory`, `microsoft`, `libre`.
3. Test on SQL Lab or create your dynamically translated dimension

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->


- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

This PR includes a fix of the error: `error: Unused "type: ignore" comment` that happens during the pre-commit. 

### Some next steps doable after this PR: 

If this PR is accepted as a feature for superset, there is some next step features that could be implemented, or created on the issue tab.
- **feature 1:** Create translation table that maps values to their various translations in other languages. That could be enriched through the interface or through file imports. Therefore the current `translate` template will mainly use the translation mappings if exists and fallback on the api if the translation is not found.
- **feature 2**: Link the translation to the selected language on Superset
- **feature 3**: Send the translation language on the body of the guest_token for embedding