### PR TITLE
fix(dashboard): Missing filter card styles

### DIFF
--- a/superset-frontend/src/dashboard/containers/DashboardPage.tsx
+++ b/superset-frontend/src/dashboard/containers/DashboardPage.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import React, { FC, useEffect, useMemo, useRef } from 'react';
+import { Global } from '@emotion/react';
 import { useHistory } from 'react-router-dom';
 import {
   CategoricalColorNamespace,
@@ -25,6 +26,7 @@ import {
   isFeatureEnabled,
   SharedLabelColorSource,
   t,
+  useTheme,
 } from '@superset-ui/core';
 import pick from 'lodash/pick';
 import { useDispatch, useSelector } from 'react-redux';
@@ -57,6 +59,7 @@ import { DashboardContextForExplore } from 'src/types/DashboardContextForExplore
 import shortid from 'shortid';
 import { RootState } from '../types';
 import { getActiveFilters } from '../util/activeDashboardFilters';
+import { filterCardPopoverStyle, headerStyles } from '../styles';
 
 export const DashboardPageIdContext = React.createContext('');
 
@@ -140,6 +143,7 @@ const useSyncDashboardStateWithLocalStorage = () => {
 };
 
 export const DashboardPage: FC<PageProps> = ({ idOrSlug }: PageProps) => {
+  const theme = useTheme();
   const dispatch = useDispatch();
   const history = useHistory();
   const dashboardPageId = useSyncDashboardStateWithLocalStorage();
@@ -274,9 +278,12 @@ export const DashboardPage: FC<PageProps> = ({ idOrSlug }: PageProps) => {
   if (!readyToRender) return <Loading />;
 
   return (
-    <DashboardPageIdContext.Provider value={dashboardPageId}>
-      <DashboardContainer />
-    </DashboardPageIdContext.Provider>
+    <>
+      <Global styles={[filterCardPopoverStyle(theme), headerStyles(theme)]} />
+      <DashboardPageIdContext.Provider value={dashboardPageId}>
+        <DashboardContainer />
+      </DashboardPageIdContext.Provider>
+    </>
   );
 };
 


### PR DESCRIPTION
### SUMMARY
Reverts a change from https://github.com/apache/superset/pull/23144/ which accidentally removed filter card styles from dashboard.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/15073128/222251665-613c952c-0ec6-498f-8318-b0b34b7ad856.png">

After:

<img width="306" alt="image" src="https://user-images.githubusercontent.com/15073128/222251369-9108fe79-aba7-4971-ba75-5c5056ce1343.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
