### PR TITLE
chore(sqllab): Remove schemaOptions from redux store

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -48,8 +48,6 @@ export const EXPAND_TABLE = 'EXPAND_TABLE';
 export const COLLAPSE_TABLE = 'COLLAPSE_TABLE';
 export const QUERY_EDITOR_SETDB = 'QUERY_EDITOR_SETDB';
 export const QUERY_EDITOR_SET_SCHEMA = 'QUERY_EDITOR_SET_SCHEMA';
-export const QUERY_EDITOR_SET_SCHEMA_OPTIONS =
-  'QUERY_EDITOR_SET_SCHEMA_OPTIONS';
 export const QUERY_EDITOR_SET_TABLE_OPTIONS = 'QUERY_EDITOR_SET_TABLE_OPTIONS';
 export const QUERY_EDITOR_SET_TITLE = 'QUERY_EDITOR_SET_TITLE';
 export const QUERY_EDITOR_SET_AUTORUN = 'QUERY_EDITOR_SET_AUTORUN';
@@ -920,10 +918,6 @@ export function queryEditorSetSchema(queryEditor, schema) {
         ),
       );
   };
-}
-
-export function queryEditorSetSchemaOptions(queryEditor, options) {
-  return { type: QUERY_EDITOR_SET_SCHEMA_OPTIONS, queryEditor, options };
 }
 
 export function queryEditorSetTableOptions(queryEditor, options) {

--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.js
@@ -44,7 +44,6 @@ describe('async actions', () => {
     latestQueryId: null,
     sql: 'SELECT *\nFROM\nWHERE',
     name: 'Untitled Query 1',
-    schemaOptions: [{ value: 'main', label: 'main', title: 'main' }],
   };
 
   let dispatch;

--- a/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
@@ -78,7 +78,6 @@ const SaveQuery = ({
     'latestQueryId',
     'queryLimit',
     'schema',
-    'schemaOptions',
     'selectedText',
     'sql',
     'tableOptions',

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
@@ -36,7 +36,6 @@ import {
   expandTable,
   queryEditorSetSchema,
   queryEditorSetTableOptions,
-  queryEditorSetSchemaOptions,
   setDatabases,
   addDangerToast,
   resetState,
@@ -228,15 +227,6 @@ const SqlEditorLeftBar = ({
     [dispatch, queryEditor],
   );
 
-  const handleSchemasLoad = useCallback(
-    (options: Array<any>) => {
-      if (queryEditor) {
-        dispatch(queryEditorSetSchemaOptions(queryEditor, options));
-      }
-    },
-    [dispatch, queryEditor],
-  );
-
   const handleDbList = useCallback(
     (result: DatabaseObject) => {
       dispatch(setDatabases(result));
@@ -265,7 +255,6 @@ const SqlEditorLeftBar = ({
         handleError={handleError}
         onDbChange={onDbChange}
         onSchemaChange={handleSchemaChange}
-        onSchemasLoad={handleSchemasLoad}
         onTableSelectChange={onTablesChange}
         onTablesLoad={handleTablesLoad}
         schema={schema}

--- a/superset-frontend/src/SqlLab/fixtures.ts
+++ b/superset-frontend/src/SqlLab/fixtures.ts
@@ -188,13 +188,6 @@ export const defaultQueryEditor = {
   tableOptions: [],
   functionNames: [],
   hideLeftBar: false,
-  schemaOptions: [
-    {
-      value: 'main',
-      label: 'main',
-      title: 'main',
-    },
-  ],
   templateParams: '{}',
 };
 

--- a/superset-frontend/src/SqlLab/hooks/useQueryEditor/useQueryEditor.test.ts
+++ b/superset-frontend/src/SqlLab/hooks/useQueryEditor/useQueryEditor.test.ts
@@ -30,12 +30,7 @@ const mockStore = configureStore(middlewares);
 test('returns selected queryEditor values', () => {
   const { result } = renderHook(
     () =>
-      useQueryEditor(defaultQueryEditor.id, [
-        'id',
-        'name',
-        'dbId',
-        'schemaOptions',
-      ]),
+      useQueryEditor(defaultQueryEditor.id, ['id', 'name', 'dbId', 'schema']),
     {
       wrapper: createWrapper({
         useRedux: true,
@@ -47,7 +42,7 @@ test('returns selected queryEditor values', () => {
     id: defaultQueryEditor.id,
     name: defaultQueryEditor.name,
     dbId: defaultQueryEditor.dbId,
-    schemaOptions: defaultQueryEditor.schemaOptions,
+    schema: defaultQueryEditor.schema,
   });
 });
 

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -587,18 +587,6 @@ export default function sqlLabReducer(state = {}, action) {
         ),
       };
     },
-    [actions.QUERY_EDITOR_SET_SCHEMA_OPTIONS]() {
-      return {
-        ...state,
-        ...alterUnsavedQueryEditorState(
-          state,
-          {
-            schemaOptions: action.options,
-          },
-          action.queryEditor.id,
-        ),
-      };
-    },
     [actions.QUERY_EDITOR_SET_TABLE_OPTIONS]() {
       return {
         ...state,

--- a/superset-frontend/src/SqlLab/types.ts
+++ b/superset-frontend/src/SqlLab/types.ts
@@ -40,7 +40,6 @@ export interface QueryEditor {
   sql: string;
   remoteId: number | null;
   tableOptions: any[];
-  schemaOptions?: SchemaOption[];
   functionNames: string[];
   validationResult?: {
     completed: boolean;

--- a/superset-frontend/src/SqlLab/utils/emptyQueryResults.test.js
+++ b/superset-frontend/src/SqlLab/utils/emptyQueryResults.test.js
@@ -47,9 +47,9 @@ describe('reduxStateToLocalStorageHelper', () => {
 
   it('should only return selected keys for query editor', () => {
     const queryEditors = [defaultQueryEditor];
-    expect(Object.keys(queryEditors[0])).toContain('schemaOptions');
+    expect(Object.keys(queryEditors[0])).toContain('schema');
 
     const clearedQueryEditors = clearQueryEditors(queryEditors);
-    expect(Object.keys(clearedQueryEditors)[0]).not.toContain('schemaOptions');
+    expect(Object.keys(clearedQueryEditors)[0]).not.toContain('schema');
   });
 });

--- a/superset-frontend/src/components/DatabaseSelector/DatabaseSelector.test.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/DatabaseSelector.test.tsx
@@ -40,7 +40,6 @@ const createProps = (): DatabaseSelectorProps => ({
   handleError: jest.fn(),
   onDbChange: jest.fn(),
   onSchemaChange: jest.fn(),
-  onSchemasLoad: jest.fn(),
 });
 
 const fakeDatabaseApiResult = {

--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -93,7 +93,6 @@ export interface DatabaseSelectorProps {
   onDbChange?: (db: DatabaseObject) => void;
   onEmptyResults?: (searchText?: string) => void;
   onSchemaChange?: (schema?: string) => void;
-  onSchemasLoad?: (schemas: Array<object>) => void;
   readOnly?: boolean;
   schema?: string;
   sqlLabMode?: boolean;
@@ -126,7 +125,6 @@ export default function DatabaseSelector({
   onDbChange,
   onEmptyResults,
   onSchemaChange,
-  onSchemasLoad,
   readOnly = false,
   schema,
   sqlLabMode = false,
@@ -230,8 +228,6 @@ export default function DatabaseSelector({
   } = useSchemas({
     dbId: currentDb?.value,
     onSuccess: data => {
-      onSchemasLoad?.(data);
-
       if (data.length === 1) {
         changeSchema(data[0]);
       } else if (!data.find(schemaOption => schema === schemaOption.value)) {

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -98,7 +98,6 @@ interface TableSelectorProps {
   isDatabaseSelectEnabled?: boolean;
   onDbChange?: (db: DatabaseObject) => void;
   onSchemaChange?: (schema?: string) => void;
-  onSchemasLoad?: (schemaOptions: SchemaOption[]) => void;
   onTablesLoad?: (options: Array<any>) => void;
   readOnly?: boolean;
   schema?: string;
@@ -160,7 +159,6 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
   isDatabaseSelectEnabled = true,
   onDbChange,
   onSchemaChange,
-  onSchemasLoad,
   onTablesLoad,
   readOnly = false,
   onEmptyResults,
@@ -335,7 +333,6 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
         onDbChange={readOnly ? undefined : internalDbChange}
         onEmptyResults={onEmptyResults}
         onSchemaChange={readOnly ? undefined : internalSchemaChange}
-        onSchemasLoad={onSchemasLoad}
         schema={currentSchema}
         sqlLabMode={sqlLabMode}
         isDatabaseSelectEnabled={isDatabaseSelectEnabled && !readOnly}

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -36,7 +36,6 @@ import RefreshLabel from 'src/components/RefreshLabel';
 import CertifiedBadge from 'src/components/CertifiedBadge';
 import WarningIconWithTooltip from 'src/components/WarningIconWithTooltip';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
-import { SchemaOption } from 'src/SqlLab/types';
 import { useTables, Table } from 'src/hooks/apiResources';
 import {
   getClientErrorMessage,


### PR DESCRIPTION
### SUMMARY
As a followup step of the `react-query` migration (#21240), this commit migrates the schemaOptions state from redux to react-query to reduce the complexity of the queryEditor state.
(The `schemaOptions` state only used in the editor for autocomplete so useQuery is a lighter way to share the state)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

- After:

<img width="382" alt="Screenshot 2023-03-01 at 11 55 04 AM" src="https://user-images.githubusercontent.com/1392866/222254800-56963b22-10a2-4bcf-8484-a0605535d485.png">
<img width="527" alt="Screenshot 2023-03-01 at 12 02 48 PM" src="https://user-images.githubusercontent.com/1392866/222254869-2f296a20-56dc-4188-8ba0-130b8ff10959.png">

- Before:

<img width="377" alt="Notification_Center" src="https://user-images.githubusercontent.com/1392866/222254686-83138e28-3aa8-4c2e-a7e7-a7018f53c6be.png">
<img width="529" alt="Screenshot 2023-03-01 at 12 04 40 PM" src="https://user-images.githubusercontent.com/1392866/222254909-b1ffe428-534f-4fd8-baa6-b2e3ec14ac01.png">

### TESTING INSTRUCTIONS
Go to sqllab and select a database to get the associated schemas
Type some part of the schema name on the editor and check the autocomplete including the fetched schemas

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @ktmud 