### PR TITLE
chore(dashboard): Disable 'Set filter mapping' when appropriate

### DIFF
--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
@@ -24,7 +24,11 @@ import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import { HeaderDropdownProps } from 'src/dashboard/components/Header/types';
 import injectCustomCss from 'src/dashboard/util/injectCustomCss';
+import { FeatureFlag } from '@superset-ui/core';
+import * as featureFlags from 'src/featureFlags';
 import HeaderActionsDropdown from '.';
+
+let isFeatureEnabledMock: jest.MockInstance<boolean, [feature: FeatureFlag]>;
 
 const createProps = () => ({
   addSuccessToast: jest.fn(),
@@ -70,9 +74,22 @@ const createProps = () => ({
   dataMask: {},
   logEvent: jest.fn(),
 });
+
 const editModeOnProps = {
   ...createProps(),
   editMode: true,
+};
+
+const editModeOnPropsWithFilterScopes = {
+  ...editModeOnProps,
+  dashboardInfo: {
+    ...editModeOnProps.dashboardInfo,
+    metadata: {
+      filter_scopes: {
+        '1': { scopes: ['ROOT_ID'], immune: [] },
+      },
+    },
+  },
 };
 
 function setup(props: HeaderDropdownProps) {
@@ -112,9 +129,60 @@ test('should render the menu items in edit mode', async () => {
   setup(editModeOnProps);
   expect(screen.getAllByRole('menuitem')).toHaveLength(4);
   expect(screen.getByText('Set auto-refresh interval')).toBeInTheDocument();
-  expect(screen.getByText('Set filter mapping')).toBeInTheDocument();
   expect(screen.getByText('Edit properties')).toBeInTheDocument();
   expect(screen.getByText('Edit CSS')).toBeInTheDocument();
+});
+
+describe('with native filters feature flag disabled', () => {
+  beforeAll(() => {
+    isFeatureEnabledMock = jest
+      .spyOn(featureFlags, 'isFeatureEnabled')
+      .mockImplementation(
+        (featureFlag: FeatureFlag) =>
+          featureFlag !== FeatureFlag.DASHBOARD_NATIVE_FILTERS,
+      );
+  });
+
+  afterAll(() => {
+    // @ts-ignore
+    isFeatureEnabledMock.restore();
+  });
+
+  it('should render filter mapping in edit mode if explicit filter scopes undefined', async () => {
+    setup(editModeOnProps);
+    expect(screen.getByText('Set filter mapping')).toBeInTheDocument();
+  });
+
+  it('should render filter mapping in edit mode if explicit filter scopes defined', async () => {
+    setup(editModeOnPropsWithFilterScopes);
+    expect(screen.getByText('Set filter mapping')).toBeInTheDocument();
+  });
+});
+
+describe('with native filters feature flag enabled', () => {
+  beforeAll(() => {
+    isFeatureEnabledMock = jest
+      .spyOn(featureFlags, 'isFeatureEnabled')
+      .mockImplementation(
+        (featureFlag: FeatureFlag) =>
+          featureFlag === FeatureFlag.DASHBOARD_NATIVE_FILTERS,
+      );
+  });
+
+  afterAll(() => {
+    // @ts-ignore
+    isFeatureEnabledMock.restore();
+  });
+
+  it('should not render filter mapping in edit mode if explicit filter scopes undefined', async () => {
+    setup(editModeOnProps);
+    expect(screen.queryByText('Set filter mapping')).not.toBeInTheDocument();
+  });
+
+  it('should render filter mapping in edit mode if explicit filter scopes defined', async () => {
+    setup(editModeOnPropsWithFilterScopes);
+    expect(screen.getByText('Set filter mapping')).toBeInTheDocument();
+  });
 });
 
 test('should show the share actions', async () => {

--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
@@ -80,7 +80,7 @@ const editModeOnProps = {
   editMode: true,
 };
 
-const editModeOnPropsWithFilterScopes = {
+const editModeOnWithFilterScopesProps = {
   ...editModeOnProps,
   dashboardInfo: {
     ...editModeOnProps.dashboardInfo,
@@ -154,7 +154,7 @@ describe('with native filters feature flag disabled', () => {
   });
 
   it('should render filter mapping in edit mode if explicit filter scopes defined', async () => {
-    setup(editModeOnPropsWithFilterScopes);
+    setup(editModeOnWithFilterScopesProps);
     expect(screen.getByText('Set filter mapping')).toBeInTheDocument();
   });
 });
@@ -180,7 +180,7 @@ describe('with native filters feature flag enabled', () => {
   });
 
   it('should render filter mapping in edit mode if explicit filter scopes defined', async () => {
-    setup(editModeOnPropsWithFilterScopes);
+    setup(editModeOnWithFilterScopesProps);
     expect(screen.getByText('Set filter mapping')).toBeInTheDocument();
   });
 });

--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx
@@ -18,6 +18,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { isEmpty } from 'lodash';
 
 import { SupersetClient, t } from '@superset-ui/core';
 
@@ -36,6 +37,7 @@ import getDashboardUrl from 'src/dashboard/util/getDashboardUrl';
 import { getActiveFilters } from 'src/dashboard/util/activeDashboardFilters';
 import { getUrlParam } from 'src/utils/urlUtils';
 import { LOG_ACTIONS_DASHBOARD_DOWNLOAD_AS_IMAGE } from 'src/logger/LogUtils';
+import { isFeatureEnabled, FeatureFlag } from 'src/featureFlags';
 
 const propTypes = {
   addSuccessToast: PropTypes.func.isRequired,
@@ -370,14 +372,18 @@ class HeaderActionsDropdown extends React.PureComponent {
             </Menu>
           )
         ) : null}
-        {editMode && (
-          <Menu.Item key={MENU_KEYS.SET_FILTER_MAPPING}>
-            <FilterScopeModal
-              className="m-r-5"
-              triggerNode={t('Set filter mapping')}
-            />
-          </Menu.Item>
-        )}
+        {editMode &&
+          !(
+            isFeatureEnabled(FeatureFlag.DASHBOARD_NATIVE_FILTERS) &&
+            isEmpty(dashboardInfo?.metadata?.filter_scopes)
+          ) && (
+            <Menu.Item key={MENU_KEYS.SET_FILTER_MAPPING}>
+              <FilterScopeModal
+                className="m-r-5"
+                triggerNode={t('Set filter mapping')}
+              />
+            </Menu.Item>
+          )}
 
         <Menu.Item key={MENU_KEYS.AUTOREFRESH_MODAL}>
           <RefreshIntervalModal


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR addresses recommendation #&#x2060;5 in https://github.com/apache/superset/issues/14383.

The "set filter mapping" dashboard menu option (see screenshot) is used to configure the filter scopes for legacy (filter-box) filters. By defaults filter scopes are implicitly defined, i.e., charts have no immunity to filter-boxes, however users can explicitly specify them (by defining their scope and inclusion/exclusion logic). 

Though both legacy and native filters can coexist the behavior is not ideal from a UX perspective, i.e., when the `DASHBOARD_NATIVE_FILTERS` feature is enabled users should strive to solely use the native filters functionality/modal to define filtering whilst simultaneously removing legacy filter-box charts.

This PR ensures that if the `DASHBOARD_NATIVE_FILTERS` feature is enabled and no legacy filter mapping is explicitly defined (filter-box charts can be present*) then the menu option to set the mapping should not be present, i.e., we should prevent users from having the ability to define legacy filter scopes. The TL;DR is we want to prevent users from creating new  legacy filter scopes when the feature is enabled.

\* If filter-box charts are present then (per my previous comment) implicit filter scope logic is still adhered to even if there's no explicitly defined legacy filter scopes. The TL;DR with this change users wont be able to configure the filter-box charts' scopes/immunity, however users should be encouraged to simply remove the filter-box charts from the dashboard and replace them with native filters.

<img width="182" alt="Screenshot 2023-03-08 at 10 11 39 PM" src="https://user-images.githubusercontent.com/4567245/223671464-c0a1cd2d-deed-4244-904e-c6200812b5dd.png">

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Added unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/14383
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
