### PR TITLE
fix: ignore ts warnings from older typescript versions

### DIFF
--- a/superset-embedded-sdk/package-lock.json
+++ b/superset-embedded-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@superset-ui/embedded-sdk",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@superset-ui/embedded-sdk",
-      "version": "0.1.0-alpha.8",
+      "version": "0.1.0-alpha.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@superset-ui/switchboard": "^0.18.26-0",

--- a/superset-embedded-sdk/package.json
+++ b/superset-embedded-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/embedded-sdk",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "SDK for embedding resources from Superset into your own application",
   "access": "public",
   "keywords": [

--- a/superset-embedded-sdk/src/index.ts
+++ b/superset-embedded-sdk/src/index.ts
@@ -150,6 +150,7 @@ export async function embedDashboard({
       });
 
       iframe.src = `${supersetDomain}/embedded/${id}${dashboardConfig}${filterConfigUrlParams}`;
+      //@ts-ignore
       mountPoint.replaceChildren(iframe);
       log('placed the iframe')
     });
@@ -173,6 +174,7 @@ export async function embedDashboard({
 
   function unmount() {
     log('unmounting');
+    //@ts-ignore
     mountPoint.replaceChildren();
   }
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This is a quick fix to remove some ts warnings. The replaceChildren method had some cross-browser compatibility issues for a while and therefore wasn't fully supported in typescript. Microsoft started supporting the type in some later versions, but whether it's because we're using the babel plugin for embedded or what, when I bumped the versions, I still am seeing this ts error, plus it introduced a few more. I decided just to comment this out for now so that we can spend more time writing tests for this feature before making any changes that might affect runtime stability.


### TESTING INSTRUCTIONS
The error in the console was `Uncaught (in promise) TypeError: Cannot read properties of null (reading 'replaceChildren')` That should be resolved with this change. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
