### PR TITLE
fix(sqllab): dedupe active_tab in tabHistory

### DIFF
--- a/superset-frontend/src/SqlLab/reducers/getInitialState.js
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.js
@@ -19,6 +19,14 @@
 import { t } from '@superset-ui/core';
 import getToastsFromPyFlashMessages from 'src/components/MessageToasts/getToastsFromPyFlashMessages';
 
+export function dedupeTabHistory(tabHistory) {
+  return tabHistory.reduce(
+    (result, tabId) =>
+      result.slice(-1)[0] === tabId ? result : result.concat(tabId),
+    [],
+  );
+}
+
 export default function getInitialState({
   defaultDbId,
   common,
@@ -193,7 +201,7 @@ export default function getInitialState({
       offline: false,
       queries,
       queryEditors: Object.values(queryEditors),
-      tabHistory,
+      tabHistory: dedupeTabHistory(tabHistory),
       tables,
       queriesLastUpdate: Date.now(),
       user,

--- a/superset-frontend/src/SqlLab/reducers/getInitialState.test.ts
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.test.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import getInitialState from './getInitialState';
+import getInitialState, { dedupeTabHistory } from './getInitialState';
 
 const apiData = {
   defaultDbId: 1,
@@ -50,5 +50,22 @@ describe('getInitialState', () => {
       getInitialState(apiDataWithTabState).sqlLab.queryEditors[0]
         .templateParams,
     ).toBeUndefined();
+  });
+
+  describe('dedupeTabHistory', () => {
+    it('should dedupe the tab history', () => {
+      [
+        { value: [], expected: [] },
+        { value: [12, 3, 4, 5, 6], expected: [12, 3, 4, 5, 6] },
+        { value: [1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2], expected: [1, 2] },
+        {
+          value: [1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3],
+          expected: [1, 2, 3],
+        },
+        { value: [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3], expected: [2, 3] },
+      ].forEach(({ value, expected }) => {
+        expect(dedupeTabHistory(value)).toEqual(expected);
+      });
+    });
   });
 });


### PR DESCRIPTION
### SUMMARY
When `SQLLAB_BACKEND_PERSISTENCE` has been deactivated after activated, active_tab will be provided during localstorage persistence mode.
This causes the appending duplicated tabId value every time page is loaded.
This commit adds the dedupe logic to clean up the duplicated values.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

- After

<img width="162" alt="Screenshot 2023-03-02 at 10 24 21 AM" src="https://user-images.githubusercontent.com/1392866/222525846-3fe135d4-e0a3-483a-b8f0-f8c7562d47bf.png">

- Before

<img width="860" alt="Screenshot 2023-03-02 at 10 23 38 AM" src="https://user-images.githubusercontent.com/1392866/222525838-c29b647d-8536-418d-a0c8-e9abe9b04f0d.png">

### TESTING INSTRUCTIONS
set SQLLAB_BACKEND_PERSISTENCE on and open SqlLab
disable SQLLAB_BACKEND_PERSISTENCE and open SqlLab
keep refresh the page and then check the redux value in the local storage

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
