### PR TITLE
fix: Dashboard containing a tab and a filter with "Select first filter value by default" enabled doesn't load

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FiltersOutOfScopeCollapsible/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FiltersOutOfScopeCollapsible/index.tsx
@@ -35,6 +35,7 @@ export const FiltersOutOfScopeCollapsible = ({
   horizontalOverflow,
 }: FiltersOutOfScopeCollapsibleProps) => (
   <AntdCollapse
+    defaultActiveKey="1"
     ghost
     bordered
     expandIconPosition="right"


### PR DESCRIPTION


<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- fix this issue with the suggested solution https://github.com/apache/superset/issues/21980

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![dashboard_tabs_before](https://user-images.githubusercontent.com/5705598/222579641-bd6af08f-5dd5-40fe-81ff-3169def26987.gif)

After:
![dashboard_tabs_after](https://user-images.githubusercontent.com/5705598/222581307-278f2104-f8b3-4087-a5be-60b2db4c7ca9.gif)
### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
