### PR TITLE
fix(migration): Address issue in #23228

### DIFF
--- a/superset/migrations/versions/2023-02-28_14-46_c0a3ea245b61_remove_show_native_filters.py
+++ b/superset/migrations/versions/2023-02-28_14-46_c0a3ea245b61_remove_show_native_filters.py
@@ -39,6 +39,7 @@ Base = declarative_base()
 
 class Dashboard(Base):
     __tablename__ = "dashboards"
+
     id = sa.Column(sa.Integer, primary_key=True)
     json_metadata = sa.Column(sa.Text)
 

--- a/superset/migrations/versions/2023-02-28_14-46_c0a3ea245b61_remove_show_native_filters.py
+++ b/superset/migrations/versions/2023-02-28_14-46_c0a3ea245b61_remove_show_native_filters.py
@@ -28,10 +28,19 @@ down_revision = "f3c2d8ec8595"
 
 import json
 
+import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.ext.declarative import declarative_base
 
 from superset import db
-from superset.models.dashboard import Dashboard
+
+Base = declarative_base()
+
+
+class Dashboard(Base):
+    __tablename__ = "dashboards"
+    id = sa.Column(sa.Integer, primary_key=True)
+    json_metadata = sa.Column(sa.Text)
 
 
 def upgrade():
@@ -45,7 +54,6 @@ def upgrade():
             if "show_native_filters" in json_metadata:
                 del json_metadata["show_native_filters"]
                 dashboard.json_metadata = json.dumps(json_metadata)
-                session.merge(dashboard)
         except Exception:  # pylint: disable=broad-except
             pass
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Per [this](https://apache-superset.slack.com/archives/G013HAE6Y0K/p1677891557595899) Slack thread, this PR addresses an issue related to updating the `dashboards` table which should leverage a skeleton SQLAlchemy model as opposed to Superset's SQLAlchemy model which includes the various mixins.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
