### PR TITLE
feat(filter_state): Added @api and @has_access_api to all methods of filter_state API.

### DIFF
--- a/superset/dashboards/filter_state/api.py
+++ b/superset/dashboards/filter_state/api.py
@@ -19,6 +19,7 @@ from typing import Type
 
 from flask import Response
 from flask_appbuilder.api import expose, protect, safe
+from flask_appbuilder.security.decorators import has_access_api
 
 from superset.dashboards.filter_state.commands.create import CreateFilterStateCommand
 from superset.dashboards.filter_state.commands.delete import DeleteFilterStateCommand
@@ -26,6 +27,7 @@ from superset.dashboards.filter_state.commands.get import GetFilterStateCommand
 from superset.dashboards.filter_state.commands.update import UpdateFilterStateCommand
 from superset.extensions import event_logger
 from superset.temporary_cache.api import TemporaryCacheRestApi
+from superset.views.base import api
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +49,8 @@ class DashboardFilterStateRestApi(TemporaryCacheRestApi):
     def get_delete_command(self) -> Type[DeleteFilterStateCommand]:
         return DeleteFilterStateCommand
 
+    @api
+    @has_access_api
     @expose("/<int:pk>/filter_state", methods=["POST"])
     @protect()
     @safe
@@ -97,6 +101,8 @@ class DashboardFilterStateRestApi(TemporaryCacheRestApi):
         """
         return super().post(pk)
 
+    @api
+    @has_access_api
     @expose("/<int:pk>/filter_state/<string:key>", methods=["PUT"])
     @protect()
     @safe
@@ -153,6 +159,8 @@ class DashboardFilterStateRestApi(TemporaryCacheRestApi):
         """
         return super().put(pk, key)
 
+    @api
+    @has_access_api
     @expose("/<int:pk>/filter_state/<string:key>", methods=["GET"])
     @protect()
     @safe
@@ -199,6 +207,8 @@ class DashboardFilterStateRestApi(TemporaryCacheRestApi):
         """
         return super().get(pk, key)
 
+    @api
+    @has_access_api
     @expose("/<int:pk>/filter_state/<string:key>", methods=["DELETE"])
     @protect()
     @safe

--- a/superset/dashboards/filter_state/api.py
+++ b/superset/dashboards/filter_state/api.py
@@ -159,8 +159,6 @@ class DashboardFilterStateRestApi(TemporaryCacheRestApi):
         """
         return super().put(pk, key)
 
-    @api
-    @has_access_api
     @expose("/<int:pk>/filter_state/<string:key>", methods=["GET"])
     @protect()
     @safe
@@ -207,8 +205,6 @@ class DashboardFilterStateRestApi(TemporaryCacheRestApi):
         """
         return super().get(pk, key)
 
-    @api
-    @has_access_api
     @expose("/<int:pk>/filter_state/<string:key>", methods=["DELETE"])
     @protect()
     @safe


### PR DESCRIPTION
### SUMMARY
The API of filter_state is already exposed but it doesn't look like other APIs. We had a problem gaining 403 Status Code when addressing this endpoint. It was because of the lack of role permissions but there were no messages in the logs. Introducing these decorators we add recording the problem to the log so it will be easier to investigate the problem. 


