### PR TITLE
fix(dashboard): Allow selecting text in cells in Table and PivotTable without triggering cross filters

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/utils/getSelectedText.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/getSelectedText.ts
@@ -16,18 +16,4 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-export { default as convertKeysToCamelCase } from './convertKeysToCamelCase';
-export { default as ensureIsArray } from './ensureIsArray';
-export { default as ensureIsInt } from './ensureIsInt';
-export { default as isDefined } from './isDefined';
-export { default as isRequired } from './isRequired';
-export { default as isEqualArray } from './isEqualArray';
-export { default as makeSingleton } from './makeSingleton';
-export { default as promiseTimeout } from './promiseTimeout';
-export { default as logging } from './logging';
-export { default as removeDuplicates } from './removeDuplicates';
-export { lruCache } from './lruCache';
-export { getSelectedText } from './getSelectedText';
-export * from './featureFlags';
-export * from './random';
-export * from './typedMemo';
+export const getSelectedText = () => window.getSelection()?.toString();

--- a/superset-frontend/packages/superset-ui-core/test/utils/getSelectedText.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/utils/getSelectedText.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { getSelectedText } from '@superset-ui/core';
+
+test('Returns null if Selection object is null', () => {
+  jest.spyOn(window, 'getSelection').mockImplementationOnce(() => null);
+  expect(getSelectedText()).toEqual(undefined);
+  jest.restoreAllMocks();
+});
+
+test('Returns selection text if Selection object is not null', () => {
+  jest
+    .spyOn(window, 'getSelection')
+    // @ts-ignore
+    .mockImplementationOnce(() => ({ toString: () => 'test string' }));
+  expect(getSelectedText()).toEqual('test string');
+  jest.restoreAllMocks();
+});

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -30,6 +30,7 @@ import {
   isAdhocColumn,
   BinaryQueryObjectFilterClause,
   t,
+  getSelectedText,
 } from '@superset-ui/core';
 import { PivotTable, sortAs, aggregatorTemplates } from './react-pivottable';
 import {
@@ -353,6 +354,11 @@ export default function PivotTableChart(props: PivotTableProps) {
       isGrandTotal: boolean,
     ) => {
       if (isSubtotal || isGrandTotal || !emitCrossFilters) {
+        return;
+      }
+
+      // allow selecting text in a cell
+      if (getSelectedText()) {
         return;
       }
 

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -41,6 +41,7 @@ import {
   DTTM_ALIAS,
   ensureIsArray,
   GenericDataType,
+  getSelectedText,
   getTimeFormatterForGranularity,
   BinaryQueryObjectFilterClause,
   styled,
@@ -493,7 +494,12 @@ export default function TableChart<D extends DataRecord = DataRecord>(
             title: typeof value === 'number' ? String(value) : undefined,
             onClick:
               emitCrossFilters && !valueRange && !isMetric
-                ? () => toggleFilter(key, value)
+                ? () => {
+                    // allow selecting text in a cell
+                    if (!getSelectedText()) {
+                      toggleFilter(key, value);
+                    }
+                  }
                 : undefined,
             onContextMenu: (e: MouseEvent) => {
               if (handleContextMenu) {


### PR DESCRIPTION

### SUMMARY
Before when user tried to select text in a cell of Table or Pivot Table chart, the cross filter would be triggered on that cell. Now we the cross filters will be triggered only if selection is empty.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/15073128/223074554-bd03e794-d52d-4963-aa55-3a7d5473c1f8.mov


After:

https://user-images.githubusercontent.com/15073128/223073838-a58fb23b-3850-47c1-aaca-2043d8860554.mov


### TESTING INSTRUCTIONS
1. Add Table and Pivot Table charts to a dashboard
2. Select text in a cell and verify that cross filtering wasn't triggered
3. Cancel the selection and click on a cell
4. Verify that cross filtering was triggered

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
