### PR TITLE
chore: log different selenium timeout errors differently

### DIFF
--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -176,22 +176,42 @@ class WebDriverProxy:
         sleep(selenium_headstart)
 
         try:
-            logger.debug("Wait for the presence of %s", element_name)
-            element = WebDriverWait(driver, self._screenshot_locate_wait).until(
-                EC.presence_of_element_located((By.CLASS_NAME, element_name))
-            )
-
-            logger.debug("Wait for chart containers to draw")
-            WebDriverWait(driver, self._screenshot_locate_wait).until(
-                EC.visibility_of_all_elements_located(
-                    (By.CLASS_NAME, "slice_container")
+            try:
+                # page didn't load
+                logger.debug("Wait for the presence of %s", element_name)
+                element = WebDriverWait(driver, self._screenshot_locate_wait).until(
+                    EC.presence_of_element_located((By.CLASS_NAME, element_name))
                 )
-            )
+            except TimeoutException as ex:
+                logger.exception("Selenium timed out requesting url %s", url)
+                raise ex
 
-            logger.debug("Wait for loading element of charts to be gone")
-            WebDriverWait(driver, self._screenshot_load_wait).until_not(
-                EC.presence_of_all_elements_located((By.CLASS_NAME, "loading"))
-            )
+            try:
+                # chart containers didn't render
+                logger.debug("Wait for chart containers to draw")
+                WebDriverWait(driver, self._screenshot_locate_wait).until(
+                    EC.visibility_of_all_elements_located(
+                        (By.CLASS_NAME, "slice_container")
+                    )
+                )
+            except TimeoutException as ex:
+                logger.exception(
+                    "Selenium timed out waiting for chart containers to draw at url %s",
+                    url,
+                )
+                raise ex
+
+            try:
+                # charts took too long to load
+                logger.debug("Wait for loading element of charts to be gone")
+                WebDriverWait(driver, self._screenshot_load_wait).until_not(
+                    EC.presence_of_all_elements_located((By.CLASS_NAME, "loading"))
+                )
+            except TimeoutException as ex:
+                logger.exception(
+                    "Selenium timed out waiting for charts to load at url %s", url
+                )
+                raise ex
 
             selenium_animation_wait = current_app.config[
                 "SCREENSHOT_SELENIUM_ANIMATION_WAIT"
@@ -215,9 +235,9 @@ class WebDriverProxy:
                     )
 
             img = element.screenshot_as_png
-
         except TimeoutException:
-            logger.exception("Selenium timed out requesting url %s", url)
+            # raise again for the finally block, but handled above
+            pass
         except StaleElementReferenceException:
             logger.exception(
                 "Selenium got a stale element while requesting url %s",

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -178,7 +178,9 @@ class WebDriverProxy:
         try:
             try:
                 # page didn't load
-                logger.debug("Wait for the presence of %s", element_name)
+                logger.debug(
+                    "Wait for the presence of %s at url: %s", element_name, url
+                )
                 element = WebDriverWait(driver, self._screenshot_locate_wait).until(
                     EC.presence_of_element_located((By.CLASS_NAME, element_name))
                 )
@@ -188,7 +190,7 @@ class WebDriverProxy:
 
             try:
                 # chart containers didn't render
-                logger.debug("Wait for chart containers to draw")
+                logger.debug("Wait for chart containers to draw at url: %s", url)
                 WebDriverWait(driver, self._screenshot_locate_wait).until(
                     EC.visibility_of_all_elements_located(
                         (By.CLASS_NAME, "slice_container")
@@ -203,7 +205,9 @@ class WebDriverProxy:
 
             try:
                 # charts took too long to load
-                logger.debug("Wait for loading element of charts to be gone")
+                logger.debug(
+                    "Wait for loading element of charts to be gone at url: %s", url
+                )
                 WebDriverWait(driver, self._screenshot_load_wait).until_not(
                     EC.presence_of_all_elements_located((By.CLASS_NAME, "loading"))
                 )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
There are three different places in Selenium screenshots where they can error. I'm logging each one differently so that we can track what's happening more granularly. I'm hoping that we can dig more into which of these issues are actionable from the system side and which take user/client action and log them accordingly (warn vs exception)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
