### PR TITLE
fix(dashboard): Infinite load when filter with default first value is out of scope

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
@@ -124,6 +124,11 @@ const FilterControls: FC<FilterControlsProps> = ({
   const [filtersInScope, filtersOutOfScope] =
     useSelectFiltersInScope(filtersWithValues);
 
+  const hasRequiredFirst = useMemo(
+    () => filtersWithValues.some(filter => filter.requiredFirst),
+    [filtersWithValues],
+  );
+
   const dashboardHasTabs = useDashboardHasTabs();
   const showCollapsePanel = dashboardHasTabs && filtersWithValues.length > 0;
 
@@ -149,6 +154,7 @@ const FilterControls: FC<FilterControlsProps> = ({
       {showCollapsePanel && (
         <FiltersOutOfScopeCollapsible
           filtersOutOfScope={filtersOutOfScope}
+          forceRender={hasRequiredFirst}
           hasTopMargin={filtersInScope.length > 0}
           renderer={renderer}
         />
@@ -264,6 +270,7 @@ const FilterControls: FC<FilterControlsProps> = ({
                   renderer={renderer}
                   rendererCrossFilter={rendererCrossFilter}
                   showCollapsePanel={showCollapsePanel}
+                  forceRenderOutOfScope={hasRequiredFirst}
                 />
               )
             : undefined

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FiltersDropdownContent/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FiltersDropdownContent/index.tsx
@@ -34,6 +34,7 @@ export interface FiltersDropdownContentProps {
     last: CrossFilterIndicator,
   ) => ReactNode;
   showCollapsePanel?: boolean;
+  forceRenderOutOfScope?: boolean;
 }
 
 export const FiltersDropdownContent = ({
@@ -43,6 +44,7 @@ export const FiltersDropdownContent = ({
   renderer,
   rendererCrossFilter,
   showCollapsePanel,
+  forceRenderOutOfScope,
 }: FiltersDropdownContentProps) => (
   <div
     css={(theme: SupersetTheme) =>
@@ -64,6 +66,7 @@ export const FiltersDropdownContent = ({
       <FiltersOutOfScopeCollapsible
         filtersOutOfScope={filtersOutOfScope}
         renderer={renderer}
+        forceRender={forceRenderOutOfScope}
         horizontalOverflow
       />
     )}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FiltersOutOfScopeCollapsible/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FiltersOutOfScopeCollapsible/index.tsx
@@ -26,6 +26,7 @@ export interface FiltersOutOfScopeCollapsibleProps {
   renderer: (filter: Filter | Divider, index: number) => ReactNode;
   hasTopMargin?: boolean;
   horizontalOverflow?: boolean;
+  forceRender?: boolean;
 }
 
 export const FiltersOutOfScopeCollapsible = ({
@@ -33,6 +34,7 @@ export const FiltersOutOfScopeCollapsible = ({
   renderer,
   hasTopMargin,
   horizontalOverflow,
+  forceRender = false,
 }: FiltersOutOfScopeCollapsibleProps) => (
   <AntdCollapse
     ghost
@@ -80,6 +82,7 @@ export const FiltersOutOfScopeCollapsible = ({
     }
   >
     <AntdCollapse.Panel
+      forceRender={forceRender}
       header={
         <span
           css={(theme: SupersetTheme) => css`


### PR DESCRIPTION
### SUMMARY
Fixes a bug which caused the dashboard to load infinitely when it contained a native filter which initially is out of scope and has "Select first filter value by default" option selected.

The bug occurred because dashboard starts loading only after native filters with "Select first filter value by default" option load first. However, if a filter is out of scope, it won't load until user changes tab so that it's finally in scope.
To fix that, this PR force renders filters out of scope if any native filter uses "Select first filter value by default" option. That, of course, is not an optimal solution as we opt out of an optimization of not rendering the filters out of scope until they are needed.
Optimally, only the charts affected by such native filters should wait for those filters to load instead of delaying rendering the whole dashboard. However, implementing that would require a large refactor and given the urgency of this bug I believe the current solution is sufficient for now.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/15073128/223431563-46610b8e-cd98-402d-bb8b-8fed0d82e328.mov

After:

https://user-images.githubusercontent.com/15073128/223434008-8bf14b17-4a66-43f4-9a7e-9117b0049ccc.mov


### TESTING INSTRUCTIONS
1. Create a dashboard with tabs and add a chart to second tab
2. Add a native filter, enable "Select first filter value by default", set the scope only to the second tab
3. Navigate back to dashboards list and refresh the page.
4. Open the dashboard
5. Verify that it loads correctly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: https://github.com/apache/superset/issues/21980
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
