### PR TITLE
chore(native-filters): Fetch only the required dataset fields

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ColumnSelect.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ColumnSelect.test.tsx
@@ -24,7 +24,7 @@ import { Column, JsonObject } from '@superset-ui/core';
 import userEvent from '@testing-library/user-event';
 import { ColumnSelect } from './ColumnSelect';
 
-fetchMock.get('glob:*/api/v1/dataset/123', {
+fetchMock.get('glob:*/api/v1/dataset/123?*', {
   body: {
     result: {
       columns: [
@@ -35,7 +35,7 @@ fetchMock.get('glob:*/api/v1/dataset/123', {
     },
   },
 });
-fetchMock.get('glob:*/api/v1/dataset/456', {
+fetchMock.get('glob:*/api/v1/dataset/456?*', {
   body: {
     result: {
       columns: [
@@ -47,7 +47,7 @@ fetchMock.get('glob:*/api/v1/dataset/456', {
   },
 });
 
-fetchMock.get('glob:*/api/v1/dataset/789', { status: 404 });
+fetchMock.get('glob:*/api/v1/dataset/789?*', { status: 404 });
 
 const createProps = (extraProps: JsonObject = {}) => ({
   filterId: 'filterId',

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ColumnSelect.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ColumnSelect.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import React, { useCallback, useState, useMemo, useEffect } from 'react';
+import rison from 'rison';
 import { Column, ensureIsArray, t, useChangeEffect } from '@superset-ui/core';
 import { Select, FormInstance } from 'src/components';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
@@ -85,7 +86,13 @@ export function ColumnSelect({
     }
     if (datasetId != null) {
       cachedSupersetGet({
-        endpoint: `/api/v1/dataset/${datasetId}`,
+        endpoint: `/api/v1/dataset/${datasetId}?q=${rison.encode({
+          columns: [
+            'columns.column_name',
+            'columns.is_dttm',
+            'columns.type_generic',
+          ],
+        })}`,
       }).then(
         ({ json: { result } }) => {
           const lookupValue = Array.isArray(value) ? value : [value];

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -664,7 +664,7 @@ const FiltersConfigForm = (
             'columns.type',
             'columns.verbose_name',
             'database.id',
-            'database_name',
+            'database.database_name',
             'datasource_type',
             'filter_select_enabled',
             'id',

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -45,6 +45,7 @@ import React, {
   useMemo,
   useState,
 } from 'react';
+import rison from 'rison';
 import { PluginFilterSelectCustomizeProps } from 'src/filters/components/Select/types';
 import { useSelector } from 'react-redux';
 import { getChartDataRequest } from 'src/components/Chart/chartAction';
@@ -654,7 +655,28 @@ const FiltersConfigForm = (
   useEffect(() => {
     if (datasetId) {
       cachedSupersetGet({
-        endpoint: `/api/v1/dataset/${datasetId}`,
+        endpoint: `/api/v1/dataset/${datasetId}?q=${rison.encode({
+          columns: [
+            'columns.column_name',
+            'columns.expression',
+            'columns.filterable',
+            'columns.is_dttm',
+            'columns.type',
+            'columns.verbose_name',
+            'database.id',
+            'database_name',
+            'datasource_type',
+            'filter_select_enabled',
+            'id',
+            'is_sqllab_view',
+            'main_dttm_col',
+            'metrics.metric_name',
+            'metrics.verbose_name',
+            'schema',
+            'sql',
+            'table_name',
+          ],
+        })}`,
       })
         .then((response: JsonResponse) => {
           setMetrics(response.json?.result?.metrics);


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR partially addresses recommendation #&#x2060;1 in https://github.com/apache/superset/issues/14383 by requesting—via the FAB API—only the required fields (columns) from the `/api/v1/dataset/{pk}` RESTful GET endpoint.

Fetching the entirety of dataset (especially a very large datasets) can be rather expensive which. https://github.com/apache/superset/pull/22413 made significant performance improvements (reducing the response time from > 300 seconds to ~ 5 seconds) however later https://github.com/apache/superset/pull/23113 was introduced to address some performance tradeoffs (in other contexts) by disabling eager loading (increasing the response time from ~ 5 seconds to ~ 30 seconds). The bulk of this increased cost was from the repeated lazy loading of the back referenced table i.e., `self.table`, for every dataset column (even though this is always the same table; possibly a SQLAlchemy quirk) for a subset of the `TableColumn` fields including the advanced data type.

This PR updates—in the context of the native filters modal—the `/api/v1/dataset/{pk}` requests to fetch only the subset of columns required in the response. This helps to ensure the we're:

1. Not building overly complex SQLAlchemy queries on the backend.
2. Reducing the response payload.

For the dataset in question said change reduced the response time from ~ 30 seconds to ~ 3 seconds which significantly improves the UX when interfacing with the modal. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: https://github.com/apache/superset/issues/14383
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
