### PR TITLE
fix(native-filters): Caching scope

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
@@ -576,7 +576,7 @@ describe('Native filters', () => {
         },
       );
       saveNativeFilterSettings([SAMPLE_CHART]);
-      enterNativeFilterEditModal();
+      enterNativeFilterEditModal(false);
       cy.get(nativeFilters.modal.tabsList.removeTab)
         .should('be.visible')
         .first()
@@ -812,7 +812,7 @@ describe('Native filters', () => {
         force: true,
       });
       cancelNativeFilterSettings();
-      enterNativeFilterEditModal();
+      enterNativeFilterEditModal(false);
       cy.get(nativeFilters.filtersList.removeIcon).first().click();
       cy.contains('You have removed this filter.').should('be.visible');
     });
@@ -855,7 +855,7 @@ describe('Native filters', () => {
         .contains(testItems.filterDefaultValue)
         .should('be.visible');
       validateFilterNameOnDashboard(testItems.topTenChart.filterColumn);
-      enterNativeFilterEditModal();
+      enterNativeFilterEditModal(false);
       deleteNativeFilter();
       saveNativeFilterSettings([SAMPLE_CHART]);
       cy.get(dataTestChartName(testItems.topTenChart.name)).within(() => {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ColumnSelect.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ColumnSelect.tsx
@@ -17,14 +17,13 @@
  * under the License.
  */
 import React, { useCallback, useState, useMemo, useEffect } from 'react';
-import { Column, ensureIsArray, SupersetClient, t } from '@superset-ui/core';
+import { Column, ensureIsArray, t } from '@superset-ui/core';
 import { useChangeEffect } from 'src/hooks/useChangeEffect';
 import { Select, FormInstance } from 'src/components';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
-import { cacheWrapper } from 'src/utils/cacheWrapper';
 import { NativeFiltersForm } from '../types';
-import { doesColumnMatchFilterType } from './utils';
+import { cachedSupersetGet, doesColumnMatchFilterType } from './utils';
 
 interface ColumnSelectProps {
   allowClear?: boolean;
@@ -37,14 +36,6 @@ interface ColumnSelectProps {
   onChange?: (value: string) => void;
   mode?: 'multiple';
 }
-
-const localCache = new Map<string, any>();
-
-const cachedSupersetGet = cacheWrapper(
-  SupersetClient.get,
-  localCache,
-  ({ endpoint }) => endpoint || '',
-);
 
 /** Special purpose AsyncSelect that selects a column from a dataset */
 // eslint-disable-next-line import/prefer-default-export

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/DatasetSelect.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/DatasetSelect.tsx
@@ -18,22 +18,13 @@
  */
 import React, { useCallback, useMemo } from 'react';
 import rison from 'rison';
-import { t, SupersetClient } from '@superset-ui/core';
+import { t } from '@superset-ui/core';
 import { AsyncSelect } from 'src/components';
-import { cacheWrapper } from 'src/utils/cacheWrapper';
 import {
   ClientErrorObject,
   getClientErrorObject,
 } from 'src/utils/getClientErrorObject';
-import { datasetToSelectOption } from './utils';
-
-const localCache = new Map<string, any>();
-
-const cachedSupersetGet = cacheWrapper(
-  SupersetClient.get,
-  localCache,
-  ({ endpoint }) => endpoint || '',
-);
+import { cachedSupersetGet, datasetToSelectOption } from './utils';
 
 interface DatasetSelectProps {
   onChange: (value: { label: string; value: number }) => void;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -34,7 +34,6 @@ import {
   NativeFilterType,
   styled,
   SupersetApiError,
-  SupersetClient,
   t,
 } from '@superset-ui/core';
 import { isEqual } from 'lodash';
@@ -70,7 +69,6 @@ import DateFilterControl from 'src/explore/components/controls/DateFilterControl
 import AdhocFilterControl from 'src/explore/components/controls/FilterControl/AdhocFilterControl';
 import { FeatureFlag, isFeatureEnabled } from 'src/featureFlags';
 import { waitForAsyncData } from 'src/middleware/asyncEvent';
-import { cacheWrapper } from 'src/utils/cacheWrapper';
 import { ClientErrorObject } from 'src/utils/getClientErrorObject';
 import { SingleValueType } from 'src/filters/components/Range/SingleValueType';
 import {
@@ -91,6 +89,7 @@ import getControlItemsMap from './getControlItemsMap';
 import RemovedFilter from './RemovedFilter';
 import { useBackendFormUpdate, useDefaultValue } from './state';
 import {
+  cachedSupersetGet,
   FILTER_SUPPORTED_TYPES,
   hasTemporalColumns,
   mostUsedDataset,
@@ -319,14 +318,6 @@ const FILTER_TYPE_NAME_MAPPING = {
   [t('Time grain')]: t('Time grain'),
   [t('Group By')]: t('Group by'),
 };
-
-const localCache = new Map<string, any>();
-
-const cachedSupersetGet = cacheWrapper(
-  SupersetClient.get,
-  localCache,
-  ({ endpoint }) => endpoint || '',
-);
 
 /**
  * The configuration form for a specific filter.

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/utils.ts
@@ -20,8 +20,14 @@ import { flatMapDeep } from 'lodash';
 import { FormInstance } from 'src/components';
 import React from 'react';
 import { CustomControlItem, Dataset } from '@superset-ui/chart-controls';
-import { Column, ensureIsArray, GenericDataType } from '@superset-ui/core';
+import {
+  Column,
+  ensureIsArray,
+  GenericDataType,
+  SupersetClient,
+} from '@superset-ui/core';
 import { DatasourcesState, ChartsState } from 'src/dashboard/types';
+import { cacheWrapper } from 'src/utils/cacheWrapper';
 
 const FILTERS_FIELD_NAME = 'filters';
 
@@ -130,3 +136,11 @@ export const mostUsedDataset = (
 
   return datasets[mostUsedDataset]?.id;
 };
+
+const localCache = new Map<string, any>();
+
+export const cachedSupersetGet = cacheWrapper(
+  SupersetClient.get,
+  localCache,
+  ({ endpoint }) => endpoint || '',
+);


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR partially addresses recommendation #&#x2060;1 in https://github.com/apache/superset/issues/14383.

I noticed that the the native filter modal was calling the RESTful GET `/api/v1/dataset/{pk}` endpoint twice (without parameters): once when it needed the columns with a dataset and once for when it required the metrics et al.

Though these calls were in theory where cached (using a local cache) via the `cachedSupersetGet` method, the local cache was defined multiple times (on a per file basis) rather than once for the entire modal. 

The TL;DR is local caches are great, so long as they're not too local. The fix is merely to define the native filter modal caching mechanism once so it can be shared by the various components.

I guess a broader question is whether rather than using a local cache whether should be caching on the server and using a 304 status code.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE

When opening the modal there are two calls to the GET `/api/v1/dataset/20` endpoint. 

<img width="1321" alt="Screenshot 2023-03-09 at 6 48 34 AM" src="https://user-images.githubusercontent.com/4567245/223800530-11cb2194-b47c-4a1b-8313-07d43a43d07e.png">

#### AFTER

When opening the modal there is one call to the GET `/api/v1/dataset/20` endpoint.

<img width="1357" alt="Screenshot 2023-03-09 at 7 44 04 AM" src="https://user-images.githubusercontent.com/4567245/223806099-976389c5-d529-425f-bc0c-1870fe0d66fe.png">

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
