### PR TITLE
docs: add lost _filters param docs

### DIFF
--- a/docs/docs/installation/sql-templating.mdx
+++ b/docs/docs/installation/sql-templating.mdx
@@ -66,7 +66,7 @@ JINJA_CONTEXT_ADDONS = {
 }
 ```
 
-Default values for jinja templates can be specified via ``Parameters`` menu in the SQL Lab user interface.
+Default values for jinja templates can be specified via `Parameters` menu in the SQL Lab user interface.
 In the UI you can assign a set of parameters as JSON
 
 ```json
@@ -74,7 +74,7 @@ In the UI you can assign a set of parameters as JSON
   "my_table": "foo"
 }
 ```
-The parameters become available in your SQL (example:SELECT * FROM {{ my_table }} ) by using Jinja templating syntax.
+The parameters become available in your SQL (example: `SELECT * FROM {{ my_table }}` ) by using Jinja templating syntax.
 SQL Lab template parameters are stored with the dataset as TEMPLATE PARAMETERS.
 
 There is a special ``_filters`` parameter which can be used to test filters used in the jinja template.

--- a/docs/docs/installation/sql-templating.mdx
+++ b/docs/docs/installation/sql-templating.mdx
@@ -75,7 +75,7 @@ In the UI you can assign a set of parameters as JSON
 }
 ```
 The parameters become available in your SQL (example: `SELECT * FROM {{ my_table }}` ) by using Jinja templating syntax.
-SQL Lab template parameters are stored with the dataset as TEMPLATE PARAMETERS.
+SQL Lab template parameters are stored with the dataset as `TEMPLATE PARAMETERS`.
 
 There is a special ``_filters`` parameter which can be used to test filters used in the jinja template.
 
@@ -211,7 +211,7 @@ Here's a concrete example:
 
 - You write the following query in SQL Lab:
 
-  ```
+  ```sql
   SELECT count(*)
   FROM ORDERS
   WHERE country_code = '{{ url_param('countrycode') }}'
@@ -222,7 +222,7 @@ Here's a concrete example:
   and your coworker in the USA the following SQL Lab URL `www.example.com/superset/sqllab?countrycode=US`
 - For your coworker in Spain, the SQL Lab query will be rendered as:
 
-  ```
+  ```sql
   SELECT count(*)
   FROM ORDERS
   WHERE country_code = 'ES'
@@ -230,7 +230,7 @@ Here's a concrete example:
 
 - For your coworker in the USA, the SQL Lab query will be rendered as:
 
-  ```
+  ```sql
   SELECT count(*)
   FROM ORDERS
   WHERE country_code = 'US'
@@ -259,7 +259,7 @@ This is useful if:
 
 Here's a concrete example:
 
-```
+```sql
 SELECT action, count(*) as times
 FROM logs
 WHERE

--- a/docs/docs/installation/sql-templating.mdx
+++ b/docs/docs/installation/sql-templating.mdx
@@ -30,7 +30,9 @@ made available in the Jinja context:
 For example, to add a time range to a virtual dataset, you can write the following:
 
 ```sql
-SELECT * from tbl where dttm_col > '{{ from_dttm }}' and dttm_col < '{{ to_dttm }}'
+SELECT *
+FROM tbl
+WHERE dttm_col > '{{ from_dttm }}' and dttm_col < '{{ to_dttm }}'
 ```
 
 You can also use [Jinja's logic](https://jinja.palletsprojects.com/en/2.11.x/templates/#tests)
@@ -63,6 +65,41 @@ JINJA_CONTEXT_ADDONS = {
     'my_crazy_macro': lambda x: x*2,
 }
 ```
+
+Default values for jinja templates can be specified via ``Parameters`` menu in the SQL Lab user interface.
+In the UI you can assign a set of parameters as JSON
+
+```json
+{
+  "my_table": "foo"
+}
+```
+The parameters become available in your SQL (example:SELECT * FROM {{ my_table }} ) by using Jinja templating syntax.
+SQL Lab template parameters are stored with the dataset as TEMPLATE PARAMETERS.
+
+There is a special ``_filters`` parameter which can be used to test filters used in the jinja template.
+
+```json
+{
+  "_filters": [
+    {
+      "col": "action_type",
+      "op": "IN",
+      "val": ["sell", "buy"]
+    }
+  ]
+}
+```
+
+```sql
+SELECT action, count(*) as times
+FROM logs
+WHERE action in {{ filter_values('action_type'))|where_in }}
+GROUP BY action
+```
+
+Note ``_filters`` is not stored with the dataset. It's only used within the SQL Lab UI.
+
 
 Besides default Jinja templating, SQL lab also supports self-defined template processor by setting
 the `CUSTOM_TEMPLATE_PROCESSORS` in your superset configuration. The values in this dictionary


### PR DESCRIPTION
### SUMMARY
I went looking around for docs that I remembered that had added about the "filter simulator" feature that @cccs-jc had added in #14765 but couldn't find it. It turns out it had been lost during the Docusaurus migration. This re-adds the missing section and does the following additonal changes:
- port the example to use the new `where_in` macro
- reformat some old code blocks to make them more consistent

### SCREENSHOT
![image](https://user-images.githubusercontent.com/33317356/224021333-55f820ae-06b0-4afe-96b1-5bd8035d6f26.png)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
