### PR TITLE
chore: bump docusaurus to latest stable

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -18,11 +18,11 @@
   "dependencies": {
     "@algolia/client-search": "^4.13.0",
     "@ant-design/icons": "^4.7.0",
-    "@docsearch/react": "^3.0.0",
-    "@docusaurus/core": "^2.0.0-beta.17",
-    "@docusaurus/plugin-client-redirects": "^2.0.0-beta.17",
-    "@docusaurus/plugin-google-gtag": "^2.0.0-beta.18",
-    "@docusaurus/preset-classic": "^2.0.0-beta.17",
+    "@docsearch/react": "^3.3.3",
+    "@docusaurus/core": "^2.3.1",
+    "@docusaurus/plugin-client-redirects": "^2.3.1",
+    "@docusaurus/plugin-google-gtag": "^2.3.1",
+    "@docusaurus/preset-classic": "^2.3.1",
     "@emotion/core": "^10.1.1",
     "@emotion/styled": "^10.0.27",
     "@mdx-js/react": "^1.6.22",
@@ -45,8 +45,8 @@
     "url-loader": "^4.1.1"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^2.0.0-beta.17",
-    "@tsconfig/docusaurus": "^1.0.4",
+    "@docusaurus/module-type-aliases": "^2.3.1",
+    "@tsconfig/docusaurus": "^1.0.6",
     "@types/react": "^17.0.42",
     "typescript": "^4.3.5",
     "webpack": "^5.61.0"


### PR DESCRIPTION
### SUMMARY
While adding some docs I noticed that Docusaurus has finally released a stable release for the 2 version. This bumps to the latest 2.3.1. I clicked around as much as I could and wasn't able to see any breakages anywhere, so it should be ok.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Running the docs locally:
![image](https://user-images.githubusercontent.com/33317356/224024483-dea681b2-a640-413d-ae0a-239db92dd75f.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
