### PR TITLE
feat(native-filters): allow cascading from time and numeric filters

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ColumnSelect.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ColumnSelect.tsx
@@ -24,7 +24,6 @@ import { useToasts } from 'src/components/MessageToasts/withToasts';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
 import { cacheWrapper } from 'src/utils/cacheWrapper';
 import { NativeFiltersForm } from '../types';
-import { doesColumnMatchFilterType } from './utils';
 
 interface ColumnSelectProps {
   allowClear?: boolean;
@@ -84,10 +83,7 @@ export function ColumnSelect({
   );
 
   useEffect(() => {
-    if (
-      currentColumn &&
-      !doesColumnMatchFilterType(currentFilterType, currentColumn)
-    ) {
+    if (currentColumn && !filterValues(currentColumn)) {
       resetColumnField();
     }
   }, [currentColumn, currentFilterType, resetColumnField]);

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/DependencyList.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/DependencyList.tsx
@@ -23,7 +23,7 @@ import { Select } from 'src/components';
 import { CollapsibleControl } from './CollapsibleControl';
 
 interface DependencyListProps {
-  availableFilters: { label: string; value: string }[];
+  availableFilters: { label: string; value: string; type: string }[];
   dependencies: string[];
   onDependenciesChange: (dependencies: string[]) => void;
   getDependencySuggestion: () => string;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/DependencyList.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/DependencyList.tsx
@@ -17,26 +17,17 @@
  * under the License.
  */
 import React, { useState } from 'react';
-import { Column, Filter, styled, t } from '@superset-ui/core';
-import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
+import { styled, t } from '@superset-ui/core';
 import Icons from 'src/components/Icons';
 import { Select } from 'src/components';
 import { CollapsibleControl } from './CollapsibleControl';
-import { ColumnSelect } from './ColumnSelect';
-import { setNativeFilterFieldValues } from './utils';
-import { StyledLabel, StyledRowFormItem } from './FiltersConfigForm';
 
 interface DependencyListProps {
   availableFilters: { label: string; value: string }[];
   dependencies: string[];
-  hasTimeDependency: boolean;
   onDependenciesChange: (dependencies: string[]) => void;
   getDependencySuggestion: () => string;
-  filterId: string;
-  filterToEdit?: Filter;
-  forceUpdate: () => void;
-  datasetId: any;
-  form: any;
+  children?: JSX.Element;
 }
 
 const MainPanel = styled.div`
@@ -184,14 +175,9 @@ const List = ({
 const DependencyList = ({
   availableFilters = [],
   dependencies = [],
-  hasTimeDependency,
   onDependenciesChange,
   getDependencySuggestion,
-  filterId,
-  filterToEdit,
-  form,
-  forceUpdate,
-  datasetId,
+  children,
 }: DependencyListProps) => {
   const hasAvailableFilters = availableFilters.length > 0;
   const hasDependencies = dependencies.length > 0;
@@ -203,7 +189,6 @@ const DependencyList = ({
     }
     onDependenciesChange(newDependencies);
   };
-  console.log(hasTimeDependency);
 
   return (
     <MainPanel>
@@ -221,46 +206,8 @@ const DependencyList = ({
           dependencies={dependencies}
           onDependenciesChange={onDependenciesChange}
           getDependencySuggestion={getDependencySuggestion}
-          hasTimeDependency={hasTimeDependency}
-          filterId={filterId}
-          filterToEdit={filterToEdit}
-          form={form}
-          forceUpdate={forceUpdate}
-          datasetId={datasetId}
         />
-        {hasTimeDependency && (
-          <StyledRowFormItem
-            name={['filters', filterId, 'granularity_sqla']}
-            label={
-              <>
-                <StyledLabel>{t('Time column')}</StyledLabel>&nbsp;
-                <InfoTooltipWithTrigger
-                  placement="top"
-                  tooltip={t(
-                    'Optional time column if time range should apply to another column than the default time column',
-                  )}
-                />
-              </>
-            }
-            initialValue={filterToEdit?.granularity_sqla}
-          >
-            <ColumnSelect
-              allowClear
-              form={form}
-              formField="granularity_sqla"
-              filterId={filterId}
-              filterValues={(column: Column) => !!column.is_dttm}
-              datasetId={datasetId}
-              onChange={column => {
-                // We need reset default value when when column changed
-                setNativeFilterFieldValues(form, filterId, {
-                  granularity_sqla: column,
-                });
-                forceUpdate();
-              }}
-            />
-          </StyledRowFormItem>
-        )}
+        {children}
       </CollapsibleControl>
     </MainPanel>
   );

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/DependencyList.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/DependencyList.tsx
@@ -23,7 +23,11 @@ import { Select } from 'src/components';
 import { CollapsibleControl } from './CollapsibleControl';
 
 interface DependencyListProps {
-  availableFilters: { label: string; value: string; type: string }[];
+  availableFilters: {
+    label: string;
+    value: string;
+    type: string | undefined;
+  }[];
   dependencies: string[];
   onDependenciesChange: (dependencies: string[]) => void;
   getDependencySuggestion: () => string;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -301,7 +301,7 @@ export interface FiltersConfigFormProps {
   form: FormInstance<NativeFiltersForm>;
   getAvailableFilters: (
     filterId: string,
-  ) => { label: string; value: string; type: string }[];
+  ) => { label: string; value: string; type: string | undefined }[];
   handleActiveFilterPanelChange: (activeFilterPanel: string | string[]) => void;
   activeFilterPanelKeys: string | string[];
   isActive: boolean;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -636,6 +636,10 @@ const FiltersConfigForm = (
   const hasTimeRange =
     formFilter?.time_range && formFilter.time_range !== 'No filter';
 
+  const hasTimeDependency = dependencies
+    .map(filterId => form.getFieldValue('filters')?.[filterId].filterType)
+    .some(filterType => filterType === 'filter_time');
+
   const hasAdhoc = formFilter?.adhoc_filters?.length > 0;
 
   const defaultToFirstItem = formFilter?.controlValues?.defaultToFirstItem;
@@ -881,6 +885,11 @@ const FiltersConfigForm = (
                   <DependencyList
                     availableFilters={availableFilters}
                     dependencies={dependencies}
+                    hasTimeDependency={hasTimeDependency}
+                    filterId={filterId}
+                    form={form}
+                    forceUpdate={forceUpdate}
+                    datasetId={datasetId}
                     onDependenciesChange={dependencies => {
                       setNativeFilterFieldValues(form, filterId, {
                         dependencies,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -299,7 +299,9 @@ export interface FiltersConfigFormProps {
   removedFilters: Record<string, FilterRemoval>;
   restoreFilter: (filterId: string) => void;
   form: FormInstance<NativeFiltersForm>;
-  getAvailableFilters: (filterId: string) => { label: string; value: string }[];
+  getAvailableFilters: (
+    filterId: string,
+  ) => { label: string; value: string; type: string }[];
   handleActiveFilterPanelChange: (activeFilterPanel: string | string[]) => void;
   activeFilterPanelKeys: string | string[];
   isActive: boolean;
@@ -636,10 +638,6 @@ const FiltersConfigForm = (
   const hasTimeRange =
     formFilter?.time_range && formFilter.time_range !== 'No filter';
 
-  const hasTimeDependency = dependencies
-    ?.map(filterId => form.getFieldValue('filters')?.[filterId]?.filterType)
-    .some(filterType => filterType === 'filter_time');
-
   const hasAdhoc = formFilter?.adhoc_filters?.length > 0;
 
   const defaultToFirstItem = formFilter?.controlValues?.defaultToFirstItem;
@@ -658,6 +656,9 @@ const FiltersConfigForm = (
 
   const availableFilters = getAvailableFilters(filterId);
   const hasAvailableFilters = availableFilters.length > 0;
+  const hasTimeDependency = availableFilters
+    .filter(filter => filter.type === 'filter_time')
+    .some(filter => dependencies.includes(filter.value));
 
   useEffect(() => {
     if (datasetId) {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
@@ -291,11 +291,12 @@ function FiltersConfigModal({
   const getAvailableFilters = useCallback(
     (filterId: string) =>
       filterIds
-        .filter(key => key !== filterId)
-        .filter(filterId => canBeUsedAsDependency(filterId))
-        .map(key => ({
-          label: getFilterTitle(key),
-          value: key,
+        .filter(id => id !== filterId)
+        .filter(id => canBeUsedAsDependency(id))
+        .map(id => ({
+          label: getFilterTitle(id),
+          value: id,
+          type: filterConfigMap[id]?.filterType,
         })),
     [canBeUsedAsDependency, filterIds, getFilterTitle],
   );

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
@@ -89,7 +89,11 @@ export interface FiltersConfigModalProps {
   onSave: (filterConfig: FilterConfiguration) => Promise<void>;
   onCancel: () => void;
 }
-export const ALLOW_DEPENDENCIES = ['filter_select'];
+export const ALLOW_DEPENDENCIES = [
+  'filter_range',
+  'filter_select',
+  'filter_time',
+];
 
 const DEFAULT_EMPTY_FILTERS: string[] = [];
 const DEFAULT_REMOVED_FILTERS: Record<string, FilterRemoval> = {};


### PR DESCRIPTION
### SUMMARY
Currently filter cascading is only supported on value filters. This adds cascading to time and numerical filters. Since the time column control is now shared between the dependent filter and pre-filter sections, it will render the time column picker in either section that is relevant.

### VIDEO
Demo of how time filters can now cascade:

https://user-images.githubusercontent.com/33317356/224089182-5e3ff108-e595-4787-ab7f-5cffb5ab416e.mp4

Value filter affecting numerical range:

https://user-images.githubusercontent.com/33317356/224090635-5fcf9189-631b-458e-bb9b-74881c0b16ff.mp4

### TESTING INSTRUCTIONS
1. Add a time filter and value filter
2. Make the value filter dependent on the time filter
3. Notice how changing the time filter affects the value filter

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
