### PR TITLE
feat(dashboard): expose the embedded dashboard configuration on the api

### DIFF
--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -187,6 +187,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         "roles.id",
         "roles.name",
         "is_managed_externally",
+        "embedded"
     ]
     if is_feature_enabled("TAGGING_SYSTEM"):
         list_columns += ["tags.id", "tags.name", "tags.type"]

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -153,6 +153,12 @@ class TagSchema(Schema):
     name = fields.String()
     type = fields.String()
 
+class EmbeddedDashboardResponseSchema(Schema):
+    uuid = fields.String()
+    allowed_domains = fields.List(fields.String())
+    dashboard_id = fields.String()
+    changed_on = fields.DateTime()
+    changed_by = fields.Nested(UserSchema)
 
 class DashboardGetResponseSchema(Schema):
     id = fields.Int()
@@ -176,6 +182,7 @@ class DashboardGetResponseSchema(Schema):
     tags = fields.Nested(TagSchema, many=True)
     changed_on_humanized = fields.String(data_key="changed_on_delta_humanized")
     is_managed_externally = fields.Boolean(allow_none=True, default=False)
+    embedded = fields.List(fields.Nested(EmbeddedDashboardResponseSchema))
 
 
 class DatabaseSchema(Schema):
@@ -322,10 +329,3 @@ class ImportV1DashboardSchema(Schema):
 class EmbeddedDashboardConfigSchema(Schema):
     allowed_domains = fields.List(fields.String(), required=True)
 
-
-class EmbeddedDashboardResponseSchema(Schema):
-    uuid = fields.String()
-    allowed_domains = fields.List(fields.String())
-    dashboard_id = fields.String()
-    changed_on = fields.DateTime()
-    changed_by = fields.Nested(UserSchema)


### PR DESCRIPTION
### SUMMARY
Adds an embedded property to the existing dashboard API that returns the embedded configuration if it exists. This users can use the API with a single call to get a list of embeddable dashboards, whilst currently this would require an extra API request per dashboard.

### TESTING INSTRUCTIONS

Run the branch, set the `EMBEDDED_SUPERSET` to `True` and configure a dashboard as embeddable within the UI. Request the dashboard api from `/api/v1/dashboard`  and request the specific dashboard api from `/api/v1/dashboard/{id}`  and review the embedded configuration.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

If there are additional automated tests that need adding and/or if the embedded configuration on the API needs to be behind the same `EMBEDDED_SUPERSET` please let me know