### PR TITLE
fix(examples): Cleanup granularity_sqla column

### DIFF
--- a/superset/examples/configs/charts/Video_Game_Sales_Filter.yaml
+++ b/superset/examples/configs/charts/Video_Game_Sales_Filter.yaml
@@ -42,7 +42,7 @@ params:
     label: Publisher
     multiple: true
     searchAllOptions: false
-  granularity_sqla: Year
+  granularity_sqla: year
   queryFields: {}
   time_range: No filter
   url_params:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Somewhat similar to https://github.com/apache/superset/pull/23260, the `granularity_sqla` field should reference the `year` column rather than `Year`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
