### PR TITLE
fix(trino): Disallow alias to source column

### DIFF
--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -46,6 +46,7 @@ logger = logging.getLogger(__name__)
 class TrinoEngineSpec(PrestoBaseEngineSpec):
     engine = "trino"
     engine_name = "Trino"
+    allows_alias_to_source_column = False
 
     @classmethod
     def extra_table_metadata(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

The Presto connector has `allows_alias_to_source_column = False` which was not replicated in the Trino connector. This is required to resolve issues when the same column name is used in both the inputs and outputs, i.e., 

```sql
SELECT
    foo
FROM 
    ...
GROUP BY 
    foo
ORDER BY
    MAX(foo) 
```

as it isn't evident which `foo` the `MAX(foo)` is referring to. This results in the Trino error, 

```
Invalid reference to output projection attribute from ORDER BY aggregation
``` 

### TESTING INSTRUCTIONS

CI and tested locally.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
