### PR TITLE
fix(dashboard): deepmerge htmlSchemaOverrides

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown.tsx
@@ -20,13 +20,22 @@ import React, { useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import rehypeRaw from 'rehype-raw';
-import { merge } from 'lodash';
+import { mergeWith, isArray } from 'lodash';
 import { FeatureFlag, isFeatureEnabled } from '../utils';
 
 interface SafeMarkdownProps {
   source: string;
   htmlSanitization?: boolean;
   htmlSchemaOverrides?: typeof defaultSchema;
+}
+
+export function getOverrideHtmlSchema(
+  originalSchema: typeof defaultSchema,
+  htmlSchemaOverrides: SafeMarkdownProps['htmlSchemaOverrides'],
+) {
+  return mergeWith(originalSchema, htmlSchemaOverrides, (objValue, srcValue) =>
+    isArray(objValue) ? objValue.concat(srcValue) : undefined,
+  );
 }
 
 function SafeMarkdown({
@@ -42,7 +51,10 @@ function SafeMarkdown({
     if (displayHtml && !escapeHtml) {
       rehypePlugins.push(rehypeRaw);
       if (htmlSanitization) {
-        const schema = merge(defaultSchema, htmlSchemaOverrides);
+        const schema = getOverrideHtmlSchema(
+          defaultSchema,
+          htmlSchemaOverrides,
+        );
         rehypePlugins.push([rehypeSanitize, schema]);
       }
     }

--- a/superset-frontend/packages/superset-ui-core/test/components/SafeMarkdown.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/components/SafeMarkdown.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { getOverrideHtmlSchema } from '../../src/components/SafeMarkdown';
+
+describe('getOverrideHtmlSchema', () => {
+  it('should append the override items', () => {
+    const original = {
+      attributes: {
+        '*': ['size'],
+      },
+      clobberPrefix: 'original-prefix',
+      tagNames: ['h1', 'h2', 'h3'],
+    };
+    const result = getOverrideHtmlSchema(original, {
+      attributes: { '*': ['src'], h1: ['style'] },
+      clobberPrefix: 'custom-prefix',
+      tagNames: ['iframe'],
+    });
+    expect(result.clobberPrefix).toEqual('custom-prefix');
+    expect(result.attributes).toEqual({ '*': ['size', 'src'], h1: ['style'] });
+    expect(result.tagNames).toEqual(['h1', 'h2', 'h3', 'iframe']);
+  });
+});


### PR DESCRIPTION
### SUMMARY
Hotfix for #21895

The existing `merge(defaultSchema, htmlSchemaOverrides)` replaces the array item rather than appending, so override item can pollute the default schema configuration.

For example:

```
const htmlSchemaOverrides = {
   tagNames: ['iframe'],
}
- with `merge(defaultSchema, htmlSchemaOverrides)
==>  ['iframe', 'h2', 'h3', 'h4', ...]

- with this hotfix

==>  ['h1', 'h2', 'h3', 'h4', ..., 'iframe']
```  

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS
- Add custom `tagNames` items in `HTML_SANITIZATION_SCHEMA_EXTENSIONS` and then create markdown h1

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @etr2460 @michael-s-molina @ktmud 