### PR TITLE
fix: revert back to use security manager authz for dashboard when get by uuid

### DIFF
--- a/superset/dashboards/dao.py
+++ b/superset/dashboards/dao.py
@@ -55,9 +55,9 @@ class DashboardDAO(BaseDAO):
                 .outerjoin(Dashboard.roles)
             )
             # Apply dashboard base filters
-            query = cls.base_filter(
-                "id", SQLAInterface(Dashboard, db.session)
-            ).apply(query, None)
+            query = cls.base_filter("id", SQLAInterface(Dashboard, db.session)).apply(
+                query, None
+            )
             dashboard = query.one_or_none()
         except ValueError:
             # if it's slug or uuid, which is more specific, just get it

--- a/superset/dashboards/filters.py
+++ b/superset/dashboards/filters.py
@@ -14,8 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import uuid
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 from flask import g
 from flask_appbuilder.security.sqla.models import Role

--- a/superset/dashboards/filters.py
+++ b/superset/dashboards/filters.py
@@ -14,7 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Any, Optional
+import uuid
+from typing import Any, Optional, Union
 
 from flask import g
 from flask_appbuilder.security.sqla.models import Role
@@ -25,7 +26,7 @@ from sqlalchemy.orm.query import Query
 from superset import db, is_feature_enabled, security_manager
 from superset.connectors.sqla.models import SqlaTable
 from superset.models.core import Database, FavStar
-from superset.models.dashboard import Dashboard, is_uuid
+from superset.models.dashboard import Dashboard
 from superset.models.embedded_dashboard import EmbeddedDashboard
 from superset.models.slice import Slice
 from superset.security.guest_token import GuestTokenResourceType, GuestUser
@@ -86,6 +87,14 @@ class DashboardTagFilter(BaseTagFilter):  # pylint: disable=too-few-public-metho
     arg_name = "dashboard_tags"
     class_name = "Dashboard"
     model = Dashboard
+
+
+def is_uuid(value: Union[str, int]) -> bool:
+    try:
+        uuid.UUID(str(value))
+        return True
+    except ValueError:
+        return False
 
 
 class DashboardAccessFilter(BaseFilter):  # pylint: disable=too-few-public-methods

--- a/superset/dashboards/filters.py
+++ b/superset/dashboards/filters.py
@@ -26,7 +26,7 @@ from sqlalchemy.orm.query import Query
 from superset import db, is_feature_enabled, security_manager
 from superset.connectors.sqla.models import SqlaTable
 from superset.models.core import Database, FavStar
-from superset.models.dashboard import Dashboard
+from superset.models.dashboard import Dashboard, is_uuid
 from superset.models.embedded_dashboard import EmbeddedDashboard
 from superset.models.slice import Slice
 from superset.security.guest_token import GuestTokenResourceType, GuestUser
@@ -87,14 +87,6 @@ class DashboardTagFilter(BaseTagFilter):  # pylint: disable=too-few-public-metho
     arg_name = "dashboard_tags"
     class_name = "Dashboard"
     model = Dashboard
-
-
-def is_uuid(value: Union[str, int]) -> bool:
-    try:
-        uuid.UUID(str(value))
-        return True
-    except ValueError:
-        return False
 
 
 class DashboardAccessFilter(BaseFilter):  # pylint: disable=too-few-public-methods

--- a/superset/dashboards/filters.py
+++ b/superset/dashboards/filters.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import uuid
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 from flask import g
 from flask_appbuilder.security.sqla.models import Role
@@ -26,7 +26,7 @@ from sqlalchemy.orm.query import Query
 from superset import db, is_feature_enabled, security_manager
 from superset.connectors.sqla.models import SqlaTable
 from superset.models.core import Database, FavStar
-from superset.models.dashboard import Dashboard
+from superset.models.dashboard import Dashboard, is_uuid
 from superset.models.embedded_dashboard import EmbeddedDashboard
 from superset.models.slice import Slice
 from superset.security.guest_token import GuestTokenResourceType, GuestUser
@@ -87,14 +87,6 @@ class DashboardTagFilter(BaseTagFilter):  # pylint: disable=too-few-public-metho
     arg_name = "dashboard_tags"
     class_name = "Dashboard"
     model = Dashboard
-
-
-def is_uuid(value: Union[str, int]) -> bool:
-    try:
-        uuid.UUID(str(value))
-        return True
-    except ValueError:
-        return False
 
 
 class DashboardAccessFilter(BaseFilter):  # pylint: disable=too-few-public-methods

--- a/superset/dashboards/filters.py
+++ b/superset/dashboards/filters.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import uuid
 from typing import Any, Optional
 
 from flask import g

--- a/superset/dashboards/permalink/commands/create.py
+++ b/superset/dashboards/permalink/commands/create.py
@@ -48,9 +48,9 @@ class CreateDashboardPermalinkCommand(BaseDashboardPermalinkCommand):
     def run(self) -> str:
         self.validate()
         try:
-            DashboardDAO.get_by_id_or_slug(self.dashboard_id)
+            dashboard = DashboardDAO.get_by_id_or_slug(self.dashboard_id)
             value = {
-                "dashboardId": self.dashboard_id,
+                "dashboardId": str(dashboard.uuid),
                 "state": self.state,
             }
             user_id = get_user_id()

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -455,7 +455,7 @@ def id_or_slug_filter(id_or_slug: Union[int, str]) -> BinaryExpression:
         return Dashboard.id == id_or_slug
     if id_or_slug.isdigit():
         return Dashboard.id == int(id_or_slug)
-    return Dashboard.slug == id_or_slug
+    return Dashboard.slug == id_or_slug or Dashboard.uuid == id_or_slug
 
 
 OnDashboardChange = Callable[[Mapper, Connection, Dashboard], Any]

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -470,10 +470,9 @@ def is_int(value: Union[str, int]) -> bool:
 def id_or_slug_filter(id_or_slug: Union[int, str]) -> BinaryExpression:
     if is_int(id_or_slug):
         return Dashboard.id == int(id_or_slug)
-    elif is_uuid(id_or_slug):
+    if is_uuid(id_or_slug):
         return Dashboard.uuid == uuid.UUID(str(id_or_slug))
-    else:
-        return Dashboard.slug == id_or_slug
+    return Dashboard.slug == id_or_slug
 
 
 OnDashboardChange = Callable[[Mapper, Connection, Dashboard], Any]

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import logging
+import uuid
 from collections import defaultdict
 from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union
@@ -450,12 +451,29 @@ class Dashboard(Model, AuditMixinNullable, ImportExportMixin):
         return qry.one_or_none()
 
 
+def is_uuid(value: Union[str, int]) -> bool:
+    try:
+        uuid.UUID(str(value))
+        return True
+    except ValueError:
+        return False
+
+
+def is_int(value: Union[str, int]) -> bool:
+    try:
+        int(value)
+        return True
+    except ValueError:
+        return False
+
+
 def id_or_slug_filter(id_or_slug: Union[int, str]) -> BinaryExpression:
-    if isinstance(id_or_slug, int):
-        return Dashboard.id == id_or_slug
-    if id_or_slug.isdigit():
+    if is_int(id_or_slug):
         return Dashboard.id == int(id_or_slug)
-    return Dashboard.slug == id_or_slug
+    elif is_uuid(id_or_slug):
+        return Dashboard.uuid == uuid.UUID(str(id_or_slug))
+    else:
+        return Dashboard.slug == id_or_slug
 
 
 OnDashboardChange = Callable[[Mapper, Connection, Dashboard], Any]

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -451,11 +451,10 @@ class Dashboard(Model, AuditMixinNullable, ImportExportMixin):
 
 
 def id_or_slug_filter(id_or_slug: Union[int, str]) -> BinaryExpression:
-    if isinstance(id_or_slug, int):
-        return Dashboard.id == id_or_slug
-    if id_or_slug.isdigit():
+    try:
         return Dashboard.id == int(id_or_slug)
-    return Dashboard.slug == id_or_slug or Dashboard.uuid == id_or_slug
+    except ValueError:
+        return Dashboard.slug == id_or_slug or Dashboard.uuid == id_or_slug
 
 
 OnDashboardChange = Callable[[Mapper, Connection, Dashboard], Any]

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -466,8 +466,7 @@ def id_or_slug_filter(id_or_slug: Union[int, str]) -> BinaryExpression:
     except ValueError:
         if not is_uuid(id_or_slug):
             return Dashboard.slug == id_or_slug
-        else:
-            return sqla.or_(Dashboard.slug == id_or_slug, Dashboard.uuid == id_or_slug)
+        return sqla.or_(Dashboard.slug == id_or_slug, Dashboard.uuid == id_or_slug)
 
 
 OnDashboardChange = Callable[[Mapper, Connection, Dashboard], Any]

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -451,22 +451,12 @@ class Dashboard(Model, AuditMixinNullable, ImportExportMixin):
         return qry.one_or_none()
 
 
-def is_uuid(value: Union[str, int]) -> bool:
-    try:
-        uuid.UUID(str(value))
-        return True
-    except ValueError:
-        return False
-
-
 def id_or_slug_filter(id_or_slug: Union[int, str]) -> BinaryExpression:
-    # create a dashboard filter that checks if id or slug or uuid matches
-    try:
+    if isinstance(id_or_slug, int):
+        return Dashboard.id == id_or_slug
+    if id_or_slug.isdigit():
         return Dashboard.id == int(id_or_slug)
-    except ValueError:
-        if not is_uuid(id_or_slug):
-            return Dashboard.slug == id_or_slug
-        return sqla.or_(Dashboard.slug == id_or_slug, Dashboard.uuid == id_or_slug)
+    return Dashboard.slug == id_or_slug
 
 
 OnDashboardChange = Callable[[Mapper, Connection, Dashboard], Any]

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import json
 import logging
-import uuid
 from collections import defaultdict
 from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -179,15 +179,19 @@ class BaseReportState:
         dashboard_state = self._report_schedule.extra.get("dashboard")
         if dashboard_state:
             permalink_key = CreateDashboardPermalinkCommand(
-                dashboard_id=str(self._report_schedule.dashboard_id),
+                dashboard_id=str(self._report_schedule.dashboard.uuid),
                 state=dashboard_state,
             ).run()
             return get_url_path("Superset.dashboard_permalink", key=permalink_key)
 
+        dashboard = self._report_schedule.dashboard
+        dashboard_id_or_slug = (
+            dashboard.uuid if dashboard and dashboard.uuid else dashboard.id
+        )
         return get_url_path(
             "Superset.dashboard",
             user_friendly=user_friendly,
-            dashboard_id_or_slug=self._report_schedule.dashboard_id,
+            dashboard_id_or_slug=dashboard_id_or_slug,
             force=force,
             **kwargs,
         )

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -505,6 +505,43 @@ class TestDashboardApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixi
         db.session.delete(dashboard)
         db.session.commit()
 
+    def test_get_draft_dashboard_without_roles_by_uuid(self):
+        """
+        Dashboard API: Test get draft dashboard without roles by uuid
+        """
+        admin = self.get_user("admin")
+        dashboard = self.insert_dashboard("title", "slug1", [admin.id])
+        assert not dashboard.published
+        assert dashboard.roles == []
+
+        self.login(username="gamma")
+        uri = f"api/v1/dashboard/{dashboard.uuid}"
+        rv = self.client.get(uri)
+        assert rv.status_code == 200
+        # rollback changes
+        db.session.delete(dashboard)
+        db.session.commit()
+
+    def test_cannot_get_draft_dashboard_with_roles_by_uuid(self):
+        """
+        Dashboard API: Test get dashboard by uuid
+        """
+        admin = self.get_user("admin")
+        admin_role = self.get_role("Admin")
+        dashboard = self.insert_dashboard(
+            "title", "slug1", [admin.id], roles=[admin_role.id]
+        )
+        assert not dashboard.published
+        assert dashboard.roles == [admin_role]
+
+        self.login(username="gamma")
+        uri = f"api/v1/dashboard/{dashboard.uuid}"
+        rv = self.client.get(uri)
+        assert rv.status_code == 403
+        # rollback changes
+        db.session.delete(dashboard)
+        db.session.commit()
+
     def test_get_dashboards_changed_on(self):
         """
         Dashboard API: Test get dashboards changed on

--- a/tests/integration_tests/dashboards/permalink/api_tests.py
+++ b/tests/integration_tests/dashboards/permalink/api_tests.py
@@ -107,7 +107,8 @@ def test_get(test_client, login_as_admin, dashboard_id: int, permalink_salt: str
     resp = test_client.get(f"api/v1/dashboard/permalink/{key}")
     assert resp.status_code == 200
     result = resp.json
-    assert result["dashboardId"] == str(dashboard_id)
+    dashboard_uuid = result["dashboardId"]
+    assert Dashboard.get(dashboard_uuid).id == dashboard_id
     assert result["state"] == STATE
     id_ = decode_permalink_id(key, permalink_salt)
     db.session.query(KeyValueEntry).filter_by(id=id_).delete()


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The [patch](https://github.com/apache/superset/pull/22358) breaks some folks functionality around report schedule for draft dashboard, permalink. This PR should:
1. bring back access check from security manager when getting dashboard by id_or_slug.
2. don't apply Dashboard base filter if it's getting by uuid.
3. dashboard create permalink should use the uuid. This allows whoever has permalink to be able to access dashboard after access check from security manager.
4. update report execution to use the dashboard uuid link rather than the int link.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
