### PR TITLE
fix(trino): normalize non-iso timestamps

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/time-format/index.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-format/index.ts
@@ -36,4 +36,6 @@ export { default as smartDateFormatter } from './formatters/smartDate';
 export { default as smartDateDetailedFormatter } from './formatters/smartDateDetailed';
 export { default as smartDateVerboseFormatter } from './formatters/smartDateVerbose';
 
+export { default as normalizeTimestamp } from './utils/normalizeTimestamp';
+
 export * from './types';

--- a/superset-frontend/packages/superset-ui-core/src/time-format/utils/normalizeTimestamp.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-format/utils/normalizeTimestamp.ts
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const TS_REGEX = /(\d{4}-\d{2}-\d{2})[\sT](\d{2}:\d{2}:\d{2}\.?\d*).*/;
+
+export default function normalizeTimestamp(value: string): string {
+  const match = value.match(TS_REGEX);
+  if (match) {
+    return `${match[1]}T${match[2]}Z`;
+  }
+  return value;
+}

--- a/superset-frontend/packages/superset-ui-core/test/time-format/utils/normalizeTimestamp.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-format/utils/normalizeTimestamp.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import normalizeTimestamp from '../../../src/time-format/utils/normalizeTimestamp';
+
+test('normalizeTimestamp should normalize typical timestamps', () => {
+  expect(normalizeTimestamp('2023-03-11 08:26:52.695 UTC')).toEqual(
+    '2023-03-11T08:26:52.695Z',
+  );
+  expect(normalizeTimestamp('2023-03-11 08:26:52.695 Europe/Helsinki')).toEqual(
+    '2023-03-11T08:26:52.695Z',
+  );
+  expect(normalizeTimestamp('2023-03-11T08:26:52.695 UTC')).toEqual(
+    '2023-03-11T08:26:52.695Z',
+  );
+  expect(normalizeTimestamp('2023-03-11T08:26:52.695')).toEqual(
+    '2023-03-11T08:26:52.695Z',
+  );
+  expect(normalizeTimestamp('2023-03-11 08:26:52')).toEqual(
+    '2023-03-11T08:26:52Z',
+  );
+});
+
+test('normalizeTimestamp should return unmatched timestamps as-is', () => {
+  expect(normalizeTimestamp('abcd')).toEqual('abcd');
+  expect(normalizeTimestamp('03/11/2023')).toEqual('03/11/2023');
+});

--- a/superset-frontend/plugins/plugin-chart-table/src/utils/DateWithFormatter.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/utils/DateWithFormatter.ts
@@ -16,9 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { DataRecordValue, TimeFormatFunction } from '@superset-ui/core';
-
-const REGEXP_TIMESTAMP_NO_TIMEZONE = /T(\d{2}:){2}\d{2}$/;
+import {
+  DataRecordValue,
+  normalizeTimestamp,
+  TimeFormatFunction,
+} from '@superset-ui/core';
 
 /**
  * Extended Date object with a custom formatter, and retains the original input
@@ -31,19 +33,12 @@ export default class DateWithFormatter extends Date {
 
   constructor(
     input: DataRecordValue,
-    {
-      formatter = String,
-      forceUTC = true,
-    }: { formatter?: TimeFormatFunction; forceUTC?: boolean } = {},
+    { formatter = String }: { formatter?: TimeFormatFunction } = {},
   ) {
     let value = input;
     // assuming timestamps without a timezone is in UTC time
-    if (
-      forceUTC &&
-      typeof value === 'string' &&
-      REGEXP_TIMESTAMP_NO_TIMEZONE.test(value)
-    ) {
-      value = `${value}Z`;
+    if (typeof value === 'string') {
+      value = normalizeTimestamp(value);
     }
 
     super(value as string);


### PR DESCRIPTION
### SUMMARY
When querying datasets with "TIMESTAMP WITH TIMEZONE" in Firefox or Safari, Table chart is unable to format the timestamp. This is due to the fact that Trino returns the value in string format that is not ISO-8601 compliant, which causes Firefox and Safari to fail to parse the value. This can be confirmed by trying to create a `Date` object in the browser debugging console with the timestamp value returned by Trino:

Chrome:
![image](https://user-images.githubusercontent.com/33317356/224633626-684b5423-ede9-4412-9980-3ee7d82ddda2.png)

Safari:
![image](https://user-images.githubusercontent.com/33317356/224639312-c7e1df7d-4e94-4908-acac-f02d406a395d.png)

Firefox:
![image](https://user-images.githubusercontent.com/33317356/224633729-61ff96a4-e598-4da7-8e15-d5b87cf13d41.png)

Notice how all three browsers are able to parse the value if the space is replaced with a "T" and the timezone is replaced with "Z" (Superset assumes all timestamps to be in "Zulu time" aka UTC timezone).

This PR ensures that "almost ISO-8601" timestamps are always normalized into proper ISO format, and any timezone info is converted into UTC. When/if we run into other funny timestamp formats we can add logic to handle them in this util to make sure they render correctly.

### AFTER
Now the timestamp with timezone displays correctly in Safari (notice the raw value returned by the query in the "Results" tab):
![image](https://user-images.githubusercontent.com/33317356/224632432-fa4ad26d-37fe-4c96-9be4-0194f75d77c2.png)

### BEFORE
Previously the timestamp would fail to render in Safari:
![image](https://user-images.githubusercontent.com/33317356/224633001-2b9382d4-51f5-484c-bb1f-02cd61ba08d3.png)


### TESTING INSTRUCTIONS
1. Query a dataset on Trino that returns "TIMESTAMP WITH TIMEZONE" without a timegrain
2. Notice how the format fails to render properly.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
