### PR TITLE
feat(embedded): Add 'urlParams' option to pass query parameters to embedded dashboard(for SQL templating)

### DIFF
--- a/superset-embedded-sdk/README.md
+++ b/superset-embedded-sdk/README.md
@@ -44,7 +44,11 @@ embedDashboard({
       hideTitle: true,
       filters: {
           expanded: true,
-      }
+      },
+      urlParams: { // General Case: If undefined, passes all query parameters on main page.
+          // ...
+          // Special Case: If specified, passes explicit query parameters only.
+      },
   },
 });
 ```

--- a/superset-embedded-sdk/src/index.ts
+++ b/superset-embedded-sdk/src/index.ts
@@ -42,6 +42,7 @@ export type UiConfigType = {
     visible?: boolean
     expanded?: boolean
   }
+  urlParams?: {[key: string]: any}
 }
 
 export type EmbedDashboardParams = {
@@ -116,6 +117,8 @@ export async function embedDashboard({
         + filterConfigKeys
           .map(key => DASHBOARD_UI_FILTER_CONFIG_URL_PARAM_KEY[key] + '=' + filterConfig[key]).join('&')
         : ""
+      let extraUrlParams = new URLSearchParams(dashboardUiConfig?.urlParams || window.location.search).toString()
+      if (!!extraUrlParams) extraUrlParams = "&" + extraUrlParams
 
       // set up the iframe's sandbox configuration
       iframe.sandbox.add("allow-same-origin"); // needed for postMessage to work
@@ -149,7 +152,7 @@ export async function embedDashboard({
         resolve(new Switchboard({ port: ourPort, name: 'superset-embedded-sdk', debug }));
       });
 
-      iframe.src = `${supersetDomain}/embedded/${id}${dashboardConfig}${filterConfigUrlParams}`;
+      iframe.src = `${supersetDomain}/embedded/${id}${dashboardConfig}${filterConfigUrlParams}${extraUrlParams}`;
       //@ts-ignore
       mountPoint.replaceChildren(iframe);
       log('placed the iframe')


### PR DESCRIPTION
### SUMMARY
Add 'urlParams' option to pass query parameters to embedded dashboard(for SQL templating)

There are 2 representative cases it can handle:
1. General Case: Passes all query parameters on main page. In this case, 'dashboardConfig' and 'filterConfigUrlParams' can be affected by query parameters on main page.
2. Special Case: If 'urlParams' specified on dashboardUiConfig option, passes explicit query parameters in 'urlParams' only. So 'dashboardConfig' and 'filterConfigUrlParams' cannot be affected by query parameters on main page, and it can restrict query parameters only necessary for Superset Dashboard. In addition, It can replace an existing embedded dashboard to a new one using updated query parameters - An embedded dashboard will be recreated when UI values change on parent page and they should be applied to the embedded dashboard.

My website provides datepicker UI component on parent page. If its value changes, Replace an embedded dashboard(used old value) to a new one(used new value). As far as I know, Destroying the old one and Creating a new one is the best. I tried refresh embedded dashboard by the message channel between the main page and iframe - it's complex

I'm using like the example below. 
```html
<script>
  var embedded_dashboard;
  
  var init = function () {
      embedded_dashboard && embedded_dashboard.unmount();  // Destroy existing dashboard
      
      // Replace with a new one
      supersetEmbeddedSdk.embedDashboard({
          // ...
          dashboardUiConfig: {
              urlParams: {
                  foo: 'new_val_1',
                  bar: 'new_val_2',
                  // ...
              },
          },
      })
          .then(switchboard => {
              embedded_dashboard = switchboard; 
          });
  }

  // call init() where need to be replaced.
</script>
```


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TESTING INSTRUCTIONS

### ADDITIONAL INFORMATION
