### PR TITLE
fix(dashboard): Cross filters with time shifted series

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -137,6 +137,7 @@ export default function transformProps(
     showValue,
     sliceId,
     timeGrainSqla,
+    timeCompare,
     stack,
     tooltipTimeFormat,
     tooltipSortByMetric,
@@ -158,8 +159,8 @@ export default function transformProps(
   const labelMap = Object.entries(label_map).reduce((acc, entry) => {
     if (
       entry[1].length > groupby.length &&
-      Array.isArray(formData.timeCompare) &&
-      formData.timeCompare.includes(entry[1][0])
+      Array.isArray(timeCompare) &&
+      timeCompare.includes(entry[1][0])
     ) {
       entry[1].shift();
     }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -107,8 +107,9 @@ export default function transformProps(
   } = chartProps;
   const { verboseMap = {} } = datasource;
   const [queryData] = queriesData;
-  const { data = [], label_map: labelMap } =
+  const { data = [], label_map = {} } =
     queryData as TimeseriesChartDataResponseResult;
+
   const dataTypes = getColtypesMapping(queryData);
   const annotationData = getAnnotationData(chartProps);
 
@@ -153,6 +154,17 @@ export default function transformProps(
     zoomable,
   }: EchartsTimeseriesFormData = { ...DEFAULT_FORM_DATA, ...formData };
   const refs: Refs = {};
+
+  const labelMap = Object.entries(label_map).reduce((acc, entry) => {
+    if (
+      entry[1].length > groupby.length &&
+      Array.isArray(formData.timeCompare) &&
+      formData.timeCompare.includes(entry[1][0])
+    ) {
+      entry[1].shift();
+    }
+    return { ...acc, [entry[0]]: entry[1] };
+  }, {});
 
   const colorScale = CategoricalColorNamespace.getScale(colorScheme as string);
   const rebasedData = rebaseForecastDatum(data, verboseMap);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
@@ -71,6 +71,7 @@ export type EchartsTimeseriesFormData = QueryFormData & {
   rowLimit: number;
   seriesType: EchartsTimeseriesSeriesType;
   stack: StackType;
+  timeCompare?: string[];
   tooltipTimeFormat?: string;
   truncateYAxis: boolean;
   yAxisFormat?: string;

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -497,4 +497,35 @@ describe('Does transformProps transform series correctly', () => {
       });
     });
   });
+
+  it('should remove time shift labels from label_map', () => {
+    const updatedChartPropsConfig = {
+      ...chartPropsConfig,
+      formData: {
+        ...formData,
+        timeCompare: ['1 year ago'],
+      },
+      queriesData: [
+        {
+          ...queriesData[0],
+          label_map: {
+            '1 year ago, foo1, bar1': ['1 year ago', 'foo1', 'bar1'],
+            '1 year ago, foo2, bar2': ['1 year ago', 'foo2', 'bar2'],
+            'foo1, bar1': ['foo1', 'bar1'],
+            'foo2, bar2': ['foo2', 'bar2'],
+          },
+        },
+      ],
+    };
+    const chartProps = new ChartProps(updatedChartPropsConfig);
+    const transformedProps = transformProps(
+      chartProps as EchartsTimeseriesChartProps,
+    );
+    expect(transformedProps.labelMap).toEqual({
+      '1 year ago, foo1, bar1': ['foo1', 'bar1'],
+      '1 year ago, foo2, bar2': ['foo2', 'bar2'],
+      'foo1, bar1': ['foo1', 'bar1'],
+      'foo2, bar2': ['foo2', 'bar2'],
+    });
+  });
 });


### PR DESCRIPTION
### SUMMARY
When user tried to use cross filtering on time shifted series, the cross filtering would take the time shift as a value rather than the series name. For example if user applied 1 year time shift on "gender" series and then applied cross filter on series "1 year ago, boy", it would emit filter `where gender in ['1 year ago']` instead of `where gender in ['boy']`.
This PR fixes that behaviour by removing time shifted series names from label map

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="1720" alt="image" src="https://user-images.githubusercontent.com/15073128/224701835-9b65c1ca-81f6-4a9f-b40b-51fdda7a7ac7.png">

After:

<img width="1723" alt="image" src="https://user-images.githubusercontent.com/15073128/224701717-abc7f3e4-f6d4-4df0-9955-e369230c4ad0.png">


### TESTING INSTRUCTIONS
1. Create a timeseries chart (for example Echarts Line chart with temporal x axis), add a groupby column, add a time shift
2. Add the chart to a dashboard and click on time shifted series to emit a cross filter
3. Verify that the emitted filter is correct

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
