### PR TITLE
feat(dashboard): Change default opacity of icon in FiltersBadge

### DIFF
--- a/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
@@ -73,27 +73,30 @@ export const FilterName = styled.span`
 `;
 
 export const FilterItem = styled.button`
-  cursor: pointer;
-  display: flex;
-  text-align: left;
-  padding: 0;
-  border: none;
-  background: none;
-  outline: none;
-  width: 100%;
+  ${({ theme }) => css`
+    cursor: pointer;
+    display: flex;
+    text-align: left;
+    padding: 0;
+    border: none;
+    background: none;
+    outline: none;
+    width: 100%;
 
-  &::-moz-focus-inner {
-    border: 0;
-  }
+    &::-moz-focus-inner {
+      border: 0;
+    }
 
-  & i svg {
-    color: transparent;
-    margin-right: ${({ theme }) => theme.gridUnit}px;
-  }
+    & i svg {
+      opacity: ${theme.opacity.mediumLight};
+      margin-right: ${theme.gridUnit}px;
+      transition: opacity ease-in-out ${theme.transitionTiming};
+    }
 
-  &:hover i svg {
-    color: inherit;
-  }
+    &:hover i svg {
+      opacity: 1;
+    }
+  `}
 `;
 
 export const FiltersContainer = styled.div`


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Before, the search icon in FiltersBadge was fully transparent by default. This PR changes the opacity to 35% by default, fully visible on hover, so that it's easier to discover

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="464" alt="image" src="https://user-images.githubusercontent.com/15073128/224712645-4c6d0a29-6a4a-4766-bea0-fd2db8276080.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

CC @kasiazjc 