### PR TITLE
fix: Handles disable Select All on Value Selection

### DIFF
--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -198,13 +198,13 @@ const Select = forwardRef(
         selectOptions.length > 0 &&
         enabledOptions.length > 1 &&
         !inputValue &&
-        !value,
+        !selectValue,
       [
         isSingleMode,
         selectOptions.length,
         enabledOptions.length,
         inputValue,
-        value,
+        selectValue,
       ],
     );
 

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -197,8 +197,15 @@ const Select = forwardRef(
         !isSingleMode &&
         selectOptions.length > 0 &&
         enabledOptions.length > 1 &&
-        !inputValue,
-      [isSingleMode, selectOptions.length, enabledOptions.length, inputValue],
+        !inputValue &&
+        !value,
+      [
+        isSingleMode,
+        selectOptions.length,
+        enabledOptions.length,
+        inputValue,
+        value,
+      ],
     );
 
     const selectAllMode = useMemo(


### PR DESCRIPTION
### SUMMARY
Once a value is selected in `Select`, the `Select All` option should be disabled. This is because the `Select` supports the `Enter` key, and it is very likely for that to be pressed twice. Once a value is selected using `Enter`, and `Enter` is pressed twice, then instead of 1 value all values(`Select All`) gets selected.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TESTING INSTRUCTIONS

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
