### PR TITLE
fix(chart-controls): Error if x_axis_sort and timeseries_limit_metric are included in main metrics

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/utils/extractExtraMetrics.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/utils/extractExtraMetrics.ts
@@ -25,12 +25,13 @@ import {
 export function extractExtraMetrics(
   formData: QueryFormData,
 ): QueryFormMetric[] {
-  const { groupby, timeseries_limit_metric, x_axis_sort } = formData;
+  const { groupby, timeseries_limit_metric, x_axis_sort, metrics } = formData;
   const extra_metrics: QueryFormMetric[] = [];
   if (
     !(groupby || []).length &&
     timeseries_limit_metric &&
-    getMetricLabel(timeseries_limit_metric) === x_axis_sort
+    getMetricLabel(timeseries_limit_metric) === x_axis_sort &&
+    !metrics?.some(metric => getMetricLabel(metric) === x_axis_sort)
   ) {
     extra_metrics.push(timeseries_limit_metric);
   }

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
@@ -79,6 +79,7 @@ export const xAxisSortControl = {
         ...ensureIsArray(controls?.metrics?.value as QueryFormMetric),
         controls?.timeseries_limit_metric?.value as QueryFormMetric,
       ].filter(Boolean);
+      const metricLabels = [...new Set(metrics.map(getMetricLabel))];
       const options = [
         ...columns.map(column => {
           const value = getColumnLabel(column);
@@ -87,8 +88,7 @@ export const xAxisSortControl = {
             label: dataset?.verbose_map?.[value] || value,
           };
         }),
-        ...metrics.map(metric => {
-          const value = getMetricLabel(metric);
+        ...metricLabels.map(value => {
           return {
             value,
             label: dataset?.verbose_map?.[value] || value,

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
@@ -88,12 +88,10 @@ export const xAxisSortControl = {
             label: dataset?.verbose_map?.[value] || value,
           };
         }),
-        ...metricLabels.map(value => {
-          return {
-            value,
-            label: dataset?.verbose_map?.[value] || value,
-          };
-        }),
+        ...metricLabels.map(value => ({
+          value,
+          label: dataset?.verbose_map?.[value] || value,
+        })),
       ];
 
       const shouldReset = !(

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/utils/extractExtraMetrics.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/utils/extractExtraMetrics.test.ts
@@ -102,3 +102,25 @@ test('returns empty array if timeseries_limit_metric and x_axis_sort are include
     }),
   ).toEqual([]);
 });
+
+test('returns empty array if timeseries_limit_metric and x_axis_sort are included in main metrics array with adhoc metrics', () => {
+  expect(
+    extractExtraMetrics({
+      ...baseFormData,
+      metrics: [
+        'a',
+        {
+          expressionType: 'SIMPLE',
+          aggregate: 'SUM',
+          column: { column_name: 'num' },
+        },
+      ],
+      timeseries_limit_metric: {
+        expressionType: 'SIMPLE',
+        aggregate: 'SUM',
+        column: { column_name: 'num' },
+      },
+      x_axis_sort: 'SUM(num)',
+    }),
+  ).toEqual([]);
+});

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/utils/extractExtraMetrics.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/utils/extractExtraMetrics.test.ts
@@ -92,3 +92,13 @@ test('returns empty array if groupby populated', () => {
     }),
   ).toEqual([]);
 });
+
+test('returns empty array if timeseries_limit_metric and x_axis_sort are included in main metrics array', () => {
+  expect(
+    extractExtraMetrics({
+      ...baseFormData,
+      timeseries_limit_metric: 'a',
+      x_axis_sort: 'a',
+    }),
+  ).toEqual([]);
+});


### PR DESCRIPTION
### SUMMARY
When user created a Echarts Bar chart and set the same "X-Axis sort by" (`x_axis_sort`) and "Sort by" (`timeseries_limit_metric`), and that metric was also used in the main metrics array, the `metrics` array in the query would contain duplicate metrics, which resulted in an error.

Additionally, it removes duplicate labels from "X-Axis sort by" options.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/15073128/225017274-cacb10cf-0a04-40f4-ac09-35d36dc3d5a4.png">

<img width="419" alt="image" src="https://user-images.githubusercontent.com/15073128/225019233-cae9a027-ca85-4030-a852-fbd58b483045.png">

After:

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/15073128/225016788-4d46c47f-d675-4b70-b19d-11c510f97069.png">


<img width="352" alt="image" src="https://user-images.githubusercontent.com/15073128/225019015-320a715c-54e7-4510-9df2-576fe051412b.png">

### TESTING INSTRUCTIONS
0. Enable GENERIC_CHART_AXES ff
1. Create Echarts Bar chart
2. Set Metrics, X-Axis Sort By and Sort By controls to the same metric
3. Verify that query is successful 
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
