### PR TITLE
feat(sqllab): log error_detail on fetch failed

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -32,7 +32,7 @@ import {
 } from 'src/components/MessageToasts/actions';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
 import COMMON_ERR_MESSAGES from 'src/utils/errorMessages';
-import { LOG_ACTIONS_SQLLAB_FETCH_QUERY } from 'src/logger/LogUtils';
+import { LOG_ACTIONS_SQLLAB_FETCH_FAILED_QUERY } from 'src/logger/LogUtils';
 import { logEvent } from 'src/logger/actions';
 import { newQueryTabName } from '../utils/newQueryTabName';
 
@@ -275,25 +275,18 @@ export function queryFailed(query, msg, link, errors) {
       ts: new Date().getTime(),
     };
     errors?.forEach(({ error_type: errorType, extra }) => {
-      if (extra?.issue_codes) {
-        extra?.issue_codes.forEach(({ message }) => {
-          dispatch(
-            logEvent(LOG_ACTIONS_SQLLAB_FETCH_QUERY, {
-              ...eventData,
-              error_type: errorType,
-              error_details: message,
-            }),
-          );
-        });
-      } else {
+      const messages = extra?.issue_codes.map(({ message }) => message) || [
+        errorType,
+      ];
+      messages.forEach(message => {
         dispatch(
-          logEvent(LOG_ACTIONS_SQLLAB_FETCH_QUERY, {
+          logEvent(LOG_ACTIONS_SQLLAB_FETCH_FAILED_QUERY, {
             ...eventData,
             error_type: errorType,
-            error_details: errorType,
+            error_details: message,
           }),
         );
-      }
+      });
     });
 
     return (

--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.js
@@ -25,7 +25,6 @@ import shortid from 'shortid';
 import * as featureFlags from 'src/featureFlags';
 import * as actions from 'src/SqlLab/actions/sqlLab';
 import { LOG_EVENT } from 'src/logger/actions';
-import { getClientErrorObject } from 'src/utils/getClientErrorObject';
 import {
   defaultQueryEditor,
   query,

--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.js
@@ -24,6 +24,8 @@ import thunk from 'redux-thunk';
 import shortid from 'shortid';
 import * as featureFlags from 'src/featureFlags';
 import * as actions from 'src/SqlLab/actions/sqlLab';
+import { LOG_EVENT } from 'src/logger/actions';
+import { getClientErrorObject } from 'src/utils/getClientErrorObject';
 import {
   defaultQueryEditor,
   query,
@@ -240,22 +242,38 @@ describe('async actions', () => {
       });
     });
 
-    it('calls queryFailed on fetch error', () => {
-      expect.assertions(1);
+    it('calls queryFailed on fetch error and logs the error details', () => {
+      expect.assertions(3);
 
       fetchMock.post(
         runQueryEndpoint,
-        { throws: { message: 'error text' } },
+        {
+          throws: {
+            message: 'error text',
+            timeout: true,
+            statusText: 'timeout',
+          },
+        },
         { overwriteRoutes: true },
       );
 
       const store = mockStore({});
-      const expectedActionTypes = [actions.START_QUERY, actions.QUERY_FAILED];
+      const expectedActionTypes = [
+        actions.START_QUERY,
+        LOG_EVENT,
+        LOG_EVENT,
+        actions.QUERY_FAILED,
+      ];
       const { dispatch } = store;
       const request = actions.runQuery(query);
       return request(dispatch, () => initialState).then(() => {
-        expect(store.getActions().map(a => a.type)).toEqual(
-          expectedActionTypes,
+        const actions = store.getActions();
+        expect(actions.map(a => a.type)).toEqual(expectedActionTypes);
+        expect(actions[1].payload.eventData.error_details).toContain(
+          'Issue 1000',
+        );
+        expect(actions[2].payload.eventData.error_details).toContain(
+          'Issue 1001',
         );
       });
     });

--- a/superset-frontend/src/logger/LogUtils.ts
+++ b/superset-frontend/src/logger/LogUtils.ts
@@ -52,12 +52,14 @@ export const LOG_ACTIONS_DASHBOARD_DOWNLOAD_AS_IMAGE =
 export const LOG_ACTIONS_CHART_DOWNLOAD_AS_IMAGE = 'chart_download_as_image';
 export const LOG_ACTIONS_SQLLAB_WARN_LOCAL_STORAGE_USAGE =
   'sqllab_warn_local_storage_usage';
+export const LOG_ACTIONS_SQLLAB_FETCH_QUERY = 'sqllab_fetch_query';
 
 // Log event types --------------------------------------------------------------
 export const LOG_EVENT_TYPE_TIMING = new Set([
   LOG_ACTIONS_LOAD_CHART,
   LOG_ACTIONS_RENDER_CHART,
   LOG_ACTIONS_HIDE_BROWSER_TAB,
+  LOG_ACTIONS_SQLLAB_FETCH_QUERY,
 ]);
 export const LOG_EVENT_TYPE_USER = new Set([
   LOG_ACTIONS_MOUNT_DASHBOARD,

--- a/superset-frontend/src/logger/LogUtils.ts
+++ b/superset-frontend/src/logger/LogUtils.ts
@@ -52,14 +52,15 @@ export const LOG_ACTIONS_DASHBOARD_DOWNLOAD_AS_IMAGE =
 export const LOG_ACTIONS_CHART_DOWNLOAD_AS_IMAGE = 'chart_download_as_image';
 export const LOG_ACTIONS_SQLLAB_WARN_LOCAL_STORAGE_USAGE =
   'sqllab_warn_local_storage_usage';
-export const LOG_ACTIONS_SQLLAB_FETCH_QUERY = 'sqllab_fetch_query';
+export const LOG_ACTIONS_SQLLAB_FETCH_FAILED_QUERY =
+  'sqllab_fetch_failed_query';
 
 // Log event types --------------------------------------------------------------
 export const LOG_EVENT_TYPE_TIMING = new Set([
   LOG_ACTIONS_LOAD_CHART,
   LOG_ACTIONS_RENDER_CHART,
   LOG_ACTIONS_HIDE_BROWSER_TAB,
-  LOG_ACTIONS_SQLLAB_FETCH_QUERY,
+  LOG_ACTIONS_SQLLAB_FETCH_FAILED_QUERY,
 ]);
 export const LOG_EVENT_TYPE_USER = new Set([
   LOG_ACTIONS_MOUNT_DASHBOARD,


### PR DESCRIPTION
### SUMMARY
This commit adds a logging event for fetch failed in sqllab in order to measure the impact of troubleshooting.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After:

<img width="649" alt="Screenshot 2023-03-14 at 1 50 16 PM" src="https://user-images.githubusercontent.com/1392866/225159348-7d4db27f-9bab-4a4d-9947-4427c3897acd.png">

Before:
N/A

### TESTING INSTRUCTIONS
Run any error query like `SELECT unknowncolumn` in sqllab
and then check the network tab for the logging event data

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
