### PR TITLE
fix(sqllab): throw errors of commented out query

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -336,9 +336,7 @@ export function cleanSqlComments(sql) {
   // it sanitizes the following comment block groups
   // group 1 -> /* */
   // group 2 -> --
-  return sql
-    .replace(/--.*?$|\/\/.*?$|\/\*[\s\S]*?\*\/|(\n\s*)+/gm, '$1')
-    .trim();
+  return sql.replace(/(--.*?$|\/\*[\s\S]*?\*\/)\n?/gm, '\n').trim();
 }
 
 export function runQuery(query) {

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -331,6 +331,12 @@ export function fetchQueryResults(query, displayLimit) {
   };
 }
 
+export function cleanSqlComments(sql) {
+  if (!sql) return '';
+
+  return sql.replace(/(\/\*[^*]*\*\/)|(\/\/[^*]*)|(--[^.].*)/gm, '').trim();
+}
+
 export function runQuery(query) {
   return function (dispatch) {
     dispatch(startQuery(query));
@@ -340,7 +346,7 @@ export function runQuery(query) {
       json: true,
       runAsync: query.runAsync,
       schema: query.schema,
-      sql: query.sql,
+      sql: cleanSqlComments(query.sql),
       sql_editor_id: query.sqlEditorId,
       tab: query.tab,
       tmp_table_name: query.tempTable,

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -333,8 +333,12 @@ export function fetchQueryResults(query, displayLimit) {
 
 export function cleanSqlComments(sql) {
   if (!sql) return '';
-
-  return sql.replace(/(\/\*[^*]*\*\/)|(\/\/[^*]*)|(--[^.].*)/gm, '').trim();
+  // it sanitizes the following comment block groups
+  // group 1 -> /* */
+  // group 2 -> --
+  return sql
+    .replace(/--.*?$|\/\/.*?$|\/\*[\s\S]*?\*\/|(\n\s*)+/gm, '$1')
+    .trim();
 }
 
 export function runQuery(query) {

--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.js
@@ -292,6 +292,29 @@ describe('async actions', () => {
     });
   });
 
+  describe('runQuery with comments', () => {
+    const makeRequest = () => {
+      const request = actions.runQuery({
+        ...query,
+        sql: 'SELECT 213--, {{ds}}\n/*\n{{new_param1}}\n{{new_param2}}*/FROM table',
+      });
+      return request(dispatch, () => initialState);
+    };
+
+    it('makes the fetch request without comments', async () => {
+      const runQueryEndpoint = 'glob:*/api/v1/sqllab/execute/';
+      fetchMock.post(runQueryEndpoint, '{}', {
+        overwriteRoutes: true,
+      });
+      await makeRequest().then(() => {
+        expect(fetchMock.calls(runQueryEndpoint)).toHaveLength(1);
+        expect(
+          JSON.parse(fetchMock.calls(runQueryEndpoint)[0][1].body).sql,
+        ).toEqual('SELECT 213\nFROM table');
+      });
+    });
+  });
+
   describe('reRunQuery', () => {
     let stub;
     beforeEach(() => {

--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.js
@@ -296,7 +296,7 @@ describe('async actions', () => {
     const makeRequest = () => {
       const request = actions.runQuery({
         ...query,
-        sql: '/*\nSELECT * FROM\n */\nSELECT 213--, {{ds}}\n/*\n{{new_param1}}\n{{new_param2}}*/FROM table',
+        sql: '/*\nSELECT * FROM\n */\nSELECT 213--, {{ds}}\n/*\n{{new_param1}}\n{{new_param2}}*/\n\nFROM table',
       });
       return request(dispatch, () => initialState);
     };
@@ -310,7 +310,7 @@ describe('async actions', () => {
         expect(fetchMock.calls(runQueryEndpoint)).toHaveLength(1);
         expect(
           JSON.parse(fetchMock.calls(runQueryEndpoint)[0][1].body).sql,
-        ).toEqual('SELECT 213\nFROM table');
+        ).toEqual('SELECT 213\n\n\nFROM table');
       });
     });
   });

--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.js
@@ -296,7 +296,7 @@ describe('async actions', () => {
     const makeRequest = () => {
       const request = actions.runQuery({
         ...query,
-        sql: 'SELECT 213--, {{ds}}\n/*\n{{new_param1}}\n{{new_param2}}*/FROM table',
+        sql: '/*\nSELECT * FROM\n */\nSELECT 213--, {{ds}}\n/*\n{{new_param1}}\n{{new_param2}}*/FROM table',
       });
       return request(dispatch, () => initialState);
     };

--- a/superset-frontend/src/SqlLab/components/RunQueryActionButton/index.tsx
+++ b/superset-frontend/src/SqlLab/components/RunQueryActionButton/index.tsx
@@ -26,6 +26,7 @@ import { DropdownButton } from 'src/components/DropdownButton';
 import { detectOS } from 'src/utils/common';
 import { QueryButtonProps } from 'src/SqlLab/types';
 import useQueryEditor from 'src/SqlLab/hooks/useQueryEditor';
+import { cleanSqlComments } from 'src/SqlLab/actions/sqlLab';
 
 export interface RunQueryActionButtonProps {
   queryEditorId: string;
@@ -105,9 +106,7 @@ const RunQueryActionButton = ({
     : Button;
 
   const sqlContent = selectedText || sql || '';
-  const isDisabled =
-    !sqlContent ||
-    !sqlContent.replace(/(\/\*[^*]*\*\/)|(\/\/[^*]*)|(--[^.].*)/gm, '').trim();
+  const isDisabled = cleanSqlComments(sqlContent).length === 0;
 
   const stopButtonTooltipText = useMemo(
     () =>


### PR DESCRIPTION
### SUMMARY
sqllab threw an error for undefined parameters even when those parameters are commented out of/not used by the query. 
This commit cleans out the commented out part from the requested query to fix the issue (and also reduce the payload size since commented-out parts are unnecessary)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After:

<img width="506" alt="Screenshot 2023-03-14 at 3 55 17 PM" src="https://user-images.githubusercontent.com/1392866/225164751-50645a6e-a6ca-40e4-9748-e9b5a468ba3b.png">

Before:
<img width="495" alt="Screenshot 2023-03-14 at 3 54 23 PM" src="https://user-images.githubusercontent.com/1392866/225164740-559f6eaf-a918-4670-912f-784aab54e9f4.png">


### TESTING INSTRUCTIONS
Go to sqllab and then run a query including a template string within comment-out block like `select 123 --,{{ds}} ` 

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
