### PR TITLE
chore: improve schema security

### DIFF
--- a/superset/db_engine_specs/drill.py
+++ b/superset/db_engine_specs/drill.py
@@ -32,7 +32,7 @@ class DrillEngineSpec(BaseEngineSpec):
     engine_name = "Apache Drill"
     default_driver = "sadrill"
 
-    dynamic_schema = True
+    supports_dynamic_schema = True
 
     _time_grain_expressions = {
         None: "{col}",
@@ -73,9 +73,22 @@ class DrillEngineSpec(BaseEngineSpec):
     @classmethod
     def adjust_database_uri(cls, uri: URL, selected_schema: Optional[str]) -> URL:
         if selected_schema:
-            uri = uri.set(database=parse.quote(selected_schema, safe=""))
+            uri = uri.set(
+                database=parse.quote(selected_schema.replace(".", "/"), safe="")
+            )
 
         return uri
+
+    @classmethod
+    def get_schema_from_engine_params(
+        cls,
+        sqlalchemy_uri: URL,
+        connect_args: Dict[str, Any],
+    ) -> Optional[str]:
+        """
+        Return the configured schema.
+        """
+        return parse.unquote(sqlalchemy_uri.database).replace("/", ".")
 
     @classmethod
     def get_url_for_impersonation(

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -98,7 +98,7 @@ class HiveEngineSpec(PrestoEngineSpec):
     allows_alias_to_source_column = True
     allows_hidden_orderby_agg = False
 
-    dynamic_schema = True
+    supports_dynamic_schema = True
 
     # When running `SHOW FUNCTIONS`, what is the name of the column with the
     # function names?
@@ -267,6 +267,17 @@ class HiveEngineSpec(PrestoEngineSpec):
             uri = uri.set(database=parse.quote(selected_schema, safe=""))
 
         return uri
+
+    @classmethod
+    def get_schema_from_engine_params(
+        cls,
+        sqlalchemy_uri: URL,
+        connect_args: Dict[str, Any],
+    ) -> Optional[str]:
+        """
+        Return the configured schema.
+        """
+        return parse.unquote(sqlalchemy_uri.database)
 
     @classmethod
     def _extract_error_message(cls, ex: Exception) -> str:

--- a/superset/db_engine_specs/mysql.py
+++ b/superset/db_engine_specs/mysql.py
@@ -69,7 +69,7 @@ class MySQLEngineSpec(BaseEngineSpec, BasicParametersMixin):
     )
     encryption_parameters = {"ssl": "1"}
 
-    dynamic_schema = True
+    supports_dynamic_schema = True
 
     column_type_mappings = (
         (
@@ -192,12 +192,27 @@ class MySQLEngineSpec(BaseEngineSpec, BasicParametersMixin):
 
     @classmethod
     def adjust_database_uri(
-        cls, uri: URL, selected_schema: Optional[str] = None
+        cls,
+        uri: URL,
+        selected_schema: Optional[str] = None,
     ) -> URL:
         if selected_schema:
             uri = uri.set(database=parse.quote(selected_schema, safe=""))
 
         return uri
+
+    @classmethod
+    def get_schema_from_engine_params(
+        cls,
+        sqlalchemy_uri: URL,
+        connect_args: Dict[str, Any],
+    ) -> Optional[str]:
+        """
+        Return the configured schema.
+
+        A MySQL database is a SQLAlchemy schema.
+        """
+        return parse.unquote(sqlalchemy_uri.database)
 
     @classmethod
     def get_datatype(cls, type_code: Any) -> Optional[str]:

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -165,7 +165,7 @@ class PrestoBaseEngineSpec(BaseEngineSpec, metaclass=ABCMeta):
     A base class that share common functions between Presto and Trino
     """
 
-    dynamic_schema = True
+    supports_dynamic_schema = True
 
     column_type_mappings = (
         (
@@ -314,6 +314,27 @@ class PrestoBaseEngineSpec(BaseEngineSpec, metaclass=ABCMeta):
             uri = uri.set(database=database)
 
         return uri
+
+    @classmethod
+    def get_schema_from_engine_params(
+        cls,
+        sqlalchemy_uri: URL,
+        connect_args: Dict[str, Any],
+    ) -> Optional[str]:
+        """
+        Return the configured schema.
+
+        For Presto the SQLAlchemy URI looks like this:
+
+            presto://localhost:8080/hive[/default]
+
+        """
+        database = sqlalchemy_uri.database.strip("/")
+
+        if "/" not in database:
+            return None
+
+        return parse.unquote(database.split("/")[1])
 
     @classmethod
     def estimate_statement_cost(cls, statement: str, cursor: Any) -> Dict[str, Any]:

--- a/superset/db_engine_specs/snowflake.py
+++ b/superset/db_engine_specs/snowflake.py
@@ -83,7 +83,7 @@ class SnowflakeEngineSpec(PostgresBaseEngineSpec):
     default_driver = "snowflake"
     sqlalchemy_uri_placeholder = "snowflake://"
 
-    dynamic_schema = True
+    supports_dynamic_schema = True
 
     _time_grain_expressions = {
         None: "{col}",
@@ -146,6 +146,22 @@ class SnowflakeEngineSpec(PostgresBaseEngineSpec):
             uri = uri.set(database=f"{database}/{selected_schema}")
 
         return uri
+
+    @classmethod
+    def get_schema_from_engine_params(
+        cls,
+        sqlalchemy_uri: URL,
+        connect_args: Dict[str, Any],
+    ) -> Optional[str]:
+        """
+        Return the configured schema.
+        """
+        database = sqlalchemy_uri.database.strip("/")
+
+        if "/" not in database:
+            return None
+
+        return parse.unquote(database.split("/")[1])
 
     @classmethod
     def epoch_to_dttm(cls) -> str:

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1787,7 +1787,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         return []
 
     def raise_for_access(
-        # pylint: disable=too-many-arguments, too-many-locals, too-many-branches
+        # pylint: disable=too-many-arguments, too-many-locals
         self,
         database: Optional["Database"] = None,
         datasource: Optional["BaseDatasource"] = None,
@@ -1823,18 +1823,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                 return
 
             if query:
-                # Some databases can change the default schema in which the query wil run,
-                # respecting the selection in SQL Lab. If that's the case, the query
-                # schema becomes the default one.
-                if database.db_engine_spec.dynamic_schema:
-                    default_schema = query.schema
-                # For other databases, the selected schema in SQL Lab is used only for
-                # table discovery and autocomplete. In this case we need to use the
-                # database default schema for tables that don't have an explicit schema.
-                else:
-                    with database.get_inspector_with_context() as inspector:
-                        default_schema = inspector.default_schema_name
-
+                default_schema = database.get_default_schema_for_query(query)
                 tables = {
                     Table(table_.table, table_.schema or default_schema)
                     for table_ in sql_parse.ParsedQuery(query.sql).tables

--- a/tests/unit_tests/db_engine_specs/test_drill.py
+++ b/tests/unit_tests/db_engine_specs/test_drill.py
@@ -20,6 +20,7 @@ from datetime import datetime
 from typing import Optional
 
 import pytest
+from sqlalchemy.engine.url import make_url
 
 from tests.unit_tests.db_engine_specs.utils import assert_convert_dttm
 from tests.unit_tests.fixtures.common import dttm
@@ -106,3 +107,18 @@ def test_convert_dttm(
     from superset.db_engine_specs.drill import DrillEngineSpec as spec
 
     assert_convert_dttm(spec, target_type, expected_result, dttm)
+
+
+def test_get_schema_from_engine_params() -> None:
+    """
+    Test ``get_schema_from_engine_params``.
+    """
+    from superset.db_engine_specs.drill import DrillEngineSpec
+
+    assert (
+        DrillEngineSpec.get_schema_from_engine_params(
+            make_url("drill+sadrill://localhost:8047/dfs/test?use_ssl=False"),
+            {},
+        )
+        == "dfs.test"
+    )

--- a/tests/unit_tests/db_engine_specs/test_hive.py
+++ b/tests/unit_tests/db_engine_specs/test_hive.py
@@ -20,6 +20,7 @@ from datetime import datetime
 from typing import Optional
 
 import pytest
+from sqlalchemy.engine.url import make_url
 
 from tests.unit_tests.db_engine_specs.utils import assert_convert_dttm
 from tests.unit_tests.fixtures.common import dttm
@@ -42,3 +43,17 @@ def test_convert_dttm(
     from superset.db_engine_specs.hive import HiveEngineSpec as spec
 
     assert_convert_dttm(spec, target_type, expected_result, dttm)
+
+
+def test_get_schema_from_engine_params() -> None:
+    """
+    Test the ``get_schema_from_engine_params`` method.
+    """
+    from superset.db_engine_specs.hive import HiveEngineSpec
+
+    assert (
+        HiveEngineSpec.get_schema_from_engine_params(
+            make_url("hive://localhost:10000/default"), {}
+        )
+        == "default"
+    )

--- a/tests/unit_tests/db_engine_specs/test_mysql.py
+++ b/tests/unit_tests/db_engine_specs/test_mysql.py
@@ -148,3 +148,17 @@ def test_cancel_query_failed(engine_mock: Mock) -> None:
     query = Query()
     cursor_mock = engine_mock.raiseError.side_effect = Exception()
     assert MySQLEngineSpec.cancel_query(cursor_mock, query, "123") is False
+
+
+def test_get_schema_from_engine_params() -> None:
+    """
+    Test the ``get_schema_from_engine_params`` method.
+    """
+    from superset.db_engine_specs.mysql import MySQLEngineSpec
+
+    assert (
+        MySQLEngineSpec.get_schema_from_engine_params(
+            make_url("mysql://user:password@host/db1"), {}
+        )
+        == "db1"
+    )

--- a/tests/unit_tests/db_engine_specs/test_postgres.py
+++ b/tests/unit_tests/db_engine_specs/test_postgres.py
@@ -21,6 +21,7 @@ from typing import Any, Dict, Optional, Type
 import pytest
 from sqlalchemy import types
 from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION, ENUM, JSON
+from sqlalchemy.engine.url import make_url
 
 from superset.utils.core import GenericDataType
 from tests.unit_tests.db_engine_specs.utils import (
@@ -89,3 +90,44 @@ def test_get_column_spec(
     from superset.db_engine_specs.postgres import PostgresEngineSpec as spec
 
     assert_column_spec(spec, native_type, sqla_type, attrs, generic_type, is_dttm)
+
+
+def test_get_schema_from_engine_params() -> None:
+    """
+    Test the ``get_schema_from_engine_params`` method.
+    """
+    from superset.db_engine_specs.postgres import PostgresEngineSpec
+
+    assert (
+        PostgresEngineSpec.get_schema_from_engine_params(
+            make_url("postgresql://user:password@host/db1"), {}
+        )
+        is None
+    )
+
+    assert (
+        PostgresEngineSpec.get_schema_from_engine_params(
+            make_url("postgresql://user:password@host/db1"),
+            {"options": "-csearch_path=secret"},
+        )
+        == "secret"
+    )
+
+    assert (
+        PostgresEngineSpec.get_schema_from_engine_params(
+            make_url("postgresql://user:password@host/db1"),
+            {"options": "-c search_path = secret -cfoo=bar -c debug"},
+        )
+        == "secret"
+    )
+
+    with pytest.raises(Exception) as excinfo:
+        PostgresEngineSpec.get_schema_from_engine_params(
+            make_url("postgresql://user:password@host/db1"),
+            {"options": "-csearch_path=secret,public"},
+        )
+    assert str(excinfo.value) == (
+        "Multiple schemas are configured in the search path, which means "
+        "Superset is unable to determine the schema of unqualified table "
+        "names and enforce permissions."
+    )

--- a/tests/unit_tests/db_engine_specs/test_presto.py
+++ b/tests/unit_tests/db_engine_specs/test_presto.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, Optional, Type
 import pytest
 import pytz
 from sqlalchemy import types
+from sqlalchemy.engine.url import make_url
 
 from superset.utils.core import GenericDataType
 from tests.unit_tests.db_engine_specs.utils import (
@@ -82,3 +83,26 @@ def test_get_column_spec(
     from superset.db_engine_specs.presto import PrestoEngineSpec as spec
 
     assert_column_spec(spec, native_type, sqla_type, attrs, generic_type, is_dttm)
+
+
+def test_get_schema_from_engine_params() -> None:
+    """
+    Test the ``get_schema_from_engine_params`` method.
+    """
+    from superset.db_engine_specs.presto import PrestoEngineSpec
+
+    assert (
+        PrestoEngineSpec.get_schema_from_engine_params(
+            make_url("presto://localhost:8080/hive/default"),
+            {},
+        )
+        == "default"
+    )
+
+    assert (
+        PrestoEngineSpec.get_schema_from_engine_params(
+            make_url("presto://localhost:8080/hive"),
+            {},
+        )
+        is None
+    )

--- a/tests/unit_tests/db_engine_specs/test_snowflake.py
+++ b/tests/unit_tests/db_engine_specs/test_snowflake.py
@@ -24,6 +24,7 @@ from unittest import mock
 
 import pytest
 from pytest_mock import MockerFixture
+from sqlalchemy.engine.url import make_url
 
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from tests.unit_tests.db_engine_specs.utils import assert_convert_dttm
@@ -169,3 +170,34 @@ def test_get_extra_params(mocker: MockerFixture) -> None:
             "connect_args": {"application": "Custom user agent", "foo": "bar"}
         }
     }
+
+
+def test_get_schema_from_engine_params() -> None:
+    """
+    Test the ``get_schema_from_engine_params`` method.
+    """
+    from superset.db_engine_specs.snowflake import SnowflakeEngineSpec
+
+    assert (
+        SnowflakeEngineSpec.get_schema_from_engine_params(
+            make_url("snowflake://user:pass@account/database_name/default"),
+            {},
+        )
+        == "default"
+    )
+
+    assert (
+        SnowflakeEngineSpec.get_schema_from_engine_params(
+            make_url("snowflake://user:pass@account/database_name"),
+            {},
+        )
+        is None
+    )
+
+    assert (
+        SnowflakeEngineSpec.get_schema_from_engine_params(
+            make_url("snowflake://user:pass@account/"),
+            {},
+        )
+        is None
+    )

--- a/tests/unit_tests/explore/utils_test.py
+++ b/tests/unit_tests/explore/utils_test.py
@@ -274,10 +274,8 @@ def test_query_no_access(mocker: MockFixture, client) -> None:
     from superset.models.core import Database
     from superset.models.sql_lab import Query
 
-    inspect = mocker.patch("superset.security.manager.inspect")
-    inspect().default_schema_name = "public"
-
     database = mocker.MagicMock()
+    database.get_default_schema_for_query.return_value = "public"
     mocker.patch(
         query_find_by_id,
         return_value=Query(database=database, sql="select * from foo"),

--- a/tests/unit_tests/security/manager_test.py
+++ b/tests/unit_tests/security/manager_test.py
@@ -52,8 +52,7 @@ def test_raise_for_access_query_default_schema(
     SqlaTable.query_datasources_by_name.return_value = []
 
     database = mocker.MagicMock()
-    database.db_engine_spec.dynamic_schema = False
-    database.get_inspector_with_context().__enter__().default_schema_name = "public"
+    database.get_default_schema_for_query.return_value = "public"
     query = mocker.MagicMock()
     query.database = database
     query.sql = "SELECT * FROM ab_user"


### PR DESCRIPTION
### SUMMARY

Superset supports permissions for schema-level access control; for example, a given user role might have access to only the schema `foo` in a given database. The problem is that **it's really hard to figure out the schema of an unqualified table name**. Eg, for the following query:

```sql
SELECT * FROM bar;
```

When a given user runs the query above, Superset needs to know what is the schema where table `bar` lives, so that it can check if the user has permission to access that schema. But **figuring out the schema is not trivial, and depends on the database engine spec and how the database configured**.

For example, for Postgres the schema will usually be `public`, the default one, [regardless of the schema selected in SQL Lab](https://github.com/apache/superset/pull/23356). But it's possible to specify a different search path when creating the database, eg:

```python
engine = create_engine("postgres://...", connect_args={"options": "-csearch_path=secret"})
```

For a database configured as above, the schema for the table `bar` in the query would be `secret`, and not `public`. To make things worse, the search path in Postgres can point to multiple schemas, in which case Superset has no idea where the data is coming from!

Other databases can specify the default schema in the SQLAlchemy URI; MySQL is one of them (though it calls it a "database"):

```
mysql://user:password@host/schema
```

In this case we can fetch the default schema for unqualified table names from the URI.

Finally, some database engine specs (like Trino, Presto, Snowflake, MySQL) can modify the schema dynamically on a per-query basis, in which case we can simply use the schema that is selected in the dropdown in SQL Lab:

https://github.com/apache/superset/blob/870bf6d0b9a9d4feaceac1544bd9eda71b803db5/superset/db_engine_specs/presto.py#L303-L316

To improve the situation this PR introduces a new method to DB engine specs, `get_default_schema_for_query`, along a couple helper methods. This method allows the security manager to know in which default schema a given query is running, so it can validate access to unqualified table names.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
