### PR TITLE
fix: schedule query option showing up

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -545,7 +545,7 @@ const SqlEditor = ({
             />
           </Menu.Item>
         )}
-        {scheduledQueriesConf && (
+        {Object.keys(scheduledQueriesConf).length > 0 && (
           <Menu.Item>
             <ScheduleQueryButton
               defaultLabel={qe.name}

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -545,7 +545,7 @@ const SqlEditor = ({
             />
           </Menu.Item>
         )}
-        {Object.keys(scheduledQueriesConf || {}).length > 0 && (
+        {!isEmpty(scheduledQueriesConf) && (
           <Menu.Item>
             <ScheduleQueryButton
               defaultLabel={qe.name}

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -545,7 +545,7 @@ const SqlEditor = ({
             />
           </Menu.Item>
         )}
-        {Object.keys(scheduledQueriesConf).length > 0 && (
+        {Object.keys(scheduledQueriesConf || {}).length > 0 && (
           <Menu.Item>
             <ScheduleQueryButton
               defaultLabel={qe.name}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The "schedule query" option in SQL Lab is showing up even when the feature is not configured... I suspect because of this change: https://github.com/apache/superset/pull/20256/files

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

![Screen Shot 2023-03-15 at 3 08 44 PM](https://user-images.githubusercontent.com/1534870/225454793-904482a6-daf4-4291-82e3-2025c8f5e282.png)

After:

![Screen Shot 2023-03-15 at 3 07 39 PM](https://user-images.githubusercontent.com/1534870/225454645-63301c18-6050-4f33-9389-933556884bc2.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
