### PR TITLE
fix(sql lab): Tracking URL getter/setter

### DIFF
--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -323,7 +323,7 @@ class Query(
         on query properties such as execution and finish time.
         """
         transform = current_app.config.get("TRACKING_URL_TRANSFORMER")
-        
+
         if url and transform:
             sig = inspect.signature(transform)
             # for backward compatibility, users may define a transformer function
@@ -331,7 +331,7 @@ class Query(
             args = [url, self][: len(sig.parameters)]
             url = transform(*args)
             logger.debug("Transformed tracking url: %s", url)
-        
+
         self._tracking_url = url
 
     def get_column(self, column_name: Optional[str]) -> Optional[Dict[str, Any]]:

--- a/tests/integration_tests/sql_lab/test_execute_sql_statements.py
+++ b/tests/integration_tests/sql_lab/test_execute_sql_statements.py
@@ -53,4 +53,4 @@ def test_non_async_execute(non_async_example_db: Database, example_query: Query)
         assert example_query.tracking_url.endswith("&foo=bar")
 
     if non_async_example_db.db_engine_spec.engine_name == "hive":
-        assert example_query.tracking_url_raw
+        assert example_query.tracking_url


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

I'm unclear if https://github.com/apache/superset/pull/20799 ever stored the correct URL in the database, but it seems like the `query.tracking_url` column is not updated with the transformed URL when the record is persisted to the database.

Although the unit tests illustrate the getter/setter behavior (and thus the link in SQL Lab works) it doesn't include a database write and thus it's unclear if SQLAlchemy invokes the getter when serializing a record to the database. Typically the getter should simply return the value whereas the setter should perform the necessary augmentation which is the logic I've implemented here, i.e., the `_tracking_url` column always contains the correct transformed value (if appropriate) whereas previous only the `tracking_url` field (proxy) was correct.
 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI. Also tested locally and confirmed that the `tracking_url` which was persisted in the database was correct.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
