### PR TITLE
fix(dashboard): `show_native_filters` leftover

### DIFF
--- a/superset/dashboards/commands/importers/v1/utils.py
+++ b/superset/dashboards/commands/importers/v1/utils.py
@@ -162,6 +162,11 @@ def import_dashboard(
 
     # TODO (betodealmeida): move this logic to import_from_dict
     config = config.copy()
+
+    # removed in https://github.com/apache/superset/pull/23228
+    if "metadata" in config and "show_native_filters" in config["metadata"]:
+        del config["metadata"]["show_native_filters"]
+
     for key, new_name in JSON_KEYS.items():
         if config.get(key) is not None:
             value = config.pop(key)

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -18,7 +18,7 @@ import json
 import re
 from typing import Any, Dict, Union
 
-from marshmallow import fields, post_load, Schema
+from marshmallow import fields, post_load, pre_load, Schema
 from marshmallow.validate import Length, ValidationError
 
 from superset.exceptions import SupersetException
@@ -134,6 +134,23 @@ class DashboardJSONMetadataSchema(Schema):
     import_time = fields.Integer()
     remote_id = fields.Integer()
     filter_bar_orientation = fields.Str(allow_none=True)
+
+    @pre_load
+    def remove_show_native_filters(  # pylint: disable=unused-argument, no-self-use
+        self,
+        data: Dict[str, Any],
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """
+        Remove ``show_native_filters`` from the JSON metadata.
+
+        This field was removed in https://github.com/apache/superset/pull/23228, but might
+        be present in old exports.
+        """
+        if "show_native_filters" in data:
+            del data["show_native_filters"]
+
+        return data
 
 
 class UserSchema(Schema):


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

https://github.com/apache/superset/pull/23228 removed `show_native_filters` from dashboards, but it can still be present in exports from older versions. When the key is present, the dashboard is imported correctly, but can't be updated because the schema of `json_metadata` is now invalid.

This PR addresses the problem by removing the field on dashboard import. Additionally, for those dashboards that have already been imported with the field, it relaxes the metadata schema to allow updates when `show_native_filters` is present, removing it before processing the metadata.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
