### PR TITLE
fix: Solve the problem of ineffective tooltip sorting

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -441,14 +441,15 @@ export default function transformProps(
         const forecastValues =
           extractForecastValuesFromTooltipParams(forecastValue);
 
-        Object.keys(forecastValues).forEach(key => {
-          const value = forecastValues[key];
+        forecastValues.forEach(item => {
           const content = formatForecastTooltipSeries({
-            ...value,
-            seriesName: key,
-            formatter: primarySeries.has(key) ? formatter : formatterSecondary,
+            ...item,
+            seriesName: item.name,
+            formatter: primarySeries.has(item.name)
+              ? formatter
+              : formatterSecondary,
           });
-          if (currentSeries.name === key) {
+          if (currentSeries.name === item.name) {
             rows.push(`<span style="font-weight: 700">${content}</span>`);
           } else {
             rows.push(`<span style="opacity: 0.7">${content}</span>`);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -419,17 +419,16 @@ export default function transformProps(
         }
 
         const rows: Array<string> = [`${tooltipFormatter(xValue)}`];
-        const forecastValues: Record<string, ForecastValue> =
+        const forecastValues: Array<ForecastValue> =
           extractForecastValuesFromTooltipParams(forecastValue, isHorizontal);
 
-        Object.keys(forecastValues).forEach(key => {
-          const value = forecastValues[key];
+        forecastValues.forEach(item => {
           const content = formatForecastTooltipSeries({
-            ...value,
-            seriesName: key,
+            ...item,
+            seriesName: item.name,
             formatter,
           });
-          if (currentSeries.name === key) {
+          if (currentSeries.name === item.name) {
             rows.push(`<span style="font-weight: 700">${content}</span>`);
           } else {
             rows.push(`<span style="opacity: 0.7">${content}</span>`);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/types.ts
@@ -81,6 +81,7 @@ export enum LegendType {
 }
 
 export type ForecastValue = {
+  name: string;
   marker: TooltipMarker;
   observation?: number;
   forecastTrend?: number;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/forecast.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/forecast.ts
@@ -55,18 +55,29 @@ export const extractForecastSeriesContexts = (
 export const extractForecastValuesFromTooltipParams = (
   params: any[],
   isHorizontal = false,
-): Record<string, ForecastValue> => {
-  const values: Record<string, ForecastValue> = {};
+): Array<ForecastValue> => {
+  const values: Array<ForecastValue> = [];
   params.forEach(param => {
     const { marker, seriesId, value } = param;
     const context = extractForecastSeriesContext(seriesId);
     const numericValue = isHorizontal ? value[0] : value[1];
     if (isNumber(numericValue)) {
-      if (!(context.name in values))
-        values[context.name] = {
+      let forecastValues: ForecastValue = {
+        name: '',
+        marker: marker || '',
+      };
+      values.forEach(item => {
+        if (item.name === context.name) {
+          forecastValues = item;
+        }
+      });
+      if (forecastValues.name === '') {
+        forecastValues = {
+          name: context.name,
           marker: marker || '',
         };
-      const forecastValues = values[context.name];
+        values.push(forecastValues);
+      }
       if (context.type === ForecastSeriesEnum.Observation)
         forecastValues.observation = numericValue;
       if (context.type === ForecastSeriesEnum.ForecastTrend)

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/forecast.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/forecast.test.ts
@@ -229,6 +229,7 @@ const formatter = getNumberFormatter(NumberFormats.INTEGER);
 test('formatForecastTooltipSeries should apply format to value', () => {
   expect(
     formatForecastTooltipSeries({
+      name: 'abc',
       seriesName: 'abc',
       marker: '<img>',
       observation: 10.1,
@@ -240,6 +241,7 @@ test('formatForecastTooltipSeries should apply format to value', () => {
 test('formatForecastTooltipSeries should show falsy value', () => {
   expect(
     formatForecastTooltipSeries({
+      name: 'abc',
       seriesName: 'abc',
       marker: '<img>',
       observation: 0,
@@ -251,6 +253,7 @@ test('formatForecastTooltipSeries should show falsy value', () => {
 test('formatForecastTooltipSeries should format full forecast', () => {
   expect(
     formatForecastTooltipSeries({
+      name: 'qwerty',
       seriesName: 'qwerty',
       marker: '<img>',
       observation: 10.1,
@@ -265,6 +268,7 @@ test('formatForecastTooltipSeries should format full forecast', () => {
 test('formatForecastTooltipSeries should format forecast without observation', () => {
   expect(
     formatForecastTooltipSeries({
+      name: 'qwerty',
       seriesName: 'qwerty',
       marker: '<img>',
       forecastTrend: 20,
@@ -278,6 +282,7 @@ test('formatForecastTooltipSeries should format forecast without observation', (
 test('formatForecastTooltipSeries should format forecast without point estimate', () => {
   expect(
     formatForecastTooltipSeries({
+      name: 'qwerty',
       seriesName: 'qwerty',
       marker: '<img>',
       observation: 10.1,
@@ -291,6 +296,7 @@ test('formatForecastTooltipSeries should format forecast without point estimate'
 test('formatForecastTooltipSeries should format forecast with only confidence band', () => {
   expect(
     formatForecastTooltipSeries({
+      name: 'qwerty',
       seriesName: 'qwerty',
       marker: '<img>',
       forecastLower: 7,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I failed to sort when I enabled tooltip sorting
![image](https://user-images.githubusercontent.com/50657209/225586286-b9666f16-d370-4383-aadb-5d5f847b0fbb.png)
I checked the code related to tooltip, and found that after finishing the tooltip sorting, the forecastValue will be recombined into an object of Record<string, ForecastValue>type, and the order of this object is uncertain, which is hashed by key, so the sorting is invalid
![image](https://user-images.githubusercontent.com/50657209/225587797-f63fab25-acc5-417b-b401-4b01291bb314.png)
I tried to replace the Record type with an ordered array, and then the sorting succeeded
![image](https://user-images.githubusercontent.com/50657209/225588097-8b5056cf-3970-48e1-ac5e-b8eb705ffa41.png)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Create a new chart, add multiple dimensions to the chart, aggregate by multiple dimensions, and then open Tooltip sorting in the chart advanced settings
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
