### PR TITLE
fix(Gauge echart): displaying column label

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Gauge/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Gauge/transformProps.ts
@@ -104,7 +104,7 @@ export default function transformProps(
   } = chartProps;
 
   const gaugeSeriesOptions = defaultGaugeSeriesOption(theme);
-  const { verboseMap } = datasource;
+  const { verboseMap = {} } = datasource;
   const {
     groupby,
     metric,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Gauge/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Gauge/transformProps.ts
@@ -147,10 +147,7 @@ export default function transformProps(
   const transformedData: GaugeDataItemOption[] = data.map(
     (data_point, index) => {
       const name = groupbyLabels
-        .map(
-          column =>
-            `${verboseMap[column] || column}: ${data_point[column]}`,
-        )
+        .map(column => `${verboseMap[column] || column}: ${data_point[column]}`)
         .join(', ');
       columnsLabelMap.set(
         name,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Gauge/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Gauge/transformProps.ts
@@ -149,9 +149,7 @@ export default function transformProps(
       const name = groupbyLabels
         .map(
           column =>
-            `${verboseMap ? verboseMap[column] : column}: ${
-              data_point[column]
-            }`,
+            `${verboseMap[column] || column}: ${data_point[column]}`,
         )
         .join(', ');
       columnsLabelMap.set(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Gauge/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Gauge/transformProps.ts
@@ -100,10 +100,11 @@ export default function transformProps(
     filterState,
     theme,
     emitCrossFilters,
+    datasource,
   } = chartProps;
 
   const gaugeSeriesOptions = defaultGaugeSeriesOption(theme);
-
+  const { verboseMap } = datasource;
   const {
     groupby,
     metric,
@@ -146,7 +147,12 @@ export default function transformProps(
   const transformedData: GaugeDataItemOption[] = data.map(
     (data_point, index) => {
       const name = groupbyLabels
-        .map(column => `${column}: ${data_point[column]}`)
+        .map(
+          column =>
+            `${verboseMap ? verboseMap[column] : column}: ${
+              data_point[column]
+            }`,
+        )
         .join(', ');
       columnsLabelMap.set(
         name,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Changed logic to display the label of field/column. Earlier it was showing field name.

For one dataset i gave label to column 'name', but it was not reflecting in chart. But now the label name is refecting in the chart

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before
![image](https://user-images.githubusercontent.com/106575591/225594800-b4b11150-84db-4ceb-a7f6-6997c7b25cb8.png)

After
![image](https://user-images.githubusercontent.com/106575591/225594837-3aadb59f-a9a1-4b00-9c35-d3217f2cd386.png)



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/16387
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
