### PR TITLE
feat(postgresql): dynamic schema

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1061,8 +1061,8 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         cls,
         uri: URL,
         connect_args: Dict[str, Any],
-        catalog: Optional[str],
-        schema: Optional[str],
+        catalog: Optional[str] = None,
+        schema: Optional[str] = None,
     ) -> Tuple[URL, Dict[str, Any]]:
         """
         Return a new URL and ``connect_args`` for a specific catalog/schema.

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -371,7 +371,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     supports_file_upload = True
 
     # Is the DB engine spec able to change the default schema? This requires implementing
-    # a custom `adjust_database_uri` method.
+    # a custom `adjust_engine_params` method.
     supports_dynamic_schema = False
 
     @classmethod
@@ -1057,11 +1057,12 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         ]
 
     @classmethod
-    def adjust_database_uri(  # pylint: disable=unused-argument
+    def adjust_engine_params(  # pylint: disable=unused-argument
         cls,
         uri: URL,
-        selected_schema: Optional[str],
-    ) -> URL:
+        connect_args: Dict[str, Any],
+        schema: Optional[str],
+    ) -> Tuple[URL, Dict[str, Any]]:
         """
         Return a modified URL with a new database component.
 
@@ -1080,7 +1081,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         Some database drivers like Presto accept '{catalog}/{schema}' in
         the database component of the URL, that can be handled here.
         """
-        return uri
+        return uri, connect_args
 
     @classmethod
     def patch(cls) -> None:

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -472,7 +472,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         Determining the correct schema is crucial for managing access to data, so please
         make sure you understand this logic when working on a new DB engine spec.
         """
-        # default schema varies on a per-query basis
+        # dynamic schema varies on a per-query basis
         if cls.supports_dynamic_schema:
             return query.schema
 
@@ -1061,25 +1061,27 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         cls,
         uri: URL,
         connect_args: Dict[str, Any],
+        catalog: Optional[str],
         schema: Optional[str],
     ) -> Tuple[URL, Dict[str, Any]]:
         """
-        Return a modified URL with a new database component.
+        Return a new URL and ``connect_args`` for a specific catalog/schema.
 
-        The URI here represents the URI as entered when saving the database,
-        ``selected_schema`` is the schema currently active presumably in
-        the SQL Lab dropdown. Based on that, for some database engine,
-        we can return a new altered URI that connects straight to the
-        active schema, meaning the users won't have to prefix the object
-        names by the schema name.
+        This is used in SQL Lab, allowing users to select a schema from the list of
+        schemas available in a given database, and have the query run with that schema as
+        the default one.
 
-        Some databases engines have 2 level of namespacing: database and
-        schema (postgres, oracle, mssql, ...)
-        For those it's probably better to not alter the database
-        component of the URI with the schema name, it won't work.
+        For some databases (like MySQL, Presto, Snowflake) this requires modifying the
+        SQLAlchemy URI before creating the connection. For others (like Postgres), it
+        requires additional parameters in ``connect_args``.
 
-        Some database drivers like Presto accept '{catalog}/{schema}' in
-        the database component of the URL, that can be handled here.
+        When a DB engine spec implements this method it should also have the attribute
+        ``supports_dynamic_schema`` set to true, so that Superset knows in which schema a
+        given query is running in order to enforce permissions (see #23385 and #23401).
+
+        Currently, changing the catalog is not supported. The method acceps a catalog so
+        that when catalog support is added to Superse the interface remains the same. This
+        is important because DB engine specs can be installed from 3rd party packages.
         """
         return uri, connect_args
 

--- a/superset/db_engine_specs/drill.py
+++ b/superset/db_engine_specs/drill.py
@@ -75,8 +75,8 @@ class DrillEngineSpec(BaseEngineSpec):
         cls,
         uri: URL,
         connect_args: Dict[str, Any],
-        catalog: Optional[str],
-        schema: Optional[str],
+        catalog: Optional[str] = None,
+        schema: Optional[str] = None,
     ) -> Tuple[URL, Dict[str, Any]]:
         if schema:
             uri = uri.set(database=parse.quote(schema.replace(".", "/"), safe=""))

--- a/superset/db_engine_specs/drill.py
+++ b/superset/db_engine_specs/drill.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 from urllib import parse
 
 from sqlalchemy import types
@@ -71,13 +71,16 @@ class DrillEngineSpec(BaseEngineSpec):
         return None
 
     @classmethod
-    def adjust_database_uri(cls, uri: URL, selected_schema: Optional[str]) -> URL:
-        if selected_schema:
-            uri = uri.set(
-                database=parse.quote(selected_schema.replace(".", "/"), safe="")
-            )
+    def adjust_engine_params(
+        cls,
+        uri: URL,
+        connect_args: Dict[str, Any],
+        schema: Optional[str],
+    ) -> Tuple[URL, Dict[str, Any]]:
+        if schema:
+            uri = uri.set(database=parse.quote(schema.replace(".", "/"), safe=""))
 
-        return uri
+        return uri, connect_args
 
     @classmethod
     def get_schema_from_engine_params(

--- a/superset/db_engine_specs/drill.py
+++ b/superset/db_engine_specs/drill.py
@@ -75,6 +75,7 @@ class DrillEngineSpec(BaseEngineSpec):
         cls,
         uri: URL,
         connect_args: Dict[str, Any],
+        catalog: Optional[str],
         schema: Optional[str],
     ) -> Tuple[URL, Dict[str, Any]]:
         if schema:

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -260,13 +260,16 @@ class HiveEngineSpec(PrestoEngineSpec):
         return None
 
     @classmethod
-    def adjust_database_uri(
-        cls, uri: URL, selected_schema: Optional[str] = None
-    ) -> URL:
-        if selected_schema:
-            uri = uri.set(database=parse.quote(selected_schema, safe=""))
+    def adjust_engine_params(
+        cls,
+        uri: URL,
+        connect_args: Dict[str, Any],
+        schema: Optional[str] = None,
+    ) -> Tuple[URL, Dict[str, Any]]:
+        if schema:
+            uri = uri.set(database=parse.quote(schema, safe=""))
 
-        return uri
+        return uri, connect_args
 
     @classmethod
     def get_schema_from_engine_params(

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -264,6 +264,7 @@ class HiveEngineSpec(PrestoEngineSpec):
         cls,
         uri: URL,
         connect_args: Dict[str, Any],
+        catalog: Optional[str] = None,
         schema: Optional[str] = None,
     ) -> Tuple[URL, Dict[str, Any]]:
         if schema:

--- a/superset/db_engine_specs/mysql.py
+++ b/superset/db_engine_specs/mysql.py
@@ -191,15 +191,16 @@ class MySQLEngineSpec(BaseEngineSpec, BasicParametersMixin):
         return None
 
     @classmethod
-    def adjust_database_uri(
+    def adjust_engine_params(
         cls,
         uri: URL,
-        selected_schema: Optional[str] = None,
-    ) -> URL:
-        if selected_schema:
-            uri = uri.set(database=parse.quote(selected_schema, safe=""))
+        connect_args: Dict[str, Any],
+        schema: Optional[str] = None,
+    ) -> Tuple[URL, Dict[str, Any]]:
+        if schema:
+            uri = uri.set(database=parse.quote(schema, safe=""))
 
-        return uri
+        return uri, connect_args
 
     @classmethod
     def get_schema_from_engine_params(

--- a/superset/db_engine_specs/mysql.py
+++ b/superset/db_engine_specs/mysql.py
@@ -195,6 +195,7 @@ class MySQLEngineSpec(BaseEngineSpec, BasicParametersMixin):
         cls,
         uri: URL,
         connect_args: Dict[str, Any],
+        catalog: Optional[str] = None,
         schema: Optional[str] = None,
     ) -> Tuple[URL, Dict[str, Any]]:
         if schema:

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -154,6 +154,7 @@ class PostgresBaseEngineSpec(BaseEngineSpec):
         cls,
         uri: URL,
         connect_args: Dict[str, Any],
+        catalog: Optional[str] = None,
         schema: Optional[str] = None,
     ) -> Tuple[URL, Dict[str, Any]]:
         if not schema:

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -305,6 +305,7 @@ class PrestoBaseEngineSpec(BaseEngineSpec, metaclass=ABCMeta):
         cls,
         uri: URL,
         connect_args: Dict[str, Any],
+        catalog: Optional[str] = None,
         schema: Optional[str] = None,
     ) -> Tuple[URL, Dict[str, Any]]:
         database = uri.database

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -301,19 +301,22 @@ class PrestoBaseEngineSpec(BaseEngineSpec, metaclass=ABCMeta):
         return "from_unixtime({col})"
 
     @classmethod
-    def adjust_database_uri(
-        cls, uri: URL, selected_schema: Optional[str] = None
-    ) -> URL:
+    def adjust_engine_params(
+        cls,
+        uri: URL,
+        connect_args: Dict[str, Any],
+        schema: Optional[str] = None,
+    ) -> Tuple[URL, Dict[str, Any]]:
         database = uri.database
-        if selected_schema and database:
-            selected_schema = parse.quote(selected_schema, safe="")
+        if schema and database:
+            schema = parse.quote(schema, safe="")
             if "/" in database:
-                database = database.split("/")[0] + "/" + selected_schema
+                database = database.split("/")[0] + "/" + schema
             else:
-                database += "/" + selected_schema
+                database += "/" + schema
             uri = uri.set(database=database)
 
-        return uri
+        return uri, connect_args
 
     @classmethod
     def get_schema_from_engine_params(

--- a/superset/db_engine_specs/snowflake.py
+++ b/superset/db_engine_specs/snowflake.py
@@ -135,17 +135,20 @@ class SnowflakeEngineSpec(PostgresBaseEngineSpec):
         return extra
 
     @classmethod
-    def adjust_database_uri(
-        cls, uri: URL, selected_schema: Optional[str] = None
-    ) -> URL:
+    def adjust_engine_params(
+        cls,
+        uri: URL,
+        connect_args: Dict[str, Any],
+        schema: Optional[str] = None,
+    ) -> Tuple[URL, Dict[str, Any]]:
         database = uri.database
-        if "/" in uri.database:
-            database = uri.database.split("/")[0]
-        if selected_schema:
-            selected_schema = parse.quote(selected_schema, safe="")
-            uri = uri.set(database=f"{database}/{selected_schema}")
+        if "/" in database:
+            database = database.split("/")[0]
+        if schema:
+            schema = parse.quote(schema, safe="")
+            uri = uri.set(database=f"{database}/{schema}")
 
-        return uri
+        return uri, connect_args
 
     @classmethod
     def get_schema_from_engine_params(

--- a/superset/db_engine_specs/snowflake.py
+++ b/superset/db_engine_specs/snowflake.py
@@ -139,6 +139,7 @@ class SnowflakeEngineSpec(PostgresBaseEngineSpec):
         cls,
         uri: URL,
         connect_args: Dict[str, Any],
+        catalog: Optional[str] = None,
         schema: Optional[str] = None,
     ) -> Tuple[URL, Dict[str, Any]]:
         database = uri.database

--- a/tests/unit_tests/db_engine_specs/test_postgres.py
+++ b/tests/unit_tests/db_engine_specs/test_postgres.py
@@ -131,3 +131,26 @@ def test_get_schema_from_engine_params() -> None:
         "Superset is unable to determine the schema of unqualified table "
         "names and enforce permissions."
     )
+
+
+def test_adjust_engine_params() -> None:
+    """
+    Test the ``adjust_engine_params`` method.
+    """
+    from superset.db_engine_specs.postgres import PostgresEngineSpec
+
+    uri = make_url("postgres://user:password@host/catalog")
+
+    assert PostgresEngineSpec.adjust_engine_params(uri, {}, "secret") == (
+        uri,
+        {"options": "-csearch_path=secret"},
+    )
+
+    assert PostgresEngineSpec.adjust_engine_params(
+        uri,
+        {"foo": "bar", "options": "-csearch_path=default -c debug=1"},
+        "secret",
+    ) == (
+        uri,
+        {"foo": "bar", "options": "-csearch_path=secret -cdebug=1"},
+    )

--- a/tests/unit_tests/db_engine_specs/test_postgres.py
+++ b/tests/unit_tests/db_engine_specs/test_postgres.py
@@ -141,7 +141,7 @@ def test_adjust_engine_params() -> None:
 
     uri = make_url("postgres://user:password@host/catalog")
 
-    assert PostgresEngineSpec.adjust_engine_params(uri, {}, "secret") == (
+    assert PostgresEngineSpec.adjust_engine_params(uri, {}, None, "secret") == (
         uri,
         {"options": "-csearch_path=secret"},
     )
@@ -149,6 +149,7 @@ def test_adjust_engine_params() -> None:
     assert PostgresEngineSpec.adjust_engine_params(
         uri,
         {"foo": "bar", "options": "-csearch_path=default -c debug=1"},
+        None,
         "secret",
     ) == (
         uri,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Builds on https://github.com/apache/superset/pull/23385. Renames the `adjust_database_uri` method to `adjust_engine_params` and makes it accept `connect_args` as well, so we can implement dynamic schema in Postgres. In addition, the method also takes an optional catalog, so in the future we can implement [proper catalog support](https://github.com/apache/superset/issues/22862).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before, when using Postgres the SQL Lab schema dropdown is not used to run the query. Note that in the example below `information_schema` is selected, but the query actually runs in the `public` schema:

![Screenshot 2023-03-16 at 15-23-18 Superset](https://user-images.githubusercontent.com/1534870/225766619-cd3f658b-74b1-4ff9-b2a1-1f779e689cb2.png)

With this PR:

![Screenshot 2023-03-16 at 15-23-34 Superset](https://user-images.githubusercontent.com/1534870/225766658-780270b1-a5de-490e-a125-0ce0ba0aeea9.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
