### PR TITLE
docs(contributing): rotate SECRET_KEY without invalid decryption key error

### DIFF
--- a/docs/docs/installation/configuring-superset.mdx
+++ b/docs/docs/installation/configuring-superset.mdx
@@ -285,7 +285,7 @@ If you want to rotate the SECRET_KEY(change the existing secret key), follow the
 Add the new SECRET_KEY and PREVIOUS_SECRET_KEY to `superset_config.py`:
 
 ```python
-PREVIOUS_SECRET_KEY = 'CURRENT_SECRET_KEY' # The default SECRET_KEY for deployment is '21thisismyscretkey12eyyh'
-SECRET_KEY = 'YOUR_OWN_RANDOM_GENERATED_SECRET_KEY'
+PREVIOUS_SECRET_KEY = 'CURRENT_SECRET_KEY' # The default SECRET_KEY for deployment is mentioned in superset/constants.py as CHANGE_ME_SECRET_KEY variable
+SECRET_KEY = 'YOUR_OWN_RANDOM_GENERATED_SECRET_KEY' # Recommended way to generate own secret key is using openssl run command -> openssl rand -base64 42
 ```
 Then run `superset re-encrypt-secrets`

--- a/docs/docs/installation/configuring-superset.mdx
+++ b/docs/docs/installation/configuring-superset.mdx
@@ -285,7 +285,13 @@ If you want to rotate the SECRET_KEY(change the existing secret key), follow the
 Add the new SECRET_KEY and PREVIOUS_SECRET_KEY to `superset_config.py`:
 
 ```python
-PREVIOUS_SECRET_KEY = 'CURRENT_SECRET_KEY' # The default SECRET_KEY for deployment is mentioned in superset/constants.py as CHANGE_ME_SECRET_KEY variable
-SECRET_KEY = 'YOUR_OWN_RANDOM_GENERATED_SECRET_KEY' # Recommended way to generate own secret key is using openssl run command -> openssl rand -base64 42
+PREVIOUS_SECRET_KEY = 'CURRENT_SECRET_KEY'
+"""
+You can find CURRENT_SECRET_KEY using following commands
+
+$ superset shell
+>>> from flask import current_app; print(current_app.config["SECRET_KEY"])
+"""
+SECRET_KEY = 'YOUR_OWN_RANDOM_GENERATED_SECRET_KEY' # generate a secure secret key using command "openssl rand -base64 42"
 ```
 Then run `superset re-encrypt-secrets`


### PR DESCRIPTION
docs: rotate SECRET_KEY without invalid decryption key error


### SUMMARY

### If someone has superset running with important stuffs and wants to change SECRET_KEY then definitely they need PREVIOUS_SECRET_KEY mentioned along with SECRET_KEY so decryption with PREVIOUS_SECRET_KEY can happen and encryption with latest SECRET_KEY can be performed. But in the documentation a wrong default SECRET_KEY is mentioned that can mislead the reader/user.