### PR TITLE
fix(docker): multi-architecture image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@
 # Node stage to deal with static asset construction
 ######################################################################
 ARG PY_VER=3.8.16-slim
-FROM node:16-slim AS superset-node
+FROM --platform=$BUILDPLATFORM node:16-slim AS superset-node
 
 ARG NPM_BUILD_CMD="build"
 ENV BUILD_CMD=${NPM_BUILD_CMD}

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@
 ######################################################################
 ARG PY_VER=3.8.16-slim
 
-# if BUILDPLATFORM is null, set it to current arch (or leave as is otherwise).
-ARG BUILDPLATFORM=${BUILDPLATFORM:-$(echo "$arch" | sed s/aarch64/arm64/ | sed s/x86_64/amd64/)}
+# if BUILDPLATFORM is null, set it to 'amd64' (or leave as is otherwise).
+ARG BUILDPLATFORM=${BUILDPLATFORM:-amd64}
 FROM --platform=${BUILDPLATFORM} node:16-slim AS superset-node
 
 ARG NPM_BUILD_CMD="build"

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,10 @@
 # Node stage to deal with static asset construction
 ######################################################################
 ARG PY_VER=3.8.16-slim
-FROM --platform=$BUILDPLATFORM node:16-slim AS superset-node
+
+# if BUILDPLATFORM is null, set it to 'amd64' (or leave as is otherwise).
+ARG BUILDPLATFORM=${BUILDPLATFORM:-amd64}
+FROM --platform=${BUILDPLATFORM} node:16-slim AS superset-node
 
 ARG NPM_BUILD_CMD="build"
 ENV BUILD_CMD=${NPM_BUILD_CMD}

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@
 ######################################################################
 ARG PY_VER=3.8.16-slim
 
-# if BUILDPLATFORM is null, set it to 'amd64' (or leave as is otherwise).
-ARG BUILDPLATFORM=${BUILDPLATFORM:-amd64}
+# if BUILDPLATFORM is null, set it to current arch (or leave as is otherwise).
+ARG BUILDPLATFORM=${BUILDPLATFORM:-$(echo "$arch" | sed s/aarch64/arm64/ | sed s/x86_64/amd64/)}
 FROM --platform=${BUILDPLATFORM} node:16-slim AS superset-node
 
 ARG NPM_BUILD_CMD="build"


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
We have a problem with multi-architecture image building:
```
docker buildx build --no-cache --platform=linux/amd64,linux/arm64 --rm -t superset --push .
```
Because we build first stage twice on `amd64` and `arm64` arch
This PR provides `--platform=$BUILDPLATFORM` flag in UI layer that ensures that this stage is build once and reuse at the second layer even if we do a multi-arch build. It's `Cross-Compilation` image building

Useful Article - https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://user-images.githubusercontent.com/29536522/225893063-506b4ca0-1850-43f0-87af-05647ce7533f.png)
_**Blue contains x86 binaries, yellow ARM binaries.**_

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
