### PR TITLE
docs(contributing): How create or change SECRET_KEY

### DIFF
--- a/docs/docs/installation/configuring-superset.mdx
+++ b/docs/docs/installation/configuring-superset.mdx
@@ -285,7 +285,11 @@ If you want to rotate the SECRET_KEY(change the existing secret key), follow the
 Add the new SECRET_KEY and PREVIOUS_SECRET_KEY to `superset_config.py`:
 
 ```python
-PREVIOUS_SECRET_KEY = 'CURRENT_SECRET_KEY' # The default SECRET_KEY for deployment is '21thisismyscretkey12eyyh'
-SECRET_KEY = 'YOUR_OWN_RANDOM_GENERATED_SECRET_KEY'
+PREVIOUS_SECRET_KEY = 'CURRENT_SECRET_KEY'
+# To find out 'CURRENT_SECRET_KEY' follow these steps
+# 1. Got to superset shell : $ superset shell
+# 2. Run the command       : >>> from flask import current_app; print(current_app.config["SECRET_KEY"])
+
+SECRET_KEY = 'YOUR_OWN_RANDOM_GENERATED_SECRET_KEY' # Generate a secure SECRET_KEY usng "openssl rand -base64 42"
 ```
 Then run `superset re-encrypt-secrets`


### PR DESCRIPTION
Explained how to change/create secret key.

### SUMMARY
When you are running an instance of superset naturally you might have added many DataBase connections, created a lot of charts and dashboards.
Suddenly if you want to change the SECRET_KEY to make your data encrypted , you need current secret key that has already encrypted your data.
Then you need to create a new SECRET_KEY

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
#### BEFORE SCREENSHOT
![image](https://user-images.githubusercontent.com/39917736/226252241-3fe86265-9a54-4bfe-8c5d-5a704916f3b5.png)


#### AFTER SCREENSHOT
![image](https://user-images.githubusercontent.com/39917736/226252271-b053d1b9-1fdd-447b-a286-c6acc32c6ae1.png)

### ADDITIONAL INFORMATION
To change the SECRET_KEY we need to provide current secret key as PREVIOUS_SECRET_KEY in superset_config.py and New secret key should be assigned to SECRET_KEY variable.
