### PR TITLE
fix(#23176): adding URL decoding to SQLAlchemy URI

### DIFF
--- a/superset/migrations/env.py
+++ b/superset/migrations/env.py
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
+import urllib.parse
 from logging.config import fileConfig
 from typing import List
-import urllib.parse
 
 from alembic import context
 from alembic.operations.ops import MigrationScript

--- a/superset/migrations/env.py
+++ b/superset/migrations/env.py
@@ -17,6 +17,7 @@
 import logging
 from logging.config import fileConfig
 from typing import List
+import urllib.parse
 
 from alembic import context
 from alembic.operations.ops import MigrationScript
@@ -42,7 +43,8 @@ if "sqlite" in DATABASE_URI:
         "SQLite Database support for metadata databases will \
         be removed in a future version of Superset."
     )
-config.set_main_option("sqlalchemy.url", DATABASE_URI)
+decoded_uri = urllib.parse.unquote(DATABASE_URI)
+config.set_main_option("sqlalchemy.url", decoded_uri)
 target_metadata = Base.metadata  # pylint: disable=no-member
 
 


### PR DESCRIPTION
<!---
fix: superset db upgrade mishandles DATABASE_URL with % in it
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Using urllib we can overcome this issue, now it is working fine

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
set the superser config like
SQLALCHEMY_DATABASE_URI = "postgres://postgres:s3kr1t@localhost:5432/postgres?application_name=superset&options=--search_path%3D%22%24user%22,superset"

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes https://github.com/apache/superset/issues/23176
