### PR TITLE
docs(security): note the need to set TALISMAN_ENABLED = True

### DIFF
--- a/docs/docs/security.mdx
+++ b/docs/docs/security.mdx
@@ -150,7 +150,7 @@ It's extremely important to correctly configure a Content Security Policy when d
 prevent many types of attacks. Superset provides two variables in `config.py` for deploying a CSP:
 
 - `TALISMAN_ENABLED` defaults to `False`; if `True` it will implement the specified CSP
-- `TALISMAN_CONFIG` holds the actual the policy definition (_see example below_).
+- `TALISMAN_CONFIG` holds the actual the policy definition (*see example below*).
 
 When running in production mode, Superset will check at startup for the presence
 of a CSP.  If one is not found, it will issue a warning with the security risks. For environments

--- a/docs/docs/security.mdx
+++ b/docs/docs/security.mdx
@@ -147,11 +147,15 @@ a certain resource type or policy area. You can check possible directives
 [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy).
 
 It's extremely important to correctly configure a Content Security Policy when deploying Superset to
-prevent many types of attacks. For that matter, Superset provides the ` TALISMAN_CONFIG` key in `config.py`
-where administrators can define the policy. When running in production mode, Superset will check for the presence
-of a policy and if it's not able to find one, it will issue a warning with the security risks. For environments
+prevent many types of attacks. Superset provides two variables in `config.py` for deploying a CSP:
+
+- `TALISMAN_ENABLED` defaults to `False`; if `True` it will implement the specified CSP
+- `TALISMAN_CONFIG` holds the actual the policy definition (_see example below_).
+
+When running in production mode, Superset will check at startup for the presence
+of a CSP.  If one is not found, it will issue a warning with the security risks. For environments
 where CSP policies are defined outside of Superset using other software, administrators can disable
-the warning using the `CONTENT_SECURITY_POLICY_WARNING` key in `config.py`.
+this warning using the `CONTENT_SECURITY_POLICY_WARNING` key in `config.py`.
 
 #### CSP Requirements
 

--- a/docs/docs/security.mdx
+++ b/docs/docs/security.mdx
@@ -149,7 +149,7 @@ a certain resource type or policy area. You can check possible directives
 It's extremely important to correctly configure a Content Security Policy when deploying Superset to
 prevent many types of attacks. Superset provides two variables in `config.py` for deploying a CSP:
 
-- `TALISMAN_ENABLED` defaults to `False`; if `True` it will implement the specified CSP
+- `TALISMAN_ENABLED` defaults to `False`; set this to `True` in order to implement a CSP
 - `TALISMAN_CONFIG` holds the actual the policy definition (*see example below*).
 
 When running in production mode, Superset will check at startup for the presence


### PR DESCRIPTION
### SUMMARY
The key **TALISMAN_ENABLED** must be set to true in the config in order for a Content Security Policy to be picked up.  Currently, that's missing from the docs.