### PR TITLE
fix: database dropdown keys

### DIFF
--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/index.tsx
@@ -928,8 +928,8 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
           ?.sort((a: DatabaseForm, b: DatabaseForm) =>
             a.name.localeCompare(b.name),
           )
-          .map((database: DatabaseForm) => (
-            <AntdSelect.Option value={database.name} key={database.name}>
+          .map((database: DatabaseForm, index: number) => (
+            <AntdSelect.Option value={database.name} key={`database-${index}`}>
               {database.name}
             </AntdSelect.Option>
           ))}

--- a/superset/db_engine_specs/clickhouse.py
+++ b/superset/db_engine_specs/clickhouse.py
@@ -246,7 +246,7 @@ class ClickHouseConnectEngineSpec(ClickHouseEngineSpec, BasicParametersMixin):
     """Engine spec for clickhouse-connect connector"""
 
     engine = "clickhousedb"
-    engine_name = "ClickHouse Connect"
+    engine_name = "ClickHouse Connect (Superset)"
 
     default_driver = "connect"
     _function_names: List[str] = []


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The latest ClickHouse driver comes with its own DB engine spec for Superset, which breaks the dropdown for selecting a database because the key in the select option is no longer unique. I fixed this by adding using the option index as the key, as well as renaming the Superset DB engine spec to "ClickHouse Connect (Superset)" to differentiate from the native DB engine spec.

In the future we should probably consider removing our ClickHouse Connect DB engine spec.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

<img width="532" alt="Screen Shot 2023-03-20 at 12 05 30 PM" src="https://user-images.githubusercontent.com/1534870/226440904-b23bcb34-7c93-4195-adbf-d30091ef297e.png">

After:

<img width="529" alt="Screen Shot 2023-03-20 at 12 02 43 PM" src="https://user-images.githubusercontent.com/1534870/226440406-92677f9b-703b-4630-9aa5-9f4123d301be.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
