### PR TITLE
feat: add ability to disable cache

### DIFF
--- a/docs/docs/installation/cache.mdx
+++ b/docs/docs/installation/cache.mdx
@@ -66,6 +66,9 @@ The cache timeout for charts may be overridden by the settings for an individual
 database. Each of these configurations will be checked in order before falling back to the default
 value defined in `DATA_CACHE_CONFIG.
 
+Note, that by setting the cache timeout to `-1`, caching for charting data can be disabled, either
+per chart, dataset or database, or by default if set in `DATA_CACHE_CONFIG`.
+
 ### SQL Lab Query Results
 
 Caching for SQL Lab query results is used when async queries are enabled and is configured using

--- a/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
@@ -938,7 +938,7 @@ class DatasourceEditor extends React.PureComponent {
           fieldKey="cache_timeout"
           label={t('Cache timeout')}
           description={t(
-            'The duration of time in seconds before the cache is invalidated',
+            'The duration of time in seconds before the cache is invalidated. Set to -1 to bypass the cache.',
           )}
           control={<TextControl controlId="cache_timeout" />}
         />

--- a/superset-frontend/src/components/Datasource/DatasourceModal.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal.tsx
@@ -101,6 +101,10 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
       postPayload: {
         data: {
           ...currentDatasource,
+          cache_timeout:
+            currentDatasource.cache_timeout === ''
+              ? null
+              : currentDatasource.cache_timeout,
           schema,
           metrics: currentDatasource?.metrics?.map(
             (metric: Record<string, unknown>) => ({

--- a/superset-frontend/src/explore/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal/index.tsx
@@ -399,7 +399,7 @@ function PropertiesModal({
               </StyledFormItem>
               <StyledHelpBlock className="help-block">
                 {t(
-                  "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the dataset's timeout if undefined.",
+                  "Duration (in seconds) of the caching timeout for this chart. Set to -1 to bypass the cache. Note this defaults to the dataset's timeout if undefined.",
                 )}
               </StyledHelpBlock>
             </FormItem>

--- a/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx
+++ b/superset-frontend/src/views/CRUD/data/database/DatabaseModal/ExtraOptions.tsx
@@ -238,7 +238,7 @@ const ExtraOptions = ({
           <div className="helper">
             {t(
               'Duration (in seconds) of the caching timeout for charts of this database.' +
-                ' A timeout of 0 indicates that the cache never expires.' +
+                ' A timeout of 0 indicates that the cache never expires, and -1 bypasses the cache.' +
                 ' Note this defaults to the global timeout if undefined.',
             )}
           </div>

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -118,7 +118,10 @@ class QueryContext:
         query_obj: QueryObject,
         force_cached: Optional[bool] = False,
     ) -> Dict[str, Any]:
-        return self._processor.get_df_payload(query_obj, force_cached)
+        return self._processor.get_df_payload(
+            query_obj=query_obj,
+            force_cached=force_cached,
+        )
 
     def get_query_result(self, query_object: QueryObject) -> QueryResult:
         return self._processor.get_query_result(query_object)

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -106,11 +106,13 @@ class QueryContextProcessor:
     ) -> Dict[str, Any]:
         """Handles caching around the df payload retrieval"""
         cache_key = self.query_cache_key(query_obj)
+        timeout = self.get_cache_timeout()
+        force_query = self._query_context.force or timeout == -1
         cache = QueryCacheManager.get(
-            cache_key,
-            CacheRegion.DATA,
-            self._query_context.force,
-            force_cached,
+            key=cache_key,
+            region=CacheRegion.DATA,
+            force_query=force_query,
+            force_cached=force_cached,
         )
 
         if query_obj and cache_key and not cache.is_loaded:
@@ -139,7 +141,7 @@ class QueryContextProcessor:
                     key=cache_key,
                     query_result=query_result,
                     annotation_data=annotation_data,
-                    force_query=self._query_context.force,
+                    force_query=force_query,
                     timeout=self.get_cache_timeout(),
                     datasource_uid=self._qc_datasource.uid,
                     region=CacheRegion.DATA,

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -526,7 +526,9 @@ class BaseViz:  # pylint: disable=too-many-public-methods
         is_loaded = False
         stacktrace = None
         df = None
-        if cache_key and cache_manager.data_cache and not self.force:
+        cache_timeout = self.cache_timeout
+        force = self.force or cache_timeout == -1
+        if cache_key and cache_manager.data_cache and not force:
             cache_value = cache_manager.data_cache.get(cache_key)
             if cache_value:
                 stats_logger.incr("loading_from_cache")
@@ -609,16 +611,16 @@ class BaseViz:  # pylint: disable=too-many-public-methods
 
             if is_loaded and cache_key and self.status != QueryStatus.FAILED:
                 set_and_log_cache(
-                    cache_manager.data_cache,
-                    cache_key,
-                    {"df": df, "query": self.query},
-                    self.cache_timeout,
-                    self.datasource.uid,
+                    cache_instance=cache_manager.data_cache,
+                    cache_key=cache_key,
+                    cache_value={"df": df, "query": self.query},
+                    cache_timeout=cache_timeout,
+                    datasource_uid=self.datasource.uid,
                 )
         return {
             "cache_key": cache_key,
             "cached_dttm": cache_value["dttm"] if cache_value is not None else None,
-            "cache_timeout": self.cache_timeout,
+            "cache_timeout": cache_timeout,
             "df": df,
             "errors": self.errors,
             "form_data": self.form_data,

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -1132,6 +1132,14 @@ def test_custom_cache_timeout(test_client, login_as_admin, physical_query_contex
     assert rv.json["result"][0]["cache_timeout"] == 5678
 
 
+def test_force_cache_timeout(test_client, login_as_admin, physical_query_context):
+    physical_query_context["custom_cache_timeout"] = -1
+    test_client.post(CHART_DATA_URI, json=physical_query_context)
+    rv = test_client.post(CHART_DATA_URI, json=physical_query_context)
+    assert rv.json["result"][0]["cached_dttm"] is None
+    assert rv.json["result"][0]["is_cached"] is None
+
+
 @mock.patch(
     "superset.common.query_context_processor.config",
     {


### PR DESCRIPTION
### SUMMARY
Currently it's only possible to bypass the chart data cache by adding the `force=true` query param if a chart cache has been defined. This can be problematic if one wants to either
1) disable caching globally by default, but make it possible to enable caching per database, dataset or chart
1) disable caching by default for a specific database, dataset or chart without disabling chart data caching globally

This PR adds support for a `-1` chart data timeout which is interpreted similarly to `force=true`, and is implemented both in the V1 chart data endpoint and `viz.py`. A test is also added to the chart data test suite. Note that the timeout value `0` is already reserved and ambiguous, and its behavior is different depending on the cache backend: sometimes is means "never expire", and other times "expire instantly" (I was not able to find a documentation reference to this, but I remember seeing it in the Flask-Caching source code while working on something else).

### AFTER
By setting the cache timeout to -1 the cache is bypassed similar to what happens if making the request with `force=true`:

https://user-images.githubusercontent.com/33317356/226584610-d396b7f7-91f2-458c-b359-491002283494.mp4

Note, that the value is still persisted in the cache if a cache is defined. This is to ensure that Global Async Queries will still work, and that other chart data requests that don't want to bypass the cache are able to retrieve the cached data (if available).

### BEFORE
Previously it was not possible to disable the cache if `CHART_DATA_CACHE` was defined (at a minimum, it was possible to set it to 1 second, which almost did the same):

https://user-images.githubusercontent.com/33317356/226584059-1025f392-e0d8-4f83-aad4-feda1852c193.mp4

In addition, if the "cache timeout" value was removed in the dataset modal, it would get saved as an empty string, which caused a 500 in the backend when trying to reopen the modal (it expects either a`null` or a number). To make sure that doesn't happen, we change the value to `null` if the value is an empty string when the dataset is saved.

<img width="512" alt="image" src="https://user-images.githubusercontent.com/33317356/226585690-29ef01f3-7fb9-4e8c-a7ec-76d7e5cc4d09.png">

### TESTING INSTRUCTIONS
1. Set the chart, dataset, database or global cache config timeout to -1
2. Go to a chart and click "Update" repeatedly
3. Notice that the cache is always bypassed

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
