### PR TITLE
fix(sankey): Return the exact faulty link instead of root

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1973,8 +1973,9 @@ class SankeyViz(BaseViz):
             def visit(vertex: str) -> Optional[Tuple[str, str]]:
                 path.add(vertex)
                 for neighbour in graph.get(vertex, ()):
-                    if neighbour in path or visit(neighbour):
-                        return (vertex, neighbour)
+                    cycle = (vertex, neighbour) if neighbour in path else visit(neighbour)
+                    if cycle:
+                        return cycle
                 path.remove(vertex)
                 return None
 


### PR DESCRIPTION
### SUMMARY

The current implementation returns the root of the faulty branch in the tree

```python
if neighbour in path or visit(neighbour):
    return (vertex, neighbour)
```

The goal of this PR is to pinpoint the exact faulty link in the tree.

```python
cycle = (vertex, neighbour) if neighbour in path else visit(neighbour)
if cycle:
    return cycle
```