### PR TITLE
chore: move some releasing commands to makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,9 @@ release.json
 # Translation binaries
 messages.mo
 
+# Releasing
+RELEASING/releasing_env
+
 docker/requirements-local.txt
 
 cache/

--- a/RELEASING/Makefile
+++ b/RELEASING/Makefile
@@ -1,0 +1,99 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+SUPERSET_RC_VERSION ?= $(shell bash -c 'read -p "Superset RC Version: " rc_version; echo $$rc_version')
+APACHE_USER_EMAIL ?= $(shell bash -c 'read -p "Apache user email: " user_email; echo $$user_email')
+GET_TOKEN ?= $(shell bash -c 'read -p "Github token: " github_token; echo $$github_token')
+$(eval dry-run:;@:)
+$(eval e-break:;@:)
+
+.PHONY: install setup cherry-tree cut-branch get-branch
+
+install:
+	pip install -r RELEASING/requirements.txt
+
+setup:
+	. set_release_env.sh $(SUPERSET_RC_VERSION) $(APACHE_USER_EMAIL)
+
+get_set_env:
+	if [[ -f releasing_env ]]; then \
+		export $(cat ./releasing_env | xargs) \
+	else \
+		make setup; \
+	fi
+
+cherry-tree:
+ifndef GITHUB_TOKEN
+	$(eval TOKEN=$(GET_TOKEN))
+else
+	$(eval TOKEN=${GITHUB_TOKEN})
+endif
+
+ifeq (dry-run, $(filter dry-run,$(MAKECMDGOALS)))
+	$(eval DRY_RUN=-nd)
+endif
+
+ifeq (e-break, $(filter e-break,$(MAKECMDGOALS)))
+	$(eval ERROR_MODE_BREAK=--error-mode break)
+endif
+	cherrytree bake -r apache/superset -m master -l v${SUPERSET_GITHUB_BRANCH} ${DRY_RUN} ${ERROR_MODE_BREAK} ${SUPERSET_GITHUB_BRANCH} --access-token ${TOKEN}
+
+cut-branch:
+ifndef ${SUPERSET_GITHUB_BRANCH}
+	make get_set_env
+	make cut-branch
+else
+	git checkout master
+	git pull
+	git checkout -b ${SUPERSET_GITHUB_BRANCH}
+	git push origin ${SUPERSET_GITHUB_BRANCH}
+endif
+
+get-branch:
+ifndef ${SUPERSET_GITHUB_BRANCH}
+	make get_set_env
+	make get-branch
+else
+	git checkout master
+	git pull
+	git checkout ${SUPERSET_GITHUB_BRANCH}
+endif
+
+# clean:
+# 	git checkout master
+
+# test-get-branch:
+#     # Test when SUPERSET_GITHUB_BRANCH is undefined
+# 	make clean  # Optional, but recommended
+# 	make get-branch SUPERSET_GITHUB_BRANCH=my_branch
+# 		# Verify that git checkout master was executed
+# 	if [ $$(git branch --show-current) != "master" ]; then \
+# 			echo "Error: Expected 'git checkout master' to be executed"; \
+# 			exit 1; \
+# 	fi
+# 	echo "Test for undefined SUPERSET_GITHUB_BRANCH passed"
+
+# 	# Test when SUPERSET_GITHUB_BRANCH is defined
+# 	make clean  # Optional, but recommended
+# 	make get_set_env
+# 	make get-branch SUPERSET_GITHUB_BRANCH=my_branch
+
+# 	# Verify that git checkout my_branch was executed
+# 	if [ $$(git branch --show-current) != "my_branch" ]; then \
+# 			echo "Error: Expected 'git checkout my_branch' to be executed"; \
+# 			exit 1; \
+# 	fi
+# 	echo "Test for defined SUPERSET_GITHUB_BRANCH passed"

--- a/RELEASING/README.md
+++ b/RELEASING/README.md
@@ -109,19 +109,7 @@ Usage (MacOS/ZSH):
 
 ```bash
 cd RELEASING
-source set_release_env.sh <SUPERSET_RC_VERSION> <PGP_KEY_FULLNAME>
-```
-
-Usage (BASH):
-
-```bash
-. set_release_env.sh <SUPERSET_RC_VERSION> <PGP_KEY_FULLNAME>
-```
-
-Example:
-
-```bash
-source set_release_env.sh 1.5.1rc1 myid@apache.org
+make setup
 ```
 
 The script will output the exported variables. Here's example for 1.5.1rc1:
@@ -155,10 +143,7 @@ The MAJOR.MINOR branch is normally a "cut" from a specific point in time from th
 When creating the initial minor release (e.g. 1.5.0), create a new branch:
 
 ```bash
-git checkout master
-git pull
-git checkout -b ${SUPERSET_GITHUB_BRANCH}
-git push origin $SUPERSET_GITHUB_BRANCH
+make cut-branch
 ```
 
 Note that this initializes a new "release cut", and is NOT needed when creating a patch release
@@ -169,9 +154,7 @@ Note that this initializes a new "release cut", and is NOT needed when creating 
 When getting ready to bake a patch release, simply checkout the relevant branch:
 
 ```bash
-git checkout master
-git pull
-git checkout ${SUPERSET_GITHUB_BRANCH}
+make get-branch
 ```
 
 ### Cherry picking
@@ -183,28 +166,26 @@ label `v1.5` should be added.
 To see how well the labelled PRs would apply to the current branch, run the following command:
 
 ```bash
-cherrytree bake -r apache/superset -m master -l v${SUPERSET_GITHUB_BRANCH} ${SUPERSET_GITHUB_BRANCH}
+make cherry-tree
 ```
 
-This requires the presence of an environment variable `GITHUB_TOKEN`. Alternatively,
-you can pass the token directly via the `--access-token` parameter (`-at` for short).
+If an environment variable `GITHUB_TOKEN` is not defined, you will be prompted for one.
 
 #### Happy path: no conflicts
 
-This will show how many cherries will apply cleanly. If there are no conflicts, you can simply apply all cherries
-by adding the `--no-dry-run` flag (`-nd` for short):
+This will show how many cherries will apply cleanly. If there are no conflicts, you can simply pass `dry-run` to the make command
 
 ```bash
-cherrytree bake -r apache/superset -m master -l v${SUPERSET_GITHUB_BRANCH} -nd ${SUPERSET_GITHUB_BRANCH}
+make cherry-tree dry-run
 ```
 
 #### Resolving conflicts
 
-If there are conflicts, you can issue the following command to apply all cherries up until the conflict automatically, and then
-break by adding the `-error-mode break` flag (`-e break` for short):
+If there are conflicts, apply all cherries up until the conflict automatically, and then
+break by running:
 
 ```bash
-cherrytree bake -r apache/superset -m master -l v${SUPERSET_GITHUB_BRANCH} -nd -e break ${SUPERSET_GITHUB_BRANCH}
+make cherry-tree e-break
 ```
 
 After applying the cleanly merged cherries, `cherrytree` will specify the SHA of the conflicted cherry. To resolve the conflict,

--- a/RELEASING/set_release_env.sh
+++ b/RELEASING/set_release_env.sh
@@ -47,7 +47,7 @@ else
   fi
   export SUPERSET_VERSION="${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}"
   export SUPERSET_RC="${VERSION_RC}"
-  export SUPERSET_GITHUB_BRANCH="${VERSION_MAJOR}.${VERSION_MINOR}"
+  export SUPERSET_GITHUB_BRANCH="bar"
   export SUPERSET_PGP_FULLNAME="${2}"
   export SUPERSET_VERSION_RC="${SUPERSET_VERSION}rc${VERSION_RC}"
   export SUPERSET_RELEASE=apache-superset-"${SUPERSET_VERSION}"
@@ -59,5 +59,6 @@ else
   echo -------------------------------
   echo Set Release env variables
   env | grep ^SUPERSET_
+  env | grep ^SUPERSET_ > releasing_env
   echo -------------------------------
 fi


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
I'm attempting to move some commands from the releasing readme into makefile commands and then create a quick read guide for iterating through releases. I find that when you're in the middle of a release, that it's easy to skip steps because you're starting in the middle of the process and inevitably don't start again from the beginning. 


### TESTING INSTRUCTIONS
You won't be able to test this in an ephemeral, but if you pull down the branch, you should be able to run the makefiles as described in original readme. 


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
