### PR TITLE
feat: Implement context menu for drill by

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/chart/types/Base.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/types/Base.ts
@@ -40,7 +40,11 @@ export interface ContextMenuFilters {
     isCurrentValueSelected?: boolean;
   };
   drillToDetail?: BinaryQueryObjectFilterClause[];
-  drillBy?: BinaryQueryObjectFilterClause[];
+  drillBy?: {
+    filters: BinaryQueryObjectFilterClause[];
+    groupbyFieldName: string;
+    adhocFilterFieldName?: string;
+  };
 }
 
 export enum AppSection {

--- a/superset-frontend/packages/superset-ui-core/src/chart/types/Base.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/types/Base.ts
@@ -31,6 +31,7 @@ export enum Behavior {
    * when dimensions are right-clicked on.
    */
   DRILL_TO_DETAIL = 'DRILL_TO_DETAIL',
+  DRILL_BY = 'DRILL_BY',
 }
 
 export interface ContextMenuFilters {
@@ -39,6 +40,7 @@ export interface ContextMenuFilters {
     isCurrentValueSelected?: boolean;
   };
   drillToDetail?: BinaryQueryObjectFilterClause[];
+  drillBy?: BinaryQueryObjectFilterClause[];
 }
 
 export enum AppSection {

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
@@ -172,7 +172,7 @@ function WorldMap(element, props) {
     const val =
       countryFieldtype === 'name' ? mapData[key]?.name : mapData[key]?.country;
     let drillToDetailFilters;
-    let drillBy;
+    let drillByFilters;
     if (val) {
       drillToDetailFilters = [
         {
@@ -182,7 +182,7 @@ function WorldMap(element, props) {
           formattedVal: val,
         },
       ];
-      drillBy = [
+      drillByFilters = [
         {
           col: entity,
           op: '==',
@@ -193,7 +193,7 @@ function WorldMap(element, props) {
     onContextMenu(pointerEvent.clientX, pointerEvent.clientY, {
       drillToDetail: drillToDetailFilters,
       crossFilter: getCrossFilterDataMask(source),
-      drillBy,
+      drillBy: { filters: drillByFilters, groupbyFieldName: 'entity' },
     });
   };
 

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
@@ -172,6 +172,7 @@ function WorldMap(element, props) {
     const val =
       countryFieldtype === 'name' ? mapData[key]?.name : mapData[key]?.country;
     let drillToDetailFilters;
+    let drillBy;
     if (val) {
       drillToDetailFilters = [
         {
@@ -181,10 +182,18 @@ function WorldMap(element, props) {
           formattedVal: val,
         },
       ];
+      drillBy = [
+        {
+          col: entity,
+          op: '==',
+          val,
+        },
+      ];
     }
     onContextMenu(pointerEvent.clientX, pointerEvent.clientY, {
       drillToDetail: drillToDetailFilters,
       crossFilter: getCrossFilterDataMask(source),
+      drillBy,
     });
   };
 

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/index.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/index.js
@@ -45,7 +45,11 @@ const metadata = new ChartMetadata({
   ],
   thumbnail,
   useLegacyApi: true,
-  behaviors: [Behavior.INTERACTIVE_CHART, Behavior.DRILL_TO_DETAIL],
+  behaviors: [
+    Behavior.INTERACTIVE_CHART,
+    Behavior.DRILL_TO_DETAIL,
+    Behavior.DRILL_BY,
+  ],
 });
 
 export default class WorldMapChartPlugin extends ChartPlugin {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/index.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t, ChartMetadata, ChartPlugin, Behavior } from '@superset-ui/core';
+import { Behavior, ChartMetadata, ChartPlugin, t } from '@superset-ui/core';
 import buildQuery from './buildQuery';
 import controlPanel from './controlPanel';
 import transformProps from './transformProps';
@@ -44,7 +44,11 @@ export default class EchartsBoxPlotChartPlugin extends ChartPlugin<
       controlPanel,
       loadChart: () => import('./EchartsBoxPlot'),
       metadata: new ChartMetadata({
-        behaviors: [Behavior.INTERACTIVE_CHART, Behavior.DRILL_TO_DETAIL],
+        behaviors: [
+          Behavior.INTERACTIVE_CHART,
+          Behavior.DRILL_TO_DETAIL,
+          Behavior.DRILL_BY,
+        ],
         category: t('Distribution'),
         credits: ['https://echarts.apache.org'],
         description: t(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/index.ts
@@ -44,7 +44,11 @@ export default class EchartsFunnelChartPlugin extends ChartPlugin<
       controlPanel,
       loadChart: () => import('./EchartsFunnel'),
       metadata: new ChartMetadata({
-        behaviors: [Behavior.INTERACTIVE_CHART, Behavior.DRILL_TO_DETAIL],
+        behaviors: [
+          Behavior.INTERACTIVE_CHART,
+          Behavior.DRILL_TO_DETAIL,
+          Behavior.DRILL_BY,
+        ],
         category: t('KPI'),
         credits: ['https://echarts.apache.org'],
         description: t(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Gauge/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Gauge/index.ts
@@ -35,7 +35,11 @@ export default class EchartsGaugeChartPlugin extends ChartPlugin<
       controlPanel,
       loadChart: () => import('./EchartsGauge'),
       metadata: new ChartMetadata({
-        behaviors: [Behavior.INTERACTIVE_CHART, Behavior.DRILL_TO_DETAIL],
+        behaviors: [
+          Behavior.INTERACTIVE_CHART,
+          Behavior.DRILL_TO_DETAIL,
+          Behavior.DRILL_BY,
+        ],
         category: t('KPI'),
         credits: ['https://echarts.apache.org'],
         description: t(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Graph/EchartsGraph.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Graph/EchartsGraph.tsx
@@ -137,11 +137,11 @@ export default function EchartsGraph({
         const data = (echartOptions as any).series[0].data as Data;
         const drillToDetailFilters =
           e.dataType === 'node' ? handleNodeClick(data) : handleEdgeClick(data);
+        const node = data.find(item => item.id === e.data.id);
         onContextMenu(pointerEvent.clientX, pointerEvent.clientY, {
           drillToDetail: drillToDetailFilters,
-          crossFilter: getCrossFilterDataMask(
-            data.find(item => item.id === e.data.id),
-          ),
+          crossFilter: getCrossFilterDataMask(node),
+          drillBy: node && [{ col: node.col, op: '==', val: node.name }],
         });
       }
     },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Graph/EchartsGraph.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Graph/EchartsGraph.tsx
@@ -138,10 +138,15 @@ export default function EchartsGraph({
         const drillToDetailFilters =
           e.dataType === 'node' ? handleNodeClick(data) : handleEdgeClick(data);
         const node = data.find(item => item.id === e.data.id);
+
         onContextMenu(pointerEvent.clientX, pointerEvent.clientY, {
           drillToDetail: drillToDetailFilters,
           crossFilter: getCrossFilterDataMask(node),
-          drillBy: node && [{ col: node.col, op: '==', val: node.name }],
+          drillBy: node && {
+            filters: [{ col: node.col, op: '==', val: node.name }],
+            groupbyFieldName:
+              node.col === formData.source ? 'source' : 'target',
+          },
         });
       }
     },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Graph/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Graph/index.ts
@@ -48,7 +48,11 @@ export default class EchartsGraphChartPlugin extends ChartPlugin {
           t('Transformable'),
         ],
         thumbnail,
-        behaviors: [Behavior.INTERACTIVE_CHART, Behavior.DRILL_TO_DETAIL],
+        behaviors: [
+          Behavior.INTERACTIVE_CHART,
+          Behavior.DRILL_TO_DETAIL,
+          Behavior.DRILL_BY,
+        ],
       }),
       transformProps,
     });

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/EchartsMixedTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/EchartsMixedTimeseries.tsx
@@ -132,11 +132,10 @@ export default function EchartsMixedTimeseries({
         const pointerEvent = eventParams.event.event;
         const drillToDetailFilters: BinaryQueryObjectFilterClause[] = [];
         const drillByFilters: BinaryQueryObjectFilterClause[] = [];
+        const isFirst = isFirstQuery(seriesIndex);
         const values = [
           ...(eventParams.name ? [eventParams.name] : []),
-          ...(isFirstQuery(seriesIndex) ? labelMap : labelMapB)[
-            eventParams.seriesName
-          ],
+          ...(isFirst ? labelMap : labelMapB)[eventParams.seriesName],
         ];
         if (data && xAxis.type === AxisType.time) {
           drillToDetailFilters.push({
@@ -152,7 +151,7 @@ export default function EchartsMixedTimeseries({
         }
         [
           ...(data && xAxis.type === AxisType.category ? [xAxis.label] : []),
-          ...(isFirstQuery(seriesIndex) ? formData.groupby : formData.groupbyB),
+          ...(isFirst ? formData.groupby : formData.groupbyB),
         ].forEach((dimension, i) =>
           drillToDetailFilters.push({
             col: dimension,
@@ -162,19 +161,22 @@ export default function EchartsMixedTimeseries({
           }),
         );
 
-        [
-          ...(isFirstQuery(seriesIndex) ? formData.groupby : formData.groupbyB),
-        ].forEach((dimension, i) =>
-          drillByFilters.push({
-            col: dimension,
-            op: '==',
-            val: values[i],
-          }),
+        [...(isFirst ? formData.groupby : formData.groupbyB)].forEach(
+          (dimension, i) =>
+            drillByFilters.push({
+              col: dimension,
+              op: '==',
+              val: values[i],
+            }),
         );
         onContextMenu(pointerEvent.clientX, pointerEvent.clientY, {
           drillToDetail: drillToDetailFilters,
           crossFilter: getCrossFilterDataMask(seriesName, seriesIndex),
-          drillBy: drillByFilters,
+          drillBy: {
+            filters: drillByFilters,
+            groupbyFieldName: isFirst ? 'groupby' : 'groupby_b',
+            adhocFilterFieldName: isFirst ? 'adhoc_filters' : 'adhoc_filters_b',
+          },
         });
       }
     },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/EchartsMixedTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/EchartsMixedTimeseries.tsx
@@ -131,42 +131,50 @@ export default function EchartsMixedTimeseries({
         const { data, seriesName, seriesIndex } = eventParams;
         const pointerEvent = eventParams.event.event;
         const drillToDetailFilters: BinaryQueryObjectFilterClause[] = [];
-        if (data) {
-          const values = [
-            ...(eventParams.name ? [eventParams.name] : []),
-            ...(isFirstQuery(seriesIndex) ? labelMap : labelMapB)[
-              eventParams.seriesName
-            ],
-          ];
-          if (xAxis.type === AxisType.time) {
-            drillToDetailFilters.push({
-              col:
-                xAxis.label === DTTM_ALIAS
-                  ? formData.granularitySqla
-                  : xAxis.label,
-              grain: formData.timeGrainSqla,
-              op: '==',
-              val: data[0],
-              formattedVal: xValueFormatter(data[0]),
-            });
-          }
-          [
-            ...(xAxis.type === AxisType.category ? [xAxis.label] : []),
-            ...(isFirstQuery(seriesIndex)
-              ? formData.groupby
-              : formData.groupbyB),
-          ].forEach((dimension, i) =>
-            drillToDetailFilters.push({
-              col: dimension,
-              op: '==',
-              val: values[i],
-              formattedVal: String(values[i]),
-            }),
-          );
+        const drillByFilters: BinaryQueryObjectFilterClause[] = [];
+        const values = [
+          ...(eventParams.name ? [eventParams.name] : []),
+          ...(isFirstQuery(seriesIndex) ? labelMap : labelMapB)[
+            eventParams.seriesName
+          ],
+        ];
+        if (data && xAxis.type === AxisType.time) {
+          drillToDetailFilters.push({
+            col:
+              xAxis.label === DTTM_ALIAS
+                ? formData.granularitySqla
+                : xAxis.label,
+            grain: formData.timeGrainSqla,
+            op: '==',
+            val: data[0],
+            formattedVal: xValueFormatter(data[0]),
+          });
         }
+        [
+          ...(data && xAxis.type === AxisType.category ? [xAxis.label] : []),
+          ...(isFirstQuery(seriesIndex) ? formData.groupby : formData.groupbyB),
+        ].forEach((dimension, i) =>
+          drillToDetailFilters.push({
+            col: dimension,
+            op: '==',
+            val: values[i],
+            formattedVal: String(values[i]),
+          }),
+        );
+
+        [
+          ...(isFirstQuery(seriesIndex) ? formData.groupby : formData.groupbyB),
+        ].forEach((dimension, i) =>
+          drillByFilters.push({
+            col: dimension,
+            op: '==',
+            val: values[i],
+          }),
+        );
         onContextMenu(pointerEvent.clientX, pointerEvent.clientY, {
           drillToDetail: drillToDetailFilters,
           crossFilter: getCrossFilterDataMask(seriesName, seriesIndex),
+          drillBy: drillByFilters,
         });
       }
     },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/index.ts
@@ -54,7 +54,11 @@ export default class EchartsTimeseriesChartPlugin extends ChartPlugin<
       controlPanel,
       loadChart: () => import('./EchartsMixedTimeseries'),
       metadata: new ChartMetadata({
-        behaviors: [Behavior.INTERACTIVE_CHART, Behavior.DRILL_TO_DETAIL],
+        behaviors: [
+          Behavior.INTERACTIVE_CHART,
+          Behavior.DRILL_TO_DETAIL,
+          Behavior.DRILL_BY,
+        ],
         category: t('Evolution'),
         credits: ['https://echarts.apache.org'],
         description: hasGenericChartAxes

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Pie/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Pie/index.ts
@@ -47,7 +47,11 @@ export default class EchartsPieChartPlugin extends ChartPlugin<
       controlPanel,
       loadChart: () => import('./EchartsPie'),
       metadata: new ChartMetadata({
-        behaviors: [Behavior.INTERACTIVE_CHART, Behavior.DRILL_TO_DETAIL],
+        behaviors: [
+          Behavior.INTERACTIVE_CHART,
+          Behavior.DRILL_TO_DETAIL,
+          Behavior.DRILL_BY,
+        ],
         category: t('Part of a Whole'),
         credits: ['https://echarts.apache.org'],
         description:

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Radar/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Radar/index.ts
@@ -46,7 +46,11 @@ export default class EchartsRadarChartPlugin extends ChartPlugin<
       controlPanel,
       loadChart: () => import('./EchartsRadar'),
       metadata: new ChartMetadata({
-        behaviors: [Behavior.INTERACTIVE_CHART, Behavior.DRILL_TO_DETAIL],
+        behaviors: [
+          Behavior.INTERACTIVE_CHART,
+          Behavior.DRILL_TO_DETAIL,
+          Behavior.DRILL_BY,
+        ],
         category: t('Ranking'),
         credits: ['https://echarts.apache.org'],
         description: t(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/EchartsSunburst.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/EchartsSunburst.tsx
@@ -110,7 +110,7 @@ export default function EchartsSunburst(props: SunburstTransformedProps) {
         const treePath = extractTreePathInfo(eventParams.treePathInfo);
         const pointerEvent = eventParams.event.event;
         const drillToDetailFilters: BinaryQueryObjectFilterClause[] = [];
-        let drillByFilters: BinaryQueryObjectFilterClause[] | undefined;
+        const drillByFilters: BinaryQueryObjectFilterClause[] = [];
         if (columns?.length) {
           treePath.forEach((path, i) =>
             drillToDetailFilters.push({
@@ -120,13 +120,11 @@ export default function EchartsSunburst(props: SunburstTransformedProps) {
               formattedVal: path,
             }),
           );
-          drillByFilters = [
-            {
-              col: columns[treePath.length - 1],
-              op: '==',
-              val: treePath[treePath.length - 1],
-            },
-          ];
+          drillByFilters.push({
+            col: columns[treePath.length - 1],
+            op: '==',
+            val: treePath[treePath.length - 1],
+          });
         }
         onContextMenu(pointerEvent.clientX, pointerEvent.clientY, {
           drillToDetail: drillToDetailFilters,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/EchartsSunburst.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/EchartsSunburst.tsx
@@ -129,7 +129,7 @@ export default function EchartsSunburst(props: SunburstTransformedProps) {
         onContextMenu(pointerEvent.clientX, pointerEvent.clientY, {
           drillToDetail: drillToDetailFilters,
           crossFilter: getCrossFilterDataMask(treePathInfo),
-          drillBy: drillByFilters,
+          drillBy: { filters: drillByFilters, groupbyFieldName: 'columns' },
         });
       }
     },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/EchartsSunburst.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/EchartsSunburst.tsx
@@ -40,7 +40,6 @@ export default function EchartsSunburst(props: SunburstTransformedProps) {
     refs,
     emitCrossFilters,
   } = props;
-
   const { columns } = formData;
 
   const getCrossFilterDataMask = useCallback(
@@ -62,7 +61,7 @@ export default function EchartsSunburst(props: SunburstTransformedProps) {
             filters:
               values.length === 0 || !columns
                 ? []
-                : columns.map((col, idx) => {
+                : columns.slice(0, treePath.length).map((col, idx) => {
                     const val = labels.map(v => v[idx]);
                     if (val === null || val === undefined)
                       return {
@@ -111,6 +110,7 @@ export default function EchartsSunburst(props: SunburstTransformedProps) {
         const treePath = extractTreePathInfo(eventParams.treePathInfo);
         const pointerEvent = eventParams.event.event;
         const drillToDetailFilters: BinaryQueryObjectFilterClause[] = [];
+        let drillByFilters: BinaryQueryObjectFilterClause[] | undefined;
         if (columns?.length) {
           treePath.forEach((path, i) =>
             drillToDetailFilters.push({
@@ -120,10 +120,18 @@ export default function EchartsSunburst(props: SunburstTransformedProps) {
               formattedVal: path,
             }),
           );
+          drillByFilters = [
+            {
+              col: columns[treePath.length - 1],
+              op: '==',
+              val: treePath[treePath.length - 1],
+            },
+          ];
         }
         onContextMenu(pointerEvent.clientX, pointerEvent.clientY, {
           drillToDetail: drillToDetailFilters,
           crossFilter: getCrossFilterDataMask(treePathInfo),
+          drillBy: drillByFilters,
         });
       }
     },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/index.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t, ChartMetadata, ChartPlugin, Behavior } from '@superset-ui/core';
+import { Behavior, ChartMetadata, ChartPlugin, t } from '@superset-ui/core';
 import transformProps from './transformProps';
 import thumbnail from './images/thumbnail.png';
 import controlPanel from './controlPanel';
@@ -31,7 +31,11 @@ export default class EchartsSunburstChartPlugin extends ChartPlugin {
       controlPanel,
       loadChart: () => import('./EchartsSunburst'),
       metadata: new ChartMetadata({
-        behaviors: [Behavior.INTERACTIVE_CHART, Behavior.DRILL_TO_DETAIL],
+        behaviors: [
+          Behavior.INTERACTIVE_CHART,
+          Behavior.DRILL_TO_DETAIL,
+          Behavior.DRILL_BY,
+        ],
         category: t('Part of a Whole'),
         credits: ['https://echarts.apache.org'],
         description: t(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Area/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Area/index.ts
@@ -50,7 +50,11 @@ export default class EchartsAreaChartPlugin extends ChartPlugin<
       controlPanel,
       loadChart: () => import('../EchartsTimeseries'),
       metadata: new ChartMetadata({
-        behaviors: [Behavior.INTERACTIVE_CHART, Behavior.DRILL_TO_DETAIL],
+        behaviors: [
+          Behavior.INTERACTIVE_CHART,
+          Behavior.DRILL_TO_DETAIL,
+          Behavior.DRILL_BY,
+        ],
         category: t('Evolution'),
         credits: ['https://echarts.apache.org'],
         description: hasGenericChartAxes

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -242,7 +242,7 @@ export default function EchartsTimeseries({
         onContextMenu(pointerEvent.clientX, pointerEvent.clientY, {
           drillToDetail: drillToDetailFilters,
           crossFilter: getCrossFilterDataMask(seriesName),
-          drillBy: drillByFilters,
+          drillBy: { filters: drillByFilters, groupbyFieldName: 'groupby' },
         });
       }
     },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -201,40 +201,48 @@ export default function EchartsTimeseries({
         eventParams.event.stop();
         const { data, seriesName } = eventParams;
         const drillToDetailFilters: BinaryQueryObjectFilterClause[] = [];
+        const drillByFilters: BinaryQueryObjectFilterClause[] = [];
         const pointerEvent = eventParams.event.event;
         const values = [
           ...(eventParams.name ? [eventParams.name] : []),
-          ...labelMap[eventParams.seriesName],
+          ...labelMap[seriesName],
         ];
-        if (data) {
-          if (xAxis.type === AxisType.time) {
-            drillToDetailFilters.push({
-              col:
-                // if the xAxis is '__timestamp', granularity_sqla will be the column of filter
-                xAxis.label === DTTM_ALIAS
-                  ? formData.granularitySqla
-                  : xAxis.label,
-              grain: formData.timeGrainSqla,
-              op: '==',
-              val: data[0],
-              formattedVal: xValueFormatter(data[0]),
-            });
-          }
-          [
-            ...(xAxis.type === AxisType.category ? [xAxis.label] : []),
-            ...formData.groupby,
-          ].forEach((dimension, i) =>
-            drillToDetailFilters.push({
-              col: dimension,
-              op: '==',
-              val: values[i],
-              formattedVal: String(values[i]),
-            }),
-          );
+        if (data && xAxis.type === AxisType.time) {
+          drillToDetailFilters.push({
+            col:
+              // if the xAxis is '__timestamp', granularity_sqla will be the column of filter
+              xAxis.label === DTTM_ALIAS
+                ? formData.granularitySqla
+                : xAxis.label,
+            grain: formData.timeGrainSqla,
+            op: '==',
+            val: data[0],
+            formattedVal: xValueFormatter(data[0]),
+          });
         }
+        [
+          ...(xAxis.type === AxisType.category && data ? [xAxis.label] : []),
+          ...formData.groupby,
+        ].forEach((dimension, i) =>
+          drillToDetailFilters.push({
+            col: dimension,
+            op: '==',
+            val: values[i],
+            formattedVal: String(values[i]),
+          }),
+        );
+        formData.groupby.forEach((dimension, i) => {
+          drillByFilters.push({
+            col: dimension,
+            op: '==',
+            val: labelMap[seriesName][i],
+          });
+        });
+
         onContextMenu(pointerEvent.clientX, pointerEvent.clientY, {
           drillToDetail: drillToDetailFilters,
           crossFilter: getCrossFilterDataMask(seriesName),
+          drillBy: drillByFilters,
         });
       }
     },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/index.ts
@@ -56,7 +56,11 @@ export default class EchartsTimeseriesBarChartPlugin extends ChartPlugin<
       controlPanel,
       loadChart: () => import('../../EchartsTimeseries'),
       metadata: new ChartMetadata({
-        behaviors: [Behavior.INTERACTIVE_CHART, Behavior.DRILL_TO_DETAIL],
+        behaviors: [
+          Behavior.INTERACTIVE_CHART,
+          Behavior.DRILL_TO_DETAIL,
+          Behavior.DRILL_BY,
+        ],
         category: t('Evolution'),
         credits: ['https://echarts.apache.org'],
         description: hasGenericChartAxes

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/index.ts
@@ -55,7 +55,11 @@ export default class EchartsTimeseriesLineChartPlugin extends ChartPlugin<
       controlPanel,
       loadChart: () => import('../../EchartsTimeseries'),
       metadata: new ChartMetadata({
-        behaviors: [Behavior.INTERACTIVE_CHART, Behavior.DRILL_TO_DETAIL],
+        behaviors: [
+          Behavior.INTERACTIVE_CHART,
+          Behavior.DRILL_TO_DETAIL,
+          Behavior.DRILL_BY,
+        ],
         category: t('Evolution'),
         credits: ['https://echarts.apache.org'],
         description: hasGenericChartAxes

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/index.ts
@@ -54,7 +54,11 @@ export default class EchartsTimeseriesScatterChartPlugin extends ChartPlugin<
       controlPanel,
       loadChart: () => import('../../EchartsTimeseries'),
       metadata: new ChartMetadata({
-        behaviors: [Behavior.INTERACTIVE_CHART, Behavior.DRILL_TO_DETAIL],
+        behaviors: [
+          Behavior.INTERACTIVE_CHART,
+          Behavior.DRILL_TO_DETAIL,
+          Behavior.DRILL_BY,
+        ],
         category: t('Evolution'),
         credits: ['https://echarts.apache.org'],
         description: hasGenericChartAxes

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/SmoothLine/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/SmoothLine/index.ts
@@ -54,7 +54,11 @@ export default class EchartsTimeseriesSmoothLineChartPlugin extends ChartPlugin<
       controlPanel,
       loadChart: () => import('../../EchartsTimeseries'),
       metadata: new ChartMetadata({
-        behaviors: [Behavior.INTERACTIVE_CHART, Behavior.DRILL_TO_DETAIL],
+        behaviors: [
+          Behavior.INTERACTIVE_CHART,
+          Behavior.DRILL_TO_DETAIL,
+          Behavior.DRILL_BY,
+        ],
         category: t('Evolution'),
         credits: ['https://echarts.apache.org'],
         description: hasGenericChartAxes

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/index.ts
@@ -45,7 +45,11 @@ export default class EchartsTimeseriesStepChartPlugin extends ChartPlugin<
       controlPanel,
       loadChart: () => import('../EchartsTimeseries'),
       metadata: new ChartMetadata({
-        behaviors: [Behavior.INTERACTIVE_CHART, Behavior.DRILL_TO_DETAIL],
+        behaviors: [
+          Behavior.INTERACTIVE_CHART,
+          Behavior.DRILL_TO_DETAIL,
+          Behavior.DRILL_BY,
+        ],
         category: t('Evolution'),
         credits: ['https://echarts.apache.org'],
         description: hasGenericChartAxes

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/index.ts
@@ -44,7 +44,11 @@ export default class EchartsTimeseriesChartPlugin extends ChartPlugin<
       controlPanel,
       loadChart: () => import('./EchartsTimeseries'),
       metadata: new ChartMetadata({
-        behaviors: [Behavior.INTERACTIVE_CHART, Behavior.DRILL_TO_DETAIL],
+        behaviors: [
+          Behavior.INTERACTIVE_CHART,
+          Behavior.DRILL_TO_DETAIL,
+          Behavior.DRILL_BY,
+        ],
         category: t('Evolution'),
         credits: ['https://echarts.apache.org'],
         description: hasGenericChartAxes

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/EchartsTreemap.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/EchartsTreemap.tsx
@@ -116,17 +116,25 @@ export default function EchartsTreemap({
         if (treePath.length > 0) {
           const pointerEvent = eventParams.event.event;
           const drillToDetailFilters: BinaryQueryObjectFilterClause[] = [];
-          treePath.forEach((path, i) =>
+          const drillByFilters: BinaryQueryObjectFilterClause[] = [];
+          treePath.forEach((path, i) => {
+            const val = path === 'null' ? NULL_STRING : path;
             drillToDetailFilters.push({
               col: groupby[i],
               op: '==',
-              val: path === 'null' ? NULL_STRING : path,
+              val,
               formattedVal: path,
-            }),
-          );
+            });
+            drillByFilters.push({
+              col: groupby[i],
+              op: '==',
+              val,
+            });
+          });
           onContextMenu(pointerEvent.clientX, pointerEvent.clientY, {
             drillToDetail: drillToDetailFilters,
             crossFilter: getCrossFilterDataMask(data, treePathInfo),
+            drillBy: drillByFilters,
           });
         }
       }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/EchartsTreemap.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/EchartsTreemap.tsx
@@ -134,7 +134,7 @@ export default function EchartsTreemap({
           onContextMenu(pointerEvent.clientX, pointerEvent.clientY, {
             drillToDetail: drillToDetailFilters,
             crossFilter: getCrossFilterDataMask(data, treePathInfo),
-            drillBy: drillByFilters,
+            drillBy: { filters: drillByFilters, groupbyFieldName: 'groupby' },
           });
         }
       }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/index.ts
@@ -46,7 +46,11 @@ export default class EchartsTreemapChartPlugin extends ChartPlugin<
       controlPanel,
       loadChart: () => import('./EchartsTreemap'),
       metadata: new ChartMetadata({
-        behaviors: [Behavior.INTERACTIVE_CHART, Behavior.DRILL_TO_DETAIL],
+        behaviors: [
+          Behavior.INTERACTIVE_CHART,
+          Behavior.DRILL_TO_DETAIL,
+          Behavior.DRILL_BY,
+        ],
         category: t('Part of a Whole'),
         credits: ['https://echarts.apache.org'],
         description: t(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/eventHandlers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/eventHandlers.ts
@@ -126,7 +126,7 @@ export const contextMenuEventHandler =
       onContextMenu(pointerEvent.clientX, pointerEvent.clientY, {
         drillToDetail: drillFilters,
         crossFilter: getCrossFilterDataMask(e.name),
-        drillBy: drillFilters,
+        drillBy: { filters: drillFilters, groupbyFieldName: 'groupby' },
       });
     }
   };

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/eventHandlers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/eventHandlers.ts
@@ -111,11 +111,11 @@ export const contextMenuEventHandler =
     if (onContextMenu) {
       e.event.stop();
       const pointerEvent = e.event.event;
-      const drillToDetailFilters: BinaryQueryObjectFilterClause[] = [];
+      const drillFilters: BinaryQueryObjectFilterClause[] = [];
       if (groupby.length > 0) {
         const values = labelMap[e.name];
         groupby.forEach((dimension, i) =>
-          drillToDetailFilters.push({
+          drillFilters.push({
             col: dimension,
             op: '==',
             val: values[i],
@@ -124,8 +124,9 @@ export const contextMenuEventHandler =
         );
       }
       onContextMenu(pointerEvent.clientX, pointerEvent.clientY, {
-        drillToDetail: drillToDetailFilters,
+        drillToDetail: drillFilters,
         crossFilter: getCrossFilterDataMask(e.name),
+        drillBy: drillFilters,
       });
     }
   };

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -478,17 +478,27 @@ export default function PivotTableChart(props: PivotTableProps) {
         onContextMenu(e.clientX, e.clientY, {
           drillToDetail: drillToDetailFilters,
           crossFilter: getCrossFilterDataMask(dataPoint),
-          drillBy: [
-            {
-              col: Object.keys(dataPoint)[0],
-              op: '==',
-              val: Object.values(dataPoint)[0],
-            },
-          ],
+          drillBy: {
+            filters: [
+              {
+                col: Object.keys(dataPoint)[0],
+                op: '==',
+                val: Object.values(dataPoint)[0],
+              },
+            ],
+            groupbyFieldName: rowKey ? 'groupbyRows' : 'groupbyColumns',
+          },
         });
       }
     },
-    [cols, dateFormatters, onContextMenu, rows, timeGrainSqla],
+    [
+      cols,
+      dateFormatters,
+      getCrossFilterDataMask,
+      onContextMenu,
+      rows,
+      timeGrainSqla,
+    ],
   );
 
   return (

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -478,6 +478,13 @@ export default function PivotTableChart(props: PivotTableProps) {
         onContextMenu(e.clientX, e.clientY, {
           drillToDetail: drillToDetailFilters,
           crossFilter: getCrossFilterDataMask(dataPoint),
+          drillBy: [
+            {
+              col: Object.keys(dataPoint)[0],
+              op: '==',
+              val: Object.values(dataPoint)[0],
+            },
+          ],
         });
       }
     },

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -478,7 +478,7 @@ export default function PivotTableChart(props: PivotTableProps) {
         onContextMenu(e.clientX, e.clientY, {
           drillToDetail: drillToDetailFilters,
           crossFilter: getCrossFilterDataMask(dataPoint),
-          drillBy: {
+          drillBy: dataPoint && {
             filters: [
               {
                 col: Object.keys(dataPoint)[0],

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/index.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/index.ts
@@ -17,12 +17,12 @@
  * under the License.
  */
 import {
-  t,
+  Behavior,
   ChartMetadata,
   ChartPlugin,
-  Behavior,
   ChartProps,
   QueryFormData,
+  t,
 } from '@superset-ui/core';
 import buildQuery from './buildQuery';
 import controlPanel from './controlPanel';
@@ -47,7 +47,11 @@ export default class PivotTableChartPlugin extends ChartPlugin<
    */
   constructor() {
     const metadata = new ChartMetadata({
-      behaviors: [Behavior.INTERACTIVE_CHART, Behavior.DRILL_TO_DETAIL],
+      behaviors: [
+        Behavior.INTERACTIVE_CHART,
+        Behavior.DRILL_TO_DETAIL,
+        Behavior.DRILL_BY,
+      ],
       category: t('Table'),
       description: t(
         'Used to summarize a set of data by grouping together multiple statistics along two axes. Examples: Sales numbers by region and month, tasks by status and assignee, active users by age and location. Not the most visually stunning visualization, but highly informative and versatile.',

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -393,13 +393,16 @@ export default function TableChart<D extends DataRecord = DataRecord>(
               : getCrossFilterDataMask(cellPoint.key, cellPoint.value),
             drillBy: cellPoint.isMetric
               ? undefined
-              : [
-                  {
-                    col: cellPoint.key,
-                    op: '==',
-                    val: cellPoint.value as string | number | boolean,
-                  },
-                ],
+              : {
+                  filters: [
+                    {
+                      col: cellPoint.key,
+                      op: '==',
+                      val: cellPoint.value as string | number | boolean,
+                    },
+                  ],
+                  groupbyFieldName: 'groupby',
+                },
           });
         }
       : undefined;

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -391,6 +391,15 @@ export default function TableChart<D extends DataRecord = DataRecord>(
             crossFilter: cellPoint.isMetric
               ? undefined
               : getCrossFilterDataMask(cellPoint.key, cellPoint.value),
+            drillBy: cellPoint.isMetric
+              ? undefined
+              : [
+                  {
+                    col: cellPoint.key,
+                    op: '==',
+                    val: cellPoint.value as string | number | boolean,
+                  },
+                ],
           });
         }
       : undefined;

--- a/superset-frontend/plugins/plugin-chart-table/src/index.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/index.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t, ChartMetadata, ChartPlugin, Behavior } from '@superset-ui/core';
+import { Behavior, ChartMetadata, ChartPlugin, t } from '@superset-ui/core';
 import transformProps from './transformProps';
 import thumbnail from './images/thumbnail.png';
 import example1 from './images/Table.jpg';
@@ -31,7 +31,11 @@ export { default as __hack__ } from './types';
 export * from './types';
 
 const metadata = new ChartMetadata({
-  behaviors: [Behavior.INTERACTIVE_CHART, Behavior.DRILL_TO_DETAIL],
+  behaviors: [
+    Behavior.INTERACTIVE_CHART,
+    Behavior.DRILL_TO_DETAIL,
+    Behavior.DRILL_BY,
+  ],
   category: t('Table'),
   canBeAnnotationTypes: ['EVENT', 'INTERVAL'],
   description: t(

--- a/superset-frontend/src/components/Chart/ChartContextMenu.tsx
+++ b/superset-frontend/src/components/Chart/ChartContextMenu.tsx
@@ -203,7 +203,8 @@ const ChartContextMenu = (
     }
     menuItems.push(
       <DrillByMenuItems
-        filters={filters?.drillBy}
+        filters={filters?.drillBy?.filters}
+        groupbyFieldName={filters?.drillBy?.groupbyFieldName}
         formData={formData}
         contextMenuY={clientY}
         submenuIndex={submenuIndex}

--- a/superset-frontend/src/components/Chart/ChartContextMenu.tsx
+++ b/superset-frontend/src/components/Chart/ChartContextMenu.tsx
@@ -36,7 +36,7 @@ import {
   t,
   useTheme,
 } from '@superset-ui/core';
-import { Datasource, RootState } from 'src/dashboard/types';
+import { RootState } from 'src/dashboard/types';
 import { findPermission } from 'src/utils/findPermission';
 import { Menu } from 'src/components/Menu';
 import { AntdDropdown as Dropdown } from 'src/components';
@@ -72,13 +72,6 @@ const ChartContextMenu = (
   );
   const crossFiltersEnabled = useSelector<RootState, boolean>(
     ({ dashboardInfo }) => dashboardInfo.crossFiltersEnabled,
-  );
-
-  const datasourceDimensions = useSelector<RootState, Datasource['columns']>(
-    state =>
-      state.datasources[formData.datasource].columns.filter(
-        column => column.groupby,
-      ),
   );
 
   const [{ filters, clientX, clientY }, setState] = useState<{
@@ -211,7 +204,6 @@ const ChartContextMenu = (
     menuItems.push(
       <DrillByMenuItems
         filters={filters?.drillBy}
-        columns={datasourceDimensions}
         formData={formData}
         contextMenuY={clientY}
         submenuIndex={submenuIndex}

--- a/superset-frontend/src/components/Chart/ChartContextMenu.tsx
+++ b/superset-frontend/src/components/Chart/ChartContextMenu.tsx
@@ -94,12 +94,15 @@ const ChartContextMenu = (
 
   const showDrillBy = isFeatureEnabled(FeatureFlag.DRILL_BY) && canExplore;
 
+  const showCrossFilters = isFeatureEnabled(
+    FeatureFlag.DASHBOARD_CROSS_FILTERS,
+  );
   const isCrossFilteringSupportedByChart = getChartMetadataRegistry()
     .get(formData.viz_type)
     ?.behaviors?.includes(Behavior.INTERACTIVE_CHART);
 
   let itemsCount = 0;
-  if (isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS)) {
+  if (showCrossFilters) {
     itemsCount += 1;
   }
   if (showDrillToDetail) {
@@ -193,16 +196,25 @@ const ChartContextMenu = (
         isContextMenu
         contextMenuY={clientY}
         onSelection={onSelection}
+        submenuIndex={showCrossFilters ? 2 : 1}
       />,
     );
   }
   if (showDrillBy) {
+    let submenuIndex = 0;
+    if (showCrossFilters) {
+      submenuIndex += 1;
+    }
+    if (showDrillToDetail) {
+      submenuIndex += 2;
+    }
     menuItems.push(
       <DrillByMenuItems
         filters={filters?.drillBy}
         columns={datasourceDimensions}
         formData={formData}
         contextMenuY={clientY}
+        submenuIndex={submenuIndex}
       />,
     );
   }

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.test.tsx
@@ -27,6 +27,7 @@ import fetchMock from 'fetch-mock';
 import { render, screen, within, waitFor } from 'spec/helpers/testing-library';
 import chartQueries, { sliceId } from 'spec/fixtures/mockChartQueries';
 import { Menu } from 'src/components/Menu';
+import { supersetGetCache } from 'src/utils/cachedSupersetGet';
 import { DrillByMenuItems, DrillByMenuItemsProps } from './DrillByMenuItems';
 
 /* eslint jest/expect-expect: ["warn", { "assertFunctionNames": ["expect*"] }] */
@@ -65,6 +66,7 @@ const renderMenu = ({
       <DrillByMenuItems
         formData={formData ?? defaultFormData}
         filters={filters}
+        groupbyFieldName="groupby"
       />
     </Menu>,
     { useRouter: true, useRedux: true },
@@ -89,7 +91,9 @@ const expectDrillByEnabled = async () => {
     name: 'Drill by',
   });
   expect(drillByMenuItem).toBeInTheDocument();
-  expect(drillByMenuItem).not.toHaveAttribute('aria-disabled');
+  await waitFor(() =>
+    expect(drillByMenuItem).not.toHaveAttribute('aria-disabled'),
+  );
   const tooltipTrigger =
     within(drillByMenuItem).queryByTestId('tooltip-trigger');
   expect(tooltipTrigger).not.toBeInTheDocument();
@@ -110,64 +114,77 @@ getChartMetadataRegistry().registerValue(
   }),
 );
 
-test('render disabled menu item for unsupported chart', async () => {
-  renderMenu({ formData: { ...defaultFormData, viz_type: 'unsupported_viz' } });
-  await expectDrillByDisabled(
-    'Drill by is not yet supported for this chart type',
-  );
-});
-
-test('render disabled menu item for supported chart, no filters', async () => {
-  renderMenu({ filters: [] });
-  await expectDrillByDisabled('Drill by is not available for this data point');
-});
-
-test('render disabled menu item for supported chart, no columns', async () => {
-  renderMenu({});
-  await expectDrillByDisabled('No dimensions available for drill by');
-});
-
-test('render menu item with submenu without searchbox', async () => {
-  const slicedColumns = defaultColumns.slice(0, 9);
-  fetchMock.get(datasetEndpointMatcher, { result: { columns: slicedColumns } });
-  renderMenu({});
-  await waitFor(() => fetchMock.called(datasetEndpointMatcher));
-  await expectDrillByEnabled();
-  slicedColumns.forEach(column => {
-    expect(screen.getByText(column.column_name)).toBeInTheDocument();
-  });
-  expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
-  fetchMock.restore();
-});
-
-test('render menu item with submenu and searchbox', async () => {
-  fetchMock.get(datasetEndpointMatcher, {
-    result: { columns: defaultColumns },
-  });
-  renderMenu({});
-  await waitFor(() => fetchMock.called(datasetEndpointMatcher));
-  await expectDrillByEnabled();
-  defaultColumns.forEach(column => {
-    expect(screen.getByText(column.column_name)).toBeInTheDocument();
+describe('Drill by menu items', () => {
+  afterEach(() => {
+    supersetGetCache.clear();
+    fetchMock.restore();
   });
 
-  const searchbox = screen.getByRole('textbox');
-  expect(searchbox).toBeInTheDocument();
+  test('render disabled menu item for unsupported chart', async () => {
+    renderMenu({
+      formData: { ...defaultFormData, viz_type: 'unsupported_viz' },
+    });
+    await expectDrillByDisabled(
+      'Drill by is not yet supported for this chart type',
+    );
+  });
 
-  userEvent.type(searchbox, 'col1');
+  test('render disabled menu item for supported chart, no filters', async () => {
+    renderMenu({ filters: [] });
+    await expectDrillByDisabled(
+      'Drill by is not available for this data point',
+    );
+  });
 
-  await screen.findByText('col1');
+  test('render disabled menu item for supported chart, no columns', async () => {
+    fetchMock.get(datasetEndpointMatcher, { result: { columns: [] } });
+    renderMenu({});
+    await waitFor(() => fetchMock.called(datasetEndpointMatcher));
+    await expectDrillByDisabled('No dimensions available for drill by');
+  });
 
-  const expectedFilteredColumnNames = ['col1', 'col10', 'col11'];
+  test('render menu item with submenu without searchbox', async () => {
+    const slicedColumns = defaultColumns.slice(0, 9);
+    fetchMock.get(datasetEndpointMatcher, {
+      result: { columns: slicedColumns },
+    });
+    renderMenu({});
+    await waitFor(() => fetchMock.called(datasetEndpointMatcher));
+    await expectDrillByEnabled();
+    slicedColumns.forEach(column => {
+      expect(screen.getByText(column.column_name)).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
 
-  defaultColumns
-    .filter(col => !expectedFilteredColumnNames.includes(col.column_name))
-    .forEach(col => {
-      expect(screen.queryByText(col.column_name)).not.toBeInTheDocument();
+  test('render menu item with submenu and searchbox', async () => {
+    fetchMock.get(datasetEndpointMatcher, {
+      result: { columns: defaultColumns },
+    });
+    renderMenu({});
+    await waitFor(() => fetchMock.called(datasetEndpointMatcher));
+    await expectDrillByEnabled();
+    defaultColumns.forEach(column => {
+      expect(screen.getByText(column.column_name)).toBeInTheDocument();
     });
 
-  expectedFilteredColumnNames.forEach(colName => {
-    expect(screen.getByText(colName)).toBeInTheDocument();
+    const searchbox = screen.getByRole('textbox');
+    expect(searchbox).toBeInTheDocument();
+
+    userEvent.type(searchbox, 'col1');
+
+    await screen.findByText('col1');
+
+    const expectedFilteredColumnNames = ['col1', 'col10', 'col11'];
+
+    defaultColumns
+      .filter(col => !expectedFilteredColumnNames.includes(col.column_name))
+      .forEach(col => {
+        expect(screen.queryByText(col.column_name)).not.toBeInTheDocument();
+      });
+
+    expectedFilteredColumnNames.forEach(colName => {
+      expect(screen.getByText(colName)).toBeInTheDocument();
+    });
   });
-  fetchMock.restore();
 });

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import {
+  Behavior,
+  ChartMetadata,
+  getChartMetadataRegistry,
+} from '@superset-ui/core';
+import { render, screen, within } from 'spec/helpers/testing-library';
+import chartQueries, { sliceId } from 'spec/fixtures/mockChartQueries';
+import { Menu } from 'src/components/Menu';
+import { DrillByMenuItems, DrillByMenuItemsProps } from './DrillByMenuItems';
+
+/* eslint jest/expect-expect: ["warn", { "assertFunctionNames": ["expect*"] }] */
+
+const { form_data: defaultFormData } = chartQueries[sliceId];
+
+const defaultColumns = [
+  { column_name: 'col1' },
+  { column_name: 'col2' },
+  { column_name: 'col3' },
+  { column_name: 'col4' },
+  { column_name: 'col5' },
+  { column_name: 'col6' },
+  { column_name: 'col7' },
+  { column_name: 'col8' },
+  { column_name: 'col9' },
+  { column_name: 'col10' },
+  { column_name: 'col11' },
+];
+
+const defaultFilters = [
+  {
+    col: 'filter_col',
+    op: '==' as const,
+    val: 'val',
+  },
+];
+
+const renderMenu = ({
+  formData = defaultFormData,
+  filters = defaultFilters,
+  columns = defaultColumns,
+}: Partial<DrillByMenuItemsProps>) =>
+  render(
+    <Menu>
+      <DrillByMenuItems
+        formData={formData ?? defaultFormData}
+        filters={filters}
+        columns={columns}
+      />
+    </Menu>,
+    { useRouter: true, useRedux: true },
+  );
+
+const expectDrillByDisabled = async (tooltipContent: string) => {
+  const drillByMenuItem = screen.getByRole('menuitem', {
+    name: 'Drill by',
+  });
+
+  expect(drillByMenuItem).toBeVisible();
+  expect(drillByMenuItem).toHaveAttribute('aria-disabled', 'true');
+  const tooltipTrigger = within(drillByMenuItem).getByTestId('tooltip-trigger');
+  userEvent.hover(tooltipTrigger as HTMLElement);
+  const tooltip = await screen.findByRole('tooltip', { name: tooltipContent });
+
+  expect(tooltip).toBeInTheDocument();
+};
+
+const expectDrillByEnabled = async () => {
+  const drillByMenuItem = screen.getByRole('menuitem', {
+    name: 'Drill by',
+  });
+  expect(drillByMenuItem).not.toHaveAttribute('aria-disabled', 'true');
+  expect(drillByMenuItem).toBeInTheDocument();
+  expect(drillByMenuItem).not.toHaveAttribute('aria-disabled');
+  const tooltipTrigger =
+    within(drillByMenuItem).queryByTestId('tooltip-trigger');
+  expect(tooltipTrigger).not.toBeInTheDocument();
+
+  userEvent.hover(
+    within(drillByMenuItem).getByRole('button', { name: 'Drill by' }),
+  );
+  expect(await screen.findByTestId('drill-by-submenu')).toBeInTheDocument();
+};
+
+getChartMetadataRegistry().registerValue(
+  'pie',
+  new ChartMetadata({
+    name: 'fake pie',
+    thumbnail: '.png',
+    useLegacyApi: false,
+    behaviors: [Behavior.DRILL_BY],
+  }),
+);
+
+test('render disabled menu item for unsupported chart', async () => {
+  renderMenu({ formData: { ...defaultFormData, viz_type: 'unsupported_viz' } });
+  await expectDrillByDisabled(
+    'Drill by is not yet supported for this chart type',
+  );
+});
+
+test('render disabled menu item for supported chart, no filters', async () => {
+  renderMenu({ filters: [] });
+  await expectDrillByDisabled('Drill by is not available for this data point');
+});
+
+test('render disabled menu item for supported chart, no columns', async () => {
+  renderMenu({ columns: [] });
+  await expectDrillByDisabled('No dimensions available for drill by');
+});
+
+test('render menu item with submenu without searchbox', async () => {
+  const slicedColumns = defaultColumns.slice(0, 9);
+  renderMenu({ columns: slicedColumns });
+  await expectDrillByEnabled();
+  slicedColumns.forEach(column => {
+    expect(screen.getByText(column.column_name)).toBeInTheDocument();
+  });
+  expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+});
+
+test('render menu item with submenu and searchbox', async () => {
+  renderMenu({});
+  await expectDrillByEnabled();
+  defaultColumns.forEach(column => {
+    expect(screen.getByText(column.column_name)).toBeInTheDocument();
+  });
+
+  const searchbox = screen.getByRole('textbox');
+  expect(searchbox).toBeInTheDocument();
+
+  userEvent.type(searchbox, 'col1');
+
+  await screen.findByText('col1');
+
+  const expectedFilteredColumnNames = ['col1', 'col10', 'col11'];
+
+  defaultColumns
+    .filter(col => !expectedFilteredColumnNames.includes(col.column_name))
+    .forEach(col => {
+      expect(screen.queryByText(col.column_name)).not.toBeInTheDocument();
+    });
+
+  expectedFilteredColumnNames.forEach(colName => {
+    expect(screen.getByText(colName)).toBeInTheDocument();
+  });
+});

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.tsx
@@ -1,0 +1,181 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, {
+  ChangeEvent,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { Menu } from 'src/components/Menu';
+import {
+  Behavior,
+  Column,
+  ContextMenuFilters,
+  css,
+  getChartMetadataRegistry,
+  t,
+  useTheme,
+} from '@superset-ui/core';
+import Icons from 'src/components/Icons';
+import { Input } from 'src/components/Input';
+import { MenuItemTooltip } from '../DisabledMenuItemTooltip';
+import { getSubmenuYOffset } from '../utils';
+
+export interface DrillByMenuItemsProps {
+  filters?: ContextMenuFilters['drillBy'];
+  formData: { [key: string]: any; viz_type: string };
+  columns: Column[];
+  contextMenuY?: number;
+}
+export const DrillByMenuItems = ({
+  filters,
+  columns,
+  formData,
+  contextMenuY = 0,
+  ...rest
+}: DrillByMenuItemsProps) => {
+  const theme = useTheme();
+  const [searchInput, setSearchInput] = useState('');
+
+  useEffect(() => {
+    // Input is displayed only when columns.length > 10
+    // Reset search input in case Input gets removed
+    setSearchInput('');
+  }, [columns.length]);
+
+  const handleInput = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    e.stopPropagation();
+    const input = e?.target?.value;
+    setSearchInput(input);
+  }, []);
+
+  const handlesDimensionContextMenu = useMemo(
+    () =>
+      getChartMetadataRegistry()
+        .get(formData.viz_type)
+        ?.behaviors.find(behavior => behavior === Behavior.DRILL_BY),
+    [formData.viz_type],
+  );
+
+  const submenuYOffset = useMemo(
+    () =>
+      getSubmenuYOffset(
+        contextMenuY,
+        columns.length > 1 ? columns.length + 1 : columns.length,
+      ),
+    [contextMenuY, columns.length],
+  );
+
+  let tooltip: ReactNode;
+
+  if (!handlesDimensionContextMenu) {
+    tooltip = t('Drill by is not yet supported for this chart type');
+  } else if (!filters) {
+    tooltip = t('Drill by is not available for this data point');
+  } else if (columns.length === 0) {
+    tooltip = t('No dimensions available for drill by');
+  }
+
+  const filteredColumns = useMemo(
+    () =>
+      columns.filter(column =>
+        (column.verbose_name || column.column_name)
+          .toLowerCase()
+          .includes(searchInput.toLowerCase()),
+      ),
+    [columns, searchInput],
+  );
+
+  return useMemo(() => {
+    if (!handlesDimensionContextMenu || !filters || columns.length === 0) {
+      return (
+        <Menu.Item key="drill-by-disabled" disabled {...rest}>
+          <div>
+            {t('Drill by')}
+            <MenuItemTooltip title={tooltip} />
+          </div>
+        </Menu.Item>
+      );
+    }
+    return (
+      <Menu.SubMenu
+        title={t('Drill by')}
+        popupOffset={[0, submenuYOffset]}
+        {...rest}
+      >
+        {columns.length > 10 && (
+          <Input
+            prefix={
+              <Icons.Search
+                iconSize="l"
+                iconColor={theme.colors.grayscale.light1}
+              />
+            }
+            onChange={handleInput}
+            placeholder={t('Search columns')}
+            value={searchInput}
+            onClick={e => {
+              // prevent closing menu when clicking on input
+              // @ts-ignore
+              e.stopImmediatePropagation();
+            }}
+            allowClear
+            css={css`
+              width: auto;
+              max-width: 100%;
+              margin: ${theme.gridUnit * 2}px ${theme.gridUnit * 3}px;
+              box-shadow: none;
+            `}
+          />
+        )}
+        {filteredColumns.length ? (
+          <div
+            css={css`
+              max-height: 200px;
+              overflow: auto;
+            `}
+          >
+            {filteredColumns.map(column => (
+              <Menu.Item key={`drill-by-item-${column.column_name}`} {...rest}>
+                {column.verbose_name || column.column_name}
+              </Menu.Item>
+            ))}
+          </div>
+        ) : (
+          <div>No columns found</div>
+        )}
+      </Menu.SubMenu>
+    );
+  }, [
+    columns.length,
+    filteredColumns,
+    filters,
+    handleInput,
+    handlesDimensionContextMenu,
+    rest,
+    searchInput,
+    submenuYOffset,
+    theme.colors.grayscale.light1,
+    theme.gridUnit,
+    tooltip,
+  ]);
+};

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.tsx
@@ -104,7 +104,7 @@ export const DrillByMenuItems = ({
           ? SEARCH_INPUT_HEIGHT
           : 0,
       ),
-    [contextMenuY, filteredColumns.length, columns.length],
+    [contextMenuY, filteredColumns.length, submenuIndex, columns.length],
   );
 
   let tooltip: ReactNode;
@@ -137,49 +137,50 @@ export const DrillByMenuItems = ({
       popupClassName="drill-by-submenu"
       {...rest}
     >
-      {columns.length > SHOW_COLUMNS_SEARCH_THRESHOLD && (
-        <Input
-          prefix={
-            <Icons.Search
-              iconSize="l"
-              iconColor={theme.colors.grayscale.light1}
-            />
-          }
-          onChange={handleInput}
-          placeholder={t('Search columns')}
-          value={searchInput}
-          onClick={e => {
-            // prevent closing menu when clicking on input
-            // @ts-ignore
-            e.stopImmediatePropagation();
-          }}
-          allowClear
-          css={css`
-            width: auto;
-            max-width: 100%;
-            margin: ${theme.gridUnit * 2}px ${theme.gridUnit * 3}px;
-            box-shadow: none;
-          `}
-        />
-      )}
-      {filteredColumns.length ? (
-        <div
-          css={css`
-            max-height: ${MAX_SUBMENU_HEIGHT}px;
-            overflow: auto;
-          `}
-        >
-          {filteredColumns.map(column => (
-            <Menu.Item key={`drill-by-item-${column.column_name}`} {...rest}>
-              {column.verbose_name || column.column_name}
-            </Menu.Item>
-          ))}
-        </div>
-      ) : (
-        <Menu.Item disabled key="no-drill-by-columns-found" {...rest}>
-          {t('No columns found')}
-        </Menu.Item>
-      )}
+      <div data-test="drill-by-submenu">
+        {columns.length > SHOW_COLUMNS_SEARCH_THRESHOLD && (
+          <Input
+            prefix={
+              <Icons.Search
+                iconSize="l"
+                iconColor={theme.colors.grayscale.light1}
+              />
+            }
+            onChange={handleInput}
+            placeholder={t('Search columns')}
+            value={searchInput}
+            onClick={e => {
+              // prevent closing menu when clicking on input
+              e.nativeEvent.stopImmediatePropagation();
+            }}
+            allowClear
+            css={css`
+              width: auto;
+              max-width: 100%;
+              margin: ${theme.gridUnit * 2}px ${theme.gridUnit * 3}px;
+              box-shadow: none;
+            `}
+          />
+        )}
+        {filteredColumns.length ? (
+          <div
+            css={css`
+              max-height: ${MAX_SUBMENU_HEIGHT}px;
+              overflow: auto;
+            `}
+          >
+            {filteredColumns.map(column => (
+              <Menu.Item key={`drill-by-item-${column.column_name}`} {...rest}>
+                {column.verbose_name || column.column_name}
+              </Menu.Item>
+            ))}
+          </div>
+        ) : (
+          <Menu.Item disabled key="no-drill-by-columns-found" {...rest}>
+            {t('No columns found')}
+          </Menu.Item>
+        )}
+      </div>
     </Menu.SubMenu>
   );
 };

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.tsx
@@ -31,6 +31,7 @@ import {
   Column,
   ContextMenuFilters,
   css,
+  ensureIsArray,
   getChartMetadataRegistry,
   t,
   useTheme,
@@ -108,15 +109,16 @@ export const DrillByMenuItems = ({
 
   let tooltip: ReactNode;
 
+  const hasFilters = ensureIsArray(filters).length;
   if (!handlesDimensionContextMenu) {
     tooltip = t('Drill by is not yet supported for this chart type');
-  } else if (!filters) {
+  } else if (!hasFilters) {
     tooltip = t('Drill by is not available for this data point');
   } else if (columns.length === 0) {
     tooltip = t('No dimensions available for drill by');
   }
 
-  if (!handlesDimensionContextMenu || !filters || columns.length === 0) {
+  if (!handlesDimensionContextMenu || !hasFilters || columns.length === 0) {
     return (
       <Menu.Item key="drill-by-disabled" disabled {...rest}>
         <div>

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailMenuItems.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailMenuItems.tsx
@@ -33,6 +33,7 @@ import { Menu } from 'src/components/Menu';
 import DrillDetailModal from './DrillDetailModal';
 import { getSubmenuYOffset } from '../utils';
 import { MenuItemTooltip } from '../DisabledMenuItemTooltip';
+import { MenuItemWithTruncation } from '../MenuItemWithTruncation';
 
 const DRILL_TO_DETAIL_TEXT = t('Drill to detail by');
 
@@ -170,7 +171,7 @@ const DrillDetailMenuItems = ({
         filters.length > 1 ? filters.length + 1 : filters.length,
         submenuIndex,
       ),
-    [contextMenuY, filters.length],
+    [contextMenuY, filters.length, submenuIndex],
   );
 
   if (handlesDimensionContextMenu && !noAggregations && filters?.length) {
@@ -178,18 +179,20 @@ const DrillDetailMenuItems = ({
       <Menu.SubMenu
         {...props}
         popupOffset={[0, submenuYOffset]}
+        popupClassName="chart-context-submenu"
         title={DRILL_TO_DETAIL_TEXT}
       >
         <div data-test="drill-to-detail-by-submenu">
           {filters.map((filter, i) => (
-            <Menu.Item
+            <MenuItemWithTruncation
               {...props}
+              tooltipText={`${DRILL_TO_DETAIL_TEXT} ${filter.formattedVal}`}
               key={`drill-detail-filter-${i}`}
               onClick={openModal.bind(null, [filter])}
             >
               {`${DRILL_TO_DETAIL_TEXT} `}
               <Filter>{filter.formattedVal}</Filter>
-            </Menu.Item>
+            </MenuItemWithTruncation>
           ))}
           {filters.length > 1 && (
             <Menu.Item
@@ -197,8 +200,10 @@ const DrillDetailMenuItems = ({
               key="drill-detail-filter-all"
               onClick={openModal.bind(null, filters)}
             >
-              {`${DRILL_TO_DETAIL_TEXT} `}
-              <Filter>{t('all')}</Filter>
+              <div>
+                {`${DRILL_TO_DETAIL_TEXT} `}
+                <Filter>{t('all')}</Filter>
+              </div>
             </Menu.Item>
           )}
         </div>

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailMenuItems.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailMenuItems.tsx
@@ -31,10 +31,9 @@ import {
 } from '@superset-ui/core';
 import { Menu } from 'src/components/Menu';
 import DrillDetailModal from './DrillDetailModal';
-import { getMenuAdjustedY, MENU_ITEM_HEIGHT } from '../utils';
+import { getSubmenuYOffset } from '../utils';
 import { MenuItemTooltip } from '../DisabledMenuItemTooltip';
 
-const MENU_PADDING = 4;
 const DRILL_TO_DETAIL_TEXT = t('Drill to detail by');
 
 const DisabledMenuItem = ({ children, ...props }: { children: ReactNode }) => (
@@ -162,13 +161,14 @@ const DrillDetailMenuItems = ({
   }
 
   // Ensure submenu doesn't appear offscreen
-  const submenuYOffset = useMemo(() => {
-    const itemsCount = filters.length > 1 ? filters.length + 1 : filters.length;
-    const submenuY =
-      contextMenuY + MENU_PADDING + MENU_ITEM_HEIGHT + MENU_PADDING;
-
-    return getMenuAdjustedY(submenuY, itemsCount) - submenuY;
-  }, [contextMenuY, filters.length]);
+  const submenuYOffset = useMemo(
+    () =>
+      getSubmenuYOffset(
+        contextMenuY,
+        filters.length > 1 ? filters.length + 1 : filters.length,
+      ),
+    [contextMenuY, filters.length],
+  );
 
   if (handlesDimensionContextMenu && !noAggregations && filters?.length) {
     drillToDetailByMenuItem = (

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailMenuItems.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailMenuItems.tsx
@@ -64,6 +64,7 @@ export type DrillDetailMenuItemsProps = {
   contextMenuY?: number;
   onSelection?: () => void;
   onClick?: (event: MouseEvent) => void;
+  submenuIndex?: number;
 };
 
 const DrillDetailMenuItems = ({
@@ -74,6 +75,7 @@ const DrillDetailMenuItems = ({
   contextMenuY = 0,
   onSelection = () => null,
   onClick = () => null,
+  submenuIndex = 0,
   ...props
 }: DrillDetailMenuItemsProps) => {
   const [modalFilters, setFilters] = useState<BinaryQueryObjectFilterClause[]>(
@@ -166,6 +168,7 @@ const DrillDetailMenuItems = ({
       getSubmenuYOffset(
         contextMenuY,
         filters.length > 1 ? filters.length + 1 : filters.length,
+        submenuIndex,
       ),
     [contextMenuY, filters.length],
   );

--- a/superset-frontend/src/components/Chart/MenuItemWithTruncation.tsx
+++ b/superset-frontend/src/components/Chart/MenuItemWithTruncation.tsx
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { ReactNode } from 'react';
+import { css, truncationCSS, useCSSTextTruncation } from '@superset-ui/core';
+import { Menu } from 'src/components/Menu';
+import { Tooltip } from 'src/components/Tooltip';
+
+export type MenuItemWithTruncationProps = {
+  tooltipText: ReactNode;
+  children: ReactNode;
+  onClick?: () => void;
+};
+
+export const MenuItemWithTruncation = ({
+  tooltipText,
+  children,
+  ...props
+}: MenuItemWithTruncationProps) => {
+  const [itemRef, itemIsTruncated] = useCSSTextTruncation<HTMLDivElement>();
+
+  return (
+    <Menu.Item
+      css={css`
+        display: flex;
+      `}
+      {...props}
+    >
+      <Tooltip title={itemIsTruncated ? tooltipText : null}>
+        <div
+          ref={itemRef}
+          css={css`
+            max-width: 100%;
+            ${truncationCSS};
+          `}
+        >
+          {children}
+        </div>
+      </Tooltip>
+    </Menu.Item>
+  );
+};

--- a/superset-frontend/src/components/Chart/utils.test.ts
+++ b/superset-frontend/src/components/Chart/utils.test.ts
@@ -39,4 +39,7 @@ test('correctly positions at lower edge of screen', () => {
   expect(getMenuAdjustedY(425, 1)).toEqual(425); // No adjustment
   expect(getMenuAdjustedY(425, 2)).toEqual(404); // Adjustment
   expect(getMenuAdjustedY(425, 3)).toEqual(372); // Adjustment
+
+  expect(getMenuAdjustedY(425, 8, 200)).toEqual(268);
+  expect(getMenuAdjustedY(425, 8, 200, 48)).toEqual(220);
 });

--- a/superset-frontend/src/components/Chart/utils.ts
+++ b/superset-frontend/src/components/Chart/utils.ts
@@ -28,21 +28,45 @@ const MENU_VERTICAL_SPACING = 32;
  * @param clientY The original Y-offset
  * @param itemsCount The number of menu items
  */
-export const getMenuAdjustedY = (clientY: number, itemsCount: number) => {
+export const getMenuAdjustedY = (
+  clientY: number,
+  itemsCount: number,
+  maxItemsContainerHeight = Number.MAX_SAFE_INTEGER,
+  additionalItemsHeight = 0,
+) => {
   // Viewport height
   const vh = Math.max(
     document.documentElement.clientHeight || 0,
     window.innerHeight || 0,
   );
 
-  const menuHeight = MENU_ITEM_HEIGHT * itemsCount + MENU_VERTICAL_SPACING;
+  const menuHeight =
+    Math.min(MENU_ITEM_HEIGHT * itemsCount, maxItemsContainerHeight) +
+    MENU_VERTICAL_SPACING +
+    additionalItemsHeight;
   // Always show the context menu inside the viewport
   return vh - clientY < menuHeight ? vh - menuHeight : clientY;
 };
 
-export const getSubmenuYOffset = (contextMenuY: number, itemsCount: number) => {
+export const getSubmenuYOffset = (
+  contextMenuY: number,
+  itemsCount: number,
+  submenuIndex = 0,
+  maxItemsContainerHeight = Number.MAX_SAFE_INTEGER,
+  additionalItemsHeight = 0,
+) => {
   const submenuY =
-    contextMenuY + MENU_PADDING + MENU_ITEM_HEIGHT + MENU_PADDING;
+    contextMenuY +
+    MENU_PADDING +
+    MENU_ITEM_HEIGHT * submenuIndex +
+    MENU_PADDING;
 
-  return getMenuAdjustedY(submenuY, itemsCount) - submenuY;
+  return (
+    getMenuAdjustedY(
+      submenuY,
+      itemsCount,
+      maxItemsContainerHeight,
+      additionalItemsHeight,
+    ) - submenuY
+  );
 };

--- a/superset-frontend/src/components/Chart/utils.ts
+++ b/superset-frontend/src/components/Chart/utils.ts
@@ -18,6 +18,7 @@
  */
 
 export const MENU_ITEM_HEIGHT = 32;
+const MENU_PADDING = 4;
 const MENU_VERTICAL_SPACING = 32;
 
 /**
@@ -27,7 +28,7 @@ const MENU_VERTICAL_SPACING = 32;
  * @param clientY The original Y-offset
  * @param itemsCount The number of menu items
  */
-export function getMenuAdjustedY(clientY: number, itemsCount: number) {
+export const getMenuAdjustedY = (clientY: number, itemsCount: number) => {
   // Viewport height
   const vh = Math.max(
     document.documentElement.clientHeight || 0,
@@ -37,4 +38,11 @@ export function getMenuAdjustedY(clientY: number, itemsCount: number) {
   const menuHeight = MENU_ITEM_HEIGHT * itemsCount + MENU_VERTICAL_SPACING;
   // Always show the context menu inside the viewport
   return vh - clientY < menuHeight ? vh - menuHeight : clientY;
-}
+};
+
+export const getSubmenuYOffset = (contextMenuY: number, itemsCount: number) => {
+  const submenuY =
+    contextMenuY + MENU_PADDING + MENU_ITEM_HEIGHT + MENU_PADDING;
+
+  return getMenuAdjustedY(submenuY, itemsCount) - submenuY;
+};

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ColumnSelect.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ColumnSelect.tsx
@@ -22,8 +22,8 @@ import { Column, ensureIsArray, t, useChangeEffect } from '@superset-ui/core';
 import { Select, FormInstance } from 'src/components';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
+import { cachedSupersetGet } from 'src/utils/cachedSupersetGet';
 import { NativeFiltersForm } from '../types';
-import { cachedSupersetGet } from './utils';
 
 interface ColumnSelectProps {
   allowClear?: boolean;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/DatasetSelect.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/DatasetSelect.tsx
@@ -24,7 +24,8 @@ import {
   ClientErrorObject,
   getClientErrorObject,
 } from 'src/utils/getClientErrorObject';
-import { cachedSupersetGet, datasetToSelectOption } from './utils';
+import { cachedSupersetGet } from 'src/utils/cachedSupersetGet';
+import { datasetToSelectOption } from './utils';
 
 interface DatasetSelectProps {
   onChange: (value: { label: string; value: number }) => void;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -60,6 +60,7 @@ import { addDangerToast } from 'src/components/MessageToasts/actions';
 import { Radio } from 'src/components/Radio';
 import Tabs from 'src/components/Tabs';
 import { Tooltip } from 'src/components/Tooltip';
+import { cachedSupersetGet } from 'src/utils/cachedSupersetGet';
 import {
   Chart,
   ChartsState,
@@ -90,7 +91,6 @@ import getControlItemsMap from './getControlItemsMap';
 import RemovedFilter from './RemovedFilter';
 import { useBackendFormUpdate, useDefaultValue } from './state';
 import {
-  cachedSupersetGet,
   hasTemporalColumns,
   mostUsedDataset,
   setNativeFilterFieldValues,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/utils.ts
@@ -20,14 +20,8 @@ import { flatMapDeep } from 'lodash';
 import { FormInstance } from 'src/components';
 import React from 'react';
 import { CustomControlItem, Dataset } from '@superset-ui/chart-controls';
-import {
-  Column,
-  ensureIsArray,
-  GenericDataType,
-  SupersetClient,
-} from '@superset-ui/core';
+import { Column, ensureIsArray, GenericDataType } from '@superset-ui/core';
 import { DatasourcesState, ChartsState } from 'src/dashboard/types';
-import { cacheWrapper } from 'src/utils/cacheWrapper';
 import { FILTER_SUPPORTED_TYPES } from './constants';
 
 const FILTERS_FIELD_NAME = 'filters';
@@ -124,11 +118,3 @@ export const mostUsedDataset = (
 
   return datasets[mostUsedDataset]?.id;
 };
-
-const localCache = new Map<string, any>();
-
-export const cachedSupersetGet = cacheWrapper(
-  SupersetClient.get,
-  localCache,
-  ({ endpoint }) => endpoint || '',
-);

--- a/superset-frontend/src/dashboard/containers/DashboardPage.tsx
+++ b/superset-frontend/src/dashboard/containers/DashboardPage.tsx
@@ -59,7 +59,11 @@ import { DashboardContextForExplore } from 'src/types/DashboardContextForExplore
 import shortid from 'shortid';
 import { RootState } from '../types';
 import { getActiveFilters } from '../util/activeDashboardFilters';
-import { filterCardPopoverStyle, headerStyles } from '../styles';
+import {
+  chartContextMenuStyles,
+  filterCardPopoverStyle,
+  headerStyles,
+} from '../styles';
 
 export const DashboardPageIdContext = React.createContext('');
 
@@ -279,7 +283,13 @@ export const DashboardPage: FC<PageProps> = ({ idOrSlug }: PageProps) => {
 
   return (
     <>
-      <Global styles={[filterCardPopoverStyle(theme), headerStyles(theme)]} />
+      <Global
+        styles={[
+          filterCardPopoverStyle(theme),
+          headerStyles(theme),
+          chartContextMenuStyles(theme),
+        ]}
+      />
       <DashboardPageIdContext.Provider value={dashboardPageId}>
         <DashboardContainer />
       </DashboardPageIdContext.Provider>

--- a/superset-frontend/src/dashboard/styles.ts
+++ b/superset-frontend/src/dashboard/styles.ts
@@ -87,3 +87,10 @@ export const filterCardPopoverStyle = (theme: SupersetTheme) => css`
     }
   }
 `;
+
+export const chartContextMenuStyles = (theme: SupersetTheme) => css`
+  .ant-dropdown-menu-submenu.chart-context-submenu {
+    max-width: ${theme.gridUnit * 60}px;
+    min-width: ${theme.gridUnit * 40}px;
+  }
+`;

--- a/superset-frontend/src/utils/cachedSupersetGet.ts
+++ b/superset-frontend/src/utils/cachedSupersetGet.ts
@@ -20,10 +20,10 @@
 import { SupersetClient } from '@superset-ui/core';
 import { cacheWrapper } from './cacheWrapper';
 
-const localCache = new Map<string, any>();
+export const supersetGetCache = new Map<string, any>();
 
 export const cachedSupersetGet = cacheWrapper(
   SupersetClient.get,
-  localCache,
+  supersetGetCache,
   ({ endpoint }) => endpoint || '',
 );

--- a/superset-frontend/src/utils/cachedSupersetGet.ts
+++ b/superset-frontend/src/utils/cachedSupersetGet.ts
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { SupersetClient } from '@superset-ui/core';
+import { cacheWrapper } from './cacheWrapper';
+
+const localCache = new Map<string, any>();
+
+export const cachedSupersetGet = cacheWrapper(
+  SupersetClient.get,
+  localCache,
+  ({ endpoint }) => endpoint || '',
+);

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -369,7 +369,7 @@ class BaseDatasource(
             generic_type = column.get("type_generic")
             if generic_type is not None:
                 column_types.add(generic_type)
-            if column["column_name"] in column_names or is_feature_enabled("DRILL_BY"):
+            if column["column_name"] in column_names:
                 filtered_columns.append(column)
 
         data["column_types"] = list(column_types)

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -369,7 +369,7 @@ class BaseDatasource(
             generic_type = column.get("type_generic")
             if generic_type is not None:
                 column_types.add(generic_type)
-            if column["column_name"] in column_names:
+            if column["column_name"] in column_names or is_feature_enabled("DRILL_BY"):
                 filtered_columns.append(column)
 
         data["column_types"] = list(column_types)


### PR DESCRIPTION
### SUMMARY
Charts that support drill by: all Echarts, World Map, Table, Pivot Table.

This PR implements right-click context menu with drill by option for charts that support the feature. When user right-click on series, the chart plugin constructs a filter object (similar to drill to detail filter), which in the result chart will be appended to original chart's adhoc filters. Then, user can select a column from drill by submenu that later will be used as a dimension of the result chart.
The columns are fetched when user opens the context menu. The result is cached, so that the request is not repeated for charts that use the same dataset. Only columns that are marked as dimensions in the dataset and are not used as dimensions of current chart can be selected.
If there are more than 10 available columns, a search input in the submenu is displayed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="605" alt="image" src="https://user-images.githubusercontent.com/15073128/226898828-caa9a7ee-32bb-4f01-b4c7-477ed6df4361.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
