### PR TITLE
refactor: introduce redux toolkit

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -84,6 +84,7 @@
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",
     "@fontsource/inter": "^4.0.0",
+    "@reduxjs/toolkit": "^1.9.3",
     "@superset-ui/chart-controls": "file:./packages/superset-ui-chart-controls",
     "@superset-ui/core": "file:./packages/superset-ui-core",
     "@superset-ui/legacy-plugin-chart-calendar": "file:./plugins/legacy-plugin-chart-calendar",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -198,7 +198,7 @@
     "react-virtualized": "9.19.1",
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
-    "redux": "^4.0.5",
+    "redux": "^4.2.1",
     "redux-localstorage": "^0.4.1",
     "redux-thunk": "^2.1.0",
     "redux-undo": "^1.0.0-beta9-9-7",

--- a/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChart.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChart.tsx
@@ -99,8 +99,10 @@ class SuperChart extends React.PureComponent<Props, {}> {
   private createChartProps = ChartProps.createSelector();
 
   private parseDimension = createSelector(
-    ({ width }: { width: string | number; height: string | number }) => width,
-    ({ height }) => height,
+    [
+      ({ width }: { width: string | number; height: string | number }) => width,
+      ({ height }) => height,
+    ],
     (width, height) => {
       // Parse them in case they are % or 'auto'
       const widthInfo = parseLength(width);

--- a/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChartCore.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChartCore.tsx
@@ -95,15 +95,17 @@ export default class SuperChartCore extends React.PureComponent<Props, {}> {
    * is changed.
    */
   processChartProps = createSelector(
-    (input: {
-      chartProps: ChartProps;
-      preTransformProps?: PreTransformProps;
-      transformProps?: TransformProps;
-      postTransformProps?: PostTransformProps;
-    }) => input.chartProps,
-    input => input.preTransformProps,
-    input => input.transformProps,
-    input => input.postTransformProps,
+    [
+      (input: {
+        chartProps: ChartProps;
+        preTransformProps?: PreTransformProps;
+        transformProps?: TransformProps;
+        postTransformProps?: PostTransformProps;
+      }) => input.chartProps,
+      input => input.preTransformProps,
+      input => input.transformProps,
+      input => input.postTransformProps,
+    ],
     (chartProps, pre = IDENTITY, transform = IDENTITY, post = IDENTITY) =>
       post(transform(pre(chartProps))),
   );
@@ -117,9 +119,11 @@ export default class SuperChartCore extends React.PureComponent<Props, {}> {
    * is changed.
    */
   private createLoadableRenderer = createSelector(
-    (input: { chartType: string; overrideTransformProps?: TransformProps }) =>
-      input.chartType,
-    input => input.overrideTransformProps,
+    [
+      (input: { chartType: string; overrideTransformProps?: TransformProps }) =>
+        input.chartType,
+      input => input.overrideTransformProps,
+    ],
     (chartType, overrideTransformProps) => {
       if (chartType) {
         const Renderer = createLoadableRenderer({

--- a/superset-frontend/plugins/preset-chart-xy/src/components/Line/Line.tsx
+++ b/superset-frontend/plugins/preset-chart-xy/src/components/Line/Line.tsx
@@ -106,11 +106,15 @@ export interface SeriesValue {
 const CIRCLE_STYLE = { strokeWidth: 1.5 };
 
 export default class LineChart extends PureComponent<Props> {
-  private createEncoder = lineEncoderFactory.createSelector();
+  private createEncoder = lineEncoderFactory.createSelector() as (
+    encoding: Partial<LineEncoding>,
+  ) => LineEncoder;
 
   private createAllSeries = createSelector(
-    (input: { encoder: LineEncoder; data: Dataset }) => input.encoder,
-    input => input.data,
+    [
+      (input: { encoder: LineEncoder; data: Dataset }) => input.encoder,
+      input => input.data,
+    ],
     (encoder, data) => {
       const { channels } = encoder;
       const fieldNames = encoder.getGroupBys();

--- a/superset-frontend/plugins/preset-chart-xy/src/utils/createMarginSelector.tsx
+++ b/superset-frontend/plugins/preset-chart-xy/src/utils/createMarginSelector.tsx
@@ -26,10 +26,12 @@ export default function createMarginSelector(
   defaultMargin: Margin = DEFAULT_MARGIN,
 ) {
   return createSelector(
-    (margin: Partial<Margin>) => margin.bottom,
-    margin => margin.left,
-    margin => margin.right,
-    margin => margin.top,
+    [
+      (margin: Partial<Margin>) => margin.bottom,
+      margin => margin.left,
+      margin => margin.right,
+      margin => margin.top,
+    ],
     (
       bottom = defaultMargin.bottom,
       left = defaultMargin.left,

--- a/superset-frontend/spec/fixtures/mockStore.js
+++ b/superset-frontend/spec/fixtures/mockStore.js
@@ -30,13 +30,13 @@ import { nativeFilters, dataMaskWith2Filters } from './mockNativeFilters';
 
 export const storeWithState = state =>
   setupStore({
-    disableDegugger: true,
+    disableDebugger: true,
     initialState: state,
   });
 
 export const getMockStore = overrideState =>
   setupStore({
-    disableDegugger: true,
+    disableDebugger: true,
     initialState: { ...mockState, ...overrideState },
   });
 
@@ -44,7 +44,7 @@ export const mockStore = getMockStore();
 
 export const getMockStoreWithTabs = () =>
   setupStore({
-    disableDegugger: true,
+    disableDebugger: true,
     initialState: {
       ...mockState,
       dashboardLayout: dashboardLayoutWithTabs,
@@ -54,7 +54,7 @@ export const getMockStoreWithTabs = () =>
 
 export const getMockStoreWithChartsInTabsAndRoot = () =>
   setupStore({
-    disableDegugger: true,
+    disableDebugger: true,
     initialState: {
       ...mockState,
       dashboardLayout: dashboardLayoutWithChartsInTabsAndRoot,
@@ -99,7 +99,7 @@ export const stateWithFilters = {
 // and one chart with no filters set.
 export const getMockStoreWithFilters = () =>
   setupStore({
-    disableDegugger: true,
+    disableDebugger: true,
     initialState: stateWithFilters,
   });
 
@@ -133,7 +133,7 @@ export const stateWithNativeFilters = {
 
 export const getMockStoreWithNativeFilters = () =>
   setupStore({
-    disableDegugger: true,
+    disableDebugger: true,
     initialState: stateWithNativeFilters,
   });
 

--- a/superset-frontend/spec/fixtures/mockStore.js
+++ b/superset-frontend/spec/fixtures/mockStore.js
@@ -16,10 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { createStore, applyMiddleware, compose } from 'redux';
-import thunk from 'redux-thunk';
-
-import { rootReducer } from 'src/views/store';
+import { setupStore } from 'src/views/store';
 import { FilterBarOrientation } from 'src/dashboard/types';
 
 import mockState from './mockState';
@@ -32,38 +29,38 @@ import { dashboardFilters } from './mockDashboardFilters';
 import { nativeFilters, dataMaskWith2Filters } from './mockNativeFilters';
 
 export const storeWithState = state =>
-  createStore(rootReducer, state, compose(applyMiddleware(thunk)));
+  setupStore({
+    disableDegugger: true,
+    initialState: state,
+  });
 
 export const getMockStore = overrideState =>
-  createStore(
-    rootReducer,
-    { ...mockState, ...overrideState },
-    compose(applyMiddleware(thunk)),
-  );
+  setupStore({
+    disableDegugger: true,
+    initialState: { ...mockState, ...overrideState },
+  });
 
 export const mockStore = getMockStore();
 
 export const getMockStoreWithTabs = () =>
-  createStore(
-    rootReducer,
-    {
+  setupStore({
+    disableDegugger: true,
+    initialState: {
       ...mockState,
       dashboardLayout: dashboardLayoutWithTabs,
       dashboardFilters: {},
     },
-    compose(applyMiddleware(thunk)),
-  );
+  });
 
 export const getMockStoreWithChartsInTabsAndRoot = () =>
-  createStore(
-    rootReducer,
-    {
+  setupStore({
+    disableDegugger: true,
+    initialState: {
       ...mockState,
       dashboardLayout: dashboardLayoutWithChartsInTabsAndRoot,
       dashboardFilters: {},
     },
-    compose(applyMiddleware(thunk)),
-  );
+  });
 
 export const mockStoreWithTabs = getMockStoreWithTabs();
 export const mockStoreWithChartsInTabsAndRoot =
@@ -101,7 +98,10 @@ export const stateWithFilters = {
 // one chart with a filter that has been rejected,
 // and one chart with no filters set.
 export const getMockStoreWithFilters = () =>
-  createStore(rootReducer, stateWithFilters);
+  setupStore({
+    disableDegugger: true,
+    initialState: stateWithFilters,
+  });
 
 export const stateWithNativeFilters = {
   ...mockState,
@@ -132,7 +132,10 @@ export const stateWithNativeFilters = {
 };
 
 export const getMockStoreWithNativeFilters = () =>
-  createStore(rootReducer, stateWithNativeFilters);
+  setupStore({
+    disableDegugger: true,
+    initialState: stateWithNativeFilters,
+  });
 
 export const stateWithoutNativeFilters = {
   ...mockState,

--- a/superset-frontend/spec/helpers/testing-library.tsx
+++ b/superset-frontend/spec/helpers/testing-library.tsx
@@ -22,19 +22,12 @@ import { render, RenderOptions } from '@testing-library/react';
 import { ThemeProvider, supersetTheme } from '@superset-ui/core';
 import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import {
-  combineReducers,
-  createStore,
-  applyMiddleware,
-  compose,
-  Store,
-} from 'redux';
-import thunk from 'redux-thunk';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import reducerIndex from 'spec/helpers/reducerIndex';
 import { QueryParamProvider } from 'use-query-params';
 import QueryProvider from 'src/views/QueryProvider';
+import { configureStore, Store } from '@reduxjs/toolkit';
 
 type Options = Omit<RenderOptions, 'queries'> & {
   useRedux?: boolean;
@@ -71,11 +64,11 @@ export function createWrapper(options?: Options) {
     if (useRedux) {
       const mockStore =
         store ??
-        createStore(
-          combineReducers(reducers || reducerIndex),
-          initialState || {},
-          compose(applyMiddleware(thunk)),
-        );
+        configureStore({
+          preloadedState: initialState || {},
+          devTools: false,
+          reducer: reducers || reducerIndex,
+        });
 
       result = <Provider store={mockStore}>{result}</Provider>;
     }

--- a/superset-frontend/src/SqlLab/App.jsx
+++ b/superset-frontend/src/SqlLab/App.jsx
@@ -17,20 +17,18 @@
  * under the License.
  */
 import React from 'react';
-import { createStore, compose, applyMiddleware } from 'redux';
+import persistState from 'redux-localstorage';
 import { Provider } from 'react-redux';
-import thunkMiddleware from 'redux-thunk';
 import { hot } from 'react-hot-loader/root';
 import { FeatureFlag, ThemeProvider } from '@superset-ui/core';
 import { GlobalStyles } from 'src/GlobalStyles';
 import QueryProvider from 'src/views/QueryProvider';
 import { initFeatureFlags, isFeatureEnabled } from 'src/featureFlags';
+import { setupStore } from 'src/views/store';
 import setupExtensions from 'src/setup/setupExtensions';
 import getBootstrapData from 'src/utils/getBootstrapData';
-import logger from 'src/middleware/loggerMiddleware';
 import getInitialState from './reducers/getInitialState';
-import rootReducer from './reducers/index';
-import { initEnhancer } from '../reduxUtils';
+import { reducers } from './reducers/index';
 import App from './components/App';
 import {
   emptyQueryResults,
@@ -109,17 +107,18 @@ const sqlLabPersistStateConfig = {
   },
 };
 
-const store = createStore(
-  rootReducer,
+export const store = setupStore({
   initialState,
-  compose(
-    applyMiddleware(thunkMiddleware, logger),
-    initEnhancer(
-      !isFeatureEnabled(FeatureFlag.SQLLAB_BACKEND_PERSISTENCE),
-      sqlLabPersistStateConfig,
-    ),
-  ),
-);
+  rootReducers: reducers,
+  ...(!isFeatureEnabled(FeatureFlag.SQLLAB_BACKEND_PERSISTENCE) && {
+    enhancers: [
+      persistState(
+        sqlLabPersistStateConfig.paths,
+        sqlLabPersistStateConfig.config,
+      ),
+    ],
+  }),
+});
 
 // Highlight the navbar menu
 const menus = document.querySelectorAll('.nav.navbar-nav li.dropdown');

--- a/superset-frontend/src/SqlLab/reducers/index.js
+++ b/superset-frontend/src/SqlLab/reducers/index.js
@@ -22,9 +22,11 @@ import sqlLab from './sqlLab';
 import localStorageUsageInKilobytes from './localStorageUsage';
 import common from './common';
 
-export default combineReducers({
+export const reducers = {
   sqlLab,
   localStorageUsageInKilobytes,
   messageToasts,
   common,
-});
+};
+
+export default combineReducers(reducers);

--- a/superset-frontend/src/views/menu.tsx
+++ b/superset-frontend/src/views/menu.tsx
@@ -34,7 +34,7 @@ import { setupStore } from './store';
 
 // Disable connecting to redux debugger so that the React app injected
 // Below the menu like SqlLab or Explore can connect its redux store to the debugger
-const store = setupStore(true);
+const store = setupStore({ disableDegugger: true });
 const bootstrapData = getBootstrapData();
 const menu = { ...bootstrapData.common.menu_data };
 

--- a/superset-frontend/src/views/menu.tsx
+++ b/superset-frontend/src/views/menu.tsx
@@ -34,7 +34,7 @@ import { setupStore } from './store';
 
 // Disable connecting to redux debugger so that the React app injected
 // Below the menu like SqlLab or Explore can connect its redux store to the debugger
-const store = setupStore({ disableDegugger: true });
+const store = setupStore({ disableDebugger: true });
 const bootstrapData = getBootstrapData();
 const menu = { ...bootstrapData.common.menu_data };
 

--- a/superset-frontend/src/views/store.ts
+++ b/superset-frontend/src/views/store.ts
@@ -121,12 +121,12 @@ const reducers = {
  * to redux debugger so the application can connect to redux debugger
  */
 export function setupStore({
-  disableDegugger = false,
+  disableDebugger = false,
   initialState = {},
   rootReducers = reducers,
   ...overrides
 }: {
-  disableDegugger?: boolean;
+  disableDebugger?: boolean;
   initialState?: ConfigureStoreOptions['preloadedState'];
   rootReducers?: ConfigureStoreOptions['reducer'];
 } & Partial<ConfigureStoreOptions> = {}): Store {
@@ -136,7 +136,7 @@ export function setupStore({
       ...rootReducers,
     },
     middleware: getDefaultMiddleware => getDefaultMiddleware().concat(logger),
-    devTools: process.env.WEBPACK_MODE === 'development' && !disableDegugger,
+    devTools: process.env.WEBPACK_MODE === 'development' && !disableDebugger,
     ...overrides,
   });
 }

--- a/superset-frontend/src/views/store.ts
+++ b/superset-frontend/src/views/store.ts
@@ -135,7 +135,14 @@ export function setupStore({
     reducer: {
       ...rootReducers,
     },
-    middleware: getDefaultMiddleware => getDefaultMiddleware().concat(logger),
+    middleware: getDefaultMiddleware =>
+      getDefaultMiddleware({
+        serializableCheck: {
+          // Ignores AbortController instances
+          ignoredActionPaths: [/queryController/g],
+          ignoredPaths: [/queryController/g],
+        },
+      }).concat(logger),
     devTools: process.env.WEBPACK_MODE === 'development' && !disableDebugger,
     ...overrides,
   });

--- a/superset-frontend/src/views/store.ts
+++ b/superset-frontend/src/views/store.ts
@@ -137,10 +137,14 @@ export function setupStore({
     },
     middleware: getDefaultMiddleware =>
       getDefaultMiddleware({
+        immutableCheck: {
+          warnAfter: 200,
+        },
         serializableCheck: {
           // Ignores AbortController instances
           ignoredActionPaths: [/queryController/g],
           ignoredPaths: [/queryController/g],
+          warnAfter: 200,
         },
       }).concat(logger),
     devTools: process.env.WEBPACK_MODE === 'development' && !disableDebugger,

--- a/superset-frontend/src/views/store.ts
+++ b/superset-frontend/src/views/store.ts
@@ -16,16 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  applyMiddleware,
-  combineReducers,
-  compose,
-  createStore,
-  Store,
-} from 'redux';
-import thunk from 'redux-thunk';
+import { configureStore, ConfigureStoreOptions, Store } from '@reduxjs/toolkit';
 import messageToastReducer from 'src/components/MessageToasts/reducers';
-import { initEnhancer } from 'src/reduxUtils';
 import charts from 'src/components/Chart/chartReducer';
 import dataMask from 'src/dataMask/reducer';
 import reports from 'src/reports/reducers/reports';
@@ -102,8 +94,7 @@ const CombinedDatasourceReducers = (
   );
 };
 
-// exported for tests
-export const rootReducer = combineReducers({
+const reducers = {
   messageToasts: messageToastReducer,
   common: noopReducer(bootstrapData.common),
   user: userReducer,
@@ -120,13 +111,7 @@ export const rootReducer = combineReducers({
   reports,
   saveModal,
   explore,
-});
-
-export const store: Store = createStore(
-  rootReducer,
-  {},
-  compose(applyMiddleware(thunk, logger), initEnhancer(false)),
-);
+};
 
 /* In some cases the jinja template injects two seperate React apps into basic.html
  * One for the top navigation Menu and one for the application below the Menu
@@ -135,13 +120,25 @@ export const store: Store = createStore(
  * setupStore with disableDebugger true enables the menu.tsx component to avoid connecting
  * to redux debugger so the application can connect to redux debugger
  */
-export function setupStore(disableDegugger = false): Store {
-  return createStore(
-    rootReducer,
-    {},
-    compose(
-      applyMiddleware(thunk, logger),
-      initEnhancer(false, undefined, disableDegugger),
-    ),
-  );
+export function setupStore({
+  disableDegugger = false,
+  initialState = {},
+  rootReducers = reducers,
+  ...overrides
+}: {
+  disableDegugger?: boolean;
+  initialState?: ConfigureStoreOptions['preloadedState'];
+  rootReducers?: ConfigureStoreOptions['reducer'];
+} & Partial<ConfigureStoreOptions> = {}): Store {
+  return configureStore({
+    preloadedState: initialState,
+    reducer: {
+      ...rootReducers,
+    },
+    middleware: getDefaultMiddleware => getDefaultMiddleware().concat(logger),
+    devTools: process.env.WEBPACK_MODE === 'development' && !disableDegugger,
+    ...overrides,
+  });
 }
+
+export const store: Store = setupStore();


### PR DESCRIPTION
### SUMMARY
Following up the discussion of #23257,
this commit introduces the redux-toolkit as a prerequisite for rdk(redux toolkit) query.

In order to consolidate the multiple state management solution, superset team decided to leverage the redux with toolkit in order to organize the existing redux state.
Redux toolkit also includes the rdk query package which can replace the existing react-query hooks (which is a similar solution to minimize the state of async api request) with a single solution.

This commit also use the configureStore method of the @reduxjs/toolkit package, which replaces createStore since Redux Toolkit is our (redux official channel) recommended approach for writing Redux logic today, including store setup, reducers, data fetching, and more.

After this commit merged, we can replace existing react-query by rdk-query too. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

N/A

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @michael-s-molina @ktmud 