### PR TITLE
feat(bigquery): `get_catalog_names`

### DIFF
--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -39,6 +39,7 @@ from superset.databases.utils import make_url_safe
 from superset.db_engine_specs.base import BaseEngineSpec, BasicPropertiesType
 from superset.db_engine_specs.exceptions import SupersetDBAPIConnectionError
 from superset.errors import SupersetError, SupersetErrorType
+from superset.exceptions import SupersetException
 from superset.sql_parse import Table
 from superset.utils import core as utils
 from superset.utils.hashing import md5_sha_from_str
@@ -344,12 +345,12 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
         :param to_sql_kwargs: The kwargs to be passed to pandas.DataFrame.to_sql` method
         """
         if not can_upload:
-            raise Exception(
+            raise SupersetException(
                 "Could not import libraries needed to upload data to BigQuery."
             )
 
         if not table.schema:
-            raise Exception("The table schema must be defined")
+            raise SupersetException("The table schema must be defined")
 
         to_gbq_kwargs = {}
         with cls.get_engine(database) as engine:
@@ -381,7 +382,9 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
         Return the BigQuery client associated with an engine.
         """
         if not dependencies_installed:
-            raise Exception("Could not import libraries needed to connect to BigQuery.")
+            raise SupersetException(
+                "Could not import libraries needed to connect to BigQuery."
+            )
 
         credentials = service_account.Credentials.from_service_account_info(
             engine.dialect.credentials_info
@@ -406,7 +409,7 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
         """
         extra = database.get_extra() or {}
         if not cls.get_allow_cost_estimate(extra):
-            raise Exception("Database does not support cost estimation")
+            raise SupersetException("Database does not support cost estimation")
 
         parsed_query = sql_parse.ParsedQuery(sql)
         statements = parsed_query.get_statements()

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -44,15 +44,19 @@ from superset.utils import core as utils
 from superset.utils.hashing import md5_sha_from_str
 
 try:
-    import pandas_gbq
     from google.cloud import bigquery
     from google.oauth2 import service_account
 
-    Client = bigquery.Client
+    dependencies_installed = True
 except ModuleNotFoundError:
-    bigquery = None
-    pandas_gbq = None
-    Client = Any  # for type checking
+    dependencies_installed = False
+
+try:
+    import pandas_gbq
+
+    can_upload = True
+except ModuleNotFoundError:
+    can_upload = False
 
 if TYPE_CHECKING:
     from superset.models.core import Database  # pragma: no cover
@@ -339,7 +343,7 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
         :param df: The dataframe with data to be uploaded
         :param to_sql_kwargs: The kwargs to be passed to pandas.DataFrame.to_sql` method
         """
-        if pandas_gbq is None or service_account is None:
+        if not can_upload:
             raise Exception(
                 "Could not import libraries needed to upload data to BigQuery."
             )
@@ -372,11 +376,11 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
         pandas_gbq.to_gbq(df, **to_gbq_kwargs)
 
     @classmethod
-    def _get_client(cls, engine: Engine) -> Client:
+    def _get_client(cls, engine: Engine) -> Any:
         """
         Return the BigQuery client associated with an engine.
         """
-        if bigquery is None or service_account is None:
+        if not dependencies_installed:
             raise Exception("Could not import libraries needed to connect to BigQuery.")
 
         credentials = service_account.Credentials.from_service_account_info(
@@ -424,6 +428,7 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
 
         In BigQuery, a catalog is called a "project".
         """
+        engine: Engine
         with database.get_sqla_engine_with_context() as engine:
             client = cls._get_client(engine)
             projects = client.list_projects()

--- a/tests/integration_tests/db_engine_specs/bigquery_tests.py
+++ b/tests/integration_tests/db_engine_specs/bigquery_tests.py
@@ -166,7 +166,9 @@ class TestBigQueryDbEngineSpec(TestDbEngineSpec):
         )
 
     @mock.patch("superset.db_engine_specs.bigquery.BigQueryEngineSpec.get_engine")
-    def test_df_to_sql(self, mock_get_engine):
+    @mock.patch("superset.db_engine_specs.bigquery.pandas_gbq")
+    @mock.patch("superset.db_engine_specs.bigquery.service_account")
+    def test_df_to_sql(self, mock_service_account, mock_pandas_gbq, mock_get_engine):
         """
         DB Eng Specs (bigquery): Test DataFrame to SQL contract
         """
@@ -203,11 +205,7 @@ class TestBigQueryDbEngineSpec(TestDbEngineSpec):
                 to_sql_kwargs=invalid_kwarg,
             )
 
-        import pandas_gbq
-        from google.oauth2 import service_account
-
-        pandas_gbq.to_gbq = mock.Mock()
-        service_account.Credentials.from_service_account_info = mock.MagicMock(
+        mock_service_account.Credentials.from_service_account_info = mock.MagicMock(
             return_value="account_info"
         )
 
@@ -223,7 +221,7 @@ class TestBigQueryDbEngineSpec(TestDbEngineSpec):
             to_sql_kwargs={"if_exists": "extra_key"},
         )
 
-        pandas_gbq.to_gbq.assert_called_with(
+        mock_pandas_gbq.to_gbq.assert_called_with(
             df,
             project_id="google-host",
             destination_table="schema.name",

--- a/tests/integration_tests/db_engine_specs/bigquery_tests.py
+++ b/tests/integration_tests/db_engine_specs/bigquery_tests.py
@@ -172,39 +172,6 @@ class TestBigQueryDbEngineSpec(TestDbEngineSpec):
         """
         DB Eng Specs (bigquery): Test DataFrame to SQL contract
         """
-        # test missing google.oauth2 dependency
-        sys.modules["pandas_gbq"] = mock.MagicMock()
-        df = DataFrame()
-        database = mock.MagicMock()
-        with self.assertRaises(Exception):
-            BigQueryEngineSpec.df_to_sql(
-                database=database,
-                table=Table(table="name", schema="schema"),
-                df=df,
-                to_sql_kwargs={},
-            )
-
-        invalid_kwargs = [
-            {"name": "some_name"},
-            {"schema": "some_schema"},
-            {"con": "some_con"},
-            {"name": "some_name", "con": "some_con"},
-            {"name": "some_name", "schema": "some_schema"},
-            {"con": "some_con", "schema": "some_schema"},
-        ]
-        # Test check for missing schema.
-        sys.modules["google.oauth2"] = mock.MagicMock()
-        for invalid_kwarg in invalid_kwargs:
-            self.assertRaisesRegex(
-                Exception,
-                "The table schema must be defined",
-                BigQueryEngineSpec.df_to_sql,
-                database=database,
-                table=Table(table="name"),
-                df=df,
-                to_sql_kwargs=invalid_kwarg,
-            )
-
         mock_service_account.Credentials.from_service_account_info = mock.MagicMock(
             return_value="account_info"
         )
@@ -214,6 +181,8 @@ class TestBigQueryDbEngineSpec(TestDbEngineSpec):
             "secrets"
         )
 
+        df = DataFrame()
+        database = mock.MagicMock()
         BigQueryEngineSpec.df_to_sql(
             database=database,
             table=Table(table="name", schema="schema"),


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Implement `get_catalog_names` for BigQuery. This is needed to support catalog-level permissions, and also for https://github.com/apache/superset/issues/22862.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

I configured a BigQuery database and ran this script:

```python
from superset.app import create_app

app = create_app()
with app.app_context():
    from superset import db
    from superset.db_engine_specs.bigquery import BigQueryEngineSpec
    from superset.models.core import Database

    database = db.session.query(Database).first()
    with database.get_inspector_with_context() as inspector:
        print(BigQueryEngineSpec.get_catalog_names(database, inspector))
```

When ran, it produced the expected output:

```python
['covid19-293320']
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
