### PR TITLE
perf(postprocessing): improve pivot postprocessing operation

### DIFF
--- a/superset/utils/pandas_postprocessing/pivot.py
+++ b/superset/utils/pandas_postprocessing/pivot.py
@@ -87,7 +87,7 @@ def pivot(  # pylint: disable=too-many-arguments,too-many-locals
     if not drop_missing_columns and columns:
         for row in df[columns].itertuples():
             for metric in aggfunc.keys():
-                series_set.add(str(tuple([metric]) + tuple(row[1:])))
+                series_set.add(tuple([metric]) + tuple(row[1:]))
 
     df = df.pivot_table(
         values=aggfunc.keys(),
@@ -101,10 +101,7 @@ def pivot(  # pylint: disable=too-many-arguments,too-many-locals
     )
 
     if not drop_missing_columns and len(series_set) > 0 and not df.empty:
-        for col in df.columns:
-            series = str(col)
-            if series not in series_set:
-                df = df.drop(col, axis=PandasAxis.COLUMN)
+        df = df.drop(df.columns.difference(series_set), axis=PandasAxis.COLUMN)
 
     if combine_value_with_metric:
         df = df.stack(0).unstack()


### PR DESCRIPTION
### SUMMARY

See the linked issue for a description of how this can affect a Superset user.

Executing a pivot for with `drop_missing_columns=False` and lots of resulting columns can increase the postprocessing time by seconds or even minutes for large datasets. The main culprit is `df.drop(...)` operation in the for loop. We can refactor this slightly, without any change to the results, and push down the postprocessing time to seconds instead of minutes for large datasets (thousands or millions of columns).

<!--- Describe the change below, including rationale and design decisions -->

### TESTING INSTRUCTIONS

Luckily, this feature is already covered by unit tests.

**Manual test to see performance improvement:**

1. Explore the example dataset `cleaned_sales_data`
2. Add multiple dimensions (e.g. `contact_first_name, contact_last_name, phone`)
3. Add any metric
4. Select the `Time-series Line Chart`
5. Click on "Update Chart"

**Results on this branch**
Chart loads within a few seconds

**Negative results (e.g. on `master`)**
Chart will time out or take a very long time

<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/23464

Related to https://github.com/apache/superset/pull/15975 - keeps the workaround and its tests, just changes the implementation very slightly.
