### PR TITLE
fix(area chart legacy): tool tip shows actual value rather than y axi…

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/utils.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/utils.js
@@ -203,7 +203,7 @@ export function generateAreaChartTooltipContent(
         series.key === 'TOTAL' ? '' : '&#9724;'
       }</td>` +
       `<td>${key}</td>` +
-      `<td>${valueFormatter(series.value)}</td>` +
+      `<td>${valueFormatter(series?.point?.y)}</td>` +
       `<td>${((100 * series.value) / total).toFixed(2)}%</td>` +
       '</tr>';
   });


### PR DESCRIPTION


<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Tha area chart was showing the decimal values when it is expanded mode rather than actula values. I made changes so that it gonna show the actual value rather than decimal values (these decimal values were representing the percentage of value w.r.t total)
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![Screenshot from 2023-03-23 14-20-31](https://user-images.githubusercontent.com/106575591/227152108-190cd867-ba79-4626-bea9-f7758b800cfa.png)
![Screenshot from 2023-03-23 14-20-57](https://user-images.githubusercontent.com/106575591/227152148-6c178112-d201-4108-94e1-a7f74c7e17e9.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/20003
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
