### PR TITLE
fix: Preserves selected scopes when toggling between scope types

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.test.tsx
@@ -129,7 +129,7 @@ describe('FilterScope', () => {
       expect(screen.getByRole('tree')).toBeInTheDocument();
       expect(
         document.querySelectorAll('.ant-tree-checkbox-checked').length,
-      ).toBe(1);
+      ).toBe(4);
     });
   });
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { FC, useCallback, useState } from 'react';
+import React, { FC, useCallback, useRef, useState } from 'react';
 import {
   NativeFilterScope,
   styled,
@@ -67,8 +67,7 @@ const FilterScope: FC<FilterScopeProps> = ({
   const [initialFilterScope] = useState(
     filterScope || getDefaultScopeValue(chartId, initiallyExcludedCharts),
   );
-  const [lastSpecificScope, setLastSpecificScope] =
-    useState(initialFilterScope);
+  const lastSpecificScope = useRef(initialFilterScope);
   const [initialScopingType] = useState(
     isScopingAll(initialFilterScope, chartId)
       ? ScopingType.all
@@ -81,7 +80,7 @@ const FilterScope: FC<FilterScopeProps> = ({
   const onUpdateFormValues = useCallback(
     (formValues: any) => {
       if (formScopingType === ScopingType.specific) {
-        setLastSpecificScope(formValues.scope);
+        lastSpecificScope.current = formValues.scope;
       }
       updateFormValues(formValues);
       setHasScopeBeenModified(true);
@@ -121,7 +120,7 @@ const FilterScope: FC<FilterScopeProps> = ({
             const scope =
               value === ScopingType.all
                 ? getDefaultScopeValue(chartId)
-                : lastSpecificScope;
+                : lastSpecificScope.current;
             updateFormValues({ scope });
             setHasScopeBeenModified(true);
             forceUpdate();

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.tsx
@@ -67,6 +67,8 @@ const FilterScope: FC<FilterScopeProps> = ({
   const [initialFilterScope] = useState(
     filterScope || getDefaultScopeValue(chartId, initiallyExcludedCharts),
   );
+  const [lastSpecificScope, setLastSpecificScope] =
+    useState(initialFilterScope);
   const [initialScopingType] = useState(
     isScopingAll(initialFilterScope, chartId)
       ? ScopingType.all
@@ -78,10 +80,13 @@ const FilterScope: FC<FilterScopeProps> = ({
 
   const onUpdateFormValues = useCallback(
     (formValues: any) => {
+      if (formScopingType === ScopingType.specific) {
+        setLastSpecificScope(formValues.scope);
+      }
       updateFormValues(formValues);
       setHasScopeBeenModified(true);
     },
-    [updateFormValues],
+    [formScopingType, updateFormValues],
   );
 
   const updateScopes = useCallback(() => {
@@ -113,12 +118,11 @@ const FilterScope: FC<FilterScopeProps> = ({
       >
         <Radio.Group
           onChange={({ target: { value } }) => {
-            if (value === ScopingType.all) {
-              const scope = getDefaultScopeValue(chartId);
-              updateFormValues({
-                scope,
-              });
-            }
+            const scope =
+              value === ScopingType.all
+                ? getDefaultScopeValue(chartId)
+                : lastSpecificScope;
+            updateFormValues({ scope });
             setHasScopeBeenModified(true);
             forceUpdate();
           }}


### PR DESCRIPTION
### SUMMARY
Preserves selected scopes when toggling between scope types.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/227277944-e01bd5c6-b02d-4ee0-a3fd-9dc64a5f2ba2.mov

https://user-images.githubusercontent.com/70410625/227278019-dd249233-c98c-4c4b-a673-2b3901efd71c.mov

### TESTING INSTRUCTIONS
Make sure the selected scopes are preserved when toggling between scope types

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
