### PR TITLE
fix: Chart crashing if timeseries_limit_metric is an empty array

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/utils/extractExtraMetrics.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/utils/extractExtraMetrics.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import {
+  ensureIsArray,
   getMetricLabel,
   QueryFormData,
   QueryFormMetric,
@@ -27,13 +28,14 @@ export function extractExtraMetrics(
 ): QueryFormMetric[] {
   const { groupby, timeseries_limit_metric, x_axis_sort, metrics } = formData;
   const extra_metrics: QueryFormMetric[] = [];
+  const limitMetric = ensureIsArray(timeseries_limit_metric)[0];
   if (
     !(groupby || []).length &&
-    timeseries_limit_metric &&
-    getMetricLabel(timeseries_limit_metric) === x_axis_sort &&
+    limitMetric &&
+    getMetricLabel(limitMetric) === x_axis_sort &&
     !metrics?.some(metric => getMetricLabel(metric) === x_axis_sort)
   ) {
-    extra_metrics.push(timeseries_limit_metric);
+    extra_metrics.push(limitMetric);
   }
   return extra_metrics;
 }

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/utils/extractExtraMetrics.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/utils/extractExtraMetrics.test.ts
@@ -124,3 +124,13 @@ test('returns empty array if timeseries_limit_metric and x_axis_sort are include
     }),
   ).toEqual([]);
 });
+
+test('returns emoty array if timeseries_limit_metric is an empty array', () => {
+  expect(
+    extractExtraMetrics({
+      ...baseFormData,
+      // @ts-ignore
+      timeseries_limit_metric: [],
+    }),
+  ).toEqual([]);
+});


### PR DESCRIPTION
### SUMMARY
In some existing charts, `timeseries_limit_metric` could be an empty array instead of expected string or metric object. That caused a bug where an empty array was pushed to `metrics` array in `buildQuery`, causing error like on the screenshot.

Shoutout to @villebro for reproducing the problem and suggesting a solution!

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://user-images.githubusercontent.com/15073128/227485630-a1149e61-b7dd-4345-a0d5-cf5eacd3c7ce.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
