### PR TITLE
chore: Adds a tooltip to pre-filter in native filters modal

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/nativeFilters.test.ts
@@ -631,7 +631,8 @@ describe('Native filters', () => {
     it('Verify setting options and tooltips for value filter', () => {
       enterNativeFilterEditModal(false);
       cy.contains('Filter value is required').should('be.visible').click();
-      checkNativeFilterTooltip(0, nativeFilterTooltips.defaultValue);
+      checkNativeFilterTooltip(0, nativeFilterTooltips.preFilter);
+      checkNativeFilterTooltip(1, nativeFilterTooltips.defaultValue);
       cy.get(nativeFilters.modal.container).should('be.visible');
       valueNativeFilterOptions.forEach(el => {
         cy.contains(el);
@@ -640,10 +641,10 @@ describe('Native filters', () => {
       cy.get(
         nativeFilters.filterConfigurationSections.checkedCheckbox,
       ).contains('Can select multiple values');
-      checkNativeFilterTooltip(1, nativeFilterTooltips.required);
-      checkNativeFilterTooltip(2, nativeFilterTooltips.defaultToFirstItem);
-      checkNativeFilterTooltip(3, nativeFilterTooltips.searchAllFilterOptions);
-      checkNativeFilterTooltip(4, nativeFilterTooltips.inverseSelection);
+      checkNativeFilterTooltip(2, nativeFilterTooltips.required);
+      checkNativeFilterTooltip(3, nativeFilterTooltips.defaultToFirstItem);
+      checkNativeFilterTooltip(4, nativeFilterTooltips.searchAllFilterOptions);
+      checkNativeFilterTooltip(5, nativeFilterTooltips.inverseSelection);
       clickOnAddFilterInModal();
       cy.contains('Values are dependent on other filters').should('exist');
     });

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/utils.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/utils.ts
@@ -85,7 +85,7 @@ export const nativeFilterTooltips = {
   multipleSelect: 'Allow selecting multiple values',
   defaultValue:
     'Default value must be set when "Filter value is required" is checked',
-  preFilter: `Limits the number of selectable values in a filter. This is useful when you want to display a subset of the column's values either for performance reasons or business rules. Some examples include limiting the number of people displayed to a particular business unit or showing only people registered in the last 90 days.`,
+  preFilter: `Add filter clauses to control the filter's source query, though only in the context of the autocomplete i.e., these conditions do not impact how the filter is applied to the dashboard. This is useful when you want to improve the query's performance by only scanning a subset of the underlying data or limit the available values displayed in the filter.`,
 };
 
 export const nativeFilterOptions = [

--- a/superset-frontend/cypress-base/cypress/integration/dashboard/utils.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/utils.ts
@@ -85,6 +85,7 @@ export const nativeFilterTooltips = {
   multipleSelect: 'Allow selecting multiple values',
   defaultValue:
     'Default value must be set when "Filter value is required" is checked',
+  preFilter: `Limits the number of selectable values in a filter. This is useful when you want to display a subset of the column's values either for performance reasons or business rules. Some examples include limiting the number of people displayed to a particular business unit or showing only people registered in the last 90 days.`,
 };
 
 export const nativeFilterOptions = [

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -956,6 +956,11 @@ const FiltersConfigForm = (
                   <CollapsibleControl
                     initialValue={hasPreFilter}
                     title={t('Pre-filter available values')}
+                    tooltip={t(`Limits the number of selectable values in a filter.
+                    This is useful when you want to display a subset of the column's values
+                    either for performance reasons or business rules. Some examples include
+                    limiting the number of people displayed to a particular business unit
+                    or showing only people registered in the last 90 days.`)}
                     onChange={checked => {
                       formChanged();
                       if (checked) {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -956,11 +956,11 @@ const FiltersConfigForm = (
                   <CollapsibleControl
                     initialValue={hasPreFilter}
                     title={t('Pre-filter available values')}
-                    tooltip={t(`Limits the number of selectable values in a filter.
-                    This is useful when you want to display a subset of the column's values
-                    either for performance reasons or business rules. Some examples include
-                    limiting the number of people displayed to a particular business unit
-                    or showing only people registered in the last 90 days.`)}
+                    tooltip={t(`Add filter clauses to control the filter's source query,
+                    though only in the context of the autocomplete i.e., these conditions
+                    do not impact how the filter is applied to the dashboard. This is useful
+                    when you want to improve the query's performance by only scanning a subset
+                    of the underlying data or limit the available values displayed in the filter.`)}
                     onChange={checked => {
                       formChanged();
                       if (checked) {


### PR DESCRIPTION
### SUMMARY
Adds a tooltip to pre-filter in native filters modal to better contextualize its use for the users.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="893" alt="Screenshot 2023-03-24 at 08 47 27" src="https://user-images.githubusercontent.com/70410625/227513672-27fe90d3-4097-4ee6-a48d-10140db57dda.png">

### TESTING INSTRUCTIONS
Check that pre-filter exhibits a tooltip.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
