### PR TITLE
perf(sqla): avoid unnecessary type check on adhoc column

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1006,17 +1006,17 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
 
         return self.make_sqla_column_compatible(sqla_metric, label)
 
-    def adhoc_column_to_sqla(
+    def adhoc_column_to_sqla(  # pylint: disable=too-many-locals
         self,
         col: AdhocColumn,
-        force_check_expression: bool = False,
+        force_type_check: bool = False,
         template_processor: Optional[BaseTemplateProcessor] = None,
     ) -> ColumnElement:
         """
         Turn an adhoc column into a sqlalchemy column.
 
         :param col: Adhoc column definition
-        :param force_check_expression: Should the expression be checked in the db.
+        :param force_type_check: Should the column type be checked in the db.
                This is needed to validate if a filter with an adhoc column
                is applicable.
         :param template_processor: template_processor instance
@@ -1041,7 +1041,7 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
             is_dttm = col_in_metadata.is_temporal
         else:
             sqla_column = literal_column(expression)
-            if has_timegrain or force_check_expression:
+            if has_timegrain or force_type_check:
                 try:
                     # probe adhoc column type
                     tbl, _ = self.get_from_clause(template_processor)
@@ -1464,7 +1464,7 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
                 try:
                     sqla_col = self.adhoc_column_to_sqla(
                         col=flt_col,
-                        force_check_expression=True,
+                        force_type_check=True,
                         template_processor=template_processor,
                     )
                     applied_adhoc_filters_columns.append(flt_col)

--- a/superset/utils/pandas_postprocessing/pivot.py
+++ b/superset/utils/pandas_postprocessing/pivot.py
@@ -28,7 +28,7 @@ from superset.utils.pandas_postprocessing.utils import (
 
 
 @validate_column_args("index", "columns")
-def pivot(  # pylint: disable=too-many-arguments,too-many-locals
+def pivot(  # pylint: disable=too-many-arguments
     df: DataFrame,
     index: List[str],
     aggregates: Dict[str, Dict[str, Any]],


### PR DESCRIPTION
### SUMMARY
PR #21163 introduced support for time grains to the base axis for both regular and adhoc columns. This caused a performance regression that executes a query to the analytical database for every adhoc column to check if it's a temporal expression or not.

This PR changes the logic slightly so that the query is executed only if needed, i.e. the base column is adhoc and has a time grain, or if the adhoc column is part of an adhoc filter. To review the PR, please use "Hide whitespace" to see the real changes more clearly.

### AFTER
On a chart with two normal adhoc columns, the query now executes in 7 seconds with only a single query being sent to the database:

![image](https://user-images.githubusercontent.com/33317356/227862791-fec19a17-b73d-4261-bfbd-aff45e251207.png)

The same chart previously executed in 22 seconds (rougly 3 x 7 seconds with 3 queries sent to the database):

![image](https://user-images.githubusercontent.com/33317356/227862961-df4811dc-dd90-4151-adb4-0d1ce657fda8.png)

### TESTING INSTRUCTIONS
1. create a chart with multiple adhoc columns
2. look at debug logs and notice an additional query being sent to the database for each adhoc column added

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
