### PR TITLE
docs: Adds notes to Superset plugin generator about TypeScript errors

### DIFF
--- a/superset-frontend/packages/generator-superset/generators/plugin-chart/templates/README.erb
+++ b/superset-frontend/packages/generator-superset/generators/plugin-chart/templates/README.erb
@@ -22,6 +22,31 @@ To add the package to Superset, go to the `superset-frontend` subdirectory in yo
 npm i -S ../../<%= packageName %>
 ```
 
+If your Superset plugin exists in the `superset-frontend` directory and you wish to resolve TypeScript errors about `@superset-ui/core` not being resolved correctly, add the following to your `tsconfig.json` file:
+
+```
+"references": [
+  {
+    "path": "../../packages/superset-ui-chart-controls"
+  },
+  {
+    "path": "../../packages/superset-ui-core"
+  }
+]
+```
+
+You may also wish to add the following to the `include` array in `tsconfig.json` to make Superset types available to your plugin:
+
+```
+"../../types/**/*"
+```
+
+Finally, if you wish to ensure your plugin `tsconfig.json` is aligned with the root Superset project, you may add the following to your `tsconfig.json` file:
+
+```
+"extends": "../../tsconfig.json",
+```
+
 After this edit the `superset-frontend/src/visualizations/presets/MainPreset.js` and make the following changes:
 
 ```js


### PR DESCRIPTION
### SUMMARY

When creating a new Superset plugin, the generator creates a `tsconfig.json` file. When trying to build Superset with this new plugin, the build fails due to TypeScript compilation errors.

This PR extends the README documentation of a generated plugin to call out some of the changes a user may want to make to fix these TypeScript errors. These suggested changes already exist in the `echarts` plugins, and served as inspiration for how to fix the TypeScript errors I encountered in my own plugin.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Screenshots of TypeScript errors after creating the plugin:

![screenshot-1](https://user-images.githubusercontent.com/128753205/228025355-9e992a67-f65a-418b-9807-88220448557c.png)
![screenshot-2](https://user-images.githubusercontent.com/128753205/228025368-9c8d4249-3977-4244-83fc-66ddbac35a23.png)
![screenshot-3](https://user-images.githubusercontent.com/128753205/228025383-5643f079-fd08-4d89-89f5-be23cbf4d6b8.png)


### TESTING INSTRUCTIONS

* Use the generator to create a new Superset plugin in the `superset-frontend/plugins/` directory alongside other plugins
* Follow the final manual steps to add this plugin to `MainPreset.js` and `package.json`
* Try to build Superset
* Notice that there are TypeScript errors such as unresolvable modules (`@superset-ui/core`)
* Notice that there are TypeScript errors such as unresolved Superset types
* Make the new changes suggested in the plugin README file
* Notice that the errors are resolved and the plugin will build successfully
