### PR TITLE
fix(dashboard): Add remark plugin on markdown

### DIFF
--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -50,6 +50,9 @@ module.exports = {
   coverageReporters: ['lcov', 'json-summary', 'html', 'text'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   snapshotSerializers: ['@emotion/jest/enzyme-serializer'],
+  transformIgnorePatterns: [
+    'node_modules/(?!remark-gfm|markdown-table|micromark-*.|decode-named-character-reference|character-entities|mdast-util-*.|unist-util-*.|ccount|escape-string-regexp)',
+  ],
   globals: {
     __DEV__: true,
     caches: true,

--- a/superset-frontend/packages/superset-ui-core/package.json
+++ b/superset-frontend/packages/superset-ui-core/package.json
@@ -55,6 +55,7 @@
     "react-markdown": "^8.0.3",
     "rehype-raw": "^6.1.1",
     "rehype-sanitize": "^5.0.1",
+    "remark-gfm": "^3.0.1",
     "reselect": "^4.0.0",
     "rison": "^0.1.1",
     "seedrandom": "^3.0.5",

--- a/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown.tsx
@@ -20,6 +20,7 @@ import React, { useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import rehypeRaw from 'rehype-raw';
+import remarkGfm from 'remark-gfm';
 import { mergeWith, isArray } from 'lodash';
 import { FeatureFlag, isFeatureEnabled } from '../utils';
 
@@ -63,7 +64,11 @@ function SafeMarkdown({
 
   // React Markdown escapes HTML by default
   return (
-    <ReactMarkdown rehypePlugins={rehypePlugins} skipHtml={!displayHtml}>
+    <ReactMarkdown
+      rehypePlugins={rehypePlugins}
+      remarkPlugins={[remarkGfm]}
+      skipHtml={!displayHtml}
+    >
       {source}
     </ReactMarkdown>
   );


### PR DESCRIPTION
### SUMMARY
Since react-markdown upgrade to latest version, table remark is no longer support in the chart markdown.
This is because the table markdown is an optional in latest react-markdown.
This commit adds the remark-gfm to support the previous support markdowns including table format.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

```
|Cell A|Cell B|Cell c|
|--|--|--|
|value1|value2|value3|
```

After:

<img width="212" alt="Screenshot 2023-03-27 at 1 40 14 PM" src="https://user-images.githubusercontent.com/1392866/228063369-82afdd2d-689b-4f98-ba26-f0f11b324374.png">

Before:

<img width="478" alt="Screenshot 2023-03-27 at 1 39 29 PM" src="https://user-images.githubusercontent.com/1392866/228063374-dad9d74f-5251-460f-890e-550a93327853.png">


### TESTING INSTRUCTIONS
Create a dashboard and adds a markdown
type the following markdown

```
|Cell A|Cell B|Cell c|
|--|--|--|
|value1|value2|value3|
```

### ADDITIONAL INFORMATION
- [x] Has associated issue: #21895
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
