### PR TITLE
fix(generic-x-axis): skip initial time filter for legacy charts

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/mixins.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/mixins.tsx
@@ -73,9 +73,11 @@ export const datePickerInAdhocFilterMixin: Pick<
   initialValue: (control: ControlState, state: ControlPanelState | null) => {
     // skip initialValue if
     // 1) GENERIC_CHART_AXES is disabled
-    // 2) there was a time filter in adhoc filters
+    // 2) the time_range control is present (this is the case for legacy charts)
+    // 3) there was a time filter in adhoc filters
     if (
       !hasGenericChartAxes ||
+      state?.controls?.time_range?.value ||
       ensureIsArray(control.value).findIndex(
         (flt: any) => flt?.operator === 'TEMPORAL_RANGE',
       ) > -1

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
@@ -57,7 +57,6 @@ import {
   D3_TIME_FORMAT_DOCS,
   DEFAULT_TIME_FORMAT,
   DEFAULT_NUMBER_FORMAT,
-  getTemporalColumns,
 } from '../utils';
 import { TIME_FILTER_LABELS } from '../constants';
 import {

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
@@ -57,6 +57,7 @@ import {
   D3_TIME_FORMAT_DOCS,
   DEFAULT_TIME_FORMAT,
   DEFAULT_NUMBER_FORMAT,
+  getTemporalColumns,
 } from '../utils';
 import { TIME_FILTER_LABELS } from '../constants';
 import {

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -495,7 +495,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
       ) => {
         const isTemporalRange = (filter: Record<string, any>) =>
           filter.operator === Operators.TEMPORAL_RANGE;
-        if (isTemporalRange(valueToBeDeleted)) {
+        if (!controls?.time_range?.value && isTemporalRange(valueToBeDeleted)) {
           const count = values.filter(isTemporalRange).length;
           if (count === 1) {
             return t(


### PR DESCRIPTION
### SUMMARY
Currently legacy charts with the time range control will get time filters doubly applied when `GENERIC_CHART_AXES` is enabled. This adds a check to skip conversion of the time range to an adhoc temporal filter if the control is present in the control panel, and also lets the user remove the last temporal filter if the time range control is present.

### AFTER
Now legacy charts only get time ranges applied once if there are no additional time filters:
![image](https://user-images.githubusercontent.com/33317356/228172016-40f805ee-45f1-47f8-aacd-014f3a3118ef.png)

### BEFORE
Previously legacy charts would automatically add the time range to the adhoc filters control, causing the time range to apply twice:
![image](https://user-images.githubusercontent.com/33317356/228172475-c8b9d524-8c0a-4ca4-9550-e5bb1aa4d912.png)

 It was also impossible to remove the last temporal filter in charts that have the time range control:
![image](https://user-images.githubusercontent.com/33317356/228172562-b1b4ec5a-ac67-4de0-8a92-21733860c1fc.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
