### PR TITLE
fix(legacy-plugin-chart-heatmap): fix adhoc column tooltip

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-heatmap/src/Heatmap.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-heatmap/src/Heatmap.js
@@ -23,6 +23,7 @@ import 'd3-svg-legend';
 import d3tip from 'd3-tip';
 import {
   getColumnLabel,
+  getMetricLabel,
   getNumberFormatter,
   NumberFormats,
   getSequentialSchemeRegistry,
@@ -339,12 +340,13 @@ function Heatmap(element, props) {
       const k = d3.mouse(this);
       const m = Math.floor(scale[0].invert(k[0]));
       const n = Math.floor(scale[1].invert(k[1]));
-      const metricLabel = typeof metric === 'object' ? metric.label : metric;
       if (m in matrix && n in matrix[m]) {
         const obj = matrix[m][n];
         s += `<div><b>${getColumnLabel(columnX)}: </b>${obj.x}<div>`;
         s += `<div><b>${getColumnLabel(columnY)}: </b>${obj.y}<div>`;
-        s += `<div><b>${metricLabel}: </b>${valueFormatter(obj.v)}<div>`;
+        s += `<div><b>${getMetricLabel(metric)}: </b>${valueFormatter(
+          obj.v,
+        )}<div>`;
         if (showPercentage) {
           s += `<div><b>%: </b>${fp(normalized ? obj.rank : obj.perc)}<div>`;
         }

--- a/superset-frontend/plugins/legacy-plugin-chart-heatmap/src/Heatmap.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-heatmap/src/Heatmap.js
@@ -22,6 +22,7 @@ import PropTypes from 'prop-types';
 import 'd3-svg-legend';
 import d3tip from 'd3-tip';
 import {
+  getColumnLabel,
   getNumberFormatter,
   NumberFormats,
   getSequentialSchemeRegistry,
@@ -44,8 +45,8 @@ const propTypes = {
   height: PropTypes.number,
   bottomMargin: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   colorScheme: PropTypes.string,
-  columnX: PropTypes.string,
-  columnY: PropTypes.string,
+  columnX: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+  columnY: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   leftMargin: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   metric: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   normalized: PropTypes.bool,
@@ -341,8 +342,8 @@ function Heatmap(element, props) {
       const metricLabel = typeof metric === 'object' ? metric.label : metric;
       if (m in matrix && n in matrix[m]) {
         const obj = matrix[m][n];
-        s += `<div><b>${columnX}: </b>${obj.x}<div>`;
-        s += `<div><b>${columnY}: </b>${obj.y}<div>`;
+        s += `<div><b>${getColumnLabel(columnX)}: </b>${obj.x}<div>`;
+        s += `<div><b>${getColumnLabel(columnY)}: </b>${obj.y}<div>`;
         s += `<div><b>${metricLabel}: </b>${valueFormatter(obj.v)}<div>`;
         if (showPercentage) {
           s += `<div><b>%: </b>${fp(normalized ? obj.rank : obj.perc)}<div>`;


### PR DESCRIPTION
### SUMMARY
The heatmap plugin doesn't account for the possibility of receiving adhoc columns as the x and y axis. This fixes that + also uses the `getMetricLabel` util for rendering the metric label.

### AFTER
Now the adhoc column label renders correctly:
![image](https://user-images.githubusercontent.com/33317356/228182815-9cbe8b0d-2f2f-4046-bb16-20942361274e.png)

### BEFORE
Previously adhoc columns displayed as [object Object]:
![image](https://user-images.githubusercontent.com/33317356/228181330-66a0a9ba-4e0d-4aaa-9abf-d9cab83c938e.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
