### PR TITLE
feat(cross-filters): using verbose map in applied cross-filters

### DIFF
--- a/superset-frontend/src/dashboard/components/FiltersBadge/index.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/index.tsx
@@ -209,6 +209,7 @@ export const FiltersBadge = ({ chartId }: FiltersBadgeProps) => {
             chart,
             present,
             dashboardInfo.metadata?.chart_configuration,
+            datasources[chart.form_data.datasource] ?? {},
           ),
         );
       }
@@ -219,6 +220,7 @@ export const FiltersBadge = ({ chartId }: FiltersBadgeProps) => {
     dashboardInfo.metadata?.chart_configuration,
     dataMask,
     nativeFilters,
+    datasources,
     nativeIndicators.length,
     present,
     prevChart?.queriesResponse,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/Vertical.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/Vertical.tsx
@@ -20,9 +20,15 @@
 import React from 'react';
 import { DataMaskStateWithId, JsonObject } from '@superset-ui/core';
 import { useSelector } from 'react-redux';
-import { DashboardLayout, RootState } from 'src/dashboard/types';
+import {
+  ChartsState,
+  DashboardLayout,
+  DatasourcesState,
+  RootState,
+} from 'src/dashboard/types';
 import crossFiltersSelector from './selectors';
 import VerticalCollapse from './VerticalCollapse';
+import { getVerboseMapsForCharts } from '../utils';
 
 const CrossFiltersVertical = () => {
   const dataMask = useSelector<RootState, DataMaskStateWithId>(
@@ -31,13 +37,19 @@ const CrossFiltersVertical = () => {
   const chartConfiguration = useSelector<RootState, JsonObject>(
     state => state.dashboardInfo.metadata?.chart_configuration,
   );
+  const datasources = useSelector<RootState, DatasourcesState>(
+    state => state.datasources,
+  );
+  const charts = useSelector<RootState, ChartsState>(state => state.charts);
   const dashboardLayout = useSelector<RootState, DashboardLayout>(
     state => state.dashboardLayout.present,
   );
+  const verboseMaps = getVerboseMapsForCharts(charts, datasources);
   const selectedCrossFilters = crossFiltersSelector({
     dataMask,
     chartConfiguration,
     dashboardLayout,
+    verboseMaps,
   });
 
   return <VerticalCollapse crossFilters={selectedCrossFilters} />;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/Vertical.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/Vertical.tsx
@@ -20,15 +20,10 @@
 import React from 'react';
 import { DataMaskStateWithId, JsonObject } from '@superset-ui/core';
 import { useSelector } from 'react-redux';
-import {
-  ChartsState,
-  DashboardLayout,
-  DatasourcesState,
-  RootState,
-} from 'src/dashboard/types';
+import { DashboardLayout, RootState } from 'src/dashboard/types';
 import crossFiltersSelector from './selectors';
 import VerticalCollapse from './VerticalCollapse';
-import { getVerboseMapsForCharts } from '../utils';
+import { GetChartsVerboseMaps } from '../utils';
 
 const CrossFiltersVertical = () => {
   const dataMask = useSelector<RootState, DataMaskStateWithId>(
@@ -37,14 +32,10 @@ const CrossFiltersVertical = () => {
   const chartConfiguration = useSelector<RootState, JsonObject>(
     state => state.dashboardInfo.metadata?.chart_configuration,
   );
-  const datasources = useSelector<RootState, DatasourcesState>(
-    state => state.datasources,
-  );
-  const charts = useSelector<RootState, ChartsState>(state => state.charts);
   const dashboardLayout = useSelector<RootState, DashboardLayout>(
     state => state.dashboardLayout.present,
   );
-  const verboseMaps = getVerboseMapsForCharts(charts, datasources);
+  const verboseMaps = GetChartsVerboseMaps();
   const selectedCrossFilters = crossFiltersSelector({
     dataMask,
     chartConfiguration,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/Vertical.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/Vertical.tsx
@@ -23,7 +23,7 @@ import { useSelector } from 'react-redux';
 import { DashboardLayout, RootState } from 'src/dashboard/types';
 import crossFiltersSelector from './selectors';
 import VerticalCollapse from './VerticalCollapse';
-import { GetChartsVerboseMaps } from '../utils';
+import { useChartsVerboseMaps } from '../utils';
 
 const CrossFiltersVertical = () => {
   const dataMask = useSelector<RootState, DataMaskStateWithId>(
@@ -35,7 +35,7 @@ const CrossFiltersVertical = () => {
   const dashboardLayout = useSelector<RootState, DashboardLayout>(
     state => state.dashboardLayout.present,
   );
-  const verboseMaps = GetChartsVerboseMaps();
+  const verboseMaps = useChartsVerboseMaps();
   const selectedCrossFilters = crossFiltersSelector({
     dataMask,
     chartConfiguration,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/selectors.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/selectors.ts
@@ -25,8 +25,9 @@ export const crossFiltersSelector = (props: {
   dataMask: DataMaskStateWithId;
   chartConfiguration: JsonObject;
   dashboardLayout: DashboardLayout;
+  verboseMaps: { [key: string]: Record<string, string> };
 }): CrossFilterIndicator[] => {
-  const { dataMask, chartConfiguration, dashboardLayout } = props;
+  const { dataMask, chartConfiguration, dashboardLayout, verboseMaps } = props;
   const chartsIds = Object.keys(chartConfiguration);
 
   return chartsIds
@@ -36,6 +37,7 @@ export const crossFiltersSelector = (props: {
         id,
         dataMask[id],
         dashboardLayout,
+        verboseMaps[id],
       );
       if (
         isDefined(filterIndicator.column) &&

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
@@ -48,8 +48,10 @@ import {
   useSelectFiltersInScope,
 } from 'src/dashboard/components/nativeFilters/state';
 import {
+  ChartsState,
   DashboardLayout,
   FilterBarOrientation,
+  DatasourcesState,
   RootState,
 } from 'src/dashboard/types';
 import DropdownContainer, {
@@ -62,6 +64,7 @@ import { FiltersDropdownContent } from '../FiltersDropdownContent';
 import crossFiltersSelector from '../CrossFilters/selectors';
 import CrossFilter from '../CrossFilters/CrossFilter';
 import { useFilterOutlined } from '../useFilterOutlined';
+import { getVerboseMapsForCharts } from '../utils';
 
 type FilterControlsProps = {
   dataMaskSelected: DataMaskStateWithId;
@@ -93,6 +96,13 @@ const FilterControls: FC<FilterControlsProps> = ({
   const dashboardLayout = useSelector<RootState, DashboardLayout>(
     state => state.dashboardLayout.present,
   );
+  const datasources = useSelector<RootState, DatasourcesState>(
+    state => state.datasources,
+  );
+  const charts = useSelector<RootState, ChartsState>(state => state.charts);
+
+  const verboseMaps = getVerboseMapsForCharts(charts, datasources);
+
   const isCrossFiltersEnabled = isFeatureEnabled(
     FeatureFlag.DASHBOARD_CROSS_FILTERS,
   );
@@ -103,6 +113,7 @@ const FilterControls: FC<FilterControlsProps> = ({
             dataMask,
             chartConfiguration,
             dashboardLayout,
+            verboseMaps,
           })
         : [],
     [chartConfiguration, dashboardLayout, dataMask, isCrossFiltersEnabled],

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
@@ -62,7 +62,7 @@ import { FiltersDropdownContent } from '../FiltersDropdownContent';
 import crossFiltersSelector from '../CrossFilters/selectors';
 import CrossFilter from '../CrossFilters/CrossFilter';
 import { useFilterOutlined } from '../useFilterOutlined';
-import { GetChartsVerboseMaps } from '../utils';
+import { useChartsVerboseMaps } from '../utils';
 
 type FilterControlsProps = {
   dataMaskSelected: DataMaskStateWithId;
@@ -94,7 +94,7 @@ const FilterControls: FC<FilterControlsProps> = ({
   const dashboardLayout = useSelector<RootState, DashboardLayout>(
     state => state.dashboardLayout.present,
   );
-  const verboseMaps = GetChartsVerboseMaps();
+  const verboseMaps = useChartsVerboseMaps();
 
   const isCrossFiltersEnabled = isFeatureEnabled(
     FeatureFlag.DASHBOARD_CROSS_FILTERS,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
@@ -48,10 +48,8 @@ import {
   useSelectFiltersInScope,
 } from 'src/dashboard/components/nativeFilters/state';
 import {
-  ChartsState,
   DashboardLayout,
   FilterBarOrientation,
-  DatasourcesState,
   RootState,
 } from 'src/dashboard/types';
 import DropdownContainer, {
@@ -64,7 +62,7 @@ import { FiltersDropdownContent } from '../FiltersDropdownContent';
 import crossFiltersSelector from '../CrossFilters/selectors';
 import CrossFilter from '../CrossFilters/CrossFilter';
 import { useFilterOutlined } from '../useFilterOutlined';
-import { getVerboseMapsForCharts } from '../utils';
+import { GetChartsVerboseMaps } from '../utils';
 
 type FilterControlsProps = {
   dataMaskSelected: DataMaskStateWithId;
@@ -96,12 +94,7 @@ const FilterControls: FC<FilterControlsProps> = ({
   const dashboardLayout = useSelector<RootState, DashboardLayout>(
     state => state.dashboardLayout.present,
   );
-  const datasources = useSelector<RootState, DatasourcesState>(
-    state => state.datasources,
-  );
-  const charts = useSelector<RootState, ChartsState>(state => state.charts);
-
-  const verboseMaps = getVerboseMapsForCharts(charts, datasources);
+  const verboseMaps = GetChartsVerboseMaps();
 
   const isCrossFiltersEnabled = isFeatureEnabled(
     FeatureFlag.DASHBOARD_CROSS_FILTERS,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Horizontal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Horizontal.tsx
@@ -28,10 +28,15 @@ import {
 } from '@superset-ui/core';
 import Icons from 'src/components/Icons';
 import Loading from 'src/components/Loading';
-import { DashboardLayout, RootState } from 'src/dashboard/types';
+import {
+  ChartsState,
+  DashboardLayout,
+  DatasourcesState,
+  RootState,
+} from 'src/dashboard/types';
 import { useSelector } from 'react-redux';
 import FilterControls from './FilterControls/FilterControls';
-import { getFilterBarTestId } from './utils';
+import { getVerboseMapsForCharts, getFilterBarTestId } from './utils';
 import { HorizontalBarProps } from './types';
 import FilterBarSettings from './FilterBarSettings';
 import FilterConfigurationLink from './FilterConfigurationLink';
@@ -117,11 +122,18 @@ const HorizontalFilterBar: React.FC<HorizontalBarProps> = ({
   const isCrossFiltersEnabled = isFeatureEnabled(
     FeatureFlag.DASHBOARD_CROSS_FILTERS,
   );
+  const datasources = useSelector<RootState, DatasourcesState>(
+    state => state.datasources,
+  );
+  const charts = useSelector<RootState, ChartsState>(state => state.charts);
+  const verboseMaps = getVerboseMapsForCharts(charts, datasources);
+
   const selectedCrossFilters = isCrossFiltersEnabled
     ? crossFiltersSelector({
         dataMask,
         chartConfiguration,
         dashboardLayout,
+        verboseMaps,
       })
     : [];
   const hasFilters = filterValues.length > 0 || selectedCrossFilters.length > 0;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Horizontal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Horizontal.tsx
@@ -28,15 +28,10 @@ import {
 } from '@superset-ui/core';
 import Icons from 'src/components/Icons';
 import Loading from 'src/components/Loading';
-import {
-  ChartsState,
-  DashboardLayout,
-  DatasourcesState,
-  RootState,
-} from 'src/dashboard/types';
+import { DashboardLayout, RootState } from 'src/dashboard/types';
 import { useSelector } from 'react-redux';
 import FilterControls from './FilterControls/FilterControls';
-import { getVerboseMapsForCharts, getFilterBarTestId } from './utils';
+import { GetChartsVerboseMaps, getFilterBarTestId } from './utils';
 import { HorizontalBarProps } from './types';
 import FilterBarSettings from './FilterBarSettings';
 import FilterConfigurationLink from './FilterConfigurationLink';
@@ -122,11 +117,7 @@ const HorizontalFilterBar: React.FC<HorizontalBarProps> = ({
   const isCrossFiltersEnabled = isFeatureEnabled(
     FeatureFlag.DASHBOARD_CROSS_FILTERS,
   );
-  const datasources = useSelector<RootState, DatasourcesState>(
-    state => state.datasources,
-  );
-  const charts = useSelector<RootState, ChartsState>(state => state.charts);
-  const verboseMaps = getVerboseMapsForCharts(charts, datasources);
+  const verboseMaps = GetChartsVerboseMaps();
 
   const selectedCrossFilters = isCrossFiltersEnabled
     ? crossFiltersSelector({

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Horizontal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Horizontal.tsx
@@ -31,7 +31,7 @@ import Loading from 'src/components/Loading';
 import { DashboardLayout, RootState } from 'src/dashboard/types';
 import { useSelector } from 'react-redux';
 import FilterControls from './FilterControls/FilterControls';
-import { GetChartsVerboseMaps, getFilterBarTestId } from './utils';
+import { useChartsVerboseMaps, getFilterBarTestId } from './utils';
 import { HorizontalBarProps } from './types';
 import FilterBarSettings from './FilterBarSettings';
 import FilterConfigurationLink from './FilterConfigurationLink';
@@ -117,7 +117,7 @@ const HorizontalFilterBar: React.FC<HorizontalBarProps> = ({
   const isCrossFiltersEnabled = isFeatureEnabled(
     FeatureFlag.DASHBOARD_CROSS_FILTERS,
   );
-  const verboseMaps = GetChartsVerboseMaps();
+  const verboseMaps = useChartsVerboseMaps();
 
   const selectedCrossFilters = isCrossFiltersEnabled
     ? crossFiltersSelector({

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
@@ -67,11 +67,12 @@ export const getVerboseMapsForCharts = (
   charts: ChartsState,
   datasources: DatasourcesState,
 ) =>
-  Object.keys(charts).reduce((obj, chartId) => {
+  Object.keys(charts).reduce((chartsVerboseMaps, chartId) => {
     const chartDatasource = datasources[charts[chartId]?.form_data?.datasource];
-    return Object.assign(obj, {
+    return {
+      ...chartsVerboseMaps,
       [chartId]: chartDatasource ? chartDatasource.verbose_map : {},
-    });
+    };
   }, {});
 
 export const FILTER_BAR_TEST_ID = 'filter-bar';

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
@@ -20,7 +20,8 @@
 import { areObjectsEqual } from 'src/reduxUtils';
 import { DataMaskStateWithId, Filter, FilterState } from '@superset-ui/core';
 import { testWithId } from 'src/utils/testUtils';
-import { ChartsState, DatasourcesState } from 'src/dashboard/types';
+import { RootState } from 'src/dashboard/types';
+import { useSelector } from 'react-redux';
 
 export const getOnlyExtraFormData = (data: DataMaskStateWithId) =>
   Object.values(data).reduce(
@@ -63,17 +64,21 @@ export const checkIsApplyDisabled = (
   );
 };
 
-export const getVerboseMapsForCharts = (
-  charts: ChartsState,
-  datasources: DatasourcesState,
-) =>
-  Object.keys(charts).reduce((chartsVerboseMaps, chartId) => {
-    const chartDatasource = datasources[charts[chartId]?.form_data?.datasource];
-    return {
-      ...chartsVerboseMaps,
-      [chartId]: chartDatasource ? chartDatasource.verbose_map : {},
-    };
-  }, {});
+export const GetChartsVerboseMaps = () =>
+  useSelector<RootState, { [chartId: string]: Record<string, string> }>(
+    state => {
+      const { charts, datasources } = state;
+
+      return Object.keys(state.charts).reduce((chartsVerboseMaps, chartId) => {
+        const chartDatasource =
+          datasources[charts[chartId]?.form_data?.datasource];
+        return {
+          ...chartsVerboseMaps,
+          [chartId]: chartDatasource ? chartDatasource.verbose_map : {},
+        };
+      }, {});
+    },
+  );
 
 export const FILTER_BAR_TEST_ID = 'filter-bar';
 export const getFilterBarTestId = testWithId(FILTER_BAR_TEST_ID);

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
@@ -64,7 +64,7 @@ export const checkIsApplyDisabled = (
   );
 };
 
-export const GetChartsVerboseMaps = () =>
+export const useChartsVerboseMaps = () =>
   useSelector<RootState, { [chartId: string]: Record<string, string> }>(
     state => {
       const { charts, datasources } = state;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
@@ -68,8 +68,10 @@ export const getVerboseMapsForCharts = (
   datasources: DatasourcesState,
 ) =>
   Object.keys(charts).reduce((obj, chartId) => {
-    const chartDatasource = datasources[charts[chartId].form_data.datasource];
-    return Object.assign(obj, { [chartId]: chartDatasource.verbose_map });
+    const chartDatasource = datasources[charts[chartId]?.form_data?.datasource];
+    return Object.assign(obj, {
+      [chartId]: chartDatasource ? chartDatasource.verbose_map : {},
+    });
   }, {});
 
 export const FILTER_BAR_TEST_ID = 'filter-bar';

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
@@ -20,6 +20,7 @@
 import { areObjectsEqual } from 'src/reduxUtils';
 import { DataMaskStateWithId, Filter, FilterState } from '@superset-ui/core';
 import { testWithId } from 'src/utils/testUtils';
+import { ChartsState, DatasourcesState } from 'src/dashboard/types';
 
 export const getOnlyExtraFormData = (data: DataMaskStateWithId) =>
   Object.values(data).reduce(
@@ -61,6 +62,15 @@ export const checkIsApplyDisabled = (
     )
   );
 };
+
+export const getVerboseMapsForCharts = (
+  charts: ChartsState,
+  datasources: DatasourcesState,
+) =>
+  Object.keys(charts).reduce((obj, chartId) => {
+    const chartDatasource = datasources[charts[chartId].form_data.datasource];
+    return Object.assign(obj, { [chartId]: chartDatasource.verbose_map });
+  }, {});
 
 export const FILTER_BAR_TEST_ID = 'filter-bar';
 export const getFilterBarTestId = testWithId(FILTER_BAR_TEST_ID);

--- a/superset-frontend/src/dashboard/components/nativeFilters/selectors.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/selectors.ts
@@ -50,6 +50,7 @@ const TIME_GRANULARITY_FIELDS = new Set(Object.values(TIME_FILTER_MAP));
 type Datasource = {
   time_grain_sqla?: [string, string][];
   granularity?: [string, string][];
+  verbose_map?: Record<string, string>;
 };
 
 type Filter = {
@@ -167,6 +168,7 @@ export const getCrossFilterIndicator = (
   chartId: number,
   dataMask: DataMask,
   dashboardLayout: DashboardLayout,
+  verboseMap: Record<string, string> = {},
 ) => {
   const filterState = dataMask?.filterState;
   const filters = dataMask?.extraFormData?.filters;
@@ -179,7 +181,7 @@ export const getCrossFilterIndicator = (
     layoutItem => layoutItem?.meta?.chartId === chartId,
   );
   const filterObject: Indicator = {
-    column,
+    column: verboseMap[column] || column,
     name:
       dashboardLayoutItem?.meta?.sliceNameOverride ||
       dashboardLayoutItem?.meta?.sliceName ||
@@ -288,6 +290,7 @@ export const selectChartCrossFilters = (
   chartConfiguration: ChartConfiguration = defaultChartConfig,
   appliedColumns: Set<string>,
   rejectedColumns: Set<string>,
+  verboseMap?: Record<string, string>,
   filterEmitter = false,
 ): Indicator[] | CrossFilterIndicator[] => {
   let crossFilterIndicators: any = [];
@@ -309,6 +312,7 @@ export const selectChartCrossFilters = (
           chartConfig.id,
           dataMask[chartConfig.id],
           dashboardLayout,
+          verboseMap,
         );
         const filterStatus = getStatus({
           label: filterIndicator.value,
@@ -337,6 +341,7 @@ export const selectNativeIndicatorsForChart = (
   chart: any,
   dashboardLayout: Layout,
   chartConfiguration: ChartConfiguration = defaultChartConfig,
+  datasource: Datasource,
 ): Indicator[] => {
   const appliedColumns = getAppliedColumns(chart);
   const rejectedColumns = getRejectedColumns(chart);
@@ -392,6 +397,7 @@ export const selectNativeIndicatorsForChart = (
       chartConfiguration,
       appliedColumns,
       rejectedColumns,
+      datasource.verbose_map,
     );
   }
   const indicators = crossFilterIndicators.concat(nativeFilterIndicators);


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Displaying human-readable column names in cross-filters by using verbose mapping from the chart's datasource.

### BEFORE
<!--- Skip this if not applicable -->
<img width="1280" alt="Screenshot_46" src="https://user-images.githubusercontent.com/66589759/228224505-8ea25877-a722-4e01-9112-72b349c0ccd7.png">

### AFTER 
<img width="1279" alt="Screenshot_45" src="https://user-images.githubusercontent.com/66589759/228224581-24d237e7-8526-4fca-ba2f-d76e314e5117.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Required feature flags: DASHBOARD_CROSS_FILTERS
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
