### PR TITLE
fix: Dashboard not loading with default first value in filter

### DIFF
--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -129,7 +129,6 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
         enableEmptyFilter && !inverseSelection && !values?.length;
 
       const suffix = inverseSelection && values?.length ? t(' (excluded)') : '';
-
       dispatchDataMask({
         type: 'filterState',
         __cache: filterState,
@@ -290,12 +289,8 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
     updateDataMask,
     data,
     groupby,
-    JSON.stringify(filterState),
+    JSON.stringify(filterState.value),
   ]);
-
-  useEffect(() => {
-    updateDataMask(filterState.value);
-  }, [JSON.stringify(filterState.value)]);
 
   useEffect(() => {
     setDataMask(dataMask);


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Users are able to configure a dashboard filter to automatically select the first value by default. However, when this function was used the dashboard didn't load properly.

The culprit was a redundant `useEffect` that caused the filter value to reset to `undefined`. By removing the redundant `useEffect` the issue is resolved.

### AFTER

https://user-images.githubusercontent.com/60598000/228280229-36b8ca35-4291-470f-87e4-12d18ba1c6f6.mp4

### TESTING INSTRUCTIONS
1. Open a Dashboard
2. Create a filter with first default value
3. The Dashboard should load successfully

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
