### PR TITLE
fix(plugin-generator): Addresses linter errors in newly generated Superset plugin

### DIFF
--- a/superset-frontend/packages/generator-superset/generators/plugin-chart/templates/package.erb
+++ b/superset-frontend/packages/generator-superset/generators/plugin-chart/templates/package.erb
@@ -28,12 +28,12 @@
   },
   "dependencies": {},
   "peerDependencies": {
+    "@airbnb/config-babel": "^2.0.1",
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
     "react": "^16.13.1"
   },
   "devDependencies": {
-    "@airbnb/config-babel": "^2.0.1",
     "@babel/cli": "^7.16.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.6.3",

--- a/superset-frontend/packages/generator-superset/generators/plugin-chart/templates/src/MyChart.erb
+++ b/superset-frontend/packages/generator-superset/generators/plugin-chart/templates/src/MyChart.erb
@@ -38,14 +38,15 @@ const Styles = styled.div<<%= packageLabel %>StylesProps>`
     /* You can use your props to control CSS! */
     margin-top: 0;
     margin-bottom: ${({ theme }) => theme.gridUnit * 3}px;
-    font-size: ${({ theme, headerFontSize }) => theme.typography.sizes[headerFontSize]}px;
-    font-weight: ${({ theme, boldText }) => theme.typography.weights[boldText ? 'bold' : 'normal']};
+    font-size: ${({ theme, headerFontSize }) =>
+      theme.typography.sizes[headerFontSize]}px;
+    font-weight: ${({ theme, boldText }) =>
+      theme.typography.weights[boldText ? 'bold' : 'normal']};
   }
 
   pre {
-    height: ${({ theme, headerFontSize, height }) => (
-      height - theme.gridUnit * 12 - theme.typography.sizes[headerFontSize]
-    )}px;
+    height: ${({ theme, headerFontSize, height }) =>
+      height - theme.gridUnit * 12 - theme.typography.sizes[headerFontSize]}px;
   }
 `;
 

--- a/superset-frontend/packages/generator-superset/generators/plugin-chart/templates/src/plugin/controlPanel.erb
+++ b/superset-frontend/packages/generator-superset/generators/plugin-chart/templates/src/plugin/controlPanel.erb
@@ -17,7 +17,11 @@
  * under the License.
  */
 import { t, validateNonEmpty } from '@superset-ui/core';
-import { ControlPanelConfig, sections, sharedControls } from '@superset-ui/chart-controls';
+import {
+  ControlPanelConfig,
+  sections,
+  sharedControls,
+} from '@superset-ui/chart-controls';
 
 const config: ControlPanelConfig = {
   /**

--- a/superset-frontend/packages/generator-superset/generators/plugin-chart/templates/src/types.erb
+++ b/superset-frontend/packages/generator-superset/generators/plugin-chart/templates/src/types.erb
@@ -16,7 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { QueryFormData, supersetTheme, TimeseriesDataRecord } from '@superset-ui/core';
+import {
+  QueryFormData,
+  supersetTheme,
+  TimeseriesDataRecord,
+} from '@superset-ui/core';
 
 export interface <%= packageLabel %>StylesProps {
   height: number;

--- a/superset-frontend/packages/generator-superset/generators/plugin-chart/templates/test/plugin/transformProps.test.erb
+++ b/superset-frontend/packages/generator-superset/generators/plugin-chart/templates/test/plugin/transformProps.test.erb
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { ChartProps } from '@superset-ui/core';
+import { ChartProps, supersetTheme } from '@superset-ui/core';
 import transformProps from '../../src/plugin/transformProps';
 
 describe('<%= packageLabel %> transformProps', () => {
@@ -34,6 +34,7 @@ describe('<%= packageLabel %> transformProps', () => {
     formData,
     width: 800,
     height: 600,
+    theme: supersetTheme,
     queriesData: [{
       data: [{ name: 'Hulk', sum__num: 1<%if (chartType === 'timeseries') { %>, __timestamp: 599616000000<% } %> }],
     }],


### PR DESCRIPTION
### SUMMARY

When creating a new Superset plugin using the plugin generator, the generated code contains linter errors that prevent Superset from building properly. This PR updates the generator `erb` templates so that they do not contain linter errors.

Note: Plugins with very long names may still generate linter errors, due to excessive line length

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before:

![default-plugin-linter-errors](https://user-images.githubusercontent.com/128753205/228305022-a2788a49-d3fb-41c7-ad6c-292e235f643e.png)

#### After:

(Build completes without errors)

### TESTING INSTRUCTIONS

* Create a new plugin using the Superset plugin generator in the `superset-frontend/plugins/` directory
* Run `npm run build` from the `superset-frontend` directory
* Confirm that build completes without linter errors (pre-existing warnings have not been addressed)

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
