### PR TITLE
fix(sqllab): dedupe table_schemas in active_tab

### DIFF
--- a/superset-frontend/src/SqlLab/reducers/getInitialState.js
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.js
@@ -113,7 +113,7 @@ export default function getInitialState({
   });
 
   const tabHistory = activeTab ? [activeTab.id.toString()] : [];
-  const tables = [];
+  let tables = {};
   if (activeTab) {
     activeTab.table_schemas
       .filter(tableSchema => tableSchema.description !== null)
@@ -146,7 +146,10 @@ export default function getInitialState({
           partitions,
           metadata,
         };
-        tables.push(table);
+        tables = {
+          ...tables,
+          [table.id]: table,
+        };
       });
   }
 
@@ -183,9 +186,15 @@ export default function getInitialState({
           },
         };
       });
-      sqlLab.tables.forEach(table =>
-        tables.push({ ...table, inLocalStorage: true }),
-      );
+      sqlLab.tables.forEach(table => {
+        tables = {
+          ...tables,
+          [table.id]: {
+            ...tables[table.id],
+            ...table,
+          },
+        };
+      });
       Object.values(sqlLab.queries).forEach(query => {
         queries[query.id] = { ...query, inLocalStorage: true };
       });
@@ -202,7 +211,7 @@ export default function getInitialState({
       queries,
       queryEditors: Object.values(queryEditors),
       tabHistory: dedupeTabHistory(tabHistory),
-      tables,
+      tables: Object.values(tables),
       queriesLastUpdate: Date.now(),
       user,
       unsavedQueryEditor,

--- a/superset-frontend/src/SqlLab/reducers/getInitialState.js
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.js
@@ -186,15 +186,16 @@ export default function getInitialState({
           },
         };
       });
-      sqlLab.tables.forEach(table => {
-        tables = {
-          ...tables,
+      tables = sqlLab.tables.reduce(
+        (merged, table) => ({
+          ...merged,
           [table.id]: {
             ...tables[table.id],
             ...table,
           },
-        };
-      });
+        }),
+        tables,
+      );
       Object.values(sqlLab.queries).forEach(query => {
         queries[query.id] = { ...query, inLocalStorage: true };
       });

--- a/superset-frontend/src/SqlLab/reducers/getInitialState.test.ts
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.test.ts
@@ -70,6 +70,10 @@ describe('getInitialState', () => {
   });
 
   describe('dedupe tables schema', () => {
+    afterEach(() => {
+      localStorage.clear();
+    });
+
     it('should dedupe the table schema', () => {
       localStorage.setItem(
         'redux',

--- a/superset-frontend/src/SqlLab/reducers/getInitialState.test.ts
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.test.ts
@@ -68,4 +68,54 @@ describe('getInitialState', () => {
       });
     });
   });
+
+  describe('dedupe tables schema', () => {
+    it('should dedupe the table schema', () => {
+      localStorage.setItem(
+        'redux',
+        JSON.stringify({
+          sqlLab: {
+            tables: [
+              { id: 1, name: 'test1' },
+              { id: 6, name: 'test6' },
+            ],
+            queryEditors: [{ id: 1, title: 'editor1' }],
+            queries: {},
+            tabHistory: [],
+          },
+        }),
+      );
+      const initializedTables = getInitialState({
+        ...apiData,
+        active_tab: {
+          id: 1,
+          table_schemas: [
+            {
+              id: 1,
+              table: 'table1',
+              tab_state_id: 1,
+              description: {
+                columns: [
+                  { name: 'id', type: 'INT' },
+                  { name: 'column2', type: 'STRING' },
+                ],
+              },
+            },
+            {
+              id: 2,
+              table: 'table2',
+              tab_state_id: 1,
+              description: {
+                columns: [
+                  { name: 'id', type: 'INT' },
+                  { name: 'column2', type: 'STRING' },
+                ],
+              },
+            },
+          ],
+        },
+      }).sqlLab.tables;
+      expect(initializedTables.map(({ id }) => id)).toEqual([1, 2, 6]);
+    });
+  });
 });


### PR DESCRIPTION
### SUMMARY
_Addition to #23265 fix_
When SQLLAB_BACKEND_PERSISTENCE has been deactivated after activated, active_tab will be provided during localstorage persistence mode.
This causes the appending duplicated table_schemas value every time page is loaded. (This causes the increasing localStorage size)
This commit adds the dedupe logic to clean up the duplicated values.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

After:
<img width="927" alt="Superset" src="https://user-images.githubusercontent.com/1392866/228337922-7f2cc767-ee99-4930-b7b0-84506cf66962.png">

Before:
<img width="876" alt="Screenshot_2023-03-27_at_4_31_59_PM" src="https://user-images.githubusercontent.com/1392866/228337462-13a7e23d-e09c-4e25-b8df-0c55b89607ce.png">

### TESTING INSTRUCTIONS
set SQLLAB_BACKEND_PERSISTENCE on and open SqlLab
select one table to fetch the table schema info
disable SQLLAB_BACKEND_PERSISTENCE and open SqlLab
keep refresh the page and then check the redux value in the local storage

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

@michael-s-molina @ktmud 