### PR TITLE
fix(plugin-chart-table): Invalid d3Formatter on String column

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -119,6 +119,7 @@ const processColumns = memoizeOne(function processColumns(
       const isMetric = metricsSet.has(key) && isNumeric(key, records);
       const isPercentMetric = percentMetricsSet.has(key);
       const isTime = dataType === GenericDataType.TEMPORAL;
+      const isNumber = dataType === GenericDataType.NUMERIC;
       const savedFormat = columnFormats?.[key];
       const numberFormat = config.d3NumberFormat || savedFormat;
 
@@ -151,7 +152,7 @@ const processColumns = memoizeOne(function processColumns(
       } else if (isPercentMetric) {
         // percent metrics have a default format
         formatter = getNumberFormatter(numberFormat || PERCENT_3_POINT);
-      } else if (isMetric || numberFormat) {
+      } else if (isMetric || (isNumber && numberFormat)) {
         formatter = getNumberFormatter(numberFormat);
       }
       return {

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -97,6 +97,7 @@ describe('plugin-chart-table', () => {
       // should successful rerender with new props
       const cells = tree.find('td');
       expect(tree.find('th').eq(1).text()).toEqual('Sum of Num');
+      expect(cells.eq(0).text()).toEqual('Michael');
       expect(cells.eq(2).text()).toEqual('12.346%');
       expect(cells.eq(4).text()).toEqual('2.47k');
     });

--- a/superset-frontend/plugins/plugin-chart-table/test/testData.ts
+++ b/superset-frontend/plugins/plugin-chart-table/test/testData.ts
@@ -144,6 +144,20 @@ const advanced: TableChartProps = {
     ...basicFormData,
     metrics: ['sum__num'],
     percent_metrics: ['pct_nice'],
+    column_config: {
+      name: {
+        d3NumberFormat: '.3s',
+      },
+      sum__num: {
+        d3NumberFormat: '.3s',
+      },
+      pct_nice: {
+        d3NumberFormat: '.3s',
+      },
+      'abc.com': {
+        d3NumberFormat: '.3s',
+      },
+    },
   },
   queriesData: [
     {


### PR DESCRIPTION
### SUMMARY
regression from #17336
column_config applied the `d3NumberFormat` to all columns including STRING column, the string column value has been converted to 'NaN' due to invalid formatter.
When dnd column is disabled, there's no option to customize the format for a column.

This commit replaces `numberFormat` to apply for Number column only.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

After:
<img width="314" alt="Screenshot 2023-03-28 at 2 06 15 PM" src="https://user-images.githubusercontent.com/1392866/228367625-d9f84993-c4aa-4432-96da-95d1e7e7c773.png">

Before:

<img width="314" alt="Screenshot 2023-03-28 at 2 05 27 PM" src="https://user-images.githubusercontent.com/1392866/228367631-f1e8e9a6-d42c-4c74-8633-ba9ac1a428e2.png">


### TESTING INSTRUCTIONS
Create a Table chart and apply the `d3NumberFormat`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @ktmud @michael-s-molina 