### PR TITLE
fix(word cloud): series label format fixed for custom sql queries

### DIFF
--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/legacyPlugin/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/legacyPlugin/transformProps.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { ChartProps } from '@superset-ui/core';
+import { ChartProps, getColumnLabel } from '@superset-ui/core';
 import { WordCloudProps, WordCloudEncoding } from '../chart/WordCloud';
 import { LegacyWordCloudFormData } from './types';
 
@@ -34,16 +34,6 @@ function getMetricLabel(
   return metric.label;
 }
 
-function getSeriesLabel(
-  series: LegacyWordCloudFormData['series'],
-): string | undefined {
-  if (typeof series === 'string' || typeof series === 'undefined') {
-    return series;
-  }
-  
-  return series.label;
-}
-
 export default function transformProps(chartProps: ChartProps): WordCloudProps {
   const { width, height, formData, queriesData } = chartProps;
   const {
@@ -57,7 +47,7 @@ export default function transformProps(chartProps: ChartProps): WordCloudProps {
   } = formData as LegacyWordCloudFormData;
 
   const metricLabel = getMetricLabel(metric);
-  const seriesLabel = getSeriesLabel(series) || '';
+  const seriesLabel = getColumnLabel(series);
 
   const encoding: Partial<WordCloudEncoding> = {
     color: {

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/legacyPlugin/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/legacyPlugin/transformProps.ts
@@ -34,6 +34,16 @@ function getMetricLabel(
   return metric.label;
 }
 
+function getSeriesLabel(
+  series: LegacyWordCloudFormData['series'],
+): string | undefined {
+  if (typeof series === 'string' || typeof series === 'undefined') {
+    return series;
+  }
+  
+  return series.label;
+}
+
 export default function transformProps(chartProps: ChartProps): WordCloudProps {
   const { width, height, formData, queriesData } = chartProps;
   const {
@@ -47,10 +57,11 @@ export default function transformProps(chartProps: ChartProps): WordCloudProps {
   } = formData as LegacyWordCloudFormData;
 
   const metricLabel = getMetricLabel(metric);
+  const seriesLabel = getSeriesLabel(series) || '';
 
   const encoding: Partial<WordCloudEncoding> = {
     color: {
-      field: series,
+      field: seriesLabel,
       scale: {
         scheme: colorScheme,
       },
@@ -68,7 +79,7 @@ export default function transformProps(chartProps: ChartProps): WordCloudProps {
             type: 'quantitative',
           },
     text: {
-      field: series,
+      field: seriesLabel,
     },
   };
 

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/legacyPlugin/types.ts
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/legacyPlugin/types.ts
@@ -17,13 +17,13 @@
  * under the License.
  */
 
-import { QueryFormData } from '@superset-ui/core';
+import { QueryFormColumn, QueryFormData } from '@superset-ui/core';
 import { RotationType } from '../chart/WordCloud';
 
 export type LegacyWordCloudFormData = QueryFormData & {
   colorScheme: string;
   rotation?: RotationType;
-  series: string;
+  series: QueryFormColumn;
   sizeFrom?: number;
   sizeTo: number;
 };

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/types.ts
@@ -17,12 +17,12 @@
  * under the License.
  */
 
-import { QueryFormData } from '@superset-ui/core';
+import { QueryFormColumn, QueryFormData } from '@superset-ui/core';
 import { WordCloudVisualProps } from './chart/WordCloud';
 
 // FormData for wordcloud contains both common properties of all form data
 // and properties specific to wordcloud visualization
 export type WordCloudFormData = QueryFormData &
   WordCloudVisualProps & {
-    series: string;
+    series: QueryFormColumn;
   };


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
fix(word cloud) - issue #19975 - series label format fixed for custom sql queries

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is a fix for issue
https://github.com/apache/superset/issues/19975
For custom sql queries the type of series field is different from string. Made changes to the interface LegacyWordCloudFormData interface and series label in encoding.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
before:
![Screenshot from 2023-03-28 12-12-58](https://user-images.githubusercontent.com/30403195/228444002-8949f1ad-cbcb-4e07-9d11-c43cea64b371.png)

after:
![Screenshot from 2023-03-28 12-09-53](https://user-images.githubusercontent.com/30403195/228444051-5bbd11e5-69a3-4feb-82d7-db8868d75312.png)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. select Girl names chart word cloud
2. for dimension, select custom sql as upper(name)
3. word cloud with upper case names should be rendered.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
