### PR TITLE
fix(dashboards): apply tag filter correctly

### DIFF
--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -596,7 +596,7 @@ function DashboardList(props: DashboardListProps) {
         key: 'tags',
         id: 'tags',
         input: 'select',
-        operator: FilterOperator.chartTags,
+        operator: FilterOperator.dashboardTags,
         unfilteredLabel: t('All'),
         fetchSelects: loadTags,
       });


### PR DESCRIPTION
### SUMMARY
Fixes #23520 - the wrong operator (chart_tags instead of dashboard_tags) assigned to tag filter of dashboards page

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: 
<img width="508" alt="image" src="https://user-images.githubusercontent.com/25038017/228508638-000ae548-2117-46f6-abc1-1a461669ea44.png">

After:
- dashboards getting filtered correctly
<img width="1332" alt="image" src="https://user-images.githubusercontent.com/25038017/228508761-5437ad81-8e2a-4109-9190-f4223b2983c4.png">

### TESTING INSTRUCTIONS
- Select a tag filter on dashboards page, it should correctly filter the dashboard list on the basis of selected tag in filter dropdown
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

- [x] Has associated issue: https://github.com/apache/superset/issues/23520
- [x] Required feature flags: TAGGING_SYSTEM
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
