### PR TITLE
fix(tags): convert postgres enum type to varchar

### DIFF
--- a/superset/migrations/versions/2023-03-29_20-30_07f9a902af1b_drop_postgres_enum_constrains_for_tags.py
+++ b/superset/migrations/versions/2023-03-29_20-30_07f9a902af1b_drop_postgres_enum_constrains_for_tags.py
@@ -23,8 +23,8 @@ Create Date: 2023-03-29 20:30:10.214951
 """
 
 # revision identifiers, used by Alembic.
-revision = '07f9a902af1b'
-down_revision = 'b5ea9d343307'
+revision = "07f9a902af1b"
+down_revision = "b5ea9d343307"
 
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/superset/migrations/versions/2023-03-29_20-30_07f9a902af1b_drop_postgres_enum_constrains_for_tags.py
+++ b/superset/migrations/versions/2023-03-29_20-30_07f9a902af1b_drop_postgres_enum_constrains_for_tags.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""drop postgres enum constrains for tags
+
+Revision ID: 07f9a902af1b
+Revises: b5ea9d343307
+Create Date: 2023-03-29 20:30:10.214951
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '07f9a902af1b'
+down_revision = 'b5ea9d343307'
+
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+def upgrade():
+    conn = op.get_bind()
+    if isinstance(conn.dialect, postgresql.dialect):
+        conn.execute(
+            'ALTER TABLE "tagged_object" ALTER COLUMN "object_type" TYPE VARCHAR'
+        )
+        conn.execute('ALTER TABLE "tag" ALTER COLUMN "type" TYPE VARCHAR')
+        conn.execute("DROP TYPE objecttypes")
+        conn.execute("DROP TYPE tagtypes")
+
+
+def downgrade():
+    # Leaving the column type as VARCHAR in case the column contains values that
+    # do not comply with the previous enum type
+    pass


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The original tags migration ended up using native postgres enums for some columns. This can cause issues since updates to the enum require a migration to alter the enum type (more info [here](https://makimo.pl/blog/upgrading-postgresqls-enum-type-with-sqlalchemy-using-alembic-migration/)). This lack of flexibility makes using postgres enums challenging. Converting the column types to varchar and allowing SQL Alchemy to handle to enum type should be fine and give us the most flexibility moving forward to add other tag types. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
