### PR TITLE
ci: disable flaky async test

### DIFF
--- a/tests/integration_tests/csv_upload_tests.py
+++ b/tests/integration_tests/csv_upload_tests.py
@@ -233,6 +233,9 @@ def test_import_csv_enforced_schema(mock_event_logger):
     if utils.backend() == "sqlite":
         pytest.skip("Sqlite doesn't support schema / database creation")
 
+    if utils.backend() == "mysql":
+        pytest.skip("This test is flaky on MySQL")
+
     full_table_name = f"admin_database.{CSV_UPLOAD_TABLE_W_SCHEMA}"
 
     # Invalid table name


### PR DESCRIPTION
### SUMMARY
Disable a test that frequently fails on the MySQL CI workflow.

### SCREENSHOT
<img width="1032" alt="image" src="https://user-images.githubusercontent.com/33317356/228746882-f22021b3-8208-4139-ae7c-9314d12861b6.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
