### PR TITLE
fix(plugin-chart-table): Include time control

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/query/extractQueryFields.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/extractQueryFields.ts
@@ -30,6 +30,7 @@ import {
   FormDataResidual,
   QueryMode,
 } from './types/QueryFormData';
+import { hasGenericChartAxes } from './getXAxis';
 
 /**
  * Extra SQL query related fields from chart form data.
@@ -105,7 +106,7 @@ export default function extractQueryFields(
     }
   });
 
-  if (includeTime && !columns.includes(DTTM_ALIAS)) {
+  if (!hasGenericChartAxes && includeTime && !columns.includes(DTTM_ALIAS)) {
     columns.unshift(DTTM_ALIAS);
   }
 

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -31,6 +31,7 @@ import {
   QueryMode,
   smartDateFormatter,
   t,
+  validateNonEmpty,
 } from '@superset-ui/core';
 import {
   ColumnOption,
@@ -341,6 +342,27 @@ const config: ControlPanelConfig = {
               resetOnHide: false,
             },
           },
+        ],
+        [
+          {
+            name: 'granularity_sqla',
+            override: {
+              visibility: ({ controls }) =>
+                !!(hasGenericChartAxes && controls.include_time.value),
+              validators: [validateNonEmpty],
+            },
+          },
+        ],
+        [
+          {
+            name: 'time_grain_sqla',
+            override: {
+              visibility: ({ controls }) =>
+                !!(hasGenericChartAxes && controls.include_time.value),
+            },
+          },
+        ],
+        [
           {
             name: 'order_desc',
             config: {

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -31,7 +31,6 @@ import {
   QueryMode,
   smartDateFormatter,
   t,
-  validateNonEmpty,
 } from '@superset-ui/core';
 import {
   ColumnOption,
@@ -328,40 +327,23 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        [
-          {
-            name: 'include_time',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Include time'),
-              description: t(
-                'Whether to include the time granularity as defined in the time section',
-              ),
-              default: false,
-              visibility: isAggMode,
-              resetOnHide: false,
-            },
-          },
-        ],
-        [
-          {
-            name: 'granularity_sqla',
-            override: {
-              visibility: ({ controls }) =>
-                !!(hasGenericChartAxes && controls.include_time.value),
-              validators: [validateNonEmpty],
-            },
-          },
-        ],
-        [
-          {
-            name: 'time_grain_sqla',
-            override: {
-              visibility: ({ controls }) =>
-                !!(hasGenericChartAxes && controls.include_time.value),
-            },
-          },
-        ],
+        !hasGenericChartAxes
+          ? [
+              {
+                name: 'include_time',
+                config: {
+                  type: 'CheckboxControl',
+                  label: t('Include time'),
+                  description: t(
+                    'Whether to include the time granularity as defined in the time section',
+                  ),
+                  default: false,
+                  visibility: isAggMode,
+                  resetOnHide: false,
+                },
+              },
+            ]
+          : [null],
         [
           {
             name: 'order_desc',

--- a/superset-frontend/src/explore/actions/hydrateExplore.ts
+++ b/superset-frontend/src/explore/actions/hydrateExplore.ts
@@ -29,8 +29,11 @@ import { Dispatch } from 'redux';
 import {
   ensureIsArray,
   getCategoricalSchemeRegistry,
+  getColumnLabel,
   getSequentialSchemeRegistry,
+  hasGenericChartAxes,
   NO_TIME_RANGE,
+  QueryFormColumn,
 } from '@superset-ui/core';
 import {
   getFormDataFromControls,
@@ -73,6 +76,23 @@ export const hydrateExplore =
       initialFormData.time_range =
         common?.conf?.DEFAULT_TIME_FILTER || NO_TIME_RANGE;
     }
+    if (
+      hasGenericChartAxes &&
+      initialFormData.include_time &&
+      initialFormData.granularity_sqla &&
+      !initialFormData.groupby?.some(
+        (col: QueryFormColumn) =>
+          getColumnLabel(col) ===
+          getColumnLabel(initialFormData.granularity_sqla!),
+      )
+    ) {
+      initialFormData.groupby = [
+        initialFormData.granularity_sqla,
+        ...ensureIsArray(initialFormData.groupby),
+      ];
+      initialFormData.granularity_sqla = undefined;
+    }
+
     if (dashboardId) {
       initialFormData.dashboardId = dashboardId;
     }


### PR DESCRIPTION
### SUMMARY
The "Include time" control in Table chart is not working properly when GENERIC_CHART_AXES is enabled because of lack of the time column in chart settings. 
This PR removes the `include_time` checkbox and if `include_time` was true before and `granularity_sqla` was set, it moves the `granularity_sqla` column to dimensions. The end result is the same as with the checkbox, except that the label of the time column is actual column name rather than "Time".

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="1728" alt="Screenshot 2023-03-30 at 13 54 33" src="https://user-images.githubusercontent.com/15073128/228828123-1cac786b-34af-49d5-b0c5-6586bce5f47f.png">

After:

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/15073128/229106788-0a52818b-fdf6-48f4-83fb-d87dbedfa4cf.png">



### TESTING INSTRUCTIONS
1. Disable GENERIC_CHART_AXES
2. Create a table chart and check "Include time", add a time column
3. Enable GENERIC_CHART_AXES
4. The "Include time" checkbox should disappear, the time column should now be added to Dimensions
5. Nothing should happen if "Include time" was not checked before enabling the feature flag

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
