### PR TITLE
feat: Add metadata bar to drill by modal

### DIFF
--- a/superset-frontend/src/components/Chart/DrillBy/DrillByChart.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByChart.tsx
@@ -45,7 +45,7 @@ export default function DrillByChart({
   let groupbyField: any = [];
   const [chartDataResult, setChartDataResult] = useState();
 
-  if (groupbyFieldName && column) {
+  if (column) {
     groupbyField = Array.isArray(formData[groupbyFieldName])
       ? [column.column_name]
       : column.column_name;
@@ -82,8 +82,8 @@ export default function DrillByChart({
           chartType={formData.viz_type}
           enableNoResults
           formData={updatedFormData}
-          height="100%"
           queriesData={chartDataResult}
+          height="100%"
           width="100%"
         />
       ) : (

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.tsx
@@ -47,6 +47,7 @@ import { MenuItemTooltip } from '../DisabledMenuItemTooltip';
 import DrillByModal from './DrillByModal';
 import { getSubmenuYOffset } from '../utils';
 import { MenuItemWithTruncation } from '../MenuItemWithTruncation';
+import { Dataset } from '../types';
 
 const MAX_SUBMENU_HEIGHT = 200;
 const SHOW_COLUMNS_SEARCH_THRESHOLD = 10;
@@ -74,6 +75,7 @@ export const DrillByMenuItems = ({
 }: DrillByMenuItemsProps) => {
   const theme = useTheme();
   const [searchInput, setSearchInput] = useState('');
+  const [dataset, setDataset] = useState<Dataset>();
   const [columns, setColumns] = useState<Column[]>([]);
   const [showModal, setShowModal] = useState(false);
   const [currentColumn, setCurrentColumn] = useState();
@@ -114,6 +116,7 @@ export const DrillByMenuItems = ({
         endpoint: `/api/v1/dataset/${datasetId}`,
       })
         .then(({ json: { result } }) => {
+          setDataset(result);
           setColumns(
             ensureIsArray(result.columns)
               .filter(column => column.groupby)
@@ -248,6 +251,7 @@ export const DrillByMenuItems = ({
         groupbyFieldName={groupbyFieldName}
         onHideModal={closeModal}
         showModal={showModal}
+        dataset={dataset!}
       />
     </>
   );

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
@@ -44,6 +44,18 @@ const drillByModalState = {
     },
   },
 };
+const dataset = {
+  changed_on_humanized: '01-01-2001',
+  created_on_humanized: '01-01-2001',
+  description: 'desc',
+  table_name: 'my_dataset',
+  owners: [
+    {
+      first_name: 'Sarah',
+      last_name: 'Connor',
+    },
+  ],
+};
 const renderModal = async (state?: object) => {
   const DrillByModalWrapper = () => {
     const [showModal, setShowModal] = useState(false);
@@ -57,6 +69,7 @@ const renderModal = async (state?: object) => {
           formData={formData}
           showModal={showModal}
           onHideModal={() => setShowModal(false)}
+          dataset={dataset}
         />
       </>
     );

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByModal.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByModal.tsx
@@ -29,6 +29,8 @@ import Modal from 'src/components/Modal';
 import Button from 'src/components/Button';
 import { useSelector } from 'react-redux';
 import { DashboardLayout, RootState } from 'src/dashboard/types';
+import { useDatasetMetadataBar } from 'src/features/datasets/metadataBar/useDatasetMetadataBar';
+import { Dataset } from '../types';
 import DrillByChart from './DrillByChart';
 
 interface ModalFooterProps {
@@ -59,6 +61,7 @@ interface DrillByModalProps {
   groupbyFieldName?: string;
   onHideModal: () => void;
   showModal: boolean;
+  dataset: Dataset;
 }
 
 export default function DrillByModal({
@@ -68,6 +71,7 @@ export default function DrillByModal({
   groupbyFieldName,
   onHideModal,
   showModal,
+  dataset,
 }: DrillByModalProps) {
   const theme = useTheme();
   const dashboardLayout = useSelector<RootState, DashboardLayout>(
@@ -80,6 +84,7 @@ export default function DrillByModal({
     chartLayoutItem?.meta.sliceNameOverride || chartLayoutItem?.meta.sliceName;
   const exploreChart = () => {};
 
+  const { metadataBar } = useDatasetMetadataBar({ dataset });
   return (
     <Modal
       css={css`
@@ -105,6 +110,7 @@ export default function DrillByModal({
       destroyOnClose
       maskClosable={false}
     >
+      {metadataBar}
       <DrillByChart
         column={column}
         filters={filters}

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByModal.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByModal.tsx
@@ -110,13 +110,21 @@ export default function DrillByModal({
       destroyOnClose
       maskClosable={false}
     >
-      {metadataBar}
-      <DrillByChart
-        column={column}
-        filters={filters}
-        formData={formData}
-        groupbyFieldName={groupbyFieldName}
-      />
+      <div
+        css={css`
+          display: flex;
+          flex-direction: column;
+          height: 100%;
+        `}
+      >
+        {metadataBar}
+        <DrillByChart
+          column={column}
+          filters={filters}
+          formData={formData}
+          groupbyFieldName={groupbyFieldName}
+        />
+      </div>
     </Modal>
   );
 }

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.test.tsx
@@ -23,6 +23,7 @@ import chartQueries, { sliceId } from 'spec/fixtures/mockChartQueries';
 import { QueryFormData, SupersetClient } from '@superset-ui/core';
 import fetchMock from 'fetch-mock';
 import DrillDetailPane from './DrillDetailPane';
+import { supersetGetCache } from 'src/utils/cachedSupersetGet';
 
 const chart = chartQueries[sliceId];
 const setup = (overrides: Record<string, any> = {}) => {
@@ -114,7 +115,10 @@ const fetchWithData = () => {
   });
 };
 
-afterEach(fetchMock.restore);
+afterEach(() => {
+  fetchMock.restore();
+  supersetGetCache.clear();
+});
 
 test('should render', async () => {
   fetchWithNoData();
@@ -180,11 +184,7 @@ test('should render the metadata bar', async () => {
 
 test('should render an error message when fails to load the metadata', async () => {
   fetchWithNoData();
-  fetchMock.get(
-    DATASET_ENDPOINT,
-    { status: 'error', error: 'Some error' },
-    { overwriteRoutes: true },
-  );
+  fetchMock.get(DATASET_ENDPOINT, { status: 400 }, { overwriteRoutes: true });
   setup();
   expect(
     await screen.findByText('There was an error loading the dataset metadata'),

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.test.tsx
@@ -17,13 +17,13 @@
  * under the License.
  */
 import React from 'react';
+import fetchMock from 'fetch-mock';
+import { QueryFormData, SupersetClient } from '@superset-ui/core';
 import { render, screen, waitFor } from 'spec/helpers/testing-library';
 import { getMockStoreWithNativeFilters } from 'spec/fixtures/mockStore';
 import chartQueries, { sliceId } from 'spec/fixtures/mockChartQueries';
-import { QueryFormData, SupersetClient } from '@superset-ui/core';
-import fetchMock from 'fetch-mock';
-import DrillDetailPane from './DrillDetailPane';
 import { supersetGetCache } from 'src/utils/cachedSupersetGet';
+import DrillDetailPane from './DrillDetailPane';
 
 const chart = chartQueries[sliceId];
 const setup = (overrides: Record<string, any> = {}) => {

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
@@ -102,8 +102,9 @@ export default function DrillDetailPane({
     [formData.datasource],
   );
 
-  const { metadataBar, status: metadataBarStatus } =
-    useDatasetMetadataBar(datasourceId);
+  const { metadataBar, status: metadataBarStatus } = useDatasetMetadataBar({
+    datasetId: datasourceId,
+  });
   // Get page of results
   const resultsPage = useMemo(() => {
     const nextResultsPage = resultsPages.get(pageIndex);

--- a/superset-frontend/src/components/Chart/types.ts
+++ b/superset-frontend/src/components/Chart/types.ts
@@ -16,11 +16,22 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { GenericDataType } from '@superset-ui/core';
 
-export type ResultsPage = {
-  total: number;
-  data: Record<string, any>[];
-  colNames: string[];
-  colTypes: GenericDataType[];
+export type Dataset = {
+  changed_by?: {
+    first_name: string;
+    last_name: string;
+  };
+  created_by?: {
+    first_name: string;
+    last_name: string;
+  };
+  changed_on_humanized: string;
+  created_on_humanized: string;
+  description: string;
+  table_name: string;
+  owners: {
+    first_name: string;
+    last_name: string;
+  }[];
 };

--- a/superset-frontend/src/features/datasets/metadataBar/DatasetMetadataBar.stories.tsx
+++ b/superset-frontend/src/features/datasets/metadataBar/DatasetMetadataBar.stories.tsx
@@ -53,7 +53,7 @@ export default {
 export const DatasetSpecific = () => {
   SupersetClient.reset();
   SupersetClient.configure({ csrfToken: '1234' }).init();
-  const { metadataBar } = useDatasetMetadataBar(1);
+  const { metadataBar } = useDatasetMetadataBar({ datasetId: 1 });
   const { width, height, ref } = useResizeDetector();
   // eslint-disable-next-line no-param-reassign
   return (

--- a/superset-frontend/src/features/datasets/metadataBar/useDatasetMetadataBar.test.tsx
+++ b/superset-frontend/src/features/datasets/metadataBar/useDatasetMetadataBar.test.tsx
@@ -20,28 +20,36 @@
 import fetchMock from 'fetch-mock';
 import { renderHook } from '@testing-library/react-hooks';
 import { createWrapper, render } from 'spec/helpers/testing-library';
+import { supersetGetCache } from 'src/utils/cachedSupersetGet';
 import { useDatasetMetadataBar } from './useDatasetMetadataBar';
 
-test('renders dataset metadata bar', async () => {
+const MOCK_DATASET = {
+  changed_on: '2023-01-26T12:06:58.733316',
+  changed_on_humanized: 'a month ago',
+  changed_by: { first_name: 'Han', last_name: 'Solo' },
+  created_by: { first_name: 'Luke', last_name: 'Skywalker' },
+  created_on: '2023-01-26T12:06:54.965034',
+  created_on_humanized: 'a month ago',
+  table_name: `This is dataset's name`,
+  owners: [
+    { first_name: 'John', last_name: 'Doe' },
+    { first_name: 'Luke', last_name: 'Skywalker' },
+  ],
+  description: 'This is a dataset description',
+};
+
+afterEach(() => {
+  fetchMock.restore();
+  supersetGetCache.clear();
+});
+
+test('renders dataset metadata bar from request', async () => {
   fetchMock.get('glob:*/api/v1/dataset/1', {
-    result: {
-      changed_on: '2023-01-26T12:06:58.733316',
-      changed_on_humanized: 'a month ago',
-      changed_by: { first_name: 'Han', last_name: 'Solo' },
-      created_by: { first_name: 'Luke', last_name: 'Skywalker' },
-      created_on: '2023-01-26T12:06:54.965034',
-      created_on_humanized: 'a month ago',
-      table_name: `This is dataset's name`,
-      owners: [
-        { first_name: 'John', last_name: 'Doe' },
-        { first_name: 'Luke', last_name: 'Skywalker' },
-      ],
-      description: 'This is a dataset description',
-    },
+    result: MOCK_DATASET,
   });
 
   const { result, waitForValueToChange } = renderHook(
-    () => useDatasetMetadataBar(1),
+    () => useDatasetMetadataBar({ datasetId: 1 }),
     {
       wrapper: createWrapper(),
     },
@@ -50,13 +58,36 @@ test('renders dataset metadata bar', async () => {
   await waitForValueToChange(() => result.current.status);
   expect(result.current.status).toEqual('complete');
 
+  expect(fetchMock.called()).toBeTruthy();
   const { findByText, findAllByRole } = render(result.current.metadataBar);
   expect(await findByText(`This is dataset's name`)).toBeVisible();
   expect(await findByText('This is a dataset description')).toBeVisible();
   expect(await findByText('Luke Skywalker')).toBeVisible();
   expect(await findByText('a month ago')).toBeVisible();
   expect(await findAllByRole('img')).toHaveLength(4);
-  fetchMock.restore();
+});
+
+test('renders dataset metadata bar without request', async () => {
+  fetchMock.get('glob:*/api/v1/dataset/1', {
+    result: {},
+  });
+
+  const { result } = renderHook(
+    () => useDatasetMetadataBar({ dataset: MOCK_DATASET }),
+    {
+      wrapper: createWrapper(),
+    },
+  );
+
+  expect(result.current.status).toEqual('complete');
+
+  expect(fetchMock.called()).toBeFalsy();
+  const { findByText, findAllByRole } = render(result.current.metadataBar);
+  expect(await findByText(`This is dataset's name`)).toBeVisible();
+  expect(await findByText('This is a dataset description')).toBeVisible();
+  expect(await findByText('Luke Skywalker')).toBeVisible();
+  expect(await findByText('a month ago')).toBeVisible();
+  expect(await findAllByRole('img')).toHaveLength(4);
 });
 
 test('renders dataset metadata bar without description and owners', async () => {
@@ -71,7 +102,7 @@ test('renders dataset metadata bar without description and owners', async () => 
   });
 
   const { result, waitForValueToChange } = renderHook(
-    () => useDatasetMetadataBar(1),
+    () => useDatasetMetadataBar({ datasetId: 1 }),
     {
       wrapper: createWrapper(),
     },
@@ -80,6 +111,7 @@ test('renders dataset metadata bar without description and owners', async () => 
   await waitForValueToChange(() => result.current.status);
   expect(result.current.status).toEqual('complete');
 
+  expect(fetchMock.called()).toBeTruthy();
   const { findByText, queryByText, findAllByRole } = render(
     result.current.metadataBar,
   );
@@ -88,6 +120,4 @@ test('renders dataset metadata bar without description and owners', async () => 
   expect(await findByText('Not available')).toBeVisible();
   expect(await findByText('a month ago')).toBeVisible();
   expect(await findAllByRole('img')).toHaveLength(3);
-
-  fetchMock.restore();
 });


### PR DESCRIPTION

### SUMMARY
Refactors `useDatasetMetadataBar` so that it can used cached requests data + adds the dataset metadata bar to drill by modal.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="933" alt="image" src="https://user-images.githubusercontent.com/15073128/229124282-8216e8b0-5c27-4105-9cab-20eb196e62ea.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
