### PR TITLE
fix: Hide FilterBar for Reports

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -583,7 +583,10 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
         {!hideDashboardHeader && <DashboardHeader />}
         {showFilterBar &&
           filterBarOrientation === FilterBarOrientation.HORIZONTAL && (
-            <FilterBar orientation={FilterBarOrientation.HORIZONTAL} />
+            <FilterBar
+              orientation={FilterBarOrientation.HORIZONTAL}
+              hidden={isReport}
+            />
           )}
         {dropIndicatorProps && <div {...dropIndicatorProps} />}
         {!isReport && topLevelTabs && !uiConfig.hideNav && (
@@ -655,18 +658,17 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
                 >
                   <StickyPanel ref={containerRef} width={filterBarWidth}>
                     <ErrorBoundary>
-                      {!isReport && (
-                        <FilterBar
-                          orientation={FilterBarOrientation.VERTICAL}
-                          verticalConfig={{
-                            filtersOpen: dashboardFiltersOpen,
-                            toggleFiltersBar: toggleDashboardFiltersOpen,
-                            width: filterBarWidth,
-                            height: filterBarHeight,
-                            offset: filterBarOffset,
-                          }}
-                        />
-                      )}
+                      <FilterBar
+                        orientation={FilterBarOrientation.VERTICAL}
+                        verticalConfig={{
+                          filtersOpen: dashboardFiltersOpen,
+                          toggleFiltersBar: toggleDashboardFiltersOpen,
+                          width: filterBarWidth,
+                          height: filterBarHeight,
+                          offset: filterBarOffset,
+                        }}
+                        hidden={isReport}
+                      />
                     </ErrorBoundary>
                   </StickyPanel>
                 </FiltersPanel>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -52,7 +52,7 @@ import ActionButtons from './ActionButtons';
 import Horizontal from './Horizontal';
 import Vertical from './Vertical';
 
-const HiddenFilerBar = styled.div`
+const HiddenFilterBar = styled.div`
   display: none;
 `;
 
@@ -282,7 +282,7 @@ const FilterBar: React.FC<FiltersBarProps> = ({
     ) : null;
 
   return hidden ? (
-    <HiddenFilerBar>{filterBarComponent}</HiddenFilerBar>
+    <HiddenFilterBar>{filterBarComponent}</HiddenFilterBar>
   ) : (
     filterBarComponent
   );

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -28,6 +28,7 @@ import {
   SLOW_DEBOUNCE,
   isNativeFilter,
   usePrevious,
+  styled,
 } from '@superset-ui/core';
 import { useHistory } from 'react-router-dom';
 import { updateDataMask, clearDataMask } from 'src/dataMask/actions';
@@ -50,6 +51,10 @@ import { createFilterKey, updateFilterKey } from './keyValue';
 import ActionButtons from './ActionButtons';
 import Horizontal from './Horizontal';
 import Vertical from './Vertical';
+
+const HiddenFilerBar = styled.div`
+  display: none;
+`;
 
 const EXCLUDED_URL_PARAMS: string[] = [
   URL_PARAMS.nativeFilters.name,
@@ -113,6 +118,7 @@ export const FilterBarScrollContext = createContext(false);
 const FilterBar: React.FC<FiltersBarProps> = ({
   orientation = FilterBarOrientation.VERTICAL,
   verticalConfig,
+  hidden = false,
 }) => {
   const history = useHistory();
   const dataMaskApplied: DataMaskStateWithId = useNativeFiltersDataMask();
@@ -247,31 +253,38 @@ const FilterBar: React.FC<FiltersBarProps> = ({
     />
   );
 
-  return orientation === FilterBarOrientation.HORIZONTAL ? (
-    <Horizontal
-      actions={actions}
-      canEdit={canEdit}
-      dashboardId={dashboardId}
-      dataMaskSelected={dataMaskSelected}
-      filterValues={filterValues}
-      isInitialized={isInitialized}
-      onSelectionChange={handleFilterSelectionChange}
-    />
-  ) : verticalConfig ? (
-    <Vertical
-      actions={actions}
-      canEdit={canEdit}
-      dataMaskSelected={dataMaskSelected}
-      filtersOpen={verticalConfig.filtersOpen}
-      filterValues={filterValues}
-      isInitialized={isInitialized}
-      isDisabled={isApplyDisabled}
-      height={verticalConfig.height}
-      offset={verticalConfig.offset}
-      onSelectionChange={handleFilterSelectionChange}
-      toggleFiltersBar={verticalConfig.toggleFiltersBar}
-      width={verticalConfig.width}
-    />
-  ) : null;
+  const filterBarComponent =
+    orientation === FilterBarOrientation.HORIZONTAL ? (
+      <Horizontal
+        actions={actions}
+        canEdit={canEdit}
+        dashboardId={dashboardId}
+        dataMaskSelected={dataMaskSelected}
+        filterValues={filterValues}
+        isInitialized={isInitialized}
+        onSelectionChange={handleFilterSelectionChange}
+      />
+    ) : verticalConfig ? (
+      <Vertical
+        actions={actions}
+        canEdit={canEdit}
+        dataMaskSelected={dataMaskSelected}
+        filtersOpen={verticalConfig.filtersOpen}
+        filterValues={filterValues}
+        isInitialized={isInitialized}
+        isDisabled={isApplyDisabled}
+        height={verticalConfig.height}
+        offset={verticalConfig.offset}
+        onSelectionChange={handleFilterSelectionChange}
+        toggleFiltersBar={verticalConfig.toggleFiltersBar}
+        width={verticalConfig.width}
+      />
+    ) : null;
+
+  return hidden ? (
+    <HiddenFilerBar>{filterBarComponent}</HiddenFilerBar>
+  ) : (
+    filterBarComponent
+  );
 };
 export default React.memo(FilterBar);

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/types.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/types.ts
@@ -47,6 +47,7 @@ interface VerticalBarConfig {
 }
 
 export interface FiltersBarProps {
+  hidden?: boolean;
   orientation: FilterBarOrientation;
   verticalConfig?: VerticalBarConfig;
 }


### PR DESCRIPTION
### SUMMARY
This PR https://github.com/apache/superset/pull/22614 introduced an issue for which the reports would not be able to execute when a filter of the FilterBar required immediate execution (see for example filters with first filter value selected by default). The reason is that the logics that run the filters are often encapsulated within the rendering of the component. By removing the rendering of the FilterBar those filters failed to execute causing the reports to fail.

This PR introduces an additional way to hide the FilterBar through the `hidden` property, which effectively only hides the FilterBar with CSS while still rendering it. While not an optimal solution, this will unblock the reports. A more in-depth refactor is required to decouple the logics of the filters from the rendering of the component.

### TESTING INSTRUCTIONS
1. Visit a Dashboard with a filter having first filter value selected by default
2. Enter reports standalone mode with `standalone=3` in the url
3. Make sure the Dashboard loads while the FilterBar is hidden

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
