### PR TITLE
fix(sqllab): undefined issue_codes on query error

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -275,7 +275,7 @@ export function queryFailed(query, msg, link, errors) {
       ts: new Date().getTime(),
     };
     errors?.forEach(({ error_type: errorType, extra }) => {
-      const messages = extra?.issue_codes.map(({ message }) => message) || [
+      const messages = extra?.issue_codes?.map(({ message }) => message) || [
         errorType,
       ];
       messages.forEach(message => {


### PR DESCRIPTION
### SUMMARY
The query execution can be failed without `issue_codes` which throws the `undefined` error on error_detail mapping operation.
<img width="608" alt="Screenshot 2023-03-31 at 4 02 29 PM" src="https://user-images.githubusercontent.com/1392866/229247690-964d5876-61da-4c20-a4f0-a38c635d9bbe.png">

This commit includes the hotfix for the case.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

No error thrown.

### TESTING INSTRUCTIONS
Query an unauthorized dataset and check the error message.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @john-bodley @ktmud @michael-s-molina 
