### PR TITLE
fix(chart-table): fixed export full csv not working

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
@@ -120,7 +120,7 @@ const buildQuery: BuildQuery<TableChartFormData> = (
 
     const moreProps: Partial<QueryObject> = {};
     const ownState = options?.ownState ?? {};
-    if (formDataCopy.server_pagination) {
+    if (formDataCopy.result_type !== 'full' && formDataCopy.server_pagination) {
       moreProps.row_limit =
         ownState.pageSize ?? formDataCopy.server_page_length;
       moreProps.row_offset =


### PR DESCRIPTION
### SUMMARY

Exporting the full CSV on the table chart with server pagination was not working properly as it was exporting only the selected page. 

After investigation, I found that the issue is because the row limit was being overridden. As a fix, I added a check to verify if the result type is full, and in that case, we won't allow editing the row_limit prop.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
You can see below a recording showing that all the data is present in the exported csv file:

[Bug Solution After.webm](https://user-images.githubusercontent.com/31275446/229398750-5708a65f-6f7b-4493-9e0d-6bb91320715e.webm)

### TESTING INSTRUCTIONS
- On your config.py file, you need to enable `ALLOW_FULL_CSV_EXPORT` flag
- Go to a table with server pagination enabled
- On the action menu, select download and click on `Export FULL CSV`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #20724
- [x] Required feature flags: ALLOW_FULL_CSV_EXPORT
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
