### PR TITLE
fix: Add default empty array to filter dependencies

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -363,7 +363,7 @@ const FiltersConfigForm = (
   const formFilter = formValues || undoFormValues || defaultFormFilter;
 
   const dependencies: string[] =
-    formFilter?.dependencies || filterToEdit?.cascadeParentIds;
+    formFilter?.dependencies || filterToEdit?.cascadeParentIds || [];
 
   const nativeFilterItems = getChartMetadataRegistry().items;
   const nativeFilterVizTypes = Object.entries(nativeFilterItems)


### PR DESCRIPTION
fix(filters): Add default empty array to filter 

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add default empty array to filter when ```formFilter?.dependencies``` and  ```filterToEdit?.cascadeParentIds``` is null or undefined

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![Captura de Tela 2023-04-03 às 14 25 32](https://user-images.githubusercontent.com/36389095/229582932-c087aa6a-c875-40ea-8912-29d0b65f1b26.png)

After:
![Captura de Tela 2023-04-03 às 14 31 20](https://user-images.githubusercontent.com/36389095/229584137-ab044401-221f-467f-b763-aee5c2d57bbf.png)

### TESTING INSTRUCTIONS

1. Go to 'dashboards'
2. Click on '+ dashboard'
3. Create any chart and add to dashboard
4. Create a time range filter for the dashboard
5. Save filters change
6. Back to add edit filters
7. Try to create new filter
8. See solution

### ADDITIONAL INFORMATION
- [X] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Fixes #23564