### PR TITLE
fix: Filter values are not updating when dependencies are set

### DIFF
--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -83,6 +83,7 @@ const Select = forwardRef(
     {
       allowClear,
       allowNewOptions = false,
+      allowSelectAll = true,
       ariaLabel,
       filterOption = true,
       header = null,
@@ -195,10 +196,17 @@ const Select = forwardRef(
     const selectAllEnabled = useMemo(
       () =>
         !isSingleMode &&
+        allowSelectAll &&
         selectOptions.length > 0 &&
         enabledOptions.length > 1 &&
         !inputValue,
-      [isSingleMode, selectOptions.length, enabledOptions.length, inputValue],
+      [
+        isSingleMode,
+        allowSelectAll,
+        selectOptions.length,
+        enabledOptions.length,
+        inputValue,
+      ],
     );
 
     const selectAllMode = useMemo(
@@ -360,9 +368,8 @@ const Select = forwardRef(
     useEffect(() => {
       // if all values are selected, add select all to value
       if (
-        !isSingleMode &&
-        ensureIsArray(value).length === selectAllEligible.length &&
-        selectOptions.length > 0
+        selectAllEnabled &&
+        ensureIsArray(value).length === selectAllEligible.length
       ) {
         setSelectValue(
           labelInValue
@@ -373,13 +380,7 @@ const Select = forwardRef(
               ] as AntdLabeledValue[]),
         );
       }
-    }, [
-      value,
-      isSingleMode,
-      labelInValue,
-      selectAllEligible.length,
-      selectOptions.length,
-    ]);
+    }, [labelInValue, selectAllEligible.length, selectAllEnabled, value]);
 
     useEffect(() => {
       const checkSelectAll = ensureIsArray(selectValue).some(

--- a/superset-frontend/src/components/Select/types.ts
+++ b/superset-frontend/src/components/Select/types.ts
@@ -156,6 +156,11 @@ export interface BaseSelectProps extends AntdExposedProps {
 
 export interface SelectProps extends BaseSelectProps {
   /**
+   * It enables the user to select all options.
+   * True by default.
+   * */
+  allowSelectAll?: boolean;
+  /**
    * It defines the options of the Select.
    * The options can be static, an array of options.
    */

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -363,7 +363,7 @@ const FiltersConfigForm = (
   const formFilter = formValues || undoFormValues || defaultFormFilter;
 
   const dependencies: string[] =
-    formFilter?.dependencies || filterToEdit?.cascadeParentIds;
+    formFilter?.dependencies || filterToEdit?.cascadeParentIds || [];
 
   const nativeFilterItems = getChartMetadataRegistry().items;
   const nativeFilterVizTypes = Object.entries(nativeFilterItems)

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -121,7 +121,6 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
       }),
     [],
   );
-  const [initialData, setInitialData] = useState<typeof data>([]);
 
   const updateDataMask = useCallback(
     (values: SelectValue) => {
@@ -238,7 +237,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
   }, [filterState.validateMessage, filterState.validateStatus]);
 
   const options = useMemo(() => {
-    const allOptions = [...data, ...initialData];
+    const allOptions = [...data];
     const uniqueOptions = uniqWith(allOptions, isEqual);
     const selectOptions: { label: string; value: DataRecordValue }[] = [];
     uniqueOptions.forEach(row => {
@@ -249,7 +248,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
       });
     });
     return selectOptions;
-  }, [data, initialData, datatype, groupby, labelFormatter]);
+  }, [data, datatype, groupby, labelFormatter]);
 
   const sortComparator = useCallback(
     (a: AntdLabeledValue, b: AntdLabeledValue) => {
@@ -296,12 +295,6 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
     setDataMask(dataMask);
   }, [JSON.stringify(dataMask)]);
 
-  useEffect(() => {
-    if (data.length && !initialData.length) {
-      setInitialData(data);
-    }
-  }, [data, initialData.length]);
-
   return (
     <FilterPluginStyle height={height} width={width}>
       <StyledFormItem
@@ -311,6 +304,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
         <Select
           allowClear
           allowNewOptions
+          allowSelectAll={!searchAllOptions}
           // @ts-ignore
           value={filterState.value || []}
           disabled={isDisabled}


### PR DESCRIPTION
### SUMMARY
https://github.com/apache/superset/pull/23400 fixed the following error:

> When the search was conducted using the "Dynamically search all filter values" in FilterBar, the original options got lost and the Select component was selecting all values as a consequence.

The strategy used for the fix was to store an array of the initial data and always append it when updating the select options. This caused a unintended problem with filter dependencies because the initial data may not be present when the filter values are affected by other filters.

Another problem is that "Dynamically search all filter values" is used when the number of options available exceeds the 1000 threshold and the user needs to search for values that are not loaded on the client side. At this moment, the select is very similar to an async select and the Select All feature will have many challenges as you can see [here](https://github.com/apache/superset/pull/20143). 

This PR removes the initial data state to fix the dependencies bug and also disables Select All when "Dynamically search all filter values" is checked.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/229586479-26717197-600a-4eab-96ca-1884be7b4a08.mov

https://user-images.githubusercontent.com/70410625/229586554-c9a120f3-1f90-49d9-a84d-617944f8b096.mov

### TESTING INSTRUCTIONS
Check the videos and referenced PRs for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
