### PR TITLE
fix: QueryParamProvider error on backend rendered views

### DIFF
--- a/superset-frontend/src/views/menu.tsx
+++ b/superset-frontend/src/views/menu.tsx
@@ -20,15 +20,16 @@
 // Menu App. Used in views that do not already include the Menu component in the layout.
 // eg, backend rendered views
 import React from 'react';
+import { Provider } from 'react-redux';
 import ReactDOM from 'react-dom';
+import { Route, BrowserRouter } from 'react-router-dom';
 import { CacheProvider } from '@emotion/react';
+import { QueryParamProvider } from 'use-query-params';
 import createCache from '@emotion/cache';
 import { ThemeProvider } from '@superset-ui/core';
 import Menu from 'src/views/components/Menu';
 import { theme } from 'src/preamble';
 import getBootstrapData from 'src/utils/getBootstrapData';
-
-import { Provider } from 'react-redux';
 import { setupStore } from './store';
 
 // Disable connecting to redux debugger so that the React app injected
@@ -46,7 +47,14 @@ const app = (
   <CacheProvider value={emotionCache}>
     <ThemeProvider theme={theme}>
       <Provider store={store}>
-        <Menu data={menu} />
+        <BrowserRouter>
+          <QueryParamProvider
+            ReactRouterRoute={Route}
+            stringifyOptions={{ encode: false }}
+          >
+            <Menu data={menu} />
+          </QueryParamProvider>
+        </BrowserRouter>
       </Provider>
     </ThemeProvider>
   </CacheProvider>


### PR DESCRIPTION
### SUMMARY
This PR fixes the following `QueryParamProvider` error on backend rendered views:

```
LocationProvider.js?e373:13 Uncaught Error: useQueryParams must be used within a QueryParamProvider
    at useLocationContext (LocationProvider.js?e373:13:1)
    at useQueryParams (useQueryParams.js?5bf2:71:1)
    at RightMenuWithQueryWrapper (RightMenu.tsx?e833:571:1)
    at renderWithHooks (react-dom.development.js?61bb:14804:1)
    at mountIndeterminateComponent (react-dom.development.js?61bb:17483:1)
    at beginWork (react-dom.development.js?61bb:18597:1)
    at HTMLUnknownElement.callCallback (react-dom.development.js?61bb:189:1)
    at Object.invokeGuardedCallbackDev (react-dom.development.js?61bb:238:1)
    at invokeGuardedCallback (react-dom.development.js?61bb:293:1)
    at beginWork$1 (react-dom.development.js?61bb:23204:1)
```

### TESTING INSTRUCTIONS
Make sure the error does not appear on backend rendered pages such as login, list of users, list of roles, etc.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
