### PR TITLE
fix(warm_up_cache): JSON serialization

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -132,6 +132,7 @@ from superset.utils.async_query_manager import AsyncQueryTokenException
 from superset.utils.cache import etag_cache
 from superset.utils.core import (
     apply_max_row_limit,
+    base_json_conv,
     DatasourceType,
     get_user_id,
     ReservedUrlParameters,
@@ -1821,7 +1822,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
                 {"slice_id": slc.id, "viz_error": error, "viz_status": status}
             )
 
-        return json_success(json.dumps(result))
+        return json_success(json.dumps(result, default=base_json_conv))
 
     @has_access_api
     @event_logger.log_this


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

A byproduct of https://github.com/apache/superset/pull/23012/, when warming a non-legacy chart it's valid for the error to be a babel form of `Empty query?` which is not JSON serializable, i.e., `json.dumps(...)` raises the following error:

```
TypeError: Object of type LazyString is not JSON serializable
```

The fix to to use the the `base_json_conv` serialization method. Having `json.dump(...)` splattered throughout the code is rather unfortunate as there's no consistency in how payload are serialized. Ideally exceptions should be raised and handled in a uniform way per [SIP-41](https://github.com/apache/superset/issues/9298).  

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Added unit test.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
