### PR TITLE
fix(revert): "fix: cache warmup solution non legacy charts. (#23012)"

### DIFF
--- a/superset/charts/commands/export.py
+++ b/superset/charts/commands/export.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 
 # keys present in the standard export that are not needed
-REMOVE_KEYS = ["datasource_type", "datasource_name", "url_params"]
+REMOVE_KEYS = ["datasource_type", "datasource_name", "query_context", "url_params"]
 
 
 class ExportChartsCommand(ExportModelsCommand):

--- a/tests/integration_tests/charts/commands_tests.py
+++ b/tests/integration_tests/charts/commands_tests.py
@@ -88,7 +88,52 @@ class TestExportChartsCommand(SupersetTestCase):
             "dataset_uuid": str(example_chart.table.uuid),
             "uuid": str(example_chart.uuid),
             "version": "1.0.0",
-            "query_context": None,
+        }
+
+    @patch("superset.security.manager.g")
+    @pytest.mark.usefixtures("load_energy_table_with_slice")
+    def test_export_chart_with_query_context(self, mock_g):
+        """Test that charts that have a query_context are exported correctly"""
+
+        mock_g.user = security_manager.find_user("alpha")
+        example_chart = db.session.query(Slice).filter_by(slice_name="Heatmap").one()
+        command = ExportChartsCommand([example_chart.id])
+
+        contents = dict(command.run())
+
+        expected = [
+            "metadata.yaml",
+            f"charts/Heatmap_{example_chart.id}.yaml",
+            "datasets/examples/energy_usage.yaml",
+            "databases/examples.yaml",
+        ]
+        assert expected == list(contents.keys())
+
+        metadata = yaml.safe_load(contents[f"charts/Heatmap_{example_chart.id}.yaml"])
+
+        assert metadata == {
+            "slice_name": "Heatmap",
+            "description": None,
+            "certified_by": None,
+            "certification_details": None,
+            "viz_type": "heatmap",
+            "params": {
+                "all_columns_x": "source",
+                "all_columns_y": "target",
+                "canvas_image_rendering": "pixelated",
+                "collapsed_fieldsets": "",
+                "linear_color_scheme": "blue_white_yellow",
+                "metric": "sum__value",
+                "normalize_across": "heatmap",
+                "slice_name": "Heatmap",
+                "viz_type": "heatmap",
+                "xscale_interval": "1",
+                "yscale_interval": "1",
+            },
+            "cache_timeout": None,
+            "dataset_uuid": str(example_chart.table.uuid),
+            "uuid": str(example_chart.uuid),
+            "version": "1.0.0",
         }
 
     @patch("superset.security.manager.g")
@@ -134,7 +179,6 @@ class TestExportChartsCommand(SupersetTestCase):
             "certification_details",
             "viz_type",
             "params",
-            "query_context",
             "cache_timeout",
             "uuid",
             "version",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This reverts https://github.com/apache/superset/pull/23012 which per https://github.com/apache/superset/pull/23012#issuecomment-1496518374 introduced two known regressions. Granted we could try to roll forward with a formulation which works for both legacy and non-legacy charts, but in the interim I think it's prudent we ensure we don't regress whilst acknowledging the fact that cache warmup for non-legacy charts is still problematic.

cc: @dheeraj-jaiswal-lowes 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
