### PR TITLE
fix(dash import): Ensure old datasource ids are not referenced in imported charts

### DIFF
--- a/superset/dashboards/commands/importers/v1/__init__.py
+++ b/superset/dashboards/commands/importers/v1/__init__.py
@@ -112,7 +112,13 @@ class ImportDashboardsCommand(ImportModelsCommand):
                 and config["dataset_uuid"] in dataset_info
             ):
                 # update datasource id, type, and name
-                config.update(dataset_info[config["dataset_uuid"]])
+                dataset_dict = dataset_info[config["dataset_uuid"]]
+                config.update(dataset_dict)
+                dataset_uid = f"{dataset_dict['datasource_id']}__{dataset_dict['datasource_type']}"
+                config["params"].update({"datasource": dataset_uid})
+                if "query_context" in config:
+                    del config["query_context"]
+
                 chart = import_chart(session, config, overwrite=False)
                 chart_ids[str(chart.uuid)] = chart.id
 

--- a/superset/dashboards/commands/importers/v1/__init__.py
+++ b/superset/dashboards/commands/importers/v1/__init__.py
@@ -114,9 +114,8 @@ class ImportDashboardsCommand(ImportModelsCommand):
                 # update datasource id, type, and name
                 dataset_dict = dataset_info[config["dataset_uuid"]]
                 config.update(dataset_dict)
-                dataset_uid = (
-                    f"{dataset_dict['datasource_id']}__{dataset_dict['datasource_type']}"
-                )
+                # pylint: disable=line-too-long
+                dataset_uid = f"{dataset_dict['datasource_id']}__{dataset_dict['datasource_type']}"
                 config["params"].update({"datasource": dataset_uid})
                 if "query_context" in config:
                     del config["query_context"]

--- a/superset/dashboards/commands/importers/v1/__init__.py
+++ b/superset/dashboards/commands/importers/v1/__init__.py
@@ -114,7 +114,9 @@ class ImportDashboardsCommand(ImportModelsCommand):
                 # update datasource id, type, and name
                 dataset_dict = dataset_info[config["dataset_uuid"]]
                 config.update(dataset_dict)
-                dataset_uid = f"{dataset_dict['datasource_id']}__{dataset_dict['datasource_type']}"
+                dataset_uid = (
+                    f"{dataset_dict['datasource_id']}__{dataset_dict['datasource_type']}"
+                )
                 config["params"].update({"datasource": dataset_uid})
                 if "query_context" in config:
                     del config["query_context"]

--- a/tests/integration_tests/dashboards/commands_tests.py
+++ b/tests/integration_tests/dashboards/commands_tests.py
@@ -565,6 +565,9 @@ class TestImportDashboardsCommand(SupersetTestCase):
         dataset = chart.table
         assert str(dataset.uuid) == dataset_config["uuid"]
 
+        assert chart.query_context is None
+        assert json.loads(chart.params)["datasource"] == dataset.uid
+
         database = dataset.database
         assert str(database.uuid) == database_config["uuid"]
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Currently, charts imported via a dashboard import contain references to the chart's old datasource id from when it was exported within their `params` and `query_context`.  This didn't result in any functionality breaking, but it would result in the following "false alarm" error message when loading the dashboard:

![Clipboard 2023-02-03 at 5 35 47 PM](https://user-images.githubusercontent.com/47196419/229955419-73f0150e-9824-41ab-bb9a-d780d28305ef.png)

There is precedent for this fix in the individual chart import, see here: https://github.com/apache/superset/blob/master/superset/charts/commands/importers/v1/__init__.py#L96



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
