### PR TITLE
fix: Ensure the reporting framework handles charts with no data

### DIFF
--- a/superset/charts/post_processing.py
+++ b/superset/charts/post_processing.py
@@ -328,14 +328,19 @@ def apply_post_process(
         if query["result_format"] not in (rf.value for rf in ChartDataResultFormat):
             raise Exception(f"Result format {query['result_format']} not supported")
 
-        if not query["data"]:
+        data = query["data"]
+
+        if isinstance(data, str):
+            data = data.strip()
+
+        if not data:
             # do not try to process empty data
             continue
 
         if query["result_format"] == ChartDataResultFormat.JSON:
-            df = pd.DataFrame.from_dict(query["data"])
+            df = pd.DataFrame.from_dict(data)
         elif query["result_format"] == ChartDataResultFormat.CSV:
-            df = pd.read_csv(StringIO(query["data"]))
+            df = pd.read_csv(StringIO(data))
 
         # convert all columns to verbose (label) name
         if datasource:

--- a/superset/utils/csv.py
+++ b/superset/utils/csv.py
@@ -111,6 +111,9 @@ def get_chart_dataframe(
     pd.set_option("display.float_format", lambda x: str(x))
     df = pd.DataFrame.from_dict(result["result"][0]["data"])
 
+    if df.empty:
+        return None
+
     try:
         # if any column type is equal to 2, need to convert data into
         # datetime timestamp for that column.

--- a/tests/unit_tests/charts/test_post_processing.py
+++ b/tests/unit_tests/charts/test_post_processing.py
@@ -18,9 +18,9 @@
 import json
 
 import pandas as pd
+import pytest
 from flask_babel import lazy_gettext as _
 from numpy import True_
-from pytest import raises
 from sqlalchemy.orm.session import Session
 
 from superset.charts.post_processing import apply_post_process, pivot_df, table
@@ -1389,7 +1389,7 @@ def test_apply_post_process_without_result_format():
     result = {"queries": [{"result_format": "foo"}]}
     form_data = {"viz_type": "pivot_table"}
 
-    with raises(Exception) as ex:
+    with pytest.raises(Exception) as ex:
         apply_post_process(result, form_data)
 
     assert ex.match("Result format foo not supported") == True
@@ -1659,12 +1659,13 @@ def test_apply_post_process_csv_format_empty_string():
     }
 
 
-def test_apply_post_process_csv_format_no_data():
+@pytest.mark.parametrize("data", [None, "", "\n"])
+def test_apply_post_process_csv_format_no_data(data):
     """
     It should be able to process csv results with no data
     """
 
-    result = {"queries": [{"result_format": ChartDataResultFormat.CSV, "data": None}]}
+    result = {"queries": [{"result_format": ChartDataResultFormat.CSV, "data": data}]}
     form_data = {
         "datasource": "19__table",
         "viz_type": "pivot_table_v2",
@@ -1726,7 +1727,7 @@ def test_apply_post_process_csv_format_no_data():
     }
 
     assert apply_post_process(result, form_data) == {
-        "queries": [{"result_format": ChartDataResultFormat.CSV, "data": None}]
+        "queries": [{"result_format": ChartDataResultFormat.CSV, "data": data}]
     }
 
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR resolves a couple of bugs with the reporting framework where the chart payload contains no data.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Added unit tests (where appropriate) and tested locally, i.e., for a chart with no data,

```
http://localhost:8088/api/v1/chart/<id>/data/?format=csv&type=post_processed&force=false
http://localhost:8088/api/v1/chart/<id>/data/?format=json&type=post_processed&force=false
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
