### PR TITLE
fix(dashboard-rbac): use normal rbac when no roles chosen

### DIFF
--- a/docs/docs/creating-charts-dashboards/creating-your-first-dashboard.mdx
+++ b/docs/docs/creating-charts-dashboards/creating-your-first-dashboard.mdx
@@ -184,9 +184,8 @@ Non-owner users access can be managed two different ways:
 
 1. Dataset permissions - if you add to the relevant role permissions to datasets it automatically grants implicit access to all dashboards that uses those permitted datasets
 2. Dashboard roles - if you enable **DASHBOARD_RBAC** [feature flag](https://superset.apache.org/docs/installation/configuring-superset#feature-flags) then you be able to manage which roles can access the dashboard
-- Having dashboard access implicitly grants read access to the associated datasets, therefore
-all charts will load their data even if feature flag is turned on and no roles assigned
-to roles the access will fallback to **Dataset permissions**
+   - Granting a role access to a dashboard will bypass dataset level checks. Having dashboard access implicitly grants read access to all the featured charts in the dashboard, and thereby also all the associated datasets.
+   - If no roles are specified for a dashboard, regular **Dataset permissions** will apply.
 
 <img src={useBaseUrl("/img/tutorial/tutorial_dashboard_access.png" )} />
 

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -555,7 +555,7 @@ const PropertiesModal = ({
             </StyledFormItem>
             <p className="help-block">
               {t(
-                'Roles is a list which defines access to the dashboard. Granting a role access to a dashboard will bypass dataset level checks. If no roles are defined, then the dashboard is available to all roles.',
+                'Roles is a list which defines access to the dashboard. Granting a role access to a dashboard will bypass dataset level checks. If no roles are defined, regular access permissions apply.',
               )}
             </p>
           </Col>

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2046,10 +2046,16 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         from superset.dashboards.commands.exceptions import DashboardAccessDeniedError
 
         def has_rbac_access() -> bool:
-            return (not is_feature_enabled("DASHBOARD_RBAC")) or any(
-                dashboard_role.id
-                in [user_role.id for user_role in self.get_user_roles()]
-                for dashboard_role in dashboard.roles
+            if not is_feature_enabled("DASHBOARD_RBAC"):
+                return True
+
+            return (
+                any(
+                    dashboard_role.id
+                    in [user_role.id for user_role in self.get_user_roles()]
+                    for dashboard_role in dashboard.roles
+                )
+                or not dashboard.roles
             )
 
         if self.is_guest_user() and dashboard.embedded:

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2046,16 +2046,13 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         from superset.dashboards.commands.exceptions import DashboardAccessDeniedError
 
         def has_rbac_access() -> bool:
-            if not is_feature_enabled("DASHBOARD_RBAC"):
+            if not is_feature_enabled("DASHBOARD_RBAC") or not dashboard.roles:
                 return True
 
-            return (
-                any(
-                    dashboard_role.id
-                    in [user_role.id for user_role in self.get_user_roles()]
-                    for dashboard_role in dashboard.roles
-                )
-                or not dashboard.roles
+            return any(
+                dashboard_role.id
+                in [user_role.id for user_role in self.get_user_roles()]
+                for dashboard_role in dashboard.roles
             )
 
         if self.is_guest_user() and dashboard.embedded:

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2076,15 +2076,18 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         from superset.models.dashboard import Dashboard
         from superset.models.slice import Slice
 
+        dashboard_ids = db.session.query(Dashboard.id)
+        dashboard_ids = DashboardAccessFilter(
+            "id", SQLAInterface(Dashboard, db.session)
+        ).apply(dashboard_ids, None)
+
         datasource_class = type(datasource)
         query = (
-            db.session.query(datasource_class)
+            db.session.query(Dashboard.id)
+            .join(Slice, Dashboard.slices)
             .join(Slice.table)
             .filter(datasource_class.id == datasource.id)
-        )
-
-        query = DashboardAccessFilter("id", SQLAInterface(Dashboard, db.session)).apply(
-            query, None
+            .filter(Dashboard.id.in_(dashboard_ids))
         )
 
         exists = db.session.query(query.exists()).scalar()

--- a/superset/utils/decorators.py
+++ b/superset/utils/decorators.py
@@ -116,9 +116,7 @@ def on_security_exception(self: Any, ex: Exception) -> Response:
 
 
 # noinspection PyPackageRequirements
-def check_dashboard_access(
-    on_error: Callable[..., Any] = on_security_exception
-) -> Callable[..., Any]:
+def check_dashboard_access(on_error: Callable[[str], Any]) -> Callable[..., Any]:
     def decorator(f: Callable[..., Any]) -> Callable[..., Any]:
         @wraps(f)
         def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
@@ -130,7 +128,7 @@ def check_dashboard_access(
                 try:
                     current_app.appbuilder.sm.raise_for_dashboard_access(dashboard)
                 except DashboardAccessDeniedError as ex:
-                    return on_error(self, ex)
+                    return on_error(str(ex))
                 except Exception as exception:
                     raise exception
 

--- a/superset/utils/decorators.py
+++ b/superset/utils/decorators.py
@@ -126,15 +126,22 @@ def check_dashboard_access(
             from superset.models.dashboard import Dashboard
 
             dashboard = Dashboard.get(str(kwargs["dashboard_id_or_slug"]))
+            has_dashboard_rbac_access = True
             if is_feature_enabled("DASHBOARD_RBAC"):
                 try:
                     current_app.appbuilder.sm.raise_for_dashboard_access(dashboard)
-                except DashboardAccessDeniedError as ex:
-                    return on_error(self, ex)
+                except DashboardAccessDeniedError:
+                    has_dashboard_rbac_access = False
                 except Exception as exception:
                     raise exception
 
-            return f(self, *args, dashboard=dashboard, **kwargs)
+            return f(
+                self,
+                *args,
+                dashboard=dashboard,
+                has_dashboard_rbac_access=has_dashboard_rbac_access,
+                **kwargs,
+            )
 
         return wrapper
 

--- a/superset/utils/decorators.py
+++ b/superset/utils/decorators.py
@@ -126,22 +126,15 @@ def check_dashboard_access(
             from superset.models.dashboard import Dashboard
 
             dashboard = Dashboard.get(str(kwargs["dashboard_id_or_slug"]))
-            has_dashboard_rbac_access = True
             if is_feature_enabled("DASHBOARD_RBAC"):
                 try:
                     current_app.appbuilder.sm.raise_for_dashboard_access(dashboard)
-                except DashboardAccessDeniedError:
-                    has_dashboard_rbac_access = False
+                except DashboardAccessDeniedError as ex:
+                    return on_error(self, ex)
                 except Exception as exception:
                     raise exception
 
-            return f(
-                self,
-                *args,
-                dashboard=dashboard,
-                has_dashboard_rbac_access=has_dashboard_rbac_access,
-                **kwargs,
-            )
+            return f(self, *args, dashboard=dashboard, **kwargs)
 
         return wrapper
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1848,6 +1848,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             abort(404)
 
         has_access_ = False
+        datasource: Optional[BaseDatasource] = None
         for datasource in dashboard.datasources:
             datasource = DatasourceDAO.get_datasource(
                 datasource_type=DatasourceType(datasource.type),
@@ -1858,14 +1859,18 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
                 datasource=datasource,
             ):
                 has_access_ = True
-                break
 
-        if has_access_ is False and config["ENABLE_ACCESS_REQUEST"]:
-            flash(
-                __(security_manager.get_datasource_access_error_msg(datasource)),
-                "danger",
-            )
-            return redirect(f"/superset/request_access/?dashboard_id={dashboard.id}")
+            if has_access_ is False and config["ENABLE_ACCESS_REQUEST"]:
+                flash(
+                    __(security_manager.get_datasource_access_error_msg(datasource)),
+                    "danger",
+                )
+                return redirect(
+                    f"/superset/request_access/?dashboard_id={dashboard.id}"
+                )
+
+            if has_access_:
+                break
 
         if not has_access_:
             flash(DashboardAccessDeniedError.message, "danger")

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -67,6 +67,7 @@ from superset.connectors.sqla.models import (
     TableColumn,
 )
 from superset.constants import QUERY_EARLY_CANCEL_KEY
+from superset.dashboards.commands.exceptions import DashboardAccessDeniedError
 from superset.dashboards.commands.importers.v0 import ImportDashboardsCommand
 from superset.dashboards.dao import DashboardDAO
 from superset.dashboards.permalink.commands.get import GetDashboardPermalinkCommand
@@ -167,6 +168,7 @@ from superset.views.utils import (
     get_form_data,
     get_viz,
     loads_request_json,
+    redirect_with_flash,
     sanitize_datasource_data,
 )
 from superset.viz import BaseViz
@@ -192,6 +194,7 @@ DATABASE_KEYS = [
     "disable_data_preview",
 ]
 
+DASHBOARD_LIST_URL = "/dashboard/list/"
 DATASOURCE_MISSING_ERR = __("The data source seems to have been deleted")
 USER_MISSING_ERR = __("The user seems to have been deleted")
 PARAMETER_MISSING_ERR = __(
@@ -1826,9 +1829,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @expose("/dashboard/<dashboard_id_or_slug>/")
     @event_logger.log_this_with_extra_payload
     @check_dashboard_access(
-        on_error=lambda self, ex: Response(
-            utils.error_msg_from_exception(ex), status=403
-        )
+        on_error=lambda msg: redirect_with_flash(DASHBOARD_LIST_URL, msg, "danger")
     )
     def dashboard(
         self,
@@ -1859,21 +1860,16 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
                 has_access_ = True
                 break
 
-            if has_access_ is False and config["ENABLE_ACCESS_REQUEST"]:
-                flash(
-                    __(security_manager.get_datasource_access_error_msg(datasource)),
-                    "danger",
-                )
-                return redirect(
-                    f"/superset/request_access/?dashboard_id={dashboard.id}"
-                )
-
-        if not has_access_:
+        if has_access_ is False and config["ENABLE_ACCESS_REQUEST"]:
             flash(
-                __("You are not authorized to view this dashboard"),
+                __(security_manager.get_datasource_access_error_msg(datasource)),
                 "danger",
             )
-            return redirect(f"/dashboard/list/")
+            return redirect(f"/superset/request_access/?dashboard_id={dashboard.id}")
+
+        if not has_access_:
+            flash(DashboardAccessDeniedError.message, "danger")
+            return redirect(DASHBOARD_LIST_URL)
 
         dash_edit_perm = security_manager.is_owner(
             dashboard

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1848,7 +1848,6 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             abort(404)
 
         has_access_ = False
-        datasource: Optional[BaseDatasource] = None
         for datasource in dashboard.datasources:
             datasource = DatasourceDAO.get_datasource(
                 datasource_type=DatasourceType(datasource.type),
@@ -1872,7 +1871,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             if has_access_:
                 break
 
-        if not has_access_:
+        if dashboard.datasources and not has_access_:
             flash(DashboardAccessDeniedError.message, "danger")
             return redirect(DASHBOARD_LIST_URL)
 

--- a/superset/views/dashboard/mixin.py
+++ b/superset/views/dashboard/mixin.py
@@ -65,7 +65,7 @@ class DashboardMixin:  # pylint: disable=too-few-public-methods
         "roles": _(
             "Roles is a list which defines access to the dashboard. "
             "Granting a role access to a dashboard will bypass dataset level checks."
-            "If no roles are defined then the dashboard is available to all roles."
+            "If no roles are defined, regular access permissions apply."
         ),
         "published": _(
             "Determines whether or not this dashboard is "

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -23,11 +23,12 @@ from urllib import parse
 import msgpack
 import pyarrow as pa
 import simplejson as json
-from flask import g, has_request_context, request
+from flask import flash, g, has_request_context, redirect, request
 from flask_appbuilder.security.sqla import models as ab_models
 from flask_appbuilder.security.sqla.models import User
 from flask_babel import _
 from sqlalchemy.orm.exc import NoResultFound
+from werkzeug.wrappers.response import Response
 
 import superset.models.core as models
 from superset import app, dataframe, db, result_set, viz
@@ -592,3 +593,8 @@ def get_cta_schema_name(
     if not func:
         return None
     return func(database, user, schema, sql)
+
+
+def redirect_with_flash(url: str, message: str, category: str) -> Response:
+    flash(message=message, category=category)
+    return redirect(url)

--- a/tests/integration_tests/dashboards/security/security_rbac_tests.py
+++ b/tests/integration_tests/dashboards/security/security_rbac_tests.py
@@ -91,10 +91,11 @@ class TestDashboardRoleBasedSecurity(BaseTestDashboardSecurity):
 
         # act
         response = self.get_dashboard_view_response(dashboard_to_access)
+        assert response.status_code == 302
 
         request_payload = get_query_context("birth_names")
         rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
-        self.assertEqual(rv.status_code, 403)
+        assert rv.status_code == 403
 
     def test_get_dashboard_view__user_with_dashboard_permission_can_not_access_draft(
         self,
@@ -111,7 +112,7 @@ class TestDashboardRoleBasedSecurity(BaseTestDashboardSecurity):
         response = self.get_dashboard_view_response(dashboard_to_access)
 
         # assert
-        self.assert403(response)
+        assert response.status_code == 302
 
         # post
         revoke_access_to_dashboard(dashboard_to_access, new_role)
@@ -205,7 +206,7 @@ class TestDashboardRoleBasedSecurity(BaseTestDashboardSecurity):
         response = self.get_dashboard_view_response(dashboard_to_access)
 
         # assert
-        self.assert403(response)
+        assert response.status_code == 302
 
     @pytest.mark.usefixtures("public_role_like_gamma")
     def test_get_dashboard_view__public_user_with_dashboard_permission_can_not_access_draft(
@@ -219,7 +220,7 @@ class TestDashboardRoleBasedSecurity(BaseTestDashboardSecurity):
         response = self.get_dashboard_view_response(dashboard_to_access)
 
         # assert
-        self.assert403(response)
+        assert response.status_code == 302
 
         # post
         revoke_access_to_dashboard(dashboard_to_access, "Public")

--- a/tests/integration_tests/dashboards/security/security_rbac_tests.py
+++ b/tests/integration_tests/dashboards/security/security_rbac_tests.py
@@ -159,30 +159,6 @@ class TestDashboardRoleBasedSecurity(BaseTestDashboardSecurity):
         db.session.commit()
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
-    def test_get_dashboard_view__user_access_regular_rbac_with_roles(self):
-        if backend() == "hive":
-            return
-
-        slice = (
-            db.session.query(Slice)
-            .filter_by(slice_name="Girl Name Cloud")
-            .one_or_none()
-        )
-        dashboard = create_dashboard_to_db(published=True, slices=[slice])
-        grant_access_to_dashboard(dashboard, "Alpha")
-        self.login("gamma_sqllab")
-
-        response = self.get_dashboard_view_response(dashboard)
-
-        self.assert200(response)
-
-        request_payload = get_query_context("birth_names")
-        rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
-        self.assertEqual(rv.status_code, 200)
-        db.session.delete(dashboard)
-        db.session.commit()
-
-    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_get_dashboard_view__user_access_with_dashboard_permission(self):
         if backend() == "hive":
             return

--- a/tests/integration_tests/dashboards/security/security_rbac_tests.py
+++ b/tests/integration_tests/dashboards/security/security_rbac_tests.py
@@ -129,9 +129,13 @@ class TestDashboardRoleBasedSecurity(BaseTestDashboardSecurity):
         dashboard = create_dashboard_to_db(published=True, slices=[slice])
         self.login("gamma")
 
+        # assert redirect on regular rbac access denied
+        response = self.get_dashboard_view_response(dashboard)
+        assert response.status_code == 302
+
         request_payload = get_query_context("birth_names")
         rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
-        self.assertEqual(rv.status_code, 403)
+        assert rv.status_code == 403
         db.session.delete(dashboard)
         db.session.commit()
 
@@ -150,11 +154,11 @@ class TestDashboardRoleBasedSecurity(BaseTestDashboardSecurity):
 
         response = self.get_dashboard_view_response(dashboard)
 
-        self.assert200(response)
+        assert response.status_code == 200
 
         request_payload = get_query_context("birth_names")
         rv = self.post_assert_metric(CHART_DATA_URI, request_payload, "data")
-        self.assertEqual(rv.status_code, 200)
+        assert rv.status_code == 200
         db.session.delete(dashboard)
         db.session.commit()
 


### PR DESCRIPTION
### SUMMARY
Currently it's impossible to use the normal RBAC model when the Dashboard RBAC  feature flag is enabled. This is contrary to the description, which on one hand states that when the FF is enabled and no roles are chosen, ALL datasets are accessible, and on the other hand states that regular dataset perms apply.

With these changes, the logic is as follows:
- If no roles are defined for a dashboard, regular RBAC always applies.
- If a role/roles are defined for a dashboard, those take precedent, i.e. regular RBAC no longer applies. This is unchanged
- Datasource permission checks now check if the user has Dashboard RBAC access to a dashboard that references the dataset - if it does, the datasource is assumed to be accessible. If not, regular RBAC applies.

In addition, tests are added, and the documentation is aligned with how the feature actually works.

In addition, when trying to access a dashboard the user didn't have access to, they would either be greeted by one of the following:

Regular RBAC:
<img width="1201" alt="image" src="https://user-images.githubusercontent.com/33317356/230331591-b4b4734f-0767-4a5c-8c7c-a8fb312be9e7.png">

Dashboard RBAC:
<img width="615" alt="image" src="https://user-images.githubusercontent.com/33317356/230331728-a1a2caac-8680-4775-b95a-0c33991430cb.png">

Now they get redirected to the main page with the following toast:
<img width="1198" alt="image" src="https://user-images.githubusercontent.com/33317356/230311995-8d07be5a-ea6b-4d03-8674-4ef0e3e2398b.png">

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Closes #18634
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
