### PR TITLE
fix(docker-compose): Make worker use correct healthcheck (#23455)

### DIFF
--- a/docker-compose-non-dev.yml
+++ b/docker-compose-non-dev.yml
@@ -73,7 +73,7 @@ services:
     user: "root"
     volumes: *superset-volumes
     healthcheck:
-      test: ["CMD-SHELL", "celery inspect ping -A superset.tasks.celery_app:app -d celery@$$HOSTNAME"]
+      test: ["CMD-SHELL", "celery -A superset.tasks.celery_app:app inspect ping -d celery@$$HOSTNAME"]
 
   superset-worker-beat:
     image: *superset-image

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,7 +121,7 @@ services:
     user: *superset-user
     volumes: *superset-volumes
     healthcheck:
-      test: ["CMD-SHELL", "celery inspect ping -A superset.tasks.celery_app:app -d celery@$$HOSTNAME"]
+      test: ["CMD-SHELL", "celery -A superset.tasks.celery_app:app inspect ping -d celery@$$HOSTNAME"]
     # Bump memory limit if processing selenium / thumbnails on superset-worker
     # mem_limit: 2038m
     # mem_reservation: 128M


### PR DESCRIPTION
### SUMMARY
Since Celery 5.0 the global options (-A, --app) [can no longer](https://docs.celeryq.dev/en/stable/history/whatsnew-5.0.html#step-1-adjust-your-command-line-invocation) be positioned after the sub-command. Instead, they must be positioned as an option for the celery command. This PR correctly positions the global option for the celery-healthcheck in docker-compose.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
```
CONTAINER ID   IMAGE                                COMMAND                     STATUS                         PORTS           NAMES                                                                 
58252b3d19e5   apache/superset:latest-dev           "/app/docker/docker-…"      Up About an hour (unhealthy)   8088/tcp        superset_worker
```
After:
```
CONTAINER ID   IMAGE                                COMMAND                     STATUS                       PORTS           NAMES                                                                 
a02f26ae8921   apache/superset:latest-dev           "/app/docker/docker-…"      Up About an hour (healthy)   8088/tcp        superset_worker
```

### TESTING INSTRUCTIONS
```docker-compose up```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: fixes #23042 and #23455
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
