### PR TITLE
fix: Disables email reports for unsaved charts

### DIFF
--- a/superset-frontend/src/components/ReportModal/HeaderReportDropdown/index.tsx
+++ b/superset-frontend/src/components/ReportModal/HeaderReportDropdown/index.tsx
@@ -18,6 +18,7 @@
  */
 import React, { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import { isEmpty } from 'lodash';
 import {
   t,
   SupersetTheme,
@@ -103,6 +104,9 @@ export interface HeaderReportProps {
   showReportSubMenu?: boolean;
 }
 
+// Same instance to be used in useEffects
+const EMPTY_OBJECT = {};
+
 export default function HeaderReportDropDown({
   dashboardId,
   chart,
@@ -116,7 +120,10 @@ export default function HeaderReportDropDown({
     const resourceType = dashboardId
       ? CreationMethod.DASHBOARDS
       : CreationMethod.CHARTS;
-    return reportSelector(state, resourceType, dashboardId || chart?.id);
+    return (
+      reportSelector(state, resourceType, dashboardId || chart?.id) ||
+      EMPTY_OBJECT
+    );
   });
 
   const isReportActive: boolean = report?.active || false;
@@ -133,6 +140,12 @@ export default function HeaderReportDropDown({
       // this is in the case that there is an anonymous user.
       return false;
     }
+
+    // Cannot add reports if the resource is not saved
+    if (!(dashboardId || chart?.id)) {
+      return false;
+    }
+
     const roles = Object.keys(user.roles || []);
     const permissions = roles.map(key =>
       user.roles[key].filter(
@@ -200,7 +213,21 @@ export default function HeaderReportDropDown({
   };
 
   const textMenu = () =>
-    report ? (
+    isEmpty(report) ? (
+      <Menu selectable={false} css={onMenuHover}>
+        <Menu.Item onClick={handleShowMenu}>
+          {DropdownItemExtension ? (
+            <StyledDropdownItemWithIcon>
+              <div>{t('Set up an email report')}</div>
+              <DropdownItemExtension />
+            </StyledDropdownItemWithIcon>
+          ) : (
+            t('Set up an email report')
+          )}
+        </Menu.Item>
+        <Menu.Divider />
+      </Menu>
+    ) : (
       isDropdownVisible && (
         <Menu selectable={false} css={{ border: 'none' }}>
           <Menu.Item
@@ -220,20 +247,6 @@ export default function HeaderReportDropDown({
           </Menu.Item>
         </Menu>
       )
-    ) : (
-      <Menu selectable={false} css={onMenuHover}>
-        <Menu.Item onClick={handleShowMenu}>
-          {DropdownItemExtension ? (
-            <StyledDropdownItemWithIcon>
-              <div>{t('Set up an email report')}</div>
-              <DropdownItemExtension />
-            </StyledDropdownItemWithIcon>
-          ) : (
-            t('Set up an email report')
-          )}
-        </Menu.Item>
-        <Menu.Divider />
-      </Menu>
     );
   const menu = () => (
     <Menu selectable={false} css={{ width: '200px' }}>

--- a/superset-frontend/src/components/ReportModal/HeaderReportDropdown/index.tsx
+++ b/superset-frontend/src/components/ReportModal/HeaderReportDropdown/index.tsx
@@ -273,7 +273,17 @@ export default function HeaderReportDropDown({
   );
 
   const iconMenu = () =>
-    report ? (
+    isEmpty(report) ? (
+      <span
+        role="button"
+        title={t('Schedule email report')}
+        tabIndex={0}
+        className="action-button action-schedule-report"
+        onClick={() => setShowModal(true)}
+      >
+        <Icons.Calendar />
+      </span>
+    ) : (
       <>
         <NoAnimationDropdown
           overlay={menu()}
@@ -291,16 +301,6 @@ export default function HeaderReportDropDown({
           </span>
         </NoAnimationDropdown>
       </>
-    ) : (
-      <span
-        role="button"
-        title={t('Schedule email report')}
-        tabIndex={0}
-        className="action-button action-schedule-report"
-        onClick={() => setShowModal(true)}
-      >
-        <Icons.Calendar />
-      </span>
     );
 
   return (

--- a/superset-frontend/src/components/ReportModal/index.tsx
+++ b/superset-frontend/src/components/ReportModal/index.tsx
@@ -93,6 +93,9 @@ type ReportObjectState = Partial<ReportObject> & {
   isSubmitting?: boolean;
 };
 
+// Same instance to be used in useEffects
+const EMPTY_OBJECT = {};
+
 function ReportModal({
   onHide,
   show = false,
@@ -147,7 +150,10 @@ function ReportModal({
     const resourceType = dashboardId
       ? CreationMethod.DASHBOARDS
       : CreationMethod.CHARTS;
-    return reportSelector(state, resourceType, dashboardId || chart?.id);
+    return (
+      reportSelector(state, resourceType, dashboardId || chart?.id) ||
+      EMPTY_OBJECT
+    );
   });
   const isEditMode = report && Object.keys(report).length;
 

--- a/superset-frontend/src/reports/actions/reports.js
+++ b/superset-frontend/src/reports/actions/reports.js
@@ -143,6 +143,8 @@ export function toggleActive(report, isActive) {
   };
 }
 
+export const DELETE_REPORT = 'DELETE_REPORT';
+
 export function deleteActiveReport(report) {
   return function deleteActiveReportThunk(dispatch) {
     return SupersetClient.delete({
@@ -152,7 +154,7 @@ export function deleteActiveReport(report) {
         dispatch(addDangerToast(t('Your report could not be deleted')));
       })
       .finally(() => {
-        dispatch(structureFetchAction);
+        dispatch({ type: DELETE_REPORT, report });
         dispatch(addSuccessToast(t('Deleted: %s', report.name)));
       });
   };

--- a/superset-frontend/src/reports/reducers/reports.js
+++ b/superset-frontend/src/reports/reducers/reports.js
@@ -18,7 +18,13 @@
  */
 /* eslint-disable camelcase */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { SET_REPORT, ADD_REPORT, EDIT_REPORT } from '../actions/reports';
+import { omit } from 'lodash';
+import {
+  SET_REPORT,
+  ADD_REPORT,
+  EDIT_REPORT,
+  DELETE_REPORT,
+} from '../actions/reports';
 
 export default function reportsReducer(state = {}, action) {
   const actionHandlers = {
@@ -75,6 +81,17 @@ export default function reportsReducer(state = {}, action) {
         [report.creation_method]: {
           ...state[report.creation_method],
           [reportTypeId]: report,
+        },
+      };
+    },
+
+    [DELETE_REPORT]() {
+      const { report } = action;
+      const reportTypeId = report.dashboard || report.chart;
+      return {
+        ...state,
+        [report.creation_method]: {
+          ...omit(state[report.creation_method], reportTypeId),
         },
       };
     },

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -867,5 +867,5 @@ export const reportSelector = (
   if (resourceId) {
     return state.reports[resourceType]?.[resourceId];
   }
-  return {};
+  return null;
 };


### PR DESCRIPTION
### SUMMARY
Changes the Email report functionality in Explore to behave in the same way as the dashboards and only allow editing after a chart is saved. Previously, the user could try to setup an email report but would face many errors because many parts of the feature depend on the saved state.

It improves rendering by returning the same instance of an empty `report`, used in `useEffect`, when there's none in the Redux store.

It also creates an specific `DELETE_REPORT` action to clearly separate the logic and avoid unnecessary queries.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/230118876-cbb050af-76e3-4655-95c2-84a03b0172d2.mov

https://user-images.githubusercontent.com/70410625/230118976-71ed8fd9-c308-4c9b-b522-1798c307fee3.mov

### TESTING INSTRUCTIONS
Check the videos for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
