### PR TITLE
fix(charts): Time range filters are not being applied to charts that were overwritten

### DIFF
--- a/superset-frontend/src/explore/actions/saveModalActions.test.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.test.js
@@ -31,6 +31,7 @@ import {
   SAVE_SLICE_FAILED,
   SAVE_SLICE_SUCCESS,
   updateSlice,
+  getSlicePayload,
 } from './saveModalActions';
 
 /**
@@ -338,4 +339,125 @@ test('getSliceDashboards with slice handles failure', async () => {
   expect(fetchMock.calls(getSliceDashboardsEndpoint)).toHaveLength(4);
   expect(dispatch.callCount).toBe(1);
   expect(dispatch.getCall(0).args[0].type).toBe(SAVE_SLICE_FAILED);
+});
+
+describe('getSlicePayload', () => {
+  const sliceName = 'Test Slice';
+  const formDataWithNativeFilters = {
+    datasource: '22__table',
+    viz_type: 'pie',
+    adhoc_filters: [],
+  };
+  const dashboards = [5];
+  const owners = [1];
+  const formDataFromSlice = {
+    datasource: '22__table',
+    viz_type: 'pie',
+    adhoc_filters: [
+      {
+        clause: 'WHERE',
+        subject: 'year',
+        operator: 'TEMPORAL_RANGE',
+        comparator: 'No filter',
+        expressionType: 'SIMPLE',
+      },
+    ],
+  };
+
+  test('should return the correct payload when no adhoc_filters are present in formDataWithNativeFilters', () => {
+    const result = getSlicePayload(
+      sliceName,
+      formDataWithNativeFilters,
+      dashboards,
+      owners,
+      formDataFromSlice,
+    );
+    expect(result).toHaveProperty('params');
+    expect(result).toHaveProperty('slice_name', sliceName);
+    expect(result).toHaveProperty(
+      'viz_type',
+      formDataWithNativeFilters.viz_type,
+    );
+    expect(result).toHaveProperty('datasource_id', 22);
+    expect(result).toHaveProperty('datasource_type', 'table');
+    expect(result).toHaveProperty('dashboards', dashboards);
+    expect(result).toHaveProperty('owners', owners);
+    expect(result).toHaveProperty('query_context');
+    expect(JSON.parse(result.params).adhoc_filters).toEqual(
+      formDataFromSlice.adhoc_filters,
+    );
+  });
+
+  test('should return the correct payload when adhoc_filters are present in formDataWithNativeFilters', () => {
+    const formDataWithAdhocFilters = {
+      ...formDataWithNativeFilters,
+      adhoc_filters: [
+        {
+          clause: 'WHERE',
+          subject: 'year',
+          operator: 'TEMPORAL_RANGE',
+          comparator: 'No filter',
+          expressionType: 'SIMPLE',
+        },
+      ],
+    };
+    const result = getSlicePayload(
+      sliceName,
+      formDataWithAdhocFilters,
+      dashboards,
+      owners,
+      formDataFromSlice,
+    );
+    expect(result).toHaveProperty('params');
+    expect(result).toHaveProperty('slice_name', sliceName);
+    expect(result).toHaveProperty(
+      'viz_type',
+      formDataWithAdhocFilters.viz_type,
+    );
+    expect(result).toHaveProperty('datasource_id', 22);
+    expect(result).toHaveProperty('datasource_type', 'table');
+    expect(result).toHaveProperty('dashboards', dashboards);
+    expect(result).toHaveProperty('owners', owners);
+    expect(result).toHaveProperty('query_context');
+    expect(JSON.parse(result.params).adhoc_filters).toEqual(
+      formDataWithAdhocFilters.adhoc_filters,
+    );
+  });
+
+  test('should return the correct payload when formDataWithNativeFilters has a filter with isExtra set to true', () => {
+    const formDataWithAdhocFiltersWithExtra = {
+      ...formDataWithNativeFilters,
+      adhoc_filters: [
+        {
+          clause: 'WHERE',
+          subject: 'year',
+          operator: 'TEMPORAL_RANGE',
+          comparator: 'No filter',
+          expressionType: 'SIMPLE',
+          isExtra: true,
+        },
+      ],
+    };
+    const result = getSlicePayload(
+      sliceName,
+      formDataWithAdhocFiltersWithExtra,
+      dashboards,
+      owners,
+      formDataFromSlice,
+    );
+    expect(result).toHaveProperty('params');
+    expect(result).toHaveProperty('slice_name', sliceName);
+    expect(result).toHaveProperty(
+      'viz_type',
+      formDataWithAdhocFiltersWithExtra.viz_type,
+    );
+    expect(result).toHaveProperty('datasource_id', 22);
+    expect(result).toHaveProperty('datasource_type', 'table');
+    expect(result).toHaveProperty('dashboards', dashboards);
+    expect(result).toHaveProperty('owners', owners);
+    expect(result).toHaveProperty('query_context');
+    expect(JSON.parse(result.params).adhoc_filters).toEqual(
+      formDataFromSlice.adhoc_filters,
+    );
+  });
 });


### PR DESCRIPTION
### SUMMARY
When `GENERIC_CHART_AXES ` FF is on and we overwrite a chart, any filter coming from the dashboard is not saved (it gets removed since its marked as `isExtra`). However, removing such filter doesn't have to mean we delete the original temporal filter if any, otherwise the dashboard wont be able to filter the chart again.

This PR keeps the original `adhoc_filters` from the slice so when calling the PUT API it doesn't get removed. So any call to  `api/v1/dashboard/{db_id}/charts` is consistent even after you overwrite the chart.



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![error](https://user-images.githubusercontent.com/38889534/230181380-9ad725e5-f3d5-4329-84e4-9c7e0e897a5b.gif)


After:
![test](https://user-images.githubusercontent.com/38889534/230218992-0714921c-e51e-4586-9881-d496d3d8229f.gif)


### TESTING INSTRUCTIONS
1. Make sure `GENERIC_CHART_AXES` FF is ON
2. Create a chart and add it to a dashboard.
3. Add a time range filter to the dashboard and apply any value.
4. Click on the chart title to access it in the Chart Builder menu.
5. Overwrite the chart (no changes are needed).
6. Go back to the dashboard, and apply any time range filter.
7. The filter must keep working after overwriting the chart


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [X] Required feature flags: `GENERIC_CHART_AXES`
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
