### PR TITLE
feat: Enables ECharts legend selector

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/transformProps.ts
@@ -226,7 +226,7 @@ export default function transformProps(
         }),
     },
     legend: {
-      ...getLegendProps(legendType, legendOrientation, showLegend),
+      ...getLegendProps(legendType, legendOrientation, showLegend, theme),
       data: keys,
     },
     series,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Graph/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Graph/transformProps.ts
@@ -171,6 +171,7 @@ export default function transformProps(
     inContextMenu,
     filterState,
     emitCrossFilters,
+    theme,
   } = chartProps;
   const data: DataRecord[] = queriesData[0].data || [];
 
@@ -324,7 +325,7 @@ export default function transformProps(
         ),
     },
     legend: {
-      ...getLegendProps(legendType, legendOrientation, showLegend),
+      ...getLegendProps(legendType, legendOrientation, showLegend, theme),
       data: categoryList,
     },
     series,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -458,7 +458,13 @@ export default function transformProps(
       },
     },
     legend: {
-      ...getLegendProps(legendType, legendOrientation, showLegend, zoomable),
+      ...getLegendProps(
+        legendType,
+        legendOrientation,
+        showLegend,
+        theme,
+        zoomable,
+      ),
       // @ts-ignore
       data: rawSeriesA
         .concat(rawSeriesB)

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
@@ -315,7 +315,7 @@ export default function transformProps(
         }),
     },
     legend: {
-      ...getLegendProps(legendType, legendOrientation, showLegend),
+      ...getLegendProps(legendType, legendOrientation, showLegend, theme),
       data: keys,
     },
     graphic: showTotal

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Radar/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Radar/transformProps.ts
@@ -237,7 +237,7 @@ export default function transformProps(
       trigger: 'item',
     },
     legend: {
-      ...getLegendProps(legendType, legendOrientation, showLegend),
+      ...getLegendProps(legendType, legendOrientation, showLegend, theme),
       data: Array.from(columnsLabelMap.keys()),
     },
     series,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -469,7 +469,13 @@ export default function transformProps(
       },
     },
     legend: {
-      ...getLegendProps(legendType, legendOrientation, showLegend, zoomable),
+      ...getLegendProps(
+        legendType,
+        legendOrientation,
+        showLegend,
+        theme,
+        zoomable,
+      ),
       data: legendData as string[],
     },
     series: dedupSeries(series),

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -28,6 +28,7 @@ import {
   NumberFormatter,
   TimeFormatter,
   AxisType,
+  SupersetTheme,
 } from '@superset-ui/core';
 import { format, LegendComponentOption, SeriesOption } from 'echarts';
 import { sumBy, meanBy, minBy, maxBy, orderBy } from 'lodash';
@@ -288,6 +289,7 @@ export function getLegendProps(
   type: LegendType,
   orientation: LegendOrientation,
   show: boolean,
+  theme: SupersetTheme,
   zoomable = false,
 ): LegendComponentOption | LegendComponentOption[] {
   const legend: LegendComponentOption | LegendComponentOption[] = {
@@ -298,6 +300,13 @@ export function getLegendProps(
       : 'vertical',
     show,
     type,
+    selector: ['all', 'inverse'],
+    selectorLabel: {
+      fontFamily: theme.typography.families.sansSerif,
+      fontSize: theme.typography.sizes.s,
+      color: theme.colors.grayscale.base,
+      borderColor: theme.colors.grayscale.base,
+    },
   };
   switch (orientation) {
     case LegendOrientation.Left:

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -20,6 +20,7 @@ import {
   DataRecord,
   getNumberFormatter,
   getTimeFormatter,
+  supersetTheme as theme,
 } from '@superset-ui/core';
 import {
   dedupSeries,
@@ -36,6 +37,16 @@ import {
 import { LegendOrientation, LegendType, SortSeriesType } from '../../src/types';
 import { defaultLegendPadding } from '../../src/defaults';
 import { NULL_STRING } from '../../src/constants';
+
+const expectedThemeProps = {
+  selector: ['all', 'inverse'],
+  selectorLabel: {
+    fontFamily: theme.typography.families.sansSerif,
+    fontSize: theme.typography.sizes.s,
+    color: theme.colors.grayscale.base,
+    borderColor: theme.colors.grayscale.base,
+  },
+};
 
 test('sortAndFilterSeries', () => {
   const data: DataRecord[] = [
@@ -409,71 +420,106 @@ describe('formatSeriesName', () => {
   describe('getLegendProps', () => {
     it('should return the correct props for scroll type with top orientation without zoom', () => {
       expect(
-        getLegendProps(LegendType.Scroll, LegendOrientation.Top, true, false),
+        getLegendProps(
+          LegendType.Scroll,
+          LegendOrientation.Top,
+          true,
+          theme,
+          false,
+        ),
       ).toEqual({
         show: true,
         top: 0,
         right: 0,
         orient: 'horizontal',
         type: 'scroll',
+        ...expectedThemeProps,
       });
     });
 
     it('should return the correct props for scroll type with top orientation with zoom', () => {
       expect(
-        getLegendProps(LegendType.Scroll, LegendOrientation.Top, true, true),
+        getLegendProps(
+          LegendType.Scroll,
+          LegendOrientation.Top,
+          true,
+          theme,
+          true,
+        ),
       ).toEqual({
         show: true,
         top: 0,
         right: 55,
         orient: 'horizontal',
         type: 'scroll',
+        ...expectedThemeProps,
       });
     });
 
     it('should return the correct props for plain type with left orientation', () => {
       expect(
-        getLegendProps(LegendType.Plain, LegendOrientation.Left, true),
+        getLegendProps(LegendType.Plain, LegendOrientation.Left, true, theme),
       ).toEqual({
         show: true,
         left: 0,
         orient: 'vertical',
         type: 'plain',
+        ...expectedThemeProps,
       });
     });
 
     it('should return the correct props for plain type with right orientation without zoom', () => {
       expect(
-        getLegendProps(LegendType.Plain, LegendOrientation.Right, false, false),
+        getLegendProps(
+          LegendType.Plain,
+          LegendOrientation.Right,
+          false,
+          theme,
+          false,
+        ),
       ).toEqual({
         show: false,
         right: 0,
         top: 0,
         orient: 'vertical',
         type: 'plain',
+        ...expectedThemeProps,
       });
     });
 
     it('should return the correct props for plain type with right orientation with zoom', () => {
       expect(
-        getLegendProps(LegendType.Plain, LegendOrientation.Right, false, true),
+        getLegendProps(
+          LegendType.Plain,
+          LegendOrientation.Right,
+          false,
+          theme,
+          true,
+        ),
       ).toEqual({
         show: false,
         right: 0,
         top: 30,
         orient: 'vertical',
         type: 'plain',
+        ...expectedThemeProps,
       });
     });
 
     it('should return the correct props for plain type with bottom orientation', () => {
       expect(
-        getLegendProps(LegendType.Plain, LegendOrientation.Bottom, false),
+        getLegendProps(
+          LegendType.Plain,
+          LegendOrientation.Bottom,
+          false,
+          theme,
+        ),
       ).toEqual({
         show: false,
         bottom: 0,
         orient: 'horizontal',
         type: 'plain',
+        ...expectedThemeProps,
       });
     });
   });


### PR DESCRIPTION
### SUMMARY
Legacy charts had the ability to click on a legend item and exclusively select that series. This was really helpful, specially when you have many items and wishes to focus on only one. ECharts has a similar but more flexible feature called Legend selector that allows a user to select all items or invert the selection. This flexibility is specially helpful when you want to compare a few items among many. This PR enables that feature.

@kasiazjc 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/230167091-b0ed4df7-318b-4042-a709-2bb106ca2097.mov

### TESTING INSTRUCTIONS
Check the video for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
