### PR TITLE
feat(presto): `get_catalog_names`

### DIFF
--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -310,7 +310,7 @@ class PostgresEngineSpec(PostgresBaseEngineSpec, BasicParametersMixin):
 SELECT datname FROM pg_database
 WHERE datistemplate = false;
             """
-            ).fetchall()
+            )
         )
 
     @classmethod

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -786,6 +786,17 @@ class PrestoEngineSpec(PrestoBaseEngineSpec):
             return {row[0] for row in results}
 
     @classmethod
+    def get_catalog_names(
+        cls,
+        database: Database,
+        inspector: Inspector,
+    ) -> List[str]:
+        """
+        Get all catalogs.
+        """
+        return [catalog for (catalog,) in inspector.bind.execute("SHOW CATALOGS")]
+
+    @classmethod
     def _create_column_info(
         cls, name: str, data_type: types.TypeEngine
     ) -> Dict[str, Any]:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Implement `get_catalog_names` for Presto/Trino. This is needed to support catalog-level permissions, and also for https://github.com/apache/superset/issues/22862.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

I configured a Trino database and ran this script:

```python
from superset.app import create_app

app = create_app()
with app.app_context():
    from superset import db
    from superset.db_engine_specs.presto import PrestoEngineSpec
    from superset.models.core import Database

    database = db.session.query(Database).first()
    with database.get_inspector_with_context() as inspector:
        print(PrestoEngineSpec.get_catalog_names(database, inspector))
```

When ran, it produced the expected output:

```
['jmx', 'memory', 'mysql', 'system', 'tpcds', 'tpch']  
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
