### PR TITLE
fix: load examples as anon user

### DIFF
--- a/superset/charts/commands/importers/v1/utils.py
+++ b/superset/charts/commands/importers/v1/utils.py
@@ -27,9 +27,12 @@ from superset.models.slice import Slice
 
 
 def import_chart(
-    session: Session, config: Dict[str, Any], overwrite: bool = False
+    session: Session,
+    config: Dict[str, Any],
+    overwrite: bool = False,
+    ignore_permissions: bool = False,
 ) -> Slice:
-    can_write = security_manager.can_access("can_write", "Chart")
+    can_write = ignore_permissions or security_manager.can_access("can_write", "Chart")
     existing = session.query(Slice).filter_by(uuid=config["uuid"]).first()
     if existing:
         if not overwrite or not can_write:

--- a/superset/commands/importers/v1/examples.py
+++ b/superset/commands/importers/v1/examples.py
@@ -21,7 +21,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import MultipleResultsFound
 from sqlalchemy.sql import select
 
-from superset import db, security_manager
+from superset import db
 from superset.charts.commands.importers.v1 import ImportChartsCommand
 from superset.charts.commands.importers.v1.utils import import_chart
 from superset.charts.schemas import ImportV1ChartSchema
@@ -42,7 +42,7 @@ from superset.datasets.commands.importers.v1 import ImportDatasetsCommand
 from superset.datasets.commands.importers.v1.utils import import_dataset
 from superset.datasets.schemas import ImportV1DatasetSchema
 from superset.models.dashboard import dashboard_slices
-from superset.utils.core import get_example_default_schema, override_user
+from superset.utils.core import get_example_default_schema
 from superset.utils.database import get_example_database
 
 
@@ -69,13 +69,12 @@ class ImportExamplesCommand(ImportModelsCommand):
 
         # rollback to prevent partial imports
         try:
-            with override_user(security_manager.find_user(username="admin")):
-                self._import(
-                    db.session,
-                    self._configs,
-                    self.overwrite,
-                    self.force_data,
-                )
+            self._import(
+                db.session,
+                self._configs,
+                self.overwrite,
+                self.force_data,
+            )
             db.session.commit()
         except Exception as ex:
             db.session.rollback()
@@ -102,7 +101,12 @@ class ImportExamplesCommand(ImportModelsCommand):
         database_ids: Dict[str, int] = {}
         for file_name, config in configs.items():
             if file_name.startswith("databases/"):
-                database = import_database(session, config, overwrite=overwrite)
+                database = import_database(
+                    session,
+                    config,
+                    overwrite=overwrite,
+                    ignore_permissions=True,
+                )
                 database_ids[str(database.uuid)] = database.id
 
         # import datasets
@@ -131,9 +135,10 @@ class ImportExamplesCommand(ImportModelsCommand):
                         config,
                         overwrite=overwrite,
                         force_data=force_data,
+                        ignore_permissions=True,
                     )
                 except MultipleResultsFound:
-                    # Multiple result can be found for datasets. There was a bug in
+                    # Multiple results can be found for datasets. There was a bug in
                     # load-examples that resulted in datasets being loaded with a NULL
                     # schema. Users could then add a new dataset with the same name in
                     # the correct schema, resulting in duplicates, since the uniqueness
@@ -156,7 +161,12 @@ class ImportExamplesCommand(ImportModelsCommand):
             ):
                 # update datasource id, type, and name
                 config.update(dataset_info[config["dataset_uuid"]])
-                chart = import_chart(session, config, overwrite=overwrite)
+                chart = import_chart(
+                    session,
+                    config,
+                    overwrite=overwrite,
+                    ignore_permissions=True,
+                )
                 chart_ids[str(chart.uuid)] = chart.id
 
         # store the existing relationship between dashboards and charts
@@ -173,7 +183,12 @@ class ImportExamplesCommand(ImportModelsCommand):
                 except KeyError:
                     continue
 
-                dashboard = import_dashboard(session, config, overwrite=overwrite)
+                dashboard = import_dashboard(
+                    session,
+                    config,
+                    overwrite=overwrite,
+                    ignore_permissions=True,
+                )
                 dashboard.published = True
 
                 for uuid in find_chart_uuids(config["position"]):

--- a/superset/dashboards/commands/importers/v1/utils.py
+++ b/superset/dashboards/commands/importers/v1/utils.py
@@ -146,9 +146,15 @@ def update_id_refs(  # pylint: disable=too-many-locals
 
 
 def import_dashboard(
-    session: Session, config: Dict[str, Any], overwrite: bool = False
+    session: Session,
+    config: Dict[str, Any],
+    overwrite: bool = False,
+    ignore_permissions: bool = False,
 ) -> Dashboard:
-    can_write = security_manager.can_access("can_write", "Dashboard")
+    can_write = ignore_permissions or security_manager.can_access(
+        "can_write",
+        "Dashboard",
+    )
     existing = session.query(Dashboard).filter_by(uuid=config["uuid"]).first()
     if existing:
         if not overwrite or not can_write:

--- a/superset/databases/commands/importers/v1/utils.py
+++ b/superset/databases/commands/importers/v1/utils.py
@@ -30,8 +30,12 @@ def import_database(
     session: Session,
     config: Dict[str, Any],
     overwrite: bool = False,
+    ignore_permissions: bool = False,
 ) -> Database:
-    can_write = security_manager.can_access("can_write", "Database")
+    can_write = ignore_permissions or security_manager.can_access(
+        "can_write",
+        "Database",
+    )
     existing = session.query(Database).filter_by(uuid=config["uuid"]).first()
     if existing:
         if not overwrite or not can_write:

--- a/superset/datasets/commands/importers/v1/utils.py
+++ b/superset/datasets/commands/importers/v1/utils.py
@@ -105,8 +105,12 @@ def import_dataset(
     config: Dict[str, Any],
     overwrite: bool = False,
     force_data: bool = False,
+    ignore_permissions: bool = False,
 ) -> SqlaTable:
-    can_write = security_manager.can_access("can_write", "Dataset")
+    can_write = ignore_permissions or security_manager.can_access(
+        "can_write",
+        "Dataset",
+    )
     existing = session.query(SqlaTable).filter_by(uuid=config["uuid"]).first()
     if existing:
         if not overwrite or not can_write:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

In https://github.com/apache/superset/pull/23200 I added permission checks when importing related assets. Before, users importing dashboards could create databases and datasets as a side effect of the import, even if they didn't have the appropriate permissions. The PR added some extra checks to prevent this from happening:

https://github.com/apache/superset/blob/56dcf25cf8ac5ed47235ebacde07200ccba257b3/superset/databases/commands/importers/v1/utils.py#L34

The change above required modifying `load-examples` to run as a user with username "admin":

https://github.com/apache/superset/blob/56dcf25cf8ac5ed47235ebacde07200ccba257b3/superset/commands/importers/v1/examples.py#L72

But the user "admin" might not exist, or might be called differently. So this PR changes `load-examples` so that the imports happen without a `current_user`, as before, while keeping the permission checks for other imports initiated via the UI.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
