### PR TITLE
feat(snowflake): `get_catalog_names`

### DIFF
--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -122,6 +122,8 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
 
     allows_hidden_cc_in_orderby = True
 
+    supports_catalog = True
+
     """
     https://www.python.org/dev/peps/pep-0249/#arraysize
     raw_connections bypass the sqlalchemy-bigquery query execution context and deal with

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -96,6 +96,7 @@ class PostgresBaseEngineSpec(BaseEngineSpec):
     engine_name = "PostgreSQL"
 
     supports_dynamic_schema = True
+    supports_catalog = True
 
     _time_grain_expressions = {
         None: "{col}",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Implement `get_catalog_names` for Snowflake. This is needed to support catalog-level permissions, and also for https://github.com/apache/superset/issues/22862.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

I configured a Snowflake database and ran this script:

```python
from superset.app import create_app

app = create_app()
with app.app_context():
    from superset import db
    from superset.db_engine_specs.snowflake import SnowflakeEngineSpec
    from superset.models.core import Database

    database = db.session.query(Database).first()
    with database.get_inspector_with_context() as inspector:
        print(SnowflakeEngineSpec.get_catalog_names(database, inspector))
```

When ran, it produced the expected output:

```
['SNOWFLAKE_SAMPLE_DATA']      
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
