### PR TITLE
feat: implement drill by table

### DIFF
--- a/superset-frontend/src/components/Chart/DrillBy/DrillByChart.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByChart.test.tsx
@@ -45,13 +45,6 @@ test('should render', async () => {
   expect(container).toBeInTheDocument();
 });
 
-test('should render loading indicator', async () => {
-  setup();
-  await waitFor(() =>
-    expect(screen.getByLabelText('Loading')).toBeInTheDocument(),
-  );
-});
-
 test('should render the "No results" components', async () => {
   setup({}, []);
   expect(await screen.findByText('No Results')).toBeInTheDocument();

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByChart.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByChart.test.tsx
@@ -22,28 +22,18 @@ import chartQueries, { sliceId } from 'spec/fixtures/mockChartQueries';
 import fetchMock from 'fetch-mock';
 import DrillByChart from './DrillByChart';
 
-const CHART_DATA_ENDPOINT =
-  'glob:*api/v1/chart/data?form_data=%7B%22slice_id%22%3A18%7D';
-
 const chart = chartQueries[sliceId];
 
-const fetchWithNoData = () => {
-  fetchMock.post(CHART_DATA_ENDPOINT, {
-    result: [
-      {
-        total_count: 0,
-        data: [],
-        colnames: [],
-        coltypes: [],
-      },
-    ],
-  });
-};
-
-const setup = (overrides: Record<string, any> = {}) =>
-  render(<DrillByChart formData={{ ...chart.form_data, ...overrides }} />, {
-    useRedux: true,
-  });
+const setup = (overrides: Record<string, any> = {}, result?: any) =>
+  render(
+    <DrillByChart
+      formData={{ ...chart.form_data, ...overrides }}
+      result={result}
+    />,
+    {
+      useRedux: true,
+    },
+  );
 
 const waitForRender = (overrides: Record<string, any> = {}) =>
   waitFor(() => setup(overrides));
@@ -51,7 +41,6 @@ const waitForRender = (overrides: Record<string, any> = {}) =>
 afterEach(fetchMock.restore);
 
 test('should render', async () => {
-  fetchWithNoData();
   const { container } = await waitForRender();
   expect(container).toBeInTheDocument();
 });
@@ -64,7 +53,6 @@ test('should render loading indicator', async () => {
 });
 
 test('should render the "No results" components', async () => {
-  fetchWithNoData();
-  setup();
+  setup({}, []);
   expect(await screen.findByText('No Results')).toBeInTheDocument();
 });

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByChart.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByChart.tsx
@@ -16,26 +16,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useEffect, useState } from 'react';
-import { BaseFormData, Behavior, css, SuperChart } from '@superset-ui/core';
-import { getChartDataRequest } from 'src/components/Chart/chartAction';
+import React from 'react';
+import {
+  BaseFormData,
+  Behavior,
+  QueryData,
+  SuperChart,
+  css,
+} from '@superset-ui/core';
+
 import Loading from 'src/components/Loading';
 
 interface DrillByChartProps {
   formData: BaseFormData & { [key: string]: any };
+  result: QueryData[];
 }
 
-export default function DrillByChart({ formData }: DrillByChartProps) {
-  const [chartDataResult, setChartDataResult] = useState();
-
-  useEffect(() => {
-    getChartDataRequest({
-      formData,
-    }).then(({ json }) => {
-      setChartDataResult(json.result);
-    });
-  }, []);
-
+export default function DrillByChart({ formData, result }: DrillByChartProps) {
   return (
     <div
       css={css`
@@ -43,14 +40,14 @@ export default function DrillByChart({ formData }: DrillByChartProps) {
         height: 100%;
       `}
     >
-      {chartDataResult ? (
+      {result ? (
         <SuperChart
           disableErrorBoundary
           behaviors={[Behavior.INTERACTIVE_CHART]}
           chartType={formData.viz_type}
           enableNoResults
           formData={formData}
-          queriesData={chartDataResult}
+          queriesData={result}
           height="100%"
           width="100%"
         />

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByChart.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByChart.tsx
@@ -25,11 +25,9 @@ import {
   css,
 } from '@superset-ui/core';
 
-import Loading from 'src/components/Loading';
-
 interface DrillByChartProps {
   formData: BaseFormData & { [key: string]: any };
-  result?: QueryData[];
+  result: QueryData[];
 }
 
 export default function DrillByChart({ formData, result }: DrillByChartProps) {
@@ -40,20 +38,16 @@ export default function DrillByChart({ formData, result }: DrillByChartProps) {
         height: 100%;
       `}
     >
-      {result ? (
-        <SuperChart
-          disableErrorBoundary
-          behaviors={[Behavior.INTERACTIVE_CHART]}
-          chartType={formData.viz_type}
-          enableNoResults
-          formData={formData}
-          queriesData={result}
-          height="100%"
-          width="100%"
-        />
-      ) : (
-        <Loading />
-      )}
+      <SuperChart
+        disableErrorBoundary
+        behaviors={[Behavior.INTERACTIVE_CHART]}
+        chartType={formData.viz_type}
+        enableNoResults
+        formData={formData}
+        queriesData={result}
+        height="100%"
+        width="100%"
+      />
     </div>
   );
 }

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByChart.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByChart.tsx
@@ -29,7 +29,7 @@ import Loading from 'src/components/Loading';
 
 interface DrillByChartProps {
   formData: BaseFormData & { [key: string]: any };
-  result: QueryData[];
+  result?: QueryData[];
 }
 
 export default function DrillByChart({ formData, result }: DrillByChartProps) {

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.tsx
@@ -244,15 +244,17 @@ export const DrillByMenuItems = ({
           )}
         </div>
       </Menu.SubMenu>
-      <DrillByModal
-        column={currentColumn}
-        filters={filters}
-        formData={formData}
-        groupbyFieldName={groupbyFieldName}
-        onHideModal={closeModal}
-        showModal={showModal}
-        dataset={dataset!}
-      />
+      {showModal && (
+        <DrillByModal
+          column={currentColumn}
+          filters={filters}
+          formData={formData}
+          groupbyFieldName={groupbyFieldName}
+          onHideModal={closeModal}
+          showModal={showModal}
+          dataset={dataset!}
+        />
+      )}
     </>
   );
 };

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.tsx
@@ -251,7 +251,6 @@ export const DrillByMenuItems = ({
           formData={formData}
           groupbyFieldName={groupbyFieldName}
           onHideModal={closeModal}
-          showModal={showModal}
           dataset={dataset!}
         />
       )}

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
@@ -71,12 +71,13 @@ const renderModal = async () => {
         <button type="button" onClick={() => setShowModal(true)}>
           Show modal
         </button>
-        <DrillByModal
-          formData={formData}
-          showModal={showModal}
-          onHideModal={() => setShowModal(false)}
-          dataset={dataset}
-        />
+        {showModal && (
+          <DrillByModal
+            formData={formData}
+            onHideModal={() => setShowModal(false)}
+            dataset={dataset}
+          />
+        )}
       </DashboardPageIdContext.Provider>
     );
   };

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
@@ -144,3 +144,17 @@ test('should generate Explore url', async () => {
     await screen.findByRole('link', { name: 'Edit chart' }),
   ).toHaveAttribute('href', '/explore/?form_data_key=123&dashboard_page_id=1');
 });
+
+test('should render radio buttons', async () => {
+  await renderModal();
+  const chartRadio = screen.getByRole('radio', { name: /chart/i });
+  const tableRadio = screen.getByRole('radio', { name: /table/i });
+
+  expect(chartRadio).toBeInTheDocument();
+  expect(tableRadio).toBeInTheDocument();
+  expect(chartRadio).toBeChecked();
+  expect(tableRadio).not.toBeChecked();
+  userEvent.click(tableRadio);
+  expect(chartRadio).not.toBeChecked();
+  expect(tableRadio).toBeChecked();
+});

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
@@ -119,9 +119,16 @@ test('should close the modal', async () => {
   expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 });
 
+test('should render loading indicator', async () => {
+  await renderModal();
+  await waitFor(() =>
+    expect(screen.getByLabelText('Loading')).toBeInTheDocument(),
+  );
+});
+
 test('should generate Explore url', async () => {
   await renderModal();
-  await waitFor(() => fetchMock.called(FORM_DATA_KEY_ENDPOINT));
+  await waitFor(() => fetchMock.called(CHART_DATA_ENDPOINT));
   const expectedRequestPayload = {
     form_data: {
       ...omitBy(
@@ -129,6 +136,9 @@ test('should generate Explore url', async () => {
         isUndefined,
       ),
       slice_id: 0,
+      result_format: 'json',
+      result_type: 'full',
+      force: false,
     },
     datasource_id: Number(formData.datasource.split('__')[0]),
     datasource_type: formData.datasource.split('__')[1],
@@ -137,9 +147,10 @@ test('should generate Explore url', async () => {
   const parsedRequestPayload = JSON.parse(
     fetchMock.lastCall()?.[1]?.body as string,
   );
-  parsedRequestPayload.form_data = JSON.parse(parsedRequestPayload.form_data);
 
-  expect(parsedRequestPayload).toEqual(expectedRequestPayload);
+  expect(parsedRequestPayload.form_data).toEqual(
+    expectedRequestPayload.form_data,
+  );
 
   expect(
     await screen.findByRole('link', { name: 'Edit chart' }),

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByModal.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByModal.tsx
@@ -22,6 +22,7 @@ import {
   BaseFormData,
   BinaryQueryObjectFilterClause,
   Column,
+  QueryData,
   css,
   ensureIsArray,
   t,
@@ -31,21 +32,30 @@ import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import Modal from 'src/components/Modal';
 import Button from 'src/components/Button';
+import { Radio } from 'src/components/Radio';
 import { DashboardLayout, RootState } from 'src/dashboard/types';
 import { DashboardPageIdContext } from 'src/dashboard/containers/DashboardPage';
 import { postFormData } from 'src/explore/exploreUtils/formData';
 import { noOp } from 'src/utils/common';
 import { simpleFilterToAdhoc } from 'src/utils/simpleFilterToAdhoc';
 import { useDatasetMetadataBar } from 'src/features/datasets/metadataBar/useDatasetMetadataBar';
-import { Dataset } from '../types';
+import { SingleQueryResultPane } from 'src/explore/components/DataTablesPane/components/SingleQueryResultPane';
+import { Dataset, DrillByType } from '../types';
 import DrillByChart from './DrillByChart';
+import { getChartDataRequest } from '../chartAction';
 
+const DATA_SIZE = 14;
 interface ModalFooterProps {
   formData: BaseFormData;
   closeModal?: () => void;
+  showEditChart: boolean;
 }
 
-const ModalFooter = ({ formData, closeModal }: ModalFooterProps) => {
+const ModalFooter = ({
+  formData,
+  closeModal,
+  showEditChart,
+}: ModalFooterProps) => {
   const [url, setUrl] = useState('');
   const dashboardPageId = useContext(DashboardPageIdContext);
   const [datasource_id, datasource_type] = formData.datasource.split('__');
@@ -62,18 +72,20 @@ const ModalFooter = ({ formData, closeModal }: ModalFooterProps) => {
   }, [dashboardPageId, datasource_id, datasource_type, formData]);
   return (
     <>
-      <Button buttonStyle="secondary" buttonSize="small" onClick={noOp}>
-        <Link
-          css={css`
-            &:hover {
-              text-decoration: none;
-            }
-          `}
-          to={url}
-        >
-          {t('Edit chart')}
-        </Link>
-      </Button>
+      {showEditChart && (
+        <Button buttonStyle="secondary" buttonSize="small" onClick={noOp}>
+          <Link
+            css={css`
+              &:hover {
+                text-decoration: none;
+              }
+            `}
+            to={url}
+          >
+            {t('Edit chart')}
+          </Link>
+        </Button>
+      )}
       <Button
         buttonStyle="primary"
         buttonSize="small"
@@ -106,6 +118,12 @@ export default function DrillByModal({
   dataset,
 }: DrillByModalProps) {
   const theme = useTheme();
+  const [chartDataResult, setChartDataResult] = useState<QueryData[]>();
+  const [showChart, setShowChart] = useState(true);
+  const [datasourceId] = useMemo(
+    () => formData.datasource.split('__'),
+    [formData.datasource],
+  );
   const dashboardLayout = useSelector<RootState, DashboardLayout>(
     state => state.dashboardLayout.present,
   );
@@ -141,7 +159,17 @@ export default function DrillByModal({
     return updatedFormData;
   }, [column, filters, formData, groupbyFieldName]);
 
+  useEffect(() => {
+    if (updatedFormData && showModal) {
+      getChartDataRequest({
+        formData: updatedFormData,
+      }).then(({ json }) => {
+        setChartDataResult(json.result);
+      });
+    }
+  }, [updatedFormData, showModal]);
   const { metadataBar } = useDatasetMetadataBar({ dataset });
+
   return (
     <Modal
       css={css`
@@ -150,9 +178,15 @@ export default function DrillByModal({
         }
       `}
       show={showModal}
-      onHide={onHideModal ?? (() => null)}
+      onHide={() => {
+        setShowChart(true);
+        setChartDataResult(undefined);
+        onHideModal();
+      }}
       title={t('Drill by: %s', chartName)}
-      footer={<ModalFooter formData={updatedFormData} />}
+      footer={
+        <ModalFooter formData={updatedFormData} showEditChart={showChart} />
+      }
       responsive
       resizable
       resizableConfig={{
@@ -160,7 +194,7 @@ export default function DrillByModal({
         minWidth: theme.gridUnit * 128,
         defaultSize: {
           width: 'auto',
-          height: '75vh',
+          height: '80vh',
         },
       }}
       draggable
@@ -175,7 +209,48 @@ export default function DrillByModal({
         `}
       >
         {metadataBar}
-        <DrillByChart formData={updatedFormData} />
+        <div
+          css={css`
+            margin-bottom: ${theme.gridUnit * 6}px;
+            .ant-radio-button-wrapper-checked:not(.ant-radio-button-wrapper-disabled):focus-within {
+              box-shadow: none;
+            }
+          `}
+        >
+          <Radio.Group
+            onChange={({ target: { value } }) => {
+              setShowChart(value === DrillByType.chart);
+            }}
+            defaultValue={DrillByType.chart}
+          >
+            <Radio.Button
+              value={DrillByType.chart}
+              data-test="drill-by-chart-radio"
+            >
+              {t('Chart')}
+            </Radio.Button>
+            <Radio.Button
+              value={DrillByType.table}
+              data-test="drill-by-table-radio"
+            >
+              {t('Table')}
+            </Radio.Button>
+          </Radio.Group>
+        </div>
+        {showChart && chartDataResult && (
+          <DrillByChart formData={updatedFormData} result={chartDataResult} />
+        )}
+        {!showChart && chartDataResult && (
+          <SingleQueryResultPane
+            data={chartDataResult[0].data}
+            colnames={chartDataResult[0].colnames}
+            coltypes={chartDataResult[0].coltypes}
+            datasourceId={datasourceId}
+            dataSize={DATA_SIZE}
+            key={1}
+            isVisible={!showChart}
+          />
+        )}
       </div>
     </Modal>
   );

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByModal.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByModal.tsx
@@ -31,6 +31,7 @@ import {
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import Modal from 'src/components/Modal';
+import Loading from 'src/components/Loading';
 import Button from 'src/components/Button';
 import { Radio } from 'src/components/Radio';
 import { DashboardLayout, RootState } from 'src/dashboard/types';
@@ -44,7 +45,7 @@ import { Dataset, DrillByType } from '../types';
 import DrillByChart from './DrillByChart';
 import { getChartDataRequest } from '../chartAction';
 
-const DATA_SIZE = 14;
+const DATA_SIZE = 15;
 interface ModalFooterProps {
   closeModal?: () => void;
   formData: BaseFormData;
@@ -111,7 +112,9 @@ export default function DrillByModal({
 }: DrillByModalProps) {
   const theme = useTheme();
   const [chartDataResult, setChartDataResult] = useState<QueryData[]>();
-  const [drillBy, setDrillBy] = useState<DrillByType>(DrillByType.Chart);
+  const [drillByDisplayMode, setDrillByDisplayMode] = useState<DrillByType>(
+    DrillByType.Chart,
+  );
   const [datasourceId] = useMemo(
     () => formData.datasource.split('__'),
     [formData.datasource],
@@ -205,7 +208,7 @@ export default function DrillByModal({
         >
           <Radio.Group
             onChange={({ target: { value } }) => {
-              setDrillBy(value);
+              setDrillByDisplayMode(value);
             }}
             defaultValue={DrillByType.Chart}
           >
@@ -223,18 +226,27 @@ export default function DrillByModal({
             </Radio.Button>
           </Radio.Group>
         </div>
-        {drillBy === DrillByType.Chart && chartDataResult && (
+        {!chartDataResult && <Loading />}
+        {drillByDisplayMode === DrillByType.Chart && chartDataResult && (
           <DrillByChart formData={updatedFormData} result={chartDataResult} />
         )}
-        {drillBy === DrillByType.Table && chartDataResult && (
-          <SingleQueryResultPane
-            colnames={chartDataResult[0].colnames}
-            coltypes={chartDataResult[0].coltypes}
-            data={chartDataResult[0].data}
-            dataSize={DATA_SIZE}
-            datasourceId={datasourceId}
-            isVisible
-          />
+        {drillByDisplayMode === DrillByType.Table && chartDataResult && (
+          <div
+            css={css`
+              .pagination-container {
+                bottom: ${-theme.gridUnit * 4}px;
+              }
+            `}
+          >
+            <SingleQueryResultPane
+              colnames={chartDataResult[0].colnames}
+              coltypes={chartDataResult[0].coltypes}
+              data={chartDataResult[0].data}
+              dataSize={DATA_SIZE}
+              datasourceId={datasourceId}
+              isVisible
+            />
+          </div>
         )}
       </div>
     </Modal>

--- a/superset-frontend/src/components/Chart/types.ts
+++ b/superset-frontend/src/components/Chart/types.ts
@@ -17,6 +17,11 @@
  * under the License.
  */
 
+export enum DrillByType {
+  chart,
+  table,
+}
+
 export type Dataset = {
   changed_by?: {
     first_name: string;

--- a/superset-frontend/src/components/Chart/types.ts
+++ b/superset-frontend/src/components/Chart/types.ts
@@ -18,8 +18,8 @@
  */
 
 export enum DrillByType {
-  chart,
-  table,
+  Chart,
+  Table,
 }
 
 export type Dataset = {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
User should be able to see the drill by results either as a chart (the same visualization type as the original chart) or as a table.
- Added radio buttons to the Modal  "Chart" and "Table"
- Default value is "Chart". If "Chart" is selected, display the drill by result as a chart.
- If "Table" is selected, display the drill by's query result as table. It should be the same table component as in Explore's "Results" section

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![DrillByTable](https://user-images.githubusercontent.com/5705598/230241608-eed690f2-8bf3-4f97-9612-b2162cde1f5b.gif)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
