### PR TITLE
fix(saved_queries): wrong enum for object_type of saved_query

### DIFF
--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -371,7 +371,7 @@ class SavedQuery(Model, AuditMixinNullable, ExtraJSONMixin, ImportExportMixin):
         secondary="tagged_object",
         primaryjoin="and_(SavedQuery.id == TaggedObject.object_id)",
         secondaryjoin="and_(TaggedObject.tag_id == Tag.id, "
-        "TaggedObject.object_type == 'saved_query')",
+        "TaggedObject.object_type == 'query')",
     )
 
     export_parent = "database"


### PR DESCRIPTION
### SUMMARY
Fixes #23610 
There is no "saved_query" enum value of object_type for saved queries as such. it should be "query" instead as it can be seen in ObjectTypes class.

### BEFORE SCREENSHOTS
<img width="1509" alt="Screenshot 2023-04-06 at 4 51 32 PM" src="https://user-images.githubusercontent.com/25038017/230378106-e1bd5b2a-cc5d-40e7-9fe9-c9e0c4d49f51.png">

### AFTER
- Saved queries list loads fine

### TESTING INSTRUCTIONS

1. Setup Postgres as backend db (as the default sqlite db doesn't really strictly checks the enum type of object_type)
2. Go to "Saved queries" page
3. The list should load fine.

### ADDITIONAL INFORMATION
- [x] Has associated issue: #23610 
- [ ] Required feature flags: TAGGING_SYSTEM
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
