### PR TITLE
fix: Increases the options limit for Annotation Layers

### DIFF
--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
@@ -47,6 +47,7 @@ import {
 import PopoverSection from 'src/components/PopoverSection';
 import ControlHeader from 'src/explore/components/ControlHeader';
 import { EmptyStateSmall } from 'src/components/EmptyState';
+import { FILTER_OPTIONS_LIMIT } from 'src/explore/constants';
 
 const AUTOMATIC_COLOR = '';
 
@@ -301,8 +302,12 @@ class AnnotationLayer extends React.PureComponent {
   fetchOptions(annotationType, sourceType, isLoadingOptions) {
     if (isLoadingOptions) {
       if (sourceType === ANNOTATION_SOURCE_TYPES.NATIVE) {
+        const queryParams = rison.encode({
+          page: 0,
+          page_size: FILTER_OPTIONS_LIMIT,
+        });
         SupersetClient.get({
-          endpoint: '/api/v1/annotation_layer/',
+          endpoint: `/api/v1/annotation_layer/?q=${queryParams}`,
         }).then(({ json }) => {
           const layers = json
             ? json.result.map(layer => ({
@@ -327,7 +332,7 @@ class AnnotationLayer extends React.PureComponent {
           order_column: 'slice_name',
           order_direction: 'asc',
           page: 0,
-          page_size: 25,
+          page_size: FILTER_OPTIONS_LIMIT,
         });
         SupersetClient.get({
           endpoint: `/api/v1/chart/?q=${queryParams}`,


### PR DESCRIPTION
### SUMMARY
Increases the options limit for Annotation Layers in Explore. Previously, the options were limited to 20 results which is a problem for organizations with many records. Following the same pattern used in filters, the limit was increased to a 1000 values. Although, 1000 values will probably be sufficient for most of organizations, the endgame solution would be to create a control using the `AsyncSelect` and replace the sync version. This change is not in the scope of this PR.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="505" alt="Screenshot 2023-04-06 at 10 47 44" src="https://user-images.githubusercontent.com/70410625/230399609-9bf9c4d3-48e5-477f-b714-3ca26cdffbf8.png">

### TESTING INSTRUCTIONS
Make sure the Annotation Layers select in Explore can show up to a 1000 values.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
