### PR TITLE
fix: Error on Cypress test

### DIFF
--- a/superset-frontend/cypress-base/cypress/integration/dashboard/editmode.test.ts
+++ b/superset-frontend/cypress-base/cypress/integration/dashboard/editmode.test.ts
@@ -725,6 +725,7 @@ describe('Dashboard edit', () => {
 
     it('should filter charts', () => {
       interceptCharts();
+      cy.get('[role="checkbox"]').click();
       cy.getBySel('dashboard-charts-filter-search-input').type('Unicode');
       cy.wait('@filtering');
       cy.getBySel('chart-card')
@@ -734,6 +735,7 @@ describe('Dashboard edit', () => {
     });
 
     it('should disable the Save button when undoing', () => {
+      cy.get('[role="checkbox"]').click();
       dragComponent('Unicode Cloud', 'card-title', false);
       cy.getBySel('header-save-button').should('be.enabled');
       discardChanges();
@@ -747,11 +749,13 @@ describe('Dashboard edit', () => {
     });
 
     it('should add charts', () => {
+      cy.get('[role="checkbox"]').click();
       dragComponent();
       cy.getBySel('dashboard-component-chart-holder').should('have.length', 1);
     });
 
     it('should remove added charts', () => {
+      cy.get('[role="checkbox"]').click();
       dragComponent('Unicode Cloud');
       cy.getBySel('dashboard-component-chart-holder').should('have.length', 1);
       cy.getBySel('dashboard-delete-component-button').click();
@@ -793,6 +797,7 @@ describe('Dashboard edit', () => {
     });
 
     it('should save', () => {
+      cy.get('[role="checkbox"]').click();
       dragComponent();
       cy.getBySel('header-save-button').should('be.enabled');
       saveChanges();


### PR DESCRIPTION
### SUMMARY
Fixes the Cypress error affecting master.

```
cypress/integration/dashboard/editmode.test

AssertionError: Timed out retrying after 8000ms: 
Expected to find element: `[data-test=chart-card]`, but never found it.
```

### TESTING INSTRUCTIONS
All E2E tests should pass.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
