### PR TITLE
chore(colors): Updating Airbnb brand colors

### DIFF
--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/editmode.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/editmode.test.ts
@@ -515,7 +515,7 @@ describe('Dashboard edit', () => {
       // label Anthony
       cy.get('[data-test-chart-name="Trends"] .line .nv-legend-symbol')
         .eq(2)
-        .should('have.css', 'fill', 'rgb(0, 122, 135)');
+        .should('have.css', 'fill', 'rgb(244, 176, 42)');
 
       // open main tab and nested tab
       openTab(0, 0);
@@ -526,7 +526,7 @@ describe('Dashboard edit', () => {
         '[data-test-chart-name="Top 10 California Names Timeseries"] .line .nv-legend-symbol',
       )
         .first()
-        .should('have.css', 'fill', 'rgb(0, 122, 135)');
+        .should('have.css', 'fill', 'rgb(244, 176, 42)');
     });
 
     it('should apply the color scheme across main tabs', () => {
@@ -557,7 +557,7 @@ describe('Dashboard edit', () => {
 
       cy.get('[data-test-chart-name="Trends"] .line .nv-legend-symbol')
         .first()
-        .should('have.css', 'fill', 'rgb(204, 0, 134)');
+        .should('have.css', 'fill', 'rgb(156, 52, 152)');
 
       // change scheme now that charts are rendered across the main tabs
       editDashboard();

--- a/superset-frontend/cypress-base/cypress/e2e/explore/visualizations/dist_bar.test.js
+++ b/superset-frontend/cypress-base/cypress/e2e/explore/visualizations/dist_bar.test.js
@@ -89,6 +89,6 @@ describe('Visualization > Distribution bar chart', () => {
     ).should('exist');
     cy.get('.dist_bar .nv-legend .nv-legend-symbol')
       .first()
-      .should('have.css', 'fill', 'rgb(255, 90, 95)');
+      .should('have.css', 'fill', 'rgb(41, 105, 107)');
   });
 });

--- a/superset-frontend/cypress-base/cypress/e2e/explore/visualizations/line.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/explore/visualizations/line.test.ts
@@ -85,7 +85,7 @@ describe('Visualization > Line', () => {
     ).should('exist');
     cy.get('.line .nv-legend .nv-legend-symbol')
       .first()
-      .should('have.css', 'fill', 'rgb(255, 90, 95)');
+      .should('have.css', 'fill', 'rgb(41, 105, 107)');
   });
 
   it('should work with adhoc metric', () => {

--- a/superset-frontend/packages/superset-ui-core/src/color/colorSchemes/categorical/airbnb.ts
+++ b/superset-frontend/packages/superset-ui-core/src/color/colorSchemes/categorical/airbnb.ts
@@ -24,20 +24,19 @@ const schemes = [
     id: 'bnbColors',
     label: 'Airbnb Colors',
     colors: [
-      '#ff385c', // rausch
-      '#92174d', // plus
-      '#460479', // luxe
-      '#222222', // hof
-      '#dddddd', // deco
-      '#c13515', // arches
-      '#d0650b', // ondo
-      '#ffaf0f', // beach
-      '#7dv734', // lima
-      '#22bc4e', // spruce
-      '#00ba92', // norrr
-      '#007e82', // babu
-      '#2875f0', // mykonou
-      '#9b3197', // omiya
+      '#29696B',
+      '#5BCACE',
+      '#F4B02A',
+      '#F1826A',
+      '#792EB2',
+      '#C96EC6',
+      '#921E50',
+      '#B27700',
+      '#9C3498',
+      '#9C3498',
+      '#E4679D',
+      '#C32F0E',
+      '#9D63CA',
     ],
   },
 ].map(s => new CategoricalScheme(s));

--- a/superset-frontend/packages/superset-ui-core/src/color/colorSchemes/categorical/airbnb.ts
+++ b/superset-frontend/packages/superset-ui-core/src/color/colorSchemes/categorical/airbnb.ts
@@ -24,27 +24,20 @@ const schemes = [
     id: 'bnbColors',
     label: 'Airbnb Colors',
     colors: [
-      '#ff5a5f', // rausch
-      '#7b0051', // hackb
-      '#007A87', // kazan
-      '#00d1c1', // babu
-      '#8ce071', // lima
-      '#ffb400', // beach
-      '#b4a76c', // barol
-      '#ff8083',
-      '#cc0086',
-      '#00a1b3',
-      '#00ffeb',
-      '#bbedab',
-      '#ffd266',
-      '#cbc29a',
-      '#ff3339',
-      '#ff1ab1',
-      '#005c66',
-      '#00b3a5',
-      '#55d12e',
-      '#b37e00',
-      '#988b4e',
+      '#ff385c', // rausch
+      '#92174d', // plus
+      '#460479', // luxe
+      '#222222', // hof
+      '#dddddd', // deco
+      '#c13515', // arches
+      '#d0650b', // ondo
+      '#ffaf0f', // beach
+      '#7dv734', // lima
+      '#22bc4e', // spruce
+      '#00ba92', // norrr
+      '#007e82', // babu
+      '#2875f0', // mykonou
+      '#9b3197', // omiya
     ],
   },
 ].map(s => new CategoricalScheme(s));

--- a/superset-frontend/packages/superset-ui-demo/storybook/stories/plugins/legacy-plugin-chart-map-box/Stories.tsx
+++ b/superset-frontend/packages/superset-ui-demo/storybook/stories/plugins/legacy-plugin-chart-map-box/Stories.tsx
@@ -42,7 +42,7 @@ export const Basic = () => {
         allColumnsY: 'LAT',
         clusteringRadius: '60',
         globalOpacity: 1,
-        mapboxColor: 'rgb(0, 122, 135)',
+        mapboxColor: 'rgb(244, 176, 42)',
         mapboxLabel: [],
         mapboxStyle: 'mapbox://styles/mapbox/light-v9',
         pandasAggfunc: 'sum',


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

The Airbnb brand color palette changed. This PR reflects these changes (per the attached screenshot).

![image](https://github.com/apache/superset/assets/4567245/54f80044-1e83-4919-ae63-8ea70bf3ec88)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
