### PR TITLE
fix(docker): optimize docker build by better utilizing build cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,13 +61,13 @@ RUN mkdir -p ${PYTHONPATH} \
     && useradd --user-group -d ${SUPERSET_HOME} -m --no-log-init --shell /bin/bash superset \
     && apt-get update -y \
     && apt-get install -y --no-install-recommends \
-    build-essential \
-    curl \
-    default-libmysqlclient-dev \
-    libsasl2-dev \
-    libsasl2-modules-gssapi-mit \
-    libpq-dev \
-    libecpg-dev \
+        build-essential \
+        curl \
+        default-libmysqlclient-dev \
+        libsasl2-dev \
+        libsasl2-modules-gssapi-mit \
+        libpq-dev \
+        libecpg-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -114,13 +114,13 @@ USER root
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
-    libnss3 \
-    libdbus-glib-1-2 \
-    libgtk-3-0 \
-    libx11-xcb1 \
-    libasound2 \
-    libxtst6 \
-    wget
+        libnss3 \
+        libdbus-glib-1-2 \
+        libgtk-3-0 \
+        libx11-xcb1 \
+        libasound2 \
+        libxtst6 \
+        wget
 
 # Install GeckoDriver WebDriver
 RUN wget https://github.com/mozilla/geckodriver/releases/download/${GECKODRIVER_VERSION}/geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz -O /tmp/geckodriver.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,44 +58,40 @@ ENV LANG=C.UTF-8 \
     SUPERSET_PORT=8088
 
 RUN mkdir -p ${PYTHONPATH} \
-        && useradd --user-group -d ${SUPERSET_HOME} -m --no-log-init --shell /bin/bash superset \
-        && apt-get update -y \
-        && apt-get install -y --no-install-recommends \
-            build-essential \
-            curl \
-            default-libmysqlclient-dev \
-            libsasl2-dev \
-            libsasl2-modules-gssapi-mit \
-            libpq-dev \
-            libecpg-dev \
-        && rm -rf /var/lib/apt/lists/*
-
-COPY ./requirements/*.txt  /app/requirements/
-COPY setup.py MANIFEST.in README.md /app/
-
-# setup.py uses the version information in package.json
-COPY superset-frontend/package.json /app/superset-frontend/
-
-RUN cd /app \
-    && mkdir -p superset/static \
-    && touch superset/static/version_info.json \
-    && pip install --no-cache -r requirements/local.txt
-
-COPY --from=superset-node /app/superset/static/assets /app/superset/static/assets
-
-## Lastly, let's install superset itself
-COPY superset /app/superset
-COPY setup.py MANIFEST.in README.md /app/
-RUN cd /app \
-        && chown -R superset:superset * \
-        && pip install -e . \
-        && flask fab babel-compile --target superset/translations
-
-COPY ./docker/run-server.sh /usr/bin/
-
-RUN chmod a+x /usr/bin/run-server.sh
+    && useradd --user-group -d ${SUPERSET_HOME} -m --no-log-init --shell /bin/bash superset \
+    && apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    default-libmysqlclient-dev \
+    libsasl2-dev \
+    libsasl2-modules-gssapi-mit \
+    libpq-dev \
+    libecpg-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
+
+COPY --chown=superset:superset ./requirements/*.txt  requirements/
+COPY --chown=superset:superset setup.py MANIFEST.in README.md ./
+
+# setup.py uses the version information in package.json
+COPY --chown=superset:superset superset-frontend/package.json superset-frontend/
+
+RUN mkdir -p superset/static \
+    && touch superset/static/version_info.json \
+    && pip install --no-cache-dir -r requirements/local.txt
+
+COPY --chown=superset:superset --from=superset-node /app/superset/static/assets superset/static/assets
+
+## Lastly, let's install superset itself
+COPY --chown=superset:superset superset superset
+RUN chown -R superset:superset ./* \
+    && pip install --no-cache-dir -e . \
+    && flask fab babel-compile --target superset/translations
+
+COPY ./docker/run-server.sh /usr/bin/
+RUN chmod a+x /usr/bin/run-server.sh
 
 USER superset
 
@@ -103,7 +99,7 @@ HEALTHCHECK CMD curl -f "http://localhost:$SUPERSET_PORT/health"
 
 EXPOSE ${SUPERSET_PORT}
 
-CMD /usr/bin/run-server.sh
+CMD ["/usr/bin/run-server.sh"]
 
 ######################################################################
 # Dev image...
@@ -118,13 +114,13 @@ USER root
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
-          libnss3 \
-          libdbus-glib-1-2 \
-          libgtk-3-0 \
-          libx11-xcb1 \
-          libasound2 \
-          libxtst6 \
-          wget
+    libnss3 \
+    libdbus-glib-1-2 \
+    libgtk-3-0 \
+    libx11-xcb1 \
+    libasound2 \
+    libxtst6 \
+    wget
 
 # Install GeckoDriver WebDriver
 RUN wget https://github.com/mozilla/geckodriver/releases/download/${GECKODRIVER_VERSION}/geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz -O /tmp/geckodriver.tar.gz && \


### PR DESCRIPTION
### SUMMARY
The `chown -R` command causes the `/app` directory contents from previous `COPY`'s to be copied up to the current layer. This results in additional redundant image size.
By using `COPY --chown` we can reduce the image size by ~130 MB.

Also
- remove duplicate `COPY setup.py MANIFEST.in README.md /app/`
- adjust indentation
- fix `pip install` option from `--no-cache` to `--no-cache-dir`

### TESTING INSTRUCTIONS
`docker build -t superset --no-cache .`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
