### PR TITLE
fix(chart): chart updates are not retained

### DIFF
--- a/superset-frontend/cypress-base/cypress/e2e/explore/utils.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/explore/utils.ts
@@ -44,7 +44,10 @@ export function interceptExploreJson() {
 }
 
 export function interceptExploreGet() {
-  cy.intercept('GET', `/api/v1/explore/?slice_id=**`).as('getExplore');
+  cy.intercept({
+    method: 'GET',
+    url: /api\/v1\/explore\/\?(form_data_key|dashboard_page_id|slice_id)=.*/,
+  }).as('getExplore');
 }
 
 export function setFilter(filter: string, option: string) {

--- a/superset-frontend/spec/fixtures/mockDashboardFormData.ts
+++ b/superset-frontend/spec/fixtures/mockDashboardFormData.ts
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/* eslint-disable theme-colors/no-literal-colors */
+import { JsonObject } from '@superset-ui/core';
+
+export const getDashboardFormData = (overrides: JsonObject = {}) => ({
+  label_colors: {
+    Girls: '#FF69B4',
+    Boys: '#ADD8E6',
+    girl: '#FF69B4',
+    boy: '#ADD8E6',
+  },
+  shared_label_colors: {
+    boy: '#ADD8E6',
+    girl: '#FF69B4',
+  },
+  color_scheme: 'd3Category20b',
+  extra_filters: [
+    {
+      col: '__time_range',
+      op: '==',
+      val: 'No filter',
+    },
+    {
+      col: '__time_grain',
+      op: '==',
+      val: 'P1D',
+    },
+    {
+      col: '__time_col',
+      op: '==',
+      val: 'ds',
+    },
+  ],
+  extra_form_data: {
+    filters: [
+      {
+        col: 'name',
+        op: 'IN',
+        val: ['Aaron'],
+      },
+      {
+        col: 'num_boys',
+        op: '<=',
+        val: 10000,
+      },
+      {
+        col: {
+          sqlExpression: 'totally viable sql expression',
+          expressionType: 'SQL',
+          label: 'My column',
+        },
+        op: 'IN',
+        val: ['Value1', 'Value2'],
+      },
+    ],
+    granularity_sqla: 'ds',
+    time_range: 'Last month',
+    time_grain_sqla: 'PT1S',
+  },
+  dashboardId: 2,
+  ...overrides,
+});

--- a/superset-frontend/spec/fixtures/mockExploreFormData.ts
+++ b/superset-frontend/spec/fixtures/mockExploreFormData.ts
@@ -16,20 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+/* eslint-disable theme-colors/no-literal-colors */
 
 import { JsonObject } from '@superset-ui/core';
-import {
-  getDashboardFormData,
-  getExploreFormData,
-} from 'spec/fixtures/mockExploreFormData';
-import { getFormDataWithDashboardContext } from './getFormDataWithDashboardContext';
 
-const getExpectedResultFormData = (overrides: JsonObject = {}) => ({
+export const getExploreFormData = (overrides: JsonObject = {}) => ({
   adhoc_filters: [
     {
-      clause: 'WHERE',
-      expressionType: 'SIMPLE',
-      operator: 'IN',
+      clause: 'WHERE' as const,
+      expressionType: 'SIMPLE' as const,
+      operator: 'IN' as const,
       subject: 'gender',
       comparator: ['boys'],
       filterOptionName: '123',
@@ -53,40 +49,12 @@ const getExpectedResultFormData = (overrides: JsonObject = {}) => ({
       filterOptionName: '567',
     },
     {
-      clause: 'WHERE',
-      expressionType: 'SIMPLE',
-      operator: 'TEMPORAL_RANGE',
+      clause: 'WHERE' as const,
+      expressionType: 'SIMPLE' as const,
+      operator: 'TEMPORAL_RANGE' as const,
       subject: 'ds',
-      comparator: 'Last month',
-      filterOptionName: expect.any(String),
-      isExtra: true,
-    },
-    {
-      clause: 'WHERE',
-      expressionType: 'SIMPLE',
-      operator: 'IN',
-      operatorId: 'IN',
-      subject: 'name',
-      comparator: ['Aaron'],
-      isExtra: true,
-      filterOptionName: expect.any(String),
-    },
-    {
-      clause: 'WHERE',
-      expressionType: 'SIMPLE',
-      operator: '<=',
-      operatorId: 'LESS_THAN_OR_EQUAL',
-      subject: 'num_boys',
-      comparator: 10000,
-      isExtra: true,
-      filterOptionName: expect.any(String),
-    },
-    {
-      clause: 'WHERE',
-      expressionType: 'SQL',
-      sqlExpression: `(totally viable sql expression) IN ('Value1', 'Value2')`,
-      filterOptionName: expect.any(String),
-      isExtra: true,
+      comparator: 'No filter',
+      filterOptionName: '678',
     },
   ],
   adhoc_filters_b: [
@@ -97,41 +65,11 @@ const getExpectedResultFormData = (overrides: JsonObject = {}) => ({
       subject: null,
       comparator: null,
       sqlExpression: "country = 'Poland'",
-      filterOptionName: expect.any(String),
-    },
-    {
-      clause: 'WHERE',
-      expressionType: 'SIMPLE',
-      operator: 'IN',
-      operatorId: 'IN',
-      subject: 'name',
-      comparator: ['Aaron'],
-      isExtra: true,
-      filterOptionName: expect.any(String),
-    },
-    {
-      clause: 'WHERE',
-      expressionType: 'SIMPLE',
-      operator: '<=',
-      operatorId: 'LESS_THAN_OR_EQUAL',
-      subject: 'num_boys',
-      comparator: 10000,
-      isExtra: true,
-      filterOptionName: expect.any(String),
-    },
-    {
-      clause: 'WHERE',
-      expressionType: 'SQL',
-      sqlExpression: `(totally viable sql expression) IN ('Value1', 'Value2')`,
-      filterOptionName: expect.any(String),
-      isExtra: true,
+      filterOptionName: '789',
     },
   ],
-  applied_time_extras: {
-    __time_grain: 'P1D',
-    __time_col: 'ds',
-  },
-  color_scheme: 'd3Category20b',
+  applied_time_extras: {},
+  color_scheme: 'supersetColors',
   datasource: '2__table',
   granularity_sqla: 'ds',
   groupby: ['gender'],
@@ -145,8 +83,12 @@ const getExpectedResultFormData = (overrides: JsonObject = {}) => ({
     label: 'Births',
   },
   slice_id: 46,
-  time_range: 'Last month',
+  time_range: '100 years ago : now',
   viz_type: 'pie',
+  ...overrides,
+});
+
+export const getDashboardFormData = (overrides: JsonObject = {}) => ({
   label_colors: {
     Girls: '#FF69B4',
     Boys: '#ADD8E6',
@@ -157,6 +99,7 @@ const getExpectedResultFormData = (overrides: JsonObject = {}) => ({
     boy: '#ADD8E6',
     girl: '#FF69B4',
   },
+  color_scheme: 'd3Category20b',
   extra_filters: [
     {
       col: '__time_range',
@@ -188,9 +131,9 @@ const getExpectedResultFormData = (overrides: JsonObject = {}) => ({
       },
       {
         col: {
+          sqlExpression: 'totally viable sql expression',
           expressionType: 'SQL',
           label: 'My column',
-          sqlExpression: 'totally viable sql expression',
         },
         op: 'IN',
         val: ['Value1', 'Value2'],
@@ -201,18 +144,5 @@ const getExpectedResultFormData = (overrides: JsonObject = {}) => ({
     time_grain_sqla: 'PT1S',
   },
   dashboardId: 2,
-  time_grain_sqla: 'PT1S',
-  granularity: 'ds',
-  extras: {
-    time_grain_sqla: 'PT1S',
-  },
   ...overrides,
-});
-
-test('merges dashboard context form data with explore form data', () => {
-  const fullFormData = getFormDataWithDashboardContext(
-    getExploreFormData(),
-    getDashboardFormData(),
-  );
-  expect(fullFormData).toEqual(getExpectedResultFormData());
 });

--- a/superset-frontend/spec/fixtures/mockExploreFormData.ts
+++ b/superset-frontend/spec/fixtures/mockExploreFormData.ts
@@ -16,8 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-/* eslint-disable theme-colors/no-literal-colors */
-
 import { JsonObject } from '@superset-ui/core';
 
 export const getExploreFormData = (overrides: JsonObject = {}) => ({
@@ -85,64 +83,5 @@ export const getExploreFormData = (overrides: JsonObject = {}) => ({
   slice_id: 46,
   time_range: '100 years ago : now',
   viz_type: 'pie',
-  ...overrides,
-});
-
-export const getDashboardFormData = (overrides: JsonObject = {}) => ({
-  label_colors: {
-    Girls: '#FF69B4',
-    Boys: '#ADD8E6',
-    girl: '#FF69B4',
-    boy: '#ADD8E6',
-  },
-  shared_label_colors: {
-    boy: '#ADD8E6',
-    girl: '#FF69B4',
-  },
-  color_scheme: 'd3Category20b',
-  extra_filters: [
-    {
-      col: '__time_range',
-      op: '==',
-      val: 'No filter',
-    },
-    {
-      col: '__time_grain',
-      op: '==',
-      val: 'P1D',
-    },
-    {
-      col: '__time_col',
-      op: '==',
-      val: 'ds',
-    },
-  ],
-  extra_form_data: {
-    filters: [
-      {
-        col: 'name',
-        op: 'IN',
-        val: ['Aaron'],
-      },
-      {
-        col: 'num_boys',
-        op: '<=',
-        val: 10000,
-      },
-      {
-        col: {
-          sqlExpression: 'totally viable sql expression',
-          expressionType: 'SQL',
-          label: 'My column',
-        },
-        op: 'IN',
-        val: ['Value1', 'Value2'],
-      },
-    ],
-    granularity_sqla: 'ds',
-    time_range: 'Last month',
-    time_grain_sqla: 'PT1S',
-  },
-  dashboardId: 2,
   ...overrides,
 });

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -266,7 +266,9 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
 
       const searchParams = new URLSearchParams(window.location.search);
       searchParams.set('save_action', this.state.action);
-      searchParams.delete('form_data_key');
+      if (this.state.action !== 'overwrite') {
+        searchParams.delete('form_data_key');
+      }
       if (this.state.action === 'saveas') {
         searchParams.set('slice_id', value.id.toString());
       }

--- a/superset-frontend/src/explore/controlUtils/getFormDataFromDashboardContext.test.ts
+++ b/superset-frontend/src/explore/controlUtils/getFormDataFromDashboardContext.test.ts
@@ -18,10 +18,8 @@
  */
 
 import { JsonObject } from '@superset-ui/core';
-import {
-  getDashboardFormData,
-  getExploreFormData,
-} from 'spec/fixtures/mockExploreFormData';
+import { getExploreFormData } from 'spec/fixtures/mockExploreFormData';
+import { getDashboardFormData } from 'spec/fixtures/mockDashboardFormData';
 import { getFormDataWithDashboardContext } from './getFormDataWithDashboardContext';
 
 const getExpectedResultFormData = (overrides: JsonObject = {}) => ({

--- a/superset-frontend/src/pages/Chart/Chart.test.tsx
+++ b/superset-frontend/src/pages/Chart/Chart.test.tsx
@@ -27,10 +27,8 @@ import {
   screen,
   fireEvent,
 } from 'spec/helpers/testing-library';
-import {
-  getDashboardFormData,
-  getExploreFormData,
-} from 'spec/fixtures/mockExploreFormData';
+import { getExploreFormData } from 'spec/fixtures/mockExploreFormData';
+import { getDashboardFormData } from 'spec/fixtures/mockDashboardFormData';
 import { LocalStorageKeys } from 'src/utils/localStorageHelpers';
 import getFormDataWithExtraFilters from 'src/dashboard/util/charts/getFormDataWithExtraFilters';
 import { URL_PARAMS } from 'src/constants';

--- a/superset-frontend/src/pages/Chart/Chart.test.tsx
+++ b/superset-frontend/src/pages/Chart/Chart.test.tsx
@@ -1,0 +1,217 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import thunk from 'redux-thunk';
+import fetchMock from 'fetch-mock';
+import configureStore from 'redux-mock-store';
+import { Link } from 'react-router-dom';
+import {
+  render,
+  waitFor,
+  screen,
+  fireEvent,
+} from 'spec/helpers/testing-library';
+import {
+  getDashboardFormData,
+  getExploreFormData,
+} from 'spec/fixtures/mockExploreFormData';
+import { LocalStorageKeys } from 'src/utils/localStorageHelpers';
+import getFormDataWithExtraFilters from 'src/dashboard/util/charts/getFormDataWithExtraFilters';
+import { URL_PARAMS } from 'src/constants';
+
+import ChartPage from '.';
+
+jest.mock('src/explore/components/ExploreViewContainer', () => () => (
+  <div data-test="mock-explore-view-container" />
+));
+jest.mock('src/dashboard/util/charts/getFormDataWithExtraFilters');
+
+const mockStore = configureStore([thunk]);
+
+describe('ChartPage', () => {
+  afterEach(() => {
+    fetchMock.reset();
+  });
+
+  test('fetches metadata on mount', async () => {
+    const store = mockStore({
+      explore: {},
+    });
+    const exploreApiRoute = 'glob:*/api/v1/explore/*';
+    const exploreFormData = getExploreFormData({
+      viz_type: 'table',
+      show_cell_bars: true,
+    });
+    fetchMock.get(exploreApiRoute, {
+      result: { dataset: { id: 1 }, form_data: exploreFormData },
+    });
+    const { getByTestId } = render(<ChartPage />, {
+      useRouter: true,
+      useRedux: true,
+      store,
+    });
+    await waitFor(() =>
+      expect(fetchMock.calls(exploreApiRoute).length).toBe(1),
+    );
+    expect(getByTestId('mock-explore-view-container')).toBeInTheDocument();
+    expect(store.getActions()).toContainEqual({
+      type: 'HYDRATE_EXPLORE',
+      data: expect.objectContaining({
+        explore: expect.objectContaining({
+          form_data: expect.objectContaining({
+            show_cell_bars: true,
+          }),
+        }),
+      }),
+    });
+  });
+
+  describe('with dashboardContextFormData', () => {
+    const dashboardPageId = 'mockPageId';
+
+    beforeEach(() => {
+      localStorage.setItem(
+        LocalStorageKeys.dashboard__explore_context,
+        JSON.stringify({
+          [dashboardPageId]: {},
+        }),
+      );
+    });
+
+    afterEach(() => {
+      localStorage.clear();
+      (getFormDataWithExtraFilters as jest.Mock).mockClear();
+    });
+
+    test('overrides the form_data with dashboardContextFormData', async () => {
+      const store = mockStore({
+        explore: {},
+      });
+      const dashboardFormData = getDashboardFormData();
+      (getFormDataWithExtraFilters as jest.Mock).mockReturnValue(
+        dashboardFormData,
+      );
+      const exploreApiRoute = 'glob:*/api/v1/explore/*';
+      const exploreFormData = getExploreFormData();
+      fetchMock.get(exploreApiRoute, {
+        result: { dataset: { id: 1 }, form_data: exploreFormData },
+      });
+      window.history.pushState(
+        {},
+        '',
+        `/?${URL_PARAMS.dashboardPageId.name}=${dashboardPageId}`,
+      );
+      render(<ChartPage />, {
+        useRouter: true,
+        useRedux: true,
+        store,
+      });
+      await waitFor(() =>
+        expect(fetchMock.calls(exploreApiRoute).length).toBe(1),
+      );
+      expect(store.getActions()).toContainEqual({
+        type: 'HYDRATE_EXPLORE',
+        data: expect.objectContaining({
+          explore: expect.objectContaining({
+            form_data: expect.objectContaining({
+              color_scheme: dashboardFormData.color_scheme,
+            }),
+          }),
+        }),
+      });
+    });
+
+    test('overrides the form_data with exploreFormData when location is updated', async () => {
+      const store = mockStore({
+        explore: {},
+      });
+      const dashboardFormData = {
+        ...getDashboardFormData(),
+        viz_type: 'table',
+        show_cell_bars: true,
+      };
+      (getFormDataWithExtraFilters as jest.Mock).mockReturnValue(
+        dashboardFormData,
+      );
+      const exploreApiRoute = 'glob:*/api/v1/explore/*';
+      const exploreFormData = getExploreFormData({
+        viz_type: 'table',
+        show_cell_bars: true,
+      });
+      fetchMock.get(exploreApiRoute, {
+        result: { dataset: { id: 1 }, form_data: exploreFormData },
+      });
+      window.history.pushState(
+        {},
+        '',
+        `/?${URL_PARAMS.dashboardPageId.name}=${dashboardPageId}`,
+      );
+      render(
+        <>
+          <Link
+            to={`/?${URL_PARAMS.dashboardPageId.name}=${dashboardPageId}&${URL_PARAMS.saveAction.name}=overwrite`}
+          >
+            Change route
+          </Link>
+          <ChartPage />
+        </>,
+        {
+          useRouter: true,
+          useRedux: true,
+          store,
+        },
+      );
+      await waitFor(() =>
+        expect(fetchMock.calls(exploreApiRoute).length).toBe(1),
+      );
+      expect(store.getActions()).toContainEqual({
+        type: 'HYDRATE_EXPLORE',
+        data: expect.objectContaining({
+          explore: expect.objectContaining({
+            form_data: expect.objectContaining({
+              show_cell_bars: dashboardFormData.show_cell_bars,
+            }),
+          }),
+        }),
+      });
+      const updatedExploreFormData = {
+        ...exploreFormData,
+        show_cell_bars: false,
+      };
+      fetchMock.reset();
+      fetchMock.get(exploreApiRoute, {
+        result: { dataset: { id: 1 }, form_data: updatedExploreFormData },
+      });
+      fireEvent.click(screen.getByText('Change route'));
+      await waitFor(() =>
+        expect(fetchMock.calls(exploreApiRoute).length).toBe(1),
+      );
+      expect(store.getActions()).toContainEqual({
+        type: 'HYDRATE_EXPLORE',
+        data: expect.objectContaining({
+          explore: expect.objectContaining({
+            form_data: expect.objectContaining({
+              show_cell_bars: updatedExploreFormData.show_cell_bars,
+            }),
+          }),
+        }),
+      });
+    });
+  });
+});

--- a/superset-frontend/src/pages/Chart/index.tsx
+++ b/superset-frontend/src/pages/Chart/index.tsx
@@ -129,12 +129,13 @@ export default function ExplorePage() {
     if (!isExploreInitialized.current || !!saveAction) {
       fetchExploreData(exploreUrlParams)
         .then(({ result }) => {
-          const formData = dashboardContextFormData
-            ? getFormDataWithDashboardContext(
-                result.form_data,
-                dashboardContextFormData,
-              )
-            : result.form_data;
+          const formData =
+            !isExploreInitialized.current && dashboardContextFormData
+              ? getFormDataWithDashboardContext(
+                  result.form_data,
+                  dashboardContextFormData,
+                )
+              : result.form_data;
           dispatch(
             hydrateExplore({
               ...result,


### PR DESCRIPTION
### SUMMARY
When a table chart saved on a dashboard and edited from the dashboard, the table reloads in the edit view and the updated option returns to the previous setting.
This bug is a regression of [#20498](https://github.com/apache/superset/pull/20498/files#diff-d682f497999ba5051d4e8efe3a9a7c06d9cc97026e134d5f2eddcffe1e902f78R51), which reloads the fetchExploreData but always overrides it with the dashboardContext (which retains the original settings).

This hotfix adds the condition of overwrite saving to retrieve the changes from updated exploreFormData.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

- After:

https://user-images.githubusercontent.com/1392866/230680771-e68eae52-5710-42fd-a044-d9d57eae254a.mov

- Before:

https://user-images.githubusercontent.com/1392866/230680765-2369dc46-97ce-4c25-bd3a-c103f35acad8.mov

### TESTING INSTRUCTIONS

1. Create a new Table chart
2. Save and publish the chart to a dashboard
3. Open the dashboard, and click "Edit" on the chart from the dashboard
4. Go to "Customize" and uncheck "Cell Bars"
5. Click save. The Cell Bars option returns to checked after saving.
6. Exit and go to the "Charts" list in Superset
7. Open your saved chart from the Charts list directly
8. Go to "Customize" and uncheck "Cell Bars"
9. Click save. The Cell Bars option retains the unchecked state


### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @michael-s-molina @ktmud cc: @john-bodley 