### PR TITLE
fix: warning of nth-child

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/src/ReactParallelCoordinates.jsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/src/ReactParallelCoordinates.jsx
@@ -106,7 +106,7 @@ export default styled(ParallelCoordinates)`
       height: 18px;
       margin: 0px;
     }
-    .parcoords .row:nth-child(odd) {
+    .parcoords .row:nth-of-type(odd) {
       background: ${addAlpha(theme.colors.grayscale.dark2, 0.05)};
     }
     .parcoords .header {

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/ReactNVD3.jsx
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/ReactNVD3.jsx
@@ -152,7 +152,7 @@ export default styled(NVD3)`
       white-space: nowrap;
       font-weight: ${({ theme }) => theme.typography.weights.bold};
     }
-    tbody tr:not(.tooltip-header) td:nth-child(2) {
+    tbody tr:not(.tooltip-header) td:nth-of-type(2) {
       word-break: break-word;
     }
   }

--- a/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/index.tsx
@@ -44,7 +44,7 @@ const SaveDatasetActionButton = ({
       font-weight: ${theme.gridUnit * 150};
       background-color: ${theme.colors.primary.light4};
       color: ${theme.colors.primary.dark1};
-      &:nth-child(2) {
+      &:nth-of-type(2) {
         &:before,
         &:hover:before {
           border-left: 2px solid ${theme.colors.primary.dark2};

--- a/superset-frontend/src/components/ButtonGroup/index.tsx
+++ b/superset-frontend/src/components/ButtonGroup/index.tsx
@@ -30,18 +30,18 @@ export default function ButtonGroup(props: ButtonGroupProps) {
       role="group"
       className={className}
       css={{
-        '& :nth-child(1):not(:nth-last-child(1))': {
+        '& :nth-of-type(1):not(:nth-last-of-type(1))': {
           borderTopRightRadius: 0,
           borderBottomRightRadius: 0,
           borderRight: 0,
           marginLeft: 0,
         },
-        '& :not(:nth-child(1)):not(:nth-last-child(1))': {
+        '& :not(:nth-of-type(1)):not(:nth-last-of-type(1))': {
           borderRadius: 0,
           borderRight: 0,
           marginLeft: 0,
         },
-        '& :nth-last-child(1):not(:nth-child(1))': {
+        '& :nth-last-of-type(1):not(:nth-of-type(1))': {
           borderTopLeftRadius: 0,
           borderBottomLeftRadius: 0,
           marginLeft: 0,

--- a/superset-frontend/src/components/DropdownButton/index.tsx
+++ b/superset-frontend/src/components/DropdownButton/index.tsx
@@ -42,7 +42,7 @@ const StyledDropdownButton = styled.div`
         background-color: ${({ theme }) => theme.colors.grayscale.light2};
         color: ${({ theme }) => theme.colors.grayscale.base};
       }
-      &:nth-child(2) {
+      &:nth-of-type(2) {
         margin: 0;
         border-radius: ${({ theme }) =>
           `0 ${theme.gridUnit}px ${theme.gridUnit}px 0`};

--- a/superset-frontend/src/components/DropdownSelectableIcon/index.tsx
+++ b/superset-frontend/src/components/DropdownSelectableIcon/index.tsx
@@ -46,7 +46,7 @@ const StyledDropdownButton = styled(
   button.ant-btn:first-of-type {
     display: none;
   }
-  > button.ant-btn:nth-child(2) {
+  > button.ant-btn:nth-of-type(2) {
     display: inline-flex;
     background-color: transparent !important;
     height: unset;


### PR DESCRIPTION
### SUMMARY
This commit replaces the `nth-child` css selector by `nth-of-type-` selector to fix the SSR warning.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After:
<img width="661" alt="Screenshot 2023-04-10 at 10 36 38 AM" src="https://user-images.githubusercontent.com/1392866/230958740-cfa5d275-36d8-4eae-a6cc-f890759318cb.png">

Before:

<img width="647" alt="Screenshot_2023-04-10_at_10_28_48_AM" src="https://user-images.githubusercontent.com/1392866/230958921-5d16ca37-7e61-42c6-b483-29adf57bccb5.png">


### TESTING INSTRUCTIONS
Go to SqlLab and open the developer console
Check the warning message

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
