### PR TITLE
fix: url_params cache miss with global async query

### DIFF
--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -21,7 +21,7 @@ import logging
 from typing import Any, Dict, Optional, TYPE_CHECKING, Union
 
 import simplejson
-from flask import current_app, make_response, request, Response
+from flask import current_app, g, make_response, request, Response
 from flask_appbuilder.api import expose, protect
 from flask_babel import gettext as _
 from marshmallow import ValidationError
@@ -299,6 +299,9 @@ class ChartDataRestApi(ChartRestApi):
         """
         try:
             cached_data = self._load_query_context_form_from_cache(cache_key)
+            # Set form_data in Flask Global as it is used as a fallback
+            # for async queries with jinja context
+            setattr(g, "form_data", cached_data)
             query_context = self._create_query_context_from_form(cached_data)
             command = ChartDataCommand(query_context)
             command.validate()

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -583,7 +583,9 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
             form_data = cached.get("form_data")
             response_type = cached.get("response_type")
-
+            # Set form_data in Flask Global as it is used as a fallback
+            # for async queries with jinja context
+            setattr(g, "form_data", form_data)
             datasource_id, datasource_type = get_datasource_info(None, None, form_data)
 
             viz_obj = get_viz(


### PR DESCRIPTION


<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes initial cache miss when global async queries are used. 

Currently, whenever a Jinja context is used in a query such as `url_params` with async queries enabled, a call to [get_form_data](https://github.com/apache/superset/blob/2.1/superset/jinja_context.py#L195) is made. `form_data` which has the url_params is used to generate extra cache keys. Right now, form_data is empty as there is no request context in async queries. This means that we are always encountering a cache miss on the first query. 

Since async queries won't have request context, we need to fallback to setting Flask global. https://github.com/apache/superset/blob/master/superset/views/utils.py#L182

### BEFORE/AFTER SCREENSHOTS OR 
BEFORE

https://user-images.githubusercontent.com/19199254/231020152-a95035bb-fd15-4f9c-adfe-53f44dbe3f7b.mov



AFTER

https://user-images.githubusercontent.com/19199254/231018854-2ad51ab0-dc99-44c9-8475-74908034f800.mov


<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: https://github.com/apache/superset/issues/16650
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
