### PR TITLE
feat(plugin-chart-echarts): add x-axis sort to multi series

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/constants.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/constants.ts
@@ -59,7 +59,7 @@ export const QueryModeLabel = {
 };
 
 export const DEFAULT_SORT_SERIES_DATA: SortSeriesData = {
-  sort_series_type: SortSeriesType.Name,
+  sort_series_type: SortSeriesType.Sum,
   sort_series_ascending: false,
 };
 
@@ -70,3 +70,8 @@ export const SORT_SERIES_CHOICES = [
   [SortSeriesType.Max, t('Maximum value')],
   [SortSeriesType.Avg, t('Average value')],
 ];
+
+export const DEFAULT_XAXIS_SORT_SERIES_DATA: SortSeriesData = {
+  sort_series_type: SortSeriesType.Name,
+  sort_series_ascending: true,
+};

--- a/superset-frontend/packages/superset-ui-chart-controls/src/constants.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/constants.ts
@@ -24,7 +24,7 @@ import {
   QueryColumn,
   DatasourceType,
 } from '@superset-ui/core';
-import { ColumnMeta } from './types';
+import { ColumnMeta, SortSeriesData, SortSeriesType } from './types';
 
 // eslint-disable-next-line import/prefer-default-export
 export const TIME_FILTER_LABELS = {
@@ -57,3 +57,16 @@ export const QueryModeLabel = {
   [QueryMode.aggregate]: t('Aggregate'),
   [QueryMode.raw]: t('Raw records'),
 };
+
+export const DEFAULT_SORT_SERIES_DATA: SortSeriesData = {
+  sort_series_type: SortSeriesType.Sum,
+  sort_series_ascending: false,
+};
+
+export const SORT_SERIES_CHOICES = [
+  [SortSeriesType.Name, t('Category name')],
+  [SortSeriesType.Sum, t('Total value')],
+  [SortSeriesType.Min, t('Minimum value')],
+  [SortSeriesType.Max, t('Maximum value')],
+  [SortSeriesType.Avg, t('Average value')],
+];

--- a/superset-frontend/packages/superset-ui-chart-controls/src/constants.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/constants.ts
@@ -59,7 +59,7 @@ export const QueryModeLabel = {
 };
 
 export const DEFAULT_SORT_SERIES_DATA: SortSeriesData = {
-  sort_series_type: SortSeriesType.Sum,
+  sort_series_type: SortSeriesType.Name,
   sort_series_ascending: false,
 };
 

--- a/superset-frontend/packages/superset-ui-chart-controls/src/sections/echartsTimeSeriesQuery.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/sections/echartsTimeSeriesQuery.tsx
@@ -22,6 +22,7 @@ import {
   contributionModeControl,
   xAxisSortControl,
   xAxisSortAscControl,
+  xAxisSortSeriesControl,
 } from '../shared-controls';
 
 const controlsWithoutXAxis: ControlSetRow[] = [
@@ -54,6 +55,7 @@ export const echartsTimeSeriesQueryWithXAxisSort: ControlPanelSectionConfig = {
     [hasGenericChartAxes ? 'x_axis' : null],
     [hasGenericChartAxes ? 'time_grain_sqla' : null],
     [hasGenericChartAxes ? xAxisSortControl : null],
+    [hasGenericChartAxes ? xAxisSortSeriesControl : null],
     [hasGenericChartAxes ? xAxisSortAscControl : null],
     ...controlsWithoutXAxis,
   ],

--- a/superset-frontend/packages/superset-ui-chart-controls/src/sections/echartsTimeSeriesQuery.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/sections/echartsTimeSeriesQuery.tsx
@@ -20,8 +20,9 @@ import { hasGenericChartAxes, t } from '@superset-ui/core';
 import { ControlPanelSectionConfig, ControlSetRow } from '../types';
 import {
   contributionModeControl,
-  xAxisSortControl,
   xAxisSortAscControl,
+  xAxisSortControl,
+  xAxisSortSeriesAscendingControl,
   xAxisSortSeriesControl,
 } from '../shared-controls';
 
@@ -55,8 +56,9 @@ export const echartsTimeSeriesQueryWithXAxisSort: ControlPanelSectionConfig = {
     [hasGenericChartAxes ? 'x_axis' : null],
     [hasGenericChartAxes ? 'time_grain_sqla' : null],
     [hasGenericChartAxes ? xAxisSortControl : null],
-    [hasGenericChartAxes ? xAxisSortSeriesControl : null],
     [hasGenericChartAxes ? xAxisSortAscControl : null],
+    [hasGenericChartAxes ? xAxisSortSeriesControl : null],
+    [hasGenericChartAxes ? xAxisSortSeriesAscendingControl : null],
     ...controlsWithoutXAxis,
   ],
 };

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
@@ -34,7 +34,10 @@ import {
   isDataset,
 } from '../types';
 import { isTemporalColumn } from '../utils';
-import { DEFAULT_SORT_SERIES_DATA, SORT_SERIES_CHOICES } from '../constants';
+import {
+  DEFAULT_XAXIS_SORT_SERIES_DATA,
+  SORT_SERIES_CHOICES,
+} from '../constants';
 
 export const contributionModeControl = {
   name: 'contributionMode',
@@ -150,7 +153,7 @@ export const xAxisSortSeriesControl = {
         ? t('Y-Axis Sort By')
         : t('X-Axis Sort By'),
     choices: SORT_SERIES_CHOICES,
-    default: DEFAULT_SORT_SERIES_DATA.sort_series_type,
+    default: DEFAULT_XAXIS_SORT_SERIES_DATA.sort_series_type,
     renderTrigger: true,
     description: t('Decides which measure to sort the base axis by.'),
     visibility: xAxisMultiSortVisibility,
@@ -165,7 +168,7 @@ export const xAxisSortSeriesAscendingControl = {
       state.form_data?.orientation === 'horizontal'
         ? t('Y-Axis Sort Ascending')
         : t('X-Axis Sort Ascending'),
-    default: true,
+    default: DEFAULT_XAXIS_SORT_SERIES_DATA.sort_series_ascending,
     description: t('Whether to sort ascending or descending on the base Axis.'),
     renderTrigger: true,
     visibility: xAxisMultiSortVisibility,

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
@@ -152,7 +152,7 @@ export const xAxisSortSeriesControl = {
     choices: SORT_SERIES_CHOICES,
     default: DEFAULT_SORT_SERIES_DATA.sort_series_type,
     renderTrigger: true,
-    description: t('Decides which value to sort the base axis by.'),
+    description: t('Decides which measure to sort the base axis by.'),
     visibility: xAxisMultiSortVisibility,
   },
 };

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
@@ -34,6 +34,7 @@ import {
   isDataset,
 } from '../types';
 import { isTemporalColumn } from '../utils';
+import { DEFAULT_SORT_SERIES_DATA, SORT_SERIES_CHOICES } from '../constants';
 
 export const contributionModeControl = {
   name: 'contributionMode',
@@ -58,6 +59,30 @@ const xAxisSortVisibility = ({ controls }: { controls: ControlStateMapping }) =>
   ) &&
   Array.isArray(controls?.groupby?.value) &&
   controls.groupby.value.length === 0;
+
+const xAxisSortAscVisibility = ({
+  controls,
+}: {
+  controls: ControlStateMapping;
+}) =>
+  isDefined(controls?.x_axis?.value) &&
+  !isTemporalColumn(
+    getColumnLabel(controls?.x_axis?.value as QueryFormColumn),
+    controls?.datasource?.datasource,
+  );
+
+const xAxisMultiSortVisibility = ({
+  controls,
+}: {
+  controls: ControlStateMapping;
+}) =>
+  isDefined(controls?.x_axis?.value) &&
+  !isTemporalColumn(
+    getColumnLabel(controls?.x_axis?.value as QueryFormColumn),
+    controls?.datasource?.datasource,
+  ) &&
+  Array.isArray(controls?.groupby?.value) &&
+  !!controls.groupby.value.length;
 
 export const xAxisSortControl = {
   name: 'x_axis_sort',
@@ -122,6 +147,23 @@ export const xAxisSortAscControl = {
         : t('X-Axis Sort Ascending'),
     default: true,
     description: t('Whether to sort ascending or descending on the base Axis.'),
-    visibility: xAxisSortVisibility,
+    visibility: xAxisSortAscVisibility,
+  },
+};
+
+export const xAxisSortSeriesControl = {
+  name: 'x_axis_sort_series',
+  config: {
+    type: 'SelectControl',
+    freeForm: false,
+    label: (state: ControlPanelState) =>
+      state.form_data?.orientation === 'horizontal'
+        ? t('Y-Axis Sort By')
+        : t('X-Axis Sort By'),
+    choices: SORT_SERIES_CHOICES,
+    default: DEFAULT_SORT_SERIES_DATA.sort_series_type,
+    renderTrigger: true,
+    description: t('Decides which value to sort the base axis by.'),
+    visibility: xAxisMultiSortVisibility,
   },
 };

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
@@ -60,17 +60,6 @@ const xAxisSortVisibility = ({ controls }: { controls: ControlStateMapping }) =>
   Array.isArray(controls?.groupby?.value) &&
   controls.groupby.value.length === 0;
 
-const xAxisSortAscVisibility = ({
-  controls,
-}: {
-  controls: ControlStateMapping;
-}) =>
-  isDefined(controls?.x_axis?.value) &&
-  !isTemporalColumn(
-    getColumnLabel(controls?.x_axis?.value as QueryFormColumn),
-    controls?.datasource?.datasource,
-  );
-
 const xAxisMultiSortVisibility = ({
   controls,
 }: {
@@ -147,7 +136,7 @@ export const xAxisSortAscControl = {
         : t('X-Axis Sort Ascending'),
     default: true,
     description: t('Whether to sort ascending or descending on the base Axis.'),
-    visibility: xAxisSortAscVisibility,
+    visibility: xAxisSortVisibility,
   },
 };
 
@@ -164,6 +153,21 @@ export const xAxisSortSeriesControl = {
     default: DEFAULT_SORT_SERIES_DATA.sort_series_type,
     renderTrigger: true,
     description: t('Decides which value to sort the base axis by.'),
+    visibility: xAxisMultiSortVisibility,
+  },
+};
+
+export const xAxisSortSeriesAscendingControl = {
+  name: 'x_axis_sort_series_ascending',
+  config: {
+    type: 'CheckboxControl',
+    label: (state: ControlPanelState) =>
+      state.form_data?.orientation === 'horizontal'
+        ? t('Y-Axis Sort Ascending')
+        : t('X-Axis Sort Ascending'),
+    default: true,
+    description: t('Whether to sort ascending or descending on the base Axis.'),
+    renderTrigger: true,
     visibility: xAxisMultiSortVisibility,
   },
 };

--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -481,3 +481,16 @@ export function isQueryResponse(
 ): datasource is QueryResponse {
   return !!datasource && 'results' in datasource && 'sql' in datasource;
 }
+
+export enum SortSeriesType {
+  Name = 'name',
+  Max = 'max',
+  Min = 'min',
+  Sum = 'sum',
+  Avg = 'avg',
+}
+
+export type SortSeriesData = {
+  sort_series_type: SortSeriesType;
+  sort_series_ascending: boolean;
+};

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/constants.ts
@@ -16,7 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { sections } from '@superset-ui/chart-controls';
+import {
+  DEFAULT_SORT_SERIES_DATA,
+  sections,
+} from '@superset-ui/chart-controls';
 import { t } from '@superset-ui/core';
 import {
   OrientationType,
@@ -25,7 +28,6 @@ import {
 } from './types';
 import {
   DEFAULT_LEGEND_FORM_DATA,
-  DEFAULT_SORT_SERIES_DATA,
   DEFAULT_TITLE_FORM_DATA,
 } from '../constants';
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -146,6 +146,8 @@ export default function transformProps(
     truncateYAxis,
     xAxis: xAxisOrig,
     xAxisLabelRotation,
+    xAxisSortSeries,
+    xAxisSortSeriesAscending,
     xAxisTimeFormat,
     xAxisTitle,
     xAxisTitleMargin,
@@ -200,6 +202,8 @@ export default function transformProps(
     isHorizontal,
     sortSeriesType,
     sortSeriesAscending,
+    xAxisSortSeries,
+    xAxisSortSeriesAscending,
   });
   const showValueIndexes = extractShowValueIndexes(rawSeries, {
     stack,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -202,8 +202,10 @@ export default function transformProps(
     isHorizontal,
     sortSeriesType,
     sortSeriesAscending,
-    xAxisSortSeries,
-    xAxisSortSeriesAscending,
+    xAxisSortSeries: groupby.length ? xAxisSortSeries : undefined,
+    xAxisSortSeriesAscending: groupby.length
+      ? xAxisSortSeriesAscending
+      : undefined,
   });
   const showValueIndexes = extractShowValueIndexes(rawSeries, {
     stack,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
@@ -24,8 +24,6 @@ import {
   LegendFormData,
   LegendOrientation,
   LegendType,
-  SortSeriesData,
-  SortSeriesType,
   TitleFormData,
 } from './types';
 
@@ -122,8 +120,3 @@ export const TOOLTIP_POINTER_MARGIN = 10;
 // If no satisfactory position can be found, how far away
 // from the edge of the window should the tooltip be kept
 export const TOOLTIP_OVERFLOW_MARGIN = 5;
-
-export const DEFAULT_SORT_SERIES_DATA: SortSeriesData = {
-  sort_series_type: SortSeriesType.Sum,
-  sort_series_ascending: false,
-};

--- a/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
@@ -22,15 +22,12 @@ import {
   ControlPanelsContainerProps,
   ControlSetItem,
   ControlSetRow,
+  DEFAULT_SORT_SERIES_DATA,
+  SORT_SERIES_CHOICES,
   sharedControls,
 } from '@superset-ui/chart-controls';
-import {
-  DEFAULT_LEGEND_FORM_DATA,
-  DEFAULT_SORT_SERIES_DATA,
-  StackControlOptions,
-} from './constants';
+import { DEFAULT_LEGEND_FORM_DATA, StackControlOptions } from './constants';
 import { DEFAULT_FORM_DATA } from './Timeseries/constants';
-import { SortSeriesType } from './types';
 
 const { legendMargin, legendOrientation, legendType, showLegend } =
   DEFAULT_LEGEND_FORM_DATA;
@@ -225,13 +222,7 @@ const sortSeriesType: ControlSetItem = {
     type: 'SelectControl',
     freeForm: false,
     label: t('Sort Series By'),
-    choices: [
-      [SortSeriesType.Name, t('Category name')],
-      [SortSeriesType.Sum, t('Total value')],
-      [SortSeriesType.Min, t('Minimum value')],
-      [SortSeriesType.Max, t('Maximum value')],
-      [SortSeriesType.Avg, t('Average value')],
-    ],
+    choices: SORT_SERIES_CHOICES,
     default: DEFAULT_SORT_SERIES_DATA.sort_series_type,
     renderTrigger: true,
     description: t(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/types.ts
@@ -167,17 +167,4 @@ export interface TreePathInfo {
   value: number | number[];
 }
 
-export enum SortSeriesType {
-  Name = 'name',
-  Max = 'max',
-  Min = 'min',
-  Sum = 'sum',
-  Avg = 'avg',
-}
-
-export type SortSeriesData = {
-  sort_series_type: SortSeriesType;
-  sort_series_ascending: boolean;
-};
-
 export * from './Timeseries/types';

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -30,6 +30,7 @@ import {
   AxisType,
   SupersetTheme,
 } from '@superset-ui/core';
+import { SortSeriesType } from '@superset-ui/chart-controls';
 import { format, LegendComponentOption, SeriesOption } from 'echarts';
 import { sumBy, meanBy, minBy, maxBy, orderBy } from 'lodash';
 import {
@@ -37,12 +38,7 @@ import {
   NULL_STRING,
   TIMESERIES_CONSTANTS,
 } from '../constants';
-import {
-  LegendOrientation,
-  LegendType,
-  SortSeriesType,
-  StackType,
-} from '../types';
+import { LegendOrientation, LegendType, StackType } from '../types';
 import { defaultLegendPadding } from '../defaults';
 
 function isDefined<T>(value: T | undefined | null): boolean {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -18,6 +18,7 @@
  * under the License.
  */
 import {
+  AxisType,
   ChartDataResponseResult,
   DataRecord,
   DataRecordValue,
@@ -27,15 +28,14 @@ import {
   NumberFormats,
   NumberFormatter,
   TimeFormatter,
-  AxisType,
   SupersetTheme,
 } from '@superset-ui/core';
 import { SortSeriesType } from '@superset-ui/chart-controls';
 import { format, LegendComponentOption, SeriesOption } from 'echarts';
-import { sumBy, meanBy, minBy, maxBy, orderBy } from 'lodash';
+import { maxBy, meanBy, minBy, orderBy, sumBy } from 'lodash';
 import {
-  StackControlsValue,
   NULL_STRING,
+  StackControlsValue,
   TIMESERIES_CONSTANTS,
 } from '../constants';
 import { LegendOrientation, LegendType, StackType } from '../types';
@@ -151,6 +151,70 @@ export function sortAndFilterSeries(
   ).map(({ name }) => name);
 }
 
+export function sortRows(
+  rows: DataRecord[],
+  xAxis: string,
+  xAxisSortSeries: SortSeriesType,
+  xAxisSortSeriesAscending: boolean,
+) {
+  const sortedRows = rows.map(row => {
+    let sortKey: DataRecordValue = '';
+    let aggregate = 0;
+    let entries = 0;
+    Object.entries(row).forEach(([key, value]) => {
+      if (key === xAxis) {
+        sortKey = value;
+      }
+      if (
+        xAxisSortSeries === SortSeriesType.Name ||
+        typeof value !== 'number'
+      ) {
+        return;
+      }
+
+      if (!(xAxisSortSeries === SortSeriesType.Avg && !isDefined(value))) {
+        entries += 1;
+      }
+
+      switch (xAxisSortSeries) {
+        case SortSeriesType.Avg:
+        case SortSeriesType.Sum:
+          aggregate += value;
+          break;
+        case SortSeriesType.Min:
+          aggregate = aggregate < value ? aggregate : value;
+          break;
+        case SortSeriesType.Max:
+          aggregate = aggregate > value ? aggregate : value;
+          break;
+        default:
+          break;
+      }
+    });
+    if (xAxisSortSeries === SortSeriesType.Avg && entries > 0) {
+      aggregate /= entries;
+    }
+
+    const value =
+      xAxisSortSeries === SortSeriesType.Name && typeof sortKey === 'string'
+        ? sortKey.toLowerCase()
+        : aggregate;
+
+    return {
+      key: sortKey,
+      value,
+      row,
+    };
+  });
+  console.log('!!!', sortedRows);
+
+  return orderBy(
+    sortedRows,
+    ['value'],
+    [xAxisSortSeriesAscending ? 'asc' : 'desc'],
+  ).map(({ row }) => row);
+}
+
 export function extractSeries(
   data: DataRecord[],
   opts: {
@@ -163,6 +227,8 @@ export function extractSeries(
     isHorizontal?: boolean;
     sortSeriesType?: SortSeriesType;
     sortSeriesAscending?: boolean;
+    xAxisSortSeries?: SortSeriesType;
+    xAxisSortSeriesAscending?: boolean;
   } = {},
 ): SeriesOption[] {
   const {
@@ -175,24 +241,30 @@ export function extractSeries(
     isHorizontal = false,
     sortSeriesType,
     sortSeriesAscending,
+    xAxisSortSeries,
+    xAxisSortSeriesAscending,
   } = opts;
   if (data.length === 0) return [];
   const rows: DataRecord[] = data.map(datum => ({
     ...datum,
     [xAxis]: datum[xAxis],
   }));
-  const series = sortAndFilterSeries(
+  const sortedSeries = sortAndFilterSeries(
     rows,
     xAxis,
     extraMetricLabels,
     sortSeriesType,
     sortSeriesAscending,
   );
+  const sortedRows =
+    isDefined(xAxisSortSeries) && isDefined(xAxisSortSeriesAscending)
+      ? sortRows(rows, xAxis, xAxisSortSeries!, xAxisSortSeriesAscending!)
+      : rows;
 
-  return series.map(name => ({
+  return sortedSeries.map(name => ({
     id: name,
     name,
-    data: rows
+    data: sortedRows
       .map((row, idx) => {
         const isNextToDefinedValue =
           isDefined(rows[idx - 1]?.[name]) || isDefined(rows[idx + 1]?.[name]);

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { SortSeriesType } from '@superset-ui/chart-controls';
 import {
   DataRecord,
   getNumberFormatter,
@@ -33,8 +34,9 @@ import {
   getOverMaxHiddenFormatter,
   sanitizeHtml,
   sortAndFilterSeries,
+  sortRows,
 } from '../../src/utils/series';
-import { LegendOrientation, LegendType, SortSeriesType } from '../../src/types';
+import { LegendOrientation, LegendType } from '../../src/types';
 import { defaultLegendPadding } from '../../src/defaults';
 import { NULL_STRING } from '../../src/constants';
 
@@ -48,42 +50,149 @@ const expectedThemeProps = {
   },
 };
 
-test('sortAndFilterSeries', () => {
-  const data: DataRecord[] = [
+const sortData: DataRecord[] = [
+  { my_x_axis: 'abc', x: 1, y: 0, z: 2 },
+  { my_x_axis: 'foo', x: null, y: 10, z: 5 },
+  { my_x_axis: null, x: 4, y: 3, z: 7 },
+];
+
+test('sortRows by name ascending', () => {
+  expect(sortRows(sortData, 'my_x_axis', SortSeriesType.Name, true)).toEqual([
     { my_x_axis: 'abc', x: 1, y: 0, z: 2 },
     { my_x_axis: 'foo', x: null, y: 10, z: 5 },
     { my_x_axis: null, x: 4, y: 3, z: 7 },
-  ];
+  ]);
+});
 
+test('sortRows by name descending', () => {
+  expect(sortRows(sortData, 'my_x_axis', SortSeriesType.Name, false)).toEqual([
+    { my_x_axis: null, x: 4, y: 3, z: 7 },
+    { my_x_axis: 'foo', x: null, y: 10, z: 5 },
+    { my_x_axis: 'abc', x: 1, y: 0, z: 2 },
+  ]);
+});
+
+test('sortRows by sum ascending', () => {
+  expect(sortRows(sortData, 'my_x_axis', SortSeriesType.Sum, true)).toEqual([
+    { my_x_axis: 'abc', x: 1, y: 0, z: 2 },
+    { my_x_axis: null, x: 4, y: 3, z: 7 },
+    { my_x_axis: 'foo', x: null, y: 10, z: 5 },
+  ]);
+});
+
+test('sortRows by sum descending', () => {
+  expect(sortRows(sortData, 'my_x_axis', SortSeriesType.Sum, false)).toEqual([
+    { my_x_axis: 'foo', x: null, y: 10, z: 5 },
+    { my_x_axis: null, x: 4, y: 3, z: 7 },
+    { my_x_axis: 'abc', x: 1, y: 0, z: 2 },
+  ]);
+});
+
+test('sortRows by avg ascending', () => {
+  expect(sortRows(sortData, 'my_x_axis', SortSeriesType.Avg, true)).toEqual([
+    { my_x_axis: 'abc', x: 1, y: 0, z: 2 },
+    { my_x_axis: null, x: 4, y: 3, z: 7 },
+    { my_x_axis: 'foo', x: null, y: 10, z: 5 },
+  ]);
+});
+
+test('sortRows by avg descending', () => {
+  expect(sortRows(sortData, 'my_x_axis', SortSeriesType.Avg, false)).toEqual([
+    { my_x_axis: 'foo', x: null, y: 10, z: 5 },
+    { my_x_axis: null, x: 4, y: 3, z: 7 },
+    { my_x_axis: 'abc', x: 1, y: 0, z: 2 },
+  ]);
+});
+
+test('sortRows by min ascending', () => {
+  expect(sortRows(sortData, 'my_x_axis', SortSeriesType.Min, true)).toEqual([
+    { my_x_axis: 'abc', x: 1, y: 0, z: 2 },
+    { my_x_axis: null, x: 4, y: 3, z: 7 },
+    { my_x_axis: 'foo', x: null, y: 10, z: 5 },
+  ]);
+});
+
+test('sortRows by min descending', () => {
+  expect(sortRows(sortData, 'my_x_axis', SortSeriesType.Min, false)).toEqual([
+    { my_x_axis: 'foo', x: null, y: 10, z: 5 },
+    { my_x_axis: null, x: 4, y: 3, z: 7 },
+    { my_x_axis: 'abc', x: 1, y: 0, z: 2 },
+  ]);
+});
+
+test('sortRows by max ascending', () => {
+  expect(sortRows(sortData, 'my_x_axis', SortSeriesType.Min, true)).toEqual([
+    { my_x_axis: 'abc', x: 1, y: 0, z: 2 },
+    { my_x_axis: null, x: 4, y: 3, z: 7 },
+    { my_x_axis: 'foo', x: null, y: 10, z: 5 },
+  ]);
+});
+
+test('sortRows by max descending', () => {
+  expect(sortRows(sortData, 'my_x_axis', SortSeriesType.Min, false)).toEqual([
+    { my_x_axis: 'foo', x: null, y: 10, z: 5 },
+    { my_x_axis: null, x: 4, y: 3, z: 7 },
+    { my_x_axis: 'abc', x: 1, y: 0, z: 2 },
+  ]);
+});
+
+test('sortAndFilterSeries by min ascending', () => {
   expect(
-    sortAndFilterSeries(data, 'my_x_axis', [], SortSeriesType.Min, true),
+    sortAndFilterSeries(sortData, 'my_x_axis', [], SortSeriesType.Min, true),
   ).toEqual(['y', 'x', 'z']);
+});
+
+test('sortAndFilterSeries by min descending', () => {
   expect(
-    sortAndFilterSeries(data, 'my_x_axis', [], SortSeriesType.Min, false),
+    sortAndFilterSeries(sortData, 'my_x_axis', [], SortSeriesType.Min, false),
   ).toEqual(['z', 'x', 'y']);
+});
+
+test('sortAndFilterSeries by max ascending', () => {
   expect(
-    sortAndFilterSeries(data, 'my_x_axis', [], SortSeriesType.Max, true),
+    sortAndFilterSeries(sortData, 'my_x_axis', [], SortSeriesType.Max, true),
   ).toEqual(['x', 'z', 'y']);
+});
+
+test('sortAndFilterSeries by max descending', () => {
   expect(
-    sortAndFilterSeries(data, 'my_x_axis', [], SortSeriesType.Max, false),
+    sortAndFilterSeries(sortData, 'my_x_axis', [], SortSeriesType.Max, false),
   ).toEqual(['y', 'z', 'x']);
+});
+
+test('sortAndFilterSeries by avg ascending', () => {
   expect(
-    sortAndFilterSeries(data, 'my_x_axis', [], SortSeriesType.Avg, true),
+    sortAndFilterSeries(sortData, 'my_x_axis', [], SortSeriesType.Avg, true),
   ).toEqual(['x', 'y', 'z']);
+});
+
+test('sortAndFilterSeries by avg descending', () => {
   expect(
-    sortAndFilterSeries(data, 'my_x_axis', [], SortSeriesType.Avg, false),
+    sortAndFilterSeries(sortData, 'my_x_axis', [], SortSeriesType.Avg, false),
   ).toEqual(['z', 'y', 'x']);
+});
+
+test('sortAndFilterSeries by sum ascending', () => {
   expect(
-    sortAndFilterSeries(data, 'my_x_axis', [], SortSeriesType.Sum, true),
+    sortAndFilterSeries(sortData, 'my_x_axis', [], SortSeriesType.Sum, true),
   ).toEqual(['x', 'y', 'z']);
+});
+
+test('sortAndFilterSeries by sum descending', () => {
   expect(
-    sortAndFilterSeries(data, 'my_x_axis', [], SortSeriesType.Sum, false),
+    sortAndFilterSeries(sortData, 'my_x_axis', [], SortSeriesType.Sum, false),
   ).toEqual(['z', 'y', 'x']);
+});
+
+test('sortAndFilterSeries by name ascending', () => {
   expect(
-    sortAndFilterSeries(data, 'my_x_axis', [], SortSeriesType.Name, true),
+    sortAndFilterSeries(sortData, 'my_x_axis', [], SortSeriesType.Name, true),
   ).toEqual(['x', 'y', 'z']);
+});
+
+test('sortAndFilterSeries by name descending', () => {
   expect(
-    sortAndFilterSeries(data, 'my_x_axis', [], SortSeriesType.Name, false),
+    sortAndFilterSeries(sortData, 'my_x_axis', [], SortSeriesType.Name, false),
   ).toEqual(['z', 'y', 'x']);
 });
 


### PR DESCRIPTION
### SUMMARY
Currently it's only possible to sort non-temporal charts by the series values if there are no dimensions selected. This adds the same sorting options to dimensional charts that's available for sorting the series. We still default to category name, so current charts will not be affected. This PR also moves the series sorting controls to `@superset-ui/chart-controls` to make them generally available.

Also note that in this case we're doing the sorting in the frontend, while in the dimensionless case we're doing the sorting in the backend. In the future we may want to consider adding this type of logic to the backend, or move all sorting to the frontend.

https://user-images.githubusercontent.com/33317356/231097350-6bba5039-60ec-467a-9e17-89b43adcbee0.mp4

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
