### PR TITLE
fix: Zero values on Dual Line axis bounds

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -844,14 +844,12 @@ function nvd3Vis(element, props) {
       }
 
       chart.yDomain1([
-        isDefined(yAxisBounds[0]) ? yAxisBounds[0] : ticks1[0],
-        isDefined(yAxisBounds[1]) ? yAxisBounds[1] : ticks1[ticks1.length - 1],
+        yAxisBounds[0] ?? ticks1[0],
+        yAxisBounds[1] ?? ticks1[ticks1.length - 1],
       ]);
       chart.yDomain2([
-        isDefined(yAxis2Bounds[0]) ? yAxis2Bounds[0] : ticks2[0],
-        isDefined(yAxis2Bounds[1])
-          ? yAxis2Bounds[1]
-          : ticks2[ticks2.length - 1],
+        yAxis2Bounds[0] ?? ticks2[0],
+        yAxis2Bounds[1] ?? ticks2[ticks2.length - 1],
       ]);
     }
 

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -844,12 +844,14 @@ function nvd3Vis(element, props) {
       }
 
       chart.yDomain1([
-        yAxisBounds[0] || ticks1[0],
-        yAxisBounds[1] || ticks1[ticks1.length - 1],
+        isDefined(yAxisBounds[0]) ? yAxisBounds[0] : ticks1[0],
+        isDefined(yAxisBounds[1]) ? yAxisBounds[1] : ticks1[ticks1.length - 1],
       ]);
       chart.yDomain2([
-        yAxis2Bounds[0] || ticks2[0],
-        yAxis2Bounds[1] || ticks2[ticks2.length - 1],
+        isDefined(yAxis2Bounds[0]) ? yAxis2Bounds[0] : ticks2[0],
+        isDefined(yAxis2Bounds[1])
+          ? yAxis2Bounds[1]
+          : ticks2[ticks2.length - 1],
       ]);
     }
 


### PR DESCRIPTION
### SUMMARY
Fix a bug that prevented a user from using zero values on Dual Line chart axis bounds.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/231240813-94355447-2575-4bfa-ad08-68d7a21fffce.mov

https://user-images.githubusercontent.com/70410625/231240873-948ec412-cb38-4edd-ae8f-32221ae515e6.mov

### TESTING INSTRUCTIONS
Check the videos for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
