### PR TITLE
fix(sqllab): rendering performance regression

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -49,7 +49,6 @@ import {
   persistEditorHeight,
   postStopQuery,
   queryEditorSetAutorun,
-  queryEditorSetSql,
   queryEditorSetAndSaveSql,
   queryEditorSetTemplateParams,
   runQueryFromSqlEditor,

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -456,7 +456,6 @@ const SqlEditor = ({
   );
 
   const onSqlChanged = sql => {
-    dispatch(queryEditorSetSql(queryEditor, sql));
     setQueryEditorAndSaveSqlWithDebounce(sql);
     // Request server-side validation of the query text
     if (canValidateQuery()) {


### PR DESCRIPTION
### SUMMARY
When a schema contains a humorous table list, rendering cost of SqlEditorLeftBar is heavy since it requires to iterate millions items. To avoid the lag of using sql editor, we should avoid the LeftBar rendering while typing.
This commit removes the unnecessary immediate `QUERY_EDITOR_SET_SQL` action (and it's already covered by the next line setQueryEditorAndSaveSqlWithDebounce function) while typing which triggers the re-rendering of SqlEditorLeftBar.

(Still need refactoring SqlEditor to avoid [observing all sqlEditor updates](https://github.com/apache/superset/blob/61ddfe69725586acab1f04b8334fc2d6181b4a4f/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.jsx#L250). I will follow up additional work once redux-toolkit (+r eact-query) migration completed)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After (no lag while typing):

https://user-images.githubusercontent.com/1392866/231286835-7c18530d-0fb6-414e-9308-94756c2bede3.mov

Before (typing at same speed):

https://user-images.githubusercontent.com/1392866/231286786-980a7910-c3bc-483c-8a07-e4399bec58d4.mov

### TESTING INSTRUCTIONS
open sqllab with a list of > 100,000 tables
typing in the sql editor

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
