### PR TITLE
feat(dashboard): make color indices referable

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/color/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/color/types.ts
@@ -17,6 +17,10 @@
  * under the License.
  */
 
+export interface ColorsInitLookup {
+  [key: string]: string | number;
+}
+
 export interface ColorsLookup {
   [key: string]: string;
 }

--- a/superset-frontend/packages/superset-ui-core/test/color/CategoricalColorScale.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/color/CategoricalColorScale.test.ts
@@ -39,7 +39,22 @@ describe('CategoricalColorScale', () => {
       expect(scale).toBeInstanceOf(CategoricalColorScale);
       expect(scale.parentForcedColors).toBe(parentForcedColors);
     });
+
+    it('can refer to colors based on their index', () => {
+      const parentForcedColors = { pig: 1, horse: 5 };
+      const scale = new CategoricalColorScale(
+        ['blue', 'red', 'green'],
+        parentForcedColors,
+      );
+      expect(scale.getColor('pig')).toEqual('red');
+      expect(parentForcedColors.pig).toEqual('red');
+
+      // can loop around the scale
+      expect(scale.getColor('horse')).toEqual('green');
+      expect(parentForcedColors.horse).toEqual('green');
+    });
   });
+
   describe('.getColor(value)', () => {
     it('returns same color for same value', () => {
       const scale = new CategoricalColorScale(['blue', 'red', 'green']);


### PR DESCRIPTION
### SUMMARY
Currently it's only possible to assign series colors on dashboards based on the color names (e.g. "red") or hex codes (e.g. "#FF0000"). This tends to be impractical, as it's often only necessary to ensure that the colors stay constant across charts. In addition, assigning fixed hex colors will fail to change if color schemes are updated.

This PR adds the option to assign colors based on the color scheme index. This ensures that the color will be fixed, but also makes it adapt to whichever color scheme is chosen. This is done by letting the `CategoricalColorScale` objects swap out the index based color reference of the `parentForcedColors` that's passed to it in the constructor (the `parentForcedColors` object is mutated by charts as series are populated, hence it's ok to make changes to the object here, too).

### SCREENSHOT
Here we're using the "D3 category 10" scheme, and assign index 2 (=the third value) for "boy" and the fixed color "red" for "girl":
![image](https://user-images.githubusercontent.com/33317356/231413848-3b6f11c6-51d4-4bcd-a595-c615823f2ad7.png)

After we do that, the charts update accordingly:
![image](https://user-images.githubusercontent.com/33317356/231414101-3fbc6387-96bc-40fd-bec1-11b6da278872.png)

If we then change the scale to the "ECharts 5.0" scheme, the dashboard updates accordingly (notice "boy" turns yellow, which is the third color in that scheme, while "girl" stays unchanged):
![image](https://user-images.githubusercontent.com/33317356/231414696-385589d3-0b92-464a-86db-88c1e05b6284.png)
![image](https://user-images.githubusercontent.com/33317356/231414769-8ad42447-963f-4b47-8024-3ca045304285.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
