### PR TITLE
fix(sqllab): infinite running state on disconnect

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -80,6 +80,7 @@ export const STOP_QUERY = 'STOP_QUERY';
 export const REQUEST_QUERY_RESULTS = 'REQUEST_QUERY_RESULTS';
 export const QUERY_SUCCESS = 'QUERY_SUCCESS';
 export const QUERY_FAILED = 'QUERY_FAILED';
+export const CLEAR_INACTIVE_QUERIES = 'CLEAR_INACTIVE_QUERIES';
 export const CLEAR_QUERY_RESULTS = 'CLEAR_QUERY_RESULTS';
 export const REMOVE_DATA_PREVIEW = 'REMOVE_DATA_PREVIEW';
 export const CHANGE_DATA_PREVIEW_ID = 'CHANGE_DATA_PREVIEW_ID';
@@ -217,6 +218,10 @@ export function estimateQueryCost(queryEditor) {
         ),
     ]);
   };
+}
+
+export function clearInactiveQueries() {
+  return { type: CLEAR_INACTIVE_QUERIES };
 }
 
 export function startQuery(query) {

--- a/superset-frontend/src/SqlLab/components/App/index.jsx
+++ b/superset-frontend/src/SqlLab/components/App/index.jsx
@@ -168,7 +168,7 @@ class App extends React.PureComponent {
   }
 
   render() {
-    const { queries, actions, queriesLastUpdate } = this.props;
+    const { queries, queriesLastUpdate } = this.props;
     if (this.state.hash && this.state.hash === '#search') {
       return window.location.replace('/superset/sqllab/history/');
     }
@@ -176,7 +176,6 @@ class App extends React.PureComponent {
       <SqlLabStyles data-test="SqlLabApp" className="App SqlLab">
         <QueryAutoRefresh
           queries={queries}
-          refreshQueries={actions?.refreshQueries}
           queriesLastUpdate={queriesLastUpdate}
         />
         <TabbedSqlEditors />

--- a/superset-frontend/src/SqlLab/components/QueryAutoRefresh/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryAutoRefresh/index.tsx
@@ -16,7 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useState } from 'react';
+import { useRef } from 'react';
+import { useDispatch } from 'react-redux';
 import { isObject } from 'lodash';
 import rison from 'rison';
 import {
@@ -27,19 +28,18 @@ import {
 } from '@superset-ui/core';
 import { QueryDictionary } from 'src/SqlLab/types';
 import useInterval from 'src/SqlLab/utils/useInterval';
+import {
+  refreshQueries,
+  clearInactiveQueries,
+} from 'src/SqlLab/actions/sqlLab';
 
-const QUERY_UPDATE_FREQ = 2000;
+export const QUERY_UPDATE_FREQ = 2000;
 const QUERY_UPDATE_BUFFER_MS = 5000;
 const MAX_QUERY_AGE_TO_POLL = 21600000;
 const QUERY_TIMEOUT_LIMIT = 10000;
 
-interface RefreshQueriesFunc {
-  (alteredQueries: any): any;
-}
-
 export interface QueryAutoRefreshProps {
   queries: QueryDictionary;
-  refreshQueries: RefreshQueriesFunc;
   queriesLastUpdate: number;
 }
 
@@ -61,20 +61,22 @@ export const shouldCheckForQueries = (queryList: QueryDictionary): boolean => {
 
 function QueryAutoRefresh({
   queries,
-  refreshQueries,
   queriesLastUpdate,
 }: QueryAutoRefreshProps) {
   // We do not want to spam requests in the case of slow connections and potentially receive responses out of order
   // pendingRequest check ensures we only have one active http call to check for query statuses
-  const [pendingRequest, setPendingRequest] = useState(false);
+  const pendingRequestRef = useRef(false);
+  const cleanInactiveRequestRef = useRef(false);
+  const dispatch = useDispatch();
 
   const checkForRefresh = () => {
-    if (!pendingRequest && shouldCheckForQueries(queries)) {
+    const shouldRequestChecking = shouldCheckForQueries(queries);
+    if (!pendingRequestRef.current && shouldRequestChecking) {
       const params = rison.encode({
         last_updated_ms: queriesLastUpdate - QUERY_UPDATE_BUFFER_MS,
       });
 
-      setPendingRequest(true);
+      pendingRequestRef.current = true;
       SupersetClient.get({
         endpoint: `/api/v1/query/updated_since?q=${params}`,
         timeout: QUERY_TIMEOUT_LIMIT,
@@ -82,18 +84,26 @@ function QueryAutoRefresh({
         .then(({ json }) => {
           if (json) {
             const jsonPayload = json as { result?: QueryResponse[] };
-            const queries =
-              jsonPayload?.result?.reduce((acc, current) => {
-                acc[current.id] = current;
-                return acc;
-              }, {}) ?? {};
-            refreshQueries?.(queries);
+            if (jsonPayload?.result?.length) {
+              const queries =
+                jsonPayload?.result?.reduce((acc, current) => {
+                  acc[current.id] = current;
+                  return acc;
+                }, {}) ?? {};
+              dispatch(refreshQueries(queries));
+            } else {
+              dispatch(clearInactiveQueries());
+            }
           }
         })
         .catch(() => {})
         .finally(() => {
-          setPendingRequest(false);
+          pendingRequestRef.current = false;
         });
+    }
+    if (!cleanInactiveRequestRef.current && !shouldRequestChecking) {
+      dispatch(clearInactiveQueries());
+      cleanInactiveRequestRef.current = true;
     }
   };
 

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -742,6 +742,21 @@ export default function sqlLabReducer(state = {}, action) {
       }
       return { ...state, queries: newQueries, queriesLastUpdate };
     },
+    [actions.CLEAR_INACTIVE_QUERIES]() {
+      const { queries } = state;
+      const cleanedQueries = Object.fromEntries(
+        Object.entries(queries).filter(([, query]) => {
+          if (
+            ['running', 'pending'].includes(query.state) &&
+            query.progress === 0
+          ) {
+            return false;
+          }
+          return true;
+        }),
+      );
+      return { ...state, queries: cleanedQueries };
+    },
     [actions.SET_USER_OFFLINE]() {
       return { ...state, offline: action.offline };
     },


### PR DESCRIPTION
### SUMMARY
If you have an existing sqllab browser tab open and for whatever reason get disconnected from the vpn and issue a query, that query tab will forever be suck in a "running/pending" state and fail to stop.
The issue is that the query request never reaches the server; whereas, it is recorded in local storage.
This commit adds the clearInactiveQuery action to clean up the queries that never connected with the server and then batches the action on QueryAutoRefresh logic.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

After:

https://user-images.githubusercontent.com/1392866/231591678-14ec6386-b79b-4e19-8ff4-c7a4781165a7.mov

Before:

https://user-images.githubusercontent.com/1392866/231591629-3326300f-3e29-4a49-b9ae-565a557000e8.mov


### TESTING INSTRUCTIONS
- Set `SQLLAB_BACKEND_PERSISTENCE` False
- Go to SQLLab
- Disconnect network after SQL Lab fully loaded
- Run an any query and then close the browser
- Reconnect internet and then open SQL Lab 
- Check the query result status

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
