### PR TITLE
fix(sqllab): Revert "rendering performance regression (#23653)"

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -49,6 +49,7 @@ import {
   persistEditorHeight,
   postStopQuery,
   queryEditorSetAutorun,
+  queryEditorSetSql,
   queryEditorSetAndSaveSql,
   queryEditorSetTemplateParams,
   runQueryFromSqlEditor,
@@ -455,6 +456,7 @@ const SqlEditor = ({
   );
 
   const onSqlChanged = sql => {
+    dispatch(queryEditorSetSql(queryEditor, sql));
     setQueryEditorAndSaveSqlWithDebounce(sql);
     // Request server-side validation of the query text
     if (canValidateQuery()) {


### PR DESCRIPTION
### SUMMARY

Found the regression by #23653 when running a query by keyboard shortcut
This reverts commit a5b6ccc1ec98cce297d5f8579c7704668fe698f3.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
N/A

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
