### PR TITLE
fix(plugin-chart-echarts): reorder totals and support multimetric sort

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
@@ -54,8 +54,8 @@ export const contributionModeControl = {
   },
 };
 
-function isNotTemporal(controls: ControlStateMapping): boolean {
-  return (
+function isTemporal(controls: ControlStateMapping): boolean {
+  return !(
     isDefined(controls?.x_axis?.value) &&
     !isTemporalColumn(
       getColumnLabel(controls?.x_axis?.value as QueryFormColumn),
@@ -65,7 +65,7 @@ function isNotTemporal(controls: ControlStateMapping): boolean {
 }
 
 const xAxisSortVisibility = ({ controls }: { controls: ControlStateMapping }) =>
-  isNotTemporal(controls) &&
+  !isTemporal(controls) &&
   ensureIsArray(controls?.groupby?.value).length === 0 &&
   ensureIsArray(controls?.metrics?.value).length === 1;
 
@@ -74,7 +74,7 @@ const xAxisMultiSortVisibility = ({
 }: {
   controls: ControlStateMapping;
 }) =>
-  isNotTemporal(controls) &&
+  !isTemporal(controls) &&
   (!!ensureIsArray(controls?.groupby?.value).length ||
     ensureIsArray(controls?.metrics?.value).length > 1);
 

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
@@ -54,27 +54,29 @@ export const contributionModeControl = {
   },
 };
 
+function isNotTemporal(controls: ControlStateMapping): boolean {
+  return (
+    isDefined(controls?.x_axis?.value) &&
+    !isTemporalColumn(
+      getColumnLabel(controls?.x_axis?.value as QueryFormColumn),
+      controls?.datasource?.datasource,
+    )
+  );
+}
+
 const xAxisSortVisibility = ({ controls }: { controls: ControlStateMapping }) =>
-  isDefined(controls?.x_axis?.value) &&
-  !isTemporalColumn(
-    getColumnLabel(controls?.x_axis?.value as QueryFormColumn),
-    controls?.datasource?.datasource,
-  ) &&
-  Array.isArray(controls?.groupby?.value) &&
-  controls.groupby.value.length === 0;
+  isNotTemporal(controls) &&
+  ensureIsArray(controls?.groupby?.value).length === 0 &&
+  ensureIsArray(controls?.metrics?.value).length === 1;
 
 const xAxisMultiSortVisibility = ({
   controls,
 }: {
   controls: ControlStateMapping;
 }) =>
-  isDefined(controls?.x_axis?.value) &&
-  !isTemporalColumn(
-    getColumnLabel(controls?.x_axis?.value as QueryFormColumn),
-    controls?.datasource?.datasource,
-  ) &&
-  Array.isArray(controls?.groupby?.value) &&
-  !!controls.groupby.value.length;
+  isNotTemporal(controls) &&
+  (!!ensureIsArray(controls?.groupby?.value).length ||
+    ensureIsArray(controls?.metrics?.value).length > 1);
 
 export const xAxisSortControl = {
   name: 'x_axis_sort',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -170,12 +170,12 @@ export default function transformProps(
   }
 
   const rebasedDataA = rebaseForecastDatum(data1, verboseMap);
-  const rawSeriesA = extractSeries(rebasedDataA, {
+  const [rawSeriesA] = extractSeries(rebasedDataA, {
     fillNeighborValue: stack ? 0 : undefined,
     xAxis: xAxisLabel,
   });
   const rebasedDataB = rebaseForecastDatum(data2, verboseMap);
-  const rawSeriesB = extractSeries(rebasedDataB, {
+  const [rawSeriesB] = extractSeries(rebasedDataB, {
     fillNeighborValue: stackB ? 0 : undefined,
     xAxis: xAxisLabel,
   });

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -126,6 +126,7 @@ export default function transformProps(
     logAxis,
     markerEnabled,
     markerSize,
+    metrics,
     minorSplitLine,
     onlyTotal,
     opacity,
@@ -193,7 +194,9 @@ export default function transformProps(
     getMetricLabel,
   );
 
-  const rawSeries = extractSeries(rebasedData, {
+  const isMultiSeries = groupby.length || metrics.length > 1;
+
+  const [rawSeries, sortedTotalValues] = extractSeries(rebasedData, {
     fillNeighborValue: stack && !forecastEnabled ? 0 : undefined,
     xAxis: xAxisLabel,
     extraMetricLabels,
@@ -202,8 +205,8 @@ export default function transformProps(
     isHorizontal,
     sortSeriesType,
     sortSeriesAscending,
-    xAxisSortSeries: groupby.length ? xAxisSortSeries : undefined,
-    xAxisSortSeriesAscending: groupby.length
+    xAxisSortSeries: isMultiSeries ? xAxisSortSeries : undefined,
+    xAxisSortSeriesAscending: isMultiSeries
       ? xAxisSortSeriesAscending
       : undefined,
   });
@@ -240,7 +243,7 @@ export default function transformProps(
       formatter,
       showValue,
       onlyTotal,
-      totalStackedValues,
+      totalStackedValues: sortedTotalValues,
       showValueIndexes,
       thresholdValues,
       richTooltip,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
@@ -23,6 +23,7 @@ import {
   ContributionType,
   QueryFormColumn,
   QueryFormData,
+  QueryFormMetric,
   TimeFormatter,
   TimeGranularity,
 } from '@superset-ui/core';
@@ -65,6 +66,7 @@ export type EchartsTimeseriesFormData = QueryFormData & {
   logAxis: boolean;
   markerEnabled: boolean;
   markerSize: number;
+  metrics: QueryFormMetric[];
   minorSplitLine: boolean;
   opacity: number;
   orderDesc: boolean;

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -56,83 +56,165 @@ const sortData: DataRecord[] = [
   { my_x_axis: null, x: 4, y: 3, z: 7 },
 ];
 
+const totalStackedValues = [3, 15, 14];
+
 test('sortRows by name ascending', () => {
-  expect(sortRows(sortData, 'my_x_axis', SortSeriesType.Name, true)).toEqual([
-    { my_x_axis: 'abc', x: 1, y: 0, z: 2 },
-    { my_x_axis: 'foo', x: null, y: 10, z: 5 },
-    { my_x_axis: null, x: 4, y: 3, z: 7 },
+  expect(
+    sortRows(
+      sortData,
+      totalStackedValues,
+      'my_x_axis',
+      SortSeriesType.Name,
+      true,
+    ),
+  ).toEqual([
+    { row: { my_x_axis: 'abc', x: 1, y: 0, z: 2 }, totalStackedValue: 3 },
+    { row: { my_x_axis: 'foo', x: null, y: 10, z: 5 }, totalStackedValue: 15 },
+    { row: { my_x_axis: null, x: 4, y: 3, z: 7 }, totalStackedValue: 14 },
   ]);
 });
 
 test('sortRows by name descending', () => {
-  expect(sortRows(sortData, 'my_x_axis', SortSeriesType.Name, false)).toEqual([
-    { my_x_axis: null, x: 4, y: 3, z: 7 },
-    { my_x_axis: 'foo', x: null, y: 10, z: 5 },
-    { my_x_axis: 'abc', x: 1, y: 0, z: 2 },
+  expect(
+    sortRows(
+      sortData,
+      totalStackedValues,
+      'my_x_axis',
+      SortSeriesType.Name,
+      false,
+    ),
+  ).toEqual([
+    { row: { my_x_axis: null, x: 4, y: 3, z: 7 }, totalStackedValue: 14 },
+    { row: { my_x_axis: 'foo', x: null, y: 10, z: 5 }, totalStackedValue: 15 },
+    { row: { my_x_axis: 'abc', x: 1, y: 0, z: 2 }, totalStackedValue: 3 },
   ]);
 });
 
 test('sortRows by sum ascending', () => {
-  expect(sortRows(sortData, 'my_x_axis', SortSeriesType.Sum, true)).toEqual([
-    { my_x_axis: 'abc', x: 1, y: 0, z: 2 },
-    { my_x_axis: null, x: 4, y: 3, z: 7 },
-    { my_x_axis: 'foo', x: null, y: 10, z: 5 },
+  expect(
+    sortRows(
+      sortData,
+      totalStackedValues,
+      'my_x_axis',
+      SortSeriesType.Sum,
+      true,
+    ),
+  ).toEqual([
+    { row: { my_x_axis: 'abc', x: 1, y: 0, z: 2 }, totalStackedValue: 3 },
+    { row: { my_x_axis: null, x: 4, y: 3, z: 7 }, totalStackedValue: 14 },
+    { row: { my_x_axis: 'foo', x: null, y: 10, z: 5 }, totalStackedValue: 15 },
   ]);
 });
 
 test('sortRows by sum descending', () => {
-  expect(sortRows(sortData, 'my_x_axis', SortSeriesType.Sum, false)).toEqual([
-    { my_x_axis: 'foo', x: null, y: 10, z: 5 },
-    { my_x_axis: null, x: 4, y: 3, z: 7 },
-    { my_x_axis: 'abc', x: 1, y: 0, z: 2 },
+  expect(
+    sortRows(
+      sortData,
+      totalStackedValues,
+      'my_x_axis',
+      SortSeriesType.Sum,
+      false,
+    ),
+  ).toEqual([
+    { row: { my_x_axis: 'foo', x: null, y: 10, z: 5 }, totalStackedValue: 15 },
+    { row: { my_x_axis: null, x: 4, y: 3, z: 7 }, totalStackedValue: 14 },
+    { row: { my_x_axis: 'abc', x: 1, y: 0, z: 2 }, totalStackedValue: 3 },
   ]);
 });
 
 test('sortRows by avg ascending', () => {
-  expect(sortRows(sortData, 'my_x_axis', SortSeriesType.Avg, true)).toEqual([
-    { my_x_axis: 'abc', x: 1, y: 0, z: 2 },
-    { my_x_axis: null, x: 4, y: 3, z: 7 },
-    { my_x_axis: 'foo', x: null, y: 10, z: 5 },
+  expect(
+    sortRows(
+      sortData,
+      totalStackedValues,
+      'my_x_axis',
+      SortSeriesType.Avg,
+      true,
+    ),
+  ).toEqual([
+    { row: { my_x_axis: 'abc', x: 1, y: 0, z: 2 }, totalStackedValue: 3 },
+    { row: { my_x_axis: null, x: 4, y: 3, z: 7 }, totalStackedValue: 14 },
+    { row: { my_x_axis: 'foo', x: null, y: 10, z: 5 }, totalStackedValue: 15 },
   ]);
 });
 
 test('sortRows by avg descending', () => {
-  expect(sortRows(sortData, 'my_x_axis', SortSeriesType.Avg, false)).toEqual([
-    { my_x_axis: 'foo', x: null, y: 10, z: 5 },
-    { my_x_axis: null, x: 4, y: 3, z: 7 },
-    { my_x_axis: 'abc', x: 1, y: 0, z: 2 },
+  expect(
+    sortRows(
+      sortData,
+      totalStackedValues,
+      'my_x_axis',
+      SortSeriesType.Avg,
+      false,
+    ),
+  ).toEqual([
+    { row: { my_x_axis: 'foo', x: null, y: 10, z: 5 }, totalStackedValue: 15 },
+    { row: { my_x_axis: null, x: 4, y: 3, z: 7 }, totalStackedValue: 14 },
+    { row: { my_x_axis: 'abc', x: 1, y: 0, z: 2 }, totalStackedValue: 3 },
   ]);
 });
 
 test('sortRows by min ascending', () => {
-  expect(sortRows(sortData, 'my_x_axis', SortSeriesType.Min, true)).toEqual([
-    { my_x_axis: 'abc', x: 1, y: 0, z: 2 },
-    { my_x_axis: null, x: 4, y: 3, z: 7 },
-    { my_x_axis: 'foo', x: null, y: 10, z: 5 },
+  expect(
+    sortRows(
+      sortData,
+      totalStackedValues,
+      'my_x_axis',
+      SortSeriesType.Min,
+      true,
+    ),
+  ).toEqual([
+    { row: { my_x_axis: 'abc', x: 1, y: 0, z: 2 }, totalStackedValue: 3 },
+    { row: { my_x_axis: null, x: 4, y: 3, z: 7 }, totalStackedValue: 14 },
+    { row: { my_x_axis: 'foo', x: null, y: 10, z: 5 }, totalStackedValue: 15 },
   ]);
 });
 
 test('sortRows by min descending', () => {
-  expect(sortRows(sortData, 'my_x_axis', SortSeriesType.Min, false)).toEqual([
-    { my_x_axis: 'foo', x: null, y: 10, z: 5 },
-    { my_x_axis: null, x: 4, y: 3, z: 7 },
-    { my_x_axis: 'abc', x: 1, y: 0, z: 2 },
+  expect(
+    sortRows(
+      sortData,
+      totalStackedValues,
+      'my_x_axis',
+      SortSeriesType.Min,
+      false,
+    ),
+  ).toEqual([
+    { row: { my_x_axis: 'foo', x: null, y: 10, z: 5 }, totalStackedValue: 15 },
+    { row: { my_x_axis: null, x: 4, y: 3, z: 7 }, totalStackedValue: 14 },
+    { row: { my_x_axis: 'abc', x: 1, y: 0, z: 2 }, totalStackedValue: 3 },
   ]);
 });
 
 test('sortRows by max ascending', () => {
-  expect(sortRows(sortData, 'my_x_axis', SortSeriesType.Min, true)).toEqual([
-    { my_x_axis: 'abc', x: 1, y: 0, z: 2 },
-    { my_x_axis: null, x: 4, y: 3, z: 7 },
-    { my_x_axis: 'foo', x: null, y: 10, z: 5 },
+  expect(
+    sortRows(
+      sortData,
+      totalStackedValues,
+      'my_x_axis',
+      SortSeriesType.Min,
+      true,
+    ),
+  ).toEqual([
+    { row: { my_x_axis: 'abc', x: 1, y: 0, z: 2 }, totalStackedValue: 3 },
+    { row: { my_x_axis: null, x: 4, y: 3, z: 7 }, totalStackedValue: 14 },
+    { row: { my_x_axis: 'foo', x: null, y: 10, z: 5 }, totalStackedValue: 15 },
   ]);
 });
 
 test('sortRows by max descending', () => {
-  expect(sortRows(sortData, 'my_x_axis', SortSeriesType.Min, false)).toEqual([
-    { my_x_axis: 'foo', x: null, y: 10, z: 5 },
-    { my_x_axis: null, x: 4, y: 3, z: 7 },
-    { my_x_axis: 'abc', x: 1, y: 0, z: 2 },
+  expect(
+    sortRows(
+      sortData,
+      totalStackedValues,
+      'my_x_axis',
+      SortSeriesType.Min,
+      false,
+    ),
+  ).toEqual([
+    { row: { my_x_axis: 'foo', x: null, y: 10, z: 5 }, totalStackedValue: 15 },
+    { row: { my_x_axis: null, x: 4, y: 3, z: 7 }, totalStackedValue: 14 },
+    { row: { my_x_axis: 'abc', x: 1, y: 0, z: 2 }, totalStackedValue: 3 },
   ]);
 });
 
@@ -215,25 +297,29 @@ describe('extractSeries', () => {
         abc: 5,
       },
     ];
-    expect(extractSeries(data)).toEqual([
-      {
-        id: 'Hulk',
-        name: 'Hulk',
-        data: [
-          ['2000-01-01', null],
-          ['2000-02-01', 2],
-          ['2000-03-01', 1],
-        ],
-      },
-      {
-        id: 'abc',
-        name: 'abc',
-        data: [
-          ['2000-01-01', 2],
-          ['2000-02-01', 10],
-          ['2000-03-01', 5],
-        ],
-      },
+    const totalStackedValues = [2, 12, 6];
+    expect(extractSeries(data, { totalStackedValues })).toEqual([
+      [
+        {
+          id: 'Hulk',
+          name: 'Hulk',
+          data: [
+            ['2000-01-01', null],
+            ['2000-02-01', 2],
+            ['2000-03-01', 1],
+          ],
+        },
+        {
+          id: 'abc',
+          name: 'abc',
+          data: [
+            ['2000-01-01', 2],
+            ['2000-02-01', 10],
+            ['2000-03-01', 5],
+          ],
+        },
+      ],
+      totalStackedValues,
     ]);
   });
 
@@ -255,20 +341,30 @@ describe('extractSeries', () => {
         abc: 5,
       },
     ];
-    expect(extractSeries(data, { xAxis: 'x', removeNulls: true })).toEqual([
-      {
-        id: 'Hulk',
-        name: 'Hulk',
-        data: [[2, 1]],
-      },
-      {
-        id: 'abc',
-        name: 'abc',
-        data: [
-          [1, 2],
-          [2, 5],
-        ],
-      },
+    const totalStackedValues = [3, 12, 8];
+    expect(
+      extractSeries(data, {
+        totalStackedValues,
+        xAxis: 'x',
+        removeNulls: true,
+      }),
+    ).toEqual([
+      [
+        {
+          id: 'Hulk',
+          name: 'Hulk',
+          data: [[2, 1]],
+        },
+        {
+          id: 'abc',
+          name: 'abc',
+          data: [
+            [1, 2],
+            [2, 5],
+          ],
+        },
+      ],
+      totalStackedValues,
     ]);
   });
 
@@ -315,23 +411,29 @@ describe('extractSeries', () => {
         abc: null,
       },
     ];
-    expect(extractSeries(data, { fillNeighborValue: 0 })).toEqual([
-      {
-        id: 'abc',
-        name: 'abc',
-        data: [
-          ['2000-01-01', null],
-          ['2000-02-01', 0],
-          ['2000-03-01', 1],
-          ['2000-04-01', 0],
-          ['2000-05-01', null],
-          ['2000-06-01', 0],
-          ['2000-07-01', 2],
-          ['2000-08-01', 3],
-          ['2000-09-01', 0],
-          ['2000-10-01', null],
-        ],
-      },
+    const totalStackedValues = [0, 0, 1, 0, 0, 0, 2, 3, 0, 0];
+    expect(
+      extractSeries(data, { totalStackedValues, fillNeighborValue: 0 }),
+    ).toEqual([
+      [
+        {
+          id: 'abc',
+          name: 'abc',
+          data: [
+            ['2000-01-01', null],
+            ['2000-02-01', 0],
+            ['2000-03-01', 1],
+            ['2000-04-01', 0],
+            ['2000-05-01', null],
+            ['2000-06-01', 0],
+            ['2000-07-01', 2],
+            ['2000-08-01', 3],
+            ['2000-09-01', 0],
+            ['2000-10-01', null],
+          ],
+        },
+      ],
+      totalStackedValues,
     ]);
   });
 });


### PR DESCRIPTION
### SUMMARY
When using the multiseries sort on generic x-axis, the totals are not sorted, causing them to display on the wrong bars. In addition, it was not possible to sort by the total bar height if there were multiple metrics. This PR fixes both issues.

### AFTER

When there are two metrics, the multiseries sort control is now displayed. In addition, the totals are displayed on the correct rows:

https://user-images.githubusercontent.com/33317356/231687625-5e81c1d0-9f8a-4388-b00e-aab6728ba97c.mp4

### BEFORE

Previously, it wasn't possible to sort by the total if there were multiple metrics (notice that one would commonly want to display NY before TX and PA before OH):
<img width="993" alt="image" src="https://user-images.githubusercontent.com/33317356/231688184-e1d1ba91-496b-4faf-b3cc-a32f05b45566.png">

In addition, when using the multiseries sort control, the totals would be displayed on the original bars, as they didn't get reordered along with the chart data (notice that the last bar shows 37.1 M births, despite the total of the series being 5.62M):

<img width="996" alt="image" src="https://user-images.githubusercontent.com/33317356/231688780-8ab46e94-beb7-4bf6-b7ff-bee90bdecc44.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
