### PR TITLE
docs(translations): point broken tutorial link to Internet Archive copy

### DIFF
--- a/docs/docs/contributing/translations.mdx
+++ b/docs/docs/contributing/translations.mdx
@@ -107,7 +107,7 @@ Run the following command to update the language files with the new extracted st
 You can then translate the strings gathered in files located under
 `superset/translation`, where there's one folder per language. You can use [Poedit](https://poedit.net/features)
 to translate the `po` file more conveniently.
-There are some [tutorials in the wiki](https://wiki.lxde.org/en/Translate_*.po_files_with_Poedit).
+Here is [a tutorial](https://web.archive.org/web/20220517065036/https://wiki.lxde.org/en/Translate_*.po_files_with_Poedit).
 
 To perform the translation on MacOS, you can install `poedit` via Homebrew:
 


### PR DESCRIPTION
Fixes [issue 23](https://www.bugherd.com/projects/334204/tasks/23) in Bugherd.

**Problem**
The wiki that hosted the page (current link: https://wiki.lxde.org/en/Translate_*.po_files_with_Poedit) is down.

**Fix**
It's now pointing to the latest snapshot at the Internet Archive's Wayback Machine.

**Other thoughts**
The tutorial itself is mostly from a 2009 blogpost, with a seemingly-minor edit in 2021.  Is this resource still relevant & the best?  I know nothing about translations.  But in the meantime, fixing the link is an obvious step.