### PR TITLE
fix: Database modal parameter inputs persisting after modal closed and reopened

### DIFF
--- a/superset-frontend/src/features/databases/DatabaseModal/ExtraOptions.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/ExtraOptions.tsx
@@ -457,7 +457,7 @@ const ExtraOptions = ({
               }
               width="100%"
               height="160px"
-              defaultValue={
+              value={
                 !Object.keys(extraJson?.metadata_params || {}).length
                   ? ''
                   : extraJson?.metadata_params
@@ -483,7 +483,7 @@ const ExtraOptions = ({
               }
               width="100%"
               height="160px"
-              defaultValue={
+              value={
                 !Object.keys(extraJson?.engine_params || {}).length
                   ? ''
                   : extraJson?.engine_params


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR makes the metadata parameter and engine parameter inputs controlled as the others on this modal are.  Without this fix, the ace editor initial default value would not be cleared when switching between databases.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
In the following examples, Connection A actually does have engine parameters, but connection B does not.
Before:
![db_modal_before](https://user-images.githubusercontent.com/47196419/231916297-e32ab53e-3f3a-46c7-9db5-0ee459fc22ac.gif)

After:
![db_modal_after](https://user-images.githubusercontent.com/47196419/231916329-8d3d3c46-e3f1-4962-9f6f-85d81b586008.gif)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
