### PR TITLE
fix: Further drill by in Pivot Table

### DIFF
--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -17,22 +17,24 @@
  * under the License.
  */
 import React, { useCallback, useMemo } from 'react';
-import { PlusSquareOutlined, MinusSquareOutlined } from '@ant-design/icons';
+import { MinusSquareOutlined, PlusSquareOutlined } from '@ant-design/icons';
 import {
   AdhocMetric,
+  BinaryQueryObjectFilterClause,
   DataRecordValue,
+  FeatureFlag,
   getColumnLabel,
   getNumberFormatter,
+  getSelectedText,
+  isAdhocColumn,
+  isFeatureEnabled,
   isPhysicalColumn,
   NumberFormatter,
   styled,
-  useTheme,
-  isAdhocColumn,
-  BinaryQueryObjectFilterClause,
   t,
-  getSelectedText,
+  useTheme,
 } from '@superset-ui/core';
-import { PivotTable, sortAs, aggregatorTemplates } from './react-pivottable';
+import { aggregatorTemplates, PivotTable, sortAs } from './react-pivottable';
 import {
   FilterType,
   MetricsLayoutEnum,
@@ -407,7 +409,10 @@ export default function PivotTableChart(props: PivotTableProps) {
       clickColumnHeaderCallback: toggleFilter,
       colTotals,
       rowTotals,
-      highlightHeaderCellsOnHover: emitCrossFilters,
+      highlightHeaderCellsOnHover:
+        emitCrossFilters ||
+        isFeatureEnabled(FeatureFlag.DRILL_BY) ||
+        isFeatureEnabled(FeatureFlag.DRILL_TO_DETAIL),
       highlightedHeaderCells: selectedFilters,
       omittedHighlightHeaderGroups: [METRIC_KEY],
       cellColorFormatters: { [METRIC_KEY]: metricColorFormatters },

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.jsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.jsx
@@ -398,11 +398,10 @@ export class TableRenderer extends React.Component {
       const colSpan = attrIdx < colKey.length ? colAttrSpans[i][attrIdx] : 1;
       let colLabelClass = 'pvtColLabel';
       if (attrIdx < colKey.length) {
-        if (
-          highlightHeaderCellsOnHover &&
-          !omittedHighlightHeaderGroups.includes(colAttrs[attrIdx])
-        ) {
-          colLabelClass += ' hoverable';
+        if (!omittedHighlightHeaderGroups.includes(colAttrs[attrIdx])) {
+          if (highlightHeaderCellsOnHover) {
+            colLabelClass += ' hoverable';
+          }
           handleContextMenu = e =>
             this.props.onContextMenu(e, colKey, undefined, {
               [attrName]: colKey[attrIdx],
@@ -598,11 +597,10 @@ export class TableRenderer extends React.Component {
     const attrValueCells = rowKey.map((r, i) => {
       let handleContextMenu;
       let valueCellClassName = 'pvtRowLabel';
-      if (
-        highlightHeaderCellsOnHover &&
-        !omittedHighlightHeaderGroups.includes(rowAttrs[i])
-      ) {
-        valueCellClassName += ' hoverable';
+      if (!omittedHighlightHeaderGroups.includes(rowAttrs[i])) {
+        if (highlightHeaderCellsOnHover) {
+          valueCellClassName += ' hoverable';
+        }
         handleContextMenu = e =>
           this.props.onContextMenu(e, undefined, rowKey, {
             [rowAttrs[i]]: r,


### PR DESCRIPTION
### SUMMARY
Due to faulty logic in Pivot Table, the right click actions were available only when cross filtering was available. That prevented applying further drill by in the drill by modal, because cross filtering is not available in the modal.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="954" alt="image" src="https://user-images.githubusercontent.com/15073128/231992010-647f0a1f-9662-4295-9674-1e28fd3c3f1e.png">

After:
<img width="984" alt="image" src="https://user-images.githubusercontent.com/15073128/231988952-899584dc-75b5-4771-b081-3c3cedd22127.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
