### PR TITLE
fix(sqllab): rendering performance regression

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -26,7 +26,7 @@ import React, {
   useCallback,
 } from 'react';
 import { CSSTransition } from 'react-transition-group';
-import { useDispatch, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import Split from 'react-split';
 import { css, FeatureFlag, styled, t, useTheme } from '@superset-ui/core';
@@ -230,6 +230,7 @@ const SqlEditor = ({
         hideLeftBar,
       };
     },
+    shallowEqual,
   );
 
   const [height, setHeight] = useState(0);


### PR DESCRIPTION
### SUMMARY
Alternative solution of #23653

When a schema contains a humorous table list, rendering cost of SqlEditorLeftBar is heavy since it requires to iterate millions items. To avoid the lag of using sql editor, we should avoid the LeftBar rendering while typing.
This commit fixes the `useSelector` in SqlEditor which triggers the re-rendering of SqlEditorLeftBar anytime redux action triggered.

P.S. - Found the root cause from https://github.com/apache/superset/pull/21320/files#diff-dac1ba995e65dfae7c9aa7a0a794036ace1eb83814e2101d354752da2bb41dfdR166 which is migrated from PureComponent to functional component without shallowEqual which causes the regression 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After (no lag while typing):

https://user-images.githubusercontent.com/1392866/231286835-7c18530d-0fb6-414e-9308-94756c2bede3.mov

<img width="874" alt="Screenshot 2023-04-14 at 11 40 54 AM" src="https://user-images.githubusercontent.com/1392866/232143507-0e6ab61d-6c45-4d08-8020-0c010ff98a92.png">


Before (typing at same speed):

https://user-images.githubusercontent.com/1392866/231286786-980a7910-c3bc-483c-8a07-e4399bec58d4.mov

<img width="710" alt="Screenshot 2023-04-14 at 11 35 32 AM" src="https://user-images.githubusercontent.com/1392866/232143531-f681937c-19ef-45cd-9936-a640cdc69a12.png">

### TESTING INSTRUCTIONS
open sqllab with a list of > 100,000 tables
typing in the sql editor

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
