### PR TITLE
feat: Add loading state to sqllab save/overwrite dataset modal

### DIFF
--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
@@ -174,6 +174,7 @@ export const SaveDatasetModal = ({
   const [selectedDatasetToOverwrite, setSelectedDatasetToOverwrite] = useState<
     SelectValue | undefined
   >(undefined);
+  const [loading, setLoading] = useState<boolean>(false);
 
   const user = useSelector<SqlLabExploreRootState, User>(user =>
     getInitialState(user),
@@ -197,6 +198,7 @@ export const SaveDatasetModal = ({
       setShouldOverwriteDataset(true);
       return;
     }
+    setLoading(true);
     const [, key] = await Promise.all([
       updateDataset(
         datasource?.dbId,
@@ -220,6 +222,7 @@ export const SaveDatasetModal = ({
         }),
       }),
     ]);
+    setLoading(false);
 
     const url = mountExploreUrl(null, {
       [URL_PARAMS.formDataKey.name]: key,
@@ -269,6 +272,7 @@ export const SaveDatasetModal = ({
   );
 
   const handleSaveInDataset = () => {
+    setLoading(true);
     const selectedColumns = datasource?.columns ?? [];
 
     // The filters param is only used to test jinja templates.
@@ -306,6 +310,7 @@ export const SaveDatasetModal = ({
         }),
       )
       .then((key: string) => {
+        setLoading(false);
         const url = mountExploreUrl(null, {
           [URL_PARAMS.formDataKey.name]: key,
         });
@@ -314,6 +319,7 @@ export const SaveDatasetModal = ({
         onHide();
       })
       .catch(() => {
+        setLoading(false);
         addDangerToast(t('An error occurred saving dataset'));
       });
   };
@@ -356,6 +362,7 @@ export const SaveDatasetModal = ({
               disabled={disableSaveAndExploreBtn}
               buttonStyle="primary"
               onClick={handleSaveInDataset}
+              loading={loading}
             >
               {buttonTextOnSave}
             </Button>
@@ -370,6 +377,7 @@ export const SaveDatasetModal = ({
                 buttonStyle="primary"
                 onClick={handleOverwriteDataset}
                 disabled={disableSaveAndExploreBtn}
+                loading={loading}
               >
                 {buttonTextOnOverwrite}
               </Button>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Overwriting datasets in particular can take a long time to run since it makes a request to `PUT /api/v1/datasets/{id}?override_columns=true`, which will execute the updated query on the DB.  Requests that can take this long should have a loading indicator to let the user know something is happening and not broken.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![dataset_overwrite_before](https://user-images.githubusercontent.com/47196419/232168299-f984ab8d-b35e-4d32-b511-cd8c44ac8d7c.gif)

After:
![dataset_overwrite_after](https://user-images.githubusercontent.com/47196419/232168308-5e42235d-f5ef-43b8-b15f-d03359c417de.gif)



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
