### PR TITLE
bug-fix-issue14186

### DIFF
--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -122,15 +122,33 @@ const BulkSelectWrapper = styled(Alert)`
 `;
 
 const bulkSelectColumnConfig = {
-  Cell: ({ row }: any) => (
-    <IndeterminateCheckbox {...row.getToggleRowSelectedProps()} id={row.id} />
-  ),
-  Header: ({ getToggleAllRowsSelectedProps }: any) => (
+  Cell: ({ row }: any) => {
+    let props = { ...row.getToggleRowSelectedProps() };
+    props.onChange = (e: { target: { checked: any; }; }) => {
+        row.original['isChecked'] = e.target.checked;
+        row.toggleRowSelected(e.target.checked);
+    };
+    if (row.original['isChecked']){
+      row.toggleRowSelected(true);
+    }
+    return (
+      <IndeterminateCheckbox {...props} id={row.id} />
+    )
+  },
+  Header: ({ getToggleAllRowsSelectedProps, rows }: any) => {
+    const props = {...getToggleAllRowsSelectedProps()};
+    props.onChange = (e: any) => {
+      rows.map((row: { original: { [x: string]: any; }; toggleRowSelected: (arg0: any) => void; })=>{
+        row.original['isChecked'] = e.target.checked;
+        row.toggleRowSelected(e.target.checked);
+      });
+    }
+    return (
     <IndeterminateCheckbox
-      {...getToggleAllRowsSelectedProps()}
+      {...props}
       id="header-toggle-all"
     />
-  ),
+  )},
   id: 'selection',
   size: 'sm',
 };
@@ -353,7 +371,12 @@ function ListView<T extends object = any>({
                         role="button"
                         tabIndex={0}
                         className="deselect-all"
-                        onClick={() => toggleAllRowsSelected(false)}
+                        onClick={() => {
+                          rows.map((row: { original: { [x: string]: any; }; toggleRowSelected: (arg0: any) => void; })=>{
+                            row.original['isChecked'] = false;
+                            row.toggleRowSelected(false);
+                          });
+                        }}
                       >
                         {t('Deselect all')}
                       </span>

--- a/superset-frontend/src/components/ListView/types.ts
+++ b/superset-frontend/src/components/ListView/types.ts
@@ -86,6 +86,7 @@ export interface FetchDataConfig {
   pageSize: number;
   sortBy: SortColumns;
   filters: FilterValue[];
+  data?:any,
 }
 
 export interface InternalFilter extends FilterValue {

--- a/superset-frontend/src/components/ListView/utils.ts
+++ b/superset-frontend/src/components/ListView/utils.ts
@@ -333,7 +333,7 @@ export function useListViewState({
 
     setQuery(queryParams, method);
 
-    fetchData({ pageIndex, pageSize, sortBy, filters });
+    fetchData({ pageIndex, pageSize, sortBy, filters, data });
   }, [fetchData, pageIndex, pageSize, sortBy, filters]);
 
   useEffect(() => {

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -121,12 +121,36 @@ export function useListViewResource<D extends object = any>(
     return Boolean(state.permissions.find(p => p === perm));
   }
 
+  function updatePreviousState(collection : any,data : any){
+    if( data != null && data.length > 0 ){
+      collection.map(
+        ( row : any ) => {
+          data.map(
+            ( item : any ) => {
+              if( row.url === item.url ){
+                if( item.isChecked != null){
+                  row['isChecked'] = item.isChecked ;
+                }else{
+                  row['isChecked'] = false ;
+                }
+              }
+            }
+          );
+          return row;
+        }
+      );
+  }
+  return collection;
+  }
+
+
   const fetchData = useCallback(
     ({
       pageIndex,
       pageSize,
       sortBy,
       filters: filterValues,
+      data
     }: FetchDataConfig) => {
       // set loading state, cache the last config for refreshing data.
       updateState({
@@ -163,8 +187,10 @@ export function useListViewResource<D extends object = any>(
       })
         .then(
           ({ json = {} }) => {
+            let collection = json.result;
+            collection = updatePreviousState(collection,data);
             updateState({
-              collection: json.result,
+              collection: collection,
               count: json.count,
               lastFetched: new Date().toISOString(),
             });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
UI does not retain the selection of the items (chart or dashboard) in the list view after a user changes sort parameters.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
All selected items change their state back to unselected

https://user-images.githubusercontent.com/94451692/227249842-2a121526-7f1d-4715-bd1f-96ef0a56009e.mov


Selection should persist throughout all the sort parameter changes

https://user-images.githubusercontent.com/94451692/227249929-7c32d4f1-8cd7-4e7a-b4a4-c001e98cbabc.mov



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/14186
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
