### PR TITLE
fix: issue #23699

### DIFF
--- a/superset-frontend/src/components/TableCollection/index.tsx
+++ b/superset-frontend/src/components/TableCollection/index.tsx
@@ -174,7 +174,7 @@ export const Table = styled.table`
     .table-cell {
       font-feature-settings: 'tnum' 1;
       text-overflow: ellipsis;
-      overflow: hidden;
+      overflow: auto;
       max-width: 320px;
       line-height: 1;
       vertical-align: middle;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Width of the Sparkline part cannot be adjusted. Seems to be permanently set to ~300px.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![Screenshot 2023-03-28 at 7 01 56 PM](https://user-images.githubusercontent.com/94451692/228254465-f6f5052f-3bee-4a4d-9b6d-4f0c266436ae.png)

![Screenshot 2023-03-28 at 7 02 14 PM](https://user-images.githubusercontent.com/94451692/228254595-263f0ffa-9b26-45f1-8452-b1ae06360ef0.png)




### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #19912
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
