### PR TITLE
fix(filters): Stop breaking if translateToSql returns an object

### DIFF
--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/AdhocFilter.test.js
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/AdhocFilter.test.js
@@ -247,4 +247,36 @@ describe('AdhocFilter', () => {
     });
     expect(adhocFilter2.comparator).toBe(null);
   });
+  it('sets the label properly if subject is a string', () => {
+    const adhocFilter2 = new AdhocFilter({
+      expressionType: EXPRESSION_TYPES.SIMPLE,
+      subject: 'order_date',
+    });
+    expect(adhocFilter2.getDefaultLabel()).toBe('order_date');
+  });
+  it('sets the label properly if subject is an object with the column_date property', () => {
+    const adhocFilter2 = new AdhocFilter({
+      expressionType: EXPRESSION_TYPES.SIMPLE,
+      subject: {
+        column_name: 'year',
+      },
+    });
+    expect(adhocFilter2.getDefaultLabel()).toBe('year');
+  });
+  it('sets the label to empty is there is no column_name in the object', () => {
+    const adhocFilter2 = new AdhocFilter({
+      expressionType: EXPRESSION_TYPES.SIMPLE,
+      subject: {
+        unknown: 'year',
+      },
+    });
+    expect(adhocFilter2.getDefaultLabel()).toBe('');
+  });
+  it('sets the label to empty is there is no subject', () => {
+    const adhocFilter2 = new AdhocFilter({
+      expressionType: EXPRESSION_TYPES.SIMPLE,
+      subject: undefined,
+    });
+    expect(adhocFilter2.getDefaultLabel()).toBe('');
+  });
 });

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/index.js
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/index.js
@@ -135,10 +135,6 @@ export default class AdhocFilter {
 
   getDefaultLabel() {
     const label = this.translateToSql();
-    // If returned value is an object after changing dataset
-    if (typeof label === 'object') {
-      return label.column_name ?? '';
-    }
     return label.length < 43 ? label : `${label.substring(0, 40)}...`;
   }
 

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/index.js
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/index.js
@@ -135,6 +135,10 @@ export default class AdhocFilter {
 
   getDefaultLabel() {
     const label = this.translateToSql();
+    // If returned value is an object after changing dataset
+    if (typeof label === 'object') {
+      return label.column_name ?? '';
+    }
     return label.length < 43 ? label : `${label.substring(0, 40)}...`;
   }
 

--- a/superset-frontend/src/explore/exploreUtils/index.js
+++ b/superset-frontend/src/explore/exploreUtils/index.js
@@ -297,7 +297,7 @@ export const getSimpleSQLExpression = (subject, operator, comparator) => {
       .indexOf(operator) >= 0;
   // If returned value is an object after changing dataset
   let expression =
-    typeof subject === 'object' ? subject.column_name ?? '' : subject ?? '';
+    typeof subject === 'object' ? subject?.column_name ?? '' : subject ?? '';
   if (subject && operator) {
     expression += ` ${operator}`;
     const firstValue =

--- a/superset-frontend/src/explore/exploreUtils/index.js
+++ b/superset-frontend/src/explore/exploreUtils/index.js
@@ -295,7 +295,9 @@ export const getSimpleSQLExpression = (subject, operator, comparator) => {
     [...MULTI_OPERATORS]
       .map(op => OPERATOR_ENUM_TO_OPERATOR_TYPE[op].operation)
       .indexOf(operator) >= 0;
-  let expression = subject ?? '';
+  // If returned value is an object after changing dataset
+  let expression =
+    typeof subject === 'object' ? subject.column_name ?? '' : subject ?? '';
   if (subject && operator) {
     expression += ` ${operator}`;
     const firstValue =


### PR DESCRIPTION
### SUMMARY
There might be times where after changing the dataset, the `translateToSql` is not just a string but an object and thus you get an error when trying to perform the substring operation. In that case we need to get the label from the `column_name` if present if not just return an empty string instead.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![error](https://user-images.githubusercontent.com/38889534/232602461-2b3fef28-44a2-49a1-ac2d-01bed6bce8b3.png)

After:
![test](https://user-images.githubusercontent.com/38889534/232603574-d13dd959-27fb-4dad-87a1-ae1ab5229439.gif)



### TESTING INSTRUCTIONS
1. Load a BigNumber chart
2. Swap the dataset to be something that has a time filter like Vehicle Sales in the examples DB
3. Change the chart type to be area chart
4. You should not get an error, instead, the filters should be populated using the new dataset info

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
