### PR TITLE
feat(sqllab): add headers when copying results to clipboard

### DIFF
--- a/superset-frontend/src/explore/components/DataTablesPane/test/DataTablesPane.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/test/DataTablesPane.test.tsx
@@ -108,7 +108,7 @@ describe('DataTablesPane', () => {
     userEvent.click(screen.getByLabelText('Copy'));
     expect(copyToClipboardSpy).toHaveBeenCalledTimes(1);
     const value = await copyToClipboardSpy.mock.calls[0][0]();
-    expect(value).toBe('2009-01-01 00:00:00\tAction\n');
+    expect(value).toBe('__timestamp\tgenre\n2009-01-01 00:00:00\tAction\n');
     copyToClipboardSpy.mockRestore();
     fetchMock.restore();
   });

--- a/superset-frontend/src/utils/common.js
+++ b/superset-frontend/src/utils/common.js
@@ -78,14 +78,20 @@ export function optionFromValue(opt) {
   return { value: optionValue(opt), label: optionLabel(opt) };
 }
 
+function getColumnName(column) {
+  return column.name || column;
+}
+
 export function prepareCopyToClipboardTabularData(data, columns) {
-  let result = `${columns.map(column => column.name || column).join('\t')}\n`;
+  let result = columns.length
+    ? `${columns.map(getColumnName).join('\t')}\n`
+    : '';
   for (let i = 0; i < data.length; i += 1) {
     const row = {};
     for (let j = 0; j < columns.length; j += 1) {
       // JavaScript does not maintain the order of a mixed set of keys (i.e integers and strings)
       // the below function orders the keys based on the column names.
-      const key = columns[j].name || columns[j];
+      const key = getColumnName(columns[j]);
       if (key in data[i]) {
         row[j] = data[i][key];
       } else {

--- a/superset-frontend/src/utils/common.js
+++ b/superset-frontend/src/utils/common.js
@@ -79,7 +79,7 @@ export function optionFromValue(opt) {
 }
 
 export function prepareCopyToClipboardTabularData(data, columns) {
-  let result = '';
+  let result = `${columns.map(column => column.name).join('\t')}\n`;
   for (let i = 0; i < data.length; i += 1) {
     const row = {};
     for (let j = 0; j < columns.length; j += 1) {

--- a/superset-frontend/src/utils/common.js
+++ b/superset-frontend/src/utils/common.js
@@ -79,7 +79,7 @@ export function optionFromValue(opt) {
 }
 
 export function prepareCopyToClipboardTabularData(data, columns) {
-  let result = `${columns.map(column => column.name).join('\t')}\n`;
+  let result = `${columns.map(column => column.name || column).join('\t')}\n`;
   for (let i = 0; i < data.length; i += 1) {
     const row = {};
     for (let j = 0; j < columns.length; j += 1) {

--- a/superset-frontend/src/utils/common.test.jsx
+++ b/superset-frontend/src/utils/common.test.jsx
@@ -52,7 +52,7 @@ describe('utils/common', () => {
     it('converts empty array', () => {
       const data = [];
       const columns = [];
-      expect(prepareCopyToClipboardTabularData(data, columns)).toEqual('\n');
+      expect(prepareCopyToClipboardTabularData(data, columns)).toEqual('');
     });
     it('converts non empty array', () => {
       const data = [

--- a/superset-frontend/src/utils/common.test.jsx
+++ b/superset-frontend/src/utils/common.test.jsx
@@ -50,28 +50,28 @@ describe('utils/common', () => {
   });
   describe('prepareCopyToClipboardTabularData', () => {
     it('converts empty array', () => {
-      const array = [];
-      const column = [];
-      expect(prepareCopyToClipboardTabularData(array, column)).toEqual('');
+      const data = [];
+      const columns = [];
+      expect(prepareCopyToClipboardTabularData(data, columns)).toEqual('\n');
     });
     it('converts non empty array', () => {
-      const array = [
+      const data = [
         { column1: 'lorem', column2: 'ipsum' },
         { column1: 'dolor', column2: 'sit', column3: 'amet' },
       ];
-      const column = ['column1', 'column2', 'column3'];
-      expect(prepareCopyToClipboardTabularData(array, column)).toEqual(
-        'lorem\tipsum\t\ndolor\tsit\tamet\n',
+      const columns = ['column1', 'column2', 'column3'];
+      expect(prepareCopyToClipboardTabularData(data, columns)).toEqual(
+        'column1\tcolumn2\tcolumn3\nlorem\tipsum\t\ndolor\tsit\tamet\n',
       );
     });
-    it('includes 0 values', () => {
-      const array = [
+    it('includes 0 values and handle column objects', () => {
+      const data = [
         { column1: 0, column2: 0 },
         { column1: 1, column2: -1, 0: 0 },
       ];
-      const column = ['column1', 'column2', '0'];
-      expect(prepareCopyToClipboardTabularData(array, column)).toEqual(
-        '0\t0\t\n1\t-1\t0\n',
+      const columns = [{ name: 'column1' }, { name: 'column2' }, { name: '0' }];
+      expect(prepareCopyToClipboardTabularData(data, columns)).toEqual(
+        'column1\tcolumn2\t0\n0\t0\t\n1\t-1\t0\n',
       );
     });
   });


### PR DESCRIPTION
### SUMMARY
When copying SQL Lab results from the query history to the clipboard, the headers are not included in the payload. This PR adds the headers. While updating the tests I noticed that we were missing test cases for what the `columns` array actually looks like; it's usually `columns: { name: string }[]`, not `columns: string[]`. I therefore updated one of the tests to use the object-based `columns` array instead of the string-based one.

### AFTER
Now when you copy this:
<img width="885" alt="image" src="https://user-images.githubusercontent.com/33317356/232719283-ef009167-4ac6-4a8b-992e-bab757711113.png">

You get this (the headers may appear to be off, but it's because they're tab separated, which isn't appropriately reflected in the code block):
```
ds	gender	name	num	state	num_boys	num_girls
1965-01-01 00:00:00.000000	boy	Aaron	369	CA	369	0
1965-01-01 00:00:00.000000	girl	Amy	494	CA	0	494
1965-01-01 00:00:00.000000	girl	Andrea	607	CA	0	607
1965-01-01 00:00:00.000000	boy	Andrew	933	CA	933	0
1965-01-01 00:00:00.000000	girl	Angela	1066	CA	0	1066
1965-01-01 00:00:00.000000	girl	Anna	564	CA	0	564
1965-01-01 00:00:00.000000	boy	Anthony	1928	CA	1928	0
1965-01-01 00:00:00.000000	girl	Barbara	922	CA	0	922
1965-01-01 00:00:00.000000	boy	Bradley	395	CA	395	0
1965-01-01 00:00:00.000000	girl	Brenda	961	CA	0	961
```

### BEFORE
Previously you got this:
```
1965-01-01 00:00:00.000000	boy	Aaron	369	CA	369	0
1965-01-01 00:00:00.000000	girl	Amy	494	CA	0	494
1965-01-01 00:00:00.000000	girl	Andrea	607	CA	0	607
1965-01-01 00:00:00.000000	boy	Andrew	933	CA	933	0
1965-01-01 00:00:00.000000	girl	Angela	1066	CA	0	1066
1965-01-01 00:00:00.000000	girl	Anna	564	CA	0	564
1965-01-01 00:00:00.000000	boy	Anthony	1928	CA	1928	0
1965-01-01 00:00:00.000000	girl	Barbara	922	CA	0	922
1965-01-01 00:00:00.000000	boy	Bradley	395	CA	395	0
1965-01-01 00:00:00.000000	girl	Brenda	961	CA	0	961
```

### TESTING INSTRUCTIONS
1. Run a query in SQL Lab
2. Go to Query History
3. Click "View" results
4. Click "Copy to clipboard"

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
