### PR TITLE
chore(chart-data): add post processing error message to response

### DIFF
--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -237,7 +237,7 @@ class QueryContextProcessor:
             try:
                 df = query_object.exec_post_processing(df)
             except InvalidPostProcessingError as ex:
-                raise QueryObjectValidationError from ex
+                raise QueryObjectValidationError(ex.message) from ex
 
         result.df = df
         result.query = query


### PR DESCRIPTION
### SUMMARY
When calling the chart data endpoint with an incorrect post processing operation, the error would get swallowed due to the reraised exception not containing a message. This adds that message from the original exception. I also checked that this was the only instance where a `QueryObjectValidationError` was not passing on a message, either a new one or the one from the original exception. We also add a test that would previously have failed due to the response being a 200 without the error message.

### AFTER
Now the 400 response of the incorrect request tells what the issue is:
![image](https://user-images.githubusercontent.com/33317356/233009280-aa232b3a-0eb8-4c8c-baea-ee6562b2a189.png)

### BEFORE
Previously the message was swallowed along with a 200 status code:
![image](https://user-images.githubusercontent.com/33317356/233009506-f36756a3-81ae-44da-88c5-180cfff89eaa.png)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
