### PR TITLE
fix: get or create db with an existing invalid URL

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -56,6 +56,7 @@ from sqlalchemy.sql import expression, Select
 
 from superset import app, db_engine_specs
 from superset.constants import LRU_CACHE_MAX_SIZE, PASSWORD_MASK
+from superset.databases.commands.exceptions import DatabaseInvalidError
 from superset.databases.utils import make_url_safe
 from superset.db_engine_specs.base import MetricType, TimeGrain
 from superset.extensions import (
@@ -888,7 +889,7 @@ class Database(
     def sqlalchemy_uri_decrypted(self) -> str:
         try:
             conn = make_url_safe(self.sqlalchemy_uri)
-        except (ArgumentError, ValueError):
+        except DatabaseInvalidError:
             # if the URI is invalid, ignore and return a placeholder url
             # (so users see 500 less often)
             return "dialect://invalid_uri"

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -47,7 +47,7 @@ from sqlalchemy import (
 from sqlalchemy.engine import Connection, Dialect, Engine
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.engine.url import URL
-from sqlalchemy.exc import ArgumentError, NoSuchModuleError
+from sqlalchemy.exc import NoSuchModuleError
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
 from sqlalchemy.pool import NullPool

--- a/tests/integration_tests/utils_tests.py
+++ b/tests/integration_tests/utils_tests.py
@@ -763,6 +763,13 @@ class TestUtils(SupersetTestCase):
         with self.assertRaises(DatabaseInvalidError):
             get_or_create_db("test_db", "yoursql:superset.db/()")
 
+    def test_get_or_create_db_existing_invalid_uri(self):
+        database = get_or_create_db("test_db", "sqlite:///superset.db")
+        database.sqlalchemy_uri = "None"
+        db.session.commit()
+        database = get_or_create_db("test_db", "sqlite:///superset.db")
+        assert database.sqlalchemy_uri == "sqlite:///superset.db"
+
     def test_get_iterable(self):
         self.assertListEqual(get_iterable(123), [123])
         self.assertListEqual(get_iterable([123]), [123])


### PR DESCRIPTION
### SUMMARY
When an existing invalid URL on the examples database exists, updating or reseting the examples database connection fails with:

``` python
121, in make_url_safe
    raise DatabaseInvalidError()  # pylint: disable=raise-missing-from
superset.databases.commands.exceptions.DatabaseInvalidError: Database parameters are invalid.
```

With this fix the `get_or_create_db` can support the existing invalid URI and update it URI with a new valid URI

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
