### PR TITLE
fix(ace-editor): use monospace fonts by default

### DIFF
--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/index.tsx
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/index.tsx
@@ -65,9 +65,6 @@ const StyledAceEditor = styled(AceEditor)`
       // double class is better than !important
       border: 1px solid ${theme.colors.grayscale.light2};
       font-feature-settings: 'liga' off, 'calt' off;
-      // Fira Code causes problem with Ace under Firefox
-      font-family: 'Menlo', 'Consolas', 'Courier New', 'Ubuntu Mono',
-        'source-code-pro', 'Lucida Console', monospace;
 
       &.ace_autocomplete {
         // Use !important because Ace Editor applies extra CSS at the last second

--- a/superset-frontend/src/components/AsyncAceEditor/index.tsx
+++ b/superset-frontend/src/components/AsyncAceEditor/index.tsx
@@ -84,6 +84,7 @@ export type AsyncAceEditorOptions = {
   defaultMode?: AceEditorMode;
   defaultTheme?: AceEditorTheme;
   defaultTabSize?: number;
+  fontFamily?: string;
   placeholder?: React.ComponentType<
     PlaceholderProps & Partial<IAceEditorProps>
   > | null;
@@ -98,6 +99,7 @@ export default function AsyncAceEditor(
     defaultMode,
     defaultTheme,
     defaultTabSize = 2,
+    fontFamily = 'Menlo, Consolas, Courier New, Ubuntu Mono, source-code-pro, Lucida Console, monospace',
     placeholder,
   }: AsyncAceEditorOptions = {},
 ) {
@@ -153,6 +155,7 @@ export default function AsyncAceEditor(
             theme={theme}
             tabSize={tabSize}
             defaultValue={defaultValue}
+            setOptions={{ fontFamily }}
             {...props}
           />
         );


### PR DESCRIPTION
### SUMMARY
Currently the adhoc popovers use a non-monospaced font on Safari, causing misplaced cursors when the statement contains bolded elements. This was not an issue in SQL Lab, which applied a custom font family. This PR moves the SQL Lab font family config into the main ACE Editor component, ensuring that all editors have the same font family.

### AFTER
Now the bolded elements no longer cause the cursor to lag behind:

https://user-images.githubusercontent.com/33317356/233307972-944f9c7b-d5ef-4dfa-89ce-fe090b796185.mp4

SQL Lab is unchanged:

<img width="507" alt="image" src="https://user-images.githubusercontent.com/33317356/233308257-47360741-59c2-4b66-bd28-1e6af1c88055.png">

### BEFORE
Before the cursor would fall behind when there were bolded elements in the statement:

https://user-images.githubusercontent.com/33317356/233308159-ca27972b-c813-4076-8ab4-1aaa358da8c0.mp4

SQL Lab before:

<img width="483" alt="image" src="https://user-images.githubusercontent.com/33317356/233308373-de2ab233-93b1-4b43-8543-0f4bd8a9a224.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
