### PR TITLE
feat(adhoc-column): add resize option

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
@@ -49,6 +49,7 @@ import {
   POPOVER_INITIAL_WIDTH,
 } from 'src/explore/constants';
 import { ExplorePageState } from 'src/explore/types';
+import useResizeButton from './useResizeButton';
 
 const StyledSelect = styled(Select)`
   .metric-option {
@@ -119,68 +120,15 @@ const ColumnSelectPopover = ({
 
   const [width, setWidth] = useState(POPOVER_INITIAL_WIDTH);
   const [height, setHeight] = useState(POPOVER_INITIAL_HEIGHT);
-  const [clientX, setClientX] = useState(0);
-  const [clientY, setClientY] = useState(0);
-  const [dragStartX, setDragStartX] = useState(0);
-  const [dragStartY, setDragStartY] = useState(0);
-  const [dragStartWidth, setDragStartWidth] = useState(width);
-  const [dragStartHeight, setDragStartHeight] = useState(height);
-  const [isDragging, setIsDragging] = useState(false);
 
-  const onMouseMove = useCallback((ev: MouseEvent): void => {
-    ev.preventDefault();
-    setClientX(ev.clientX);
-    setClientY(ev.clientY);
-  }, []);
-
-  const onMouseUp = useCallback(() => {
-    setIsDragging(false);
-  }, []);
-
-  const onDragDown = useCallback((ev: React.MouseEvent): void => {
-    setDragStartX(ev.clientX);
-    setDragStartY(ev.clientY);
-    setIsDragging(true);
-  }, []);
-
-  useEffect(() => {
-    if (isDragging) {
-      document.addEventListener('mousemove', onMouseMove);
-    } else {
-      setDragStartWidth(width);
-      setDragStartHeight(height);
-      document.removeEventListener('mousemove', onMouseMove);
-    }
-  }, [onMouseMove, isDragging]);
-
-  useEffect(() => {
-    if (isDragging) {
-      setWidth(
-        Math.max(
-          dragStartWidth + (clientX - dragStartX),
-          POPOVER_INITIAL_WIDTH,
-        ),
-      );
-      setHeight(
-        Math.max(
-          dragStartHeight + (clientY - dragStartY),
-          POPOVER_INITIAL_HEIGHT,
-        ),
-      );
-    }
-  }, [
-    isDragging,
-    clientX,
-    clientY,
-    dragStartWidth,
-    dragStartHeight,
-    dragStartX,
-    dragStartY,
-  ]);
-
-  useEffect(() => {
-    document.addEventListener('mouseup', onMouseUp);
-  }, [onMouseUp]);
+  const resizeButton = useResizeButton(
+    POPOVER_INITIAL_WIDTH,
+    POPOVER_INITIAL_HEIGHT,
+    width,
+    height,
+    setWidth,
+    setHeight,
+  );
 
   const sqlEditorRef = useRef(null);
 
@@ -482,13 +430,7 @@ const ColumnSelectPopover = ({
         >
           {t('Save')}
         </Button>
-        <i
-          role="button"
-          aria-label="Resize"
-          tabIndex={0}
-          onMouseDown={onDragDown}
-          className="fa fa-expand edit-popover-resize text-muted"
-        />
+        {resizeButton}
       </div>
     </Form>
   );

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
@@ -118,16 +118,9 @@ const ColumnSelectPopover = ({
     ColumnMeta | undefined
   >(initialSimpleColumn);
 
-  const [width, setWidth] = useState(POPOVER_INITIAL_WIDTH);
-  const [height, setHeight] = useState(POPOVER_INITIAL_HEIGHT);
-
-  const resizeButton = useResizeButton(
+  const [resizeButton, width, height] = useResizeButton(
     POPOVER_INITIAL_WIDTH,
     POPOVER_INITIAL_HEIGHT,
-    width,
-    height,
-    setWidth,
-    setHeight,
   );
 
   const sqlEditorRef = useRef(null);

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/useResizeButton.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/useResizeButton.tsx
@@ -19,17 +19,19 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 import throttle from 'lodash/throttle';
+import {
+  POPOVER_INITIAL_HEIGHT,
+  POPOVER_INITIAL_WIDTH,
+} from 'src/explore/constants';
 
 const RESIZE_THROTTLE_MS = 50;
 
 export default function useResizeButton(
   minWidth: number,
   minHeight: number,
-  width: number,
-  height: number,
-  setWidth: (newWidth: number) => void,
-  setHeight: (newHeight: number) => void,
-) {
+): [JSX.Element, number, number] {
+  const [width, setWidth] = useState(POPOVER_INITIAL_WIDTH);
+  const [height, setHeight] = useState(POPOVER_INITIAL_HEIGHT);
   const [clientX, setClientX] = useState(0);
   const [clientY, setClientY] = useState(0);
   const [dragStartX, setDragStartX] = useState(0);
@@ -123,13 +125,15 @@ export default function useResizeButton(
     return () => document.removeEventListener('mouseup', onMouseUp);
   }, [onMouseUp]);
 
-  return (
+  return [
     <i
       role="button"
       aria-label="Resize"
       tabIndex={0}
       onMouseDown={onDragDown}
       className="fa fa-expand edit-popover-resize text-muted"
-    />
-  );
+    />,
+    width,
+    height,
+  ];
 }

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/useResizeButton.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/useResizeButton.tsx
@@ -1,0 +1,118 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+
+export default function useResizeButton(
+  minWidth: number,
+  minHeight: number,
+  width: number,
+  height: number,
+  setWidth: (newWidth: number) => void,
+  setHeight: (newHeight: number) => void,
+) {
+  const [clientX, setClientX] = useState(0);
+  const [clientY, setClientY] = useState(0);
+  const [dragStartX, setDragStartX] = useState(0);
+  const [dragStartY, setDragStartY] = useState(0);
+  const [dragStartWidth, setDragStartWidth] = useState(width);
+  const [dragStartHeight, setDragStartHeight] = useState(height);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const onMouseMove = useCallback((ev: MouseEvent): void => {
+    ev.preventDefault();
+    setClientX(ev.clientX);
+    setClientY(ev.clientY);
+  }, []);
+
+  const onMouseUp = useCallback(() => {
+    setIsDragging(false);
+  }, []);
+
+  const onDragDown = useCallback((ev: React.MouseEvent): void => {
+    setDragStartX(ev.clientX);
+    setDragStartY(ev.clientY);
+    setIsDragging(true);
+  }, []);
+
+  useEffect(() => {
+    if (isDragging) {
+      document.addEventListener('mousemove', onMouseMove);
+    } else {
+      setDragStartWidth(width);
+      setDragStartHeight(height);
+      document.removeEventListener('mousemove', onMouseMove);
+    }
+  }, [onMouseMove, isDragging]);
+
+  const handleResize = useCallback(
+    (
+      dragStartX: number,
+      dragStartY: number,
+      dragStartWidth: number,
+      dragStartHeight: number,
+      clientX: number,
+      clientY: number,
+      minWidth: number,
+      minHeight: number,
+    ) => {
+      setWidth(Math.max(dragStartWidth + (clientX - dragStartX), minWidth));
+      setHeight(Math.max(dragStartHeight + (clientY - dragStartY), minHeight));
+    },
+    [setHeight, setWidth],
+  );
+
+  useEffect(() => {
+    if (isDragging) {
+      handleResize(
+        dragStartX,
+        dragStartY,
+        dragStartWidth,
+        dragStartHeight,
+        clientX,
+        clientY,
+        minWidth,
+        minHeight,
+      );
+    }
+  }, [
+    isDragging,
+    clientX,
+    clientY,
+    dragStartWidth,
+    dragStartHeight,
+    dragStartX,
+    dragStartY,
+  ]);
+
+  useEffect(() => {
+    document.addEventListener('mouseup', onMouseUp);
+    return () => document.removeEventListener('mouseup', onMouseUp);
+  }, [onMouseUp]);
+
+  return (
+    <i
+      role="button"
+      aria-label="Resize"
+      tabIndex={0}
+      onMouseDown={onDragDown}
+      className="fa fa-expand edit-popover-resize text-muted"
+    />
+  );
+}

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/useResizeButton.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/useResizeButton.tsx
@@ -18,6 +18,9 @@
  */
 
 import React, { useCallback, useEffect, useState } from 'react';
+import throttle from 'lodash/throttle';
+
+const RESIZE_THROTTLE_MS = 50;
 
 export default function useResizeButton(
   minWidth: number,
@@ -62,25 +65,8 @@ export default function useResizeButton(
   }, [onMouseMove, isDragging]);
 
   const handleResize = useCallback(
-    (
-      dragStartX: number,
-      dragStartY: number,
-      dragStartWidth: number,
-      dragStartHeight: number,
-      clientX: number,
-      clientY: number,
-      minWidth: number,
-      minHeight: number,
-    ) => {
-      setWidth(Math.max(dragStartWidth + (clientX - dragStartX), minWidth));
-      setHeight(Math.max(dragStartHeight + (clientY - dragStartY), minHeight));
-    },
-    [setHeight, setWidth],
-  );
-
-  useEffect(() => {
-    if (isDragging) {
-      handleResize(
+    throttle(
+      ({
         dragStartX,
         dragStartY,
         dragStartWidth,
@@ -89,7 +75,38 @@ export default function useResizeButton(
         clientY,
         minWidth,
         minHeight,
-      );
+      }: {
+        dragStartX: number;
+        dragStartY: number;
+        dragStartWidth: number;
+        dragStartHeight: number;
+        clientX: number;
+        clientY: number;
+        minWidth: number;
+        minHeight: number;
+      }): void => {
+        setWidth(Math.max(dragStartWidth + (clientX - dragStartX), minWidth));
+        setHeight(
+          Math.max(dragStartHeight + (clientY - dragStartY), minHeight),
+        );
+      },
+      RESIZE_THROTTLE_MS,
+    ),
+    [setHeight, setWidth],
+  );
+
+  useEffect(() => {
+    if (isDragging) {
+      handleResize({
+        dragStartX,
+        dragStartY,
+        dragStartWidth,
+        dragStartHeight,
+        clientX,
+        clientY,
+        minWidth,
+        minHeight,
+      });
     }
   }, [
     isDragging,

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.jsx
@@ -150,7 +150,7 @@ export default class AdhocFilterEditPopover extends React.Component {
         POPOVER_INITIAL_WIDTH,
       ),
       height: Math.max(
-        this.dragStartHeight + (e.clientY - this.dragStartY) * 2,
+        this.dragStartHeight + (e.clientY - this.dragStartY),
         POPOVER_INITIAL_HEIGHT,
       ),
     });

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx
@@ -248,7 +248,7 @@ export default class AdhocMetricEditPopover extends React.PureComponent {
         POPOVER_INITIAL_WIDTH,
       ),
       height: Math.max(
-        this.dragStartHeight + (e.clientY - this.dragStartY) * 2,
+        this.dragStartHeight + (e.clientY - this.dragStartY),
         POPOVER_INITIAL_HEIGHT,
       ),
     });

--- a/superset-frontend/src/explore/constants.ts
+++ b/superset-frontend/src/explore/constants.ts
@@ -158,6 +158,4 @@ export const TIME_FILTER_MAP = {
 
 export const POPOVER_INITIAL_HEIGHT = 240;
 export const POPOVER_INITIAL_WIDTH = 320;
-export const UNRESIZABLE_POPOVER_WIDTH = 296;
-
 export const UNSAVED_CHART_ID = 0;


### PR DESCRIPTION
### SUMMARY
This PR adds resizing to the adhoc column popover, and is based on what's currently used in the metric and filter popovers. This is often needed when writing custom SQL expressions. In addition, the height multiplier of 2 is removed from the metric and filter popovers, as it only makes intuitive sense when the popover placement is set to `left`, in which case the popover grows both upwards and downwards. Since we let AntD decide which placement to use, it makes more sense to not apply multiplier, as the popover often grows out of bounds quickly, causing weird side-effects when the placement changes. This also felt unintuitive, as the vertical movement was doubled, as opposed to horizontal movement, which was not multiplied.

### AFTER
Now the adhoc column popover is resizable:
<img width="806" alt="image" src="https://user-images.githubusercontent.com/33317356/233337423-e379c836-7e38-4f6b-a8cc-638ab1b9c79f.png">

Also, the removed multiplier makes the resize action be in line with the vertical mouse movement:

https://user-images.githubusercontent.com/33317356/233341632-b633fdba-1a5d-40a3-b909-f939c8191569.mp4

### BEFORE
Previously the adhoc column popover wasn't resizable:
<img width="647" alt="image" src="https://user-images.githubusercontent.com/33317356/233339014-04fae34a-7808-473c-aa02-e3f4eb1be536.png">

Also, the multiplier caused the resize action to feel unintuitive with top placement:

https://user-images.githubusercontent.com/33317356/233341488-04728fca-a063-43b8-9109-117801f8ae0c.mp4

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
