### PR TITLE
fix: Further drilling by different groupby fields

### DIFF
--- a/superset-frontend/src/components/Chart/ChartContextMenu/ChartContextMenu.tsx
+++ b/superset-frontend/src/components/Chart/ChartContextMenu/ChartContextMenu.tsx
@@ -234,9 +234,7 @@ const ChartContextMenu = (
     }
     menuItems.push(
       <DrillByMenuItems
-        filters={filters?.drillBy?.filters}
-        groupbyFieldName={filters?.drillBy?.groupbyFieldName}
-        adhocFilterFieldName={filters?.drillBy?.adhocFilterFieldName}
+        drillByConfig={filters?.drillBy}
         onSelection={onSelection}
         formData={formData}
         contextMenuY={clientY}

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.test.tsx
@@ -61,15 +61,14 @@ const defaultFilters = [
 
 const renderMenu = ({
   formData = defaultFormData,
-  filters = defaultFilters,
+  drillByConfig = { filters: defaultFilters, groupbyFieldName: 'groupby' },
   ...rest
 }: Partial<DrillByMenuItemsProps>) =>
   render(
     <Menu>
       <DrillByMenuItems
         formData={formData ?? defaultFormData}
-        filters={filters}
-        groupbyFieldName="groupby"
+        drillByConfig={drillByConfig}
         {...rest}
       />
     </Menu>,
@@ -133,7 +132,7 @@ test('render disabled menu item for unsupported chart', async () => {
 });
 
 test('render disabled menu item for supported chart, no filters', async () => {
-  renderMenu({ filters: [] });
+  renderMenu({ drillByConfig: { filters: [], groupbyFieldName: 'groupby' } });
   await expectDrillByDisabled('Drill by is not available for this data point');
 });
 
@@ -237,6 +236,6 @@ test('When menu item is clicked, call onSelection with clicked column and drill 
       column_name: 'col1',
       groupby: true,
     },
-    defaultFilters,
+    { filters: defaultFilters, groupbyFieldName: 'groupby' },
   );
 });

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.tsx
@@ -29,8 +29,8 @@ import { Menu } from 'src/components/Menu';
 import {
   BaseFormData,
   Behavior,
-  BinaryQueryObjectFilterClause,
   Column,
+  ContextMenuFilters,
   css,
   ensureIsArray,
   getChartMetadataRegistry,
@@ -55,12 +55,10 @@ const SHOW_COLUMNS_SEARCH_THRESHOLD = 10;
 const SEARCH_INPUT_HEIGHT = 48;
 
 export interface DrillByMenuItemsProps {
-  filters?: BinaryQueryObjectFilterClause[];
+  drillByConfig?: ContextMenuFilters['drillBy'];
   formData: BaseFormData & { [key: string]: any };
   contextMenuY?: number;
   submenuIndex?: number;
-  groupbyFieldName?: string;
-  adhocFilterFieldName?: string;
   onSelection?: (...args: any) => void;
   onClick?: (event: MouseEvent) => void;
   openNewModal?: boolean;
@@ -68,9 +66,7 @@ export interface DrillByMenuItemsProps {
 }
 
 export const DrillByMenuItems = ({
-  filters,
-  groupbyFieldName,
-  adhocFilterFieldName,
+  drillByConfig,
   formData,
   contextMenuY = 0,
   submenuIndex = 0,
@@ -90,13 +86,13 @@ export const DrillByMenuItems = ({
   const handleSelection = useCallback(
     (event, column) => {
       onClick(event);
-      onSelection(column, filters);
+      onSelection(column, drillByConfig);
       setCurrentColumn(column);
       if (openNewModal) {
         setShowModal(true);
       }
     },
-    [filters, onClick, onSelection, openNewModal],
+    [drillByConfig, onClick, onSelection, openNewModal],
   );
   const closeModal = useCallback(() => {
     setShowModal(false);
@@ -108,7 +104,9 @@ export const DrillByMenuItems = ({
     setSearchInput('');
   }, [columns.length]);
 
-  const hasDrillBy = ensureIsArray(filters).length && groupbyFieldName;
+  const hasDrillBy =
+    ensureIsArray(drillByConfig?.filters).length &&
+    drillByConfig?.groupbyFieldName;
 
   const handlesDimensionContextMenu = useMemo(
     () =>
@@ -131,9 +129,9 @@ export const DrillByMenuItems = ({
               .filter(column => column.groupby)
               .filter(
                 column =>
-                  !ensureIsArray(formData[groupbyFieldName]).includes(
-                    column.column_name,
-                  ) &&
+                  !ensureIsArray(
+                    formData[drillByConfig.groupbyFieldName ?? ''],
+                  ).includes(column.column_name) &&
                   column.column_name !== formData.x_axis &&
                   ensureIsArray(excludedColumns)?.every(
                     excludedCol =>
@@ -151,7 +149,7 @@ export const DrillByMenuItems = ({
     addDangerToast,
     excludedColumns,
     formData,
-    groupbyFieldName,
+    drillByConfig?.groupbyFieldName,
     handlesDimensionContextMenu,
     hasDrillBy,
   ]);
@@ -269,10 +267,8 @@ export const DrillByMenuItems = ({
       {showModal && (
         <DrillByModal
           column={currentColumn}
-          filters={filters}
+          drillByConfig={drillByConfig}
           formData={formData}
-          groupbyFieldName={groupbyFieldName}
-          adhocFilterFieldName={adhocFilterFieldName}
           onHideModal={closeModal}
           dataset={dataset!}
         />

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
@@ -82,6 +82,7 @@ const renderModal = async (modalProps: Partial<DrillByModalProps> = {}) => {
             formData={formData}
             onHideModal={() => setShowModal(false)}
             dataset={dataset}
+            drillByConfig={{ groupbyFieldName: 'groupby', filters: [] }}
             {...modalProps}
           />
         )}
@@ -148,7 +149,10 @@ test('should render alert banner when results fail to load', async () => {
 test('should generate Explore url', async () => {
   await renderModal({
     column: { column_name: 'name' },
-    filters: [{ col: 'gender', op: '==', val: 'boy' }],
+    drillByConfig: {
+      filters: [{ col: 'gender', op: '==', val: 'boy' }],
+      groupbyFieldName: 'groupby',
+    },
   });
   await waitFor(() => fetchMock.called(CHART_DATA_ENDPOINT));
   const expectedRequestPayload = {
@@ -208,7 +212,10 @@ test('should render radio buttons', async () => {
 test('render breadcrumbs', async () => {
   await renderModal({
     column: { column_name: 'name' },
-    filters: [{ col: 'gender', op: '==', val: 'boy' }],
+    drillByConfig: {
+      filters: [{ col: 'gender', op: '==', val: 'boy' }],
+      groupbyFieldName: 'groupby',
+    },
   });
 
   const breadcrumbItems = screen.getAllByTestId('drill-by-breadcrumb-item');


### PR DESCRIPTION

### SUMMARY
Some charts, like Pivot Table (`groupbyRows`, `groupbyColumns`), Mixed Chart (`groupby`, `groupby_b`) or Graph (`source`, `target`) have more than 1 dimensions field in their form data.
If user started drilling by 1 field (e.g. `groupbyRows`) and then attempted further drilling by another field (e.g. `groupbyColumns`), the drilling would incorrectly apply the selected dimension to the first field instead of the second.
Moreover, if a chart has multiple adhoc filter fields (Mixed Chart - `adhoc_filters` and `adhoc_filters_b`), the same problem would occur - the filter might get applied to the wrong field.

This PR fixes the issue by passing the information about current drilling config to the modal, so that it knows how to construct the form data of the drilled chart.

Also, we save the history of drilling configs in the state so that the "undo" feature also works correctly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/15073128/233418484-ca6aa116-02a5-4d6e-8bee-44f48ac94434.mov

After:

https://user-images.githubusercontent.com/15073128/233418176-2014ba47-1aa5-4004-ad73-e40c94589e12.mov

### TESTING INSTRUCTIONS

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
