### PR TITLE
test: cover empty AdvancedDataTypes internet_address and internet_port

### DIFF
--- a/tests/unit_tests/advanced_data_type/types_tests.py
+++ b/tests/unit_tests/advanced_data_type/types_tests.py
@@ -79,6 +79,29 @@ def test_cidr_func_invalid_ip():
     assert internet_address.translate_type(cidr_request) == cidr_response
 
 
+def test_cidr_func_empty_ip():
+    """Test to see if the cidr_func behaves as expected when no IP is passed in"""
+    cidr_request: AdvancedDataTypeRequest = {
+        "advanced_data_type": "cidr",
+        "values": [""],
+    }
+    cidr_response: AdvancedDataTypeResponse = {
+        "values": [""],
+        "error_message": "",
+        "display_value": "",
+        "valid_filter_operators": [
+            FilterStringOperators.EQUALS,
+            FilterStringOperators.GREATER_THAN_OR_EQUAL,
+            FilterStringOperators.GREATER_THAN,
+            FilterStringOperators.IN,
+            FilterStringOperators.LESS_THAN,
+            FilterStringOperators.LESS_THAN_OR_EQUAL,
+        ],
+    }
+
+    assert internet_address.translate_type(cidr_request) == cidr_response
+
+
 def test_port_translation_func_valid_port_number():
     """Test to see if the port_translation_func behaves as expected when a valid port number
     is passed in"""

--- a/tests/unit_tests/advanced_data_type/types_tests.py
+++ b/tests/unit_tests/advanced_data_type/types_tests.py
@@ -198,6 +198,30 @@ def test_port_translation_func_invalid_port_number():
     assert port.translate_type(port_request) == port_response
 
 
+def test_port_translation_func_empty_port_number():
+    """Test to see if the port_translation_func behaves as expected when no port
+    number is passed in"""
+    port_request: AdvancedDataTypeRequest = {
+        "advanced_data_type": "port",
+        "values": [""],
+    }
+    port_response: AdvancedDataTypeResponse = {
+        "values": [[""]],
+        "error_message": "",
+        "display_value": "",
+        "valid_filter_operators": [
+            FilterStringOperators.EQUALS,
+            FilterStringOperators.GREATER_THAN_OR_EQUAL,
+            FilterStringOperators.GREATER_THAN,
+            FilterStringOperators.IN,
+            FilterStringOperators.LESS_THAN,
+            FilterStringOperators.LESS_THAN_OR_EQUAL,
+        ],
+    }
+
+    assert port.translate_type(port_request) == port_response
+
+
 def test_cidr_translate_filter_func_equals():
     """Test to see if the cidr_translate_filter_func behaves as expected when the EQUALS
     operator is used"""


### PR DESCRIPTION
### SUMMARY
This PR adds two tests for `AdvancedDataTypes` `internet_address` and `internet_port` when no value was passed in.

### TESTING INSTRUCTIONS
`pytest` or `./scripts/tests/run.sh`

