### PR TITLE
fix: Drill by modal resizing

### DIFF
--- a/superset-frontend/src/components/Chart/DrillBy/DrillByChart.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByChart.tsx
@@ -49,6 +49,7 @@ export default function DrillByChart({
       css={css`
         width: 100%;
         height: 100%;
+        min-height: 0;
       `}
     >
       <SuperChart


### PR DESCRIPTION

### SUMMARY
When user used drill by feature in World Map chart, the modal would start growing vertically.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://user-images.githubusercontent.com/15073128/233432773-149e6521-e476-42d1-84f5-4777fd8c939e.mov

After:

<img width="1697" alt="image" src="https://user-images.githubusercontent.com/15073128/233432921-ddc340ca-2c38-47e4-9a19-620a46e957fa.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
