### PR TITLE
fix: Make sure the DeprecatedSelect label is always a string

### DIFF
--- a/superset-frontend/src/components/DeprecatedSelect/DeprecatedSelect.tsx
+++ b/superset-frontend/src/components/DeprecatedSelect/DeprecatedSelect.tsx
@@ -161,13 +161,15 @@ function styled<
       filterOption,
       ignoreAccents = false, // default is `true`, but it is slow
 
+      asText = (value: any) => (value ? String(value) : ''),
+
       getOptionValue = option =>
         typeof option === 'string' ? option : option[valueKey],
 
       getOptionLabel = option =>
         typeof option === 'string'
           ? option
-          : String(option[labelKey]) || String(option[valueKey]),
+          : asText(option[labelKey]) || asText(option[valueKey]),
 
       formatOptionLabel = (
         option: OptionType,

--- a/superset-frontend/src/components/DeprecatedSelect/DeprecatedSelect.tsx
+++ b/superset-frontend/src/components/DeprecatedSelect/DeprecatedSelect.tsx
@@ -167,7 +167,7 @@ function styled<
       getOptionLabel = option =>
         typeof option === 'string'
           ? option
-          : option[labelKey] || option[valueKey],
+          : String(option[labelKey]) || String(option[valueKey]),
 
       formatOptionLabel = (
         option: OptionType,

--- a/superset-frontend/src/components/DeprecatedSelect/DeprecatedSelect.tsx
+++ b/superset-frontend/src/components/DeprecatedSelect/DeprecatedSelect.tsx
@@ -161,7 +161,7 @@ function styled<
       filterOption,
       ignoreAccents = false, // default is `true`, but it is slow
 
-      asText = (value: any) => (value ? String(value) : ''),
+      asText = (value: any) => String(value ?? ''),
 
       getOptionValue = option =>
         typeof option === 'string' ? option : option[valueKey],


### PR DESCRIPTION
### SUMMARY
The `options` property of the `DeprecatedSelect` has its type defined from `OptionType` which extends `OptionTypeBase` and allows `any` values. Because of that, this PR adds an explicit string conversion when processing the `label` property to make sure it's a text and prevent rendering exceptions. One example of the necessary conversion is when the options have `BigNumber` as labels.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
