### PR TITLE
chore: fix deprecation warnings for SQLALchemy URL

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1947,7 +1947,7 @@ class BasicParametersMixin:
             query.update(cls.encryption_parameters)
 
         return str(
-            URL(
+            URL.create(
                 f"{cls.engine}+{cls.default_driver}".rstrip("+"),  # type: ignore
                 username=parameters.get("username"),
                 password=parameters.get("password"),

--- a/superset/db_engine_specs/clickhouse.py
+++ b/superset/db_engine_specs/clickhouse.py
@@ -314,7 +314,7 @@ class ClickHouseConnectEngineSpec(ClickHouseEngineSpec, BasicParametersMixin):
         if not url_params.get("database"):
             url_params["database"] = "__default__"
         url_params.pop("encryption", None)
-        return str(URL(f"{cls.engine}+{cls.default_driver}", **url_params))
+        return str(URL.create(f"{cls.engine}+{cls.default_driver}", **url_params))
 
     @classmethod
     def get_parameters_from_uri(

--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -200,7 +200,7 @@ class DatabricksNativeEngineSpec(DatabricksODBCEngineSpec, BasicParametersMixin)
             query.update(cls.encryption_parameters)
 
         return str(
-            URL(
+            URL.create(
                 f"{cls.engine}+{cls.default_driver}".rstrip("+"),
                 username="token",
                 password=parameters.get("access_token"),

--- a/superset/db_engine_specs/snowflake.py
+++ b/superset/db_engine_specs/snowflake.py
@@ -265,7 +265,7 @@ class SnowflakeEngineSpec(PostgresBaseEngineSpec):
         ] = None,
     ) -> str:
         return str(
-            URL(
+            URL.create(
                 "snowflake",
                 username=parameters.get("username"),
                 password=parameters.get("password"),

--- a/tests/unit_tests/db_engine_specs/test_drill.py
+++ b/tests/unit_tests/db_engine_specs/test_drill.py
@@ -36,7 +36,7 @@ def test_odbc_impersonation() -> None:
 
     from superset.db_engine_specs.drill import DrillEngineSpec
 
-    url = URL("drill+odbc")
+    url = URL.create("drill+odbc")
     username = "DoAsUser"
     url = DrillEngineSpec.get_url_for_impersonation(url, True, username)
     assert url.query["DelegationUID"] == username
@@ -52,7 +52,7 @@ def test_jdbc_impersonation() -> None:
 
     from superset.db_engine_specs.drill import DrillEngineSpec
 
-    url = URL("drill+jdbc")
+    url = URL.create("drill+jdbc")
     username = "DoAsUser"
     url = DrillEngineSpec.get_url_for_impersonation(url, True, username)
     assert url.query["impersonation_target"] == username
@@ -68,7 +68,7 @@ def test_sadrill_impersonation() -> None:
 
     from superset.db_engine_specs.drill import DrillEngineSpec
 
-    url = URL("drill+sadrill")
+    url = URL.create("drill+sadrill")
     username = "DoAsUser"
     url = DrillEngineSpec.get_url_for_impersonation(url, True, username)
     assert url.query["impersonation_target"] == username
@@ -86,7 +86,7 @@ def test_invalid_impersonation() -> None:
     from superset.db_engine_specs.drill import DrillEngineSpec
     from superset.db_engine_specs.exceptions import SupersetDBAPIProgrammingError
 
-    url = URL("drill+foobar")
+    url = URL.create("drill+foobar")
     username = "DoAsUser"
 
     with pytest.raises(SupersetDBAPIProgrammingError):


### PR DESCRIPTION
### SUMMARY
SQLAlchemy URL() is [deprecated since SQLAlchemy 1.4](https://docs.sqlalchemy.org/en/20/changelog/migration_14.html#the-url-object-is-now-immutable) in favor of URL.create()

### TESTING INSTRUCTIONS
`pytest` or `./scripts/tests/run.sh`
