### PR TITLE
fix: superset db upgrade not working due to removal of FLAGS variable…

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -64,7 +64,7 @@ logger = logging.getLogger(__name__)
 sqlparse.keywords.SQL_REGEX.insert(
     0,
     (
-        re.compile(r"'(''|\\\\|\\|[^'])*'", sqlparse.keywords.FLAGS).match,
+        re.compile(r"'(''|\\\\|\\|[^'])*'", (re.IGNORECASE | re.UNICODE)).match,
         sqlparse.tokens.String.Single,
     ),
 )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
In [superset/sql_parse.py](https://github.com/apache/superset/blob/master/superset/sql_parse.py#L67) sqlparse.keywords.FLAGS is used.
However, sqlparse has removed the FLAGS variable from the code [sqlparse/kewords.py](https://github.com/andialbrecht/sqlparse/blob/0.4.4/sqlparse/keywords.py).

This leads to an AttributeError when running the CLI command
```
$ superset db upgrade
AttributeError: module 'sqlparse.keywords' has no attribute 'FLAGS'
```

This PR fixes that by replacing the sqlparse.keywords.FLAGS variable in sql_parse.py with the value originally defined in sqlparse.keywords.FLAGS.


### TESTING INSTRUCTIONS

### ADDITIONAL INFORMATION

Fixes #23742 
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
