### PR TITLE
fix(native-filters): Fix encoding of non-temporal default values

### DIFF
--- a/superset/utils/dashboard_filter_scopes_converter.py
+++ b/superset/utils/dashboard_filter_scopes_converter.py
@@ -268,13 +268,13 @@ def convert_filter_scopes_to_native_filters(  # pylint: disable=invalid-name,too
                         if not default:
                             default = config.get("defaultValue")
 
-                            if default:
-                                if config["multiple"]:
-                                    default = default.split(";")
-                                else:
-                                    default = [default]
+                            if default and config["multiple"]:
+                                default = default.split(";")
 
                         if default:
+                            if not isinstance(default, list):
+                                default = [default]
+
                             fltr["defaultDataMask"] = {
                                 "extraFormData": {
                                     "filters": [


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Whilst working on https://github.com/apache/superset/pull/23269 I misinterpreted the encoding of the dashboard level default values for the non-temporal filters, i.e., in the following `dashboards.json_metadata`,

```
{
  "default_filters": "{\"1\": {\"baz\": [\"foo\"]}, \"2\": {\"bar\": \"foo\"}",
  ...
}
```

only filters which allow multiple selections (`baz`) are encoded as a list whereas non-multiple selections are encoded as a scalar (`bar`), whereas I had initially thought they were all encoded as a list.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Tested locally.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
