### PR TITLE
chore: Deprecates FilterBox

### DIFF
--- a/RESOURCES/FEATURE_FLAGS.md
+++ b/RESOURCES/FEATURE_FLAGS.md
@@ -76,7 +76,6 @@ These features flags are **safe for production**. They have been tested and will
 - ALLOW_ADHOC_SUBQUERY
 - DASHBOARD_CROSS_FILTERS
 - DASHBOARD_RBAC [(docs)](https://superset.apache.org/docs/creating-charts-dashboards/first-dashboard#manage-access-to-dashboards)
-- DASHBOARD_NATIVE_FILTERS
 - DATAPANEL_CLOSED_BY_DEFAULT
 - DISABLE_LEGACY_DATASOURCE_EDITOR
 - DRUID_JOINS
@@ -98,4 +97,5 @@ These features flags currently default to True and **will be removed in a future
 
 [//]: # "PLEASE KEEP THE LIST SORTED ALPHABETICALLY"
 
+- DASHBOARD_NATIVE_FILTERS
 - GENERIC_CHART_AXES

--- a/superset-frontend/src/features/alerts/AlertReportModal.test.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.test.tsx
@@ -64,7 +64,7 @@ test('renders the appropriate dropdown in Message Content section', async () => 
 
   expect(await screen.findByRole('radio', { name: /chart/i })).toBeChecked();
   expect(
-    screen.getByRole('radio', {
+    await screen.findByRole('radio', {
       name: /dashboard/i,
     }),
   ).not.toBeChecked();

--- a/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
+++ b/superset-frontend/src/visualizations/FilterBox/FilterBox.jsx
@@ -122,6 +122,9 @@ const StyledFilterContainer = styled.div`
   `}
 `;
 
+/**
+ * @deprecated in version 3.0.
+ */
 class FilterBox extends React.PureComponent {
   constructor(props) {
     super(props);

--- a/superset-frontend/src/visualizations/FilterBox/FilterBoxChartPlugin.js
+++ b/superset-frontend/src/visualizations/FilterBox/FilterBoxChartPlugin.js
@@ -25,7 +25,7 @@ import controlPanel from './controlPanel';
 
 const metadata = new ChartMetadata({
   category: t('Tools'),
-  name: t('Filter box'),
+  name: t('Filter box (deprecated)'),
   description:
     t(`Chart component that lets you add a custom filter UI in your dashboard. When added to dashboard, a filter box lets users specify specific values or ranges to filter charts by. The charts that each filter box is applied to can be fine tuned as well in the dashboard view.
 
@@ -33,8 +33,12 @@ const metadata = new ChartMetadata({
   exampleGallery: [{ url: example1 }, { url: example2 }],
   thumbnail,
   useLegacyApi: true,
+  tags: [t('Legacy'), t('Deprecated')],
 });
 
+/**
+ * @deprecated in version 3.0.
+ */
 export default class FilterBoxChartPlugin extends ChartPlugin {
   constructor() {
     super({

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -50,6 +50,7 @@ import pandas as pd
 import polyline
 import simplejson as json
 from dateutil import relativedelta as rdelta
+from deprecation import deprecated
 from flask import request
 from flask_babel import gettext as __, lazy_gettext as _
 from geopy.point import Point
@@ -2134,6 +2135,7 @@ class WorldMapViz(BaseViz):
         return data
 
 
+@deprecated(deprecated_in="3.0")
 class FilterBoxViz(BaseViz):
 
     """A multi filter, multi-choice filter box to make dashboards interactive"""


### PR DESCRIPTION
### SUMMARY
This PR deprecates `FilterBox` chart by adding the necessary comments/annotations to code and modifying the plugin metadata with the `(deprecated)` suffix and `Legacy` and `Deprecated` tags.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1084" alt="Screenshot 2023-04-23 at 12 14 42" src="https://user-images.githubusercontent.com/70410625/233848387-dfefd488-aae0-44b4-b93f-cdefc62877a7.png">

### TESTING INSTRUCTIONS
Check that FilterBox is deprecated in the viz picker.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
