### PR TITLE
fix: Docker ephemeral env

### DIFF
--- a/.github/workflows/docker-ephemeral-env.yml
+++ b/.github/workflows/docker-ephemeral-env.yml
@@ -1,4 +1,4 @@
-name: Push ephmereral env image
+name: Push ephemeral env image
 
 on:
   workflow_run:
@@ -17,14 +17,14 @@ jobs:
         id: check
         shell: bash
         run: |
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          if [ -n "${{ (secrets.AWS_ACCESS_KEY_ID != '' &&
-                        secrets.AWS_ACCESS_KEY_ID != '' &&
-                        secrets.AWS_SECRET_ACCESS_KEY != '' &&
-                        secrets.AWS_SECRET_ACCESS_KEY != '') || '' }}" ]; then
-            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
-          fi
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            if [ -n "${{ (secrets.AWS_ACCESS_KEY_ID != '' &&
+              secrets.AWS_ACCESS_KEY_ID != '' &&
+              secrets.AWS_SECRET_ACCESS_KEY != '' &&
+              secrets.AWS_SECRET_ACCESS_KEY != '') || '' }}" ]; then
+              echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+            fi
 
   docker_ephemeral_env:
     needs: config
@@ -33,66 +33,66 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: 'Download artifact'
-      uses: actions/github-script@v3.1.0
-      with:
-        script: |
-          const artifacts = await github.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: ${{ github.event.workflow_run.id }},
-          });
+      - name: "Download artifact"
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            const artifacts = await github.actions.listWorkflowRunArtifacts({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: ${{ github.event.workflow_run.id }},
+            });
 
-          core.info('*** artifacts')
-          core.info(JSON.stringify(artifacts))
+            core.info('*** artifacts')
+            core.info(JSON.stringify(artifacts))
 
-          const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-            return artifact.name == "build"
-          })[0];
-          if(!matchArtifact) return core.setFailed("Build artifacts not found")
+            const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "build"
+            })[0];
+            if(!matchArtifact) return core.setFailed("Build artifacts not found")
 
-          const download = await github.actions.downloadArtifact({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              artifact_id: matchArtifact.id,
-              archive_format: 'zip',
-          });
-          var fs = require('fs');
-          fs.writeFileSync('${{github.workspace}}/build.zip', Buffer.from(download.data));
+            const download = await github.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: matchArtifact.id,
+                archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/build.zip', Buffer.from(download.data));
 
-    - run: unzip build.zip
+      - run: unzip build.zip
 
-    - name: Display downloaded files (debug)
-      run: ls -la
+      - name: Display downloaded files (debug)
+        run: ls -la
 
-    - name: Get SHA
-      id: get-sha
-      run: echo "::set-output name=sha::$(cat ./SHA)"
+      - name: Get SHA
+        id: get-sha
+        run: echo "::set-output name=sha::$(cat ./SHA)"
 
-    - name: Get PR
-      id: get-pr
-      run: echo "::set-output name=num::$(cat ./PR-NUM)"
+      - name: Get PR
+        id: get-pr
+        run: echo "::set-output name=num::$(cat ./PR-NUM)"
 
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: us-west-2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
 
-    - name: Login to Amazon ECR
-      id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
 
-    - name: Load, tag and push image to ECR
-      id: push-image
-      env:
-        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        ECR_REPOSITORY: superset-ci
-        SHA: ${{ steps.get-sha.outputs.sha }}
-        IMAGE_TAG: pr-${{ steps.get-pr.outputs.num }}
-      run: |
-        docker load < $SHA.tar.gz
-        docker tag $SHA $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-        docker tag $SHA $ECR_REGISTRY/$ECR_REPOSITORY:$SHA
-        docker push -a $ECR_REGISTRY/$ECR_REPOSITORY
+      - name: Load, tag and push image to ECR
+        id: push-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: superset-ci
+          SHA: ${{ steps.get-sha.outputs.sha }}
+          IMAGE_TAG: pr-${{ steps.get-pr.outputs.num }}
+        run: |
+          docker load < $SHA.tar.gz
+          docker tag $SHA $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker tag $SHA $ECR_REGISTRY/$ECR_REPOSITORY:$SHA
+          docker push -a $ECR_REGISTRY/$ECR_REPOSITORY


### PR DESCRIPTION
### SUMMARY
Fixes Docker ephemeral env secrets step. It was using a wrong indentation and interpreting `aws-access-key-id` and `aws-secret-access-key` as parameters of `steps` instead of `run`.

### TESTING INSTRUCTIONS
Check that you don't get a `Push ephmereral env image: No jobs were run` error when opening a new PR.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
