### PR TITLE
fix(plugin-chart-handlebars): Fix TypeError when using handlebars columns raw mode

### DIFF
--- a/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controls/columns.tsx
+++ b/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controls/columns.tsx
@@ -68,7 +68,7 @@ const dndAllColumns: typeof sharedControls.groupby = {
       if (datasource?.columns[0]?.hasOwnProperty('filterable')) {
         newState.options = (datasource as Dataset)?.columns?.filter(
           (c: ColumnMeta) => c.filterable,
-        ); 
+        );
       } else newState.options = datasource.columns;
     }
     newState.queryMode = getQueryMode(controls);

--- a/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controls/columns.tsx
+++ b/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controls/columns.tsx
@@ -66,10 +66,9 @@ const dndAllColumns: typeof sharedControls.groupby = {
     const newState: ExtraControlProps = {};
     if (datasource) {
       if (datasource?.columns[0]?.hasOwnProperty('filterable')) {
-        const options = (datasource as Dataset).columns;
-        newState.options = Object.fromEntries(
-          options.map((option: ColumnMeta) => [option.column_name, option]),
-        );
+        newState.options = (datasource as Dataset)?.columns?.filter(
+          (c: ColumnMeta) => c.filterable,
+        ); 
       } else newState.options = datasource.columns;
     }
     newState.queryMode = getQueryMode(controls);


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
As already indicated in issue #22548 there is a TypeError when using the Handlebars visualization in the raw record mode. This seems to have been caused by adding the columns as an object instead of the expected array. I have simply taken the relevant code from the table plugin and replaced the invalid code with it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

From  #22548:
![afbeelding](https://user-images.githubusercontent.com/3202998/234138950-4fd598a6-bb7c-41b3-a8a7-afd97fdcd8d9.png)

Local testing after the fix:
![afbeelding](https://user-images.githubusercontent.com/3202998/234139427-cf15468d-0c57-417c-8fb9-4dc24ac8920b.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

* Load any dataset into a Handlebars chart
* Switch to `raw records` query mode
* Verify that there is no TypeError

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #22548 
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
