### PR TITLE
fix(sqllab): test failed due to legacy api url

### DIFF
--- a/superset-frontend/src/SqlLab/components/ExploreCtasResultsButton/ExploreCtasResultsButton.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ExploreCtasResultsButton/ExploreCtasResultsButton.test.tsx
@@ -32,7 +32,7 @@ import ExploreCtasResultsButton, {
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
 
-const getOrCreateTableEndpoint = `glob:*/superset/get_or_create_table/`;
+const getOrCreateTableEndpoint = `glob:*/api/v1/dataset/get_or_create/`;
 
 const setup = (props: Partial<ExploreCtasResultsButtonProps>, store?: Store) =>
   render(
@@ -63,7 +63,7 @@ describe('ExploreCtasResultsButton', () => {
 
     postFormSpy.mockClear();
     fetchMock.reset();
-    fetchMock.post(getOrCreateTableEndpoint, { table_id: 1234 });
+    fetchMock.post(getOrCreateTableEndpoint, { result: { table_id: 1234 } });
 
     fireEvent.click(getByText('Explore'));
 
@@ -82,8 +82,7 @@ describe('ExploreCtasResultsButton', () => {
     postFormSpy.mockClear();
     fetchMock.reset();
     fetchMock.post(getOrCreateTableEndpoint, {
-      status: 500,
-      body: { message: 'Unexpected all to v1 API' },
+      throws: new Error('Unexpected all to v1 API'),
     });
 
     fireEvent.click(getByText('Explore'));


### PR DESCRIPTION
### SUMMARY

Following unit test failed due to #22916 
It's because the test uses the legacy api endpoint but the api is migrated to new [endpoint](https://github.com/apache/superset/pull/22931/files#diff-1fe9f23910bda67f66ff7b5e9127cdaba0d304153a5246dbcb2d76d70d2e5a4fR1516)

It looks like the PR made and passed CI before the api migration completed.

This commit fixes the test code to pass the CI

```
FAIL src/SqlLab/components/ExploreCtasResultsButton/ExploreCtasResultsButton.test.tsx (5.404 s)
  ● Console
    console.warn
      Unmatched POST to http://localhost/api/v1/dataset/get_or_create/

      178 |   }
      179 |
    > 180 |   return fetchWithRetry(url, request);
          |          ^
      181 | }
      182 |
```


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
