### PR TITLE
fix: Hide FiltersPanel in standalone mode 3

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -153,11 +153,12 @@ const StyledDiv = styled.div`
 `;
 
 // @z-index-above-dashboard-charts + 1 = 11
-const FiltersPanel = styled.div<{ width: number }>`
+const FiltersPanel = styled.div<{ width: number; hidden: boolean }>`
   grid-column: 1;
   grid-row: 1 / span 2;
   z-index: 11;
   width: ${({ width }) => width}px;
+  ${({ hidden }) => hidden && `display: none;`}
 `;
 
 const StickyPanel = styled.div<{ width: number }>`
@@ -654,6 +655,7 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
               return (
                 <FiltersPanel
                   width={filterBarWidth}
+                  hidden={isReport}
                   data-test="dashboard-filters-panel"
                 >
                   <StickyPanel ref={containerRef} width={filterBarWidth}>

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -669,7 +669,6 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
                           height: filterBarHeight,
                           offset: filterBarOffset,
                         }}
-                        hidden={isReport}
                       />
                     </ErrorBoundary>
                   </StickyPanel>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -52,6 +52,8 @@ import ActionButtons from './ActionButtons';
 import Horizontal from './Horizontal';
 import Vertical from './Vertical';
 
+// FilterBar is just being hidden as it must still
+// render fully due to encapsulated logics
 const HiddenFilterBar = styled.div`
   display: none;
 `;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This PR https://github.com/apache/superset/pull/23543 fixed an issue for which reports would have to render but not display. However, it failed to hide the FiltersPanel (wrapper of the vertical FilterBar) that gets a fixed width and shows as a blank space in reports.

### BEFORE

![Clipboard 2023-17-03 at 12 05 28 PM](https://user-images.githubusercontent.com/60598000/234287132-3bcafda0-efa4-4454-8b4f-343238e7b4c9.png)

### TESTING INSTRUCTIONS
1. Visit a Dashboard with existing filters
2. Enter reports standalone mode with standalone=3 in the url
3. Make sure the Dashboard loads while the FilterBar is hidden fully and there is no blank space

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
