### PR TITLE
fix(rls api): Add missing init file

### DIFF
--- a/superset/row_level_security/__init__.py
+++ b/superset/row_level_security/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/superset/row_level_security/commands/create.py
+++ b/superset/row_level_security/commands/create.py
@@ -24,7 +24,7 @@ from superset.commands.exceptions import DatasourceNotFoundValidationError
 from superset.commands.utils import populate_roles
 from superset.connectors.sqla.models import SqlaTable
 from superset.dao.exceptions import DAOCreateFailedError
-from superset.extensions import appbuilder, db, security_manager
+from superset.extensions import db
 from superset.row_level_security.dao import RLSDAO
 
 logger = logging.getLogger(__name__)
@@ -42,7 +42,7 @@ class CreateRLSRuleCommand(BaseCommand):
             rule = RLSDAO.create(self._properties)
         except DAOCreateFailedError as ex:
             logger.exception(ex.exception)
-            raise DAOCreateFailedError
+            raise ex
 
         return rule
 

--- a/superset/row_level_security/commands/update.py
+++ b/superset/row_level_security/commands/update.py
@@ -24,7 +24,7 @@ from superset.commands.exceptions import DatasourceNotFoundValidationError
 from superset.commands.utils import populate_roles
 from superset.connectors.sqla.models import RowLevelSecurityFilter, SqlaTable
 from superset.dao.exceptions import DAOUpdateFailedError
-from superset.extensions import appbuilder, db, security_manager
+from superset.extensions import db
 from superset.row_level_security.commands.exceptions import RLSRuleNotFoundError
 from superset.row_level_security.dao import RLSDAO
 
@@ -45,7 +45,7 @@ class UpdateRLSRuleCommand(BaseCommand):
             rule = RLSDAO.update(self._model, self._properties)
         except DAOUpdateFailedError as ex:
             logger.exception(ex.exception)
-            raise DAOUpdateFailedError
+            raise ex
 
         return rule
 

--- a/superset/row_level_security/schemas.py
+++ b/superset/row_level_security/schemas.py
@@ -25,10 +25,14 @@ from superset.utils.core import RowLevelSecurityFilterType
 id_description = "Unique if of rls filter"
 name_description = "Name of rls filter"
 description_description = "Detailed description"
+# pylint: disable=line-too-long
 filter_type_description = "Regular filters add where clauses to queries if a user belongs to a role referenced in the filter, base filters apply filters to all queries except the roles defined in the filter, and can be used to define what users can see if no RLS filters within a filter group apply to them."
 tables_description = "These are the tables this filter will be applied to."
+# pylint: disable=line-too-long
 roles_description = "For regular filters, these are the roles this filter will be applied to. For base filters, these are the roles that the filter DOES NOT apply to, e.g. Admin if admin should see all data."
+# pylint: disable=line-too-long
 group_key_description = "Filters with the same group key will be ORed together within the group, while different filter groups will be ANDed together. Undefined group keys are treated as unique groups, i.e. are not grouped together. For example, if a table has three filters, of which two are for departments Finance and Marketing (group key = 'department'), and one refers to the region Europe (group key = 'region'), the filter clause would apply the filter (department = 'Finance' OR department = 'Marketing') AND (region = 'Europe')."
+# pylint: disable=line-too-long
 clause_description = "This is the condition that will be added to the WHERE clause. For example, to only return rows for a particular client, you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role, a base filter can be created with the clause `1 = 0` (always false)."
 
 get_delete_ids_schema = {"type": "array", "items": {"type": "integer"}}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We're seeing problems deploying as a result of this

```
File ".../superset/initialization/__init__.py", line 153, in init_views
    from superset.row_level_security.api import RLSRestApi
ModuleNotFoundError: No module named 'superset.row_level_security'
```

Several linting errors were undetected as a result of this too, the PR resolves these

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
