### PR TITLE
fix(config and clickhouse): the lack of time filter constraints in join subqueries

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -1554,6 +1554,9 @@ class ExtraRelatedQueryFilters(TypedDict, total=False):
 
 EXTRA_RELATED_QUERY_FILTERS: ExtraRelatedQueryFilters = {}
 
+# clickhouse  time_groupby_inline config
+TIME_GROUPBY_INLINE = True
+
 
 # -------------------------------------------------------------------
 # *                WARNING:  STOP EDITING  HERE                    *

--- a/superset/db_engine_specs/clickhouse.py
+++ b/superset/db_engine_specs/clickhouse.py
@@ -29,6 +29,7 @@ from sqlalchemy import types
 from sqlalchemy.engine.url import URL
 from urllib3.exceptions import NewConnectionError
 
+from superset import app  
 from superset.databases.utils import make_url_safe
 from superset.db_engine_specs.base import (
     BaseEngineSpec,
@@ -46,6 +47,7 @@ from superset.utils.network import is_hostname_valid, is_port_open
 if TYPE_CHECKING:
     from superset.models.core import Database
 
+config = app.config
 logger = logging.getLogger(__name__)
 
 
@@ -53,7 +55,7 @@ class ClickHouseBaseEngineSpec(BaseEngineSpec):
     """Shared engine spec for ClickHouse."""
 
     time_secondary_columns = True
-    time_groupby_inline = True
+    time_groupby_inline = config['TIME_GROUPBY_INLINE']
 
     _time_grain_expressions = {
         None: "{col}",


### PR DESCRIPTION


<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


at first we use mysql engine creating slice like this:

```
SELECT DATE(date) AS __timestamp,
       movie_title AS movie_title,
       sum(uv) AS `SUM(uv)`
FROM movie
INNER JOIN
  (SELECT movie_title AS movie_title__,
          sum(uv) AS mme_inner__
   FROM movie
   WHERE time_type = 'daily'
     AND date >= STR_TO_DATE('2023-03-12', '%Y-%m-%d')
     AND date < STR_TO_DATE('2023-03-15', '%Y-%m-%d')
   GROUP BY movie_title
   ORDER BY sum(pv) DESC
   LIMIT 5) AS anon_1 ON movie_title = movie_title__
WHERE date >= STR_TO_DATE('2023-03-12', '%Y-%m-%d')
  AND date < STR_TO_DATE('2023-03-15', '%Y-%m-%d')
  AND time_type = 'daily'
GROUP BY movie_title,
         DATE(date)
ORDER BY sum(pv) DESC
LIMIT 10000;
```

there is date time filter in the join clause;
and then we change our database to clickhouse, but the sql changed with same filters
like this:

```
SELECT DATE(date) AS __timestamp,
       movie_title AS movie_title,
       sum(uv) AS `SUM(uv)`
FROM movie
INNER JOIN
  (SELECT movie_title AS movie_title__,
          sum(uv) AS mme_inner__
   FROM movie
   WHERE time_type = 'daily'
   GROUP BY movie_title
   ORDER BY sum(pv) DESC
   LIMIT 5) AS anon_1 ON movie_title = movie_title__
WHERE date >= STR_TO_DATE('2023-03-12', '%Y-%m-%d')
  AND date < STR_TO_DATE('2023-03-15', '%Y-%m-%d')
  AND time_type = 'daily'
GROUP BY movie_title,
         DATE(date)
ORDER BY sum(pv) DESC
LIMIT 10000;
```

there's no date filter in the join clause

if change the ```time_groupby_inline``` to True, it works as mysql engine 

so we  want this flag   True , because If we have several years of data in our table, it will error .

oh, i find that this question is unrelated to that issue ，sorry about this and I have changed the title
