### PR TITLE
chore: update bleach

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,7 +23,7 @@ bcrypt==4.0.1
     # via paramiko
 billiard==3.6.4.0
     # via celery
-bleach==3.3.1
+bleach==6.0.0
     # via apache-superset
 brotli==1.0.9
     # via flask-compress
@@ -124,6 +124,8 @@ geopy==2.2.0
     # via apache-superset
 graphlib-backport==1.0.3
     # via apache-superset
+greenlet==2.0.2
+    # via sqlalchemy
 gunicorn==20.1.0
     # via apache-superset
 hashids==1.3.1
@@ -136,8 +138,6 @@ humanize==3.11.0
     # via apache-superset
 idna==3.2
     # via email-validator
-importlib-metadata==6.0.0
-    # via flask
 isodate==0.6.0
     # via apache-superset
 itsdangerous==2.1.1
@@ -189,7 +189,6 @@ ordered-set==4.1.0
     # via flask-limiter
 packaging==21.3
     # via
-    #   bleach
     #   deprecation
     #   limits
 pandas==1.5.3
@@ -326,8 +325,6 @@ wtforms-json==0.3.3
     # via apache-superset
 xlsxwriter==3.0.7
     # via apache-superset
-zipp==3.15.0
-    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     },
     install_requires=[
         "backoff>=1.8.0",
-        "bleach>=3.0.2, <4.0.0",
+        "bleach>=6.0.0, <7.0.0",
         "cachelib>=0.4.1,<0.5",
         "celery>=5.2.2, <6.0.0",
         "click>=8.0.3",

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -35,10 +35,10 @@ from superset.utils.decorators import statsd_gauge
 
 logger = logging.getLogger(__name__)
 
-TABLE_TAGS = ["table", "th", "tr", "td", "thead", "tbody", "tfoot"]
+TABLE_TAGS = {"table", "th", "tr", "td", "thead", "tbody", "tfoot"}
 TABLE_ATTRIBUTES = ["colspan", "rowspan", "halign", "border", "class"]
 
-ALLOWED_TAGS = [
+ALLOWED_TAGS = {
     "a",
     "abbr",
     "acronym",
@@ -54,7 +54,7 @@ ALLOWED_TAGS = [
     "p",
     "strong",
     "ul",
-] + TABLE_TAGS
+} | TABLE_TAGS
 
 ALLOWED_ATTRIBUTES = {
     "a": ["href", "title"],

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -664,7 +664,7 @@ def error_msg_from_exception(ex: Exception) -> str:
 
 
 def markdown(raw: str, markup_wrap: Optional[bool] = False) -> str:
-    safe_markdown_tags = [
+    safe_markdown_tags = {
         "h1",
         "h2",
         "h3",
@@ -690,7 +690,7 @@ def markdown(raw: str, markup_wrap: Optional[bool] = False) -> str:
         "dt",
         "img",
         "a",
-    ]
+    }
     safe_markdown_attrs = {
         "img": ["src", "alt", "title"],
         "a": ["href", "alt", "title"],


### PR DESCRIPTION
### SUMMARY
Update bleach to [latest 6.0.0 version](https://bleach.readthedocs.io/en/latest/changes.html#version-6-0-0-january-23rd-2023). Also, heads-up on bleach is deprecated and will only receive security fixes. https://github.com/apache/superset/discussions/23838


### TESTING INSTRUCTIONS
`pytest` or `./scripts/tests/run.sh`

