### PR TITLE
fix(tests): Ensure deterministic SELECT ordering for CSV upload tests

### DIFF
--- a/tests/integration_tests/csv_upload_tests.py
+++ b/tests/integration_tests/csv_upload_tests.py
@@ -385,12 +385,12 @@ def test_import_csv(mock_event_logger):
     )
     # make sure that john and empty string are replaced with None
     with test_db.get_sqla_engine_with_context() as engine:
-        data = engine.execute(f"SELECT * from {CSV_UPLOAD_TABLE} ORDER BY b").fetchall()
+        data = engine.execute(f"SELECT * from {CSV_UPLOAD_TABLE} ORDER BY c").fetchall()
         assert data == [(None, 1, "x"), ("paul", 2, None)]
         # default null values
         upload_csv(CSV_FILENAME2, CSV_UPLOAD_TABLE, extra={"if_exists": "replace"})
         # make sure that john and empty string are replaced with None
-        data = engine.execute(f"SELECT * from {CSV_UPLOAD_TABLE} ORDER BY b").fetchall()
+        data = engine.execute(f"SELECT * from {CSV_UPLOAD_TABLE} ORDER BY c").fetchall()
         assert data == [("john", 1, "x"), ("paul", 2, None)]
 
     # cleanup

--- a/tests/integration_tests/csv_upload_tests.py
+++ b/tests/integration_tests/csv_upload_tests.py
@@ -480,7 +480,9 @@ def test_import_excel(mock_event_logger):
     )
 
     with test_db.get_sqla_engine_with_context() as engine:
-        data = engine.execute(f"SELECT * from {EXCEL_UPLOAD_TABLE} ORDER BY b").fetchall()
+        data = engine.execute(
+            f"SELECT * from {EXCEL_UPLOAD_TABLE} ORDER BY b"
+        ).fetchall()
         assert data == [(0, "john", 1), (1, "paul", 2)]
 
 
@@ -544,7 +546,9 @@ def test_import_parquet(mock_event_logger):
     assert success_msg_f1 in resp
 
     with test_db.get_sqla_engine_with_context() as engine:
-        data = engine.execute(f"SELECT * from {PARQUET_UPLOAD_TABLE} ORDER BY b").fetchall()
+        data = engine.execute(
+            f"SELECT * from {PARQUET_UPLOAD_TABLE} ORDER BY b"
+        ).fetchall()
         assert data == [("john", 1), ("paul", 2)]
 
     # replace table with zip file
@@ -555,5 +559,7 @@ def test_import_parquet(mock_event_logger):
     assert success_msg_f2 in resp
 
     with test_db.get_sqla_engine_with_context() as engine:
-        data = engine.execute(f"SELECT * from {PARQUET_UPLOAD_TABLE} ORDER BY b").fetchall()
+        data = engine.execute(
+            f"SELECT * from {PARQUET_UPLOAD_TABLE} ORDER BY b"
+        ).fetchall()
         assert data == [("john", 1), ("paul", 2), ("max", 3), ("bob", 4)]

--- a/tests/integration_tests/csv_upload_tests.py
+++ b/tests/integration_tests/csv_upload_tests.py
@@ -122,8 +122,9 @@ def create_columnar_files():
     pd.DataFrame({"a": ["max", "bob"], "b": [3, 4]}).to_parquet(PARQUET_FILENAME2)
     
     with zipfile.ZipFile(ZIP_FILENAME, "w") as archive:
-        for filename in [PARQUET_FILENAME1, PARQUET_FILENAME2]:
-            archive.write(filename, filename)
+        archive.write(PARQUET_FILENAME1)
+        archive.write(PARQUET_FILENAME2)
+
     yield
     os.remove(ZIP_FILENAME)
     shutil.rmtree(ZIP_DIRNAME)

--- a/tests/integration_tests/csv_upload_tests.py
+++ b/tests/integration_tests/csv_upload_tests.py
@@ -120,7 +120,7 @@ def create_columnar_files():
     os.mkdir(ZIP_DIRNAME)
     pd.DataFrame({"a": ["john", "paul"], "b": [1, 2]}).to_parquet(PARQUET_FILENAME1)
     pd.DataFrame({"a": ["max", "bob"], "b": [3, 4]}).to_parquet(PARQUET_FILENAME2)
-    
+
     with zipfile.ZipFile(ZIP_FILENAME, "w") as archive:
         archive.write(PARQUET_FILENAME1)
         archive.write(PARQUET_FILENAME2)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Some unit tests are failing ([example](https://github.com/apache/superset/actions/runs/4823298353/jobs/8591610034?pr=23832)) as `SELECT` statements do not guarantee deterministic ordering unless an `ORDER BY` clause is used. It's unclear why these unit tests are failing somewhat consistently now, though it _might_ be due to a non-deterministic file ordering when adding files to a zip file.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
