### PR TITLE
fix(alerts): flaky test error

### DIFF
--- a/superset-frontend/src/features/alerts/AlertReportModal.test.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.test.tsx
@@ -21,8 +21,15 @@ import { render, screen, waitFor } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
 import AlertReportModal from './AlertReportModal';
 
+jest.mock('src/components/AsyncAceEditor', () => ({
+  ...jest.requireActual('src/components/AsyncAceEditor'),
+  TextAreaEditor: () => <div data-test="react-ace" />,
+}));
+
+const onHide = jest.fn();
+
 test('allows change to None in log retention', async () => {
-  render(<AlertReportModal show />, { useRedux: true });
+  render(<AlertReportModal show onHide={onHide} />, { useRedux: true });
   // open the log retention select
   userEvent.click(screen.getByText('90 days'));
   // change it to 30 days
@@ -42,7 +49,7 @@ test('allows change to None in log retention', async () => {
 });
 
 test('renders the appropriate dropdown in Message Content section', async () => {
-  render(<AlertReportModal show />, { useRedux: true });
+  render(<AlertReportModal show onHide={onHide} />, { useRedux: true });
 
   const chartRadio = screen.getByRole('radio', { name: /chart/i });
 
@@ -62,7 +69,8 @@ test('renders the appropriate dropdown in Message Content section', async () => 
   // Click the chart radio option
   userEvent.click(chartRadio);
 
-  expect(await screen.findByRole('radio', { name: /chart/i })).toBeChecked();
+  await waitFor(() => expect(chartRadio).toBeChecked());
+
   expect(
     await screen.findByRole('radio', {
       name: /dashboard/i,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This commit fixes the following flaky test error.

```
✕ renders the appropriate dropdown in Message Content section (1160 ms)

  ● renders the appropriate dropdown in Message Content section

    expect(element).toBeChecked()

    Received element is not checked:
      <input class="ant-radio-input" type="radio" value="chart" />

      63 |   userEvent.click(chartRadio);
      64 |
    > 65 |   expect(await screen.findByRole('radio', { name: /chart/i })).toBeChecked();
```

This commit also cleaned up warnings related to the react-ace editor and onHide prop by using jest.mock.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

After:

<img width="489" alt="Screenshot 2023-04-27 at 9 35 27 PM" src="https://user-images.githubusercontent.com/1392866/235055147-3ad91659-8655-4038-8e39-e23749152bbb.png">


Before:

<img width="493" alt="Screenshot 2023-04-27 at 9 33 39 PM" src="https://user-images.githubusercontent.com/1392866/235055041-1d75a2f7-7f08-4bc4-b31b-050102338674.png">

### TESTING INSTRUCTIONS

> npm run test

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
