### PR TITLE
fix: Native time range filter in legacy charts

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts
@@ -22,12 +22,16 @@ import {
   D3_FORMAT_DOCS,
   D3_TIME_FORMAT_OPTIONS,
   getStandardizedControls,
-  sections,
 } from '@superset-ui/chart-controls';
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
-    sections.legacyRegularTime,
+    {
+      label: t('Time'),
+      expanded: true,
+      description: t('Time related form attributes'),
+      controlSetRows: [['granularity_sqla'], ['time_range']],
+    },
     {
       label: t('Query'),
       expanded: true,

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1160,6 +1160,14 @@ def merge_extra_form_data(form_data: Dict[str, Any]) -> None:
                     for fltr in append_filters
                     if fltr
                 )
+    if (
+        form_data.get("time_range")
+        and not form_data.get("granularity")
+        and not form_data.get("granularity_sqla")
+    ):
+        for adhoc_filter in form_data.get("adhoc_filters", []):
+            if adhoc_filter.get("operator") == "TEMPORAL_RANGE":
+                adhoc_filter["comparator"] = form_data["time_range"]
 
 
 def merge_extra_filters(form_data: Dict[str, Any]) -> None:


### PR DESCRIPTION

### SUMMARY
Some legacy charts (e.g. Heatmap and Bar Chart) were not getting dashboard time range filters applied with GENERIC_CHART_AXES enabled. This PR manually converts the time range into an adhoc filter, similarly how it's done for v1 charts.

Additionally, this PR brings back the time section for Calendar Heatmap chart, which was broken without it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/15073128/235162705-66399bd0-018f-4b63-bcae-24c7b13893f9.png">

After:

<img width="1686" alt="image" src="https://user-images.githubusercontent.com/15073128/235162781-f6b90ff6-828d-41dd-8a0c-13678ccd53e3.png">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
