### PR TITLE
feat: Changes the Select component to preserve the search value when selecting

### DIFF
--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/nativeFilters.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/nativeFilters.test.ts
@@ -396,6 +396,7 @@ describe('Horizontal FilterBar', () => {
     setFilterBarOrientation('horizontal');
     enterNativeFilterEditModal();
     inputNativeFilterDefaultValue('Albania');
+    cy.get('.ant-select-selection-search-input').clear({ force: true });
     inputNativeFilterDefaultValue('Algeria', true);
     saveNativeFilterSettings([SAMPLE_CHART]);
     cy.getBySel('filter-bar').within(() => {

--- a/superset-frontend/src/components/Select/AsyncSelect.tsx
+++ b/superset-frontend/src/components/Select/AsyncSelect.tsx
@@ -482,6 +482,7 @@ const AsyncSelect = forwardRef(
         <StyledSelect
           allowClear={!isLoading && allowClear}
           aria-label={ariaLabel || name}
+          autoClearSearchValue={false}
           dropdownRender={dropdownRender}
           filterOption={handleFilterOption}
           filterSort={sortComparatorWithSearch}

--- a/superset-frontend/src/components/Select/Select.test.tsx
+++ b/superset-frontend/src/components/Select/Select.test.tsx
@@ -127,6 +127,11 @@ const type = (text: string) => {
   return userEvent.type(select, text, { delay: 10 });
 };
 
+const clearTypedText = () => {
+  const select = getSelect();
+  userEvent.clear(select);
+};
+
 const open = () => waitFor(() => userEvent.click(getSelect()));
 
 test('displays a header', async () => {
@@ -801,6 +806,7 @@ test('"Select All" is checked when unchecking a newly added option and all the o
   expect(await findSelectOption(selectAllOptionLabel(10))).toBeInTheDocument();
   // add a new option
   await type(`${NEW_OPTION}{enter}`);
+  clearTypedText();
   expect(await findSelectOption(selectAllOptionLabel(11))).toBeInTheDocument();
   expect(await findSelectOption(NEW_OPTION)).toBeInTheDocument();
   // select all should be selected
@@ -830,6 +836,7 @@ test('does not render "Select All" when there are 0 or 1 options', async () => {
   );
   expect(screen.queryByText(selectAllOptionLabel(1))).not.toBeInTheDocument();
   await type(`${NEW_OPTION}{enter}`);
+  clearTypedText();
   expect(screen.queryByText(selectAllOptionLabel(2))).toBeInTheDocument();
 });
 

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -456,6 +456,7 @@ const Select = forwardRef(
         <StyledSelect
           allowClear={!isLoading && allowClear}
           aria-label={ariaLabel || name}
+          autoClearSearchValue={false}
           dropdownRender={dropdownRender}
           filterOption={handleFilterOption}
           filterSort={sortComparatorWithSearch}


### PR DESCRIPTION
### SUMMARY
Sets `autoClearSearchValue={false}` in the `Select` component to to preserve the search value when selecting. Only applies when `mode` is set to `multiple`.

Resolves https://github.com/apache/superset/issues/23315

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://user-images.githubusercontent.com/70410625/235214442-ca997850-83bb-4ea6-a9c5-b94e03bf7260.mov



### TESTING INSTRUCTIONS
Make sure the search value is preserved when selecting.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
