### PR TITLE
fix(dremio): query with alias

### DIFF
--- a/superset/db_engine_specs/dremio.py
+++ b/superset/db_engine_specs/dremio.py
@@ -26,6 +26,8 @@ class DremioEngineSpec(BaseEngineSpec):
     engine = "dremio"
     engine_name = "Dremio"
 
+    allows_alias_in_select = False
+
     _time_grain_expressions = {
         None: "{col}",
         "PT1S": "DATE_TRUNC('second', {col})",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

With `GENERIC_CHART_AXES` enabled we're producing queries that are invalid for Dremio, eg:

```sql
SELECT DATE_TRUNC('day', pickup_date) AS pickup_date,
       COUNT(*)
FROM "reporting"."nyc_trips_weather"
GROUP BY DATE_TRUNC('day', pickup_date)
```

This happens because Dremio gets confused by the alias `pickup_date` and the actual column `pickup_date`.

The solution I found was to turn off projection aliases for Dremio.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

![Screenshot 2023-04-28 at 13-02-04 Superset](https://user-images.githubusercontent.com/1534870/235242900-da395f52-ebcd-4ebe-bbe6-dbbd9f34f1ad.png)

After:

![Screenshot 2023-04-28 at 13-01-37 Superset](https://user-images.githubusercontent.com/1534870/235242833-08e68230-52fd-4bb2-9010-796167a7e802.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Connect to Dremio and create a "Big number with trendline" chart showing a simple `COUNT(*)`.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
