### PR TITLE
fix(sql-editor): Fix run stop button color to improve usability

### DIFF
--- a/superset-frontend/src/SqlLab/components/RunQueryActionButton/index.tsx
+++ b/superset-frontend/src/SqlLab/components/RunQueryActionButton/index.tsx
@@ -146,7 +146,9 @@ const RunQueryActionButton = ({
               ),
               trigger: 'click',
             }
-          : { buttonStyle: 'primary' })}
+          : {
+              buttonStyle: shouldShowStopBtn ? 'danger' : 'primary',
+            })}
       >
         {buildText(shouldShowStopBtn, selectedText)}
       </ButtonComponent>

--- a/superset-frontend/src/SqlLab/components/RunQueryActionButton/index.tsx
+++ b/superset-frontend/src/SqlLab/components/RunQueryActionButton/index.tsx
@@ -44,7 +44,7 @@ const buildText = (
   if (shouldShowStopButton) {
     return (
       <>
-        <i className="fa fa-stop-circle-o" /> {t('Stop')}
+        <i className="fa fa-stop" /> {t('Stop')}
       </>
     );
   }

--- a/superset-frontend/src/SqlLab/components/RunQueryActionButton/index.tsx
+++ b/superset-frontend/src/SqlLab/components/RunQueryActionButton/index.tsx
@@ -44,7 +44,7 @@ const buildText = (
   if (shouldShowStopButton) {
     return (
       <>
-        <i className="fa fa-stop" /> {t('Stop')}
+        <i className="fa fa-stop-circle-o" /> {t('Stop')}
       </>
     );
   }
@@ -147,7 +147,7 @@ const RunQueryActionButton = ({
               trigger: 'click',
             }
           : {
-              buttonStyle: shouldShowStopBtn ? 'danger' : 'primary',
+              buttonStyle: shouldShowStopBtn ? 'warning' : 'primary',
             })}
       >
         {buildText(shouldShowStopBtn, selectedText)}

--- a/superset-frontend/src/explore/components/RunQueryButton/index.tsx
+++ b/superset-frontend/src/explore/components/RunQueryButton/index.tsx
@@ -42,7 +42,7 @@ export const RunQueryButton = ({
 }: RunQueryButtonProps) =>
   loading ? (
     <Button onClick={onStop} buttonStyle="warning" disabled={!canStopQuery}>
-      <i className="fa fa-stop-circle-o" /> {t('Stop')}
+      <i className="fa fa-stop" /> {t('Stop')}
     </Button>
   ) : (
     <Button


### PR DESCRIPTION
### SUMMARY
During the running state of a query, users may find it challenging to distinguish between the stop button and the run button due to their similar color schemes. As a result, users may accidentally click the stop button, causing unintended interruption of the query's execution.

This pull request proposes to modify the color of the stop button to make it more distinct from the run button during query execution. By doing so, it will be easier for users to differentiate between the two buttons and avoid accidentally clicking the stop button, thereby preventing unintentional interruption of the query's execution.

Edit:
As part of this PR, we have also updated the explore view's stop button icon, to match it with sql lab stop button icon, for the sake of consistency.

Before:
<img width="165" alt="Screenshot 2023-04-30 at 8 22 07 PM" src="https://user-images.githubusercontent.com/97945303/235517875-f4ec1ac0-33a7-4729-afe0-1c33e973e874.png">

After:
<img width="162" alt="Screenshot 2023-05-03 at 1 26 46 AM" src="https://user-images.githubusercontent.com/97945303/235866637-e8e53ed4-44bc-4fd7-a113-ad74ae35c4a0.png">



### TESTING INSTRUCTIONS
- Open SQL Lab
- Hit the run button to execute a query
- Check out the updated stop button color
