### PR TITLE
feat: Considers GENERIC_CHART_AXES in viz migrations

### DIFF
--- a/superset/migrations/shared/migrate_viz/base.py
+++ b/superset/migrations/shared/migrate_viz/base.py
@@ -16,14 +16,15 @@
 # under the License.
 from __future__ import annotations
 
+import copy
 import json
-from typing import Dict, Set
+from typing import Any, Dict, Set
 
 from alembic import op
 from sqlalchemy import and_, Column, Integer, String, Text
 from sqlalchemy.ext.declarative import declarative_base
 
-from superset import db
+from superset import db, is_feature_enabled
 from superset.migrations.shared.utils import paginated_update, try_load_json
 
 Base = declarative_base()
@@ -52,7 +53,7 @@ class MigrateViz:
         self.data = try_load_json(form_data)
 
     def _pre_action(self) -> None:
-        """some actions before migrate"""
+        """Some actions before migrate"""
 
     def _migrate(self) -> None:
         if self.data.get("viz_type") != self.source_viz_type:
@@ -68,22 +69,51 @@ class MigrateViz:
 
             if key in self.rename_keys:
                 rv_data[self.rename_keys[key]] = value
+                continue
 
             if key in self.remove_keys:
                 continue
 
             rv_data[key] = value
 
+        generic_chart_axes = is_feature_enabled("GENERIC_CHART_AXES")
+        if generic_chart_axes:
+            self._migrate_temporal_filter(rv_data)
+
         self.data = rv_data
 
     def _post_action(self) -> None:
-        """some actions after migrate"""
+        """Some actions after migrate"""
+
+    def _migrate_temporal_filter(self, rv_data: Dict[str, Any]) -> None:
+        """Adds a temporal filter."""
+        granularity_sqla = rv_data.pop("granularity_sqla", None)
+        time_range = rv_data.pop("time_range", None)
+
+        if not granularity_sqla or not time_range:
+            return
+
+        temporal_filter = {
+            "clause": "WHERE",
+            "subject": granularity_sqla,
+            "operator": "TEMPORAL_RANGE",
+            "comparator": time_range,
+            "expressionType": "SIMPLE",
+        }
+
+        if isinstance(granularity_sqla, dict):
+            temporal_filter["comparator"] = None
+            temporal_filter["expressionType"] = "SQL"
+            temporal_filter["subject"] = granularity_sqla["label"]
+            temporal_filter["sqlExpression"] = granularity_sqla["sqlExpression"]
+
+        rv_data["adhoc_filters"] = rv_data.get("adhoc_filters", []) + [temporal_filter]
 
     @classmethod
     def upgrade_slice(cls, slc: Slice) -> Slice:
         clz = cls(slc.params)
         slc.viz_type = cls.target_viz_type
-        form_data_bak = clz.data.copy()
+        form_data_bak = copy.deepcopy(clz.data)
 
         clz._pre_action()
         clz._migrate()

--- a/superset/migrations/shared/migrate_viz/base.py
+++ b/superset/migrations/shared/migrate_viz/base.py
@@ -24,7 +24,7 @@ from alembic import op
 from sqlalchemy import and_, Column, Integer, String, Text
 from sqlalchemy.ext.declarative import declarative_base
 
-from superset import db, is_feature_enabled
+from superset import conf, db, is_feature_enabled
 from superset.migrations.shared.utils import paginated_update, try_load_json
 
 Base = declarative_base()
@@ -76,8 +76,7 @@ class MigrateViz:
 
             rv_data[key] = value
 
-        generic_chart_axes = is_feature_enabled("GENERIC_CHART_AXES")
-        if generic_chart_axes:
+        if is_feature_enabled("GENERIC_CHART_AXES"):
             self._migrate_temporal_filter(rv_data)
 
         self.data = rv_data
@@ -88,9 +87,9 @@ class MigrateViz:
     def _migrate_temporal_filter(self, rv_data: Dict[str, Any]) -> None:
         """Adds a temporal filter."""
         granularity_sqla = rv_data.pop("granularity_sqla", None)
-        time_range = rv_data.pop("time_range", None)
+        time_range = rv_data.pop("time_range", conf.get("DEFAULT_TIME_FILTER"))
 
-        if not granularity_sqla or not time_range:
+        if not granularity_sqla:
             return
 
         temporal_filter = {

--- a/superset/migrations/shared/migrate_viz/base.py
+++ b/superset/migrations/shared/migrate_viz/base.py
@@ -87,7 +87,7 @@ class MigrateViz:
     def _migrate_temporal_filter(self, rv_data: Dict[str, Any]) -> None:
         """Adds a temporal filter."""
         granularity_sqla = rv_data.pop("granularity_sqla", None)
-        time_range = rv_data.pop("time_range", conf.get("DEFAULT_TIME_FILTER"))
+        time_range = rv_data.pop("time_range", None) or conf.get("DEFAULT_TIME_FILTER")
 
         if not granularity_sqla:
             return


### PR DESCRIPTION
### SUMMARY
This PR changes the base migration class so that if `GENERIC_CHART_AXES` is enabled when migrating a chart, the temporal filter will be created for the new viz type. It also fixes an issue where renaming a key was not deleting the old key and ensures that the `form_data` backup is a deep copy of the original `form_data`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
