### PR TITLE
fix(sqllab): clean comments within quotes

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -366,21 +366,28 @@ function splitByQuotedBlock(str) {
   let currentQuote = '';
   let chunkStart = 0;
 
-  str.split('').forEach((currentChar, i) => {
+  let i = 0;
+  while (i < str.length) {
+    const currentChar = str[i];
     if (
       currentQuote ? currentChar === currentQuote : quotes.includes(currentChar)
     ) {
+      let chunk;
       if (currentQuote) {
-        chunks.push(str.substring(chunkStart, i + 1));
+        chunk = str.substring(chunkStart, i + 1);
         chunkStart = i + 1;
         currentQuote = '';
       } else {
-        chunks.push(str.substring(chunkStart, i));
+        chunk = str.substring(chunkStart, i);
         chunkStart = i;
         currentQuote = currentChar;
       }
+      if (chunk) {
+        chunks.push(chunk);
+      }
     }
-  });
+    i += 1;
+  }
 
   if (chunkStart < str.length) {
     const lastChunk = str.substring(chunkStart);

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -399,17 +399,22 @@ export function cleanSqlComments(sql) {
   // group 1 -> /* */
   // group 2 -> --
   const chunks = splitByQuotedBlock(sql);
-  return chunks
-    .map((chunk, index) =>
-      quotes.includes(chunk[0]) ? `${quotedBlockHash}:${index}:` : chunk,
-    )
-    .join('')
-    .replace(/(--.*?$|\/\*[\s\S]*?\*\/)\n?/gm, '\n')
-    .replace(
-      quotedBlockMatch,
-      quotedBlock => chunks[quotedBlock.match(/:\d+/)[0].substring(1)],
-    )
-    .trim();
+  return (
+    chunks
+      // replace quoted blocks in a hash format
+      .map((chunk, index) =>
+        quotes.includes(chunk[0]) ? `${quotedBlockHash}:${index}:` : chunk,
+      )
+      .join('')
+      // Clean out the commented-out blocks
+      .replace(/(--.*?$|\/\*[\s\S]*?\*\/)\n?/gm, '\n')
+      .trim()
+      // restore quoted block to the original value
+      .replace(
+        quotedBlockMatch,
+        quotedBlock => chunks[quotedBlock.match(/:\d+/)[0].substring(1)],
+      )
+  );
 }
 
 export function runQuery(query) {

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -368,8 +368,7 @@ function splitByQuotedBlock(str) {
 
   str.split('').forEach((currentChar, i) => {
     if (
-      (currentQuote && currentChar === currentQuote) ||
-      (!currentQuote && quotes.includes(currentChar))
+      currentQuote ? currentChar === currentQuote : quotes.includes(currentChar)
     ) {
       if (currentQuote) {
         chunks.push(str.substring(chunkStart, i + 1));

--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.js
@@ -312,7 +312,16 @@ describe('async actions', () => {
     const makeRequest = () => {
       const request = actions.runQuery({
         ...query,
-        sql: '/*\nSELECT * FROM\n */\nSELECT 213--, {{ds}}\n/*\n{{new_param1}}\n{{new_param2}}*/\n\nFROM table',
+        sql: `/*
+  SELECT * FROM
+*/
+SELECT 213--, {{ds}} "quote out"
+/*
+{{new_param1}}
+{{new_param2}}*/
+
+FROM table
+WHERE value = '--"NULL"--' --{{test_param}}`,
       });
       return request(dispatch, () => initialState);
     };
@@ -326,7 +335,7 @@ describe('async actions', () => {
         expect(fetchMock.calls(runQueryEndpoint)).toHaveLength(1);
         expect(
           JSON.parse(fetchMock.calls(runQueryEndpoint)[0][1].body).sql,
-        ).toEqual('SELECT 213\n\n\nFROM table');
+        ).toEqual(`SELECT 213\n\n\nFROM table\nWHERE value = '--"NULL"--'`);
       });
     });
   });


### PR DESCRIPTION
### SUMMARY
minor regression from #23378

The regex for commented out block also clean up the block within the quotes.
Therefore following query threw a syntax error since it removes the quoted value.

```
SELECT * FROM table WHERE column = '--unknown--';
==> 
SELECT * FROM table WHERE column = '
```

This commit adds the condition to skip the quoted block.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After:

```
SELECT * FROM table WHERE column = '--unknown--';
==> 
SELECT * FROM table WHERE column = '--unknown--';
```

Before:

```
SELECT * FROM table WHERE column = '--unknown--';
==> 
SELECT * FROM table WHERE column = '
```


### TESTING INSTRUCTIONS
Added tests for edge cases

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
