### PR TITLE
feat: Adds a control to set the Secondary Y-axis bounds in Mixed charts

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
@@ -35,6 +35,7 @@ import { legendSection, richTooltipSection } from '../controls';
 
 const {
   area,
+  independentYAxesBounds,
   logAxis,
   markerEnabled,
   markerSize,
@@ -49,7 +50,6 @@ const {
   yAxisBounds,
   zoomable,
   xAxisLabelRotation,
-  yAxisIndex,
 } = DEFAULT_FORM_DATA;
 
 function createQuerySection(
@@ -235,23 +235,6 @@ function createCustomizeSection(
         },
       },
     ],
-    [
-      {
-        name: `yAxisIndex${controlSuffix}`,
-        config: {
-          type: 'SelectControl',
-          label: t('Y Axis'),
-          choices: [
-            [0, t('Primary')],
-            [1, t('Secondary')],
-          ],
-          default: yAxisIndex,
-          clearable: false,
-          renderTrigger: true,
-          description: t('Primary or secondary y-axis'),
-        },
-      },
-    ],
   ];
 }
 
@@ -367,11 +350,11 @@ const config: ControlPanelConfig = {
             name: 'y_axis_bounds',
             config: {
               type: 'BoundsControl',
-              label: t('Y Axis Bounds'),
+              label: t('Primary y-axis Bounds'),
               renderTrigger: true,
               default: yAxisBounds,
               description: t(
-                'Bounds for the Y-axis. When left empty, the bounds are ' +
+                'Bounds for the primary Y-axis. When left empty, the bounds are ' +
                   'dynamically defined based on the min/max of the data. Note that ' +
                   "this feature will only expand the axis range. It won't " +
                   "narrow the data's extent.",
@@ -397,6 +380,23 @@ const config: ControlPanelConfig = {
               renderTrigger: true,
               default: logAxis,
               description: t('Logarithmic scale on primary y-axis'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'y_axis_bounds_secondary',
+            config: {
+              type: 'BoundsControl',
+              label: t('Secondary y-axis Bounds'),
+              renderTrigger: true,
+              default: yAxisBounds,
+              description: t(
+                `Bounds for the secondary Y-axis. Only works when Independent Y-axes
+                bounds is enabled. When left empty, the bounds are dynamically defined
+                based on the min/max of the data. Note that this feature will only expand
+                the axis range. It won't narrow the data's extent.`,
+              ),
             },
           },
         ],
@@ -430,6 +430,20 @@ const config: ControlPanelConfig = {
               renderTrigger: true,
               default: logAxis,
               description: t('Logarithmic scale on secondary y-axis'),
+            },
+          },
+        ],
+        [
+          {
+            name: `independentYAxesBounds`,
+            config: {
+              type: 'CheckboxControl',
+              label: t('Independent Y-axes bounds'),
+              renderTrigger: true,
+              default: independentYAxesBounds,
+              description: t(
+                'Whether to display Y-axes bounds independently of each other',
+              ),
             },
           },
         ],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
@@ -409,8 +409,8 @@ const config: ControlPanelConfig = {
               renderTrigger: true,
               default: yAxisBounds,
               description: t(
-                `Bounds for the secondary Y-axis. Only works when Independent Y-axes
-                bounds is enabled. When left empty, the bounds are dynamically defined
+                `Bounds for the secondary Y-axis. Only works when Independent Y-axis
+                bounds are enabled. When left empty, the bounds are dynamically defined
                 based on the min/max of the data. Note that this feature will only expand
                 the axis range. It won't narrow the data's extent.`,
               ),

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
@@ -35,7 +35,6 @@ import { legendSection, richTooltipSection } from '../controls';
 
 const {
   area,
-  independentYAxesBounds,
   logAxis,
   markerEnabled,
   markerSize,
@@ -50,6 +49,7 @@ const {
   yAxisBounds,
   zoomable,
   xAxisLabelRotation,
+  yAxisIndex,
 } = DEFAULT_FORM_DATA;
 
 function createQuerySection(
@@ -232,6 +232,23 @@ function createCustomizeSection(
           description: t(
             'Size of marker. Also applies to forecast observations.',
           ),
+        },
+      },
+    ],
+    [
+      {
+        name: `yAxisIndex${controlSuffix}`,
+        config: {
+          type: 'SelectControl',
+          label: t('Y Axis'),
+          choices: [
+            [0, t('Primary')],
+            [1, t('Secondary')],
+          ],
+          default: yAxisIndex,
+          clearable: false,
+          renderTrigger: true,
+          description: t('Primary or secondary y-axis'),
         },
       },
     ],
@@ -430,20 +447,6 @@ const config: ControlPanelConfig = {
               renderTrigger: true,
               default: logAxis,
               description: t('Logarithmic scale on secondary y-axis'),
-            },
-          },
-        ],
-        [
-          {
-            name: `independentYAxesBounds`,
-            config: {
-              type: 'CheckboxControl',
-              label: t('Independent Y-axes bounds'),
-              renderTrigger: true,
-              default: independentYAxesBounds,
-              description: t(
-                'Whether to display Y-axes bounds independently of each other',
-              ),
             },
           },
         ],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -139,8 +139,8 @@ export default function transformProps(
     yAxisFormatSecondary,
     xAxisTimeFormat,
     yAxisBounds,
-    yAxisIndex,
-    yAxisIndexB,
+    yAxisBoundsSecondary,
+    independentYAxesBounds,
     yAxisTitleSecondary,
     zoomable,
     richTooltip,
@@ -159,6 +159,8 @@ export default function transformProps(
     percentageThreshold,
   }: EchartsMixedTimeseriesFormData = { ...DEFAULT_FORM_DATA, ...formData };
 
+  const yAxisIndex = 0;
+  const yAxisIndexB = independentYAxesBounds ? 1 : 0;
   const refs: Refs = {};
   const colorScale = CategoricalColorNamespace.getScale(colorScheme as string);
 
@@ -285,10 +287,13 @@ export default function transformProps(
 
   // yAxisBounds need to be parsed to replace incompatible values with undefined
   let [min, max] = (yAxisBounds || []).map(parseYAxisBound);
+  let [minSecondary, maxSecondary] = (yAxisBoundsSecondary || []).map(
+    parseYAxisBound,
+  );
 
   const maxLabelFormatter = getOverMaxHiddenFormatter({ max, formatter });
   const maxLabelFormatterSecondary = getOverMaxHiddenFormatter({
-    max,
+    max: maxSecondary,
     formatter: formatterSecondary,
   });
 
@@ -348,6 +353,8 @@ export default function transformProps(
   if (contributionMode === 'row' && stack) {
     if (min === undefined) min = 0;
     if (max === undefined) max = 1;
+    if (minSecondary === undefined) minSecondary = 0;
+    if (maxSecondary === undefined) maxSecondary = 1;
   }
 
   const tooltipFormatter =
@@ -415,8 +422,8 @@ export default function transformProps(
       {
         ...defaultYAxis,
         type: logAxisSecondary ? 'log' : 'value',
-        min,
-        max,
+        min: minSecondary,
+        max: maxSecondary,
         minorTick: { show: true },
         splitLine: { show: false },
         minorSplitLine: { show: minorSplitLine },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -140,7 +140,8 @@ export default function transformProps(
     xAxisTimeFormat,
     yAxisBounds,
     yAxisBoundsSecondary,
-    independentYAxesBounds,
+    yAxisIndex,
+    yAxisIndexB,
     yAxisTitleSecondary,
     zoomable,
     richTooltip,
@@ -159,8 +160,6 @@ export default function transformProps(
     percentageThreshold,
   }: EchartsMixedTimeseriesFormData = { ...DEFAULT_FORM_DATA, ...formData };
 
-  const yAxisIndex = 0;
-  const yAxisIndexB = independentYAxesBounds ? 1 : 0;
   const refs: Refs = {};
   const colorScale = CategoricalColorNamespace.getScale(colorScheme as string);
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
@@ -82,8 +82,7 @@ export type EchartsMixedTimeseriesFormData = QueryFormData & {
   showValueB: boolean;
   stack: StackType;
   stackB: StackType;
-  yAxisIndex?: number;
-  yAxisIndexB?: number;
+  independentYAxesBounds: boolean;
   groupby: QueryFormColumn[];
   groupbyB: QueryFormColumn[];
 } & LegendFormData &
@@ -123,8 +122,7 @@ export const DEFAULT_FORM_DATA: EchartsMixedTimeseriesFormData = {
   showValueB: TIMESERIES_DEFAULTS.showValue,
   stack: TIMESERIES_DEFAULTS.stack,
   stackB: TIMESERIES_DEFAULTS.stack,
-  yAxisIndex: 0,
-  yAxisIndexB: 0,
+  independentYAxesBounds: false,
   groupby: [],
   groupbyB: [],
   zoomable: TIMESERIES_DEFAULTS.zoomable,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
@@ -82,7 +82,8 @@ export type EchartsMixedTimeseriesFormData = QueryFormData & {
   showValueB: boolean;
   stack: StackType;
   stackB: StackType;
-  independentYAxesBounds: boolean;
+  yAxisIndex?: number;
+  yAxisIndexB?: number;
   groupby: QueryFormColumn[];
   groupbyB: QueryFormColumn[];
 } & LegendFormData &
@@ -122,7 +123,8 @@ export const DEFAULT_FORM_DATA: EchartsMixedTimeseriesFormData = {
   showValueB: TIMESERIES_DEFAULTS.showValue,
   stack: TIMESERIES_DEFAULTS.stack,
   stackB: TIMESERIES_DEFAULTS.stack,
-  independentYAxesBounds: false,
+  yAxisIndex: 0,
+  yAxisIndexB: 0,
   groupby: [],
   groupbyB: [],
   zoomable: TIMESERIES_DEFAULTS.zoomable,


### PR DESCRIPTION
### SUMMARY
This PR introduces a control to set the Secondary Y-axis bounds for Mixed charts.

It's out of the scope of this PR to improve the categorization and display positions of the controls but we should definitely do it in a follow-up PR because it's not very user friendly. @kasiazjc 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://user-images.githubusercontent.com/70410625/236025589-bfc4c6bf-1371-40aa-8bcd-fb33449751d8.mov

### TESTING INSTRUCTIONS
Check the video for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
