### PR TITLE
fix(celery worker): install unzip & wget

### DIFF
--- a/docs/docs/installation/running-on-kubernetes.mdx
+++ b/docs/docs/installation/running-on-kubernetes.mdx
@@ -305,6 +305,7 @@ supersetWorker:
       # Install chrome webdriver
       # See https://github.com/apache/superset/blob/4fa3b6c7185629b87c27fc2c0e5435d458f7b73d/docs/src/pages/docs/installation/email_reports.mdx
       apt update
+      apt install wget unzip -y
       wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
       apt install -y --no-install-recommends ./google-chrome-stable_current_amd64.deb
       wget https://chromedriver.storage.googleapis.com/88.0.4324.96/chromedriver_linux64.zip


### PR DESCRIPTION


<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I stumbled upon this issue that the worker was not able to install chrome and chromedriver because wget and unzip were missing. So adding them during worker init will fix the issue.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before adding:
![image](https://user-images.githubusercontent.com/35467078/235964743-a7cf3613-8dde-41b3-8539-c831063d5096.png)

After adding:
![image](https://user-images.githubusercontent.com/35467078/235964847-7ab6ecee-8d6f-4ef5-8c8b-f43804362231.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Simply try to init the worker with Kubernetes config, with apt install unzip wget -y added to the command: part.
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
