### PR TITLE
fix: timeout should be an integer

### DIFF
--- a/superset/utils/cache.py
+++ b/superset/utils/cache.py
@@ -95,8 +95,7 @@ def view_cache_key(*args: Any, **kwargs: Any) -> str:  # pylint: disable=unused-
 
 
 def memoized_func(
-    key: Optional[str] = None,
-    cache: Cache = cache_manager.cache,
+    key: Optional[str] = None, cache: Cache = cache_manager.cache
 ) -> Callable[..., Any]:
     """
     Decorator with configurable key and cache backend.
@@ -143,7 +142,7 @@ def memoized_func(
             if not kwargs.get("force") and obj is not None:
                 return obj
             obj = f(*args, **kwargs)
-            cache.set(cache_key, obj, timeout=kwargs.get("cache_timeout"))
+            cache.set(cache_key, obj, timeout=kwargs.get("cache_timeout", 0))
             return obj
 
         return wrapped_f


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The cache timeout should be an integer, but we're setting it to `None` when it's not specified. Instead, we should use 0 for no expiration.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

N/A

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
