### PR TITLE
chore: relax Flask version constraint

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -75,7 +75,7 @@ dnspython==2.1.0
     # via email-validator
 email-validator==1.1.3
     # via flask-appbuilder
-flask==2.1.3
+flask==2.2.5
     # via
     #   apache-superset
     #   flask-appbuilder
@@ -124,6 +124,8 @@ geopy==2.2.0
     # via apache-superset
 graphlib-backport==1.0.3
     # via apache-superset
+greenlet==2.0.2
+    # via sqlalchemy
 gunicorn==20.1.0
     # via apache-superset
 hashids==1.3.1
@@ -136,8 +138,6 @@ humanize==3.11.0
     # via apache-superset
 idna==3.2
     # via email-validator
-importlib-metadata==6.3.0
-    # via flask
 importlib-resources==5.12.0
     # via limits
 isodate==0.6.0
@@ -168,6 +168,7 @@ markupsafe==2.1.1
     # via
     #   jinja2
     #   mako
+    #   werkzeug
     #   wtforms
 marshmallow==3.13.0
     # via
@@ -299,7 +300,6 @@ typing-extensions==4.4.0
     #   apache-superset
     #   flask-limiter
     #   limits
-    #   rich
 urllib3==1.26.6
     # via selenium
 vine==5.0.0
@@ -309,7 +309,7 @@ vine==5.0.0
     #   kombu
 wcwidth==0.2.5
     # via prompt-toolkit
-werkzeug==2.1.2
+werkzeug==2.3.3
     # via
     #   flask
     #   flask-jwt-extended
@@ -326,10 +326,6 @@ wtforms-json==0.3.5
     # via apache-superset
 xlsxwriter==3.0.7
     # via apache-superset
-zipp==3.15.0
-    # via
-    #   importlib-metadata
-    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -10,10 +10,8 @@
     # via
     #   -r requirements/base.in
     #   -r requirements/docker.in
-gevent==21.8.0
+gevent==22.10.2
     # via -r requirements/docker.in
-greenlet==1.1.3.post0
-    # via gevent
 psycopg2-binary==2.9.6
     # via apache-superset
 zope-event==4.5.0

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -137,8 +137,3 @@ trino==0.319.0
     # via apache-superset
 websocket-client==1.2.0
     # via docker
-wrapt==1.12.1
-    # via astroid
-# The following packages are considered to be unsafe in a requirements file:
-# pip
-# setuptools

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
         "cron-descriptor",
         "cryptography>=39.0.1, <40",
         "deprecation>=2.1.0, <2.2.0",
-        "flask>=2.1.3, <2.2",
+        "flask>=2.1.3, <2.3",
         "flask-appbuilder>=4.3.0, <5.0.0",
         "flask-caching>=1.10.1, <1.11",
         "flask-compress>=1.13, <2.0",

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -805,7 +805,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
             buf,
             mimetype="application/zip",
             as_attachment=True,
-            attachment_filename=filename,
+            download_name=filename,
         )
         if token:
             response.set_cookie(token, "done", max_age=600)

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -819,7 +819,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
                 buf,
                 mimetype="application/zip",
                 as_attachment=True,
-                attachment_filename=filename,
+                download_name=filename,
             )
             if token:
                 response.set_cookie(token, "done", max_age=600)

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -1058,7 +1058,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
             buf,
             mimetype="application/zip",
             as_attachment=True,
-            attachment_filename=filename,
+            download_name=filename,
         )
         if token:
             response.set_cookie(token, "done", max_age=600)

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -524,7 +524,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
                 buf,
                 mimetype="application/zip",
                 as_attachment=True,
-                attachment_filename=filename,
+                download_name=filename,
             )
             if token:
                 response.set_cookie(token, "done", max_age=600)

--- a/superset/importexport/api.py
+++ b/superset/importexport/api.py
@@ -87,7 +87,7 @@ class ImportExportRestApi(BaseSupersetApi):
             buf,
             mimetype="application/zip",
             as_attachment=True,
-            attachment_filename=filename,
+            download_name=filename,
         )
         return response
 

--- a/superset/queries/saved_queries/api.py
+++ b/superset/queries/saved_queries/api.py
@@ -284,7 +284,7 @@ class SavedQueryRestApi(BaseSupersetModelRestApi):
             buf,
             mimetype="application/zip",
             as_attachment=True,
-            attachment_filename=filename,
+            download_name=filename,
         )
         if token:
             response.set_cookie(token, "done", max_age=600)

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -490,7 +490,7 @@ def show_http_exception(ex: HTTPException) -> FlaskResponse:
         and ex.code in {404, 500}
     ):
         path = resource_filename("superset", f"static/assets/{ex.code}.html")
-        return send_file(path, cache_timeout=0), ex.code
+        return send_file(path, max_age=0), ex.code
 
     return json_errors_response(
         errors=[
@@ -512,7 +512,7 @@ def show_command_errors(ex: CommandException) -> FlaskResponse:
     logger.warning("CommandException", exc_info=True)
     if "text/html" in request.accept_mimetypes and not config["DEBUG"]:
         path = resource_filename("superset", "static/assets/500.html")
-        return send_file(path, cache_timeout=0), 500
+        return send_file(path, max_age=0), 500
 
     extra = ex.normalized_messages() if isinstance(ex, CommandInvalidError) else {}
     return json_errors_response(
@@ -534,7 +534,7 @@ def show_unexpected_exception(ex: Exception) -> FlaskResponse:
     logger.exception(ex)
     if "text/html" in request.accept_mimetypes and not config["DEBUG"]:
         path = resource_filename("superset", "static/assets/500.html")
-        return send_file(path, cache_timeout=0), 500
+        return send_file(path, max_age=0), 500
 
     return json_errors_response(
         errors=[


### PR DESCRIPTION
Flask 2.1 no longer seems to be receiving updates.

In order to keep receveiving critical Flask updates, the upper version
constraint for Flask should be raised to a compatible newer version.

I picked Flask 2.2 as the compatible version.

This only required addressing one single old Flask 2.0 deprecation
warning which is now a removed function in Flask 2.2
