### PR TITLE
fix: methods incorrect type and update deprecated targets

### DIFF
--- a/superset/advanced_data_type/api.py
+++ b/superset/advanced_data_type/api.py
@@ -53,7 +53,7 @@ class AdvancedDataTypeRestApi(BaseSupersetApi):
 
     @protect()
     @safe
-    @expose("/convert", methods=["GET"])
+    @expose("/convert", methods=("GET",))
     @permission_name("read")
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.get",
@@ -111,7 +111,7 @@ class AdvancedDataTypeRestApi(BaseSupersetApi):
 
     @protect()
     @safe
-    @expose("/types", methods=["GET"])
+    @expose("/types", methods=("GET",))
     @permission_name("read")
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.get",

--- a/superset/annotation_layers/annotations/api.py
+++ b/superset/annotation_layers/annotations/api.py
@@ -135,7 +135,7 @@ class AnnotationRestApi(BaseSupersetModelRestApi):
             {"col": "layer", "opr": "rel_o_m", "value": layer_id}
         )
 
-    @expose("/<int:pk>/annotation/", methods=["GET"])
+    @expose("/<int:pk>/annotation/", methods=("GET",))
     @protect()
     @safe
     @permission_name("get")
@@ -196,7 +196,7 @@ class AnnotationRestApi(BaseSupersetModelRestApi):
         self._apply_layered_relation_to_rison(pk, kwargs["rison"])
         return self.get_list_headless(**kwargs)
 
-    @expose("/<int:pk>/annotation/<int:annotation_id>", methods=["GET"])
+    @expose("/<int:pk>/annotation/<int:annotation_id>", methods=("GET",))
     @protect()
     @safe
     @permission_name("get")
@@ -253,7 +253,7 @@ class AnnotationRestApi(BaseSupersetModelRestApi):
         self._apply_layered_relation_to_rison(pk, kwargs["rison"])
         return self.get_headless(annotation_id, **kwargs)
 
-    @expose("/<int:pk>/annotation/", methods=["POST"])
+    @expose("/<int:pk>/annotation/", methods=("POST",))
     @protect()
     @safe
     @statsd_metrics
@@ -321,7 +321,7 @@ class AnnotationRestApi(BaseSupersetModelRestApi):
             )
             return self.response_422(message=str(ex))
 
-    @expose("/<int:pk>/annotation/<int:annotation_id>", methods=["PUT"])
+    @expose("/<int:pk>/annotation/<int:annotation_id>", methods=("PUT",))
     @protect()
     @safe
     @statsd_metrics
@@ -396,7 +396,7 @@ class AnnotationRestApi(BaseSupersetModelRestApi):
             )
             return self.response_422(message=str(ex))
 
-    @expose("/<int:pk>/annotation/<int:annotation_id>", methods=["DELETE"])
+    @expose("/<int:pk>/annotation/<int:annotation_id>", methods=("DELETE",))
     @protect()
     @safe
     @statsd_metrics
@@ -451,7 +451,7 @@ class AnnotationRestApi(BaseSupersetModelRestApi):
             )
             return self.response_422(message=str(ex))
 
-    @expose("/<int:pk>/annotation/", methods=["DELETE"])
+    @expose("/<int:pk>/annotation/", methods=("DELETE",))
     @protect()
     @safe
     @statsd_metrics

--- a/superset/annotation_layers/api.py
+++ b/superset/annotation_layers/api.py
@@ -112,7 +112,7 @@ class AnnotationLayerRestApi(BaseSupersetModelRestApi):
     openapi_spec_tag = "Annotation Layers"
     openapi_spec_methods = openapi_spec_methods_override
 
-    @expose("/<int:pk>", methods=["DELETE"])
+    @expose("/<int:pk>", methods=("DELETE",))
     @protect()
     @safe
     @statsd_metrics
@@ -166,7 +166,7 @@ class AnnotationLayerRestApi(BaseSupersetModelRestApi):
             )
             return self.response_422(message=str(ex))
 
-    @expose("/", methods=["POST"])
+    @expose("/", methods=("POST",))
     @protect()
     @safe
     @statsd_metrics
@@ -231,7 +231,7 @@ class AnnotationLayerRestApi(BaseSupersetModelRestApi):
             )
             return self.response_422(message=str(ex))
 
-    @expose("/<int:pk>", methods=["PUT"])
+    @expose("/<int:pk>", methods=("PUT",))
     @protect()
     @safe
     @statsd_metrics
@@ -303,7 +303,7 @@ class AnnotationLayerRestApi(BaseSupersetModelRestApi):
             )
             return self.response_422(message=str(ex))
 
-    @expose("/", methods=["DELETE"])
+    @expose("/", methods=("DELETE",))
     @protect()
     @safe
     @statsd_metrics

--- a/superset/async_events/api.py
+++ b/superset/async_events/api.py
@@ -32,7 +32,7 @@ class AsyncEventsRestApi(BaseSupersetApi):
     resource_name = "async_event"
     allow_browser_login = True
 
-    @expose("/", methods=["GET"])
+    @expose("/", methods=("GET",))
     @event_logger.log_this
     @protect()
     @safe

--- a/superset/available_domains/api.py
+++ b/superset/available_domains/api.py
@@ -38,7 +38,7 @@ class AvailableDomainsRestApi(BaseSupersetApi):
     openapi_spec_tag = "Available Domains"
     openapi_spec_component_schemas = (AvailableDomainsSchema,)
 
-    @expose("/", methods=["GET"])
+    @expose("/", methods=("GET",))
     @protect()
     @safe
     @statsd_metrics

--- a/superset/cachekeys/api.py
+++ b/superset/cachekeys/api.py
@@ -44,7 +44,7 @@ class CacheRestApi(BaseSupersetModelRestApi):
 
     openapi_spec_component_schemas = (CacheInvalidationRequestSchema,)
 
-    @expose("/invalidate", methods=["POST"])
+    @expose("/invalidate", methods=("POST",))
     @protect()
     @safe
     @statsd_metrics

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -277,7 +277,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
 
     allowed_rel_fields = {"owners", "created_by"}
 
-    @expose("/", methods=["POST"])
+    @expose("/", methods=("POST",))
     @protect()
     @safe
     @statsd_metrics
@@ -339,7 +339,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
             )
             return self.response_422(message=str(ex))
 
-    @expose("/<pk>", methods=["PUT"])
+    @expose("/<pk>", methods=("PUT",))
     @protect()
     @safe
     @statsd_metrics
@@ -416,7 +416,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
 
         return response
 
-    @expose("/<pk>", methods=["DELETE"])
+    @expose("/<pk>", methods=("DELETE",))
     @protect()
     @safe
     @statsd_metrics
@@ -472,7 +472,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
             )
             return self.response_422(message=str(ex))
 
-    @expose("/", methods=["DELETE"])
+    @expose("/", methods=("DELETE",))
     @protect()
     @safe
     @statsd_metrics
@@ -531,7 +531,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
         except ChartBulkDeleteFailedError as ex:
             return self.response_422(message=str(ex))
 
-    @expose("/<pk>/cache_screenshot/", methods=["GET"])
+    @expose("/<pk>/cache_screenshot/", methods=("GET",))
     @protect()
     @rison(screenshot_query_schema)
     @safe
@@ -605,7 +605,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
 
         return trigger_celery()
 
-    @expose("/<pk>/screenshot/<digest>/", methods=["GET"])
+    @expose("/<pk>/screenshot/<digest>/", methods=("GET",))
     @protect()
     @safe
     @statsd_metrics
@@ -659,7 +659,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
         # TODO: return an empty image
         return self.response_404()
 
-    @expose("/<pk>/thumbnail/<digest>/", methods=["GET"])
+    @expose("/<pk>/thumbnail/<digest>/", methods=("GET",))
     @protect()
     @rison(thumbnail_query_schema)
     @safe
@@ -746,7 +746,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
             FileWrapper(screenshot), mimetype="image/png", direct_passthrough=True
         )
 
-    @expose("/export/", methods=["GET"])
+    @expose("/export/", methods=("GET",))
     @protect()
     @safe
     @statsd_metrics
@@ -811,7 +811,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
             response.set_cookie(token, "done", max_age=600)
         return response
 
-    @expose("/favorite_status/", methods=["GET"])
+    @expose("/favorite_status/", methods=("GET",))
     @protect()
     @safe
     @rison(get_fav_star_ids_schema)
@@ -861,7 +861,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
         ]
         return self.response(200, result=res)
 
-    @expose("/<pk>/favorites/", methods=["POST"])
+    @expose("/<pk>/favorites/", methods=("POST",))
     @protect()
     @safe
     @statsd_metrics
@@ -905,7 +905,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
         ChartDAO.add_favorite(chart)
         return self.response(200, result="OK")
 
-    @expose("/<pk>/favorites/", methods=["DELETE"])
+    @expose("/<pk>/favorites/", methods=("DELETE",))
     @protect()
     @safe
     @statsd_metrics
@@ -949,7 +949,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
         ChartDAO.remove_favorite(chart)
         return self.response(200, result="OK")
 
-    @expose("/import/", methods=["POST"])
+    @expose("/import/", methods=("POST",))
     @protect()
     @statsd_metrics
     @event_logger.log_this_with_context(

--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -59,7 +59,7 @@ logger = logging.getLogger(__name__)
 class ChartDataRestApi(ChartRestApi):
     include_route_methods = {"get_data", "data", "data_from_cache"}
 
-    @expose("/<int:pk>/data/", methods=["GET"])
+    @expose("/<int:pk>/data/", methods=("GET",))
     @protect()
     @statsd_metrics
     @event_logger.log_this_with_context(
@@ -171,7 +171,7 @@ class ChartDataRestApi(ChartRestApi):
             command=command, form_data=form_data, datasource=query_context.datasource
         )
 
-    @expose("/data", methods=["POST"])
+    @expose("/data", methods=("POST",))
     @protect()
     @statsd_metrics
     @event_logger.log_this_with_context(
@@ -257,7 +257,7 @@ class ChartDataRestApi(ChartRestApi):
             command, form_data=form_data, datasource=query_context.datasource
         )
 
-    @expose("/data/<cache_key>", methods=["GET"])
+    @expose("/data/<cache_key>", methods=("GET",))
     @protect()
     @statsd_metrics
     @event_logger.log_this_with_context(

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -434,7 +434,13 @@ class TableModelView(  # pylint: disable=too-many-ancestors
     def _delete(self, pk: int) -> None:
         DeleteMixin._delete(self, pk)
 
-    @expose("/edit/<pk>", methods=["GET", "POST"])
+    @expose(
+        "/edit/<pk>",
+        methods=(
+            "GET",
+            "POST",
+        ),
+    )
     @has_access
     def edit(self, pk: str) -> FlaskResponse:
         """Simple hack to redirect to explore view after saving"""

--- a/superset/css_templates/api.py
+++ b/superset/css_templates/api.py
@@ -87,7 +87,7 @@ class CssTemplateRestApi(BaseSupersetModelRestApi):
     openapi_spec_tag = "CSS Templates"
     openapi_spec_methods = openapi_spec_methods_override
 
-    @expose("/", methods=["DELETE"])
+    @expose("/", methods=("DELETE",))
     @protect()
     @safe
     @statsd_metrics

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -296,7 +296,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             self.appbuilder.app.config["VERSION_SHA"],
         )
 
-    @expose("/<id_or_slug>", methods=["GET"])
+    @expose("/<id_or_slug>", methods=("GET",))
     @protect()
     @etag_cache(
         get_last_modified=lambda _self, id_or_slug: DashboardDAO.get_dashboard_changed_on(  # pylint: disable=line-too-long,useless-suppression
@@ -354,7 +354,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         )
         return self.response(200, result=result)
 
-    @expose("/<id_or_slug>/datasets", methods=["GET"])
+    @expose("/<id_or_slug>/datasets", methods=("GET",))
     @protect()
     @etag_cache(
         get_last_modified=lambda _self, id_or_slug: DashboardDAO.get_dashboard_and_datasets_changed_on(  # pylint: disable=line-too-long,useless-suppression
@@ -423,7 +423,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         except DashboardNotFoundError:
             return self.response_404()
 
-    @expose("/<id_or_slug>/charts", methods=["GET"])
+    @expose("/<id_or_slug>/charts", methods=("GET",))
     @protect()
     @etag_cache(
         get_last_modified=lambda _self, id_or_slug: DashboardDAO.get_dashboard_and_slices_changed_on(  # pylint: disable=line-too-long,useless-suppression
@@ -490,7 +490,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         except DashboardNotFoundError:
             return self.response_404()
 
-    @expose("/", methods=["POST"])
+    @expose("/", methods=("POST",))
     @protect()
     @safe
     @statsd_metrics
@@ -552,7 +552,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             )
             return self.response_422(message=str(ex))
 
-    @expose("/<pk>", methods=["PUT"])
+    @expose("/<pk>", methods=("PUT",))
     @protect()
     @safe
     @statsd_metrics
@@ -638,7 +638,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             response = self.response_422(message=str(ex))
         return response
 
-    @expose("/<pk>", methods=["DELETE"])
+    @expose("/<pk>", methods=("DELETE",))
     @protect()
     @safe
     @statsd_metrics
@@ -694,7 +694,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             )
             return self.response_422(message=str(ex))
 
-    @expose("/", methods=["DELETE"])
+    @expose("/", methods=("DELETE",))
     @protect()
     @safe
     @statsd_metrics
@@ -755,7 +755,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         except DashboardBulkDeleteFailedError as ex:
             return self.response_422(message=str(ex))
 
-    @expose("/export/", methods=["GET"])
+    @expose("/export/", methods=("GET",))
     @protect()
     @safe
     @statsd_metrics
@@ -841,7 +841,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             resp.set_cookie(token, "done", max_age=600)
         return resp
 
-    @expose("/<pk>/thumbnail/<digest>/", methods=["GET"])
+    @expose("/<pk>/thumbnail/<digest>/", methods=("GET",))
     @protect()
     @safe
     @rison(thumbnail_query_schema)
@@ -943,7 +943,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             FileWrapper(screenshot), mimetype="image/png", direct_passthrough=True
         )
 
-    @expose("/favorite_status/", methods=["GET"])
+    @expose("/favorite_status/", methods=("GET",))
     @protect()
     @safe
     @statsd_metrics
@@ -994,7 +994,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         ]
         return self.response(200, result=res)
 
-    @expose("/<pk>/favorites/", methods=["POST"])
+    @expose("/<pk>/favorites/", methods=("POST",))
     @protect()
     @safe
     @statsd_metrics
@@ -1038,7 +1038,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         DashboardDAO.add_favorite(dashboard)
         return self.response(200, result="OK")
 
-    @expose("/<pk>/favorites/", methods=["DELETE"])
+    @expose("/<pk>/favorites/", methods=("DELETE",))
     @protect()
     @safe
     @statsd_metrics
@@ -1082,7 +1082,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         DashboardDAO.remove_favorite(dashboard)
         return self.response(200, result="OK")
 
-    @expose("/import/", methods=["POST"])
+    @expose("/import/", methods=("POST",))
     @protect()
     @statsd_metrics
     @event_logger.log_this_with_context(
@@ -1206,7 +1206,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         command.run()
         return self.response(200, message="OK")
 
-    @expose("/<id_or_slug>/embedded", methods=["GET"])
+    @expose("/<id_or_slug>/embedded", methods=("GET",))
     @protect()
     @safe
     @permission_name("read")
@@ -1330,7 +1330,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         except ValidationError as error:
             return self.response_400(message=error.messages)
 
-    @expose("/<id_or_slug>/embedded", methods=["DELETE"])
+    @expose("/<id_or_slug>/embedded", methods=("DELETE",))
     @protect()
     @safe
     @permission_name("set_embedded")
@@ -1372,7 +1372,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             DashboardDAO.delete(embedded)
         return self.response(200, message="OK")
 
-    @expose("/<id_or_slug>/copy/", methods=["POST"])
+    @expose("/<id_or_slug>/copy/", methods=("POST",))
     @protect()
     @safe
     @permission_name("write")

--- a/superset/dashboards/filter_sets/api.py
+++ b/superset/dashboards/filter_sets/api.py
@@ -126,7 +126,7 @@ class FilterSetRestApi(BaseSupersetModelRestApi):
         # pylint: disable=bad-super-call
         super(BaseSupersetModelRestApi, self)._init_properties()
 
-    @expose("/<int:dashboard_id>/filtersets", methods=["GET"])
+    @expose("/<int:dashboard_id>/filtersets", methods=("GET",))
     @protect()
     @safe
     @permission_name("get")
@@ -189,7 +189,7 @@ class FilterSetRestApi(BaseSupersetModelRestApi):
         )
         return self.get_list_headless(**kwargs)
 
-    @expose("/<int:dashboard_id>/filtersets", methods=["POST"])
+    @expose("/<int:dashboard_id>/filtersets", methods=("POST",))
     @protect()
     @safe
     @statsd_metrics
@@ -256,7 +256,7 @@ class FilterSetRestApi(BaseSupersetModelRestApi):
         except DashboardNotFoundError:
             return self.response_404()
 
-    @expose("/<int:dashboard_id>/filtersets/<int:pk>", methods=["PUT"])
+    @expose("/<int:dashboard_id>/filtersets/<int:pk>", methods=("PUT",))
     @protect()
     @safe
     @statsd_metrics
@@ -328,7 +328,7 @@ class FilterSetRestApi(BaseSupersetModelRestApi):
             logger.error(err)
             return self.response(err.status)
 
-    @expose("/<int:dashboard_id>/filtersets/<int:pk>", methods=["DELETE"])
+    @expose("/<int:dashboard_id>/filtersets/<int:pk>", methods=("DELETE",))
     @protect()
     @safe
     @statsd_metrics

--- a/superset/dashboards/filter_state/api.py
+++ b/superset/dashboards/filter_state/api.py
@@ -47,7 +47,7 @@ class DashboardFilterStateRestApi(TemporaryCacheRestApi):
     def get_delete_command(self) -> Type[DeleteFilterStateCommand]:
         return DeleteFilterStateCommand
 
-    @expose("/<int:pk>/filter_state", methods=["POST"])
+    @expose("/<int:pk>/filter_state", methods=("POST",))
     @protect()
     @safe
     @event_logger.log_this_with_context(
@@ -97,7 +97,7 @@ class DashboardFilterStateRestApi(TemporaryCacheRestApi):
         """
         return super().post(pk)
 
-    @expose("/<int:pk>/filter_state/<string:key>", methods=["PUT"])
+    @expose("/<int:pk>/filter_state/<string:key>", methods=("PUT",))
     @protect()
     @safe
     @event_logger.log_this_with_context(
@@ -153,7 +153,7 @@ class DashboardFilterStateRestApi(TemporaryCacheRestApi):
         """
         return super().put(pk, key)
 
-    @expose("/<int:pk>/filter_state/<string:key>", methods=["GET"])
+    @expose("/<int:pk>/filter_state/<string:key>", methods=("GET",))
     @protect()
     @safe
     @event_logger.log_this_with_context(
@@ -199,7 +199,7 @@ class DashboardFilterStateRestApi(TemporaryCacheRestApi):
         """
         return super().get(pk, key)
 
-    @expose("/<int:pk>/filter_state/<string:key>", methods=["DELETE"])
+    @expose("/<int:pk>/filter_state/<string:key>", methods=("DELETE",))
     @protect()
     @safe
     @event_logger.log_this_with_context(

--- a/superset/dashboards/permalink/api.py
+++ b/superset/dashboards/permalink/api.py
@@ -47,7 +47,7 @@ class DashboardPermalinkRestApi(BaseSupersetApi):
     openapi_spec_tag = "Dashboard Permanent Link"
     openapi_spec_component_schemas = (DashboardPermalinkPostSchema,)
 
-    @expose("/<pk>/permalink", methods=["POST"])
+    @expose("/<pk>/permalink", methods=("POST",))
     @protect()
     @safe
     @event_logger.log_this_with_context(
@@ -114,7 +114,7 @@ class DashboardPermalinkRestApi(BaseSupersetApi):
         except DashboardNotFoundError as ex:
             return self.response(404, message=str(ex))
 
-    @expose("/permalink/<string:key>", methods=["GET"])
+    @expose("/permalink/<string:key>", methods=("GET",))
     @protect()
     @safe
     @event_logger.log_this_with_context(

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -237,7 +237,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         ValidateSQLResponse,
     )
 
-    @expose("/<int:pk>", methods=["GET"])
+    @expose("/<int:pk>", methods=("GET",))
     @protect()
     @safe
     def get(self, pk: int, **kwargs: Any) -> Response:
@@ -278,7 +278,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         except SupersetException as ex:
             return self.response(ex.status, message=ex.message)
 
-    @expose("/", methods=["POST"])
+    @expose("/", methods=("POST",))
     @protect()
     @safe
     @statsd_metrics
@@ -366,7 +366,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         except SupersetException as ex:
             return self.response(ex.status, message=ex.message)
 
-    @expose("/<int:pk>", methods=["PUT"])
+    @expose("/<int:pk>", methods=("PUT",))
     @protect()
     @safe
     @statsd_metrics
@@ -450,7 +450,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         except SSHTunnelingNotEnabledError as ex:
             return self.response_400(message=str(ex))
 
-    @expose("/<int:pk>", methods=["DELETE"])
+    @expose("/<int:pk>", methods=("DELETE",))
     @protect()
     @safe
     @statsd_metrics
@@ -633,7 +633,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         except DatabaseTablesUnexpectedError as ex:
             return self.response_422(ex.message)
 
-    @expose("/<int:pk>/table/<table_name>/<schema_name>/", methods=["GET"])
+    @expose("/<int:pk>/table/<table_name>/<schema_name>/", methods=("GET",))
     @protect()
     @check_datasource_access
     @safe
@@ -696,7 +696,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         self.incr_stats("success", self.table_metadata.__name__)
         return self.response(200, **table_info)
 
-    @expose("/<int:pk>/table_extra/<table_name>/<schema_name>/", methods=["GET"])
+    @expose("/<int:pk>/table_extra/<table_name>/<schema_name>/", methods=("GET",))
     @protect()
     @check_datasource_access
     @safe
@@ -759,8 +759,8 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         )
         return self.response(200, **payload)
 
-    @expose("/<int:pk>/select_star/<table_name>/", methods=["GET"])
-    @expose("/<int:pk>/select_star/<table_name>/<schema_name>/", methods=["GET"])
+    @expose("/<int:pk>/select_star/<table_name>/", methods=("GET",))
+    @expose("/<int:pk>/select_star/<table_name>/<schema_name>/", methods=("GET",))
     @protect()
     @check_datasource_access
     @safe
@@ -821,7 +821,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         self.incr_stats("success", self.select_star.__name__)
         return self.response(200, result=result)
 
-    @expose("/test_connection/", methods=["POST"])
+    @expose("/test_connection/", methods=("POST",))
     @protect()
     @statsd_metrics
     @event_logger.log_this_with_context(
@@ -871,7 +871,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         except SSHTunnelingNotEnabledError as ex:
             return self.response_400(message=str(ex))
 
-    @expose("/<int:pk>/related_objects/", methods=["GET"])
+    @expose("/<int:pk>/related_objects/", methods=("GET",))
     @protect()
     @safe
     @statsd_metrics
@@ -940,7 +940,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
             },
         )
 
-    @expose("/<int:pk>/validate_sql/", methods=["POST"])
+    @expose("/<int:pk>/validate_sql/", methods=("POST",))
     @protect()
     @statsd_metrics
     @event_logger.log_this_with_context(
@@ -1000,7 +1000,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         except DatabaseNotFoundError:
             return self.response_404()
 
-    @expose("/export/", methods=["GET"])
+    @expose("/export/", methods=("GET",))
     @protect()
     @safe
     @statsd_metrics
@@ -1064,7 +1064,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
             response.set_cookie(token, "done", max_age=600)
         return response
 
-    @expose("/import/", methods=["POST"])
+    @expose("/import/", methods=("POST",))
     @protect()
     @statsd_metrics
     @event_logger.log_this_with_context(
@@ -1185,7 +1185,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         command.run()
         return self.response(200, message="OK")
 
-    @expose("/<int:pk>/function_names/", methods=["GET"])
+    @expose("/<int:pk>/function_names/", methods=("GET",))
     @protect()
     @safe
     @statsd_metrics
@@ -1227,7 +1227,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
             function_names=database.function_names,
         )
 
-    @expose("/available/", methods=["GET"])
+    @expose("/available/", methods=("GET",))
     @protect()
     @statsd_metrics
     @event_logger.log_this_with_context(
@@ -1338,7 +1338,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
 
         return self.response(200, databases=response)
 
-    @expose("/validate_parameters/", methods=["POST"])
+    @expose("/validate_parameters/", methods=("POST",))
     @protect()
     @statsd_metrics
     @event_logger.log_this_with_context(
@@ -1395,7 +1395,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         command.run()
         return self.response(200, message="OK")
 
-    @expose("/<int:pk>/ssh_tunnel/", methods=["DELETE"])
+    @expose("/<int:pk>/ssh_tunnel/", methods=("DELETE",))
     @protect()
     @statsd_metrics
     @event_logger.log_this_with_context(

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -256,7 +256,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     list_outer_default_load = True
     show_outer_default_load = True
 
-    @expose("/", methods=["POST"])
+    @expose("/", methods=("POST",))
     @protect()
     @safe
     @statsd_metrics
@@ -319,7 +319,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
             )
             return self.response_422(message=str(ex))
 
-    @expose("/<pk>", methods=["PUT"])
+    @expose("/<pk>", methods=("PUT",))
     @protect()
     @safe
     @statsd_metrics
@@ -406,7 +406,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
             response = self.response_422(message=str(ex))
         return response
 
-    @expose("/<pk>", methods=["DELETE"])
+    @expose("/<pk>", methods=("DELETE",))
     @protect()
     @safe
     @statsd_metrics
@@ -462,7 +462,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
             )
             return self.response_422(message=str(ex))
 
-    @expose("/export/", methods=["GET"])
+    @expose("/export/", methods=("GET",))
     @protect()
     @safe
     @statsd_metrics
@@ -546,7 +546,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
             mimetype="application/text",
         )
 
-    @expose("/duplicate", methods=["POST"])
+    @expose("/duplicate", methods=("POST",))
     @protect()
     @safe
     @statsd_metrics
@@ -617,7 +617,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
             )
             return self.response_422(message=str(ex))
 
-    @expose("/<pk>/refresh", methods=["PUT"])
+    @expose("/<pk>/refresh", methods=("PUT",))
     @protect()
     @safe
     @statsd_metrics
@@ -673,7 +673,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
             )
             return self.response_422(message=str(ex))
 
-    @expose("/<pk>/related_objects", methods=["GET"])
+    @expose("/<pk>/related_objects", methods=("GET",))
     @protect()
     @safe
     @statsd_metrics
@@ -735,7 +735,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
             dashboards={"count": len(dashboards), "result": dashboards},
         )
 
-    @expose("/", methods=["DELETE"])
+    @expose("/", methods=("DELETE",))
     @protect()
     @safe
     @statsd_metrics
@@ -798,7 +798,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         except DatasetBulkDeleteFailedError as ex:
             return self.response_422(message=str(ex))
 
-    @expose("/import/", methods=["POST"])
+    @expose("/import/", methods=("POST",))
     @protect()
     @statsd_metrics
     @event_logger.log_this_with_context(
@@ -931,7 +931,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         command.run()
         return self.response(200, message="OK")
 
-    @expose("/get_or_create/", methods=["POST"])
+    @expose("/get_or_create/", methods=("POST",))
     @protect()
     @safe
     @statsd_metrics

--- a/superset/datasets/columns/api.py
+++ b/superset/datasets/columns/api.py
@@ -45,7 +45,7 @@ class DatasetColumnsRestApi(BaseSupersetModelRestApi):
 
     openapi_spec_tag = "Datasets"
 
-    @expose("/<int:pk>/column/<int:column_id>", methods=["DELETE"])
+    @expose("/<int:pk>/column/<int:column_id>", methods=("DELETE",))
     @protect()
     @safe
     @statsd_metrics

--- a/superset/datasets/metrics/api.py
+++ b/superset/datasets/metrics/api.py
@@ -45,7 +45,7 @@ class DatasetMetricRestApi(BaseSupersetModelRestApi):
 
     openapi_spec_tag = "Datasets"
 
-    @expose("/<int:pk>/metric/<int:metric_id>", methods=["DELETE"])
+    @expose("/<int:pk>/metric/<int:metric_id>", methods=("DELETE",))
     @protect()
     @safe
     @statsd_metrics

--- a/superset/datasource/api.py
+++ b/superset/datasource/api.py
@@ -37,7 +37,7 @@ class DatasourceRestApi(BaseSupersetApi):
 
     @expose(
         "/<datasource_type>/<int:datasource_id>/column/<column_name>/values/",
-        methods=["GET"],
+        methods=("GET",),
     )
     @protect()
     @safe

--- a/superset/embedded/api.py
+++ b/superset/embedded/api.py
@@ -58,7 +58,7 @@ class EmbeddedDashboardRestApi(BaseSupersetModelRestApi):
 
     embedded_response_schema = EmbeddedDashboardResponseSchema()
 
-    @expose("/<uuid>", methods=["GET"])
+    @expose("/<uuid>", methods=("GET",))
     @protect()
     @safe
     @statsd_metrics

--- a/superset/explore/api.py
+++ b/superset/explore/api.py
@@ -44,7 +44,7 @@ class ExploreRestApi(BaseSupersetApi):
     openapi_spec_tag = "Explore"
     openapi_spec_component_schemas = (ExploreContextSchema,)
 
-    @expose("/", methods=["GET"])
+    @expose("/", methods=("GET",))
     @protect()
     @safe
     @statsd_metrics

--- a/superset/explore/form_data/api.py
+++ b/superset/explore/form_data/api.py
@@ -47,7 +47,7 @@ class ExploreFormDataRestApi(BaseSupersetApi):
     openapi_spec_tag = "Explore Form Data"
     openapi_spec_component_schemas = (FormDataPostSchema, FormDataPutSchema)
 
-    @expose("/form_data", methods=["POST"])
+    @expose("/form_data", methods=("POST",))
     @protect()
     @safe
     @statsd_metrics
@@ -112,7 +112,7 @@ class ExploreFormDataRestApi(BaseSupersetApi):
         except TemporaryCacheResourceNotFoundError as ex:
             return self.response(404, message=str(ex))
 
-    @expose("/form_data/<string:key>", methods=["PUT"])
+    @expose("/form_data/<string:key>", methods=("PUT",))
     @protect()
     @safe
     @statsd_metrics
@@ -186,7 +186,7 @@ class ExploreFormDataRestApi(BaseSupersetApi):
         except TemporaryCacheResourceNotFoundError as ex:
             return self.response(404, message=str(ex))
 
-    @expose("/form_data/<string:key>", methods=["GET"])
+    @expose("/form_data/<string:key>", methods=("GET",))
     @protect()
     @safe
     @statsd_metrics
@@ -238,7 +238,7 @@ class ExploreFormDataRestApi(BaseSupersetApi):
         except TemporaryCacheResourceNotFoundError as ex:
             return self.response(404, message=str(ex))
 
-    @expose("/form_data/<string:key>", methods=["DELETE"])
+    @expose("/form_data/<string:key>", methods=("DELETE",))
     @protect()
     @safe
     @statsd_metrics

--- a/superset/explore/permalink/api.py
+++ b/superset/explore/permalink/api.py
@@ -49,7 +49,7 @@ class ExplorePermalinkRestApi(BaseSupersetApi):
     openapi_spec_tag = "Explore Permanent Link"
     openapi_spec_component_schemas = (ExplorePermalinkPostSchema,)
 
-    @expose("/permalink", methods=["POST"])
+    @expose("/permalink", methods=("POST",))
     @protect()
     @safe
     @statsd_metrics
@@ -110,7 +110,7 @@ class ExplorePermalinkRestApi(BaseSupersetApi):
         except (ChartNotFoundError, DatasetNotFoundError) as ex:
             return self.response(404, message=str(ex))
 
-    @expose("/permalink/<string:key>", methods=["GET"])
+    @expose("/permalink/<string:key>", methods=("GET",))
     @protect()
     @safe
     @statsd_metrics

--- a/superset/importexport/api.py
+++ b/superset/importexport/api.py
@@ -42,7 +42,7 @@ class ImportExportRestApi(BaseSupersetApi):
     openapi_spec_tag = "Import/export"
     allow_browser_login = True
 
-    @expose("/export/", methods=["GET"])
+    @expose("/export/", methods=("GET",))
     @protect()
     @statsd_metrics
     @event_logger.log_this_with_context(
@@ -91,7 +91,7 @@ class ImportExportRestApi(BaseSupersetApi):
         )
         return response
 
-    @expose("/import/", methods=["POST"])
+    @expose("/import/", methods=("POST",))
     @protect()
     @statsd_metrics
     @event_logger.log_this_with_context(

--- a/superset/key_value/commands/create.py
+++ b/superset/key_value/commands/create.py
@@ -81,7 +81,7 @@ class CreateKeyValueCommand(BaseCommand):
     def create(self) -> Key:
         try:
             value = self.codec.encode(self.value)
-        except Exception as ex:  # pylint: disable=broad-except
+        except Exception as ex:
             raise KeyValueCreateFailedError("Unable to encode value") from ex
         entry = KeyValueEntry(
             resource=self.resource.value,

--- a/superset/queries/api.py
+++ b/superset/queries/api.py
@@ -202,7 +202,7 @@ class QueryRestApi(BaseSupersetModelRestApi):
         except SupersetException as ex:
             return self.response(ex.status, message=ex.message)
 
-    @expose("/stop", methods=["POST"])
+    @expose("/stop", methods=("POST",))
     @protect()
     @safe
     @statsd_metrics

--- a/superset/queries/saved_queries/api.py
+++ b/superset/queries/saved_queries/api.py
@@ -174,7 +174,7 @@ class SavedQueryRestApi(BaseSupersetModelRestApi):
     def pre_update(self, item: SavedQuery) -> None:
         self.pre_add(item)
 
-    @expose("/", methods=["DELETE"])
+    @expose("/", methods=("DELETE",))
     @protect()
     @safe
     @statsd_metrics
@@ -227,7 +227,7 @@ class SavedQueryRestApi(BaseSupersetModelRestApi):
         except SavedQueryBulkDeleteFailedError as ex:
             return self.response_422(message=str(ex))
 
-    @expose("/export/", methods=["GET"])
+    @expose("/export/", methods=("GET",))
     @protect()
     @safe
     @statsd_metrics
@@ -290,7 +290,7 @@ class SavedQueryRestApi(BaseSupersetModelRestApi):
             response.set_cookie(token, "done", max_age=600)
         return response
 
-    @expose("/import/", methods=["POST"])
+    @expose("/import/", methods=("POST",))
     @protect()
     @statsd_metrics
     @event_logger.log_this_with_context(

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -235,7 +235,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
     openapi_spec_tag = "Report Schedules"
     openapi_spec_methods = openapi_spec_methods_override
 
-    @expose("/<int:pk>", methods=["DELETE"])
+    @expose("/<int:pk>", methods=("DELETE",))
     @protect()
     @safe
     @permission_name("delete")
@@ -291,7 +291,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
             )
             return self.response_422(message=str(ex))
 
-    @expose("/", methods=["POST"])
+    @expose("/", methods=("POST",))
     @protect()
     @statsd_metrics
     @permission_name("post")
@@ -365,7 +365,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
             )
             return self.response_422(message=str(ex))
 
-    @expose("/<int:pk>", methods=["PUT"])
+    @expose("/<int:pk>", methods=("PUT",))
     @protect()
     @safe
     @statsd_metrics
@@ -448,7 +448,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
             )
             return self.response_422(message=str(ex))
 
-    @expose("/", methods=["DELETE"])
+    @expose("/", methods=("DELETE",))
     @protect()
     @safe
     @statsd_metrics

--- a/superset/reports/logs/api.py
+++ b/superset/reports/logs/api.py
@@ -91,7 +91,7 @@ class ReportExecutionLogRestApi(BaseSupersetModelRestApi):
             {"col": "report_schedule", "opr": "rel_o_m", "value": layer_id}
         )
 
-    @expose("/<int:pk>/log/", methods=["GET"])
+    @expose("/<int:pk>/log/", methods=("GET",))
     @protect()
     @safe
     @permission_name("get")
@@ -152,7 +152,7 @@ class ReportExecutionLogRestApi(BaseSupersetModelRestApi):
         self._apply_layered_relation_to_rison(pk, kwargs["rison"])
         return self.get_list_headless(**kwargs)
 
-    @expose("/<int:pk>/log/<int:log_id>", methods=["GET"])
+    @expose("/<int:pk>/log/<int:log_id>", methods=("GET",))
     @protect()
     @safe
     @permission_name("get")

--- a/superset/row_level_security/api.py
+++ b/superset/row_level_security/api.py
@@ -124,7 +124,7 @@ class RLSRestApi(BaseSupersetModelRestApi):
     allowed_rel_fields = {"tables", "roles"}
     base_related_field_filters = app.config["RLS_BASE_RELATED_FIELD_FILTERS"]
 
-    @expose("/", methods=["POST"])
+    @expose("/", methods=("POST",))
     @protect()
     @safe
     @statsd_metrics
@@ -202,7 +202,7 @@ class RLSRestApi(BaseSupersetModelRestApi):
             )
             return self.response_422(message=str(ex))
 
-    @expose("/<int:pk>", methods=["PUT"])
+    @expose("/<int:pk>", methods=("PUT",))
     @protect()
     @safe
     @statsd_metrics
@@ -291,7 +291,7 @@ class RLSRestApi(BaseSupersetModelRestApi):
         except RLSRuleNotFoundError as ex:
             return self.response_404()
 
-    @expose("/", methods=["DELETE"])
+    @expose("/", methods=("DELETE",))
     @protect()
     @safe
     @statsd_metrics

--- a/superset/security/api.py
+++ b/superset/security/api.py
@@ -82,7 +82,7 @@ class SecurityRestApi(BaseSupersetApi):
     allow_browser_login = True
     openapi_spec_tag = "Security"
 
-    @expose("/csrf_token/", methods=["GET"])
+    @expose("/csrf_token/", methods=("GET",))
     @event_logger.log_this
     @protect()
     @safe
@@ -112,7 +112,7 @@ class SecurityRestApi(BaseSupersetApi):
         """
         return self.response(200, result=generate_csrf())
 
-    @expose("/guest_token/", methods=["POST"])
+    @expose("/guest_token/", methods=("POST",))
     @event_logger.log_this
     @protect()
     @safe

--- a/superset/sqllab/api.py
+++ b/superset/sqllab/api.py
@@ -85,7 +85,7 @@ class SqlLabRestApi(BaseSupersetApi):
         QueryExecutionResponseSchema,
     )
 
-    @expose("/estimate/", methods=["POST"])
+    @expose("/estimate/", methods=("POST",))
     @protect()
     @statsd_metrics
     @requires_json
@@ -250,7 +250,7 @@ class SqlLabRestApi(BaseSupersetApi):
             200,
         )
 
-    @expose("/execute/", methods=["POST"])
+    @expose("/execute/", methods=("POST",))
     @protect()
     @statsd_metrics
     @requires_json

--- a/superset/tags/api.py
+++ b/superset/tags/api.py
@@ -127,7 +127,7 @@ class TagRestApi(BaseSupersetModelRestApi):
             f'{self.appbuilder.app.config["VERSION_SHA"]}'
         )
 
-    @expose("/<int:object_type>/<int:object_id>/", methods=["POST"])
+    @expose("/<int:object_type>/<int:object_id>/", methods=("POST",))
     @protect()
     @safe
     @statsd_metrics
@@ -198,7 +198,7 @@ class TagRestApi(BaseSupersetModelRestApi):
             )
             return self.response_422(message=str(ex))
 
-    @expose("/<int:object_type>/<int:object_id>/<tag>/", methods=["DELETE"])
+    @expose("/<int:object_type>/<int:object_id>/<tag>/", methods=("DELETE",))
     @protect()
     @safe
     @statsd_metrics
@@ -266,7 +266,7 @@ class TagRestApi(BaseSupersetModelRestApi):
             )
             return self.response_422(message=str(ex))
 
-    @expose("/", methods=["DELETE"])
+    @expose("/", methods=("DELETE",))
     @protect()
     @safe
     @statsd_metrics
@@ -321,7 +321,7 @@ class TagRestApi(BaseSupersetModelRestApi):
         except TagDeleteFailedError as ex:
             return self.response_422(message=str(ex))
 
-    @expose("/get_objects/", methods=["GET"])
+    @expose("/get_objects/", methods=("GET",))
     @protect()
     @safe
     @statsd_metrics

--- a/superset/views/alerts.py
+++ b/superset/views/alerts.py
@@ -39,7 +39,7 @@ class BaseAlertReportView(BaseSupersetView):
             return abort(404)
         return super().render_app_template()
 
-    @expose("/<pk>/log/", methods=["GET"])
+    @expose("/<pk>/log/", methods=("GET",))
     @has_access
     @permission_name("read")
     def log(self, pk: int) -> FlaskResponse:  # pylint: disable=unused-argument

--- a/superset/views/api.py
+++ b/superset/views/api.py
@@ -50,7 +50,7 @@ class Api(BaseSupersetView):
     @api
     @handle_api_exception
     @has_access_api
-    @expose("/v1/query/", methods=["POST"])
+    @expose("/v1/query/", methods=("POST",))
     def query(self) -> FlaskResponse:
         """
         Takes a query_obj constructed in the client and returns payload data response
@@ -72,7 +72,7 @@ class Api(BaseSupersetView):
     @api
     @handle_api_exception
     @has_access_api
-    @expose("/v1/form_data/", methods=["GET"])
+    @expose("/v1/form_data/", methods=("GET",))
     def query_form_data(self) -> FlaskResponse:  # pylint: disable=no-self-use
         """
         Get the formdata stored in the database for existing slice.
@@ -93,7 +93,7 @@ class Api(BaseSupersetView):
     @handle_api_exception
     @has_access_api
     @rison(get_time_range_schema)
-    @expose("/v1/time_range/", methods=["GET"])
+    @expose("/v1/time_range/", methods=("GET",))
     def time_range(self, **kwargs: Any) -> FlaskResponse:
         """Get actually time range from human readable string or datetime expression"""
         time_range = kwargs["rison"]

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -531,7 +531,7 @@ class BaseSupersetModelRestApi(ModelRestApi, BaseSupersetApiMixin):
         self.send_stats_metrics(response, self.delete.__name__, duration)
         return response
 
-    @expose("/related/<column_name>", methods=["GET"])
+    @expose("/related/<column_name>", methods=("GET",))
     @protect()
     @safe
     @statsd_metrics
@@ -610,7 +610,7 @@ class BaseSupersetModelRestApi(ModelRestApi, BaseSupersetApiMixin):
 
         return self.response(200, count=total_rows, result=result)
 
-    @expose("/distinct/<column_name>", methods=["GET"])
+    @expose("/distinct/<column_name>", methods=("GET",))
     @protect()
     @safe
     @statsd_metrics

--- a/superset/views/chart/views.py
+++ b/superset/views/chart/views.py
@@ -50,7 +50,13 @@ class SliceModelView(
     def pre_delete(self, item: "SliceModelView") -> None:
         security_manager.raise_for_ownership(item)
 
-    @expose("/add", methods=["GET", "POST"])
+    @expose(
+        "/add",
+        methods=(
+            "GET",
+            "POST",
+        ),
+    )
     @has_access
     def add(self) -> FlaskResponse:
         return super().render_app_template()

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -228,7 +228,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
     @has_access_api
     @event_logger.log_this
-    @expose("/override_role_permissions/", methods=["POST"])
+    @expose("/override_role_permissions/", methods=("POST",))
     @deprecated()
     def override_role_permissions(self) -> FlaskResponse:
         """Updates the role with the give datasource permissions.
@@ -282,7 +282,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
     @has_access
     @event_logger.log_this
-    @expose("/request_access/", methods=["POST"])
+    @expose("/request_access/", methods=("POST",))
     @deprecated()
     def request_access(self) -> FlaskResponse:
         datasources = set()
@@ -326,7 +326,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
     @has_access
     @event_logger.log_this
-    @expose("/approve", methods=["POST"])
+    @expose("/approve", methods=("POST",))
     @deprecated()
     def approve(self) -> FlaskResponse:  # pylint: disable=too-many-locals,no-self-use
         def clean_fulfilled_requests(session: Session) -> None:
@@ -566,7 +566,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @has_access_api
     @handle_api_exception
     @permission_name("explore_json")
-    @expose("/explore_json/data/<cache_key>", methods=["GET"])
+    @expose("/explore_json/data/<cache_key>", methods=("GET",))
     @check_resource_permissions(check_explore_cache_perms)
     def explore_json_data(self, cache_key: str) -> FlaskResponse:
         """Serves cached result data for async explore_json calls
@@ -708,7 +708,13 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
     @has_access
     @event_logger.log_this
-    @expose("/import_dashboards/", methods=["GET", "POST"])
+    @expose(
+        "/import_dashboards/",
+        methods=(
+            "GET",
+            "POST",
+        ),
+    )
     def import_dashboards(self) -> FlaskResponse:
         """Overrides the dashboards using json instances from the file."""
         import_file = request.files.get("file")
@@ -789,8 +795,20 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
     @has_access
     @event_logger.log_this
-    @expose("/explore/<datasource_type>/<int:datasource_id>/", methods=["GET", "POST"])
-    @expose("/explore/", methods=["GET", "POST"])
+    @expose(
+        "/explore/<datasource_type>/<int:datasource_id>/",
+        methods=(
+            "GET",
+            "POST",
+        ),
+    )
+    @expose(
+        "/explore/",
+        methods=(
+            "GET",
+            "POST",
+        ),
+    )
     @deprecated()
     # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     def explore(
@@ -1248,8 +1266,14 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @api
     @has_access_api
     @event_logger.log_this
-    @expose("/copy_dash/<int:dashboard_id>/", methods=["GET", "POST"])
-    @deprecated()
+    @expose(
+        "/copy_dash/<int:dashboard_id>/",
+        methods=(
+            "GET",
+            "POST",
+        ),
+    )
+    @deprecated(new_target="api/v1/dashboard/<dash_id>/copy/")
     def copy_dash(  # pylint: disable=no-self-use
         self, dashboard_id: int
     ) -> FlaskResponse:
@@ -1300,7 +1324,13 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @api
     @has_access_api
     @event_logger.log_this
-    @expose("/save_dash/<int:dashboard_id>/", methods=["GET", "POST"])
+    @expose(
+        "/save_dash/<int:dashboard_id>/",
+        methods=(
+            "GET",
+            "POST",
+        ),
+    )
     @deprecated()
     def save_dash(  # pylint: disable=no-self-use
         self, dashboard_id: int
@@ -1347,7 +1377,8 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @api
     @has_access_api
     @event_logger.log_this
-    @expose("/add_slices/<int:dashboard_id>/", methods=["POST"])
+    @expose("/add_slices/<int:dashboard_id>/", methods=("POST",))
+    @deprecated(new_target="api/v1/chart/<id>/")
     def add_slices(  # pylint: disable=no-self-use
         self, dashboard_id: int
     ) -> FlaskResponse:
@@ -1366,7 +1397,13 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @api
     @has_access_api
     @event_logger.log_this
-    @expose("/testconn", methods=["POST", "GET"])
+    @expose(
+        "/testconn",
+        methods=(
+            "GET",
+            "POST",
+        ),
+    )
     @deprecated(new_target="/api/v1/database/test_connection/")
     def testconn(self) -> FlaskResponse:  # pylint: disable=no-self-use
         """Tests a sqla connection"""
@@ -1455,7 +1492,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @api
     @has_access_api
     @event_logger.log_this
-    @expose("/recent_activity/<int:user_id>/", methods=["GET"])
+    @expose("/recent_activity/<int:user_id>/", methods=("GET",))
     @deprecated(new_target="/api/v1/log/recent_activity/<user_id>/")
     def recent_activity(self, user_id: int) -> FlaskResponse:
         """Recent activity (actions) for a given user"""
@@ -1476,7 +1513,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @api
     @has_access_api
     @event_logger.log_this
-    @expose("/available_domains/", methods=["GET"])
+    @expose("/available_domains/", methods=("GET",))
     @deprecated(new_target="/api/v1/available_domains/")
     def available_domains(self) -> FlaskResponse:  # pylint: disable=no-self-use
         """
@@ -1491,7 +1528,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @api
     @has_access_api
     @event_logger.log_this
-    @expose("/fave_dashboards_by_username/<username>/", methods=["GET"])
+    @expose("/fave_dashboards_by_username/<username>/", methods=("GET",))
     @deprecated(new_target="api/v1/dashboard/favorite_status/")
     def fave_dashboards_by_username(self, username: str) -> FlaskResponse:
         """This lets us use a user's username to pull favourite dashboards"""
@@ -1501,7 +1538,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @api
     @has_access_api
     @event_logger.log_this
-    @expose("/fave_dashboards/<int:user_id>/", methods=["GET"])
+    @expose("/fave_dashboards/<int:user_id>/", methods=("GET",))
     @deprecated(new_target="api/v1/dashboard/favorite_status/")
     def fave_dashboards(self, user_id: int) -> FlaskResponse:
         error_obj = self.get_user_activity_access_error(user_id)
@@ -1538,7 +1575,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @api
     @has_access_api
     @event_logger.log_this
-    @expose("/created_dashboards/<int:user_id>/", methods=["GET"])
+    @expose("/created_dashboards/<int:user_id>/", methods=("GET",))
     @deprecated(new_target="api/v1/dashboard/")
     def created_dashboards(self, user_id: int) -> FlaskResponse:
         error_obj = self.get_user_activity_access_error(user_id)
@@ -1569,9 +1606,9 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @api
     @has_access_api
     @event_logger.log_this
-    @expose("/user_slices", methods=["GET"])
-    @expose("/user_slices/<int:user_id>/", methods=["GET"])
-    @deprecated()
+    @expose("/user_slices", methods=("GET",))
+    @expose("/user_slices/<int:user_id>/", methods=("GET",))
+    @deprecated(new_target="/api/v1/chart/")
     def user_slices(self, user_id: Optional[int] = None) -> FlaskResponse:
         """List of slices a user owns, created, modified or faved"""
         if not user_id:
@@ -1623,8 +1660,8 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @api
     @has_access_api
     @event_logger.log_this
-    @expose("/created_slices", methods=["GET"])
-    @expose("/created_slices/<int:user_id>/", methods=["GET"])
+    @expose("/created_slices", methods=("GET",))
+    @expose("/created_slices/<int:user_id>/", methods=("GET",))
     @deprecated(new_target="api/v1/chart/")
     def created_slices(self, user_id: Optional[int] = None) -> FlaskResponse:
         """List of slices created by this user"""
@@ -1655,9 +1692,9 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @api
     @has_access_api
     @event_logger.log_this
-    @expose("/fave_slices", methods=["GET"])
-    @expose("/fave_slices/<int:user_id>/", methods=["GET"])
-    @deprecated()
+    @expose("/fave_slices", methods=("GET",))
+    @expose("/fave_slices/<int:user_id>/", methods=("GET",))
+    @deprecated(new_target="api/v1/chart/")
     def fave_slices(self, user_id: Optional[int] = None) -> FlaskResponse:
         """Favorite slices for a user"""
         if user_id is None:
@@ -1696,7 +1733,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @event_logger.log_this
     @api
     @has_access_api
-    @expose("/warm_up_cache/", methods=["GET"])
+    @expose("/warm_up_cache/", methods=("GET",))
     def warm_up_cache(  # pylint: disable=too-many-locals,no-self-use
         self,
     ) -> FlaskResponse:
@@ -1794,7 +1831,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @has_access_api
     @event_logger.log_this
     @expose("/favstar/<class_name>/<int:obj_id>/<action>/")
-    @deprecated()
+    @deprecated(new_target="api/v1/dashboard|chart/<pk>/favorites/")
     def favstar(  # pylint: disable=no-self-use
         self, class_name: str, obj_id: int, action: str
     ) -> FlaskResponse:
@@ -1910,7 +1947,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         )
 
     @has_access
-    @expose("/dashboard/p/<key>/", methods=["GET"])
+    @expose("/dashboard/p/<key>/", methods=("GET",))
     def dashboard_permalink(  # pylint: disable=no-self-use
         self,
         key: str,
@@ -1936,12 +1973,12 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @api
     @has_access
     @event_logger.log_this
-    @expose("/log/", methods=["POST"])
+    @expose("/log/", methods=("POST",))
     def log(self) -> FlaskResponse:  # pylint: disable=no-self-use
         return Response(status=200)
 
     @has_access
-    @expose("/get_or_create_table/", methods=["POST"])
+    @expose("/get_or_create_table/", methods=("POST",))
     @event_logger.log_this
     @deprecated(new_target="api/v1/dataset/get_or_create/")
     def sqllab_table_viz(self) -> FlaskResponse:  # pylint: disable=no-self-use
@@ -1983,9 +2020,9 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         return json_success(json.dumps({"table_id": table.id}))
 
     @has_access
-    @expose("/sqllab_viz/", methods=["POST"])
+    @expose("/sqllab_viz/", methods=("POST",))
     @event_logger.log_this
-    @deprecated()
+    @deprecated(new_target="api/v1/dataset/")
     def sqllab_viz(self) -> FlaskResponse:  # pylint: disable=no-self-use
         data = json.loads(request.form["data"])
         try:
@@ -2074,10 +2111,10 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         return json_success(json.dumps(payload))
 
     @has_access_api
-    @expose("/estimate_query_cost/<int:database_id>/", methods=["POST"])
-    @expose("/estimate_query_cost/<int:database_id>/<schema>/", methods=["POST"])
+    @expose("/estimate_query_cost/<int:database_id>/", methods=("POST",))
+    @expose("/estimate_query_cost/<int:database_id>/<schema>/", methods=("POST",))
     @event_logger.log_this
-    @deprecated()
+    @deprecated(new_target="api/v1/sqllab/estimate/")
     def estimate_query_cost(  # pylint: disable=no-self-use
         self, database_id: int, schema: Optional[str] = None
     ) -> FlaskResponse:
@@ -2120,7 +2157,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @has_access_api
     @expose("/results/<key>/")
     @event_logger.log_this
-    @deprecated(new_target="/api/v1/sqllab/results/")
+    @deprecated(new_target="api/v1/sqllab/results/")
     def results(self, key: str) -> FlaskResponse:
         return self.results_exec(key)
 
@@ -2232,7 +2269,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
     @has_access_api
     @handle_api_exception
-    @expose("/stop_query/", methods=["POST"])
+    @expose("/stop_query/", methods=("POST",))
     @event_logger.log_this
     @backoff.on_exception(
         backoff.constant,
@@ -2270,7 +2307,13 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
     @has_access_api
     @event_logger.log_this
-    @expose("/validate_sql_json/", methods=["POST", "GET"])
+    @expose(
+        "/validate_sql_json/",
+        methods=(
+            "GET",
+            "POST",
+        ),
+    )
     @deprecated(new_target="/api/v1/database/<pk>/validate_sql/")
     def validate_sql_json(
         # pylint: disable=too-many-locals,no-self-use
@@ -2343,7 +2386,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @has_access_api
     @handle_api_exception
     @event_logger.log_this
-    @expose("/sql_json/", methods=["POST"])
+    @expose("/sql_json/", methods=("POST",))
     @deprecated(new_target="/api/v1/sqllab/execute/")
     def sql_json(self) -> FlaskResponse:
         errors = SqlJsonPayloadSchema().validate(request.json)
@@ -2421,7 +2464,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @has_access
     @event_logger.log_this
     @expose("/csv/<client_id>")
-    @deprecated(new_target="/api/v1/sqllab/export/")
+    @deprecated(new_target="api/v1/sqllab/export/")
     def csv(self, client_id: str) -> FlaskResponse:  # pylint: disable=no-self-use
         """Download the query results as csv."""
         logger.info("Exporting CSV file [%s]", client_id)
@@ -2727,7 +2770,13 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
     @has_access
     @event_logger.log_this
-    @expose("/sqllab/", methods=["GET", "POST"])
+    @expose(
+        "/sqllab/",
+        methods=(
+            "GET",
+            "POST",
+        ),
+    )
     def sqllab(self) -> FlaskResponse:
         """SQL Editor"""
         payload = {
@@ -2754,7 +2803,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
     @has_access
     @event_logger.log_this
-    @expose("/sqllab/history/", methods=["GET"])
+    @expose("/sqllab/history/", methods=("GET",))
     @event_logger.log_this
     def sqllab_history(self) -> FlaskResponse:
         return super().render_app_template()
@@ -2763,7 +2812,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @has_access_api
     @event_logger.log_this
     @expose("/schemas_access_for_file_upload")
-    @deprecated()
+    @deprecated(new_target="api/v1/database/{pk}/schemas_access_for_file_upload/")
     def schemas_access_for_file_upload(self) -> FlaskResponse:
         """
         This method exposes an API endpoint to

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1403,9 +1403,9 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             "GET",
             "POST",
         ),
-    )
+    )  # pylint: disable=no-self-use
     @deprecated(new_target="/api/v1/database/test_connection/")
-    def testconn(self) -> FlaskResponse:  # pylint: disable=no-self-use
+    def testconn(self) -> FlaskResponse:
         """Tests a sqla connection"""
         db_name = request.json.get("name")
         uri = request.json.get("uri")

--- a/superset/views/database/views.py
+++ b/superset/views/database/views.py
@@ -123,7 +123,7 @@ class CustomFormView(SimpleFormView):
     your form pre-processing and post-processing
     """
 
-    @expose("/form", methods=["GET"])
+    @expose("/form", methods=("GET",))
     @has_access
     def this_form_get(self) -> Any:
         self._init_vars()
@@ -137,7 +137,7 @@ class CustomFormView(SimpleFormView):
             appbuilder=self.appbuilder,
         )
 
-    @expose("/form", methods=["POST"])
+    @expose("/form", methods=("POST",))
     @has_access
     def this_form_post(self) -> Any:
         self._init_vars()

--- a/superset/views/datasource/views.py
+++ b/superset/views/datasource/views.py
@@ -62,7 +62,7 @@ from superset.views.utils import sanitize_datasource_data
 class Datasource(BaseSupersetView):
     """Datasource-related views"""
 
-    @expose("/save/", methods=["POST"])
+    @expose("/save/", methods=("POST",))
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.save",
         log_to_statsd=False,
@@ -201,7 +201,7 @@ class Datasource(BaseSupersetView):
             raise DatasetNotFoundError() from ex
         return self.json_response(external_metadata)
 
-    @expose("/samples", methods=["POST"])
+    @expose("/samples", methods=("POST",))
     @has_access_api
     @api
     @handle_api_exception
@@ -233,7 +233,7 @@ class DatasetEditor(BaseSupersetView):
     def root(self) -> FlaskResponse:
         return super().render_app_template()
 
-    @expose("/<pk>", methods=["GET"])
+    @expose("/<pk>", methods=("GET",))
     @has_access
     @permission_name("read")
     # pylint: disable=unused-argument

--- a/superset/views/key_value.py
+++ b/superset/views/key_value.py
@@ -43,7 +43,7 @@ class KV(BaseSupersetView):
 
     @event_logger.log_this
     @has_access_api
-    @expose("/store/", methods=["POST"])
+    @expose("/store/", methods=("POST",))
     def store(self) -> FlaskResponse:  # pylint: disable=no-self-use
         try:
             value = request.form.get("data")
@@ -56,7 +56,7 @@ class KV(BaseSupersetView):
 
     @event_logger.log_this
     @has_access_api
-    @expose("/<int:key_id>/", methods=["GET"])
+    @expose("/<int:key_id>/", methods=("GET",))
     def get_value(self, key_id: int) -> FlaskResponse:  # pylint: disable=no-self-use
         try:
             kv = db.session.query(models.KeyValue).filter_by(id=key_id).scalar()

--- a/superset/views/log/api.py
+++ b/superset/views/log/api.py
@@ -82,7 +82,7 @@ class LogRestApi(LogMixin, BaseSupersetModelRestApi):
             return self.response(403, message=ex.message)
         return None
 
-    @expose("/recent_activity/<int:user_id>/", methods=["GET"])
+    @expose("/recent_activity/<int:user_id>/", methods=("GET",))
     @protect()
     @safe
     @statsd_metrics

--- a/superset/views/sql_lab/views.py
+++ b/superset/views/sql_lab/views.py
@@ -138,7 +138,7 @@ def _get_owner_id(tab_state_id: int) -> int:
 
 class TabStateView(BaseSupersetView):
     @has_access_api
-    @expose("/", methods=["POST"])
+    @expose("/", methods=("POST",))
     def post(self) -> FlaskResponse:  # pylint: disable=no-self-use
         query_editor = json.loads(request.form["queryEditor"])
         tab_state = TabState(
@@ -165,7 +165,7 @@ class TabStateView(BaseSupersetView):
         return json_success(json.dumps({"id": tab_state.id}))
 
     @has_access_api
-    @expose("/<int:tab_state_id>", methods=["DELETE"])
+    @expose("/<int:tab_state_id>", methods=("DELETE",))
     def delete(self, tab_state_id: int) -> FlaskResponse:  # pylint: disable=no-self-use
         if _get_owner_id(tab_state_id) != get_user_id():
             return Response(status=403)
@@ -180,7 +180,7 @@ class TabStateView(BaseSupersetView):
         return json_success(json.dumps("OK"))
 
     @has_access_api
-    @expose("/<int:tab_state_id>", methods=["GET"])
+    @expose("/<int:tab_state_id>", methods=("GET",))
     def get(self, tab_state_id: int) -> FlaskResponse:  # pylint: disable=no-self-use
         if _get_owner_id(tab_state_id) != get_user_id():
             return Response(status=403)
@@ -193,7 +193,7 @@ class TabStateView(BaseSupersetView):
         )
 
     @has_access_api
-    @expose("<int:tab_state_id>/activate", methods=["POST"])
+    @expose("<int:tab_state_id>/activate", methods=("POST",))
     def activate(  # pylint: disable=no-self-use
         self, tab_state_id: int
     ) -> FlaskResponse:
@@ -212,7 +212,7 @@ class TabStateView(BaseSupersetView):
         return json_success(json.dumps(tab_state_id))
 
     @has_access_api
-    @expose("<int:tab_state_id>", methods=["PUT"])
+    @expose("<int:tab_state_id>", methods=("PUT",))
     def put(self, tab_state_id: int) -> FlaskResponse:  # pylint: disable=no-self-use
         if _get_owner_id(tab_state_id) != get_user_id():
             return Response(status=403)
@@ -223,7 +223,7 @@ class TabStateView(BaseSupersetView):
         return json_success(json.dumps(tab_state_id))
 
     @has_access_api
-    @expose("<int:tab_state_id>/migrate_query", methods=["POST"])
+    @expose("<int:tab_state_id>/migrate_query", methods=("POST",))
     def migrate_query(  # pylint: disable=no-self-use
         self, tab_state_id: int
     ) -> FlaskResponse:
@@ -238,7 +238,7 @@ class TabStateView(BaseSupersetView):
         return json_success(json.dumps(tab_state_id))
 
     @has_access_api
-    @expose("<int:tab_state_id>/query/<client_id>", methods=["DELETE"])
+    @expose("<int:tab_state_id>/query/<client_id>", methods=("DELETE",))
     def delete_query(  # pylint: disable=no-self-use
         self, tab_state_id: int, client_id: str
     ) -> FlaskResponse:
@@ -276,7 +276,7 @@ class TabStateView(BaseSupersetView):
 
 class TableSchemaView(BaseSupersetView):
     @has_access_api
-    @expose("/", methods=["POST"])
+    @expose("/", methods=("POST",))
     def post(self) -> FlaskResponse:  # pylint: disable=no-self-use
         table = json.loads(request.form["table"])
 
@@ -301,7 +301,7 @@ class TableSchemaView(BaseSupersetView):
         return json_success(json.dumps({"id": table_schema.id}))
 
     @has_access_api
-    @expose("/<int:table_schema_id>", methods=["DELETE"])
+    @expose("/<int:table_schema_id>", methods=("DELETE",))
     def delete(  # pylint: disable=no-self-use
         self, table_schema_id: int
     ) -> FlaskResponse:
@@ -312,7 +312,7 @@ class TableSchemaView(BaseSupersetView):
         return json_success(json.dumps("OK"))
 
     @has_access_api
-    @expose("/<int:table_schema_id>/expanded", methods=["POST"])
+    @expose("/<int:table_schema_id>/expanded", methods=("POST",))
     def expanded(  # pylint: disable=no-self-use
         self, table_schema_id: int
     ) -> FlaskResponse:

--- a/superset/views/tags.py
+++ b/superset/views/tags.py
@@ -72,7 +72,7 @@ class TagView(BaseSupersetView):
             raise NotFound()
 
     @has_access_api
-    @expose("/tags/", methods=["GET"])
+    @expose("/tags/", methods=("GET",))
     def tags(self) -> FlaskResponse:  # pylint: disable=no-self-use
         query = db.session.query(Tag).all()
         results = [

--- a/superset/views/users/api.py
+++ b/superset/views/users/api.py
@@ -32,7 +32,7 @@ class CurrentUserRestApi(BaseSupersetApi):
     openapi_spec_tag = "Current User"
     openapi_spec_component_schemas = (UserResponseSchema,)
 
-    @expose("/", methods=["GET"])
+    @expose("/", methods=("GET",))
     @safe
     def get_me(self) -> Response:
         """Get the user object corresponding to the agent making the request
@@ -62,7 +62,7 @@ class CurrentUserRestApi(BaseSupersetApi):
 
         return self.response(200, result=user_response_schema.dump(g.user))
 
-    @expose("/roles/", methods=["GET"])
+    @expose("/roles/", methods=("GET",))
     @safe
     def get_my_roles(self) -> Response:
         """Get the user roles corresponding to the agent making the request


### PR DESCRIPTION
### SUMMARY

While gradually adding type annotations to FAB, having `@expose` methods as a List popped up as an error.

ref: https://github.com/dpgaspar/Flask-AppBuilder/blob/master/flask_appbuilder/api/__init__.py#L189

Also updated missing target to deprecation warnings 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
