### PR TITLE
fix: update migration chart_ds_constraint to have seperate batch op

### DIFF
--- a/superset/migrations/versions/2023-03-27_12-30_7e67aecbf3f1_chart_ds_constraint.py
+++ b/superset/migrations/versions/2023-03-27_12-30_7e67aecbf3f1_chart_ds_constraint.py
@@ -84,7 +84,6 @@ def upgrade_slc(slc: Slice) -> None:
 def upgrade():
     bind = op.get_bind()
     session = db.Session(bind=bind)
-
     with op.batch_alter_table("slices") as batch_op:
         for slc in session.query(Slice).filter(Slice.datasource_type != "table").all():
             if slc.datasource_type == "query":
@@ -97,6 +96,10 @@ def upgrade():
                     slc.datasource_type,
                 )
 
+    # need commit the updated values for Slice.datasource_type before creating constraint
+    session.commit()
+
+    with op.batch_alter_table("slices") as batch_op:
         batch_op.create_check_constraint(
             "ck_chart_datasource", "datasource_type in ('table')"
         )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Getting errors for constraint in same batch operation, so refactoring to commit before adding a new constraint

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
