### PR TITLE
fix(sqllab): custom url params disappeared

### DIFF
--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors/TabbedSqlEditors.test.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors/TabbedSqlEditors.test.jsx
@@ -35,7 +35,7 @@ import { newQueryTabName } from 'src/SqlLab/utils/newQueryTabName';
 import QueryProvider from 'src/views/QueryProvider';
 
 fetchMock.get('glob:*/api/v1/database/*', {});
-fetchMock.get('glob:*/savedqueryviewapi/api/get/*', {});
+fetchMock.get('glob:*/api/v1/saved_query/*', {});
 fetchMock.get('glob:*/kv/*', {});
 
 describe('TabbedSqlEditors', () => {
@@ -129,6 +129,18 @@ describe('TabbedSqlEditors', () => {
       await mountWithAct();
       expect(window.history.replaceState.getCall(0).args[2]).toBe(
         '/superset/sqllab',
+      );
+    });
+    it('should handle custom url params', async () => {
+      uriStub.returns({
+        sql: 1,
+        dbid: 1,
+        custom_value: 'str',
+        extra_attr1: 'true',
+      });
+      await mountWithAct();
+      expect(window.history.replaceState.getCall(0).args[2]).toBe(
+        '/superset/sqllab?custom_value=str&extra_attr1=true',
       );
     });
   });

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.jsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import React from 'react';
+import pick from 'lodash/pick';
 import PropTypes from 'prop-types';
 import { EditableTabs } from 'src/components/Tabs';
 import { connect } from 'react-redux';
@@ -117,6 +118,7 @@ class TabbedSqlEditors extends React.PureComponent {
     // but for some reason this data isn't being passed properly through
     // the reducer.
     const bootstrapData = getBootstrapData();
+    const queryParameters = URI(window.location).search(true);
     const {
       id,
       name,
@@ -132,7 +134,7 @@ class TabbedSqlEditors extends React.PureComponent {
       ...urlParams
     } = {
       ...bootstrapData.requested_query,
-      ...URI(window.location).search(true),
+      ...queryParameters,
     };
 
     // Popping a new tab based on the querystring
@@ -169,7 +171,7 @@ class TabbedSqlEditors extends React.PureComponent {
         };
         this.props.actions.addQueryEditor(newQueryEditor);
       }
-      this.popNewTab(urlParams);
+      this.popNewTab(pick(urlParams, Object.keys(queryParameters)));
     } else if (isNewQuery || this.props.queryEditors.length === 0) {
       this.newQueryEditor();
 

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.jsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors/index.jsx
@@ -117,56 +117,63 @@ class TabbedSqlEditors extends React.PureComponent {
     // but for some reason this data isn't being passed properly through
     // the reducer.
     const bootstrapData = getBootstrapData();
-    const query = {
+    const {
+      id,
+      name,
+      sql,
+      savedQueryId,
+      datasourceKey,
+      queryId,
+      dbid,
+      dbname,
+      schema,
+      autorun,
+      new: isNewQuery,
+      ...urlParams
+    } = {
       ...bootstrapData.requested_query,
       ...URI(window.location).search(true),
     };
 
     // Popping a new tab based on the querystring
-    if (
-      query.id ||
-      query.sql ||
-      query.savedQueryId ||
-      query.datasourceKey ||
-      query.queryId
-    ) {
-      if (query.id) {
-        this.props.actions.popStoredQuery(query.id);
-      } else if (query.savedQueryId) {
-        this.props.actions.popSavedQuery(query.savedQueryId);
-      } else if (query.queryId) {
-        this.props.actions.popQuery(query.queryId);
-      } else if (query.datasourceKey) {
-        this.props.actions.popDatasourceQuery(query.datasourceKey, query.sql);
-      } else if (query.sql) {
-        let dbId = query.dbid;
-        if (dbId) {
-          dbId = parseInt(dbId, 10);
+    if (id || sql || savedQueryId || datasourceKey || queryId) {
+      if (id) {
+        this.props.actions.popStoredQuery(id);
+      } else if (savedQueryId) {
+        this.props.actions.popSavedQuery(savedQueryId);
+      } else if (queryId) {
+        this.props.actions.popQuery(queryId);
+      } else if (datasourceKey) {
+        this.props.actions.popDatasourceQuery(datasourceKey, sql);
+      } else if (sql) {
+        let databaseId = dbid;
+        if (databaseId) {
+          databaseId = parseInt(databaseId, 10);
         } else {
           const { databases } = this.props;
-          const dbName = query.dbname;
-          if (dbName) {
+          const databaseName = dbname;
+          if (databaseName) {
             Object.keys(databases).forEach(db => {
-              if (databases[db].database_name === dbName) {
-                dbId = databases[db].id;
+              if (databases[db].database_name === databaseName) {
+                databaseId = databases[db].id;
               }
             });
           }
         }
         const newQueryEditor = {
-          name: query.name,
-          dbId,
-          schema: query.schema,
-          autorun: query.autorun,
-          sql: query.sql,
+          name,
+          dbId: databaseId,
+          schema,
+          autorun,
+          sql,
         };
         this.props.actions.addQueryEditor(newQueryEditor);
       }
-      this.popNewTab();
-    } else if (query.new || this.props.queryEditors.length === 0) {
+      this.popNewTab(urlParams);
+    } else if (isNewQuery || this.props.queryEditors.length === 0) {
       this.newQueryEditor();
 
-      if (query.new) {
+      if (isNewQuery) {
         window.history.replaceState({}, document.title, this.state.sqlLabUrl);
       }
     } else {
@@ -187,9 +194,10 @@ class TabbedSqlEditors extends React.PureComponent {
     }
   }
 
-  popNewTab() {
+  popNewTab(urlParams) {
     // Clean the url in browser history
-    window.history.replaceState({}, document.title, this.state.sqlLabUrl);
+    const updatedUrl = `${URI(this.state.sqlLabUrl).query(urlParams)}`;
+    window.history.replaceState({}, document.title, updatedUrl);
   }
 
   activeQueryEditor() {


### PR DESCRIPTION
### SUMMARY
SQLLab supports the custom url parameters using jinja template. However the custom url parameters are gone when user consists with the copied url(or saved query link). The bug is caused by the broken url update logic.

This commit fixes the logic to include the custom url parameters while updating new url.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After:

https://user-images.githubusercontent.com/1392866/236574821-fb170097-0a04-4253-a4ff-24639634a776.mov

Before:

https://user-images.githubusercontent.com/1392866/236574824-db073336-08c8-4e7a-835c-a278279eca2a.mov


### TESTING INSTRUCTIONS

- save a query (or copy link)
- pasted the url in the browser address input box and then add extra custom parameters
- check the updated url whether it includes the custom parameters

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
