### PR TITLE
feat(chart-controls): Show detailed data type tooltip when hovering type icon

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/ColumnOption.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/ColumnOption.tsx
@@ -63,16 +63,16 @@ export function ColumnOption({
 
   return (
     <StyleOverrides>
-      <Tooltip
-        id="metric-type-tooltip"
-        title={columnTypeTooltipText}
-        placement="bottomRight"
-        align={{ offset: [8, -2] }}
-      >
-        <span>
-          {showType && type !== undefined && <ColumnTypeLabel type={type} />}
-        </span>
-      </Tooltip>
+      {showType && (
+        <Tooltip
+          id="metric-type-tooltip"
+          title={columnTypeTooltipText}
+          placement="bottomRight"
+          align={{ offset: [8, -2] }}
+        >
+          <span>{type !== undefined && <ColumnTypeLabel type={type} />}</span>
+        </Tooltip>
+      )}
       <Tooltip id="metric-name-tooltip" title={tooltipText}>
         <span
           className="option-label column-option-label"

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/ColumnOption.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/ColumnOption.tsx
@@ -22,7 +22,7 @@ import { Tooltip } from './Tooltip';
 import { ColumnTypeLabel } from './ColumnTypeLabel/ColumnTypeLabel';
 import CertifiedIconWithTooltip from './CertifiedIconWithTooltip';
 import { ColumnMeta } from '../types';
-import { getColumnLabelText, getColumnTooltipNode } from './labelUtils';
+import { getColumnLabelText, getColumnTooltipNode, getColumnTypeTooltipNode } from './labelUtils';
 import { SQLPopover } from './SQLPopover';
 
 export type ColumnOptionProps = {
@@ -48,14 +48,20 @@ export function ColumnOption({
   const hasExpression = expression && expression !== column_name;
   const type = hasExpression ? 'expression' : type_generic;
   const [tooltipText, setTooltipText] = useState<ReactNode>(column.column_name);
+  const [columnTypeTooltipText, setcolumnTypeTooltipText] = useState<ReactNode>(column.type);
 
   useLayoutEffect(() => {
     setTooltipText(getColumnTooltipNode(column, labelRef));
+    setcolumnTypeTooltipText(getColumnTypeTooltipNode(column));
   }, [labelRef, column]);
 
   return (
     <StyleOverrides>
-      {showType && type !== undefined && <ColumnTypeLabel type={type} />}
+      <Tooltip id="metric-type-tooltip" title={columnTypeTooltipText} placement="bottomRight">
+        <span>
+          {showType && type !== undefined && <ColumnTypeLabel type={type} />}
+        </span>
+      </Tooltip>
       <Tooltip id="metric-name-tooltip" title={tooltipText}>
         <span
           className="option-label column-option-label"

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/ColumnOption.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/ColumnOption.tsx
@@ -22,7 +22,11 @@ import { Tooltip } from './Tooltip';
 import { ColumnTypeLabel } from './ColumnTypeLabel/ColumnTypeLabel';
 import CertifiedIconWithTooltip from './CertifiedIconWithTooltip';
 import { ColumnMeta } from '../types';
-import { getColumnLabelText, getColumnTooltipNode, getColumnTypeTooltipNode } from './labelUtils';
+import {
+  getColumnLabelText,
+  getColumnTooltipNode,
+  getColumnTypeTooltipNode,
+} from './labelUtils';
 import { SQLPopover } from './SQLPopover';
 
 export type ColumnOptionProps = {
@@ -48,7 +52,9 @@ export function ColumnOption({
   const hasExpression = expression && expression !== column_name;
   const type = hasExpression ? 'expression' : type_generic;
   const [tooltipText, setTooltipText] = useState<ReactNode>(column.column_name);
-  const [columnTypeTooltipText, setcolumnTypeTooltipText] = useState<ReactNode>(column.type);
+  const [columnTypeTooltipText, setcolumnTypeTooltipText] = useState<ReactNode>(
+    column.type,
+  );
 
   useLayoutEffect(() => {
     setTooltipText(getColumnTooltipNode(column, labelRef));
@@ -57,7 +63,11 @@ export function ColumnOption({
 
   return (
     <StyleOverrides>
-      <Tooltip id="metric-type-tooltip" title={columnTypeTooltipText} placement="bottomRight">
+      <Tooltip
+        id="metric-type-tooltip"
+        title={columnTypeTooltipText}
+        placement="bottomRight"
+      >
         <span>
           {showType && type !== undefined && <ColumnTypeLabel type={type} />}
         </span>

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/ColumnOption.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/ColumnOption.tsx
@@ -67,6 +67,7 @@ export function ColumnOption({
         id="metric-type-tooltip"
         title={columnTypeTooltipText}
         placement="bottomRight"
+        align={{ offset: [8, -2] }}
       >
         <span>
           {showType && type !== undefined && <ColumnTypeLabel type={type} />}

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/ColumnOption.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/ColumnOption.tsx
@@ -63,14 +63,16 @@ export function ColumnOption({
 
   return (
     <StyleOverrides>
-      {showType && (
+      {showType && type !== undefined && (
         <Tooltip
           id="metric-type-tooltip"
           title={columnTypeTooltipText}
           placement="bottomRight"
           align={{ offset: [8, -2] }}
         >
-          <span>{type !== undefined && <ColumnTypeLabel type={type} />}</span>
+          <span>
+            <ColumnTypeLabel type={type} />
+          </span>
         </Tooltip>
       )}
       <Tooltip id="metric-name-tooltip" title={tooltipText}>

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.tsx
@@ -59,6 +59,19 @@ export const isLabelTruncated = (labelRef?: React.RefObject<any>): boolean =>
 export const getColumnLabelText = (column: ColumnMeta): string =>
   column.verbose_name || column.column_name;
 
+export const getColumnTypeTooltipNode = (
+  column: ColumnMeta,
+  labelRef?: React.RefObject<any>,
+): ReactNode => {
+  if (!column.type) {
+    return null;
+  }
+
+  return (
+    <TooltipSection label={t('Column datatype')} text={column.type.toLowerCase()} />
+  );
+};
+
 export const getColumnTooltipNode = (
   column: ColumnMeta,
   labelRef?: React.RefObject<any>,

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.tsx
@@ -59,10 +59,7 @@ export const isLabelTruncated = (labelRef?: React.RefObject<any>): boolean =>
 export const getColumnLabelText = (column: ColumnMeta): string =>
   column.verbose_name || column.column_name;
 
-export const getColumnTypeTooltipNode = (
-  column: ColumnMeta,
-  labelRef?: React.RefObject<any>,
-): ReactNode => {
+export const getColumnTypeTooltipNode = (column: ColumnMeta): ReactNode => {
   if (!column.type) {
     return null;
   }

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.tsx
@@ -68,7 +68,10 @@ export const getColumnTypeTooltipNode = (
   }
 
   return (
-    <TooltipSection label={t('Column datatype')} text={column.type.toLowerCase()} />
+    <TooltipSection
+      label={t('Column datatype')}
+      text={column.type.toLowerCase()}
+    />
   );
 };
 

--- a/superset-frontend/packages/superset-ui-chart-controls/test/components/labelUtils.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/components/labelUtils.test.tsx
@@ -66,7 +66,6 @@ test('should get null as tooltip', () => {
 });
 
 test('should get null for column datatype tooltip when type is blank', () => {
-  const ref = { current: { scrollWidth: 100, clientWidth: 100 } };
   expect(
     getColumnTypeTooltipNode({
       id: 123,
@@ -79,7 +78,6 @@ test('should get null for column datatype tooltip when type is blank', () => {
 });
 
 test('should get column datatype rendered as tooltip when column has a type', () => {
-  const ref = { current: { scrollWidth: 100, clientWidth: 100 } };
   renderWithTheme(
     <>
       {getColumnTypeTooltipNode({

--- a/superset-frontend/packages/superset-ui-chart-controls/test/components/labelUtils.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/components/labelUtils.test.tsx
@@ -24,6 +24,7 @@ import {
   getColumnLabelText,
   getColumnTooltipNode,
   getMetricTooltipNode,
+  getColumnTypeTooltipNode,
 } from '../../src/components/labelUtils';
 
 const renderWithTheme = (ui: ReactElement) =>
@@ -62,6 +63,37 @@ test('should get null as tooltip', () => {
       ref,
     ),
   ).toBe(null);
+});
+
+test('should get null for column datatype tooltip when type is blank', () => {
+  const ref = { current: { scrollWidth: 100, clientWidth: 100 } };
+  expect(
+    getColumnTypeTooltipNode({
+      id: 123,
+      column_name: 'column name',
+      verbose_name: '',
+      description: '',
+      type: '',
+    }),
+  ).toBe(null);
+});
+
+test('should get column datatype rendered as tooltip when column has a type', () => {
+  const ref = { current: { scrollWidth: 100, clientWidth: 100 } };
+  renderWithTheme(
+    <>
+      {getColumnTypeTooltipNode({
+        id: 123,
+        column_name: 'column name',
+        verbose_name: 'verbose name',
+        description: 'A very important column',
+        type: 'text',
+      })}
+    </>,
+  );
+
+  expect(screen.getByText('Column datatype')).toBeVisible();
+  expect(screen.getByText('text')).toBeVisible();
 });
 
 test('should get column name, verbose name and description when it has a verbose name', () => {


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix for issue - [https://github.com/apache/superset/issues/13248](https://github.com/apache/superset/issues/13248)
Minor improvement: It show the type as in `VARCHAR(50), text, double precision` when hovering the icon in the metadata panel Please refer the after screenshots below for more understanding.

### AFTER SCREENSHOTS 
![tooltip datatype in chart 1](https://user-images.githubusercontent.com/34643160/236852622-cdd7cab3-4880-470e-91f5-6f75f8eb6386.png)
![tooltip datatype in chart 2](https://user-images.githubusercontent.com/34643160/236852762-b198bd99-4852-4230-b450-157115352fe1.png)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Please verify changes from my fork

1. Click on charts from headers section to see all charts
2. Click and open any chart
3. On the left side there will be columns of table and column options
4. If we hover on the icon (`abc, #` etc.) of column type, it should open a tooltip with detailed data type of that particular column

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes https://github.com/apache/superset/issues/13248
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
