### PR TITLE
fix: MySQL et al. super calls

### DIFF
--- a/superset/db_engine_specs/mysql.py
+++ b/superset/db_engine_specs/mysql.py
@@ -211,7 +211,7 @@ class MySQLEngineSpec(BaseEngineSpec, BasicParametersMixin):
             catalog,
             schema,
         )
-        
+
         if schema:
             uri = uri.set(database=parse.quote(schema, safe=""))
 

--- a/superset/db_engine_specs/mysql.py
+++ b/superset/db_engine_specs/mysql.py
@@ -205,9 +205,13 @@ class MySQLEngineSpec(BaseEngineSpec, BasicParametersMixin):
         catalog: Optional[str] = None,
         schema: Optional[str] = None,
     ) -> Tuple[URL, Dict[str, Any]]:
-        uri, new_connect_args = super(
-            MySQLEngineSpec, MySQLEngineSpec
-        ).adjust_engine_params(uri, connect_args, catalog, schema)
+        uri, new_connect_args = super().adjust_engine_params(
+            uri,
+            connect_args,
+            catalog,
+            schema,
+        )
+        
         if schema:
             uri = uri.set(database=parse.quote(schema, safe=""))
 

--- a/superset/db_engine_specs/ocient.py
+++ b/superset/db_engine_specs/ocient.py
@@ -261,9 +261,7 @@ class OcientEngineSpec(BaseEngineSpec):
         cls, cursor: Any, limit: Optional[int] = None
     ) -> List[Tuple[Any, ...]]:
         try:
-            rows: List[Tuple[Any, ...]] = super(OcientEngineSpec, cls).fetch_data(
-                cursor, limit
-            )
+            rows: List[Tuple[Any, ...]] = super().fetch_data(cursor, limit)
         except Exception as exception:
             with OcientEngineSpec.query_id_mapping_lock:
                 del OcientEngineSpec.query_id_mapping[


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

When invoking `super` we shouldn't explicitly be specifying the `MySQLEngineSpec` for the `type` and `object_or_type` arguments as there's no guarantee that the `MySQLEngineSpec` class is the class which gets instantiated, i.e., this could serve as a base class for another connector such as a custom StarRocks connector.

The issue with the current implementation is if you provide logic of the following, 

```python
class StarRocksEngineSpec(MySQLEngineSpec):
    """
    The StarRocks engine specification.
    """

    disallow_uri_query_params = set()
    enforce_uri_query_params = {}
    engine = "starrocks"
    engine_name = "StarRocks"
```

when `adjust_engine_params` is invoked it's using the `MySQLEnginSpec.enforce_uri_query_params` et al. class level parameters. Simply invoking `super` without parameters resolves this issue.

I grokked the entire engine specs and made sure that all `super` calls were of the form `super()` which mean updating the Ocient connector as well.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
