### PR TITLE
feat: Adds Line chart migration logic

### DIFF
--- a/superset/cli/viz_migrations.py
+++ b/superset/cli/viz_migrations.py
@@ -24,12 +24,12 @@ from superset import db
 
 
 class VizType(str, Enum):
-    TREEMAP = "treemap"
-    DUAL_LINE = "dual_line"
     AREA = "area"
+    DUAL_LINE = "dual_line"
+    LINE = "line"
     PIVOT_TABLE = "pivot_table"
     SUNBURST = "sunburst"
-    LINE = "line"
+    TREEMAP = "treemap"
 
 
 @click.group()
@@ -84,12 +84,12 @@ def migrate(viz_type: VizType, is_downgrade: bool = False) -> None:
     )
 
     migrations = {
-        VizType.TREEMAP: MigrateTreeMap,
-        VizType.DUAL_LINE: MigrateDualLine,
         VizType.AREA: MigrateAreaChart,
+        VizType.DUAL_LINE: MigrateDualLine,
+        VizType.LINE: MigrateLineChart,
         VizType.PIVOT_TABLE: MigratePivotTable,
         VizType.SUNBURST: MigrateSunburst,
-        VizType.LINE: MigrateLineChart,
+        VizType.TREEMAP: MigrateTreeMap,
     }
     if is_downgrade:
         migrations[viz_type].downgrade(db.session)

--- a/superset/cli/viz_migrations.py
+++ b/superset/cli/viz_migrations.py
@@ -29,6 +29,7 @@ class VizType(str, Enum):
     AREA = "area"
     PIVOT_TABLE = "pivot_table"
     SUNBURST = "sunburst"
+    LINE = "line"
 
 
 @click.group()
@@ -79,6 +80,7 @@ def migrate(viz_type: VizType, is_downgrade: bool = False) -> None:
         MigratePivotTable,
         MigrateSunburst,
         MigrateTreeMap,
+        MigrateLineChart,
     )
 
     migrations = {
@@ -87,6 +89,7 @@ def migrate(viz_type: VizType, is_downgrade: bool = False) -> None:
         VizType.AREA: MigrateAreaChart,
         VizType.PIVOT_TABLE: MigratePivotTable,
         VizType.SUNBURST: MigrateSunburst,
+        VizType.LINE: MigrateLineChart,
     }
     if is_downgrade:
         migrations[viz_type].downgrade(db.session)

--- a/superset/cli/viz_migrations.py
+++ b/superset/cli/viz_migrations.py
@@ -77,10 +77,10 @@ def migrate(viz_type: VizType, is_downgrade: bool = False) -> None:
     from superset.migrations.shared.migrate_viz.processors import (
         MigrateAreaChart,
         MigrateDualLine,
+        MigrateLineChart,
         MigratePivotTable,
         MigrateSunburst,
         MigrateTreeMap,
-        MigrateLineChart,
     )
 
     migrations = {

--- a/superset/migrations/shared/migrate_viz/processors.py
+++ b/superset/migrations/shared/migrate_viz/processors.py
@@ -140,7 +140,7 @@ class TimeseriesChart(MigrateViz):
 
     def _pre_action(self) -> None:
         self.data["contributionMode"] = "row" if self.data.get("contribution") else None
-        self.data["zoomable"] = False if self.data.get("show_brush") == "no" else True
+        self.data["zoomable"] = self.data.get("show_brush") != "no"
         self.data["markerEnabled"] = self.data.get("show_markers") or False
         self.data["y_axis_showminmax"] = True
 

--- a/superset/migrations/shared/migrate_viz/processors.py
+++ b/superset/migrations/shared/migrate_viz/processors.py
@@ -16,6 +16,8 @@
 # under the License.
 from typing import Any
 
+from superset.utils.core import as_list
+
 from .base import MigrateViz
 
 
@@ -155,7 +157,9 @@ class TimeseriesChart(MigrateViz):
             self.data["rolling_type"] = rolling_type
 
         if time_compare := self.data.get("time_compare"):
-            self.data["time_compare"] = [value + " ago" for value in time_compare]
+            self.data["time_compare"] = [
+                value + " ago" for value in as_list(time_compare) if value
+            ]
 
         comparison_type = self.data.get("comparison_type") or "values"
         self.data["comparison_type"] = (

--- a/superset/migrations/shared/migrate_viz/processors.py
+++ b/superset/migrations/shared/migrate_viz/processors.py
@@ -131,3 +131,60 @@ class MigrateSunburst(MigrateViz):
     source_viz_type = "sunburst"
     target_viz_type = "sunburst_v2"
     rename_keys = {"groupby": "columns"}
+
+
+class TimeseriesChart(MigrateViz):
+    has_x_axis_control = True
+
+    def _pre_action(self) -> None:
+        self.data["contributionMode"] = "row" if self.data.get("contribution") else None
+
+        show_brush = self.data.get("show_brush")
+        self.data["zoomable"] = False if show_brush == "no" else True
+
+        self.data["markerEnabled"] = self.data.get("show_markers")
+        self.data["y_axis_showminmax"] = True
+
+        bottom_margin = self.data.get("bottom_margin")
+        if self.data.get("x_axis_label") and (
+            not bottom_margin or bottom_margin == "auto"
+        ):
+            self.data["bottom_margin"] = 30
+
+        if (rolling_type := self.data.get("rolling_type")) and rolling_type != "None":
+            self.data["rolling_type"] = rolling_type
+
+        if time_compare := self.data.get("time_compare"):
+            self.data["time_compare"] = [value + " ago" for value in time_compare]
+
+        comparison_type = self.data.get("comparison_type") or "values"
+        self.data["comparison_type"] = (
+            "difference" if comparison_type == "absolute" else comparison_type
+        )
+
+
+class MigrateLineChart(TimeseriesChart):
+    source_viz_type = "line"
+    target_viz_type = "echarts_timeseries_line"
+    rename_keys = {
+        "x_axis_label": "x_axis_title",
+        "bottom_margin": "x_axis_title_margin",
+        "x_axis_format": "x_axis_time_format",
+        "y_axis_label": "y_axis_title",
+        "left_margin": "y_axis_title_margin",
+        "y_axis_showminmax": "truncateYAxis",
+        "y_log_scale": "logAxis",
+    }
+
+    def _pre_action(self) -> None:
+        super()._pre_action()
+
+        line_interpolation = self.data.get("line_interpolation")
+        if line_interpolation == "cardinal":
+            self.target_viz_type = "echarts_timeseries_smooth"
+        elif line_interpolation == "step-before":
+            self.target_viz_type = "echarts_timeseries_step"
+            self.data["seriesType"] = "start"
+        elif line_interpolation == "step-after":
+            self.target_viz_type = "echarts_timeseries_step"
+            self.data["seriesType"] = "end"

--- a/superset/migrations/shared/migrate_viz/processors.py
+++ b/superset/migrations/shared/migrate_viz/processors.py
@@ -140,11 +140,8 @@ class TimeseriesChart(MigrateViz):
 
     def _pre_action(self) -> None:
         self.data["contributionMode"] = "row" if self.data.get("contribution") else None
-
-        show_brush = self.data.get("show_brush")
-        self.data["zoomable"] = False if show_brush == "no" else True
-
-        self.data["markerEnabled"] = self.data.get("show_markers")
+        self.data["zoomable"] = False if self.data.get("show_brush") == "no" else True
+        self.data["markerEnabled"] = self.data.get("show_markers") or False
         self.data["y_axis_showminmax"] = True
 
         bottom_margin = self.data.get("bottom_margin")


### PR DESCRIPTION
### SUMMARY
This PR adds the Line chart migration logic (NVD3 ➡️ ECharts). Users can execute this migration using the [migrate_viz](https://github.com/apache/superset/pull/25304) CLI command and disable the legacy version with the [VIZ_TYPE_DENYLIST](https://github.com/apache/superset/blob/ec6191023263ac5f8292dd37f037805c3196e029/superset/config.py#L829) configuration.

@sadpandajoe @jinghua-qa 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1483" alt="Screenshot 2023-09-19 at 11 08 10" src="https://github.com/apache/superset/assets/70410625/641fe3e7-a87c-4f80-a4c1-8d28f8f131b5">
<img width="1484" alt="Screenshot 2023-09-19 at 11 09 30" src="https://github.com/apache/superset/assets/70410625/8347b2c9-40a9-4211-b8a6-176a6bb1feca">

### TESTING INSTRUCTIONS
1 - Upgrade a Line chart using the CLI command
2 - Check the new chart
3 - Downgrade a Line chart using the CLI command 
4 - Check the legacy chart

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
