### PR TITLE
fix(migration): handle permalink edge cases correctly

### DIFF
--- a/superset/explore/permalink/commands/create.py
+++ b/superset/explore/permalink/commands/create.py
@@ -45,7 +45,7 @@ class CreateExplorePermalinkCommand(BaseExplorePermalinkCommand):
             value = {
                 "chartId": self.chart_id,
                 "datasourceId": datasource_id,
-                "datasourceType": datasource_type,
+                "datasourceType": datasource_type.value,
                 "datasource": self.datasource,
                 "state": self.state,
             }

--- a/superset/migrations/versions/2023-05-01_12-03_9c2a5681ddfd_convert_key_value_entries_to_json.py
+++ b/superset/migrations/versions/2023-05-01_12-03_9c2a5681ddfd_convert_key_value_entries_to_json.py
@@ -45,7 +45,10 @@ RESOURCES_TO_MIGRATE = ("app", "dashboard_permalink", "explore_permalink")
 
 class RestrictedUnpickler(pickle.Unpickler):
     def find_class(self, module, name):
-        raise pickle.UnpicklingError(f"Unpickling of {module}.{name} is forbidden")
+        if not (module == "superset.utils.core" and name == "DatasourceType"):
+            raise pickle.UnpicklingError(f"Unpickling of {module}.{name} is forbidden")
+
+        return super().find_class(module, name)
 
 
 class KeyValueEntry(Base):
@@ -63,7 +66,16 @@ def upgrade():
             KeyValueEntry.resource.in_(RESOURCES_TO_MIGRATE)
         )
     ):
-        value = RestrictedUnpickler(io.BytesIO(entry.value)).load() or {}
+        try:
+            value = RestrictedUnpickler(io.BytesIO(entry.value)).load() or {}
+        except pickle.UnpicklingError as ex:
+            if str(ex) == "pickle data was truncated":
+                # make truncated values that were created prior to #20385 an empty
+                # dict so that downgrading will work properly.
+                value = {}
+            else:
+                raise
+
         entry.value = bytes(json.dumps(value), encoding="utf-8")
 
 


### PR DESCRIPTION
### SUMMARY
This is a continuation of #23888 and addresses two issues that were identified after this PR was merged:
- On MySQL, large key-value entries that had been persisted prior to #20385 and exceeded the column size would cause the migration to fail, as the pickled value was truncated. This checks for truncation errors during deserialization, and replaces the value with an empty dict to ensure that the value is deserializable in the future.
- Deserializing Explore permalinks failed, as one of the values in the dict was a string Enum that hadn't been cast to a pure `str` (apparently my devenv didn't have a single Explore permalink when I ran the migration 🙁). For this reason we add a check to `find_class` to make sure `superset.utils.core.DatasourceType` is a valid class. Note that this problem will now go away, as the JSON codec ensures that the Enum becomes a simple string in the future. In addition and to be more explicit, we cast `datasourceType` in the Explore payload of the create command to a `str` which is the correct type based on the `ExplorePermalinkValue` type: https://github.com/apache/superset/blob/d96b72d46fe6e7b8a0a4749032c13322396633e1/superset/explore/permalink/types.py#L25-L34

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. downgrade your devenv to `7e67aecbf3f1`, checkout master prior to `f1fa1a733d247ec4793c17b69c4eb40c631c5080`  and create an Explore permalink
2. checkout latest master branch, run `superset db upgrade` and notice the error
3. checkout this PR, rerun `superset db upgrade` and see the migration complete
4. To validate that downgrading and re-upgrading works, run `superset db downgrade 7e67aecbf3f1 && superset db upgrade"

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
