### PR TITLE
docs(frontend): Fixed typo in command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -591,7 +591,7 @@ Error: You must provide the URL of lib/mappings.wasm by calling SourceMapConsume
 ```
 Then put this:
 ```bash
-export NODE_OPTIONS=--no-experimental-fetch`
+export NODE_OPTIONS=--no-experimental-fetch
 ```
 
 #### Webpack dev server


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There is a typo in command with extra  tick in command `export NODE_OPTIONS=--no-experimental-fetch` which gives error. So, removed typo in this PR.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

- Try fresh installation
- after superset/superset-frontend when you will do npm run dev-server , then following error will come.

`Error: You must provide the URL of lib/mappings.wasm by calling SourceMapConsumer.initialize({ 'lib/mappings.wasm': ... }) before using SourceMapConsumer at readWasm (/home/test/superset_setup/superset/superset-frontend/node_modules/react-hot-loader/node_modules/source-map/lib/read-wasm.js:8:13) at wasm (/home/test/superset_setup/superset/superset-frontend/node_modules/react-hot-loader/node_modules/source-map/lib/wasm.js:25:16) at /home/test/superset_setup/superset/superset-frontend/node_modules/react-hot-loader/node_modules/source-map/lib/source-map-consumer.js:264:14 `

- Above error was resolved by doing following:

`export NODE_OPTIONS=--no-experimental-fetch`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
