### PR TITLE
docs: correct databricks pip package name

### DIFF
--- a/docs/docs/databases/databricks.mdx
+++ b/docs/docs/databases/databricks.mdx
@@ -10,7 +10,7 @@ version: 1
 Databricks now offer a native DB API 2.0 driver, `databricks-sql-connector`, that can be used with the `sqlalchemy-databricks` dialect. You can install both with:
 
 ```bash
-pip install "superset[databricks]"
+pip install "apache-superset[databricks]"
 ```
 
 To use the Hive connector you need the following information from your cluster:


### PR DESCRIPTION

### SUMMARY
The docs reference the old pip package [superset](https://pypi.org/project/superset/0.30.1/). It should reference the new one [apache-superset](https://pypi.org/project/apache-superset/)



### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
