### PR TITLE
docs(feature flags): remove the conflicting entry for DRILL_BY

### DIFF
--- a/RESOURCES/FEATURE_FLAGS.md
+++ b/RESOURCES/FEATURE_FLAGS.md
@@ -27,7 +27,6 @@ These features are considered **unfinished** and should only be used on developm
 
 [//]: # "PLEASE KEEP THE LIST SORTED ALPHABETICALLY"
 
-- DRILL_BY
 - ENABLE_ADVANCED_DATA_TYPES
 - ENABLE_TEMPLATE_REMOVE_FILTERS
 - KV_STORE


### PR DESCRIPTION
`DRILL_BY` is listed in two sections, "in development" and "in testing." This removes it from the "in development" list.