### PR TITLE
fix:  that there is no copy filter when copying the dashboard

### DIFF
--- a/superset/dashboards/dao.py
+++ b/superset/dashboards/dao.py
@@ -260,7 +260,7 @@ class DashboardDAO(BaseDAO):
             }
             md["default_filters"] = json.dumps(applicable_filters)
 
-            if 'native_filter_configuration' in data:
+            if 'native_filter_configuration' in data and old_to_new_slice_ids:
                 # replace native_filter_id and immune ids
                 # from old slice id to new slice id:
                 for filter_config in data['native_filter_configuration']:

--- a/superset/dashboards/dao.py
+++ b/superset/dashboards/dao.py
@@ -260,6 +260,26 @@ class DashboardDAO(BaseDAO):
             }
             md["default_filters"] = json.dumps(applicable_filters)
 
+            if 'native_filter_configuration' in data:
+                # replace native_filter_id and immune ids
+                # from old slice id to new slice id:
+                for filter_config in data['native_filter_configuration']:
+                    old_scopes = filter_config['chartsInScope']
+                    new_scopes = []
+                    for old_scope in old_scopes:
+                        new_scopes.append(old_to_new_slice_ids[old_scope])
+                    filter_config['chartsInScope'] = new_scopes
+                    scope = filter_config['scope']
+                    if 'excluded' in scope:
+                        excluded_scopes = scope['excluded']
+                        new_excluded_scopes = []
+                        for excluded_scope in excluded_scopes:
+                            new_excluded_scopes.append(
+                                old_to_new_slice_ids[excluded_scope])
+                        scope['excluded'] = new_excluded_scopes
+            md["native_filter_configuration"] = data.get("native_filter_configuration",
+                                                         {})
+
             # positions have its own column, no need to store it in metadata
             md.pop("positions", None)
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I found that after I selected the copy slice when I was copying the dashboard, 
the new dashboard does not have the filter of the original dashboard.
Although there is a relevant copy default_filter in the code, it does not take effect, 
so I fixed it. I am not sure this is a bug, please Community maintainers view
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
before:
https://github.com/apache/superset/assets/40172777/8ee17250-f362-4a59-bda3-5c3ca8cb79a7
after:

https://github.com/apache/superset/assets/40172777/f1d3a2e9-7fac-408a-9b0d-c858334df117



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
