### PR TITLE
fix(table): condition formatting can't formate 0 values

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -461,9 +461,10 @@ export default function TableChart<D extends DataRecord = DataRecord>(
             columnColorFormatters!
               .filter(formatter => formatter.column === column.key)
               .forEach(formatter => {
-                const formatterResult = value
-                  ? formatter.getColorFromValue(value as number)
-                  : false;
+                const formatterResult =
+                  value !== undefined
+                    ? formatter.getColorFromValue(value as number)
+                    : false;
                 if (formatterResult) {
                   backgroundColor = formatterResult;
                 }

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -462,7 +462,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
               .filter(formatter => formatter.column === column.key)
               .forEach(formatter => {
                 const formatterResult =
-                  value !== undefined
+                  value || value === 0
                     ? formatter.getColorFromValue(value as number)
                     : false;
                 if (formatterResult) {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Conditional formatting was not working for cells with value 0. This PR fixes the issue.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
#### Before
![image](https://github.com/apache/superset/assets/66589759/edaccf52-d420-4368-a315-84cd5e22a2a1)

#### After
![image](https://github.com/apache/superset/assets/66589759/32d78737-5080-4932-bc40-aaa8146b7a00)


### TESTING INSTRUCTIONS
1. Create a table chart.
2. Create a metric from SQL `(0)`.
3. Add a condition for the metric.
4. The don't condition works for cells with value 0.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
