### PR TITLE
fix(dashboard): Inoperable dashboard filter slider when range is <= 1

### DIFF
--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
@@ -300,6 +300,16 @@ export default function RangeFilterPlugin(props: PluginFilterRangeProps) {
     }
   }, [enableSingleExactValue]);
 
+  const MIN_NUM_STEPS = 20;
+  const stepHeuristic = (min: number, max: number) => {
+    const maxStepSize = (max - min) / MIN_NUM_STEPS;
+    // normalizedStepSize: .06 -> .01, .003 -> .001
+    const normalizedStepSize = '1E' + Math.floor(Math.log10(maxStepSize));
+    return Math.min(1, parseFloat(normalizedStepSize));
+  };
+
+  const step = stepHeuristic(min, max);
+
   return (
     <FilterPluginStyle height={height} width={width}>
       {Number.isNaN(Number(min)) || Number.isNaN(Number(max)) ? (
@@ -323,6 +333,7 @@ export default function RangeFilterPlugin(props: PluginFilterRangeProps) {
               <AntdSlider
                 min={min}
                 max={max}
+                step={step}
                 value={minMax[maxIndex]}
                 tipFormatter={tipFormatter}
                 marks={marks}
@@ -335,6 +346,7 @@ export default function RangeFilterPlugin(props: PluginFilterRangeProps) {
                 validateStatus={filterState.validateStatus}
                 min={min}
                 max={max}
+                step={step}
                 value={minMax[minIndex]}
                 tipFormatter={tipFormatter}
                 marks={marks}
@@ -346,6 +358,7 @@ export default function RangeFilterPlugin(props: PluginFilterRangeProps) {
               <AntdSlider
                 min={min}
                 max={max}
+                step={step}
                 included={false}
                 value={minMax[minIndex]}
                 tipFormatter={tipFormatter}
@@ -359,6 +372,7 @@ export default function RangeFilterPlugin(props: PluginFilterRangeProps) {
                 range
                 min={min}
                 max={max}
+                step={step}
                 value={minMax}
                 onAfterChange={handleAfterChange}
                 onChange={handleChange}

--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
@@ -304,7 +304,7 @@ export default function RangeFilterPlugin(props: PluginFilterRangeProps) {
   const stepHeuristic = (min: number, max: number) => {
     const maxStepSize = (max - min) / MIN_NUM_STEPS;
     // normalizedStepSize: .06 -> .01, .003 -> .001
-    const normalizedStepSize = '1E' + Math.floor(Math.log10(maxStepSize));
+    const normalizedStepSize = `1E${Math.floor(Math.log10(maxStepSize))}`;
     return Math.min(1, parseFloat(normalizedStepSize));
   };
 


### PR DESCRIPTION
### SUMMARY
`antd`'s slider, as used in dashboard filters, has a step size of 1 (`antd`'s default). So when the entire range of numbers is within 1, the slider is inoperable.

A few possible solutions -- I chose option (3):

1. Set the step size to something static that fixes this particular issue, like .01.  This makes things better for this case, but worse for cases where a step size of `1` is sufficient.
2. Let the user choose a step size in the filter setup dialog.  Nice because it makes things explicit, but adds extra UI stuff and users have to make extra decisions.
3. Come up with a heuristic for choosing a step size.  Nice because it works by default, and without any extra work from the user.  If we want the user to be able to choose their own step size, that could be a feature rather than a bug fix (and seems to be in-progress [over here](https://github.com/apache/superset/pull/18009
))

This solution preserves the default behavior where the rightmost digit moves up and down by 1, while accounting for the cases where that 1 ought to be after the decimal point. The calculated step-size is the largest such number (but not larger than `1`) that accommodates the minimum number of steps we'd want to have (`MIN_NUM_STEPS`)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://github.com/apache/superset/assets/99757211/1f513f77-2c30-4c64-baff-088d3fcc236b


https://github.com/apache/superset/assets/99757211/72188e8b-0e76-4a23-ab5b-d9709072532a



### TESTING INSTRUCTIONS
#### How to reproduce the bug

1. Create a chart using a dataset that has a column whose values are within a range of `1`.   E.g. a column all of whose values are between 0 and 1.
1a. If you don't have such a dataset, edit a dataset using "calculated columns" to create one.
2. Create a dashboard that uses that chart.
3. Add a numerical range filter to that dashboard, connected to the column in step (1).
5. Try to use the slider

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
Fixes #24010
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
