### PR TITLE
feat(docker): Build python 3.11 docker image

### DIFF
--- a/.github/workflows/docker_build_push.sh
+++ b/.github/workflows/docker_build_push.sh
@@ -71,6 +71,20 @@ docker build --target lean \
   .
 
 #
+# Build the "lean311" image
+#
+docker build --target lean \
+  -t "${REPO_NAME}:${SHA}-py311" \
+  -t "${REPO_NAME}:${REFSPEC}-py311" \
+  -t "${REPO_NAME}:${LATEST_TAG}-py311" \
+  --build-arg PY_VER="3.11-slim"\
+  --label "sha=${SHA}" \
+  --label "built_at=$(date)" \
+  --label "target=lean311" \
+  --label "build_actor=${GITHUB_ACTOR}" \
+  .
+
+#
 # Build the "websocket" image
 #
 docker build \


### PR DESCRIPTION
### SUMMARY
We want to use Python 3.11 in the docker image to benefit from its performance improvements. 

### TESTING INSTRUCTIONS
Run the docker build and see if it works with Python 3.11

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backward-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

I am not changing the default image version which is using PY 3.9. I just added the ability to create additional images with 3.11 so that we can use it with Superset's code base.
Talking of database drivers, Many of the drivers we use, do support Py 3.11. For e.g. pyathena, redshift-connector, pyscopg2, and many more.
