### PR TITLE
chore(docs): add version for postgres when doing brew install

### DIFF
--- a/docs/docs/installation/installing-superset-from-scratch.mdx
+++ b/docs/docs/installation/installing-superset-from-scratch.mdx
@@ -61,7 +61,7 @@ We don't recommend using the system installed Python. Instead, first install the
 [homebrew](https://brew.sh/) manager and then run the following commands:
 
 ```
-brew install readline pkg-config libffi openssl mysql postgresql
+brew install readline pkg-config libffi openssl mysql postgresql@14
 ```
 
 You should install a recent version of Python (the official docker image uses 3.8.16). We'd recommend using a Python version manager like [pyenv](https://github.com/pyenv/pyenv) (and also [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv)).

--- a/docs/docs/security.mdx
+++ b/docs/docs/security.mdx
@@ -20,7 +20,7 @@ permissions associated with each role (e.g. by removing or adding permissions to
 associated with each role will be re-synchronized to their original values when you run
 the **superset init** command (often done between Superset versions).
 
-A table with the permissions for these roles can be found at [/RESOURCES/STANDARD_ROLES.md](/RESOURCES/STANDARD_ROLES.md).
+A table with the permissions for these roles can be found at [/RESOURCES/STANDARD_ROLES.md](https://github.com/apache/superset/blob/master/RESOURCES/STANDARD_ROLES.mdd).
 
 ### Admin
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Hopefully this change to the docs points users toward the right thing to do here! This should resolve an error that I (and apparently others) ran into. Fixes https://github.com/apache/superset/issues/22897

Added bycatch: fixing a link that was breaking builds. Apparently you can't use a relative link that goes outside the docusaurus folder, so I just used a link to the referenced file on the repo.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
