### PR TITLE
chore(sqllab): Remove functionNames from sqlLab state

### DIFF
--- a/superset-frontend/spec/helpers/testing-library.tsx
+++ b/superset-frontend/spec/helpers/testing-library.tsx
@@ -73,7 +73,7 @@ export function createWrapper(options?: Options) {
       result = <DndProvider backend={HTML5Backend}>{result}</DndProvider>;
     }
 
-    if (useRedux) {
+    if (useRedux || store) {
       const mockStore =
         store ?? createStore(initialState, reducers || reducerIndex);
       result = <Provider store={mockStore}>{result}</Provider>;

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -1555,34 +1555,3 @@ export function createCtasDatasource(vizOptions) {
       });
   };
 }
-
-export function queryEditorSetFunctionNames(queryEditor, dbId) {
-  return function (dispatch) {
-    return SupersetClient.get({
-      endpoint: encodeURI(`/api/v1/database/${dbId}/function_names/`),
-    })
-      .then(({ json }) =>
-        dispatch({
-          type: QUERY_EDITOR_SET_FUNCTION_NAMES,
-          queryEditor,
-          functionNames: json.function_names,
-        }),
-      )
-      .catch(err => {
-        if (err.status === 404) {
-          // for databases that have been deleted, just reset the function names
-          dispatch({
-            type: QUERY_EDITOR_SET_FUNCTION_NAMES,
-            queryEditor,
-            functionNames: [],
-          });
-        } else {
-          dispatch(
-            addDangerToast(
-              t('An error occurred while fetching function names.'),
-            ),
-          );
-        }
-      });
-  };
-}

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
@@ -29,7 +29,6 @@ import querystring from 'query-string';
 
 import {
   queryEditorSetDb,
-  queryEditorSetFunctionNames,
   addTable,
   removeTables,
   collapseTable,
@@ -142,7 +141,6 @@ const SqlEditorLeftBar = ({
   const onDbChange = ({ id: dbId }: { id: number }) => {
     setEmptyState(false);
     dispatch(queryEditorSetDb(queryEditor, dbId));
-    dispatch(queryEditorSetFunctionNames(queryEditor, dbId));
   };
 
   const selectedTableNames = useMemo(

--- a/superset-frontend/src/SqlLab/fixtures.ts
+++ b/superset-frontend/src/SqlLab/fixtures.ts
@@ -185,7 +185,6 @@ export const defaultQueryEditor = {
   name: 'Untitled Query 1',
   schema: 'main',
   remoteId: null,
-  functionNames: [],
   hideLeftBar: false,
   templateParams: '{}',
 };

--- a/superset-frontend/src/SqlLab/reducers/getInitialState.js
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.js
@@ -56,7 +56,6 @@ export default function getInitialState({
     autorun: false,
     templateParams: null,
     dbId: defaultDbId,
-    functionNames: [],
     queryLimit: common.conf.DEFAULT_SQLLAB_LIMIT,
     validationResult: {
       id: null,
@@ -87,7 +86,6 @@ export default function getInitialState({
         autorun: activeTab.autorun,
         templateParams: activeTab.template_params || undefined,
         dbId: activeTab.database_id,
-        functionNames: [],
         schema: activeTab.schema,
         queryLimit: activeTab.query_limit,
         validationResult: {

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -563,18 +563,6 @@ export default function sqlLabReducer(state = {}, action) {
         ),
       };
     },
-    [actions.QUERY_EDITOR_SET_FUNCTION_NAMES]() {
-      return {
-        ...state,
-        ...alterUnsavedQueryEditorState(
-          state,
-          {
-            functionNames: action.functionNames,
-          },
-          action.queryEditor.id,
-        ),
-      };
-    },
     [actions.QUERY_EDITOR_SET_SCHEMA]() {
       return {
         ...state,

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
@@ -209,14 +209,15 @@ describe('sqlLabReducer', () => {
       newState = sqlLabReducer(newState, action);
       expect(newState.unsavedQueryEditor.sql).toBe(expectedSql);
       const interceptedAction = {
-        type: actions.QUERY_EDITOR_SET_FUNCTION_NAMES,
+        type: actions.QUERY_EDITOR_PERSIST_HEIGHT,
         queryEditor: newState.queryEditors[0],
-        functionNames: ['func1', 'func2'],
+        northPercent: 46,
+        southPercent: 54,
       };
       newState = sqlLabReducer(newState, interceptedAction);
       expect(newState.unsavedQueryEditor.sql).toBe(expectedSql);
-      expect(newState.queryEditors[0].functionNames).toBe(
-        interceptedAction.functionNames,
+      expect(newState.queryEditors[0].northPercent).toBe(
+        interceptedAction.northPercent,
       );
     });
   });

--- a/superset-frontend/src/SqlLab/types.ts
+++ b/superset-frontend/src/SqlLab/types.ts
@@ -39,7 +39,6 @@ export interface QueryEditor {
   autorun: boolean;
   sql: string;
   remoteId: number | null;
-  functionNames: string[];
   validationResult?: {
     completed: boolean;
     errors: SupersetError[];

--- a/superset-frontend/src/hooks/apiResources/databaseFunctions.test.ts
+++ b/superset-frontend/src/hooks/apiResources/databaseFunctions.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import fetchMock from 'fetch-mock';
+import { act, renderHook } from '@testing-library/react-hooks';
+import {
+  createWrapper,
+  defaultStore as store,
+} from 'spec/helpers/testing-library';
+import { api } from 'src/hooks/apiResources/queryApi';
+import { useDatabaseFunctionsQuery } from './databaseFunctions';
+
+const fakeApiResult = {
+  function_names: ['abs', 'avg', 'sum'],
+};
+
+const expectedResult = fakeApiResult.function_names;
+const expectDbId = 'db1';
+const dbFunctionNamesApiRoute = `glob:*/api/v1/database/${expectDbId}/function_names/`;
+
+afterEach(() => {
+  fetchMock.reset();
+  act(() => {
+    store.dispatch(api.util.resetApiState());
+  });
+});
+
+beforeEach(() => {
+  fetchMock.get(dbFunctionNamesApiRoute, fakeApiResult);
+});
+
+test('returns api response mapping json result', async () => {
+  const { result, waitFor } = renderHook(
+    () =>
+      useDatabaseFunctionsQuery({
+        dbId: expectDbId,
+      }),
+    {
+      wrapper: createWrapper({
+        useRedux: true,
+        store,
+      }),
+    },
+  );
+  await waitFor(() =>
+    expect(fetchMock.calls(dbFunctionNamesApiRoute).length).toBe(1),
+  );
+  expect(result.current.data).toEqual(expectedResult);
+  expect(fetchMock.calls(dbFunctionNamesApiRoute).length).toBe(1);
+  act(() => {
+    result.current.refetch();
+  });
+  await waitFor(() =>
+    expect(fetchMock.calls(dbFunctionNamesApiRoute).length).toBe(2),
+  );
+  expect(result.current.data).toEqual(expectedResult);
+});
+
+test('returns cached data without api request', async () => {
+  const { result, waitFor, rerender } = renderHook(
+    () =>
+      useDatabaseFunctionsQuery({
+        dbId: expectDbId,
+      }),
+    {
+      wrapper: createWrapper({
+        store,
+        useRedux: true,
+      }),
+    },
+  );
+  await waitFor(() => expect(result.current.data).toEqual(expectedResult));
+  expect(fetchMock.calls(dbFunctionNamesApiRoute).length).toBe(1);
+  rerender();
+  await waitFor(() => expect(result.current.data).toEqual(expectedResult));
+  expect(fetchMock.calls(dbFunctionNamesApiRoute).length).toBe(1);
+});

--- a/superset-frontend/src/hooks/apiResources/databaseFunctions.ts
+++ b/superset-frontend/src/hooks/apiResources/databaseFunctions.ts
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { api } from './queryApi';
+
+export type FetchDataFunctionsQueryParams = {
+  dbId?: string | number;
+};
+
+type FunctionNamesResponse = {
+  json: {
+    function_names: string[];
+  };
+  response: Response;
+};
+
+const databaseFunctionApi = api.injectEndpoints({
+  endpoints: builder => ({
+    databaseFunctions: builder.query<string[], FetchDataFunctionsQueryParams>({
+      providesTags: ['DatabaseFunctions'],
+      query: ({ dbId }) => ({
+        endpoint: `/api/v1/database/${dbId}/function_names/`,
+        transformResponse: ({ json }: FunctionNamesResponse) =>
+          json.function_names,
+      }),
+    }),
+  }),
+});
+
+export const { useDatabaseFunctionsQuery } = databaseFunctionApi;

--- a/superset-frontend/src/hooks/apiResources/queryApi.ts
+++ b/superset-frontend/src/hooks/apiResources/queryApi.ts
@@ -65,7 +65,7 @@ export const supersetClientQuery: BaseQueryFn<
 
 export const api = createApi({
   reducerPath: 'queryApi',
-  tagTypes: ['Schemas', 'Tables'],
+  tagTypes: ['Schemas', 'Tables', 'DatabaseFunctions'],
   endpoints: () => ({}),
   baseQuery: supersetClientQuery,
 });


### PR DESCRIPTION
### SUMMARY
Similar to #23488 and #23257, this commit migrates the functionNames state from redux to rdk-query to reduce the complexity of the queryEditor state.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After:

https://github.com/apache/superset/assets/1392866/5a216877-6aff-480e-b5d7-ba7f5e8dc249

<img width="586" alt="Screenshot 2023-05-11 at 1 52 26 PM" src="https://github.com/apache/superset/assets/1392866/24245269-29e8-46e9-9917-f28d0d266d71">

Before:

https://github.com/apache/superset/assets/1392866/8fc6aeba-8ecf-491c-bd48-12f9d83c75f6

<img width="555" alt="Screenshot_2023-05-11_at_1_51_47_PM" src="https://github.com/apache/superset/assets/1392866/4e375e2b-a206-4f66-b853-b8a33fab6914">

### TESTING INSTRUCTIONS
Go to sqllab and select a database to get the associated function names
Type some part of the function name on the editor and check the autocomplete including the fetched schemas

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
