### PR TITLE
feat: robust(er) adhoc query validation

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -327,6 +327,8 @@ sqlalchemy-utils==0.38.3
     # via
     #   apache-superset
     #   flask-appbuilder
+sqloxide==0.1.36
+    # via apache-superset
 sqlparse==0.4.4
     # via apache-superset
 sshtunnel==0.4.0

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -106,8 +106,6 @@ rfc3986==2.0.0
     # via tableschema
 s3transfer==0.6.1
     # via boto3
-sqloxide==0.1.33
-    # via -r requirements/development.in
 stack-data==0.6.2
     # via ipython
 tableschema==1.20.2

--- a/setup.py
+++ b/setup.py
@@ -125,6 +125,7 @@ setup(
         "slack_sdk>=3.19.0, <4",
         "sqlalchemy>=1.4, <2",
         "sqlalchemy-utils>=0.38.3, <0.39",
+        "sqloxide>=0.1, <0.2",
         "sqlparse>=0.4.4, <0.5",
         "tabulate>=0.8.9, <0.9",
         "typing-extensions>=4, <5",

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -52,6 +52,7 @@ from superset.models.helpers import (
     ExploreMixin,
     ExtraJSONMixin,
     ImportExportMixin,
+    process_sql_expression,
 )
 from superset.sql_parse import CtasMethod, ParsedQuery, Table
 from superset.sqllab.limiting_factor import LimitingFactor
@@ -345,7 +346,7 @@ class Query(
         :rtype: sqlalchemy.sql.column
         """
         label = get_column_name(col)
-        expression = self._process_sql_expression(
+        expression = process_sql_expression(
             expression=col["sqlExpression"],
             database_id=self.database_id,
             schema=self.schema,

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -1287,16 +1287,16 @@ def test_sqlparse_issue_652():
 @pytest.mark.parametrize(
     "sql,expected",
     [
-        ("SELECT * FROM table", True),
-        ("SELECT a FROM (SELECT 1 AS a) JOIN (SELECT * FROM table)", True),
+        ("SELECT * FROM 'table'", True),
+        ("SELECT a FROM (SELECT 1 AS a) JOIN (SELECT * FROM 'table')", True),
         ("(SELECT COUNT(DISTINCT name) AS foo FROM    birth_names)", True),
-        ("COUNT(*)", False),
+        ("SELECT COUNT(*)", False),
         ("SELECT a FROM (SELECT 1 AS a)", False),
-        ("SELECT a FROM (SELECT 1 AS a) JOIN table", True),
+        ("SELECT a FROM (SELECT 1 AS a) JOIN 'table'", True),
         ("SELECT * FROM (SELECT 1 AS foo, 2 AS bar) ORDER BY foo ASC, bar", False),
         ("SELECT * FROM other_table", True),
-        ("extract(HOUR from from_unixtime(hour_ts)", False),
-        ("(SELECT * FROM table)", True),
+        ("SELECT extract(HOUR from from_unixtime(hour_ts))", False),
+        ("(SELECT * FROM 'table')", True),
         ("(SELECT COUNT(DISTINCT name) from birth_names)", True),
         (
             "(SELECT table_name FROM information_schema.tables WHERE table_name LIKE '%user%' LIMIT 1)",
@@ -1304,6 +1304,10 @@ def test_sqlparse_issue_652():
         ),
         (
             "(SELECT table_name FROM /**/ information_schema.tables WHERE table_name LIKE '%user%' LIMIT 1)",
+            True,
+        ),
+        (
+            "SELECT table_name FROM (information_schema.tables) WHERE table_name LIKE '%user%' LIMIT 1",
             True,
         ),
     ],
@@ -1315,8 +1319,7 @@ def test_has_table_query(sql: str, expected: bool) -> None:
     This is used to prevent ad-hoc metrics from querying unauthorized tables, bypassing
     row-level security.
     """
-    statement = sqlparse.parse(sql)[0]
-    assert has_table_query(statement) == expected
+    assert has_table_query(sql) == expected
 
 
 @pytest.mark.parametrize(
@@ -1784,21 +1787,20 @@ def test_extract_table_references(mocker: MockerFixture) -> None:
         Table(table="other_table", schema=None, catalog=None),
     }
 
-    # test falling back to sqlparse
-    logger = mocker.patch("superset.sql_parse.logger")
-    sql = "SELECT * FROM table UNION ALL SELECT * FROM other_table"
+    sql = "SELECT * FROM 'table' UNION ALL SELECT * FROM other_table"
     assert extract_table_references(
         sql,
         "trino",
-    ) == {Table(table="other_table", schema=None, catalog=None)}
-    logger.warning.assert_called_once()
-
-    logger = mocker.patch("superset.migrations.shared.utils.logger")
-    sql = "SELECT * FROM table UNION ALL SELECT * FROM other_table"
-    assert extract_table_references(sql, "trino", show_warning=False) == {
-        Table(table="other_table", schema=None, catalog=None)
+    ) == {
+        Table(table="table", schema=None, catalog=None),
+        Table(table="other_table", schema=None, catalog=None),
     }
-    logger.warning.assert_not_called()
+
+    sql = "SELECT * FROM 'table' UNION ALL SELECT * FROM other_table"
+    assert extract_table_references(sql, "trino", show_warning=False) == {
+        Table(table="table", schema=None, catalog=None),
+        Table(table="other_table", schema=None, catalog=None),
+    }
 
 
 def test_is_select() -> None:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The function `has_table_query` is used to detect if a given query is selecting from one or more tables, in order to prevent malicious ad-hoc expressions that bypass RLS. Because `sqlparse` is non-validating the function needs to keep track of a lot of state, and often fails on edge cases.

This PR rewrites the function to use `sqloxide`. The advantage is that the function is now more robust, supporting custom dialects and handling more edge cases. There are a couple disadvantages, though:

- `sqloxide` was an optional dependency, with this PR it becomes mandatory.
- The function `has_table_query` now requires a full SQL query, so for validating expressions they need to be wrapped in `f"SELECT {expression}"`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

The unit tests pass mostly unmodified, the only exception is that `table` is usually a reserved keyword and had to be quoted in order to `sqloxide` to parse it (`sqlparse` is much more lenient). I added a new test to cover another edge case that was found could bypass RLS.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
