### PR TITLE
feat: implement time grain in temporal filters

### DIFF
--- a/superset/db_engine_specs/db2.py
+++ b/superset/db_engine_specs/db2.py
@@ -27,7 +27,7 @@ class Db2EngineSpec(BaseEngineSpec):
 
     _time_grain_expressions = {
         None: "{col}",
-        "PT1S": "CAST({col} as TIMESTAMP)" " - MICROSECOND({col}) MICROSECONDS",
+        "PT1S": "CAST({col} as TIMESTAMP) - MICROSECOND({col}) MICROSECONDS",
         "PT1M": "CAST({col} as TIMESTAMP)"
         " - SECOND({col}) SECONDS"
         " - MICROSECOND({col}) MICROSECONDS",
@@ -45,7 +45,7 @@ class Db2EngineSpec(BaseEngineSpec):
         "P3M": "{col} - (DAY({col})-1) DAYS"
         " - (MONTH({col})-1) MONTHS"
         " + ((QUARTER({col})-1) * 3) MONTHS",
-        "P1Y": "{col} - (DAY({col})-1) DAYS" " - (MONTH({col})-1) MONTHS",
+        "P1Y": "{col} - (DAY({col})-1) DAYS - (MONTH({col})-1) MONTHS",
     }
 
     @classmethod

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -124,7 +124,7 @@ class HiveEngineSpec(PrestoEngineSpec):
     jobs_stats_r = re.compile(r".*INFO.*Total jobs = (?P<max_jobs>[0-9]+)")
     # 17/02/07 19:37:08 INFO ql.Driver: Launching Job 2 out of 5
     launching_job_r = re.compile(
-        ".*INFO.*Launching Job (?P<job_number>[0-9]+) out of " "(?P<max_jobs>[0-9]+)"
+        ".*INFO.*Launching Job (?P<job_number>[0-9]+) out of (?P<max_jobs>[0-9]+)"
     )
     # 17/02/07 19:36:58 INFO exec.Task: 2017-02-07 19:36:58,152 Stage-18
     # map = 0%,  reduce = 0%

--- a/superset/db_engine_specs/mysql.py
+++ b/superset/db_engine_specs/mysql.py
@@ -131,13 +131,13 @@ class MySQLEngineSpec(BaseEngineSpec, BasicParametersMixin):
         " + SECOND({col})) SECOND)",
         "PT1M": "DATE_ADD(DATE({col}), "
         "INTERVAL (HOUR({col})*60 + MINUTE({col})) MINUTE)",
-        "PT1H": "DATE_ADD(DATE({col}), " "INTERVAL HOUR({col}) HOUR)",
+        "PT1H": "DATE_ADD(DATE({col}), INTERVAL HOUR({col}) HOUR)",
         "P1D": "DATE({col})",
-        "P1W": "DATE(DATE_SUB({col}, " "INTERVAL DAYOFWEEK({col}) - 1 DAY))",
-        "P1M": "DATE(DATE_SUB({col}, " "INTERVAL DAYOFMONTH({col}) - 1 DAY))",
+        "P1W": "DATE(DATE_SUB({col}, INTERVAL DAYOFWEEK({col}) - 1 DAY))",
+        "P1M": "DATE(DATE_SUB({col}, INTERVAL DAYOFMONTH({col}) - 1 DAY))",
         "P3M": "MAKEDATE(YEAR({col}), 1) "
         "+ INTERVAL QUARTER({col}) QUARTER - INTERVAL 1 QUARTER",
-        "P1Y": "DATE(DATE_SUB({col}, " "INTERVAL DAYOFYEAR({col}) - 1 DAY))",
+        "P1Y": "DATE(DATE_SUB({col}, INTERVAL DAYOFYEAR({col}) - 1 DAY))",
         "1969-12-29T00:00:00Z/P1W": "DATE(DATE_SUB({col}, "
         "INTERVAL DAYOFWEEK(DATE_SUB({col}, "
         "INTERVAL 1 DAY)) - 1 DAY))",

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1288,12 +1288,22 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
         time_col: "TableColumn",
         start_dttm: Optional[sa.DateTime],
         end_dttm: Optional[sa.DateTime],
+        time_grain: Optional[str] = None,
         label: Optional[str] = "__time",
         template_processor: Optional[BaseTemplateProcessor] = None,
     ) -> ColumnElement:
-        col = self.convert_tbl_column_to_sqla_col(
-            time_col, label=label, template_processor=template_processor
+        col = (
+            time_col.get_timestamp_expression(
+                time_grain=time_grain,
+                label=label,
+                template_processor=template_processor,
+            )
+            if time_grain
+            else self.convert_tbl_column_to_sqla_col(
+                time_col, label=label, template_processor=template_processor
+            )
         )
+
         l = []
         if start_dttm:
             l.append(
@@ -1353,6 +1363,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
         """
         Return a SQLAlchemy Core element representation of self to be used in a query.
 
+        :param column: column object
         :param time_grain: Optional time grain, e.g. P1Y
         :param label: alias/label that column is expected to have
         :param template_processor: template processor
@@ -1699,6 +1710,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                 continue
             flt_col = flt["col"]
             val = flt.get("val")
+            flt_grain = flt.get("grain")
             op = flt["op"].upper()
             col_obj: Optional["TableColumn"] = None
             sqla_col: Optional[Column] = None
@@ -1855,6 +1867,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                                 time_col=col_obj,
                                 start_dttm=_since,
                                 end_dttm=_until,
+                                time_grain=flt_grain,
                                 label=sqla_col.key,
                                 template_processor=template_processor,
                             )
@@ -1945,7 +1958,6 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                 inner_groupby_exprs = []
                 inner_select_exprs = []
                 for gby_name, gby_obj in groupby_series_columns.items():
-                    label = get_column_name(gby_name)
                     inner = self.make_sqla_column_compatible(gby_obj, gby_name + "__")
                     inner_groupby_exprs.append(inner)
                     inner_select_exprs.append(inner)

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -1180,7 +1180,7 @@ def test_time_filter_with_grain(test_client, login_as_admin, physical_query_cont
         assert "DATE(DATE_SUB(col5, INTERVAL DAYOFWEEK(col5) - 1 DAY)) >=" in query
     elif backend == "postgresql":
         assert "DATE_TRUNC('week', col5) >=" in query
-    elif backend == "postgresql":
+    elif backend == "presto":
         assert "date_trunc('week', CAST(col5 AS TIMESTAMP)) >=" in query
 
 

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -1159,6 +1159,31 @@ def test_custom_cache_timeout(test_client, login_as_admin, physical_query_contex
     assert rv.json["result"][0]["cache_timeout"] == 5678
 
 
+def test_time_filter_with_grain(test_client, login_as_admin, physical_query_context):
+    physical_query_context["queries"][0]["filters"] = [
+        {
+            "col": "col5",
+            "op": "TEMPORAL_RANGE",
+            "val": "Last quarter : ",
+            "grain": "P1W",
+        },
+    ]
+    rv = test_client.post(CHART_DATA_URI, json=physical_query_context)
+    query = rv.json["result"][0]["query"]
+    backend = get_example_database().backend
+    if backend == "sqlite":
+        assert (
+            "DATETIME(col5, 'start of day', -strftime('%w', col5) || ' days') >="
+            in query
+        )
+    elif backend == "mysql":
+        assert "DATE(DATE_SUB(col5, " "INTERVAL DAYOFWEEK(col5) - 1 DAY)) >=" in query
+    elif backend == "postgresql":
+        assert "DATE_TRUNC('week', col5) >=" in query
+    elif backend == "postgresql":
+        assert "date_trunc('week', CAST(col5 AS TIMESTAMP)) >=" in query
+
+
 def test_force_cache_timeout(test_client, login_as_admin, physical_query_context):
     physical_query_context["custom_cache_timeout"] = -1
     test_client.post(CHART_DATA_URI, json=physical_query_context)

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -1177,7 +1177,7 @@ def test_time_filter_with_grain(test_client, login_as_admin, physical_query_cont
             in query
         )
     elif backend == "mysql":
-        assert "DATE(DATE_SUB(col5, " "INTERVAL DAYOFWEEK(col5) - 1 DAY)) >=" in query
+        assert "DATE(DATE_SUB(col5, INTERVAL DAYOFWEEK(col5) - 1 DAY)) >=" in query
     elif backend == "postgresql":
         assert "DATE_TRUNC('week', col5) >=" in query
     elif backend == "postgresql":


### PR DESCRIPTION
### SUMMARY
While the `QueryObjectFilterClause` currently supports passing a `grain` (see here: https://github.com/apache/superset/blob/7fe0ca12c0ae24c9b2546118e9ebdb94a9e3a22d/superset/utils/core.py#L223-L228), it was not used in the construction of the actual WHERE clause. This adds support for adding a time grain to temporal filters, making it possible to filter by full time periods. For example, the date `2000-01-01` (Saturday) becomes `1999-12-26` (the previous Monday) with weekly timegrain. Without applying the time grain to the temporal range, the observation for the first week in the query will only consist of two days (Saturday and Sunday), which can give the impression that the events for Monday-Friday never took place.

While writing the test I noticed we had many redundant split strings (they were likely split before due to line width, but were moved on the same line by black). So I cleaned up the ones I found under `db_engine_specs`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
