### PR TITLE
fix: always allow tags to be returned via the API

### DIFF
--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -144,9 +144,10 @@ class ChartRestApi(BaseSupersetModelRestApi):
         "viz_type",
         "query_context",
         "is_managed_externally",
+        "tags.id",
+        "tags.name",
+        "tags.type",
     ]
-    if is_feature_enabled("TAGGING_SYSTEM"):
-        show_columns += ["tags.id", "tags.name", "tags.type"]
 
     show_select_columns = show_columns + ["table.id"]
     list_columns = [
@@ -194,9 +195,10 @@ class ChartRestApi(BaseSupersetModelRestApi):
         "thumbnail_url",
         "url",
         "viz_type",
+        "tags.id",
+        "tags.name",
+        "tags.type",
     ]
-    if is_feature_enabled("TAGGING_SYSTEM"):
-        list_columns += ["tags.id", "tags.name", "tags.type"]
     list_select_columns = list_columns + ["changed_by_fk", "changed_on"]
     order_columns = [
         "changed_by.first_name",
@@ -224,9 +226,8 @@ class ChartRestApi(BaseSupersetModelRestApi):
         "dashboards",
         "slice_name",
         "viz_type",
+        "tags",
     ]
-    if is_feature_enabled("TAGGING_SYSTEM"):
-        search_columns += ["tags"]
     base_order = ("changed_on", "desc")
     base_filters = [["id", ChartFilter, lambda: []]]
     search_filters = {
@@ -237,10 +238,8 @@ class ChartRestApi(BaseSupersetModelRestApi):
         ],
         "slice_name": [ChartAllTextFilter],
         "created_by": [ChartHasCreatedByFilter, ChartCreatedByMeFilter],
+        "tags": [ChartTagFilter],
     }
-    if is_feature_enabled("TAGGING_SYSTEM"):
-        search_filters["tags"] = [ChartTagFilter]
-
     # Will just affect _info endpoint
     edit_columns = ["slice_name"]
     add_columns = edit_columns

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -290,6 +290,7 @@ class ChartPutSchema(Schema):
     )
     is_managed_externally = fields.Boolean(allow_none=True, dump_default=False)
     external_url = fields.String(allow_none=True)
+    tags = fields.Nested(TagSchema, many=True)
 
 
 class ChartGetDatasourceObjectDataResponseSchema(Schema):

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -28,6 +28,7 @@ from marshmallow_enum import EnumField
 from superset import app
 from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
 from superset.db_engine_specs.base import builtin_time_grains
+from superset.tags.models import TagTypes
 from superset.utils import pandas_postprocessing, schema as utils
 from superset.utils.core import (
     AnnotationType,
@@ -152,7 +153,7 @@ openapi_spec_methods_override = {
 class TagSchema(Schema):
     id = fields.Int()
     name = fields.String()
-    type = fields.Int()
+    type = EnumField(TagTypes, by_value=True)
 
 
 class ChartEntityResponseSchema(Schema):

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -152,7 +152,7 @@ openapi_spec_methods_override = {
 class TagSchema(Schema):
     id = fields.Int()
     name = fields.String()
-    type = fields.String()
+    type = fields.Int()
 
 
 class ChartEntityResponseSchema(Schema):

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -20,8 +20,10 @@ from typing import Any, Dict, Union
 
 from marshmallow import fields, post_load, pre_load, Schema
 from marshmallow.validate import Length, ValidationError
+from marshmallow_enum import EnumField
 
 from superset.exceptions import SupersetException
+from superset.tags.models import TagTypes
 from superset.utils import core as utils
 
 get_delete_ids_schema = {"type": "array", "items": {"type": "integer"}}
@@ -169,7 +171,7 @@ class RolesSchema(Schema):
 class TagSchema(Schema):
     id = fields.Int()
     name = fields.String()
-    type = fields.Int()
+    type = EnumField(TagTypes, by_value=True)
 
 
 class DashboardGetResponseSchema(Schema):

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -169,7 +169,7 @@ class RolesSchema(Schema):
 class TagSchema(Schema):
     id = fields.Int()
     name = fields.String()
-    type = fields.String()
+    type = fields.Int()
 
 
 class DashboardGetResponseSchema(Schema):


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Going to soften the `TAGGING_SYSTEM`, and always allow tags to be returned regardless of the feature flag.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
