### PR TITLE
chore: Replace deprecated command with environment file

### DIFF
--- a/scripts/tag_latest_release.sh
+++ b/scripts/tag_latest_release.sh
@@ -98,13 +98,13 @@ done
 
 if [ -z "${GITHUB_TAG_NAME}" ]; then
     echo "Missing tag parameter, usage: ./scripts/tag_latest_release.sh <GITHUB_TAG_NAME>"
-    echo "::set-output name=SKIP_TAG::true"
+    echo "SKIP_TAG=true" >>$GITHUB_OUTPUT
     exit 1
 fi
 
 if [ -z "$(git_show_ref)" ]; then
     echo "The tag ${GITHUB_TAG_NAME} does not exist. Please use a different tag."
-    echo "::set-output name=SKIP_TAG::true"
+    echo "SKIP_TAG=true" >>$GITHUB_OUTPUT
     exit 0
 fi
 
@@ -112,7 +112,7 @@ fi
 if ! [[ ${GITHUB_TAG_NAME} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
 then
   echo "This tag ${GITHUB_TAG_NAME} is not a valid release version. Not tagging."
-  echo "::set-output name=SKIP_TAG::true"
+  echo "SKIP_TAG=true" >>$GITHUB_OUTPUT
   exit 1
 fi
 
@@ -177,14 +177,14 @@ done
 # Determine the result based on the comparison
 if [[ -z "$compare_result" ]]; then
     echo "Versions are equal"
-    echo "::set-output name=SKIP_TAG::true"
+    echo "SKIP_TAG=true" >>$GITHUB_OUTPUT
 elif [[ "$compare_result" == "greater" ]]; then
     echo "This release tag ${GITHUB_TAG_NAME} is newer than the latest."
-    echo "::set-output name=SKIP_TAG::false"
+    echo "SKIP_TAG=false" >>$GITHUB_OUTPUT
     # Add other actions you want to perform for a newer version
 elif [[ "$compare_result" == "lesser" ]]; then
     echo "This release tag ${GITHUB_TAG_NAME} is older than the latest."
     echo "This release tag ${GITHUB_TAG_NAME} is not the latest. Not tagging."
     # if you've gotten this far, then we don't want to run any tags in the next step
-    echo "::set-output name=SKIP_TAG::true"
+    echo "SKIP_TAG=true" >>$GITHUB_OUTPUT
 fi


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Resolve #24061

Update workflows and shell scripts to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' -o -name '*.sh'  | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
echo "::set-output name=count::$count"
```

**TO-BE**

```yml
echo "count=$count" >> $GITHUB_OUTPUT
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
