### PR TITLE
feat: split database information

### DIFF
--- a/superset-frontend/src/features/databases/DatabaseModal/index.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/index.tsx
@@ -542,6 +542,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
     'database',
     t('database'),
     addDangerToast,
+    'connection',
   );
 
   const [tabKey, setTabKey] = useState<string>(DEFAULT_TAB_KEY);

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -224,6 +224,7 @@ export function useSingleViewResource<D extends object = any>(
   resourceName: string,
   resourceLabel: string, // resourceLabel for translations
   handleErrorMsg: (errorMsg: string) => void,
+  path_suffix = '',
 ) {
   const [state, setState] = useState<SingleViewResourceState<D>>({
     loading: false,
@@ -242,8 +243,12 @@ export function useSingleViewResource<D extends object = any>(
         loading: true,
       });
 
+      const endpoint =
+        path_suffix !== ''
+          ? `/api/v1/${resourceName}/${resourceID}/${path_suffix}`
+          : `/api/v1/${resourceName}/${resourceID}`;
       return SupersetClient.get({
-        endpoint: `/api/v1/${resourceName}/${resourceID}`,
+        endpoint,
       })
         .then(
           ({ json = {} }) => {

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -243,10 +243,9 @@ export function useSingleViewResource<D extends object = any>(
         loading: true,
       });
 
+      const baseEndpoint = `/api/v1/${resourceName}/${resourceID}`;
       const endpoint =
-        path_suffix !== ''
-          ? `/api/v1/${resourceName}/${resourceID}/${path_suffix}`
-          : `/api/v1/${resourceName}/${resourceID}`;
+        path_suffix !== '' ? `${baseEndpoint}/${path_suffix}` : baseEndpoint;
       return SupersetClient.get({
         endpoint,
       })

--- a/superset/constants.py
+++ b/superset/constants.py
@@ -154,6 +154,7 @@ MODEL_API_RW_METHOD_PERMISSION_MAP = {
     "add_objects": "write",
     "delete_object": "write",
     "copy_dash": "write",
+    "get_connection": "write",
 }
 
 EXTRA_FORM_DATA_APPEND_KEYS = {

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -221,6 +221,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
 
     openapi_spec_tag = "Database"
     openapi_spec_component_schemas = (
+        DatabaseConnectionSchema,
         DatabaseFunctionNamesResponse,
         DatabaseSchemaAccessForFileUploadResponse,
         DatabaseRelatedObjectsResponse,
@@ -239,7 +240,33 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @protect()
     @safe
     def get_connection(self, pk: int) -> Response:
-        """Get database connection info."""
+        """Get database connection info.
+        ---
+        get:
+          description: >-
+            Get a database connection info
+          parameters:
+          - in: path
+            schema:
+              type: integer
+            description: The database id
+            name: pk
+          responses:
+            200:
+              description: Database with connection info
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/DatabaseConnectionSchema"
+            400:
+              $ref: '#/components/responses/400'
+            401:
+              $ref: '#/components/responses/401'
+            422:
+              $ref: '#/components/responses/422'
+            500:
+              $ref: '#/components/responses/500'
+        """
         database = DatabaseDAO.find_by_id(pk)
         database_connection_schema = DatabaseConnectionSchema()
         response = {

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -146,8 +146,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         "driver",
         "force_ctas_schema",
         "impersonate_user",
-        "extra",
-        "server_cert",
         "is_managed_externally",
         "engine_information",
     ]
@@ -243,7 +241,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         """Get database connection info.
         ---
         get:
-          description: >-
+          summary: >-
             Get a database connection info
           parameters:
           - in: path

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -880,3 +880,86 @@ class DatabaseSchemaAccessForFileUploadResponse(Schema):
             "information"
         },
     )
+
+
+class DatabaseConnectionSchema(Schema):
+    """
+    Schema with database connection information.
+
+    This is only for admins (who have ``can_create`` on ``Database``).
+    """
+
+    allow_ctas = fields.Boolean(metadata={"description": allow_ctas_description})
+    allow_cvas = fields.Boolean(metadata={"description": allow_cvas_description})
+    allow_dml = fields.Boolean(metadata={"description": allow_dml_description})
+    allow_file_upload = fields.Boolean(
+        metadata={"description": allow_file_upload_description}
+    )
+    allow_run_async = fields.Boolean(
+        metadata={"description": allow_run_async_description}
+    )
+    backend = fields.String(
+        allow_none=True, metadata={"description": "SQLAlchemy engine to use"}
+    )
+    cache_timeout = fields.Integer(
+        metadata={"description": cache_timeout_description}, allow_none=True
+    )
+    configuration_method = fields.String(
+        metadata={"description": configuration_method_description},
+    )
+    database_name = fields.String(
+        metadata={"description": database_name_description},
+        allow_none=True,
+        validate=Length(1, 250),
+    )
+    driver = fields.String(
+        allow_none=True, metadata={"description": "SQLAlchemy driver to use"}
+    )
+    engine_information = fields.Dict(keys=fields.String(), values=fields.Raw())
+    expose_in_sqllab = fields.Boolean(
+        metadata={"description": expose_in_sqllab_description}
+    )
+    extra = fields.String(
+        metadata={"description": extra_description}, validate=extra_validator
+    )
+    force_ctas_schema = fields.String(
+        metadata={"description": force_ctas_schema_description},
+        allow_none=True,
+        validate=Length(0, 250),
+    )
+    id = fields.Integer(metadata={"description": "Database ID (for updates)"})
+    impersonate_user = fields.Boolean(
+        metadata={"description": impersonate_user_description}
+    )
+    is_managed_externally = fields.Boolean(allow_none=True, dump_default=False)
+    server_cert = fields.String(
+        metadata={"description": server_cert_description},
+        allow_none=True,
+        validate=server_cert_validator,
+    )
+    uuid = fields.String(required=False)
+    ssh_tunnel = fields.Nested(DatabaseSSHTunnel, allow_none=True)
+    masked_encrypted_extra = fields.String(
+        metadata={"description": encrypted_extra_description},
+        validate=encrypted_extra_validator,
+        allow_none=True,
+    )
+    parameters = fields.Dict(
+        keys=fields.String(),
+        values=fields.Raw(),
+        metadata={"description": "DB-specific parameters for configuration"},
+    )
+    parameters_schema = fields.Dict(
+        keys=fields.String(),
+        values=fields.Raw(),
+        metadata={
+            "description": (
+                "JSONSchema for configuring the database by "
+                "parameters instead of SQLAlchemy URI"
+            ),
+        },
+    )
+    sqlalchemy_uri = fields.String(
+        metadata={"description": sqlalchemy_uri_description},
+        validate=[Length(1, 1024), sqlalchemy_uri_validator],
+    )

--- a/tests/unit_tests/databases/api_test.py
+++ b/tests/unit_tests/databases/api_test.py
@@ -77,6 +77,7 @@ def test_password_mask(
     Database.metadata.create_all(session.get_bind())  # pylint: disable=no-member
 
     database = Database(
+        uuid=UUID("02feae18-2dd6-4bb4-a9c0-49e9d4f29d58"),
         database_name="my_database",
         sqlalchemy_uri="gsheets://",
         encrypted_extra=json.dumps(
@@ -103,12 +104,161 @@ def test_password_mask(
     mocker.patch("sqlalchemy.engine.URL.get_driver_name", return_value="gsheets")
     mocker.patch("superset.utils.log.DBEventLogger.log")
 
-    response = client.get("/api/v1/database/1")
+    response = client.get("/api/v1/database/1/connection")
+
+    # check that private key is masked
     assert (
         response.json["result"]["parameters"]["service_account_info"]["private_key"]
         == "XXXXXXXXXX"
     )
     assert "encrypted_extra" not in response.json["result"]
+
+
+def test_database_connection(
+    mocker: MockFixture,
+    app: Any,
+    session: Session,
+    client: Any,
+    full_api_access: None,
+) -> None:
+    """
+    Test that connection info is only returned in ``api/v1/database/${id}/connection``.
+    """
+    from superset.databases.api import DatabaseRestApi
+    from superset.models.core import Database
+
+    DatabaseRestApi.datamodel.session = session
+
+    # create table for databases
+    Database.metadata.create_all(session.get_bind())  # pylint: disable=no-member
+
+    database = Database(
+        uuid=UUID("02feae18-2dd6-4bb4-a9c0-49e9d4f29d58"),
+        database_name="my_database",
+        sqlalchemy_uri="gsheets://",
+        encrypted_extra=json.dumps(
+            {
+                "service_account_info": {
+                    "type": "service_account",
+                    "project_id": "black-sanctum-314419",
+                    "private_key_id": "259b0d419a8f840056158763ff54d8b08f7b8173",
+                    "private_key": "SECRET",
+                    "client_email": "google-spreadsheets-demo-servi@black-sanctum-314419.iam.gserviceaccount.com",
+                    "client_id": "114567578578109757129",
+                    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                    "token_uri": "https://oauth2.googleapis.com/token",
+                    "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+                    "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/google-spreadsheets-demo-servi%40black-sanctum-314419.iam.gserviceaccount.com",
+                },
+            }
+        ),
+    )
+    session.add(database)
+    session.commit()
+
+    # mock the lookup so that we don't need to include the driver
+    mocker.patch("sqlalchemy.engine.URL.get_driver_name", return_value="gsheets")
+    mocker.patch("superset.utils.log.DBEventLogger.log")
+
+    response = client.get("/api/v1/database/1/connection")
+    assert response.json == {
+        "id": 1,
+        "result": {
+            "allow_ctas": False,
+            "allow_cvas": False,
+            "allow_dml": False,
+            "allow_file_upload": False,
+            "allow_run_async": False,
+            "backend": "gsheets",
+            "cache_timeout": None,
+            "configuration_method": "sqlalchemy_form",
+            "database_name": "my_database",
+            "driver": "gsheets",
+            "engine_information": {
+                "disable_ssh_tunneling": True,
+                "supports_file_upload": False,
+            },
+            "expose_in_sqllab": True,
+            "extra": '{\n    "metadata_params": {},\n    "engine_params": {},\n    "metadata_cache_timeout": {},\n    "schemas_allowed_for_file_upload": []\n}\n',
+            "force_ctas_schema": None,
+            "id": 1,
+            "impersonate_user": False,
+            "is_managed_externally": False,
+            "masked_encrypted_extra": json.dumps(
+                {
+                    "service_account_info": {
+                        "type": "service_account",
+                        "project_id": "black-sanctum-314419",
+                        "private_key_id": "259b0d419a8f840056158763ff54d8b08f7b8173",
+                        "private_key": "XXXXXXXXXX",
+                        "client_email": "google-spreadsheets-demo-servi@black-sanctum-314419.iam.gserviceaccount.com",
+                        "client_id": "114567578578109757129",
+                        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                        "token_uri": "https://oauth2.googleapis.com/token",
+                        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+                        "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/google-spreadsheets-demo-servi%40black-sanctum-314419.iam.gserviceaccount.com",
+                    }
+                }
+            ),
+            "parameters": {
+                "service_account_info": {
+                    "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+                    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                    "client_email": "google-spreadsheets-demo-servi@black-sanctum-314419.iam.gserviceaccount.com",
+                    "client_id": "114567578578109757129",
+                    "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/google-spreadsheets-demo-servi%40black-sanctum-314419.iam.gserviceaccount.com",
+                    "private_key": "XXXXXXXXXX",
+                    "private_key_id": "259b0d419a8f840056158763ff54d8b08f7b8173",
+                    "project_id": "black-sanctum-314419",
+                    "token_uri": "https://oauth2.googleapis.com/token",
+                    "type": "service_account",
+                }
+            },
+            "parameters_schema": {
+                "properties": {
+                    "catalog": {"type": "object"},
+                    "service_account_info": {
+                        "description": "Contents of GSheets JSON credentials.",
+                        "type": "string",
+                        "x-encrypted-extra": True,
+                    },
+                },
+                "type": "object",
+            },
+            "server_cert": None,
+            "sqlalchemy_uri": "gsheets://",
+            "uuid": "02feae18-2dd6-4bb4-a9c0-49e9d4f29d58",
+        },
+    }
+
+    response = client.get("/api/v1/database/1")
+    assert response.json == {
+        "id": 1,
+        "result": {
+            "allow_ctas": False,
+            "allow_cvas": False,
+            "allow_dml": False,
+            "allow_file_upload": False,
+            "allow_run_async": False,
+            "backend": "gsheets",
+            "cache_timeout": None,
+            "configuration_method": "sqlalchemy_form",
+            "database_name": "my_database",
+            "driver": "gsheets",
+            "engine_information": {
+                "disable_ssh_tunneling": True,
+                "supports_file_upload": False,
+            },
+            "expose_in_sqllab": True,
+            "extra": '{\n    "metadata_params": {},\n    "engine_params": {},\n    "metadata_cache_timeout": {},\n    "schemas_allowed_for_file_upload": []\n}\n',
+            "force_ctas_schema": None,
+            "id": 1,
+            "impersonate_user": False,
+            "is_managed_externally": False,
+            "server_cert": None,
+            "uuid": "02feae18-2dd6-4bb4-a9c0-49e9d4f29d58",
+        },
+    }
 
 
 @pytest.mark.skip(reason="Works locally but fails on CI")

--- a/tests/unit_tests/databases/api_test.py
+++ b/tests/unit_tests/databases/api_test.py
@@ -250,12 +250,10 @@ def test_database_connection(
                 "supports_file_upload": False,
             },
             "expose_in_sqllab": True,
-            "extra": '{\n    "metadata_params": {},\n    "engine_params": {},\n    "metadata_cache_timeout": {},\n    "schemas_allowed_for_file_upload": []\n}\n',
             "force_ctas_schema": None,
             "id": 1,
             "impersonate_user": False,
             "is_managed_externally": False,
-            "server_cert": None,
             "uuid": "02feae18-2dd6-4bb4-a9c0-49e9d4f29d58",
         },
     }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Move potentially sensitive database information (SQLAlchemy URI, eg) to a separate endpoint that can be only accessed by the admin (`can_write` on `Database`).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Added new test, updated old one.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
