### PR TITLE
fix: Handle python_date_format in ExploreMixin 

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1269,17 +1269,12 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
 
         return or_(*groups)
 
-    def dttm_sql_literal(
-        self,
-        col: "TableColumn",
-        dttm: sa.DateTime,
-        col_type: Optional[str],
-    ) -> str:
+    def dttm_sql_literal(self, dttm: datetime, col: "TableColumn") -> str:
         """Convert datetime object to a SQL expression string"""
 
         sql = (
-            self.db_engine_spec.convert_dttm(col_type, dttm, db_extra=None)
-            if col_type
+            self.db_engine_spec.convert_dttm(col.type, dttm, db_extra=self.db_extra)
+            if col.type
             else None
         )
 
@@ -1330,14 +1325,14 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
             l.append(
                 col
                 >= self.db_engine_spec.get_text_clause(
-                    self.dttm_sql_literal(time_col, start_dttm, time_col.type)
+                    self.dttm_sql_literal(start_dttm, time_col)
                 )
             )
         if end_dttm:
             l.append(
                 col
                 < self.db_engine_spec.get_text_clause(
-                    self.dttm_sql_literal(time_col, end_dttm, time_col.type)
+                    self.dttm_sql_literal(end_dttm, time_col)
                 )
             )
         return and_(*l)

--- a/tests/unit_tests/models/core_test.py
+++ b/tests/unit_tests/models/core_test.py
@@ -16,11 +16,16 @@
 # under the License.
 
 # pylint: disable=import-outside-toplevel
-
+import json
+from datetime import datetime
 from typing import List, Optional
 
+import pytest
 from pytest_mock import MockFixture
 from sqlalchemy.engine.reflection import Inspector
+
+from superset.connectors.sqla.models import SqlaTable, TableColumn
+from superset.models.core import Database
 
 
 def test_get_metrics(mocker: MockFixture) -> None:
@@ -143,3 +148,62 @@ def test_get_db_engine_spec(mocker: MockFixture) -> None:
         ).db_engine_spec
         == OldDBEngineSpec
     )
+
+
+@pytest.mark.parametrize(
+    "dttm,col,database,result",
+    [
+        (
+            datetime(2023, 1, 1, 1, 23, 45, 600000),
+            TableColumn(python_date_format="epoch_s"),
+            Database(),
+            "1672536225",
+        ),
+        (
+            datetime(2023, 1, 1, 1, 23, 45, 600000),
+            TableColumn(python_date_format="epoch_ms"),
+            Database(),
+            "1672536225000",
+        ),
+        (
+            datetime(2023, 1, 1, 1, 23, 45, 600000),
+            TableColumn(python_date_format="%Y-%m-%d"),
+            Database(),
+            "'2023-01-01'",
+        ),
+        (
+            datetime(2023, 1, 1, 1, 23, 45, 600000),
+            TableColumn(column_name="ds"),
+            Database(
+                extra=json.dumps(
+                    {
+                        "python_date_format_by_column_name": {
+                            "ds": "%Y-%m-%d",
+                        },
+                    },
+                ),
+                sqlalchemy_uri="foo://",
+            ),
+            "'2023-01-01'",
+        ),
+        (
+            datetime(2023, 1, 1, 1, 23, 45, 600000),
+            TableColumn(),
+            Database(sqlalchemy_uri="foo://"),
+            "'2023-01-01 01:23:45.600000'",
+        ),
+        (
+            datetime(2023, 1, 1, 1, 23, 45, 600000),
+            TableColumn(type="TimeStamp"),
+            Database(sqlalchemy_uri="trino://"),
+            "TIMESTAMP '2023-01-01 01:23:45.600000'",
+        ),
+    ],
+)
+def test_dttm_sql_literal(
+    dttm: datetime,
+    col: TableColumn,
+    database: Database,
+    result: str,
+) -> None:
+    assert SqlaTable(database=database).dttm_sql_literal(dttm, col) == result

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@
 # Remember to start celery workers to run celery tests, e.g.
 # celery --app=superset.tasks.celery_app:app worker -Ofair -c 2
 [testenv]
-basepython = python3.8
+basepython = python3.10
 ignore_basepython_conflict = true
 commands =
     superset db upgrade


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR fixes an issue introduced in https://github.com/apache/superset/pull/20938 however it didn't surface until https://github.com/apache/superset/pull/22853 which resulted in a somewhat bad correctness regression as the resulting generated SQL was incorrect when filtering the temporal column, i.e., rather than queries being generated of the form,

```sql
WHERE
    ds >= '2023-01-01'
```

they were being generated as:

```sql
WHERE
    ds >= '2023-01-01 00:00:00.000000'
```

which due to lexicographical ordering would wrongfully exclude any records where `ds` = `2023-01-01`.





The TL;DR is https://github.com/apache/superset/pull/20938 replicated logic from the  `TableColumn` class however it did not include the logic which adhered to the Python date/time format meaning that columns which weren't handled by the DB engine spec `convert_dttm` method were cast to an ISO 8601 formatted string adhering to the `Y-%m-%d %H:%M:%S.%f` format.

This PR adds the missing logic and removes the now unused (per https://github.com/apache/superset/pull/22853) `TableColumn` methods to help improve the code hygiene and readability—having two or more instances of the same function makes the code very difficult to grok. @hughhhh I would suggest you perform a second pass to make sure all the legacy logic which was ported to the `ExploreMixin` has been removed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Added unit tests which would have hopefully helped discovered the issue.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
