### PR TITLE
chore(trino): Bump Trino version to address an IANA time zone issue

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -122,8 +122,6 @@ geographiclib==1.52
     # via geopy
 geopy==2.2.0
     # via apache-superset
-greenlet==2.0.2
-    # via sqlalchemy
 gunicorn==20.1.0
     # via apache-superset
 hashids==1.3.1
@@ -136,8 +134,6 @@ humanize==3.11.0
     # via apache-superset
 idna==3.2
     # via email-validator
-importlib-metadata==6.3.0
-    # via flask
 importlib-resources==5.12.0
     # via limits
 isodate==0.6.0
@@ -326,10 +322,6 @@ wtforms-json==0.3.5
     # via apache-superset
 xlsxwriter==3.0.7
     # via apache-superset
-zipp==3.15.0
-    # via
-    #   importlib-metadata
-    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -130,7 +130,7 @@ sqlalchemy-bigquery==1.6.1
     # via apache-superset
 statsd==4.0.1
     # via -r requirements/testing.in
-trino==0.323.0
+trino==0.324.0
     # via apache-superset
 tzdata==2023.3
     # via pytz-deprecation-shim

--- a/setup.py
+++ b/setup.py
@@ -174,7 +174,7 @@ setup(
         "pinot": ["pinotdb>=0.3.3, <0.4"],
         "postgres": ["psycopg2-binary==2.9.6"],
         "presto": ["pyhive[presto]>=0.6.5"],
-        "trino": ["trino>=0.323.0"],
+        "trino": ["trino>=0.324.0"],
         "prophet": ["prophet>=1.0.1, <1.1", "pystan<3.0"],
         "redshift": ["sqlalchemy-redshift>=0.8.1, < 0.9"],
         "rockset": ["rockset>=0.8.10, <0.9"],


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR bumps the minimal requirement for the `python-trino-client` as, per the [0.324.0](https://github.com/trinodb/trino-python-client/blob/master/CHANGES.md#release-03240) release notes, the latest release includes a vital fix to address an IANA time zone issue.

Note as part of this change I rebuilt the frozen requirements via:

```
> python3.9 -m pip install -r requirements/integration.txt
> pip-compile-multi --no-upgrade
```

which, in addition to bumping the `trino` package, removed some legacy requirement which likely were removed in previous PRs without refreezing the requirements.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
