### PR TITLE
chore(Bard): de-flaking cypress 'show error alerts on dynamic form fo…

### DIFF
--- a/superset-frontend/cypress-base/cypress/e2e/database/modal.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/database/modal.test.ts
@@ -72,9 +72,18 @@ describe('Add database', () => {
   it('show error alerts on dynamic form for bad port', () => {
     // click postgres dynamic form
     cy.get('.preferred > :nth-child(1)').click();
-    cy.get('input[name="host"]').focus().type('localhost');
-    cy.get('input[name="port"]').focus().type('123');
-    cy.get('input[name="database"]').focus();
+
+    // wait for the form to load
+    cy.waitUntil(() => cy.get('.ant-form-item-explain-error').isPresent());
+
+    // enter the host and port
+    cy.get('input[name="host"]').type('localhost');
+    cy.get('input[name="port"]').type('123');
+
+    // submit the form
+    cy.get('button[type="submit"]').click();
+
+    // assert that the error message is displayed
     cy.get('.ant-form-item-explain-error').contains('The port is closed');
   });
 });

--- a/superset-frontend/cypress-base/cypress/e2e/database/modal.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/database/modal.test.ts
@@ -19,7 +19,6 @@
 import { DATABASE_LIST } from 'cypress/utils/urls';
 import 'cypress-wait-until';
 
-
 function closeModal() {
   cy.get('body').then($body => {
     if ($body.find('[data-test="database-modal"]').length) {
@@ -71,12 +70,14 @@ describe('Add database', () => {
     );
   });
 
-  it('show error alerts on dynamic form for bad port', async () => {
+  it('show error alerts on dynamic form for bad port', () => {
     // click postgres dynamic form
     cy.get('.preferred > :nth-child(1)').click();
 
     // wait for the form to load
-    cy.waitUntil(() => cy.get('.ant-form-item-explain-error').should('be.visible'));
+    cy.waitUntil(() =>
+      cy.get('.ant-form-item-explain-error').should('be.visible'),
+    );
 
     // enter the host and port
     cy.get('input[name="host"]').type('localhost');

--- a/superset-frontend/cypress-base/cypress/e2e/database/modal.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/database/modal.test.ts
@@ -17,6 +17,8 @@
  * under the License.
  */
 import { DATABASE_LIST } from 'cypress/utils/urls';
+import 'cypress-wait-until';
+
 
 function closeModal() {
   cy.get('body').then($body => {
@@ -69,12 +71,12 @@ describe('Add database', () => {
     );
   });
 
-  it('show error alerts on dynamic form for bad port', () => {
+  it('show error alerts on dynamic form for bad port', async () => {
     // click postgres dynamic form
     cy.get('.preferred > :nth-child(1)').click();
 
     // wait for the form to load
-    cy.waitUntil(() => cy.get('.ant-form-item-explain-error').isPresent());
+    cy.waitUntil(() => cy.get('.ant-form-item-explain-error').should('be.visible'));
 
     // enter the host and port
     cy.get('input[name="host"]').type('localhost');

--- a/superset-frontend/cypress-base/package-lock.json
+++ b/superset-frontend/cypress-base/package-lock.json
@@ -22,6 +22,7 @@
       "devDependencies": {
         "@types/querystringify": "^2.0.0",
         "cypress": "^10.11.0",
+        "cypress-wait-until": "^1.7.2",
         "eslint-plugin-cypress": "^2.12.1"
       }
     },
@@ -5826,6 +5827,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/cypress-wait-until": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/cypress-wait-until/-/cypress-wait-until-1.7.2.tgz",
+      "integrity": "sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q==",
+      "dev": true
     },
     "node_modules/cypress/node_modules/buffer": {
       "version": "5.7.1",
@@ -15833,6 +15840,12 @@
           }
         }
       }
+    },
+    "cypress-wait-until": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/cypress-wait-until/-/cypress-wait-until-1.7.2.tgz",
+      "integrity": "sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q==",
+      "dev": true
     },
     "d3-array": {
       "version": "2.12.0",

--- a/superset-frontend/cypress-base/package-lock.json
+++ b/superset-frontend/cypress-base/package-lock.json
@@ -14,6 +14,7 @@
         "@superset-ui/core": "^0.18.8",
         "brace": "^0.11.1",
         "cy-verify-downloads": "^0.1.6",
+        "cypress-wait-until": "^1.7.2",
         "querystringify": "^2.2.0",
         "react-dom": "^16.13.0",
         "rison": "^0.1.1",
@@ -22,7 +23,6 @@
       "devDependencies": {
         "@types/querystringify": "^2.0.0",
         "cypress": "^10.11.0",
-        "cypress-wait-until": "^1.7.2",
         "eslint-plugin-cypress": "^2.12.1"
       }
     },
@@ -5831,8 +5831,7 @@
     "node_modules/cypress-wait-until": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/cypress-wait-until/-/cypress-wait-until-1.7.2.tgz",
-      "integrity": "sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q==",
-      "dev": true
+      "integrity": "sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q=="
     },
     "node_modules/cypress/node_modules/buffer": {
       "version": "5.7.1",
@@ -15844,8 +15843,7 @@
     "cypress-wait-until": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/cypress-wait-until/-/cypress-wait-until-1.7.2.tgz",
-      "integrity": "sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q==",
-      "dev": true
+      "integrity": "sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q=="
     },
     "d3-array": {
       "version": "2.12.0",

--- a/superset-frontend/cypress-base/package.json
+++ b/superset-frontend/cypress-base/package.json
@@ -21,6 +21,7 @@
     "@superset-ui/core": "^0.18.8",
     "brace": "^0.11.1",
     "cy-verify-downloads": "^0.1.6",
+    "cypress-wait-until": "^1.7.2",
     "querystringify": "^2.2.0",
     "react-dom": "^16.13.0",
     "rison": "^0.1.1",
@@ -29,7 +30,6 @@
   "devDependencies": {
     "@types/querystringify": "^2.0.0",
     "cypress": "^10.11.0",
-    "cypress-wait-until": "^1.7.2",
     "eslint-plugin-cypress": "^2.12.1"
   }
 }

--- a/superset-frontend/cypress-base/package.json
+++ b/superset-frontend/cypress-base/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@types/querystringify": "^2.0.0",
     "cypress": "^10.11.0",
+    "cypress-wait-until": "^1.7.2",
     "eslint-plugin-cypress": "^2.12.1"
   }
 }


### PR DESCRIPTION
…r bad port'

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Using GPT to de-flake this Cypress test. Let's see how it does!
<img width="1273" alt="image" src="https://github.com/apache/superset/assets/812905/ea703ea1-666a-4441-a0a0-4b2999718af1">

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
