### PR TITLE
fix: from other dashboard 'filters' will confict 'requiredFirst' option…

### DIFF
--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -269,7 +269,10 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
         : null;
       // firstItem[0] !== undefined for a case when groupby changed but new data still not fetched
       // TODO: still need repopulate default value in config modal when column changed
-      if (firstItem?.[0] !== undefined) {
+      const searchParams = new URLSearchParams(window.location.search);
+      const searchFilters = searchParams.get('filters');
+      // avoid 'filters' of url to confict update with 'requiredFirst'; fix refresh again and again..
+      if (firstItem?.[0] !== undefined && !searchFilters) {
         updateDataMask(firstItem);
       }
     } else if (isDisabled) {


### PR DESCRIPTION
Describe:

Jumping from the Kanban link to another Kanban with default filtering conditions will result in a dead cycle

fix(dashboard): load charts correctly

### TESTING INSTRUCTIONS
#### How to reproduce the bug
    1, Add clickable links to the charts in the dashboard, such as [id]
    2, Create a Kanban using the same chart as the first step
    3, Create a new filter condition on the created dashboard, with mandatory configuration and the first item selected by default, such as [id]
    4, Open the previous kanban and click on the [id] link in the icon, Then there will be a dead cycle


### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
