### PR TITLE
chore(Bard): re-enabling and de-flaking a Cypress test (in theory)

### DIFF
--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/editmode.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/editmode.test.ts
@@ -20,6 +20,7 @@ import { SAMPLE_DASHBOARD_1, TABBED_DASHBOARD } from 'cypress/utils/urls';
 import { drag, resize, waitForChartLoad } from 'cypress/utils';
 import * as ace from 'brace';
 import { interceptGet, interceptUpdate, openTab } from './utils';
+import 'cypress-wait-until';
 import {
   interceptExploreJson,
   interceptFiltering as interceptCharts,
@@ -738,7 +739,7 @@ describe('Dashboard edit', () => {
       cy.get('[role="checkbox"]').click();
       dragComponent('Unicode Cloud', 'card-title', false);
       cy.getBySel('header-save-button').should('be.enabled');
-      cy.waitUntil(() => cy.getBySel('header-save-button').isVisible());
+      cy.waitUntil(() => cy.getBySel('header-save-button').should('be.visible'));
       cy.contains('header-save-button', 'Save');
       discardChanges();
       cy.wait(1000);

--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/editmode.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/editmode.test.ts
@@ -734,15 +734,18 @@ describe('Dashboard edit', () => {
       cy.getBySel('dashboard-charts-filter-search-input').clear();
     });
 
-    // TODO fix this test! This was the #1 flaky test as of 4/21/23 according to cypress dashboard.
-    xit('should disable the Save button when undoing', () => {
+    it('should disable the Save button when undoing', () => {
       cy.get('[role="checkbox"]').click();
       dragComponent('Unicode Cloud', 'card-title', false);
       cy.getBySel('header-save-button').should('be.enabled');
+      cy.waitUntil(() => cy.getBySel('header-save-button').isVisible());
+      cy.contains('header-save-button', 'Save');
       discardChanges();
+      cy.wait(1000);
       cy.getBySel('header-save-button').should('be.disabled');
     });
   });
+
 
   describe('Components', () => {
     beforeEach(() => {

--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/editmode.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/editmode.test.ts
@@ -739,14 +739,15 @@ describe('Dashboard edit', () => {
       cy.get('[role="checkbox"]').click();
       dragComponent('Unicode Cloud', 'card-title', false);
       cy.getBySel('header-save-button').should('be.enabled');
-      cy.waitUntil(() => cy.getBySel('header-save-button').should('be.visible'));
+      cy.waitUntil(() =>
+        cy.getBySel('header-save-button').should('be.visible'),
+      );
       cy.contains('header-save-button', 'Save');
       discardChanges();
       cy.wait(1000);
       cy.getBySel('header-save-button').should('be.disabled');
     });
   });
-
 
   describe('Components', () => {
     beforeEach(() => {

--- a/superset-frontend/cypress-base/package-lock.json
+++ b/superset-frontend/cypress-base/package-lock.json
@@ -22,6 +22,7 @@
       "devDependencies": {
         "@types/querystringify": "^2.0.0",
         "cypress": "^10.11.0",
+        "cypress-wait-until": "^1.7.2",
         "eslint-plugin-cypress": "^2.12.1"
       }
     },
@@ -5826,6 +5827,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/cypress-wait-until": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/cypress-wait-until/-/cypress-wait-until-1.7.2.tgz",
+      "integrity": "sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q==",
+      "dev": true
     },
     "node_modules/cypress/node_modules/buffer": {
       "version": "5.7.1",
@@ -15833,6 +15840,12 @@
           }
         }
       }
+    },
+    "cypress-wait-until": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/cypress-wait-until/-/cypress-wait-until-1.7.2.tgz",
+      "integrity": "sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q==",
+      "dev": true
     },
     "d3-array": {
       "version": "2.12.0",

--- a/superset-frontend/cypress-base/package-lock.json
+++ b/superset-frontend/cypress-base/package-lock.json
@@ -14,6 +14,7 @@
         "@superset-ui/core": "^0.18.8",
         "brace": "^0.11.1",
         "cy-verify-downloads": "^0.1.6",
+        "cypress-wait-until": "^1.7.2",
         "querystringify": "^2.2.0",
         "react-dom": "^16.13.0",
         "rison": "^0.1.1",
@@ -22,7 +23,6 @@
       "devDependencies": {
         "@types/querystringify": "^2.0.0",
         "cypress": "^10.11.0",
-        "cypress-wait-until": "^1.7.2",
         "eslint-plugin-cypress": "^2.12.1"
       }
     },
@@ -5831,8 +5831,7 @@
     "node_modules/cypress-wait-until": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/cypress-wait-until/-/cypress-wait-until-1.7.2.tgz",
-      "integrity": "sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q==",
-      "dev": true
+      "integrity": "sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q=="
     },
     "node_modules/cypress/node_modules/buffer": {
       "version": "5.7.1",
@@ -15844,8 +15843,7 @@
     "cypress-wait-until": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/cypress-wait-until/-/cypress-wait-until-1.7.2.tgz",
-      "integrity": "sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q==",
-      "dev": true
+      "integrity": "sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q=="
     },
     "d3-array": {
       "version": "2.12.0",

--- a/superset-frontend/cypress-base/package.json
+++ b/superset-frontend/cypress-base/package.json
@@ -21,6 +21,7 @@
     "@superset-ui/core": "^0.18.8",
     "brace": "^0.11.1",
     "cy-verify-downloads": "^0.1.6",
+    "cypress-wait-until": "^1.7.2",
     "querystringify": "^2.2.0",
     "react-dom": "^16.13.0",
     "rison": "^0.1.1",
@@ -29,7 +30,6 @@
   "devDependencies": {
     "@types/querystringify": "^2.0.0",
     "cypress": "^10.11.0",
-    "cypress-wait-until": "^1.7.2",
     "eslint-plugin-cypress": "^2.12.1"
   }
 }

--- a/superset-frontend/cypress-base/package.json
+++ b/superset-frontend/cypress-base/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@types/querystringify": "^2.0.0",
     "cypress": "^10.11.0",
+    "cypress-wait-until": "^1.7.2",
     "eslint-plugin-cypress": "^2.12.1"
   }
 }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This test was previously `xit`-ed in [another PR](https://github.com/apache/superset/pull/23772) because it was the flakiest of all tests. Let's see if Bard can fix that!

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
