### PR TITLE
fix: Make drill by work correctly with time filters

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/query/convertFilter.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/convertFilter.ts
@@ -34,6 +34,7 @@ export default function convertFilter(
     return {
       col: subject,
       op: operator,
+      grain: filter.timeGrain,
     };
   }
   if (isBinaryAdhocFilter(filter)) {
@@ -43,6 +44,7 @@ export default function convertFilter(
       col: subject,
       op: operator,
       val: filter.comparator,
+      grain: filter.timeGrain,
     };
   }
 
@@ -52,5 +54,6 @@ export default function convertFilter(
     col: subject,
     op: operator,
     val: filter.comparator,
+    grain: filter.timeGrain,
   };
 }

--- a/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
@@ -40,13 +40,13 @@ export type BaseQueryObjectFilterClause = {
 
 export type BinaryQueryObjectFilterClause = BaseQueryObjectFilterClause & {
   op: BinaryOperator;
-  val: string | number | boolean;
+  val: string | number | boolean | Date;
   formattedVal?: string;
 };
 
 export type SetQueryObjectFilterClause = BaseQueryObjectFilterClause & {
   op: SetOperator;
-  val: (string | number | boolean)[];
+  val: (string | number | boolean | Date)[];
   formattedVal?: string[];
 };
 

--- a/superset-frontend/packages/superset-ui-core/src/time-format/index.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-format/index.ts
@@ -37,5 +37,6 @@ export { default as smartDateDetailedFormatter } from './formatters/smartDateDet
 export { default as smartDateVerboseFormatter } from './formatters/smartDateVerbose';
 
 export { default as normalizeTimestamp } from './utils/normalizeTimestamp';
+export { default as createTimeRangeFromGranularity } from './utils/createTimeRangeFromGranularity';
 
 export * from './types';

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByModal.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByModal.tsx
@@ -26,14 +26,11 @@ import React, {
 } from 'react';
 import {
   BaseFormData,
-  BinaryQueryObjectFilterClause,
   Column,
   ContextMenuFilters,
   css,
   ensureIsArray,
-  GenericDataType,
   isDefined,
-  isPhysicalColumn,
   QueryData,
   t,
   useTheme,
@@ -206,17 +203,6 @@ export default function DrillByModal({
     { groupby: column || [] },
   ]);
 
-  const isSimpleFilterTemporal = useCallback(
-    (filter: BinaryQueryObjectFilterClause) =>
-      isPhysicalColumn(filter.col) &&
-      dataset.columns?.some(
-        column =>
-          column.column_name === filter.col &&
-          (column.type_generic === GenericDataType.TEMPORAL || column.is_dttm),
-      ),
-    [dataset.columns],
-  );
-
   const getNewGroupby = useCallback(
     (groupbyCol: Column, fieldName = groupbyFieldName) =>
       Array.isArray(formData[fieldName])
@@ -244,7 +230,6 @@ export default function DrillByModal({
               simpleFilterToAdhoc(
                 filter,
                 CLAUSES.WHERE,
-                isSimpleFilterTemporal(filter),
                 formData.time_grain_sqla,
               ),
             ),
@@ -259,7 +244,7 @@ export default function DrillByModal({
           overridenAdhocFilterFields: new Set<string>(),
         },
       ),
-    [getNewGroupby, isSimpleFilterTemporal],
+    [formData.time_grain_sqla, getNewGroupby],
   );
 
   const getFiltersFromConfigsByFieldName = useCallback(
@@ -273,14 +258,13 @@ export default function DrillByModal({
             simpleFilterToAdhoc(
               filter,
               CLAUSES.WHERE,
-              isSimpleFilterTemporal(filter),
               formData.time_grain_sqla,
             ),
           ),
         ];
         return acc;
       }, {}),
-    [drillByConfigs, isSimpleFilterTemporal],
+    [drillByConfigs, formData.time_grain_sqla],
   );
 
   const onBreadcrumbClick = useCallback(

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByModal.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByModal.tsx
@@ -245,6 +245,7 @@ export default function DrillByModal({
                 filter,
                 CLAUSES.WHERE,
                 isSimpleFilterTemporal(filter),
+                formData.time_grain_sqla,
               ),
             ),
           ];
@@ -273,6 +274,7 @@ export default function DrillByModal({
               filter,
               CLAUSES.WHERE,
               isSimpleFilterTemporal(filter),
+              formData.time_grain_sqla,
             ),
           ),
         ];

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByModal.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByModal.tsx
@@ -48,6 +48,7 @@ import { DashboardPageIdContext } from 'src/dashboard/containers/DashboardPage';
 import { postFormData } from 'src/explore/exploreUtils/formData';
 import { CLAUSES } from 'src/explore/components/controls/FilterControl/types';
 import { simpleFilterToAdhoc } from 'src/utils/simpleFilterToAdhoc';
+import { removeRedundantTemporalAdhocFilters } from 'src/utils/removeRedundantTemporalAdhocFilters';
 import { useDatasetMetadataBar } from 'src/features/datasets/metadataBar/useDatasetMetadataBar';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
 import Alert from 'src/components/Alert';
@@ -332,10 +333,10 @@ export default function DrillByModal({
     Object.keys(adhocFilters).forEach(adhocFilterFieldName => {
       updatedFormData = {
         ...updatedFormData,
-        [adhocFilterFieldName]: [
+        [adhocFilterFieldName]: removeRedundantTemporalAdhocFilters([
           ...ensureIsArray(formData[adhocFilterFieldName]),
           ...adhocFilters[adhocFilterFieldName],
-        ],
+        ]),
       };
     });
 

--- a/superset-frontend/src/utils/removeRedundantTemporalAdhocFilters.test.ts
+++ b/superset-frontend/src/utils/removeRedundantTemporalAdhocFilters.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AdhocFilter } from '@superset-ui/core';
+import { removeRedundantTemporalAdhocFilters } from './removeRedundantTemporalAdhocFilters';
+
+it('should remove temporal filter with no value if there is another filter that targets the same column', () => {
+  const filters: AdhocFilter[] = [
+    {
+      expressionType: 'SIMPLE',
+      clause: 'WHERE',
+      subject: 'gender',
+      operator: '==',
+      comparator: 'boy',
+    },
+    {
+      expressionType: 'SIMPLE',
+      clause: 'WHERE',
+      subject: 'ds',
+      operator: 'TEMPORAL_RANGE',
+      comparator: 'No filter',
+    },
+    {
+      expressionType: 'SIMPLE',
+      clause: 'WHERE',
+      subject: 'ds',
+      operator: 'TEMPORAL_RANGE',
+      comparator: '2 weeks ago',
+    },
+    {
+      expressionType: 'SIMPLE',
+      clause: 'WHERE',
+      subject: 'name',
+      operator: '==',
+      comparator: 'John',
+    },
+  ];
+
+  expect(removeRedundantTemporalAdhocFilters(filters)).toEqual([
+    {
+      expressionType: 'SIMPLE',
+      clause: 'WHERE',
+      subject: 'gender',
+      operator: '==',
+      comparator: 'boy',
+    },
+    {
+      expressionType: 'SIMPLE',
+      clause: 'WHERE',
+      subject: 'ds',
+      operator: 'TEMPORAL_RANGE',
+      comparator: '2 weeks ago',
+    },
+    {
+      expressionType: 'SIMPLE',
+      clause: 'WHERE',
+      subject: 'name',
+      operator: '==',
+      comparator: 'John',
+    },
+  ]);
+});
+
+it('should not remove temporal filter with no value if there is no other filter that targets the same column', () => {
+  const filters: AdhocFilter[] = [
+    {
+      expressionType: 'SIMPLE',
+      clause: 'WHERE',
+      subject: 'gender',
+      operator: '==',
+      comparator: 'boy',
+    },
+    {
+      expressionType: 'SIMPLE',
+      clause: 'WHERE',
+      subject: 'ds',
+      operator: 'TEMPORAL_RANGE',
+      comparator: 'No filter',
+    },
+    {
+      expressionType: 'SIMPLE',
+      clause: 'WHERE',
+      subject: 'name',
+      operator: '==',
+      comparator: 'John',
+    },
+  ];
+
+  expect(removeRedundantTemporalAdhocFilters(filters)).toEqual(filters);
+});

--- a/superset-frontend/src/utils/removeRedundantTemporalAdhocFilters.ts
+++ b/superset-frontend/src/utils/removeRedundantTemporalAdhocFilters.ts
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  AdhocFilter,
+  isBinaryAdhocFilter,
+  isSimpleAdhocFilter,
+  NO_TIME_RANGE,
+} from '@superset-ui/core';
+import { Operators } from 'src/explore/constants';
+
+export const removeRedundantTemporalAdhocFilters = (filters: AdhocFilter[]) =>
+  filters.reduce((acc: AdhocFilter[], curr) => {
+    if (
+      !(
+        isSimpleAdhocFilter(curr) &&
+        isBinaryAdhocFilter(curr) &&
+        curr.operator === Operators.TEMPORAL_RANGE &&
+        curr.comparator === NO_TIME_RANGE &&
+        filters.some(
+          f =>
+            isSimpleAdhocFilter(f) &&
+            isBinaryAdhocFilter(f) &&
+            f.operator === Operators.TEMPORAL_RANGE &&
+            f.comparator !== NO_TIME_RANGE &&
+            f.subject === curr.subject,
+        )
+      )
+    ) {
+      acc.push(curr);
+    }
+    return acc;
+  }, []);

--- a/superset-frontend/src/utils/simpleFilterToAdhoc.ts
+++ b/superset-frontend/src/utils/simpleFilterToAdhoc.ts
@@ -52,23 +52,6 @@ export const simpleFilterToAdhoc = (
         comparator: 'val' in filterClause ? filterClause.val : undefined,
       } as SimpleAdhocFilter),
     };
-  } else if (
-    isTemporal &&
-    'val' in filterClause &&
-    (typeof filterClause.val === 'number' || filterClause.val instanceof Date)
-  ) {
-    const [start, end] = createTimeRangeFromGranularity(
-      new Date(filterClause.val),
-      timeGrain,
-    );
-    result = {
-      expressionType: 'SIMPLE',
-      clause,
-      operator: Operators.TEMPORAL_RANGE,
-      operatorId: Operators.TEMPORAL_RANGE,
-      subject: filterClause.col,
-      comparator: `${start.toISOString()} : ${end.toISOString()}`,
-    } as SimpleAdhocFilter;
   } else {
     result = {
       expressionType: 'SIMPLE',
@@ -79,6 +62,7 @@ export const simpleFilterToAdhoc = (
       )?.[0],
       subject: filterClause.col,
       comparator: 'val' in filterClause ? filterClause.val : undefined,
+      timeGrain,
     } as SimpleAdhocFilter;
   }
   if (filterClause.isExtra) {

--- a/superset-frontend/src/utils/simpleFilterToAdhoc.ts
+++ b/superset-frontend/src/utils/simpleFilterToAdhoc.ts
@@ -18,7 +18,6 @@
  */
 import {
   AdhocFilter,
-  createTimeRangeFromGranularity,
   isAdhocColumn,
   QueryObjectFilterClause,
   SimpleAdhocFilter,
@@ -28,17 +27,13 @@ import {
   CLAUSES,
   EXPRESSION_TYPES,
 } from '../explore/components/controls/FilterControl/types';
-import {
-  OPERATOR_ENUM_TO_OPERATOR_TYPE,
-  Operators,
-} from '../explore/constants';
+import { OPERATOR_ENUM_TO_OPERATOR_TYPE } from '../explore/constants';
 import { translateToSql } from '../explore/components/controls/FilterControl/utils/translateToSQL';
 
 export const simpleFilterToAdhoc = (
   filterClause: QueryObjectFilterClause,
   clause: CLAUSES = CLAUSES.WHERE,
-  isTemporal = false,
-  timeGrain: TimeGranularity = 'P1D',
+  timeGrain: TimeGranularity,
 ) => {
   let result: AdhocFilter;
   if (isAdhocColumn(filterClause.col)) {

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -218,6 +218,7 @@ class AdhocFilterClause(TypedDict, total=False):
     subject: str
     isExtra: Optional[bool]
     sqlExpression: Optional[str]
+    timeGrain: Optional[str]
 
 
 class QueryObjectFilterClause(TypedDict, total=False):
@@ -1091,6 +1092,7 @@ def simple_filter_to_adhoc(
         "comparator": filter_clause.get("val"),
         "operator": filter_clause["op"],
         "subject": cast(str, filter_clause["col"]),
+        "timeGrain": filter_clause.get("grain"),
     }
     if filter_clause.get("isExtra"):
         result["isExtra"] = True


### PR DESCRIPTION

### SUMMARY
Previously, when user applied drill by on a series of temporal dimension, the related adhoc filter would be a simple equality comparison to a timestamp. Now, we create a proper temporal range filter based on timestamp and chosen granularity.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:


https://github.com/apache/superset/assets/15073128/47d4a92e-54e6-4ec3-83ae-cc07dacc656f


After:

https://github.com/apache/superset/assets/15073128/31150ecd-de3e-4c21-9742-fc22febbf8aa



### TESTING INSTRUCTIONS
1. Enable `DRILL_BY` feature flag
2. Add some charts with temporal dimensions to the dashboard
3. Drill by on a temporal series
4. Verify (either by checking the request payload or opening explore) that related adhoc filter is a temporal range filter

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
