### PR TITLE
chore: Refactor command exceptions

### DIFF
--- a/superset/annotation_layers/annotations/commands/create.py
+++ b/superset/annotation_layers/annotations/commands/create.py
@@ -73,6 +73,4 @@ class CreateAnnotationCommand(BaseCommand):
             exceptions.append(AnnotationDatesValidationError())
 
         if exceptions:
-            exception = AnnotationInvalidError()
-            exception.add_list(exceptions)
-            raise exception
+            raise AnnotationInvalidError(exceptions=exceptions)

--- a/superset/annotation_layers/annotations/commands/update.py
+++ b/superset/annotation_layers/annotations/commands/update.py
@@ -87,6 +87,4 @@ class UpdateAnnotationCommand(BaseCommand):
             exceptions.append(AnnotationDatesValidationError())
 
         if exceptions:
-            exception = AnnotationInvalidError()
-            exception.add_list(exceptions)
-            raise exception
+            raise AnnotationInvalidError(exceptions=exceptions)

--- a/superset/annotation_layers/commands/create.py
+++ b/superset/annotation_layers/commands/create.py
@@ -54,6 +54,4 @@ class CreateAnnotationLayerCommand(BaseCommand):
             exceptions.append(AnnotationLayerNameUniquenessValidationError())
 
         if exceptions:
-            exception = AnnotationLayerInvalidError()
-            exception.add_list(exceptions)
-            raise exception
+            raise AnnotationLayerInvalidError(exceptions=exceptions)

--- a/superset/annotation_layers/commands/update.py
+++ b/superset/annotation_layers/commands/update.py
@@ -63,6 +63,4 @@ class UpdateAnnotationLayerCommand(BaseCommand):
             exceptions.append(AnnotationLayerNameUniquenessValidationError())
 
         if exceptions:
-            exception = AnnotationLayerInvalidError()
-            exception.add_list(exceptions)
-            raise exception
+            raise AnnotationLayerInvalidError(exceptions=exceptions)

--- a/superset/charts/commands/create.py
+++ b/superset/charts/commands/create.py
@@ -77,6 +77,4 @@ class CreateChartCommand(CreateMixin, BaseCommand):
         except ValidationError as ex:
             exceptions.append(ex)
         if exceptions:
-            exception = ChartInvalidError()
-            exception.add_list(exceptions)
-            raise exception
+            raise ChartInvalidError(exceptions=exceptions)

--- a/superset/charts/commands/update.py
+++ b/superset/charts/commands/update.py
@@ -114,6 +114,4 @@ class UpdateChartCommand(UpdateMixin, BaseCommand):
             self._properties["dashboards"] = dashboards
 
         if exceptions:
-            exception = ChartInvalidError()
-            exception.add_list(exceptions)
-            raise exception
+            raise ChartInvalidError(exceptions=exceptions)

--- a/superset/commands/exceptions.py
+++ b/superset/commands/exceptions.py
@@ -56,22 +56,26 @@ class CommandInvalidError(CommandException):
 
     status = 422
 
-    def __init__(self, message: str = "") -> None:
-        self._invalid_exceptions: List[ValidationError] = []
+    def __init__(
+        self,
+        message: str = "",
+        exceptions: Optional[List[ValidationError]] = None,
+    ) -> None:
+        self._exceptions = exceptions or []
         super().__init__(message)
 
-    def add(self, exception: ValidationError) -> None:
-        self._invalid_exceptions.append(exception)
+    def append(self, exception: ValidationError) -> None:
+        self._exceptions.append(exception)
 
-    def add_list(self, exceptions: List[ValidationError]) -> None:
-        self._invalid_exceptions.extend(exceptions)
+    def extend(self, exceptions: List[ValidationError]) -> None:
+        self._exceptions.extend(exceptions)
 
     def get_list_classnames(self) -> List[str]:
-        return list(sorted({ex.__class__.__name__ for ex in self._invalid_exceptions}))
+        return list(sorted({ex.__class__.__name__ for ex in self._exceptions}))
 
     def normalized_messages(self) -> Dict[Any, Any]:
         errors: Dict[Any, Any] = {}
-        for exception in self._invalid_exceptions:
+        for exception in self._exceptions:
             errors.update(exception.normalized_messages())
         return errors
 

--- a/superset/commands/importers/v1/__init__.py
+++ b/superset/commands/importers/v1/__init__.py
@@ -108,9 +108,10 @@ class ImportModelsCommand(BaseCommand):
         self._prevent_overwrite_existing_model(exceptions)
 
         if exceptions:
-            exception = CommandInvalidError(f"Error importing {self.model_name}")
-            exception.add_list(exceptions)
-            raise exception
+            raise CommandInvalidError(
+                f"Error importing {self.model_name}",
+                exceptions,
+            )
 
     def _prevent_overwrite_existing_model(  # pylint: disable=invalid-name
         self, exceptions: List[ValidationError]

--- a/superset/commands/importers/v1/assets.py
+++ b/superset/commands/importers/v1/assets.py
@@ -172,6 +172,7 @@ class ImportAssetsCommand(BaseCommand):
         )
 
         if exceptions:
-            exception = CommandInvalidError("Error importing assets")
-            exception.add_list(exceptions)
-            raise exception
+            raise CommandInvalidError(
+                "Error importing assets",
+                exceptions,
+            )

--- a/superset/dashboards/commands/create.py
+++ b/superset/dashboards/commands/create.py
@@ -63,9 +63,7 @@ class CreateDashboardCommand(CreateMixin, BaseCommand):
         except ValidationError as ex:
             exceptions.append(ex)
         if exceptions:
-            exception = DashboardInvalidError()
-            exception.add_list(exceptions)
-            raise exception
+            raise DashboardInvalidError(exceptions=exceptions)
 
         try:
             roles = populate_roles(role_ids)
@@ -73,6 +71,4 @@ class CreateDashboardCommand(CreateMixin, BaseCommand):
         except ValidationError as ex:
             exceptions.append(ex)
         if exceptions:
-            exception = DashboardInvalidError()
-            exception.add_list(exceptions)
-            raise exception
+            raise DashboardInvalidError(exceptions=exceptions)

--- a/superset/dashboards/commands/update.py
+++ b/superset/dashboards/commands/update.py
@@ -92,9 +92,7 @@ class UpdateDashboardCommand(UpdateMixin, BaseCommand):
         except ValidationError as ex:
             exceptions.append(ex)
         if exceptions:
-            exception = DashboardInvalidError()
-            exception.add_list(exceptions)
-            raise exception
+            raise DashboardInvalidError(exceptions=exceptions)
 
         # Validate/Populate role
         if roles_ids is None:
@@ -105,6 +103,4 @@ class UpdateDashboardCommand(UpdateMixin, BaseCommand):
         except ValidationError as ex:
             exceptions.append(ex)
         if exceptions:
-            exception = DashboardInvalidError()
-            exception.add_list(exceptions)
-            raise exception
+            raise DashboardInvalidError(exceptions=exceptions)

--- a/superset/databases/commands/create.py
+++ b/superset/databases/commands/create.py
@@ -141,7 +141,7 @@ class CreateDatabaseCommand(BaseCommand):
                 exceptions.append(DatabaseExistsValidationError())
         if exceptions:
             exception = DatabaseInvalidError()
-            exception.add_list(exceptions)
+            exception.extend(exceptions)
             event_logger.log_with_context(
                 action="db_connection_failed.{}.{}".format(
                     exception.__class__.__name__,

--- a/superset/databases/commands/update.py
+++ b/superset/databases/commands/update.py
@@ -177,6 +177,4 @@ class UpdateDatabaseCommand(BaseCommand):
             ):
                 exceptions.append(DatabaseExistsValidationError())
         if exceptions:
-            exception = DatabaseInvalidError()
-            exception.add_list(exceptions)
-            raise exception
+            raise DatabaseInvalidError(exceptions=exceptions)

--- a/superset/databases/ssh_tunnel/commands/create.py
+++ b/superset/databases/ssh_tunnel/commands/create.py
@@ -82,7 +82,7 @@ class CreateSSHTunnelCommand(BaseCommand):
             exceptions.append(SSHTunnelRequiredFieldValidationError("private_key"))
         if exceptions:
             exception = SSHTunnelInvalidError()
-            exception.add_list(exceptions)
+            exception.extend(exceptions)
             event_logger.log_with_context(
                 action="ssh_tunnel_creation_failed.{}.{}".format(
                     exception.__class__.__name__,

--- a/superset/databases/ssh_tunnel/commands/update.py
+++ b/superset/databases/ssh_tunnel/commands/update.py
@@ -58,6 +58,6 @@ class UpdateSSHTunnelCommand(BaseCommand):
             "private_key_password"
         )
         if private_key_password and private_key is None:
-            exception = SSHTunnelInvalidError()
-            exception.add(SSHTunnelRequiredFieldValidationError("private_key"))
-            raise exception
+            raise SSHTunnelInvalidError(
+                exceptions=[SSHTunnelRequiredFieldValidationError("private_key")]
+            )

--- a/superset/datasets/commands/create.py
+++ b/superset/datasets/commands/create.py
@@ -87,6 +87,4 @@ class CreateDatasetCommand(CreateMixin, BaseCommand):
         except ValidationError as ex:
             exceptions.append(ex)
         if exceptions:
-            exception = DatasetInvalidError()
-            exception.add_list(exceptions)
-            raise exception
+            raise DatasetInvalidError(exceptions=exceptions)

--- a/superset/datasets/commands/duplicate.py
+++ b/superset/datasets/commands/duplicate.py
@@ -128,6 +128,4 @@ class DuplicateDatasetCommand(CreateMixin, BaseCommand):
             exceptions.append(ex)
 
         if exceptions:
-            exception = DatasetInvalidError()
-            exception.add_list(exceptions)
-            raise exception
+            raise DatasetInvalidError(exceptions=exceptions)

--- a/superset/datasets/commands/update.py
+++ b/superset/datasets/commands/update.py
@@ -124,9 +124,7 @@ class UpdateDatasetCommand(UpdateMixin, BaseCommand):
             self._validate_metrics(metrics, exceptions)
 
         if exceptions:
-            exception = DatasetInvalidError()
-            exception.add_list(exceptions)
-            raise exception
+            raise DatasetInvalidError(exceptions=exceptions)
 
     def _validate_columns(
         self, columns: List[Dict[str, Any]], exceptions: List[ValidationError]

--- a/superset/reports/commands/create.py
+++ b/superset/reports/commands/create.py
@@ -117,9 +117,7 @@ class CreateReportScheduleCommand(CreateMixin, BaseReportScheduleCommand):
         except ValidationError as ex:
             exceptions.append(ex)
         if exceptions:
-            exception = ReportScheduleInvalidError()
-            exception.add_list(exceptions)
-            raise exception
+            raise ReportScheduleInvalidError(exceptions=exceptions)
 
     def _validate_report_extra(self, exceptions: List[ValidationError]) -> None:
         extra: Optional[ReportScheduleExtra] = self._properties.get("extra")

--- a/superset/reports/commands/update.py
+++ b/superset/reports/commands/update.py
@@ -124,6 +124,4 @@ class UpdateReportScheduleCommand(UpdateMixin, BaseReportScheduleCommand):
         except ValidationError as ex:
             exceptions.append(ex)
         if exceptions:
-            exception = ReportScheduleInvalidError()
-            exception.add_list(exceptions)
-            raise exception
+            raise ReportScheduleInvalidError(exceptions=exceptions)

--- a/superset/tags/commands/create.py
+++ b/superset/tags/commands/create.py
@@ -60,6 +60,4 @@ class CreateCustomTagCommand(CreateMixin, BaseCommand):
                 TagCreateFailedError(f"invalid object type {self._object_type}")
             )
         if exceptions:
-            exception = TagInvalidError()
-            exception.add_list(exceptions)
-            raise exception
+            raise TagInvalidError(exceptions=exceptions)

--- a/superset/tags/commands/delete.py
+++ b/superset/tags/commands/delete.py
@@ -86,9 +86,7 @@ class DeleteTaggedObjectCommand(DeleteMixin, BaseCommand):
                         )
                     )
         if exceptions:
-            exception = TagInvalidError()
-            exception.add_list(exceptions)
-            raise exception
+            raise TagInvalidError(exceptions=exceptions)
 
 
 class DeleteTagsCommand(DeleteMixin, BaseCommand):
@@ -110,6 +108,4 @@ class DeleteTagsCommand(DeleteMixin, BaseCommand):
             if not TagDAO.find_by_name(tag):
                 exceptions.append(TagNotFoundError(tag))
         if exceptions:
-            exception = TagInvalidError()
-            exception.add_list(exceptions)
-            raise exception
+            raise TagInvalidError(exceptions=exceptions)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Whilst debugging an issue I came across a frequently repeated pattern:

```python
if exceptions:
    exception = AnnotationInvalidError()
    exception.add_list(exceptions)
    raise exception
```

These exceptions are derived from the `CommandInvalidError` class which included the `add` and `add_list` methods and had no way of adding the exceptions when constructing the error.  To adhere to the DRY principle this PR performs the following:

1. Renames `add` to `append`—akin to `list.append`.
2. Renames `add_list` to `extend`—akin to `list.extend`.
3. Add the ability to specify the exceptions in the `__init__` method.

where the later means that the snippet of code above reduces to,

```python
if exceptions:
    raise AnnotationInvalidError(exceptions=exceptions)
```


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
