### PR TITLE
fix(sqllab): Disable Select All on table selector

### DIFF
--- a/superset-frontend/src/components/TableSelector/TableSelector.test.tsx
+++ b/superset-frontend/src/components/TableSelector/TableSelector.test.tsx
@@ -95,7 +95,26 @@ test('renders with default props', async () => {
   });
 });
 
-test('renders table options', async () => {
+test('skips select all options', async () => {
+  fetchMock.get(schemaApiRoute, { result: ['test_schema'] });
+  fetchMock.get(tablesApiRoute, getTableMockFunction());
+
+  const props = createProps();
+  render(<TableSelector {...props} tableSelectMode="multiple" />, {
+    useRedux: true,
+    store,
+  });
+  const tableSelect = screen.getByRole('combobox', {
+    name: 'Select table or type to search tables',
+  });
+  userEvent.click(tableSelect);
+  expect(
+    await screen.findByRole('option', { name: 'table_a' }),
+  ).toBeInTheDocument();
+  expect(screen.queryByRole('option', { name: /Select All/i })).toBeFalsy();
+});
+
+test('renders table options without Select All option', async () => {
   fetchMock.get(schemaApiRoute, { result: ['test_schema'] });
   fetchMock.get(tablesApiRoute, getTableMockFunction());
 

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -297,6 +297,7 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
         mode={tableSelectMode}
         value={tableSelectValue}
         allowClear={tableSelectMode === 'multiple'}
+        allowSelectAll={false}
       />
     );
 


### PR DESCRIPTION
### SUMMARY
After https://github.com/apache/superset/pull/22084 merged, all SyncSelect has "Select All" option including a database selector.  This change easily hits the tens (and can be thousands) of table preview fetches since the option triggers the preview request.
This commit disables the "Select All" option for TableSelector to resolve the issue. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After:

<img width="389" alt="Screenshot 2023-05-18 at 10 24 20 AM" src="https://github.com/apache/superset/assets/1392866/58113050-fbfd-4e48-be5e-d2e545ac7140">

Before:

<img width="402" alt="Screenshot 2023-05-18 at 10 23 28 AM" src="https://github.com/apache/superset/assets/1392866/e21744ad-acfb-472f-8cea-302682800354">

### TESTING INSTRUCTIONS

Go to SQLLab and verify that no options for "Select All" in table selector

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
