### PR TITLE
fix: Revert tox basepython

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@
 # Remember to start celery workers to run celery tests, e.g.
 # celery --app=superset.tasks.celery_app:app worker -Ofair -c 2
 [testenv]
-basepython = python3.8
+basepython = python3.9
 ignore_basepython_conflict = true
 commands =
     superset db upgrade

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@
 # Remember to start celery workers to run celery tests, e.g.
 # celery --app=superset.tasks.celery_app:app worker -Ofair -c 2
 [testenv]
-basepython = python3.10
+basepython = python3.8
 ignore_basepython_conflict = true
 commands =
     superset db upgrade


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Accidentally in https://github.com/apache/superset/pull/24068 I merged a change which bumped the `basepython` in the `tox.ini` whilst testing locally. This PR reverts said mistake. Note that in https://github.com/apache/superset/pull/23890 we dropped support for Python 3.8 and thus the `tox` basepython should have also been bumped.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
