### PR TITLE
chore: deprecate rls base related filters

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -24,6 +24,7 @@ assists people when migrating to a new version.
 
 ## Next
 
+- [24128](https://github.com/apache/superset/pull/24128) The `RLS_BASE_RELATED_FIELD_FILTERS` config parameter has been removed. Now the Tables dropdown will feature the same tables that the user is able to see elsewhere in the application using the standard `DatasourceFilter`, and the Roles dropdown will be filtered using the filter defined in `EXTRA_RELATED_QUERY_FILTERS["role"]`.
 - [23785](https://github.com/apache/superset/pull/23785) Deprecated the following feature flags: `CLIENT_CACHE`, `DASHBOARD_CACHE`, `DASHBOARD_FILTERS_EXPERIMENTAL`, `DASHBOARD_NATIVE_FILTERS`, `DASHBOARD_NATIVE_FILTERS_SET`, `DISABLE_DATASET_SOURCE_EDIT`, `ENABLE_EXPLORE_JSON_CSRF_PROTECTION`, `REMOVE_SLICE_LEVEL_LABEL_COLORS`. It also removed `DASHBOARD_EDIT_CHART_IN_NEW_TAB` as the feature is supported without the need for a feature flag.
 - [23652](https://github.com/apache/superset/pull/23652) Enables GENERIC_CHART_AXES feature flag by default.
 - [23226](https://github.com/apache/superset/pull/23226) Migrated endpoint `/estimate_query_cost/<int:database_id>` to `/api/v1/sqllab/estimate/`. Corresponding permissions are can estimate query cost on SQLLab. Make sure you add/replace the necessary permissions on any custom roles you may have.

--- a/superset-frontend/src/features/rls/RowLevelSecurityModal.tsx
+++ b/superset-frontend/src/features/rls/RowLevelSecurityModal.tsx
@@ -401,7 +401,9 @@ function RowLevelSecurityModal(props: RowLevelSecurityModalProps) {
 
           <StyledInputContainer>
             <div className="control-label">
-              {t('Roles')}{' '}
+              {currentRule.filter_type === FilterType.BASE
+                ? t('Excluded roles')
+                : t('Roles')}{' '}
               <InfoTooltip
                 tooltip={t(
                   'For regular filters, these are the roles this filter will be applied to. For base filters, these are the roles that the filter DOES NOT apply to, e.g. Admin if admin should see all data.',

--- a/superset/config.py
+++ b/superset/config.py
@@ -1379,18 +1379,6 @@ TALISMAN_CONFIG = {
     "force_https_permanent": False,
 }
 
-# It is possible to customize which tables and roles are featured in the RLS
-# dropdown. When set, this dict is assigned to `filter_rel_fields`
-# on `RLSRestApi`. Example:
-#
-# from flask_appbuilder.models.sqla import filters
-
-# RLS_BASE_RELATED_FIELD_FILTERS = {
-#     "tables": [["table_name", filters.FilterStartsWith, "birth"]],
-#     "roles": [["name", filters.FilterContains, "Admin"]]
-# }
-RLS_BASE_RELATED_FIELD_FILTERS: Dict[str, BaseFilter] = {}
-
 #
 # Flask session cookie options
 #

--- a/superset/config.py
+++ b/superset/config.py
@@ -53,7 +53,6 @@ from cachelib.base import BaseCache
 from celery.schedules import crontab
 from dateutil import tz
 from flask import Blueprint
-from flask_appbuilder.models.filters import BaseFilter
 from flask_appbuilder.security.manager import AUTH_DB
 from pandas._libs.parsers import STR_NA_VALUES  # pylint: disable=no-name-in-module
 from sqlalchemy.orm.query import Query

--- a/superset/row_level_security/api.py
+++ b/superset/row_level_security/api.py
@@ -24,7 +24,6 @@ from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_babel import ngettext
 from marshmallow import ValidationError
 
-from superset import app
 from superset.commands.exceptions import (
     DatasourceNotFoundValidationError,
     RolesNotFoundValidationError,

--- a/superset/row_level_security/api.py
+++ b/superset/row_level_security/api.py
@@ -44,11 +44,13 @@ from superset.row_level_security.schemas import (
     RLSPutSchema,
     RLSShowSchema,
 )
+from superset.views.base import DatasourceFilter
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
     requires_json,
     statsd_metrics,
 )
+from superset.views.filters import BaseFilterRelatedRoles
 
 logger = logging.getLogger(__name__)
 
@@ -122,7 +124,10 @@ class RLSRestApi(BaseSupersetModelRestApi):
     edit_model_schema = RLSPutSchema()
 
     allowed_rel_fields = {"tables", "roles"}
-    base_related_field_filters = app.config["RLS_BASE_RELATED_FIELD_FILTERS"]
+    base_related_field_filters = {
+        "tables": [["id", DatasourceFilter, lambda: []]],
+        "roles": [["id", BaseFilterRelatedRoles, lambda: []]],
+    }
 
     @expose("/", methods=("POST",))
     @protect()


### PR DESCRIPTION
### SUMMARY

This is a follow-up to the work done in #23777, more specifically this discussion: https://github.com/apache/superset/pull/23777#discussion_r1174893780

Currently Row Level Security has a dedicated set of related base filters that makes it possible to customize the filters that are applied on the Table and Role models. These are defined on the `RLS_BASE_RELATED_FIELD_FILTERS` config parameter.

Having these undefined by default is counter intuitive, as it means that a user that is given RLS access will be able to see ALL datasets under the RLS table dropdown, irrespective of which tables they see under the Datasets menu. To streamline this we should just use the same base filter we use for the dataset list view (`DatasourceFilter`).

For roles, the PR #22526 introduced the possibility to define a base filter for Roles. To avoid having duplicated logic and to give the users a unified UX, we can reuse the Role filter that users can define via the `EXTRA_RELATED_QUERY_FILTERS` config flag.

### SCREENSHOTS

This is the datasets view for a user that is only able to access two datasets on the instance (the Gamma user only has database access to the BurgerKing database, despite there being many other databases/datasets on the instance).
![image](https://github.com/apache/superset/assets/33317356/b2dfc894-a7bc-4854-ba2c-56ae80c3ce56)

With the `DASHBOARD_RBAC` feature enabled and a custom Roles filter, the user was only able to see the `Team-BurgerKing` role:
![image](https://github.com/apache/superset/assets/33317356/26a90104-2354-4597-97aa-8a8a4b833c12)

Previously, the same user would see all tables and roles on the instance if they had RLS perms. After this change the RLS dropdowns are aligned with what's available elsewhere:

RLS tables:
![image](https://github.com/apache/superset/assets/33317356/9d33ad4a-5836-4d93-94e7-a06af96521c7)

RLS roles:
![image](https://github.com/apache/superset/assets/33317356/ffc96f1d-cba1-4fd1-9b18-2d17f2e5376e)

As a bycatch, the "Roles" title is also changed to "Excluded roles" if the filter type is set to "Base" (this is similar to how the list view):
![image](https://github.com/apache/superset/assets/33317356/7ec6b89c-0da1-4ac2-bf07-1b1d97064721)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
