### PR TITLE
fix(sqllab): Table options rendering regression

### DIFF
--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -47,6 +47,7 @@ import {
   selectAllOption,
   mapValues,
   mapOptions,
+  hasCustomLabels,
 } from './utils';
 import { SelectOptionsType, SelectProps } from './types';
 import {
@@ -440,6 +441,11 @@ const Select = forwardRef(
       onChange?.(newValues, newOptions);
     };
 
+    const shouldUseChildrenOptions = useMemo(
+      () => !selectAllEnabled || hasCustomLabels(options),
+      [selectAllEnabled, options],
+    );
+
     const customMaxTagPlaceholder = () => {
       const num_selected = ensureIsArray(selectValue).length;
       const num_shown = maxTagCount as number;
@@ -493,6 +499,7 @@ const Select = forwardRef(
               <StyledCheckOutlined iconSize="m" aria-label="check" />
             )
           }
+          {...(!shouldUseChildrenOptions && { options: fullSelectOptions })}
           oneLine={oneLine}
           tagRender={customTagRender}
           {...props}
@@ -508,7 +515,7 @@ const Select = forwardRef(
               {selectAllLabel()}
             </Option>
           )}
-          {renderSelectOptions(fullSelectOptions)}
+          {shouldUseChildrenOptions && renderSelectOptions(fullSelectOptions)}
         </StyledSelect>
       </StyledContainer>
     );

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -441,8 +441,8 @@ const Select = forwardRef(
       onChange?.(newValues, newOptions);
     };
 
-    const shouldUseChildrenOptions = useMemo(
-      () => !selectAllEnabled || hasCustomLabels(options),
+    const shouldRenderChildrenOptions = useMemo(
+      () => selectAllEnabled || hasCustomLabels(options),
       [selectAllEnabled, options],
     );
 
@@ -499,7 +499,7 @@ const Select = forwardRef(
               <StyledCheckOutlined iconSize="m" aria-label="check" />
             )
           }
-          {...(!shouldUseChildrenOptions && { options: fullSelectOptions })}
+          {...(!shouldRenderChildrenOptions && { options: fullSelectOptions })}
           oneLine={oneLine}
           tagRender={customTagRender}
           {...props}
@@ -515,7 +515,8 @@ const Select = forwardRef(
               {selectAllLabel()}
             </Option>
           )}
-          {shouldUseChildrenOptions && renderSelectOptions(fullSelectOptions)}
+          {shouldRenderChildrenOptions &&
+            renderSelectOptions(fullSelectOptions)}
         </StyledSelect>
       </StyledContainer>
     );


### PR DESCRIPTION
### SUMMARY

There's a rendering perf regression from #22084

When SelectAll feature introduced by [#22084
](https://github.com/apache/superset/pull/22084/files#diff-0cb43ca54c9f49fa7c2283133c0841b0c8fb7b464130038d7dba2543cca5b498L329), Select component became rendering options by jsx only. This makes the performance degraded for the large size options.
```
options | Select options. Will get better perf than jsx definition
-- | --
```

This commit recovers the way to use options prop as before (including SelectAll condition)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

After: (~100ms)
<img width="565" alt="Screenshot 2023-05-19 at 11 22 50 AM" src="https://github.com/apache/superset/assets/1392866/0d2d7974-e85e-48d0-bbe8-f02c41d2421c">


Before: (>5000ms)
<img width="756" alt="Screenshot 2023-05-19 at 11 18 14 AM" src="https://github.com/apache/superset/assets/1392866/594f793f-f8f9-4fb0-91a9-f9ebe5e7873b">

### TESTING INSTRUCTIONS
select a large size table option schema
click the table dropdown and then measure the delay

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
