### PR TITLE
fix: Ensure "Import Dashboard" menu item adheres to PVM

### DIFF
--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -116,6 +116,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         # the global Flask app
         #
         # pylint: disable=import-outside-toplevel,too-many-locals,too-many-statements
+        from superset import security_manager
         from superset.advanced_data_type.api import AdvancedDataTypeRestApi
         from superset.annotation_layers.annotations.api import AnnotationRestApi
         from superset.annotation_layers.api import AnnotationLayerRestApi
@@ -334,10 +335,12 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
             category="Manage",
             category_label=__("Manage"),
             category_icon="fa-wrench",
-            cond=lambda: not feature_flag_manager.is_feature_enabled(
-                "VERSIONED_EXPORT"
+            cond=lambda: (
+                security_manager.can_access("can_import_dashboards", "Superset")
+                and not feature_flag_manager.is_feature_enabled("VERSIONED_EXPORT")
             ),
         )
+
         appbuilder.add_link(
             "SQL Editor",
             label=__("SQL Lab"),


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR partially addresses Superset 3.0 task [#36](https://github.com/orgs/apache/projects/201/views/1?filterQuery=version&pane=issue&itemId=26124635). The "Import Dashboard" menu item should adhere to the PVM and only render if the current user has the `can import dashboards`/`Superset` permission/view menu. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### WITH PERMISSION

<img width="196" alt="Screenshot 2023-05-19 at 1 24 05 PM" src="https://github.com/apache/superset/assets/4567245/92856fb3-df37-42c7-9c95-d78a2f2e1512">

##### WITHOUT PERMISSION

<img width="173" alt="Screenshot 2023-05-19 at 1 32 49 PM" src="https://github.com/apache/superset/assets/4567245/be3e4535-e5ba-4eb2-a5ce-09b3e627bdc0">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
