### PR TITLE
chore: bump postgresql in docker-compose and github workflows

### DIFF
--- a/.github/workflows/superset-applitool-cypress.yml
+++ b/.github/workflows/superset-applitool-cypress.yml
@@ -40,7 +40,7 @@ jobs:
       APPLITOOLS_BATCH_NAME: Superset Cypress
     services:
       postgres:
-        image: postgres:14-alpine
+        image: postgres:15-alpine
         env:
           POSTGRES_USER: superset
           POSTGRES_PASSWORD: superset

--- a/.github/workflows/superset-cli.yml
+++ b/.github/workflows/superset-cli.yml
@@ -21,7 +21,7 @@ jobs:
       SUPERSET__SQLALCHEMY_DATABASE_URI: postgresql+psycopg2://superset:superset@127.0.0.1:15432/superset
     services:
       postgres:
-        image: postgres:14-alpine
+        image: postgres:15-alpine
         env:
           POSTGRES_USER: superset
           POSTGRES_PASSWORD: superset

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -34,7 +34,7 @@ jobs:
       GITHUB_TOKEN: ${{ github.token }}
     services:
       postgres:
-        image: postgres:14-alpine
+        image: postgres:15-alpine
         env:
           POSTGRES_USER: superset
           POSTGRES_PASSWORD: superset

--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -88,7 +88,7 @@ jobs:
       SUPERSET__SQLALCHEMY_DATABASE_URI: postgresql+psycopg2://superset:superset@127.0.0.1:15432/superset
     services:
       postgres:
-        image: postgres:14-alpine
+        image: postgres:15-alpine
         env:
           POSTGRES_USER: superset
           POSTGRES_PASSWORD: superset

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -23,7 +23,7 @@ jobs:
       SUPERSET__SQLALCHEMY_EXAMPLES_URI: presto://localhost:15433/memory/default
     services:
       postgres:
-        image: postgres:14-alpine
+        image: postgres:15-alpine
         env:
           POSTGRES_USER: superset
           POSTGRES_PASSWORD: superset
@@ -101,7 +101,7 @@ jobs:
       UPLOAD_FOLDER: /tmp/.superset/uploads/
     services:
       postgres:
-        image: postgres:14-alpine
+        image: postgres:15-alpine
         env:
           POSTGRES_USER: superset
           POSTGRES_PASSWORD: superset

--- a/docker-compose-non-dev.yml
+++ b/docker-compose-non-dev.yml
@@ -34,7 +34,7 @@ services:
 
   db:
     env_file: docker/.env-non-dev
-    image: postgres:14
+    image: postgres:15
     container_name: superset_db
     restart: unless-stopped
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
 
   db:
     env_file: docker/.env
-    image: postgres:14
+    image: postgres:15
     container_name: superset_db
     restart: unless-stopped
     ports:

--- a/docs/docs/installation/configuring-superset.mdx
+++ b/docs/docs/installation/configuring-superset.mdx
@@ -103,10 +103,10 @@ database engine on a separate host or container.
 
 Superset supports the following database engines/versions:
 
-| Database Engine                                           | Supported Versions                |
-| --------------------------------------------------------- | --------------------------------- |
-| [PostgreSQL](https://www.postgresql.org/)                 | 10.X, 11.X, 12.X, 13.X, 14.X      |
-| [MySQL](https://www.mysql.com/)                           | 5.X                               |
+| Database Engine                                           | Supported Versions                 |
+| --------------------------------------------------------- | ---------------------------------- |
+| [PostgreSQL](https://www.postgresql.org/)                 | 10.X, 11.X, 12.X, 13.X, 14.X, 15.X |
+| [MySQL](https://www.mysql.com/)                           | 5.X                                |
 
 
 Use the following database drivers and connection strings:


### PR DESCRIPTION
### SUMMARY

This PR bumps to postgresql:15 image version in Dockerfile and GH workflows.

---

Postgres 15.0 change log: https://www.postgresql.org/docs/release/15.0/

From Postgres release [news](https://www.postgresql.org/about/news/postgresql-15-released-2526/): 
> In this latest release, PostgreSQL improves on its in-memory and on-disk [sorting](https://www.postgresql.org/docs/15/queries-order.html) algorithms, with benchmarks showing speedups of 25% - 400% based on which data types are sorted. Using row_number(), rank(), dense_rank(), and count() as [window functions](https://www.postgresql.org/docs/15/functions-window.html) also have performance benefits in PostgreSQL 15. Queries using [SELECT DISTINCT](https://www.postgresql.org/docs/15/queries-select-lists.html#QUERIES-DISTINCT) can now be [executed in parallel](https://www.postgresql.org/docs/15/parallel-query.html).

---

**Note**: The Helm Chart already uses PostgreSQL 15 as introduced in https://github.com/apache/superset/pull/22590. Version >=12 uses postgres 15.X. See https://github.com/bitnami/charts/tree/main/bitnami/postgresql/#to-1200

### TESTING INSTRUCTIONS
`./scripts/tests/run.sh` and all CI jobs run successfully

