### PR TITLE
fix(permalink): parsing urlParams as well

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1959,7 +1959,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         dashboard_id, state = value["dashboardId"], value.get("state", {})
         url = f"/superset/dashboard/{dashboard_id}?permalink_key={key}"
         if url_params := state.get("urlParams"):
-            params = parse.urlencode(url_params)
+            params = parse.urlencode(dict(url_params))
             url = f"{url}&{params}"
         hash_ = state.get("anchor", state.get("hash"))
         if hash_:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
When reading urlParams from a permalink, an error occurs because the `urlencode` function expects a dictionary, but urlParams is a 2D array. To resolve this, we simply need to use `dict(urlParams)` and it will work correctly.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
