### PR TITLE
feat: add connector for QuestDB timeseries database

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -90,6 +90,7 @@ assists people when migrating to a new version.
 - [22798](https://github.com/apache/superset/pull/22798): To make the welcome page more relevant in production environments, the last tab on the welcome page has been changed from to feature all charts/dashboards the user has access to (previously only examples were shown). To keep current behavior unchanged, add the following to your `superset_config.py`: `WELCOME_PAGE_LAST_TAB = "examples"`
 - [22328](https://github.com/apache/superset/pull/22328): For deployments that have enabled the "THUMBNAILS" feature flag, the function that calculates dashboard digests has been updated to consider additional properties to more accurately identify changes in the dashboard metadata. This change will invalidate all currently cached dashboard thumbnails.
 - [21765](https://github.com/apache/superset/pull/21765): For deployments that have enabled the "ALERT_REPORTS" feature flag, Gamma users will no longer have read and write access to Alerts & Reports by default. To give Gamma users the ability to schedule reports from the Dashboard and Explore view like before, create an additional role with "can read on ReportSchedule" and "can write on ReportSchedule" permissions. To further give Gamma users access to the "Alerts & Reports" menu and CRUD view, add "menu access on Manage" and "menu access on Alerts & Report" permissions to the role.
+- [24172](https://github.com/apache/superset/pull/24172) Add connector for QuestDB timeseries database (@marregui)
 
 ### Potential Downtime
 

--- a/docs/docs/databases/questdb.mdx
+++ b/docs/docs/databases/questdb.mdx
@@ -1,0 +1,32 @@
+---
+title: QuestDB
+hide_title: true
+sidebar_position: 27
+version: 1
+---
+
+## QuestDB
+
+To use **QuestDB** with **Superset** add this Python module:
+
+```text
+questdb-connect>=1.0.8
+```
+
+When running Superset with `docker-compose`, add the above dependency to
+your `./docker/requirements-local.txt` file.
+
+## Connection string
+
+The connection string is as follows:
+
+```text
+questdb://<user>:<password>@<host>:<port>/<database>
+```
+
+examples:
+
+```
+questdb://admin:quest@localhost:8812/main
+questdb://admin:quest@host.docker.internal:8812/main (when running in docker)
+```

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -120,6 +120,7 @@ pytest-mock==3.10.0
     # via -r requirements/testing.in
 pytz-deprecation-shim==0.1.0.post0
     # via tzlocal
+questdb-connect==1.0.8
 requests-oauthlib==1.3.1
     # via google-auth-oauthlib
 rfc3339-validator==0.1.4

--- a/setup.py
+++ b/setup.py
@@ -138,6 +138,7 @@ setup(
             "google-cloud-bigquery>=3.10.0",
         ],
         "clickhouse": ["clickhouse-connect>=0.5.14, <1.0"],
+        "questdb": ["questdb-connect>=1.0.8"],
         "cockroachdb": ["cockroachdb>=0.3.5, <0.4"],
         "cors": ["flask-cors>=2.0.0"],
         "crate": ["crate[sqlalchemy]>=0.26.0, <0.27"],

--- a/superset/db_engine_specs/questdb.py
+++ b/superset/db_engine_specs/questdb.py
@@ -1,0 +1,339 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import Any
+
+import questdb_connect.types as qdbc_types
+from flask_babel import gettext as __
+from marshmallow import fields, Schema
+from questdb_connect.common import remove_public_schema
+from sqlalchemy.engine.base import Engine
+from sqlalchemy.engine.reflection import Inspector
+from sqlalchemy.sql.expression import text, TextClause
+from sqlalchemy.types import TypeEngine
+
+from superset.db_engine_specs.base import (
+    BaseEngineSpec,
+    BasicParametersMixin,
+    BasicParametersType,
+)
+from superset.models.core import Database
+from superset.models.sql_lab import Query
+from superset.utils import core as utils
+from superset.utils.core import GenericDataType
+
+
+class QuestDbParametersSchema(Schema):
+    username = fields.String(
+        description=__("user"),
+        dump_default="admin",
+        load_default="admin",
+    )
+    password = fields.String(
+        description=__("password"),
+        dump_default="quest",
+        load_default="quest",
+    )
+    host = fields.String(
+        description=__("host"),
+        dump_default="host.docker.internal",
+        load_default="host.docker.internal",
+    )
+    port = fields.Integer(
+        description=__("port"),
+        dump_default="8812",
+        load_default="8812",
+    )
+    database = fields.String(
+        description=__("database"),
+        dump_default="main",
+        load_default="main",
+    )
+
+
+class QuestDbEngineSpec(BaseEngineSpec, BasicParametersMixin):
+    engine = "questdb"
+    engine_name = "QuestDB"
+    default_driver = "psycopg2"
+    encryption_parameters = {"sslmode": "prefer"}
+    sqlalchemy_uri_placeholder = "questdb://user:password@host:port/database"
+    parameters_schema = QuestDbParametersSchema()
+    time_groupby_inline = False
+    allows_hidden_cc_in_orderby = True
+    time_secondary_columns = True
+    try_remove_schema_from_table_name = True
+    max_column_name_length = 120
+    supports_dynamic_schema = False
+    top_keywords: set[str] = set({})
+    # https://en.wikipedia.org/wiki/ISO_8601#Durations
+    # https://questdb.io/docs/reference/function/date-time/#date_trunc
+    _time_grain_expressions = {
+        None: "{col}",
+        "PT1S": "DATE_TRUNC('second', {col})",
+        "PT1M": "DATE_TRUNC('minute', {col})",
+        "PT1H": "DATE_TRUNC('hour', {col})",
+        "P1D": "DATE_TRUNC('day', {col})",
+        "P1W": "DATE_TRUNC('week', {col})",
+        "P1M": "DATE_TRUNC('month', {col})",
+        "P1Y": "DATE_TRUNC('year', {col})",
+        "P3M": "DATE_TRUNC('quarter', {col})",
+    }
+    column_type_mappings = (
+        (
+            re.compile("^LONG256", re.IGNORECASE),
+            qdbc_types.Long256,
+            GenericDataType.STRING,
+        ),
+        (
+            re.compile("^BOOLEAN", re.IGNORECASE),
+            qdbc_types.Boolean,
+            GenericDataType.BOOLEAN,
+        ),
+        (
+            re.compile("^BYTE", re.IGNORECASE),
+            qdbc_types.Byte,
+            GenericDataType.NUMERIC,
+        ),
+        (
+            re.compile("^SHORT", re.IGNORECASE),
+            qdbc_types.Short,
+            GenericDataType.NUMERIC,
+        ),
+        (re.compile("^INT", re.IGNORECASE), qdbc_types.Int, GenericDataType.NUMERIC),
+        (
+            re.compile("^LONG", re.IGNORECASE),
+            qdbc_types.Long,
+            GenericDataType.NUMERIC,
+        ),
+        (
+            re.compile("^FLOAT", re.IGNORECASE),
+            qdbc_types.Float,
+            GenericDataType.NUMERIC,
+        ),
+        (
+            re.compile("^DOUBLE'", re.IGNORECASE),
+            qdbc_types.Double,
+            GenericDataType.NUMERIC,
+        ),
+        (
+            re.compile("^SYMBOL", re.IGNORECASE),
+            qdbc_types.Symbol,
+            GenericDataType.STRING,
+        ),
+        (
+            re.compile("^STRING", re.IGNORECASE),
+            qdbc_types.String,
+            GenericDataType.STRING,
+        ),
+        (
+            re.compile("^UUID", re.IGNORECASE),
+            qdbc_types.UUID,
+            GenericDataType.STRING,
+        ),
+        (
+            re.compile("^CHAR", re.IGNORECASE),
+            qdbc_types.Char,
+            GenericDataType.STRING,
+        ),
+        (
+            re.compile("^TIMESTAMP", re.IGNORECASE),
+            qdbc_types.Timestamp,
+            GenericDataType.TEMPORAL,
+        ),
+        (
+            re.compile("^DATE", re.IGNORECASE),
+            qdbc_types.Date,
+            GenericDataType.TEMPORAL,
+        ),
+        (
+            re.compile(r"^GEOHASH\(\d+[b|c]\)", re.IGNORECASE),
+            qdbc_types.GeohashLong,
+            GenericDataType.STRING,
+        ),
+    )
+
+    @classmethod
+    def build_sqlalchemy_uri(
+        cls,
+        parameters: BasicParametersType,
+        encrypted_extra: dict[str, str] | None = None,
+    ) -> str:
+        host = parameters.get("host")
+        port = parameters.get("port")
+        username = parameters.get("username")
+        password = parameters.get("password")
+        database = parameters.get("database")
+        return f"questdb://{username}:{password}@{host}:{port}/{database}"
+
+    @classmethod
+    def get_default_schema_for_query(
+        cls,
+        database: Database,
+        query: Query,
+    ) -> str | None:
+        """Return the default schema for a given query."""
+        return None
+
+    @classmethod
+    def epoch_to_dttm(cls) -> str:
+        """SQL expression that converts epoch (seconds) to datetime that can be used
+        in a query. The reference column should be denoted as `{col}` in the return
+        expression, e.g. "FROM_UNIXTIME({col})"
+        :return: SQL Expression
+        """
+        return "{col} * 1000000"
+
+    @classmethod
+    def convert_dttm(
+        cls, target_type: str, dttm: datetime, db_extra: dict[str, Any] | None = None
+    ) -> str | None:
+        """Convert a Python `datetime` object to a SQL expression.
+        :param target_type: The target type of expression
+        :param dttm: The datetime object
+        :return: The SQL expression
+        """
+        type_u = target_type.upper()
+        if type_u == "DATE":
+            return f"TO_DATE('{dttm.date().isoformat()}', 'YYYY-MM-DD')"
+        if type_u in ("DATETIME", "TIMESTAMP"):
+            dttm_formatted = dttm.isoformat(sep="T", timespec="microseconds")
+            return f"TO_TIMESTAMP('{dttm_formatted}', 'yyyy-MM-ddTHH:mm:ss.SSSUUUZ')"
+        return None
+
+    @classmethod
+    def get_datatype(cls, type_code: Any) -> str | None:
+        """Change column type code from cursor description to string representation.
+        :param type_code: Type code from cursor description
+        :return: String representation of type code
+        """
+        if type_code and isinstance(type_code, str):
+            return type_code.upper()
+        return str(type_code)
+
+    @classmethod
+    def get_column_spec(
+        cls,
+        native_type: str | None,
+        db_extra: dict[str, Any] | None = None,
+        source: utils.ColumnTypeSource = utils.ColumnTypeSource.GET_TABLE,
+    ) -> utils.ColumnSpec | None:
+        """Get generic type related specs regarding a native column type.
+        :param native_type: Native database type
+        :param db_extra: The database extra object
+        :param source: Type coming from the database table or cursor description
+        :return: ColumnSpec object
+        """
+        sqla_type = qdbc_types.resolve_type_from_name(native_type)
+        if not sqla_type:
+            return BaseEngineSpec.get_column_spec(native_type, db_extra, source)
+        name_u = sqla_type.__visit_name__
+        generic_type = GenericDataType.STRING
+        if name_u == "BOOLEAN":
+            generic_type = GenericDataType.BOOLEAN
+        elif name_u in ("BYTE", "SHORT", "INT", "LONG", "FLOAT", "DOUBLE"):
+            generic_type = GenericDataType.NUMERIC
+        elif name_u in ("SYMBOL", "STRING", "CHAR", "LONG256", "UUID"):
+            generic_type = GenericDataType.STRING
+        elif name_u in ("DATE", "TIMESTAMP"):
+            generic_type = GenericDataType.TEMPORAL
+        elif "GEOHASH" in name_u and "(" in name_u and ")" in name_u:
+            generic_type = GenericDataType.STRING
+        return utils.ColumnSpec(
+            sqla_type,
+            generic_type,
+            generic_type == GenericDataType.TEMPORAL,
+        )
+
+    @classmethod
+    def get_sqla_column_type(
+        cls,
+        native_type: str | None,
+        db_extra: dict[str, Any] | None = None,
+        source: utils.ColumnTypeSource = utils.ColumnTypeSource.GET_TABLE,
+    ) -> TypeEngine | None:
+        """Converts native database type to sqlalchemy column type.
+        :param native_type: Native database type
+        :param db_extra: The database extra object
+        :param source: Type coming from the database table or cursor description
+        :return: ColumnSpec object
+        """
+        return qdbc_types.resolve_type_from_name(native_type).impl
+
+    @classmethod
+    def select_star(  # pylint: disable=too-many-arguments
+        cls,
+        database: Database,
+        table_name: str,
+        engine: Engine,
+        schema: str | None = None,
+        limit: int = 100,
+        show_cols: bool = False,
+        indent: bool = True,
+        latest_partition: bool = True,
+        cols: list[dict[str, Any]] | None = None,
+    ) -> str:
+        """Generate a "SELECT * from table_name" query with appropriate limit.
+        :param database: Database instance
+        :param table_name: Table name, unquoted
+        :param engine: SqlAlchemy Engine instance
+        :param schema: Schema, unquoted
+        :param limit: limit to impose on query
+        :param show_cols: Show columns in query; otherwise use "*"
+        :param indent: Add indentation to query
+        :param latest_partition: Only query the latest partition
+        :param cols: Columns to include in query
+        :return: SQL query
+        """
+        return super().select_star(
+            database,
+            table_name,
+            engine,
+            None,
+            limit,
+            show_cols,
+            indent,
+            latest_partition,
+            cols,
+        )
+
+    @classmethod
+    def get_allow_cost_estimate(cls, extra: dict[str, Any]) -> bool:
+        return False
+
+    @classmethod
+    def get_view_names(
+        cls,
+        database: Database,
+        inspector: Inspector,
+        schema: str | None,
+    ) -> set[str]:
+        return set()
+
+    @classmethod
+    def get_text_clause(cls, clause: str) -> TextClause:
+        """
+        SQLAlchemy wrapper to ensure text clauses are escaped properly
+
+        :param clause: string clause with potentially unescaped characters
+        :return: text clause with escaped characters
+        """
+        if cls.allows_escaped_colons:
+            clause = clause.replace(":", "\\:")
+        return text(remove_public_schema(clause))

--- a/tests/integration_tests/db_engine_specs/questdb_tests.py
+++ b/tests/integration_tests/db_engine_specs/questdb_tests.py
@@ -1,0 +1,148 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+from unittest import mock
+
+from sqlalchemy import column, literal_column
+from sqlalchemy.dialects import postgresql
+
+from superset.db_engine_specs import load_engine_specs
+from superset.db_engine_specs.questdb import QuestDbEngineSpec
+from tests.integration_tests.db_engine_specs.base_tests import TestDbEngineSpec
+
+
+class TestQuestDbEngineSpec(TestDbEngineSpec):
+    def test_get_table_names(self):
+        """
+        DB Eng Specs (QuestDB): Test get table names
+        """
+        inspector = mock.Mock()
+        inspector.get_table_names = mock.Mock(
+            return_value=["public.table", "table_2", '"public.table_3"']
+        )
+        pg_result = QuestDbEngineSpec.get_table_names(
+            database=mock.ANY, schema="public", inspector=inspector
+        )
+        self.assertEqual(pg_result, {"table", '"public.table_3"', "table_2"})
+
+    def test_time_exp_literal_no_grain(self):
+        """
+        DB Eng Specs (QuestDB): Test no grain literal column
+        """
+        col = literal_column("COALESCE(a, b)")
+        expr = QuestDbEngineSpec.get_timestamp_expr(col, None, None)
+        result = str(expr.compile(None, dialect=postgresql.dialect()))
+        self.assertEqual(result, "COALESCE(a, b)")
+
+    def test_time_exp_literal_1y_grain(self):
+        """
+        DB Eng Specs (QuestDB): Test grain literal column 1 YEAR
+        """
+        col = literal_column("COALESCE(a, b)")
+        expr = QuestDbEngineSpec.get_timestamp_expr(col, None, "P1Y")
+        result = str(expr.compile(None, dialect=postgresql.dialect()))
+        self.assertEqual(result, "DATE_TRUNC('year', COALESCE(a, b))")
+
+    def test_time_ex_lowr_col_no_grain(self):
+        """
+        DB Eng Specs (QuestDB): Test no grain expr lower case
+        """
+        col = column("lower_case")
+        expr = QuestDbEngineSpec.get_timestamp_expr(col, None, None)
+        result = str(expr.compile(None, dialect=postgresql.dialect()))
+        self.assertEqual(result, "lower_case")
+
+    def test_time_exp_lowr_col_sec_1y(self):
+        """
+        DB Eng Specs (QuestDB): Test grain expr lower case 1 YEAR
+        """
+        col = column("lower_case")
+        expr = QuestDbEngineSpec.get_timestamp_expr(col, "epoch_s", "P1Y")
+        result = str(expr.compile(None, dialect=postgresql.dialect()))
+        self.assertEqual(
+            result,
+            "DATE_TRUNC('year', lower_case * 1000000)",
+        )
+
+    def test_time_exp_mixd_case_col_1y(self):
+        """
+        DB Eng Specs (QuestDB): Test grain expr mixed case 1 YEAR
+        """
+        col = column("MixedCase")
+        expr = QuestDbEngineSpec.get_timestamp_expr(col, None, "P1Y")
+        result = str(expr.compile(None, dialect=postgresql.dialect()))
+        self.assertEqual(result, "DATE_TRUNC('year', \"MixedCase\")")
+
+    def test_engine_alias_name(self):
+        """
+        DB Eng Specs (QuestDB): Test "QuestDB" in engine spec
+        """
+        backends = set()
+        for engine in load_engine_specs():
+            backends.add(engine.engine)
+            backends.update(engine.engine_aliases)
+        self.assertTrue("questdb" in backends)
+
+
+def test_base_parameters_mixin():
+    sqlalchemy_uri = QuestDbEngineSpec.build_sqlalchemy_uri(
+        {
+            "username": "admin",
+            "password": "quest",
+            "host": "localhost",
+            "port": 8812,
+            "database": "main",
+        }
+    )
+    assert sqlalchemy_uri == "questdb://admin:quest@localhost:8812/main"
+
+    assert QuestDbEngineSpec.get_parameters_from_uri(sqlalchemy_uri) == {
+        "database": "main",
+        "encryption": False,
+        "host": "localhost",
+        "password": "quest",
+        "port": 8812,
+        "query": {},
+        "username": "admin",
+    }
+
+    assert QuestDbEngineSpec.parameters_json_schema() == {
+        "properties": {
+            "database": {
+                "default": "main",
+                "description": "database",
+                "type": "string",
+            },
+            "host": {
+                "default": "host.docker.internal",
+                "description": "host",
+                "type": "string",
+            },
+            "password": {
+                "default": "quest",
+                "description": "password",
+                "type": "string",
+            },
+            "port": {
+                "default": 8812,
+                "description": "port",
+                "format": "int32",
+                "type": "integer",
+            },
+            "username": {"default": "admin", "description": "user", "type": "string"},
+        },
+        "type": "object",
+    }

--- a/tests/unit_tests/db_engine_specs/test_questdb.py
+++ b/tests/unit_tests/db_engine_specs/test_questdb.py
@@ -1,0 +1,113 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import datetime
+
+import pytest
+from questdb_connect.types import QUESTDB_TYPES, Timestamp
+from sqlalchemy.types import TypeEngine
+
+from superset.db_engine_specs.questdb import QuestDbEngineSpec
+
+
+def test_build_sqlalchemy_uri():
+    request_uri = QuestDbEngineSpec.build_sqlalchemy_uri(
+        {
+            "host": "localhost",
+            "port": "8812",
+            "username": "admin",
+            "password": "quest",
+            "database": "main",
+        }
+    )
+    assert request_uri == "questdb://admin:quest@localhost:8812/main"
+
+
+def test_default_schema_for_query():
+    assert QuestDbEngineSpec.get_default_schema_for_query("main", None) == None
+
+
+def test_get_text_clause():
+    sql_clause = "SELECT * FROM public.mytable t1"
+    sql_clause += " JOIN public.myclient t2 ON t1.id = t2.id"
+    expected_clause = "SELECT * FROM mytable t1 JOIN myclient t2 ON t1.id = t2.id"
+    actual_clause = str(QuestDbEngineSpec.get_text_clause(sql_clause))
+    print(f"sql: {sql_clause}, ex: {expected_clause}, ac: {actual_clause}")
+    assert expected_clause == actual_clause
+
+
+def test_epoch_to_dttm():
+    assert QuestDbEngineSpec.epoch_to_dttm() == "{col} * 1000000"
+
+
+@pytest.mark.parametrize(
+    ("target_type", "expected_result", "dttm"),
+    [
+        (
+            "Date",
+            "TO_DATE('2023-04-28', 'YYYY-MM-DD')",
+            datetime.datetime(2023, 4, 28, 23, 55, 59, 281567),
+        ),
+        (
+            "DateTime",
+            "TO_TIMESTAMP('2023-04-28T23:55:59.281567', 'yyyy-MM-ddTHH:mm:ss.SSSUUUZ')",
+            datetime.datetime(2023, 4, 28, 23, 55, 59, 281567),
+        ),
+        (
+            "TimeStamp",
+            "TO_TIMESTAMP('2023-04-28T23:55:59.281567', 'yyyy-MM-ddTHH:mm:ss.SSSUUUZ')",
+            datetime.datetime(2023, 4, 28, 23, 55, 59, 281567),
+        ),
+        ("UnknownType", None, datetime.datetime(2023, 4, 28, 23, 55, 59, 281567)),
+    ],
+)
+def test_convert_dttm(target_type, expected_result, dttm) -> None:
+    # datetime(year, month, day, hour, minute, second, microsecond)
+    for target in (
+        target_type,
+        target_type.upper(),
+        target_type.lower(),
+        target_type.capitalize(),
+    ):
+        assert expected_result == QuestDbEngineSpec.convert_dttm(
+            target_type=target, dttm=dttm
+        )
+
+
+def test_get_datatype():
+    assert QuestDbEngineSpec.get_datatype("int") == "INT"
+    assert QuestDbEngineSpec.get_datatype(["int"]) == "['int']"
+
+
+def test_get_column_spec():
+    for native_type in QUESTDB_TYPES:
+        column_spec = QuestDbEngineSpec.get_column_spec(native_type.__visit_name__)
+        assert native_type == column_spec.sqla_type
+        assert native_type != Timestamp or column_spec.is_dttm
+
+
+def test_get_sqla_column_type():
+    for native_type in QUESTDB_TYPES:
+        column_type = QuestDbEngineSpec.get_sqla_column_type(native_type.__visit_name__)
+        assert isinstance(column_type, TypeEngine.__class__)
+
+
+def test_get_allow_cost_estimate():
+    assert not QuestDbEngineSpec.get_allow_cost_estimate(extra=None)
+
+
+def test_get_view_names():
+    assert set() == QuestDbEngineSpec.get_view_names("main", None, None)


### PR DESCRIPTION
This PR adds an Engine Spec for [QuestDB](https://github.com/questdb/questdb) a timeseries database.

The original Spec resides within module [questdb-connect](https://github.com/questdb/questdb-connect) and has been tested against Apache Superset 2.0 by the following means:

- clone this repo
- configure a secret key
- create file `docker/requirements-local.txt` with content
   ```shell
   questdb-connect>=1.0.8
   ```
- docker-compose up
- then I start a QuestDB instance [https://questdb.io/docs/](https://questdb.io/docs/)
- and I can reach it and play with it through URL `questdb://admin:quest@host.docker.internal:8812/main` defined as an OTHER connection

With this PR we would like to migrate the Engine Spec from the `questdb-connect` repo to `superset's`, as well as to enable a drop down from superset's UI so that users can select QUESTDB rightaway rather than configuring the connection through OTHER.