### PR TITLE
fix(explore): rendering regression on standalone

### DIFF
--- a/superset-frontend/src/explore/components/ExploreChartPanel/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel/index.jsx
@@ -418,7 +418,11 @@ const ExploreChartPanel = ({
     if (!bodyClasses.includes(standaloneClass)) {
       document.body.className += ` ${standaloneClass}`;
     }
-    return standaloneChartBody;
+    return (
+      <div id="app" data-test="standalone-app" ref={resizeObserverRef}>
+        {standaloneChartBody}
+      </div>
+    );
   }
 
   return (

--- a/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
@@ -97,14 +97,19 @@ fetchMock.get('glob:*/api/v1/explore/form_data*', {});
 fetchMock.get('glob:*/api/v1/chart/favorite_status*', {
   result: [{ value: true }],
 });
+fetchMock.get('glob:*/api/v1/chart/*', {
+  result: {},
+});
 
 const defaultPath = '/explore/';
 const renderWithRouter = ({
   search = '',
   overridePathname,
+  initialState = reduxState,
 }: {
   search?: string;
   overridePathname?: string;
+  initialState?: object;
 } = {}) => {
   const path = overridePathname ?? defaultPath;
   Object.defineProperty(window, 'location', {
@@ -118,7 +123,7 @@ const renderWithRouter = ({
         <ExploreViewContainer />
       </Route>
     </MemoryRouter>,
-    { useRedux: true, initialState: reduxState },
+    { useRedux: true, initialState },
   );
 };
 
@@ -144,6 +149,16 @@ test('generates a new form_data param when none is available', async () => {
     expect.stringMatching('datasource_id'),
   );
   replaceState.mockRestore();
+});
+
+test('renders chart in standalone mode', () => {
+  const { queryByTestId } = renderWithRouter({
+    initialState: {
+      ...reduxState,
+      explore: { ...reduxState.explore, standalone: true },
+    },
+  });
+  expect(queryByTestId('standalone-app')).toBeTruthy();
 });
 
 test('generates a different form_data param when one is provided and is mounting', async () => {


### PR DESCRIPTION
### SUMMARY
This commit fixes the rendering regression in standalone mode(and reports) by [#23778](https://github.com/apache/superset/pull/23778)
The issue is the standalone renders the chart container only so there's no observeRef exists to initialize the chart size.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After:
(Render a chart in a standalone)

Before:
(Empty screen)

### TESTING INSTRUCTIONS
Go to any chart explore link
Add `&standalone=true` parameter at the end

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
