### PR TITLE
fix(plugin-chart-echarts): force min y-tick for log axis with zero

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -247,7 +247,7 @@ export function extractSeries(
     xAxisSortSeries?: SortSeriesType;
     xAxisSortSeriesAscending?: boolean;
   } = {},
-): [SeriesOption[], number[]] {
+): [SeriesOption[], number[], number | undefined] {
   const {
     fillNeighborValue,
     xAxis = DTTM_ALIAS,
@@ -261,7 +261,7 @@ export function extractSeries(
     xAxisSortSeries,
     xAxisSortSeriesAscending,
   } = opts;
-  if (data.length === 0) return [[], []];
+  if (data.length === 0) return [[], [], undefined];
   const rows: DataRecord[] = data.map(datum => ({
     ...datum,
     [xAxis]: datum[xAxis],
@@ -287,18 +287,27 @@ export function extractSeries(
           totalStackedValue: totalStackedValues[idx],
         }));
 
+  let minPositiveValue: number | undefined;
   const finalSeries = sortedSeries.map(name => ({
     id: name,
     name,
     data: sortedRows
       .map(({ row, totalStackedValue }, idx) => {
+        const currentValue = row[name];
+        if (
+          typeof currentValue === 'number' &&
+          currentValue > 0 &&
+          (minPositiveValue === undefined || minPositiveValue > currentValue)
+        ) {
+          minPositiveValue = currentValue;
+        }
         const isNextToDefinedValue =
           isDefined(rows[idx - 1]?.[name]) || isDefined(rows[idx + 1]?.[name]);
         const isFillNeighborValue =
-          !isDefined(row[name]) &&
+          !isDefined(currentValue) &&
           isNextToDefinedValue &&
           fillNeighborValue !== undefined;
-        let value: DataRecordValue | undefined = row[name];
+        let value: DataRecordValue | undefined = currentValue;
         if (isFillNeighborValue) {
           value = fillNeighborValue;
         } else if (
@@ -315,6 +324,7 @@ export function extractSeries(
   return [
     finalSeries,
     sortedRows.map(({ totalStackedValue }) => totalStackedValue),
+    minPositiveValue,
   ];
 }
 
@@ -517,4 +527,9 @@ export function getOverMaxHiddenFormatter(
       }`,
     id: NumberFormats.OVER_MAX_HIDDEN,
   });
+}
+
+export function calculateLowerLogTick(minPositiveValue: number) {
+  const logBase10 = Math.floor(Math.log10(minPositiveValue));
+  return Math.pow(10, logBase10);
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -25,6 +25,7 @@ import {
   supersetTheme as theme,
 } from '@superset-ui/core';
 import {
+  calculateLowerLogTick,
   dedupSeries,
   extractGroupbyLabel,
   extractSeries,
@@ -321,6 +322,7 @@ describe('extractSeries', () => {
         },
       ],
       totalStackedValues,
+      1,
     ]);
   });
 
@@ -366,6 +368,7 @@ describe('extractSeries', () => {
         },
       ],
       totalStackedValues,
+      1,
     ]);
   });
 
@@ -435,6 +438,7 @@ describe('extractSeries', () => {
         },
       ],
       totalStackedValues,
+      1,
     ]);
   });
 });
@@ -856,4 +860,13 @@ describe('getOverMaxHiddenFormatter', () => {
     expect(formatter.format(81000)).toEqual('81000');
     expect(formatter.format(50000)).toEqual('50000');
   });
+});
+
+test('calculateLowerLogTick', () => {
+  expect(calculateLowerLogTick(1000000)).toEqual(1000000);
+  expect(calculateLowerLogTick(456)).toEqual(100);
+  expect(calculateLowerLogTick(100)).toEqual(100);
+  expect(calculateLowerLogTick(99)).toEqual(10);
+  expect(calculateLowerLogTick(2)).toEqual(1);
+  expect(calculateLowerLogTick(0.005)).toEqual(0.001);
 });


### PR DESCRIPTION
### SUMMARY
When choosing "Log axis" for a set of series that contain zero values, the y-axis is fixed to the interval 1-10, despite values being in excess of 10. To get around this limitation, we calculate the best lower bound for the chart by recording the lowest positive series value on the chart and set the minimum based on that if undefined. This appears to be how Google Sheets does it; the resulting chart in GS is very similar to the one that this solution produces. Note, that if the user wishes to specify a custom lower bound, that will be used.

### AFTER
For a series with the lowest defined value at approx. 400, the lower tick mark is set to 100:
![image](https://github.com/apache/superset/assets/33317356/ca600117-e2ea-4f26-a61c-2826e5db4ac2)
If a min bound is specified, the calculated lower bound is not used:
![image](https://github.com/apache/superset/assets/33317356/f82da012-dff7-4184-a0ea-b1594a559277)

### BEFORE
Previously, the y-axis would be fixed to 1-10:
![image](https://github.com/apache/superset/assets/33317356/25ae77c4-a4d3-4b13-a1d1-e847d70ae582)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
