### PR TITLE
chore: remove user registrations menu for non-admins

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -34,6 +34,7 @@ assists people when migrating to a new version.
 
 ### Breaking Changes
 
+- [24198](https://github.com/apache/superset/pull/24198) The FAB views `User Registrations` and `User's Statistics` have been changed to Admin only. To re-enable them for non-admin users, please add the following perms to your custom role: `menu access on User's Statistics` and `menu access on User Registrations`.
 - [24354](https://github.com/apache/superset/pull/24354): Removed deprecated APIs `/superset/testconn`, `/superset/validate_sql_json/`, `/superset/schemas_access_for_file_upload`, `/superset/extra_table_metadata`
 - [24381](https://github.com/apache/superset/pull/24381): Removed deprecated API `/superset/available_domains/`
 - [24359](https://github.com/apache/superset/pull/24359): Removed deprecated APIs `/superset/estimate_query_cost/..`, `/superset/results/..`, `/superset/sql_json/..`, `/superset/csv/..`

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -88,7 +88,7 @@ flask==2.2.5
     #   flask-migrate
     #   flask-sqlalchemy
     #   flask-wtf
-flask-appbuilder==4.3.0
+flask-appbuilder==4.3.2
     # via apache-superset
 flask-babel==1.0.0
     # via flask-appbuilder

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         "cryptography>=39.0.1, <40",
         "deprecation>=2.1.0, <2.2.0",
         "flask>=2.2.5, <3.0.0",
-        "flask-appbuilder>=4.3.0, <5.0.0",
+        "flask-appbuilder>=4.3.2, <5.0.0",
         "flask-caching>=1.10.1, <1.11",
         "flask-compress>=1.13, <2.0",
         "flask-talisman>=1.0.0, <2.0",

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -175,6 +175,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         "RowLevelSecurityFiltersModelView",
         "Security",
         "SQL Lab",
+        "User's Statistics",
     } | USER_MODEL_VIEWS
 
     ALPHA_ONLY_VIEW_MENUS = {

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -175,6 +175,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         "RowLevelSecurityFiltersModelView",
         "Security",
         "SQL Lab",
+        "User Registrations",
         "User's Statistics",
     } | USER_MODEL_VIEWS
 


### PR DESCRIPTION
### SUMMARY
Currently only Admins have "menu access on Security", but despite that, non-admins have "menu access on User's Statistics" and "menu access on "User Registrations" which belong under the "Security" menu. This removes menu access, as they aren't really able to access the menu. We also bump FAB to the lastest version, which includes a fix to the "User Registrations" view registration: https://github.com/dpgaspar/Flask-AppBuilder/pull/2051

### AFTER
After the change, a Gamma user with Alerts & Reports and RLS access will only see the RLS menu under Security:
![image](https://github.com/apache/superset/assets/33317356/79d8b2cf-d5f0-42aa-a2f6-d7fd3858a507)

### BEFORE
Previously, they would also see the User Registrations menu:
![image](https://github.com/apache/superset/assets/33317356/190af523-3ac3-4d3d-92dc-c34a2e771c6a)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
