### PR TITLE
chore(ssh): Allow users to set TUNNEL_TIMEOUT from config

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -494,7 +494,7 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     # Allow users to enable ssh tunneling when creating a DB.
     # Users must check whether the DB engine supports SSH Tunnels
     # otherwise enabling this flag won't have any effect on the DB.
-    "SSH_TUNNELING": True,
+    "SSH_TUNNELING": False,
     "AVOID_COLORS_COLLISION": True,
 }
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -515,7 +515,7 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
 # ----------------------------------------------------------------------
 SSH_TUNNEL_MANAGER_CLASS = "superset.extensions.ssh.SSHManager"
 SSH_TUNNEL_LOCAL_BIND_ADDRESS = "127.0.0.1"
-SSH_TUNNEL_TIMEOUT = 1.0
+SSH_TUNNEL_TIMEOUT_SEC = 10.0
 
 # Feature flags may also be set via 'SUPERSET_FEATURE_' prefixed environment vars.
 DEFAULT_FEATURE_FLAGS.update(

--- a/superset/config.py
+++ b/superset/config.py
@@ -494,7 +494,7 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     # Allow users to enable ssh tunneling when creating a DB.
     # Users must check whether the DB engine supports SSH Tunnels
     # otherwise enabling this flag won't have any effect on the DB.
-    "SSH_TUNNELING": False,
+    "SSH_TUNNELING": True,
     "AVOID_COLORS_COLLISION": True,
 }
 
@@ -515,6 +515,7 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
 # ----------------------------------------------------------------------
 SSH_TUNNEL_MANAGER_CLASS = "superset.extensions.ssh.SSHManager"
 SSH_TUNNEL_LOCAL_BIND_ADDRESS = "127.0.0.1"
+SSH_TUNNEL_TIMEOUT = 1.0
 
 # Feature flags may also be set via 'SUPERSET_FEATURE_' prefixed environment vars.
 DEFAULT_FEATURE_FLAGS.update(

--- a/superset/extensions/ssh.py
+++ b/superset/extensions/ssh.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING
 
 from flask import Flask
 from paramiko import RSAKey
-from sshtunnel import open_tunnel, SSHTunnelForwarder
+from sshtunnel import open_tunnel, SSHTunnelForwarder, TUNNEL_TIMEOUT
 
 from superset.databases.utils import make_url_safe
 
@@ -34,6 +34,7 @@ class SSHManager:
     def __init__(self, app: Flask) -> None:
         super().__init__()
         self.local_bind_address = app.config["SSH_TUNNEL_LOCAL_BIND_ADDRESS"]
+        TUNNEL_TIMEOUT = app.config["SSH_TUNNEL_TIMEOUT"]
 
     def build_sqla_url(  # pylint: disable=no-self-use
         self, sqlalchemy_url: str, server: SSHTunnelForwarder

--- a/superset/extensions/ssh.py
+++ b/superset/extensions/ssh.py
@@ -20,9 +20,9 @@ import logging
 from io import StringIO
 from typing import TYPE_CHECKING
 
+import sshtunnel
 from flask import Flask
 from paramiko import RSAKey
-from sshtunnel import open_tunnel, SSHTunnelForwarder, TUNNEL_TIMEOUT
 
 from superset.databases.utils import make_url_safe
 
@@ -34,10 +34,10 @@ class SSHManager:
     def __init__(self, app: Flask) -> None:
         super().__init__()
         self.local_bind_address = app.config["SSH_TUNNEL_LOCAL_BIND_ADDRESS"]
-        TUNNEL_TIMEOUT = app.config["SSH_TUNNEL_TIMEOUT"]
+        sshtunnel.TUNNEL_TIMEOUT = app.config["SSH_TUNNEL_TIMEOUT_SEC"]
 
     def build_sqla_url(  # pylint: disable=no-self-use
-        self, sqlalchemy_url: str, server: SSHTunnelForwarder
+        self, sqlalchemy_url: str, server: sshtunnel.SSHTunnelForwarder
     ) -> str:
         # override any ssh tunnel configuration object
         url = make_url_safe(sqlalchemy_url)
@@ -50,7 +50,7 @@ class SSHManager:
         self,
         ssh_tunnel: "SSHTunnel",
         sqlalchemy_database_uri: str,
-    ) -> SSHTunnelForwarder:
+    ) -> sshtunnel.SSHTunnelForwarder:
         url = make_url_safe(sqlalchemy_database_uri)
         params = {
             "ssh_address_or_host": (ssh_tunnel.server_address, ssh_tunnel.server_port),
@@ -69,7 +69,7 @@ class SSHManager:
             )
             params["ssh_pkey"] = private_key
 
-        return open_tunnel(**params)
+        return sshtunnel.open_tunnel(**params)
 
 
 class SSHManagerFactory:

--- a/tests/unit_tests/extensions/ssh_test.py
+++ b/tests/unit_tests/extensions/ssh_test.py
@@ -26,7 +26,10 @@ from superset.extensions.ssh import SSHManagerFactory
 def test_ssh_tunnel_timeout_setting() -> None:
     app = Mock()
     app.config = {
-        "SSH_TUNNEL_TIMEOUT_SEC": 123.0,
+        "SSH_TUNNEL_MAX_RETRIES": 2,
+        "SSH_TUNNEL_LOCAL_BIND_ADDRESS": "test",
+        "SSH_TUNNEL_TIMEOUT_SEC": 10.0,
+        "SSH_TUNNEL_MANAGER_CLASS": "superset.extensions.ssh.SSHManager",
     }
     factory = SSHManagerFactory()
     factory.init_app(app)

--- a/tests/unit_tests/extensions/ssh_test.py
+++ b/tests/unit_tests/extensions/ssh_test.py
@@ -28,7 +28,7 @@ def test_ssh_tunnel_timeout_setting() -> None:
     app.config = {
         "SSH_TUNNEL_MAX_RETRIES": 2,
         "SSH_TUNNEL_LOCAL_BIND_ADDRESS": "test",
-        "SSH_TUNNEL_TIMEOUT_SEC": 10.0,
+        "SSH_TUNNEL_TIMEOUT_SEC": 123.0,
         "SSH_TUNNEL_MANAGER_CLASS": "superset.extensions.ssh.SSHManager",
     }
     factory = SSHManagerFactory()

--- a/tests/unit_tests/extensions/ssh_test.py
+++ b/tests/unit_tests/extensions/ssh_test.py
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+import sshtunnel
+
+from superset.extensions.ssh import SSHManagerFactory
+
+
+def test_ssh_tunnel_timeout_setting() -> None:
+    app = Mock()
+    app.config = {
+        "SSH_TUNNEL_TIMEOUT_SEC": 123.0,
+    }
+    factory = SSHManagerFactory()
+    factory.init_app(app)
+    assert sshtunnel.TUNNEL_TIMEOUT == 123.0


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Creating a new config variable `SSH_TUNNEL_TIMEOUT` this setting will allow `sshtunnel` to hold request for this time limit with the VPC.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
