### PR TITLE
fix: Typescript warnings when importing types

### DIFF
--- a/superset-frontend/src/components/Checkbox/index.tsx
+++ b/superset-frontend/src/components/Checkbox/index.tsx
@@ -16,5 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-export { default, CheckboxProps } from 'src/components/Checkbox/Checkbox';
+export { default } from 'src/components/Checkbox/Checkbox';
+export type { CheckboxProps } from 'src/components/Checkbox/Checkbox';
 export * from 'src/components/Checkbox/CheckboxIcons';

--- a/superset-frontend/src/components/MetadataBar/index.tsx
+++ b/superset-frontend/src/components/MetadataBar/index.tsx
@@ -16,14 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import MetadataBar, {
-  MetadataBarProps,
-  MIN_NUMBER_ITEMS,
-  MAX_NUMBER_ITEMS,
-} from './MetadataBar';
+import MetadataBar, { MIN_NUMBER_ITEMS, MAX_NUMBER_ITEMS } from './MetadataBar';
+
+export type { MetadataBarProps } from './MetadataBar';
 
 export default MetadataBar;
 
-export { MetadataBarProps, MIN_NUMBER_ITEMS, MAX_NUMBER_ITEMS };
+export { MIN_NUMBER_ITEMS, MAX_NUMBER_ITEMS };
 
 export * from './ContentType';

--- a/superset-frontend/src/components/Popover/index.tsx
+++ b/superset-frontend/src/components/Popover/index.tsx
@@ -18,8 +18,8 @@
  */
 import { Popover } from 'antd';
 
-export { PopoverProps } from 'antd/lib/popover';
-export { TooltipPlacement } from 'antd/lib/tooltip';
+export type { PopoverProps } from 'antd/lib/popover';
+export type { TooltipPlacement } from 'antd/lib/tooltip';
 
 // Eventually Popover can be wrapped and customized in this file
 // for now we're just redirecting

--- a/superset-frontend/src/components/Table/index.tsx
+++ b/superset-frontend/src/components/Table/index.tsx
@@ -44,7 +44,7 @@ export enum ETableAction {
   FILTER = 'filter',
 }
 
-export { ColumnsType };
+export type { ColumnsType };
 export type OnChangeFunction<RecordType> =
   AntTableProps<RecordType>['onChange'];
 

--- a/superset-frontend/src/dashboard/types.ts
+++ b/superset-frontend/src/dashboard/types.ts
@@ -34,7 +34,7 @@ import { UrlParamEntries } from 'src/utils/urlUtils';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
 import { ChartState } from '../explore/types';
 
-export { Dashboard } from 'src/types/Dashboard';
+export type { Dashboard } from 'src/types/Dashboard';
 
 export type ChartReducerInitialState = typeof chart;
 

--- a/superset-frontend/src/hooks/apiResources/queryApi.ts
+++ b/superset-frontend/src/hooks/apiResources/queryApi.ts
@@ -27,7 +27,7 @@ import {
   RequestBase,
 } from '@superset-ui/core';
 
-export { JsonResponse, TextResponse } from '@superset-ui/core';
+export type { JsonResponse, TextResponse } from '@superset-ui/core';
 
 export const supersetClientQuery: BaseQueryFn<
   Pick<RequestBase, 'method' | 'body' | 'jsonPayload' | 'postPayload'> & {


### PR DESCRIPTION
### SUMMARY
This PR fixes Typescript warnings related to importing types. See [Type-Only Imports and Export](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export) for more information.

The following warnings have been removed:

<img width="1280" alt="Screenshot 2023-05-25 at 16 17 25" src="https://github.com/apache/superset/assets/70410625/54a7d48b-9331-46ae-99de-9fef065b77bb">

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
