### PR TITLE
docs: removed extra ` from documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -591,7 +591,7 @@ Error: You must provide the URL of lib/mappings.wasm by calling SourceMapConsume
 ```
 Then put this:
 ```bash
-export NODE_OPTIONS=--no-experimental-fetch`
+export NODE_OPTIONS=--no-experimental-fetch
 ```
 
 #### Webpack dev server

--- a/docs/docs/installation/configuring-superset.mdx
+++ b/docs/docs/installation/configuring-superset.mdx
@@ -75,7 +75,7 @@ WTF_CSRF_EXEMPT_LIST = [‘’]
 Superset requires a user-specified SECRET_KEY to start up.  This requirement was [added in version 2.1.0 to force secure configurations](https://preset.io/blog/superset-security-update-default-secret_key-vulnerability/).  Add a strong SECRET_KEY to your `superset_config.py` file like:
 
 ```python
-SECRET_KEY = 'YOUR_OWN_RANDOM_GENERATED_SECRET_KEY'`
+SECRET_KEY = 'YOUR_OWN_RANDOM_GENERATED_SECRET_KEY'
 ```
 
 You can generate a strong secure key with `openssl rand -base64 42`.


### PR DESCRIPTION
docs: removed extra ` from documentation

### SUMMARY
Removed extra ` from CONTRIBUTING.md documentation under frontend local setup

#24230 
