### PR TITLE
docs: point the reader to "setup.py" for latest package version

### DIFF
--- a/docs/docs/databases/installing-database-drivers.mdx
+++ b/docs/docs/databases/installing-database-drivers.mdx
@@ -20,8 +20,7 @@ which is part of the Python standard library.
 You’ll need to install the required packages for the database you want to use as your metadata database
 as well as the packages needed to connect to the databases you want to access through Superset.
 
-A list of some of the recommended packages is shown below,
-for the versions that are compatible with Superset please refer to [setup.py](https://github.com/apache/superset/blob/master/setup.py).
+Some of the recommended packages is shown below. Please refer to [setup.py](https://github.com/apache/superset/blob/master/setup.py) for the versions that are compatible with Superset.
 
 | Database                                                  | PyPI package                                                                       | Connection String                                                                                           |
 | --------------------------------------------------------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |

--- a/docs/docs/databases/installing-database-drivers.mdx
+++ b/docs/docs/databases/installing-database-drivers.mdx
@@ -20,7 +20,8 @@ which is part of the Python standard library.
 You’ll need to install the required packages for the database you want to use as your metadata database
 as well as the packages needed to connect to the databases you want to access through Superset.
 
-A list of some of the recommended packages.
+A list of some of the recommended packages is shown below,
+for the versions that are compatible with Superset please refer to [setup.py](https://github.com/apache/superset/blob/master/setup.py).
 
 | Database                                                  | PyPI package                                                                       | Connection String                                                                                           |
 | --------------------------------------------------------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |

--- a/docs/docs/databases/installing-database-drivers.mdx
+++ b/docs/docs/databases/installing-database-drivers.mdx
@@ -16,14 +16,16 @@ install new database drivers into your Superset configuration.
 ### Supported Databases and Dependencies
 
 Superset does not ship bundled with connectivity to databases, except for SQLite,
-which is part of the Python standard library. You’ll need to install the required packages for the database you want to use as your metadata database as well as the packages needed to connect to the databases you want to access through Superset.
+which is part of the Python standard library.
+You’ll need to install the required packages for the database you want to use as your metadata database
+as well as the packages needed to connect to the databases you want to access through Superset.
 
 A list of some of the recommended packages.
 
 | Database                                                  | PyPI package                                                                       | Connection String                                                                                           |
 | --------------------------------------------------------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| [Amazon Athena](/docs/databases/athena)                   | `pip install "PyAthenaJDBC>1.0.9` , `pip install "PyAthena>1.2.0`                  | `awsathena+rest://{aws_access_key_id}:{aws_secret_access_key}@athena.{region_name}.amazonaws.com/{ `        |
-| [Amazon DynamoDB](/docs/databases/dynamodb)               | `pip install "PyDynamoDB>=0.4.2`                                                   | `dynamodb://{access_key_id}:{secret_access_key}@dynamodb.{region_name}.amazonaws.com?connector=superset`    |
+| [Amazon Athena](/docs/databases/athena)                   | `pip install pyathena[pandas]` , `pip install PyAthenaJDBC`                        | `awsathena+rest://{aws_access_key_id}:{aws_secret_access_key}@athena.{region_name}.amazonaws.com/{ `        |
+| [Amazon DynamoDB](/docs/databases/dynamodb)               | `pip install pydynamodb`                                                           | `dynamodb://{access_key_id}:{secret_access_key}@dynamodb.{region_name}.amazonaws.com?connector=superset`    |
 | [Amazon Redshift](/docs/databases/redshift)               | `pip install sqlalchemy-redshift`                                                  | ` redshift+psycopg2://<userName>:<DBPassword>@<AWS End Point>:5439/<Database Name>`                         |
 | [Apache Drill](/docs/databases/drill)                     | `pip install sqlalchemy-drill`                                                     | `drill+sadrill:// For JDBC drill+jdbc://`                                                                   |
 | [Apache Druid](/docs/databases/druid)                     | `pip install pydruid`                                                              | `druid://<User>:<password>@<Host>:<Port-default-9088>/druid/v2/sql`                                         |
@@ -35,8 +37,8 @@ A list of some of the recommended packages.
 | [Apache Spark SQL](/docs/databases/spark-sql)             | `pip install pyhive`                                                               | `hive://hive@{hostname}:{port}/{database}`                                                                  |
 | [Ascend.io](/docs/databases/ascend)                       | `pip install impyla`                                                               | `ascend://{username}:{password}@{hostname}:{port}/{database}?auth_mechanism=PLAIN;use_ssl=true`             |
 | [Azure MS SQL](/docs/databases/sql-server)                | `pip install pymssql`                                                              | `mssql+pymssql://UserName@presetSQL:TestPassword@presetSQL.database.windows.net:1433/TestSchema`            |
-| [Big Query](/docs/databases/bigquery)                     | `pip install sqlalchemy-bigquery`                                                           | `bigquery://{project_id}`                                                                                   |
-| [ClickHouse](/docs/databases/clickhouse)                  | `pip install clickhouse-connect`                                                   | `clickhousedb://{username}:{password}@{hostname}:{port}/{database}`                                    |
+| [Big Query](/docs/databases/bigquery)                     | `pip install sqlalchemy-bigquery`                                                  | `bigquery://{project_id}`                                                                                   |
+| [ClickHouse](/docs/databases/clickhouse)                  | `pip install clickhouse-connect`                                                   | `clickhousedb://{username}:{password}@{hostname}:{port}/{database}`                                         |
 | [CockroachDB](/docs/databases/cockroachdb)                | `pip install cockroachdb`                                                          | `cockroachdb://root@{hostname}:{port}/{database}?sslmode=disable`                                           |
 | [Dremio](/docs/databases/dremio)                          | `pip install sqlalchemy_dremio`                                                    | `dremio://user:pwd@host:31010/`                                                                             |
 | [Elasticsearch](/docs/databases/elasticsearch)            | `pip install elasticsearch-dbapi`                                                  | `elasticsearch+http://{user}:{password}@{host}:9200/`                                                       |

--- a/docs/docs/databases/installing-database-drivers.mdx
+++ b/docs/docs/databases/installing-database-drivers.mdx
@@ -20,7 +20,7 @@ which is part of the Python standard library.
 You’ll need to install the required packages for the database you want to use as your metadata database
 as well as the packages needed to connect to the databases you want to access through Superset.
 
-Some of the recommended packages is shown below. Please refer to [setup.py](https://github.com/apache/superset/blob/master/setup.py) for the versions that are compatible with Superset.
+Some of the recommended packages are shown below. Please refer to [setup.py](https://github.com/apache/superset/blob/master/setup.py) for the versions that are compatible with Superset.
 
 | Database                                                  | PyPI package                                                                       | Connection String                                                                                           |
 | --------------------------------------------------------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
### SUMMARY
Related to #24200.
In page `Install Database Drivers`, point the reader to `setup.py` for the latest package versions that are compatible with Superset. This way, the document will be more resilient to version upgrades.
