### PR TITLE
fix(dataset-api): allow undefined schema in post

### DIFF
--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -78,7 +78,7 @@ class DatasetMetricsPutSchema(Schema):
 
 class DatasetPostSchema(Schema):
     database = fields.Integer(required=True)
-    schema = fields.String(validate=Length(0, 250))
+    schema = fields.String(allow_none=True, validate=Length(0, 250))
     table_name = fields.String(required=True, allow_none=False, validate=Length(1, 250))
     sql = fields.String(allow_none=True)
     owners = fields.List(fields.Integer())
@@ -236,7 +236,9 @@ class GetOrCreateDatasetSchema(Schema):
         required=True, metadata={"description": "ID of database table belongs to"}
     )
     schema = fields.String(
-        metadata={"description": "The schema the table belongs to"}, allow_none=True
+        allow_none=True,
+        validate=Length(0, 250),
+        metadata={"description": "The schema the table belongs to"},
     )
     template_params = fields.String(
         metadata={"description": "Template params for the table"}

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -530,7 +530,7 @@ class TestDatasetApi(SupersetTestCase):
         self.login(username="admin")
         table_data = {
             "database": main_db.id,
-            "schema": "",
+            "schema": None,
             "table_name": "ab_permission",
         }
         uri = "api/v1/dataset/"


### PR DESCRIPTION
### SUMMARY
The POST schema in the datasets API didn't accept `None` values, unlike the other schemas (check e.g. PUT here: https://github.com/apache/superset/blob/50535e427e51743e298d46009d51b08ef2380012/superset/datasets/schemas.py#L95)

### BEFORE
Previously saving a dataset with an undefined schema caused an error:
<img width="1138" alt="image" src="https://github.com/apache/superset/assets/33317356/de385139-1f9c-4872-b2b4-cc1ed91ebe07">

### TESTING INSTRUCTIONS
1. Go to SQL Lab, choose a db but don't select a schema
2. Write a query, create a chart, and try to save as a dataset
3. Get error

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
