### PR TITLE
fix: dashboard ownership check

### DIFF
--- a/superset-frontend/src/dashboard/util/permissionUtils.ts
+++ b/superset-frontend/src/dashboard/util/permissionUtils.ts
@@ -42,7 +42,7 @@ const isUserDashboardOwner = (
   user: UserWithPermissionsAndRoles | UndefinedUser,
 ) =>
   isUserWithPermissionsAndRoles(user) &&
-  dashboard.owners.some(owner => owner.username === user.username);
+  dashboard.owners.some(owner => owner.id === user.userId);
 
 export const canUserEditDashboard = (
   dashboard: Dashboard,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fix dashboard ownership check. There's currently a bug where non-admin users can't edit a dashboard (even a new one) because `username` was removed from the API response payload in https://github.com/apache/superset/pull/24056, making this check fail:

https://github.com/apache/superset/blob/674da1b2095ff74f7bf82be795b065e2d9f1760a/superset-frontend/src/dashboard/util/permissionUtils.ts#L45

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

I'm adding the tests in a separate PR, so we can cherry-pick this quickly.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
