### PR TITLE
docs: fix broken link in the security page

### DIFF
--- a/docs/docs/security.mdx
+++ b/docs/docs/security.mdx
@@ -20,7 +20,7 @@ permissions associated with each role (e.g. by removing or adding permissions to
 associated with each role will be re-synchronized to their original values when you run
 the **superset init** command (often done between Superset versions).
 
-A table with the permissions for these roles can be found at [/RESOURCES/STANDARD_ROLES.md](https://github.com/apache/superset/blob/master/RESOURCES/STANDARD_ROLES.mdd).
+A table with the permissions for these roles can be found at [/RESOURCES/STANDARD_ROLES.md](https://github.com/apache/superset/blob/master/RESOURCES/STANDARD_ROLES.md).
 
 ### Admin
 


### PR DESCRIPTION
### SUMMARY
Fixed the link to `STANDARD_ROLES.md` in the Security page (removed extra `d`)

### ADDITIONAL INFORMATION

Fixes #24252
