### PR TITLE
feat: update makefile with new commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,11 +93,11 @@ py-lint: pre-commit
 js-format:
 	cd superset-frontend; npm run prettier
 
-flask-app:
+flask-app: activate
 	flask run -p 8088 --with-threads --reload --debugger
 
 node-app:
-	cd superset-frontend; npm run dev-server
+	cd superset-frontend; nvm use; npm run dev-server
 
 build-cypress:
 	cd superset-frontend; npm run build-instrumented
@@ -115,3 +115,21 @@ report-celery-beat:
 
 admin-user:
 	superset fab create-admin
+
+# Create a postgres instance using docker
+# CLI: $ psql postgresql://postgres:1234@localhost:5432/postgres
+# superset_config.py: SQLALCHEMY_DATABASE_URI = 'postgresql://postgres:1234@localhost:5432/postgres'
+db:
+	# start postgres with detached mode
+	docker run -d -p 127.0.0.1:5432:5432 -e POSTGRES_PASSWORD="1234" --name pg postgres:alpine;\
+	EXIT_CODE=$$?;\
+	echo $$EXIT_CODE;\
+	echo "command exited with $$EXIT_CODE";\
+	if [ $$EXIT_CODE -ne "0" ]; then docker start pg; echo "DB has been created"; fi
+
+db-stop:
+	docker stop pg
+
+# Primarily made for GH codespaces but this flow could work on your local as well
+api: db flask-app
+client: node-app

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ flask-app: activate
 	flask run -p 8088 --with-threads --reload --debugger
 
 node-app:
-	cd superset-frontend; nvm use; npm run dev-server
+	cd superset-frontend; npm run dev-server
 
 build-cypress:
 	cd superset-frontend; npm run build-instrumented

--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,16 @@ db:
 db-stop:
 	docker stop pg
 
+cache:
+	docker run -d --name redis-stack-server -p 6379:6379 redis/redis-stack-server:latest;\
+	EXIT_CODE=$$?;\
+	echo $$EXIT_CODE;\
+	echo "command exited with $$EXIT_CODE";\
+	if [ $$EXIT_CODE -ne "0" ]; then docker start redis-stack-server; echo "cache has been created"; fi
+
+cache-stop:
+	docker stop redis-stack-server
+
 # Primarily made for GH codespaces but this flow could work on your local as well
-api: db flask-app
+api: db cache flask-app
 client: node-app


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Been working in Github Codespaces for a while now, and wanted to create new make commands to make it easier for folks to spin up s2 in the same envs. The idea here is we start to make more intelligent recipes in our makefiles that can handle failures and run the right command with devs having to figure it out on themselves

```bash
# installs all necessary requirements
$ make install

# starts postgres instance + starts flask app
$ make api 

# spins up node app
$ make client 
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
