### PR TITLE
fix: Text utils null value when reading module

### DIFF
--- a/superset-frontend/src/utils/textUtils.ts
+++ b/superset-frontend/src/utils/textUtils.ts
@@ -15,17 +15,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-/* eslint-disable global-require */
 const loadModule = () => {
-  let module;
   try {
-    // @ts-ignore
-    module = require('../../../superset_text'); // eslint-disable-line import/no-unresolved
+    // eslint-disable-next-line global-require
+    return require('../../../superset_text.yml') || {};
   } catch (e) {
-    module = {};
+    return {};
   }
-  return module;
 };
 
 const supersetText = loadModule();


### PR DESCRIPTION
### SUMMARY
Follow-up of https://github.com/apache/superset/pull/24250 that fixes an error when loading `superset_text.yml`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1008" alt="Screenshot 2023-06-05 at 11 57 45" src="https://github.com/apache/superset/assets/70410625/a969123b-73b0-4596-b6c0-511e89cdf428">

### TESTING INSTRUCTIONS
Make sure the error does not happen when running with `npm run dev-server`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
