### PR TITLE
fix: Removes file extension from textUtils

### DIFF
--- a/superset-frontend/src/utils/textUtils.ts
+++ b/superset-frontend/src/utils/textUtils.ts
@@ -17,8 +17,8 @@
  */
 const loadModule = () => {
   try {
-    // eslint-disable-next-line global-require
-    return require('../../../superset_text.yml') || {};
+    // eslint-disable-next-line global-require, import/no-unresolved
+    return require('../../../superset_text') || {};
   } catch (e) {
     return {};
   }


### PR DESCRIPTION
### SUMMARY
Follow-up of https://github.com/apache/superset/pull/24291 to remove the file extension.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
