### PR TITLE
fix: Copy dashboard filters when copying dashboard

### DIFF
--- a/superset/dashboards/dao.py
+++ b/superset/dashboards/dao.py
@@ -331,6 +331,7 @@ class DashboardDAO(BaseDAO):
         else:
             dash.slices = original_dash.slices
 
+        dash.params = original_dash.params
         cls.set_dash_metadata(dash, metadata, old_to_new_slice_ids)
         db.session.add(dash)
         db.session.commit()


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR will make it so that dashboard native filters are properly copied when copying a dashboard using the "Save as" option in the UI.  This functionality broke as a result of an [api v1 migration](https://github.com/apache/superset/pull/23112).

`set_dash_metadata` just takes the current dash's params and adds certain keys from the data dict passed in.  Before calling `set_dash_metadata`, the newly copied dashboard should share the same metadata as the original dash so that no keys are lost, in this case `native_filter_configuration` was being lost.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![copy_dash_filters_before](https://github.com/apache/superset/assets/47196419/291771f1-c2ca-475f-b8b2-2e018f5091f6)

After:
![copy_dash_filters_after](https://github.com/apache/superset/assets/47196419/596cf5f0-f913-4f5b-962a-883f51333b91)



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
