### PR TITLE
fix(dashboard): max call size stack error

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/utils.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/utils.test.ts
@@ -18,7 +18,8 @@
  */
 import { Behavior, FeatureFlag } from '@superset-ui/core';
 import * as featureFlags from 'src/featureFlags';
-import { nativeFilterGate } from './utils';
+import { DashboardLayout } from 'src/dashboard/types';
+import { nativeFilterGate, findTabsWithChartsInScope } from './utils';
 
 let isFeatureEnabledMock: jest.MockInstance<boolean, [feature: FeatureFlag]>;
 
@@ -123,4 +124,41 @@ describe('nativeFilterGate', () => {
       expect(nativeFilterGate([Behavior.NATIVE_FILTER])).toEqual(false);
     });
   });
+});
+
+test('findTabsWithChartsInScope should handle a recursive layout structure', () => {
+  const dashboardLayout = {
+    DASHBOARD_VERSION_KEY: 'v2',
+    ROOT_ID: {
+      children: ['GRID_ID'],
+      id: 'ROOT_ID',
+      type: 'ROOT',
+    },
+    GRID_ID: {
+      children: ['TAB-LrujeuD5Qn', 'TABS-kN7tw6vFif'],
+      id: 'GRID_ID',
+      parents: ['ROOT_ID'],
+      type: 'GRID',
+    },
+    'TAB-LrujeuD5Qn': {
+      children: ['TABS-kN7tw6vFif'],
+      id: 'TAB-LrujeuD5Qn',
+      meta: {
+        text: 'View by Totals',
+      },
+      parents: ['ROOT_ID'],
+      type: 'TAB',
+    },
+    'TABS-kN7tw6vFif': {
+      children: ['TAB-LrujeuD5Qn', 'TAB--7BUkKkNl'],
+      id: 'TABS-kN7tw6vFif',
+      meta: {},
+      parents: ['ROOT_ID'],
+      type: 'TABS',
+    },
+  } as any as DashboardLayout;
+
+  expect(Array.from(findTabsWithChartsInScope(dashboardLayout, []))).toEqual(
+    [],
+  );
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/utils.ts
@@ -154,7 +154,12 @@ const findTabsWithChartsInScopeHelper = (
   componentId: string,
   tabIds: string[],
   tabsToHighlight: Set<string>,
+  visited: Set<string>,
 ) => {
+  if (visited.has(componentId)) {
+    return;
+  }
+  visited.add(componentId);
   if (
     dashboardLayout?.[componentId]?.type === CHART_TYPE &&
     chartsInScope.includes(dashboardLayout[componentId]?.meta?.chartId)
@@ -175,6 +180,7 @@ const findTabsWithChartsInScopeHelper = (
       childId,
       isComponentATab(dashboardLayout, childId) ? [...tabIds, childId] : tabIds,
       tabsToHighlight,
+      visited,
     ),
   );
 };
@@ -187,6 +193,7 @@ export const findTabsWithChartsInScope = (
   const rootChildId = dashboardRoot.children[0];
   const hasTopLevelTabs = rootChildId !== DASHBOARD_GRID_ID;
   const tabsInScope = new Set<string>();
+  const visited = new Set<string>();
   if (hasTopLevelTabs) {
     dashboardLayout[rootChildId]?.children?.forEach(tabId =>
       findTabsWithChartsInScopeHelper(
@@ -195,6 +202,7 @@ export const findTabsWithChartsInScope = (
         tabId,
         [tabId],
         tabsInScope,
+        visited,
       ),
     );
   } else {
@@ -207,6 +215,7 @@ export const findTabsWithChartsInScope = (
           element.id,
           [element.id],
           tabsInScope,
+          visited,
         ),
       );
   }


### PR DESCRIPTION
### SUMMARY
There's a case that dashboardLayout consists of the circular structure. Following is the case:

<img width="344" alt="Screenshot 2023-06-06 at 4 26 31 PM" src="https://github.com/apache/superset/assets/1392866/38064f9b-6049-4a8b-962e-971d3e06b861">

This causes the max. call stack size error in findTabsWithChartsInScopeHelper.
This commit fixes the infinite recursive loop in the circular structure.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

After:
No error

Before:
Maximum call stack size exceeded

### TESTING INSTRUCTIONS
unit test with circular structure

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
