### PR TITLE
feat(docker): add GUNICORN_LOGLEVEL env var

### DIFF
--- a/docker/run-server.sh
+++ b/docker/run-server.sh
@@ -26,6 +26,7 @@ gunicorn \
     --workers ${SERVER_WORKER_AMOUNT:-1} \
     --worker-class ${SERVER_WORKER_CLASS:-gthread} \
     --threads ${SERVER_THREADS_AMOUNT:-20} \
+    --log-level "${GUNICORN_LOGLEVEL:info}" \
     --timeout ${GUNICORN_TIMEOUT:-60} \
     --keep-alive ${GUNICORN_KEEPALIVE:-2} \
     --max-requests ${WORKER_MAX_REQUESTS:-0} \


### PR DESCRIPTION

### SUMMARY
to debug gunicorn, it is useful to specify the log level. This env var gives the possibility to define it in the docker image

### TESTING INSTRUCTIONS
in the docker sub directory, run this to build and run the new container:

`docker build -t test . && docker run --name test -e GUNICORN_LOGLEVEL=debug -it test`

after the build logs, you will see that gunicorn logs now way more verbose than when running with the the `-e GUNICORN_LOGLEVEL=debug` flag.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
