### PR TITLE
docs: add link to intro with supported database types

### DIFF
--- a/docs/docs/intro.mdx
+++ b/docs/docs/intro.mdx
@@ -59,7 +59,8 @@ Superset is also cloud-native in the sense that it is flexible and lets you choo
 - Results backend (Redis, S3, Memcached, etc.),
 - Caching layer (Redis, Memcached, etc.)
 
-Superset also works well with [event-logging](https://superset.apache.org/docs/installation/event-logging/) services like StatsD, NewRelic, and DataDog.
+Superset also works well with [event-logging](https://superset.apache.org/docs/installation/event-logging/)
+services like StatsD, NewRelic, and DataDog.
 
 Superset is currently run at scale at many companies. For example, Superset is run in Airbnb’s
 production environment inside Kubernetes and serves 600+ daily active users viewing over 100K charts

--- a/docs/docs/intro.mdx
+++ b/docs/docs/intro.mdx
@@ -36,7 +36,7 @@ Superset provides:
 - Code-free visualization builder to extract and present datasets
 - A world-class SQL IDE for preparing data for visualization, including a rich metadata browser
 - A lightweight semantic layer which empowers data analysts to quickly define custom dimensions and metrics
-- Out-of-the-box support for most SQL-speaking databases
+- Out-of-the-box support for [most SQL-speaking databases](https://superset.apache.org/docs/databases/installing-database-drivers/)
 - Seamless, in-memory asynchronous caching and queries
 - An extensible security model that allows configuration of very intricate rules on who can access which product features and datasets.
 - Integration with major authentication backends (database, OpenID, LDAP, OAuth, REMOTE_USER, etc)
@@ -59,8 +59,7 @@ Superset is also cloud-native in the sense that it is flexible and lets you choo
 - Results backend (Redis, S3, Memcached, etc.),
 - Caching layer (Redis, Memcached, etc.)
 
-Superset also works well with services like NewRelic, StatsD and DataDog, and has the ability to run
-analytic workloads against most popular database technologies.
+Superset also works well with [event-logging](https://superset.apache.org/docs/installation/event-logging/) services like StatsD, NewRelic, and DataDog.
 
 Superset is currently run at scale at many companies. For example, Superset is run in Airbnb’s
 production environment inside Kubernetes and serves 600+ daily active users viewing over 100K charts


### PR DESCRIPTION
Minor docs changed as discussed on Slack: https://apache-superset.slack.com/archives/C04QTKFJ41X/p1684847133345339