### PR TITLE
fix: DB extension collapse

### DIFF
--- a/superset-frontend/src/features/databases/DatabaseModal/ExtraOptions.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/ExtraOptions.tsx
@@ -466,7 +466,8 @@ const ExtraOptions = ({
             </div>
           }
           key={extraExtension?.title}
-          collapsible={extraExtension.enabled?.() ? 'header' : 'disabled'}
+          // @ts-ignore, 'icon' is valid in >=4.9.0 but missing from `CollapsibleType`
+          collapsible={extraExtension.enabled?.() ? 'icon' : 'disabled'}
         >
           <StyledInputContainer css={no_margin_bottom}>
             <ExtraExtensionComponent db={db} onEdit={extraExtension.onEdit} />


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fix the caret in the DB extension extra option, making it expand/collapse the panel.

For some reason the type `icon` is only present in the `CollapsibleType` enum in antd 4.24.0 (we're using 4.10.3), but it works correctly as seen in the screencasts below.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

https://github.com/apache/superset/assets/1534870/dc6dab0c-6699-438d-82b3-32177574ba05

After:

https://github.com/apache/superset/assets/1534870/2eb76f63-9a24-4090-a3ec-b7e756b97ccc

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
