### PR TITLE
chore: Deprecates some NVD3 charts in 3.0

### DIFF
--- a/superset-frontend/cypress-base/cypress/e2e/chart_list/filter.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/chart_list/filter.test.ts
@@ -41,7 +41,7 @@ describe('Charts filters', () => {
   });
 
   it('should allow filtering by "Chart type" correctly', () => {
-    setFilter('Chart type', 'Area Chart (deprecated)');
+    setFilter('Chart type', 'Area Chart (legacy)');
     setFilter('Chart type', 'Bubble Chart');
   });
 

--- a/superset-frontend/cypress-base/cypress/e2e/chart_list/filter.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/chart_list/filter.test.ts
@@ -41,7 +41,7 @@ describe('Charts filters', () => {
   });
 
   it('should allow filtering by "Chart type" correctly', () => {
-    setFilter('Chart type', 'Area Chart (legacy)');
+    setFilter('Chart type', 'Area Chart (deprecated)');
     setFilter('Chart type', 'Bubble Chart');
   });
 

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Area/index.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Area/index.js
@@ -38,7 +38,7 @@ const metadata = new ChartMetadata({
     { url: example3, caption: t('Video game consoles') },
     { url: example4, caption: t('Vehicle Types') },
   ],
-  name: t('Area Chart (legacy)'),
+  name: t('Area Chart (deprecated)'),
   supportedAnnotationTypes: [ANNOTATION_TYPES.INTERVAL, ANNOTATION_TYPES.EVENT],
   tags: [
     t('Aesthetic'),
@@ -58,6 +58,9 @@ const metadata = new ChartMetadata({
   useLegacyApi: true,
 });
 
+/**
+ * @deprecated in version 3.0.
+ */
 export default class AreaChartPlugin extends ChartPlugin {
   constructor() {
     super({

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Area/index.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Area/index.js
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t, ChartMetadata, ChartPlugin } from '@superset-ui/core';
+import { t, ChartMetadata, ChartPlugin, ChartLabel } from '@superset-ui/core';
 import transformProps from '../transformProps';
 import example1 from './images/example1.jpg';
 import example2 from './images/example2.jpg';
@@ -38,7 +38,8 @@ const metadata = new ChartMetadata({
     { url: example3, caption: t('Video game consoles') },
     { url: example4, caption: t('Vehicle Types') },
   ],
-  name: t('Area Chart (deprecated)'),
+  label: ChartLabel.DEPRECATED,
+  name: t('Area Chart (legacy)'),
   supportedAnnotationTypes: [ANNOTATION_TYPES.INTERVAL, ANNOTATION_TYPES.EVENT],
   tags: [
     t('Aesthetic'),

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bar/index.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bar/index.js
@@ -32,7 +32,7 @@ const metadata = new ChartMetadata({
     'Visualize how a metric changes over time using bars. Add a group by column to visualize group level metrics and how they change over time.',
   ),
   exampleGallery: [{ url: example1 }, { url: example2 }, { url: example3 }],
-  name: t('Time-series Bar Chart (legacy)'),
+  name: t('Time-series Bar Chart (deprecated)'),
   supportedAnnotationTypes: [ANNOTATION_TYPES.INTERVAL, ANNOTATION_TYPES.EVENT],
   tags: [
     t('Bar'),
@@ -44,11 +44,16 @@ const metadata = new ChartMetadata({
     t('Proportional'),
     t('Advanced-Analytics'),
     t('nvd3'),
+    t('Legacy'),
+    t('Deprecated'),
   ],
   thumbnail,
   useLegacyApi: true,
 });
 
+/**
+ * @deprecated in version 3.0.
+ */
 export default class BarChartPlugin extends ChartPlugin {
   constructor() {
     super({

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bar/index.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Bar/index.js
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t, ChartMetadata, ChartPlugin } from '@superset-ui/core';
+import { t, ChartMetadata, ChartPlugin, ChartLabel } from '@superset-ui/core';
 import transformProps from '../transformProps';
 import thumbnail from './images/thumbnail.png';
 import example1 from './images/Time_Series_Bar_Chart.jpg';
@@ -32,7 +32,8 @@ const metadata = new ChartMetadata({
     'Visualize how a metric changes over time using bars. Add a group by column to visualize group level metrics and how they change over time.',
   ),
   exampleGallery: [{ url: example1 }, { url: example2 }, { url: example3 }],
-  name: t('Time-series Bar Chart (deprecated)'),
+  label: ChartLabel.DEPRECATED,
+  name: t('Time-series Bar Chart (legacy)'),
   supportedAnnotationTypes: [ANNOTATION_TYPES.INTERVAL, ANNOTATION_TYPES.EVENT],
   tags: [
     t('Bar'),

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t, ChartMetadata, ChartPlugin } from '@superset-ui/core';
+import { t, ChartMetadata, ChartPlugin, ChartLabel } from '@superset-ui/core';
 import transformProps from '../transformProps';
 import thumbnail from './images/thumbnail.png';
 import example1 from './images/Bar_Chart.jpg';
@@ -35,7 +35,8 @@ const metadata = new ChartMetadata({
     { url: example2, caption: 'Grouped style' },
     { url: example3 },
   ],
-  name: t('Bar Chart (deprecated)'),
+  label: ChartLabel.DEPRECATED,
+  name: t('Bar Chart (legacy)'),
   tags: [
     t('Additive'),
     t('Bar'),

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js
@@ -16,12 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  t,
-  ChartMetadata,
-  ChartPlugin,
-  hasGenericChartAxes,
-} from '@superset-ui/core';
+import { t, ChartMetadata, ChartPlugin } from '@superset-ui/core';
 import transformProps from '../transformProps';
 import thumbnail from './images/thumbnail.png';
 import example1 from './images/Bar_Chart.jpg';
@@ -40,7 +35,7 @@ const metadata = new ChartMetadata({
     { url: example2, caption: 'Grouped style' },
     { url: example3 },
   ],
-  name: hasGenericChartAxes ? t('Bar Chart (legacy)') : t('Bar Chart'),
+  name: t('Bar Chart (deprecated)'),
   tags: [
     t('Additive'),
     t('Bar'),
@@ -53,11 +48,15 @@ const metadata = new ChartMetadata({
     t('Stacked'),
     t('Vertical'),
     t('nvd3'),
+    t('Deprecated'),
   ],
   thumbnail,
   useLegacyApi: true,
 });
 
+/**
+ * @deprecated in version 3.0.
+ */
 export default class DistBarChartPlugin extends ChartPlugin {
   constructor() {
     super({

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Line/index.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Line/index.js
@@ -35,7 +35,7 @@ const metadata = new ChartMetadata({
     { url: example2 },
     { url: battery, caption: t('Battery level over time') },
   ],
-  name: t('Line Chart (legacy)'),
+  name: t('Line Chart (deprecated)'),
   supportedAnnotationTypes: [
     ANNOTATION_TYPES.TIME_SERIES,
     ANNOTATION_TYPES.INTERVAL,
@@ -47,6 +47,9 @@ const metadata = new ChartMetadata({
   useLegacyApi: true,
 });
 
+/**
+ * @deprecated in version 3.0.
+ */
 export default class LineChartPlugin extends ChartPlugin {
   constructor() {
     super({

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Line/index.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Line/index.js
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t, ChartMetadata, ChartPlugin } from '@superset-ui/core';
+import { t, ChartMetadata, ChartPlugin, ChartLabel } from '@superset-ui/core';
 import transformProps from '../transformProps';
 import example1 from './images/LineChart.jpg';
 import example2 from './images/LineChart2.jpg';
@@ -35,7 +35,8 @@ const metadata = new ChartMetadata({
     { url: example2 },
     { url: battery, caption: t('Battery level over time') },
   ],
-  name: t('Line Chart (deprecated)'),
+  label: ChartLabel.DEPRECATED,
+  name: t('Line Chart (legacy)'),
   supportedAnnotationTypes: [
     ANNOTATION_TYPES.TIME_SERIES,
     ANNOTATION_TYPES.INTERVAL,

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Pie/index.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Pie/index.js
@@ -24,11 +24,15 @@ import controlPanel from './controlPanel';
 const metadata = new ChartMetadata({
   credits: ['http://nvd3.org'],
   description: '',
-  name: t('Pie Chart'),
+  name: t('Pie Chart (deprecated)'),
   thumbnail,
   useLegacyApi: true,
+  tags: [t('Legacy'), t('nvd3'), t('Deprecated')],
 });
 
+/**
+ * @deprecated in version 3.0.
+ */
 export default class PieChartPlugin extends ChartPlugin {
   constructor() {
     super({

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Pie/index.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Pie/index.js
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t, ChartMetadata, ChartPlugin } from '@superset-ui/core';
+import { t, ChartMetadata, ChartPlugin, ChartLabel } from '@superset-ui/core';
 import transformProps from '../transformProps';
 import thumbnail from './images/thumbnail.png';
 import controlPanel from './controlPanel';
@@ -24,7 +24,8 @@ import controlPanel from './controlPanel';
 const metadata = new ChartMetadata({
   credits: ['http://nvd3.org'],
   description: '',
-  name: t('Pie Chart (deprecated)'),
+  label: ChartLabel.DEPRECATED,
+  name: t('Pie Chart (legacy)'),
   thumbnail,
   useLegacyApi: true,
   tags: [t('Legacy'), t('nvd3'), t('Deprecated')],

--- a/superset-frontend/src/visualizations/FilterBox/FilterBoxChartPlugin.js
+++ b/superset-frontend/src/visualizations/FilterBox/FilterBoxChartPlugin.js
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t, ChartMetadata, ChartPlugin } from '@superset-ui/core';
+import { t, ChartMetadata, ChartPlugin, ChartLabel } from '@superset-ui/core';
 import transformProps from './transformProps';
 import thumbnail from './images/thumbnail.png';
 import example1 from './images/example1.jpg';
@@ -25,7 +25,8 @@ import controlPanel from './controlPanel';
 
 const metadata = new ChartMetadata({
   category: t('Tools'),
-  name: t('Filter box (deprecated)'),
+  label: ChartLabel.DEPRECATED,
+  name: t('Filter box (legacy)'),
   description:
     t(`Chart component that lets you add a custom filter UI in your dashboard. When added to dashboard, a filter box lets users specify specific values or ranges to filter charts by. The charts that each filter box is applied to can be fine tuned as well in the dashboard view.
 


### PR DESCRIPTION
### SUMMARY
Deprecates the following NVD3 charts in 3.0 to be removed in the next major version:
- Area
- Bar
- Dist Bar
- Line
- Pie

NVD3 charts that have a migration and an ECharts replacement will be removed in 3.0. The others remain untouched until we provide a migration and ECharts replacement in a future major version.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="752" alt="Screenshot 2023-06-08 at 15 08 24" src="https://github.com/apache/superset/assets/70410625/b2ff1991-4308-41d0-bc30-6e7bf69af43b">

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
