### PR TITLE
chore: changing FLASK_ENV to FLASK_DEBUG

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 FLASK_APP="superset.app:create_app()"
-FLASK_ENV="development"
+FLASK_DEBUG=true

--- a/.github/workflows/superset-applitool-cypress.yml
+++ b/.github/workflows/superset-applitool-cypress.yml
@@ -28,7 +28,7 @@ jobs:
         browser: ["chrome"]
         node: [16]
     env:
-      FLASK_ENV: development
+      FLASK_DEBUG: true
       SUPERSET_CONFIG: tests.integration_tests.superset_test_config
       SUPERSET__SQLALCHEMY_DATABASE_URI: postgresql+psycopg2://superset:superset@127.0.0.1:15432/superset
       PYTHONPATH: ${{ github.workspace }}

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -26,7 +26,7 @@ jobs:
         containers: [1, 2, 3]
         browser: ["chrome"]
     env:
-      FLASK_ENV: development
+      FLASK_DEBUG: true
       SUPERSET_CONFIG: tests.integration_tests.superset_test_config
       SUPERSET__SQLALCHEMY_DATABASE_URI: postgresql+psycopg2://superset:superset@127.0.0.1:15432/superset
       PYTHONPATH: ${{ github.workspace }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -453,7 +453,7 @@ superset load-examples
 # Start the Flask dev web server from inside your virtualenv.
 # Note that your page may not have CSS at this point.
 # See instructions below how to build the front-end assets.
-FLASK_ENV=development superset run -p 8088 --with-threads --reload --debugger
+FLASK_DEBUG=true superset run -p 8088 --with-threads --reload --debugger
 ```
 
 Or you can install via our Makefile
@@ -477,7 +477,7 @@ $ make pre-commit
 via `.flaskenv`, however if needed, it should be set to `superset.app:create_app()`**
 
 If you have made changes to the FAB-managed templates, which are not built the same way as the newer, React-powered front-end assets, you need to start the app without the `--with-threads` argument like so:
-`FLASK_ENV=development superset run -p 8088 --reload --debugger`
+`FLASK_DEBUG=true superset run -p 8088 --reload --debugger`
 
 #### Dependencies
 
@@ -518,7 +518,7 @@ def FLASK_APP_MUTATOR(app):
 Then make sure you run your WSGI server using the right worker type:
 
 ```bash
-FLASK_ENV=development gunicorn "superset.app:create_app()" -k "geventwebsocket.gunicorn.workers.GeventWebSocketWorker" -b 127.0.0.1:8088 --reload
+FLASK_DEBUG=true gunicorn "superset.app:create_app()" -k "geventwebsocket.gunicorn.workers.GeventWebSocketWorker" -b 127.0.0.1:8088 --reload
 ```
 
 You can log anything to the browser console, including objects:
@@ -603,7 +603,7 @@ So a typical development workflow is the following:
 1. [run Superset locally](#flask-server) using Flask, on port `8088` — but don't access it directly,<br/>
    ```bash
    # Install Superset and dependencies, plus load your virtual environment first, as detailed above.
-   FLASK_ENV=development superset run -p 8088 --with-threads --reload --debugger
+   FLASK_DEBUG=true superset run -p 8088 --with-threads --reload --debugger
    ```
 2. in parallel, run the Webpack dev server locally on port `9000`,<br/>
    ```bash
@@ -922,7 +922,7 @@ For debugging locally using VSCode, you can configure a launch configuration fil
             "module": "flask",
             "env": {
                 "FLASK_APP": "superset",
-                "FLASK_ENV": "development"
+                "FLASK_DEBUG": "true"
             },
             "args": [
                 "run",

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ FROM python:${PY_VER} AS lean
 
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
-    FLASK_ENV=production \
+    FLASK_DEBUG=true \
     FLASK_APP="superset.app:create_app()" \
     PYTHONPATH="/app/pythonpath" \
     SUPERSET_HOME="/app/superset_home" \

--- a/RELEASING/from_tarball_entrypoint.sh
+++ b/RELEASING/from_tarball_entrypoint.sh
@@ -38,5 +38,5 @@ superset init
 # Loading examples
 superset load-examples
 
-FLASK_ENV=development FLASK_APP="superset.app:create_app()" \
+FLASK_DEBUG=true FLASK_APP="superset.app:create_app()" \
 flask run -p 8088 --with-threads --reload --debugger --host=0.0.0.0

--- a/docker/.env
+++ b/docker/.env
@@ -39,7 +39,7 @@ PYTHONPATH=/app/pythonpath:/app/docker/pythonpath_dev
 REDIS_HOST=redis
 REDIS_PORT=6379
 
-FLASK_ENV=development
+FLASK_DEBUG=true
 SUPERSET_ENV=development
 SUPERSET_LOAD_EXAMPLES=yes
 CYPRESS_CONFIG=false

--- a/docker/.env-non-dev
+++ b/docker/.env-non-dev
@@ -39,7 +39,6 @@ PYTHONPATH=/app/pythonpath:/app/docker/pythonpath_dev
 REDIS_HOST=redis
 REDIS_PORT=6379
 
-FLASK_ENV=production
 SUPERSET_ENV=production
 SUPERSET_LOAD_EXAMPLES=yes
 SUPERSET_SECRET_KEY=TEST_NON_DEV_SECRET

--- a/superset/config.py
+++ b/superset/config.py
@@ -244,7 +244,7 @@ WTF_CSRF_EXEMPT_LIST = [
 ]
 
 # Whether to run the web server in debug mode or not
-DEBUG = os.environ.get("FLASK_ENV") == "development"
+DEBUG = os.environ.get("FLASK_DEBUG")
 FLASK_USE_RELOAD = True
 
 # Enable profiling of Python calls. Turn this on and append ``?_instrument=1``
@@ -1508,7 +1508,7 @@ WELCOME_PAGE_LAST_TAB: (
 # Configuration for environment tag shown on the navbar. Setting 'text' to '' will hide the tag.
 # 'color' can either be a hex color code, or a dot-indexed theme color (e.g. error.base)
 ENVIRONMENT_TAG_CONFIG = {
-    "variable": "FLASK_ENV",
+    "variable": "FLASK_DEBUG",
     "values": {
         "development": {
             "color": "error.base",
@@ -1573,7 +1573,7 @@ elif importlib.util.find_spec("superset_config") and not is_test():
     try:
         # pylint: disable=import-error,wildcard-import,unused-wildcard-import
         import superset_config
-        from superset_config import *  # type: ignore
+        from superset_config import *
 
         print(f"Loaded your LOCAL configuration at [{superset_config.__file__}]")
     except Exception:

--- a/superset/config.py
+++ b/superset/config.py
@@ -244,7 +244,7 @@ WTF_CSRF_EXEMPT_LIST = [
 ]
 
 # Whether to run the web server in debug mode or not
-DEBUG = True if str(os.environ.get("FLASK_DEBUG")).lower() in ("true", "1") else False
+DEBUG = str(os.environ.get("FLASK_DEBUG")).lower() in ("true", "1")
 FLASK_USE_RELOAD = True
 
 # Enable profiling of Python calls. Turn this on and append ``?_instrument=1``

--- a/superset/config.py
+++ b/superset/config.py
@@ -244,7 +244,7 @@ WTF_CSRF_EXEMPT_LIST = [
 ]
 
 # Whether to run the web server in debug mode or not
-DEBUG = True if str(os.environ.get("FLASK_DEBUG")).lower() in ('true', '1') else False
+DEBUG = True if str(os.environ.get("FLASK_DEBUG")).lower() in ("true", "1") else False
 FLASK_USE_RELOAD = True
 
 # Enable profiling of Python calls. Turn this on and append ``?_instrument=1``

--- a/superset/config.py
+++ b/superset/config.py
@@ -244,7 +244,7 @@ WTF_CSRF_EXEMPT_LIST = [
 ]
 
 # Whether to run the web server in debug mode or not
-DEBUG = os.environ.get("FLASK_DEBUG")
+DEBUG = True if str(os.environ.get("FLASK_DEBUG")).lower() in ('true', '1') else False
 FLASK_USE_RELOAD = True
 
 # Enable profiling of Python calls. Turn this on and append ``?_instrument=1``

--- a/superset/config.py
+++ b/superset/config.py
@@ -1573,7 +1573,7 @@ elif importlib.util.find_spec("superset_config") and not is_test():
     try:
         # pylint: disable=import-error,wildcard-import,unused-wildcard-import
         import superset_config
-        from superset_config import *
+        from superset_config import *  # type: ignore
 
         print(f"Loaded your LOCAL configuration at [{superset_config.__file__}]")
     except Exception:


### PR DESCRIPTION
### SUMMARY
The environment var FLASK_ENV was [deprecated](https://github.com/pallets/flask/issues/4714), same function will use FLASK_DEBUG. This PR intend to fix a warning when I start werkzeug server.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### After
<img width="1198" alt="image" src="https://github.com/apache/superset/assets/2016594/7208273e-4c16-41c2-8c0d-5aa9d6af2616">

### Before
<img width="1161" alt="image" src="https://github.com/apache/superset/assets/2016594/3665b0ff-eb0a-47d9-9b6c-ce52287742b5">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
