### PR TITLE
feat(cli): add assets-import and assets-export

### DIFF
--- a/superset/cli/importexport.py
+++ b/superset/cli/importexport.py
@@ -71,8 +71,10 @@ if feature_flags.get("VERSIONED_EXPORT"):
     )
     def export_assets(assets_file: Optional[str] = None) -> None:
         """Export assets from ZIP file"""
+        # pylint: disable=import-outside-toplevel
         from superset.commands.export.assets import ExportAssetsCommand
 
+        # pylint: disable=assigning-non-slot
         g.user = security_manager.find_user(username="admin")
 
         timestamp = datetime.now().strftime("%Y%m%dT%H%M%S")
@@ -106,12 +108,13 @@ if feature_flags.get("VERSIONED_EXPORT"):
     )
     @click.option(
         "--passwords",
-        help='DB passwords with the following format {"databases/examples.yaml": "superset"}',
+        help="DB passwords",
     )
     def import_assets(
         path: str, username: Optional[str], passwords: Optional[str] = None
     ) -> None:
         """Import assets from ZIP file"""
+        # pylint: disable=import-outside-toplevel
         from superset.commands.importers.v1.assets import ImportAssetsCommand
         from superset.commands.importers.v1.utils import get_contents_from_bundle
 


### PR DESCRIPTION
### SUMMARY
Analog to the API, this PR adds the possibility to import and export assets from Superset CLI. 

AFAIK the unversioned `importexport` will be deprecated, so this new functionality applies to the versioned `importexport` only.

### TESTING INSTRUCTIONS
export
- `superset export-assets --help`

import
- `superset import-assets --help`

test
- `scripts/tests/run.sh --module tests/integration_tests/cli_tests.py`

### ADDITIONAL INFORMATION
- [x] Required feature flags: `VERSIONED_EXPORT`
- [x] Introduces new feature or API

