### PR TITLE
feat(sqllab): add shortcut for run current sql

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -333,6 +333,59 @@ const SqlEditor = ({
         },
       },
       {
+        name: 'runQuery3',
+        key: 'ctrl+shift+enter',
+        descr: t('Run current query'),
+        func: editor => {
+          if (!editor.getValue().trim()) {
+            return;
+          }
+          const session = editor.getSession();
+          const cursorPosition = editor.getCursorPosition();
+          const totalLine = session.getLength();
+          let end = editor.find(';', {
+            backwards: false,
+            skipCurrent: true,
+            start: cursorPosition,
+          })?.end;
+          if (!end || end.row < cursorPosition.row) {
+            end = {
+              row: totalLine + 1,
+              column: 0,
+            };
+          }
+          let start = editor.find(';', {
+            backwards: true,
+            skipCurrent: true,
+            start: cursorPosition,
+          })?.end;
+          let currentLine = editor.find(';', {
+            backwards: true,
+            skipCurrent: true,
+            start: cursorPosition,
+          })?.end?.row;
+          if (!currentLine || currentLine > cursorPosition.row) {
+            currentLine = 0;
+          }
+          let content =
+            currentLine === start?.row
+              ? session.getLine(currentLine).slice(start.column).trim()
+              : session.getLine(currentLine).trim();
+          while (!content && currentLine < totalLine) {
+            currentLine += 1;
+            content = session.getLine(currentLine).trim();
+          }
+          if (currentLine !== start?.row) {
+            start = { row: currentLine, column: 0 };
+          }
+          editor.selection.setRange({
+            start: start ?? { row: 0, column: 0 },
+            end,
+          });
+          startQuery();
+        },
+      },
+      {
         name: 'newTab',
         key: userOS === 'Windows' ? 'ctrl+q' : 'ctrl+t',
         descr: t('New tab'),

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -364,7 +364,12 @@ const SqlEditor = ({
             skipCurrent: true,
             start: cursorPosition,
           })?.end?.row;
-          if (!currentLine || currentLine > cursorPosition.row) {
+          if (
+            !currentLine ||
+            currentLine > cursorPosition.row ||
+            (currentLine === cursorPosition.row &&
+              start?.column > cursorPosition.column)
+          ) {
             currentLine = 0;
           }
           let content =
@@ -383,6 +388,8 @@ const SqlEditor = ({
             end,
           });
           startQuery();
+          editor.selection.clearSelection();
+          editor.moveCursorToPosition(cursorPosition);
         },
       },
       {


### PR DESCRIPTION
### SUMMARY
The manual selection of the current query is time-consuming. (Longer the query more time it takes to select manually)
This commit creates a new shortcut(`ctrl + shift + enter`) which automatically detects and selects the range of the current query and then run the selection in order to reduce the manual selection work.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

After:

https://github.com/apache/superset/assets/1392866/d146c9a5-5819-4fe2-af22-6281f3bb0de6

Before:

https://github.com/apache/superset/assets/1392866/45f22a20-32b3-4eab-b075-95bf4e108df6



### TESTING INSTRUCTIONS
Hit "Ctrl+Shift+Enter" on sql editor

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
