### PR TITLE
chore: Removes getUiOverrideRegistry

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -33,6 +33,7 @@ assists people when migrating to a new version.
 
 ### Breaking Changes
 
+- [24330](https://github.com/apache/superset/pull/24330) Removes `getUiOverrideRegistry` from `ExtensionsRegistry`.
 - [23933](https://github.com/apache/superset/pull/23933) Removes the deprecated Multiple Line Charts.
 - [23741](https://github.com/apache/superset/pull/23741) Migrates the TreeMap chart and removes the legacy Treemap code.
 - [23712](https://github.com/apache/superset/pull/23712) Migrates the Pivot Table v1 chart to v2 and removes v1 code.

--- a/superset-frontend/packages/superset-ui-core/src/ui-overrides/ExtensionsRegistry.ts
+++ b/superset-frontend/packages/superset-ui-core/src/ui-overrides/ExtensionsRegistry.ts
@@ -29,7 +29,3 @@ class ExtensionsRegistry extends TypedRegistry<Extensions> {
 }
 
 export const getExtensionsRegistry = makeSingleton(ExtensionsRegistry, {});
-
-// Exporting this under the old name for backwards compatibility.
-// After downstream folks have migrated to `getExtensionsRegistry`, we should remove this.
-export const getUiOverrideRegistry = getExtensionsRegistry;

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -26,7 +26,7 @@ import {
   FeatureFlag,
   t,
   getSharedLabelColor,
-  getUiOverrideRegistry,
+  getExtensionsRegistry,
 } from '@superset-ui/core';
 import { Global } from '@emotion/react';
 import { isFeatureEnabled } from 'src/featureFlags';
@@ -58,7 +58,7 @@ import { PageHeaderWithActions } from 'src/components/PageHeaderWithActions';
 import { DashboardEmbedModal } from '../DashboardEmbedControls';
 import OverwriteConfirm from '../OverwriteConfirm';
 
-const uiOverrideRegistry = getUiOverrideRegistry();
+const extensionsRegistry = getExtensionsRegistry();
 
 const propTypes = {
   addSuccessToast: PropTypes.func.isRequired,
@@ -495,7 +495,7 @@ class Header extends React.PureComponent {
       dashboardTitleChanged(updates.title);
     };
 
-    const NavExtension = uiOverrideRegistry.get('dashboard.nav.right');
+    const NavExtension = extensionsRegistry.get('dashboard.nav.right');
 
     return (
       <div


### PR DESCRIPTION
### SUMMARY
Removes `getUiOverrideRegistry` from `ExtensionsRegistry` as part of 3.0 cleanup.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
