### PR TITLE
chore: remove deprecated api /superset/override_role_permissions

### DIFF
--- a/tests/integration_tests/access_tests.py
+++ b/tests/integration_tests/access_tests.py
@@ -16,7 +16,6 @@
 # under the License.
 # isort:skip_file
 """Unit tests for Superset"""
-import json
 import unittest
 from typing import Optional
 from unittest import mock
@@ -143,79 +142,6 @@ class TestRequestAccess(SupersetTestCase):
         override_me.permissions = []
         db.session.commit()
         db.session.close()
-
-    def test_override_role_permissions_is_admin_only(self):
-        self.logout()
-        self.login("alpha")
-        response = self.client.post(
-            "/superset/override_role_permissions/",
-            data=json.dumps(ROLE_TABLES_PERM_DATA),
-            content_type="application/json",
-            follow_redirects=True,
-        )
-        self.assertNotEqual(405, response.status_code)
-
-    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
-    def test_override_role_permissions_1_table(self):
-        database = get_example_database()
-        with database.get_sqla_engine_with_context() as engine:
-            schema = inspect(engine).default_schema_name
-
-        perm_data = ROLE_TABLES_PERM_DATA.copy()
-        perm_data["database"][0]["schema"][0]["name"] = schema
-
-        response = self.client.post(
-            "/superset/override_role_permissions/",
-            data=json.dumps(perm_data),
-            content_type="application/json",
-        )
-        self.assertEqual(201, response.status_code)
-
-        updated_override_me = security_manager.find_role("override_me")
-        self.assertEqual(1, len(updated_override_me.permissions))
-        birth_names = self.get_table(name="birth_names")
-        self.assertEqual(
-            birth_names.perm, updated_override_me.permissions[0].view_menu.name
-        )
-        self.assertEqual(
-            "datasource_access", updated_override_me.permissions[0].permission.name
-        )
-
-    @pytest.mark.usefixtures(
-        "load_energy_table_with_slice", "load_birth_names_dashboard_with_slices"
-    )
-    def test_override_role_permissions_drops_absent_perms(self):
-        database = get_example_database()
-        with database.get_sqla_engine_with_context() as engine:
-            schema = inspect(engine).default_schema_name
-
-        override_me = security_manager.find_role("override_me")
-        override_me.permissions.append(
-            security_manager.find_permission_view_menu(
-                view_menu_name=self.get_table(name="energy_usage").perm,
-                permission_name="datasource_access",
-            )
-        )
-        db.session.flush()
-
-        perm_data = ROLE_TABLES_PERM_DATA.copy()
-        perm_data["database"][0]["schema"][0]["name"] = schema
-
-        response = self.client.post(
-            "/superset/override_role_permissions/",
-            data=json.dumps(perm_data),
-            content_type="application/json",
-        )
-        self.assertEqual(201, response.status_code)
-        updated_override_me = security_manager.find_role("override_me")
-        self.assertEqual(1, len(updated_override_me.permissions))
-        birth_names = self.get_table(name="birth_names")
-        self.assertEqual(
-            birth_names.perm, updated_override_me.permissions[0].view_menu.name
-        )
-        self.assertEqual(
-            "datasource_access", updated_override_me.permissions[0].permission.name
-        )
 
     def test_clean_requests_after_role_extend(self):
         session = db.session


### PR DESCRIPTION
### SUMMARY
Removes old deprecated API `/superset/override_role_permissions/`

Related with the ongoing effort for removing deprecated APIs from `/superset`: https://github.com/apache/superset/discussions/24332

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
