### PR TITLE
fix: Viz migration adjustments - 1

### DIFF
--- a/superset/migrations/shared/migrate_viz/base.py
+++ b/superset/migrations/shared/migrate_viz/base.py
@@ -25,6 +25,7 @@ from sqlalchemy import and_, Column, Integer, String, Text
 from sqlalchemy.ext.declarative import declarative_base
 
 from superset import conf, db, is_feature_enabled
+from superset.constants import TimeGrain
 from superset.migrations.shared.utils import paginated_update, try_load_json
 
 Base = declarative_base()
@@ -95,6 +96,7 @@ class MigrateViz:
 
         if self.has_x_axis_control:
             rv_data["x_axis"] = granularity_sqla
+            rv_data["time_grain_sqla"] = rv_data.get("time_grain_sqla") or TimeGrain.DAY
 
         temporal_filter = {
             "clause": "WHERE",

--- a/superset/migrations/shared/migrate_viz/processors.py
+++ b/superset/migrations/shared/migrate_viz/processors.py
@@ -80,13 +80,15 @@ class MigratePivotTable(MigrateViz):
     def _pre_action(self) -> None:
         if pivot_margins := self.data.get("pivot_margins"):
             self.data["colTotals"] = pivot_margins
-            self.data["rowTotals"] = pivot_margins
 
         if pandas_aggfunc := self.data.get("pandas_aggfunc"):
             self.data["pandas_aggfunc"] = self.aggregation_mapping[pandas_aggfunc]
 
+        self.data["rowOrder"] = "value_z_to_a"
+
 
 class MigrateDualLine(MigrateViz):
+    has_x_axis_control = True
     source_viz_type = "dual_line"
     target_viz_type = "mixed_timeseries"
     rename_keys = {

--- a/tests/unit_tests/migrations/viz/pivot_table_v1_v2_test.py
+++ b/tests/unit_tests/migrations/viz/pivot_table_v1_v2_test.py
@@ -45,7 +45,7 @@ TARGET_FORM_DATA = {
     "granularity_sqla": "ds",
     "groupbyColumns": ["state"],
     "groupbyRows": ["name"],
-    "rowTotals": True,
+    "rowOrder": "value_z_to_a",
     "series_limit_metric": "count",
     "time_range": "100 years ago : now",
     "transposePivot": True,


### PR DESCRIPTION
### SUMMARY
Makes adjustments to the viz migrations to fix problems found during tests.

- Adjusts the Pivot Table migration to account only for the column totals instead of rows and columns given that the legacy chart didn't support row totals.
- Adjusts the Pivot Table to sort the rows by descending values given that this was the original algorithm in the legacy version.
- Adjusts the Dual Line migration to account for the `GENERIC_CHART_AXES` feature flag.
- Adjusts migrations that contain a X-axis control to set the time grain as Day by default if none is provided

@jinghua-qa 

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
