### PR TITLE
feat: add a tooltip to clarify metric_name in the DatasetEditor

### DIFF
--- a/superset-frontend/src/components/Datasource/CollectionTable.tsx
+++ b/superset-frontend/src/components/Datasource/CollectionTable.tsx
@@ -226,7 +226,7 @@ export default class CRUDCollection extends React.PureComponent<
     return label;
   }
 
-  getTooltip(col: any) {
+  getTooltip(col: string) {
     const { columnLabelTooltips } = this.props;
     return columnLabelTooltips?.[col];
   }

--- a/superset-frontend/src/components/Datasource/CollectionTable.tsx
+++ b/superset-frontend/src/components/Datasource/CollectionTable.tsx
@@ -323,7 +323,7 @@ export default class CRUDCollection extends React.PureComponent<
   renderTH(col: string, sortColumns: Array<string>) {
     const tooltip = this.getTooltip(col);
     return (
-      <th key={col}>
+      <th key={col} className="no-wrap">
         {this.getLabel(col)}
         {tooltip && (
           <>

--- a/superset-frontend/src/components/Datasource/CollectionTable.tsx
+++ b/superset-frontend/src/components/Datasource/CollectionTable.tsx
@@ -18,12 +18,14 @@
  */
 import React, { ReactNode } from 'react';
 import shortid from 'shortid';
+
+import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
 import { t, styled } from '@superset-ui/core';
+
 import Button from 'src/components/Button';
 import Icons from 'src/components/Icons';
 import Fieldset from './Fieldset';
 import { recurseReactClone } from './utils';
-import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
 
 interface CRUDCollectionProps {
   allowAddItem?: boolean;
@@ -317,6 +319,7 @@ export default class CRUDCollection extends React.PureComponent<
     }
     return <Icons.Sort onClick={this.sortColumn(col, 1)} />;
   }
+
   renderTH(col, sortColumns) {
     const tooltip = this.getTooltip(col);
     return (

--- a/superset-frontend/src/components/Datasource/CollectionTable.tsx
+++ b/superset-frontend/src/components/Datasource/CollectionTable.tsx
@@ -320,7 +320,7 @@ export default class CRUDCollection extends React.PureComponent<
     return <Icons.Sort onClick={this.sortColumn(col, 1)} />;
   }
 
-  renderTH(col, sortColumns) {
+  renderTH(col: string, sortColumns: Array<string>) {
     const tooltip = this.getTooltip(col);
     return (
       <th key={col}>

--- a/superset-frontend/src/components/Datasource/CollectionTable.tsx
+++ b/superset-frontend/src/components/Datasource/CollectionTable.tsx
@@ -23,12 +23,14 @@ import Button from 'src/components/Button';
 import Icons from 'src/components/Icons';
 import Fieldset from './Fieldset';
 import { recurseReactClone } from './utils';
+import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
 
 interface CRUDCollectionProps {
   allowAddItem?: boolean;
   allowDeletes?: boolean;
   collection: Array<object>;
   columnLabels?: object;
+  columnLabelTooltips?: object;
   emptyMessage?: ReactNode;
   expandFieldset?: ReactNode;
   extraButtons?: ReactNode;
@@ -222,6 +224,11 @@ export default class CRUDCollection extends React.PureComponent<
     return label;
   }
 
+  getTooltip(col: any) {
+    const { columnLabelTooltips } = this.props;
+    return columnLabelTooltips?.[col];
+  }
+
   changeCollection(collection: any, newItem?: object) {
     this.setState({ collection });
     if (this.props.onChange) {
@@ -310,6 +317,24 @@ export default class CRUDCollection extends React.PureComponent<
     }
     return <Icons.Sort onClick={this.sortColumn(col, 1)} />;
   }
+  renderTH(col, sortColumns) {
+    const tooltip = this.getTooltip(col);
+    return (
+      <th key={col}>
+        {this.getLabel(col)}
+        {tooltip && (
+          <>
+            {' '}
+            <InfoTooltipWithTrigger
+              label={t('description')}
+              tooltip={tooltip}
+            />
+          </>
+        )}
+        {sortColumns?.includes(col) && this.renderSortIcon(col)}
+      </th>
+    );
+  }
 
   renderHeaderRow() {
     const cols = this.effectiveTableColumns();
@@ -319,12 +344,7 @@ export default class CRUDCollection extends React.PureComponent<
       <thead>
         <tr>
           {expandFieldset && <th aria-label="Expand" className="tiny-cell" />}
-          {cols.map(col => (
-            <th key={col}>
-              {this.getLabel(col)}
-              {sortColumns?.includes(col) && this.renderSortIcon(col)}
-            </th>
-          ))}
+          {cols.map(col => this.renderTH(col, sortColumns))}
           {extraButtons}
           {allowDeletes && (
             <th key="delete-item" aria-label="Delete" className="tiny-cell" />

--- a/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
@@ -182,10 +182,10 @@ function ColumnCollectionTable({
   allowAddItem,
   allowEditDataType,
   itemGenerator,
+  columnLabelTooltips,
 }) {
   return (
     <CollectionTable
-      collection={columns}
       tableColumns={
         isFeatureEnabled(FeatureFlag.ENABLE_ADVANCED_DATA_TYPES)
           ? [
@@ -229,6 +229,8 @@ function ColumnCollectionTable({
       allowDeletes
       allowAddItem={allowAddItem}
       itemGenerator={itemGenerator}
+      collection={columns}
+      columnLabelTooltips={columnLabelTooltips}
       stickyHeader
       expandFieldset={
         <FormContainer>
@@ -1424,6 +1426,13 @@ class DatasourceEditor extends React.PureComponent {
                 onColumnsChange={calculatedColumns =>
                   this.setColumns({ calculatedColumns })
                 }
+                columnLabelTooltips={{
+                  column_name: t(
+                    'This field is used as a unique identifier to attach ' +
+                      'the calculated dimension to charts. It is also used ' +
+                      'as the alias in the SQL query.',
+                  ),
+                }}
                 onDatasourceChange={this.onDatasourceChange}
                 datasource={datasource}
                 editableColumnName

--- a/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
@@ -1194,9 +1194,16 @@ class DatasourceEditor extends React.PureComponent {
         tableColumns={['metric_name', 'verbose_name', 'expression']}
         sortColumns={['metric_name', 'verbose_name', 'expression']}
         columnLabels={{
-          metric_name: t('Metric'),
+          metric_name: t('Metric Key'),
           verbose_name: t('Label'),
           expression: t('SQL expression'),
+        }}
+        columnLabelTooltips={{
+          metric_name: t(
+            'This field is used as a unique identifier to attach ' +
+              'the metric to charts. It is also used as the alias in the ' +
+              'SQL query.',
+          ),
         }}
         expandFieldset={
           <FormContainer>

--- a/superset-frontend/src/components/Datasource/DatasourceEditor.test.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceEditor.test.jsx
@@ -29,6 +29,12 @@ const props = {
   addSuccessToast: () => {},
   addDangerToast: () => {},
   onChange: () => {},
+  columnLabels: {
+    state: 'State',
+  },
+  columnLabelTooltips: {
+    state: 'This is a tooltip for `state`',
+  },
 };
 const DATASOURCE_ENDPOINT = 'glob:*/datasource/external_metadata_by_name/*';
 


### PR DESCRIPTION
<img width="768" alt="Screen Shot 2023-06-09 at 5 41 02 PM" src="https://github.com/apache/superset/assets/487433/8e192806-532d-47de-94ee-00be79aefccc">
<img width="902" alt="Screen Shot 2023-06-12 at 4 42 27 PM" src="https://github.com/apache/superset/assets/487433/3f708a8c-6b99-4e71-bb0f-0aa99e72b620">



### SUMMARY
Adding this tooltip that clarifies the usage of the Metric field in the dataset's metric list. It seems critical to let the user know how this is used.

I don't think this is  how we want this to work (user-provided name as a unique key to associate with charts, but somehow is important to let the user know about it)

Longer term, we should use UUIDs for metrics internally and rename this "Metric Alias" or just get rid of it.