### PR TITLE
chore: Disable redux errors

### DIFF
--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -116,6 +116,8 @@ const plugins = [
   // expose mode variable to other modules
   new webpack.DefinePlugin({
     'process.env.WEBPACK_MODE': JSON.stringify(mode),
+    'process.env.REDUX_DEFAULT_MIDDLEWARE':
+      process.env.REDUX_DEFAULT_MIDDLEWARE,
   }),
 
   new CopyPlugin({


### PR DESCRIPTION
### SUMMARY
Due to long standing issues with Superset's redux store, recently introduced redux-toolkit produces hundreds of console errors related to violating state immutability and saving un-serializable objects. Though the errors are accurate, they make development work harder due to cluttering the browser console. This PR disables the Redux middleware responsible for issuing those errors by default.
If you'd like to enable those errors to work on improving the Redux state, you can do that by setting env variable `REDUX_DEFAULT_MIDDLEWARE` to true. To do that, you can run frontend with the following script:
```
REDUX_DEFAULT_MIDDLEWARE=true npm run dev-server
```
or
```
export REDUX_DEFAULT_MIDDLEWARE=true
npm run dev-server
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
