### PR TITLE
fix: deck.gl Scatterplot min/max radius

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/Scatter.jsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/Scatter.jsx
@@ -83,8 +83,8 @@ export function getLayer(
     fp64: true,
     getFillColor: d => d.color,
     getRadius: d => d.radius,
-    radiusMinPixels: fd.min_radius || null,
-    radiusMaxPixels: fd.max_radius || null,
+    radiusMinPixels: Number(fd.min_radius) || null,
+    radiusMaxPixels: Number(fd.max_radius) || null,
     stroked: false,
     ...commonLayerProps(
       fd,


### PR DESCRIPTION

### SUMMARY
Fixes setting min/max radius in deck.gl Scatterplot chart. Sometimes when user changed the value the circles would disappear, because the input was actually treated as a string and deck.gl expects a number

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1728" alt="image" src="https://github.com/apache/superset/assets/15073128/8744a456-54c3-4f97-bd8c-610eab3123f9">

After:
<img width="1728" alt="image" src="https://github.com/apache/superset/assets/15073128/2fbdfc7a-b484-41b5-a6d3-8d44b9e9ca42">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
