### PR TITLE
feat: make data tables support html

### DIFF
--- a/superset-frontend/packages/superset-ui-core/package.json
+++ b/superset-frontend/packages/superset-ui-core/package.json
@@ -60,7 +60,8 @@
     "reselect": "^4.0.0",
     "rison": "^0.1.1",
     "seedrandom": "^3.0.5",
-    "whatwg-fetch": "^3.0.0"
+    "whatwg-fetch": "^3.0.0",
+    "xss": "^1.0.14"
   },
   "devDependencies": {
     "@emotion/styled": "^11.3.0",

--- a/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import React from 'react';
 import {
   sanitizeHtml,
   isProbablyHTML,

--- a/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
@@ -108,6 +108,6 @@ describe('removeHTMLTags', () => {
   test('should handle malformed HTML tags and remove only well-formed tags', () => {
     const input = '<div><h1>Unclosed tag';
     const output = removeHTMLTags(input);
-    expect(output).toBe('<div>Unclosed tag');
+    expect(output).toBe('Unclosed tag');
   });
 });

--- a/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  sanitizeHtml,
+  isProbablyHTML,
+  sanitizeHtmlIfNeeded,
+  safeHtmlSpan,
+} from './html';
+
+describe('sanitizeHtml', () => {
+  test('should sanitize the HTML string', () => {
+    const htmlString = '<script>alert("XSS")</script>';
+    const sanitizedString = sanitizeHtml(htmlString);
+    expect(sanitizedString).not.toContain('script');
+  });
+});
+
+describe('isProbablyHTML', () => {
+  test('should return true if the text contains HTML tags', () => {
+    const htmlText = '<div>Some HTML content</div>';
+    const isHTML = isProbablyHTML(htmlText);
+    expect(isHTML).toBe(true);
+  });
+
+  test('should return false if the text does not contain HTML tags', () => {
+    const plainText = 'Just a plain text';
+    const isHTML = isProbablyHTML(plainText);
+    expect(isHTML).toBe(false);
+  });
+});
+
+describe('sanitizeHtmlIfNeeded', () => {
+  test('should sanitize the HTML string if it contains HTML tags', () => {
+    const htmlString = '<div>Some <b>HTML</b> content</div>';
+    const sanitizedString = sanitizeHtmlIfNeeded(htmlString);
+    expect(sanitizedString).toEqual(htmlString);
+  });
+
+  test('should return the string as is if it does not contain HTML tags', () => {
+    const plainText = 'Just a plain text';
+    const sanitizedString = sanitizeHtmlIfNeeded(plainText);
+    expect(sanitizedString).toEqual(plainText);
+  });
+});
+
+describe('safeHtmlSpan', () => {
+  test('should return a safe HTML span when the input is HTML', () => {
+    const htmlString = '<div>Some <b>HTML</b> content</div>';
+    const safeSpan = safeHtmlSpan(htmlString);
+    expect(safeSpan).toEqual(
+      <span
+        className="safe-html-wrapper"
+        dangerouslySetInnerHTML={{ __html: htmlString }}
+      />,
+    );
+  });
+
+  test('should return the input string as is when it is not HTML', () => {
+    const plainText = 'Just a plain text';
+    const result = safeHtmlSpan(plainText);
+    expect(result).toEqual(plainText);
+  });
+});

--- a/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
@@ -21,6 +21,7 @@ import {
   isProbablyHTML,
   sanitizeHtmlIfNeeded,
   safeHtmlSpan,
+  removeHTMLTags,
 } from './html';
 
 describe('sanitizeHtml', () => {
@@ -75,5 +76,37 @@ describe('safeHtmlSpan', () => {
     const plainText = 'Just a plain text';
     const result = safeHtmlSpan(plainText);
     expect(result).toEqual(plainText);
+  });
+});
+
+describe('removeHTMLTags', () => {
+  test('should remove HTML tags from the string', () => {
+    const input = '<p>Hello, <strong>World!</strong></p>';
+    const output = removeHTMLTags(input);
+    expect(output).toBe('Hello, World!');
+  });
+
+  test('should return the same string when no HTML tags are present', () => {
+    const input = 'This is a plain text.';
+    const output = removeHTMLTags(input);
+    expect(output).toBe('This is a plain text.');
+  });
+
+  test('should remove nested HTML tags and return combined text content', () => {
+    const input = '<div><h1>Title</h1><p>Content</p></div>';
+    const output = removeHTMLTags(input);
+    expect(output).toBe('TitleContent');
+  });
+
+  test('should handle self-closing tags and return an empty string', () => {
+    const input = '<img src="image.png" alt="Image">';
+    const output = removeHTMLTags(input);
+    expect(output).toBe('');
+  });
+
+  test('should handle malformed HTML tags and remove only well-formed tags', () => {
+    const input = '<div><h1>Unclosed tag';
+    const output = removeHTMLTags(input);
+    expect(output).toBe('<div>Unclosed tag');
   });
 });

--- a/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { FilterXSS, getDefaultWhiteList } from 'xss';
+
+const xssFilter = new FilterXSS({
+  whiteList: {
+    ...getDefaultWhiteList(),
+    span: ['style', 'class', 'title'],
+    div: ['style', 'class'],
+    a: ['style', 'class', 'href', 'title', 'target'],
+    img: ['style', 'class', 'src', 'alt', 'title', 'width', 'height'],
+    video: [
+      'autoplay',
+      'controls',
+      'loop',
+      'preload',
+      'src',
+      'height',
+      'width',
+      'muted',
+    ],
+  },
+  stripIgnoreTag: true,
+  css: false,
+});
+
+export function sanitizeHtml(htmlString: string) {
+  return xssFilter.process(htmlString);
+}
+
+export function isProbablyHTML(text: string) {
+  return /<[^>]+>/.test(text);
+}
+
+export function sanitizeHtmlIfNeeded(htmlString: string) {
+  return isProbablyHTML(htmlString) ? sanitizeHtml(htmlString) : htmlString;
+}
+
+export function safeHtmlSpan(possiblyHtmlString: string) {
+  const isHtml = isProbablyHTML(possiblyHtmlString);
+  if (isHtml) {
+    return (
+      <span
+        className="safe-html-wrapper"
+        dangerouslySetInnerHTML={{ __html: sanitizeHtml(possiblyHtmlString) }}
+      />
+    );
+  }
+  return possiblyHtmlString;
+}

--- a/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
@@ -47,3 +47,7 @@ export function safeHtmlSpan(possiblyHtmlString: string) {
   }
   return possiblyHtmlString;
 }
+
+export function removeHTMLTags(str: string): string {
+  return str.replace(/<[^>]*>/g, '');
+}

--- a/superset-frontend/packages/superset-ui-core/src/utils/index.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/index.ts
@@ -31,3 +31,4 @@ export { getSelectedText } from './getSelectedText';
 export * from './featureFlags';
 export * from './random';
 export * from './typedMemo';
+export * from './html';

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/components/Tooltip.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/components/Tooltip.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { styled } from '@superset-ui/core';
+import { styled, safeHtmlSpan } from '@superset-ui/core';
 import React, { useMemo } from 'react';
 import { filterXSS } from 'xss';
 
@@ -55,28 +55,12 @@ export default function Tooltip(props: TooltipProps) {
   }
 
   const { x, y, content } = tooltip;
-
-  if (typeof content === 'string') {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const contentHtml = useMemo(
-      () => ({
-        __html: filterXSS(content, { stripIgnoreTag: true }),
-      }),
-      [content],
-    );
-    return (
-      <StyledDiv top={y} left={x}>
-        <div
-          // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={contentHtml}
-        />
-      </StyledDiv>
-    );
-  }
+  let safeContent =
+    typeof content === 'string' ? safeHtmlSpan(content) : content;
 
   return (
     <StyledDiv top={y} left={x}>
-      {content}
+      {safeContent}
     </StyledDiv>
   );
 }

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/components/Tooltip.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/components/Tooltip.tsx
@@ -18,8 +18,7 @@
  */
 
 import { styled, safeHtmlSpan } from '@superset-ui/core';
-import React, { useMemo } from 'react';
-import { filterXSS } from 'xss';
+import React from 'react';
 
 export type TooltipProps = {
   tooltip:

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/components/Tooltip.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/components/Tooltip.tsx
@@ -55,7 +55,7 @@ export default function Tooltip(props: TooltipProps) {
   }
 
   const { x, y, content } = tooltip;
-  let safeContent =
+  const safeContent =
     typeof content === 'string' ? safeHtmlSpan(content) : content;
 
   return (

--- a/superset-frontend/plugins/plugin-chart-table/src/utils/formatValue.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/utils/formatValue.ts
@@ -16,40 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { FilterXSS, getDefaultWhiteList } from 'xss';
 import {
   DataRecordValue,
   GenericDataType,
   getNumberFormatter,
+  isProbablyHTML,
+  sanitizeHtml,
 } from '@superset-ui/core';
 import { DataColumnMeta } from '../types';
 import DateWithFormatter from './DateWithFormatter';
-
-const xss = new FilterXSS({
-  whiteList: {
-    ...getDefaultWhiteList(),
-    span: ['style', 'class', 'title'],
-    div: ['style', 'class'],
-    a: ['style', 'class', 'href', 'title', 'target'],
-    img: ['style', 'class', 'src', 'alt', 'title', 'width', 'height'],
-    video: [
-      'autoplay',
-      'controls',
-      'loop',
-      'preload',
-      'src',
-      'height',
-      'width',
-      'muted',
-    ],
-  },
-  stripIgnoreTag: true,
-  css: false,
-});
-
-function isProbablyHTML(text: string) {
-  return /<[^>]+>/.test(text);
-}
 
 /**
  * Format text for cell value.
@@ -76,7 +51,7 @@ function formatValue(
     return [false, formatter(value as number)];
   }
   if (typeof value === 'string') {
-    return isProbablyHTML(value) ? [true, xss.process(value)] : [false, value];
+    return isProbablyHTML(value) ? [true, sanitizeHtml(value)] : [false, value];
   }
   return [false, value.toString()];
 }

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailMenuItems.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailMenuItems.tsx
@@ -50,7 +50,13 @@ const DisabledMenuItem = ({ children, ...props }: { children: ReactNode }) => (
     </div>
   </Menu.Item>
 );
-const Filter = ({ children: ReactNode, stripHTML = false }) => {
+const Filter = ({
+  children,
+  stripHTML = false,
+}: {
+  children: ReactNode;
+  stripHTML: boolean;
+}) => {
   const content =
     stripHTML && typeof children === 'string'
       ? removeHTMLTags(children)

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailMenuItems.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailMenuItems.tsx
@@ -26,6 +26,7 @@ import {
   extractQueryFields,
   getChartMetadataRegistry,
   QueryFormData,
+  removeHTMLTags,
   styled,
   t,
 } from '@superset-ui/core';
@@ -49,8 +50,14 @@ const DisabledMenuItem = ({ children, ...props }: { children: ReactNode }) => (
     </div>
   </Menu.Item>
 );
-
-const Filter = styled.span`
+const Filter = ({ children, stripHTML = false }) => {
+  const content =
+    stripHTML && typeof children == 'string'
+      ? removeHTMLTags(children)
+      : children;
+  return <span>{content}</span>;
+};
+const StyledFilter = styled(Filter)`
   ${({ theme }) => `
      font-weight: ${theme.typography.weights.bold};
      color: ${theme.colors.primary.base};
@@ -191,7 +198,7 @@ const DrillDetailMenuItems = ({
               onClick={openModal.bind(null, [filter])}
             >
               {`${DRILL_TO_DETAIL_TEXT} `}
-              <Filter>{filter.formattedVal}</Filter>
+              <StyledFilter stripHTML>{filter.formattedVal}</StyledFilter>
             </MenuItemWithTruncation>
           ))}
           {filters.length > 1 && (
@@ -202,7 +209,7 @@ const DrillDetailMenuItems = ({
             >
               <div>
                 {`${DRILL_TO_DETAIL_TEXT} `}
-                <Filter>{t('all')}</Filter>
+                <StyledFilter>{t('all')}</StyledFilter>
               </div>
             </Menu.Item>
           )}

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailMenuItems.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailMenuItems.tsx
@@ -52,7 +52,7 @@ const DisabledMenuItem = ({ children, ...props }: { children: ReactNode }) => (
 );
 const Filter = ({ children, stripHTML = false }) => {
   const content =
-    stripHTML && typeof children == 'string'
+    stripHTML && typeof children === 'string'
       ? removeHTMLTags(children)
       : children;
   return <span>{content}</span>;

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailMenuItems.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailMenuItems.tsx
@@ -50,7 +50,7 @@ const DisabledMenuItem = ({ children, ...props }: { children: ReactNode }) => (
     </div>
   </Menu.Item>
 );
-const Filter = ({ children, stripHTML = false }) => {
+const Filter = ({ children: ReactNode, stripHTML = false }) => {
   const content =
     stripHTML && typeof children === 'string'
       ? removeHTMLTags(children)

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailMenuItems.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailMenuItems.tsx
@@ -50,6 +50,7 @@ const DisabledMenuItem = ({ children, ...props }: { children: ReactNode }) => (
     </div>
   </Menu.Item>
 );
+
 const Filter = ({
   children,
   stripHTML = false,
@@ -63,6 +64,7 @@ const Filter = ({
       : children;
   return <span>{content}</span>;
 };
+
 const StyledFilter = styled(Filter)`
   ${({ theme }) => `
      font-weight: ${theme.typography.weights.bold};
@@ -215,7 +217,7 @@ const DrillDetailMenuItems = ({
             >
               <div>
                 {`${DRILL_TO_DETAIL_TEXT} `}
-                <StyledFilter>{t('all')}</StyledFilter>
+                <StyledFilter stripHTML={false}>{t('all')}</StyledFilter>
               </div>
             </Menu.Item>
           )}

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
@@ -300,6 +300,7 @@ export default function DrillDetailPane({
           }
           resizable
           virtualize
+          allowHTML
         />
       </Resizable>
     );

--- a/superset-frontend/src/components/FilterableTable/index.tsx
+++ b/superset-frontend/src/components/FilterableTable/index.tsx
@@ -349,14 +349,15 @@ const FilterableTable = ({
 
   const renderTableCell = (cellData: CellDataType, columnKey: string) => {
     const cellNode = getCellContent({ cellData, columnKey });
-    const content =
-      cellData === null ? <i className="text-muted">{cellNode}</i> : cellNode;
+    if (cellData === null) {
+      return <i className="text-muted">{cellNode}</i>;
+    }
     const jsonObject = safeJsonObjectParse(cellData);
     if (jsonObject) {
       return renderJsonModal(cellNode, jsonObject, cellData);
     }
-    if (allowHTML) {
-      return safeHtmlSpan(cellData);
+    if (allowHTML && typeof cellData === 'string') {
+      return safeHtmlSpan(cellNode);
     }
     return content;
   };

--- a/superset-frontend/src/components/FilterableTable/index.tsx
+++ b/superset-frontend/src/components/FilterableTable/index.tsx
@@ -353,7 +353,8 @@ const FilterableTable = ({
     const jsonObject = safeJsonObjectParse(cellData);
     if (jsonObject) {
       return renderJsonModal(cellNode, jsonObject, cellData);
-    } else if (allowHTML) {
+    }
+    if (allowHTML) {
       return safeHtmlSpan(cellData);
     }
     return content;

--- a/superset-frontend/src/components/FilterableTable/index.tsx
+++ b/superset-frontend/src/components/FilterableTable/index.tsx
@@ -121,6 +121,7 @@ export interface FilterableTableProps {
   // need antd 5.0 to support striped color pattern
   striped?: boolean;
   expandedColumns?: string[];
+  allowHTML?: boolean;
 }
 
 const FilterableTable = ({

--- a/superset-frontend/src/components/FilterableTable/index.tsx
+++ b/superset-frontend/src/components/FilterableTable/index.tsx
@@ -22,6 +22,7 @@ import { JSONTree } from 'react-json-tree';
 import {
   getMultipleTextDimensions,
   t,
+  safeHtmlSpan,
   styled,
   useTheme,
 } from '@superset-ui/core';
@@ -128,6 +129,7 @@ const FilterableTable = ({
   height,
   filterText = '',
   expandedColumns = [],
+  allowHTML = true,
 }: FilterableTableProps) => {
   const formatTableData = (data: Record<string, unknown>[]): Datum[] =>
     data.map(row => {
@@ -351,6 +353,8 @@ const FilterableTable = ({
     const jsonObject = safeJsonObjectParse(cellData);
     if (jsonObject) {
       return renderJsonModal(cellNode, jsonObject, cellData);
+    } else if (allowHTML) {
+      return safeHtmlSpan(cellData);
     }
     return content;
   };

--- a/superset-frontend/src/components/FilterableTable/index.tsx
+++ b/superset-frontend/src/components/FilterableTable/index.tsx
@@ -359,7 +359,7 @@ const FilterableTable = ({
     if (allowHTML && typeof cellData === 'string') {
       return safeHtmlSpan(cellNode);
     }
-    return content;
+    return cellNode;
   };
 
   // exclude the height of the horizontal scroll bar from the height of the table

--- a/superset-frontend/src/components/Table/VirtualTable.tsx
+++ b/superset-frontend/src/components/Table/VirtualTable.tsx
@@ -222,7 +222,7 @@ const VirtualTable = <RecordType extends object>(
             content = render(content, data, rowIndex);
           }
 
-          if (allowHTML && typeof content == 'string') {
+          if (allowHTML && typeof content === 'string') {
             content = safeHtmlSpan(content);
           }
 

--- a/superset-frontend/src/components/Table/VirtualTable.tsx
+++ b/superset-frontend/src/components/Table/VirtualTable.tsx
@@ -25,12 +25,13 @@ import classNames from 'classnames';
 import { useResizeDetector } from 'react-resize-detector';
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { VariableSizeGrid as Grid } from 'react-window';
-import { useTheme, styled } from '@superset-ui/core';
+import { useTheme, styled, safeHtmlSpan } from '@superset-ui/core';
 
 import { TableSize, ETableAction } from './index';
 
 interface VirtualTableProps<RecordType> extends AntTableProps<RecordType> {
   height?: number;
+  allowHTML?: boolean;
 }
 
 const StyledCell = styled('div')<{ height?: number }>(
@@ -71,7 +72,15 @@ const MIDDLE = 47;
 const VirtualTable = <RecordType extends object>(
   props: VirtualTableProps<RecordType>,
 ) => {
-  const { columns, pagination, onChange, height, scroll, size } = props;
+  const {
+    columns,
+    pagination,
+    onChange,
+    height,
+    scroll,
+    size,
+    allowHTML = false,
+  } = props;
   const [tableWidth, setTableWidth] = useState<number>(0);
   const onResize = useCallback((width: number) => {
     setTableWidth(width);
@@ -211,6 +220,10 @@ const VirtualTable = <RecordType extends object>(
           if (typeof render === 'function') {
             // Use render function to generate formatted content using column's render function
             content = render(content, data, rowIndex);
+          }
+
+          if (allowHTML && typeof content == 'string') {
+            content = safeHtmlSpan(content);
           }
 
           return (

--- a/superset-frontend/src/components/Table/index.tsx
+++ b/superset-frontend/src/components/Table/index.tsx
@@ -145,6 +145,11 @@ export interface TableProps<RecordType> {
    * Returns props that should be applied to each row component.
    */
   onRow?: AntTableProps<RecordType>['onRow'];
+  /**
+   * Will render html safely if set to true, anchor tags and such. Currently
+   * only supported for virtualize == true
+   */
+  allowHTML?: boolean;
 }
 
 const defaultRowSelection: React.Key[] = [];
@@ -249,6 +254,7 @@ export function Table<RecordType extends object>(
     onChange = noop,
     recordCount,
     onRow,
+    allowHTML = false,
   } = props;
 
   const wrapperRef = useRef<HTMLDivElement | null>(null);
@@ -384,6 +390,7 @@ export function Table<RecordType extends object>(
     bordered,
   };
 
+  console.log('YO--HTML:', allowHTML);
   return (
     <ConfigProvider renderEmpty={renderEmpty}>
       <div ref={wrapperRef}>
@@ -405,6 +412,7 @@ export function Table<RecordType extends object>(
                 scrollToFirstRowOnChange: false,
               }),
             }}
+            allowHTML={allowHTML}
           />
         )}
       </div>

--- a/superset-frontend/src/components/Table/index.tsx
+++ b/superset-frontend/src/components/Table/index.tsx
@@ -390,7 +390,6 @@ export function Table<RecordType extends object>(
     bordered,
   };
 
-  console.log('YO--HTML:', allowHTML);
   return (
     <ConfigProvider renderEmpty={renderEmpty}>
       <div ref={wrapperRef}>

--- a/superset-frontend/src/components/TableCollection/index.tsx
+++ b/superset-frontend/src/components/TableCollection/index.tsx
@@ -295,7 +295,6 @@ export default React.memo(
                   const isWrapText = columnsForWrapText?.includes(
                     cell.column.Header as string,
                   );
-
                   return (
                     <td
                       data-test="table-row-cell"

--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -21,6 +21,7 @@ import {
   css,
   GenericDataType,
   getTimeFormatter,
+  safeHtmlSpan,
   styled,
   t,
   TimeFormats,
@@ -263,6 +264,7 @@ export const useTableColumns = (
   datasourceId?: string,
   isVisible?: boolean,
   moreConfigs?: { [key: string]: Partial<Column> },
+  allowHTML?: boolean = false,
 ) => {
   const [originalFormattedTimeColumns, setOriginalFormattedTimeColumns] =
     useState<string[]>(getTimeColumns(datasourceId));
@@ -345,6 +347,9 @@ export const useTableColumns = (
                     typeof value === 'number'
                   ) {
                     return timeFormatter(value);
+                  }
+                  if (typeof value === 'string' && allowHTML) {
+                    return safeHtmlSpan(value);
                   }
                   return String(value);
                 },

--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -264,7 +264,7 @@ export const useTableColumns = (
   datasourceId?: string,
   isVisible?: boolean,
   moreConfigs?: { [key: string]: Partial<Column> },
-  allowHTML? = false,
+  allowHTML?: boolean,
 ) => {
   const [originalFormattedTimeColumns, setOriginalFormattedTimeColumns] =
     useState<string[]>(getTimeColumns(datasourceId));

--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -264,7 +264,7 @@ export const useTableColumns = (
   datasourceId?: string,
   isVisible?: boolean,
   moreConfigs?: { [key: string]: Partial<Column> },
-  allowHTML?: boolean = false,
+  allowHTML? = false,
 ) => {
   const [originalFormattedTimeColumns, setOriginalFormattedTimeColumns] =
     useState<string[]>(getTimeColumns(datasourceId));

--- a/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
@@ -92,7 +92,7 @@ export const SamplesPane = ({
     data,
     datasourceId,
     isVisible,
-    null, // moreConfig
+    {}, // moreConfig
     true, // allowHTML
   );
   const filteredData = useFilteredTableData(filterText, data);

--- a/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
@@ -92,6 +92,8 @@ export const SamplesPane = ({
     data,
     datasourceId,
     isVisible,
+    null, // moreConfig
+    true, // allowHTML
   );
   const filteredData = useFilteredTableData(filterText, data);
 

--- a/superset-frontend/src/explore/components/DataTablesPane/components/SingleQueryResultPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/SingleQueryResultPane.tsx
@@ -44,6 +44,8 @@ export const SingleQueryResultPane = ({
     data,
     datasourceId,
     isVisible,
+    null, // moreConfig
+    true, // allowHTML
   );
   const filteredData = useFilteredTableData(filterText, data);
 

--- a/superset-frontend/src/explore/components/DataTablesPane/components/SingleQueryResultPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/SingleQueryResultPane.tsx
@@ -44,7 +44,7 @@ export const SingleQueryResultPane = ({
     data,
     datasourceId,
     isVisible,
-    null, // moreConfig
+    {}, // moreConfig
     true, // allowHTML
   );
   const filteredData = useFilteredTableData(filterText, data);


### PR DESCRIPTION
### SUMMARY
allowing links and other basic HTML to render in data tables safely. This tackles:
- in SQL Lab
- in the Explore south pane in `Results`
- in the Explore south pane in `Samples`
- in "drill to details" menu picker (removes html tags if any)
- in the table view of Drill to details

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="460" alt="Screen Shot 2023-06-12 at 2 23 41 PM" src="https://github.com/apache/superset/assets/487433/3df03a4b-da97-4ea4-adf4-cc2cd469a48c">
<img width="857" alt="Screen Shot 2023-06-12 at 2 23 26 PM" src="https://github.com/apache/superset/assets/487433/63f64efb-ce02-4bc8-bbdf-35ac8a55babd">
<img width="689" alt="Screen Shot 2023-06-12 at 5 44 15 PM" src="https://github.com/apache/superset/assets/487433/cac19acd-66a2-45bf-957f-1e1bccfcd029">
<img width="670" alt="Screen Shot 2023-06-12 at 5 48 58 PM" src="https://github.com/apache/superset/assets/487433/3c4ca154-ee2e-4c79-b74b-e4e9a42ab0ce">


### TESTING INSTRUCTIONS
* create an expression or calculated dim
* render in SQL Lab, samples, result set view

### ADDITIONAL INFORMATION
