### PR TITLE
feat(Boxplot): Allow configuration of y-axis range

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts
@@ -159,6 +159,20 @@ const config: ControlPanelConfig = {
           },
         ],
         ['zoomable'],
+        [
+          {
+            name: 'y_axis_slider',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Y-axis range slider'),
+              default: false,
+              renderTrigger: true,
+              description: t(
+                'Show a draggable slider to control the visible range of the Y-axis.',
+              ),
+            },
+          },
+        ],
       ],
     },
   ],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/transformProps.ts
@@ -74,6 +74,7 @@ export default function transformProps(
     yAxisTitlePosition,
     sliceId,
     zoomable,
+    yAxisSlider,
   } = formData as BoxPlotQueryFormData;
   const refs: Refs = {};
   const colorFn = CategoricalColorNamespace.getScale(colorScheme as string);
@@ -257,6 +258,28 @@ export default function transformProps(
     convertInteger(yAxisTitleMargin),
     convertInteger(xAxisTitleMargin),
   );
+  const dataZoom = [
+    ...(zoomable
+      ? [
+          {
+            type: 'inside',
+            zoomOnMouseWheel: false,
+            moveOnMouseWheel: true,
+          },
+        ]
+      : []),
+    ...(yAxisSlider
+      ? [
+          {
+            type: 'slider',
+            show: true,
+            yAxisIndex: [0],
+            // Adjust the axis window without dropping data points outside the range.
+            filterMode: 'none',
+          },
+        ]
+      : []),
+  ];
   const echartOptions: EChartsCoreOption = {
     grid: {
       ...defaultGrid,
@@ -298,15 +321,7 @@ export default function transformProps(
         },
       },
     },
-    dataZoom: zoomable
-      ? [
-          {
-            type: 'inside',
-            zoomOnMouseWheel: false,
-            moveOnMouseWheel: true,
-          },
-        ]
-      : [],
+    dataZoom,
   };
 
   return {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/types.ts
@@ -30,6 +30,7 @@ export type BoxPlotQueryFormData = QueryFormData & {
   numberFormat?: string;
   whiskerOptions?: BoxPlotFormDataWhiskerOptions;
   xTickLayout?: BoxPlotFormXTickLayout;
+  yAxisSlider?: boolean;
 } & TitleFormData;
 
 export type BoxPlotFormDataWhiskerOptions =

--- a/superset-frontend/plugins/plugin-chart-echarts/test/BoxPlot/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/BoxPlot/transformProps.test.ts
@@ -71,6 +71,15 @@ describe('BoxPlot transformProps', () => {
     theme: supersetTheme,
   });
 
+  const buildChartProps = (formDataOverrides: Partial<SqlaFormData> = {}) =>
+    new ChartProps({
+      formData: { ...formData, ...formDataOverrides },
+      width: 800,
+      height: 600,
+      queriesData: chartProps.queriesData,
+      theme: supersetTheme,
+    }) as EchartsBoxPlotChartProps;
+
   test('should transform chart props for viz', () => {
     expect(transformProps(chartProps as EchartsBoxPlotChartProps)).toEqual(
       expect.objectContaining({
@@ -123,6 +132,43 @@ describe('BoxPlot transformProps', () => {
           ]),
         }),
       }),
+    );
+  });
+
+  test('should add a vertical Y-axis slider to dataZoom when yAxisSlider is enabled', () => {
+    const { echartOptions } = transformProps(
+      buildChartProps({ yAxisSlider: true }),
+    );
+    expect((echartOptions as any).dataZoom).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'slider',
+          show: true,
+          yAxisIndex: [0],
+          filterMode: 'none',
+        }),
+      ]),
+    );
+  });
+
+  test('should not add a Y-axis slider when yAxisSlider is disabled', () => {
+    const { echartOptions } = transformProps(
+      buildChartProps({ yAxisSlider: false }),
+    );
+    expect((echartOptions as any).dataZoom).not.toContainEqual(
+      expect.objectContaining({ type: 'slider' }),
+    );
+  });
+
+  test('should combine zoomable and yAxisSlider dataZoom entries', () => {
+    const { echartOptions } = transformProps(
+      buildChartProps({ zoomable: true, yAxisSlider: true }),
+    );
+    expect((echartOptions as any).dataZoom).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'inside' }),
+        expect.objectContaining({ type: 'slider', yAxisIndex: [0] }),
+      ]),
     );
   });
 });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Added a range slider for Box plot parellel to Y-axis where user can select certain range on the Y-axis
Here is the discussion Link : https://github.com/apache/superset/issues/16745

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
