### PR TITLE
chore: remove deprecated api /superset/available_domains

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -34,6 +34,7 @@ assists people when migrating to a new version.
 
 ### Breaking Changes
 
+- [---](https://github.com/apache/superset/pull/-): Removed deprecated API `/superset/available_domains/`
 - [24345](https://github.com/apache/superset/pull/24345) Converts `ENABLE_BROAD_ACTIVITY_ACCESS` and `MENU_HIDE_USER_INFO` into feature flags and changes the value of `ENABLE_BROAD_ACTIVITY_ACCESS` to `False` as it's more secure.
 - [24342](https://github.com/apache/superset/pull/24342): Removed deprecated API `/superset/tables/<int:db_id>/<schema>/...`
 - [24335](https://github.com/apache/superset/pull/24335): Removed deprecated API `/superset/filter/<datasource_type>/<int:datasource_id>/<column>/`

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1131,21 +1131,6 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @api
     @has_access_api
     @event_logger.log_this
-    @expose("/available_domains/", methods=("GET",))
-    @deprecated(new_target="/api/v1/available_domains/")
-    def available_domains(self) -> FlaskResponse:  # pylint: disable=no-self-use
-        """
-        Returns the list of available Superset Webserver domains (if any)
-        defined in config. This enables charts embedded in other apps to
-        leverage domain sharding if appropriately configured.
-        """
-        return Response(
-            json.dumps(conf.get("SUPERSET_WEBSERVER_DOMAINS")), mimetype="text/json"
-        )
-
-    @api
-    @has_access_api
-    @event_logger.log_this
     @expose("/fave_dashboards_by_username/<username>/", methods=("GET",))
     @deprecated(new_target="api/v1/dashboard/favorite_status/")
     def fave_dashboards_by_username(self, username: str) -> FlaskResponse:


### PR DESCRIPTION
### SUMMARY
Removes deprecated API `/superset/available_domains/`

Effort on removing deprecated API from /superset: https://github.com/apache/superset/discussions/24332

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
