### PR TITLE
feat: Allows new values for single value filters

### DIFF
--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -38,7 +38,6 @@ import { SLOW_DEBOUNCE } from 'src/constants';
 import { hasOption, propertyComparator } from 'src/components/Select/utils';
 import { FilterBarOrientation } from 'src/dashboard/types';
 import { uniqWith, isEqual } from 'lodash';
-import { SelectOptionsType } from 'src/components/Select/types';
 import { PluginFilterSelectProps, SelectValue } from './types';
 import { FilterPluginStyle, StatusMessage, StyledFormItem } from '../common';
 import { getDataRecordFormatter, getSelectExtraFormData } from '../../utils';

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -233,26 +233,28 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
     return undefined;
   }, [filterState.validateMessage, filterState.validateStatus]);
 
-  const options = useMemo(() => {
+  const uniqueOptions = useMemo(() => {
     const allOptions = [...data];
-    const uniqueOptions = uniqWith(allOptions, isEqual);
-    const selectOptions: SelectOptionsType = [];
-    uniqueOptions.forEach(row => {
+    return uniqWith(allOptions, isEqual).map(row => {
       const [value] = groupby.map(col => row[col]);
-      selectOptions.push({
+      return {
         label: labelFormatter(value, datatype),
         value,
-      });
+        isNewOption: false,
+      };
     });
-    if (search && !multiSelect && !hasOption(search, selectOptions, true)) {
-      selectOptions.unshift({
+  }, [data, datatype, groupby, labelFormatter]);
+
+  const options = useMemo(() => {
+    if (search && !multiSelect && !hasOption(search, uniqueOptions, true)) {
+      uniqueOptions.unshift({
         label: search,
         value: search,
         isNewOption: true,
       });
     }
-    return selectOptions;
-  }, [data, datatype, groupby, labelFormatter, multiSelect, search]);
+    return uniqueOptions;
+  }, [multiSelect, search, uniqueOptions]);
 
   const sortComparator = useCallback(
     (a: AntdLabeledValue, b: AntdLabeledValue) => {

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -35,7 +35,7 @@ import debounce from 'lodash/debounce';
 import { useImmerReducer } from 'use-immer';
 import { Select } from 'src/components';
 import { SLOW_DEBOUNCE } from 'src/constants';
-import { propertyComparator } from 'src/components/Select/utils';
+import { hasOption, propertyComparator } from 'src/components/Select/utils';
 import { FilterBarOrientation } from 'src/dashboard/types';
 import { uniqWith, isEqual } from 'lodash';
 import { SelectOptionsType } from 'src/components/Select/types';
@@ -244,15 +244,12 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
         value,
       });
     });
-    if (!multiSelect && search) {
-      const found = selectOptions.find(option => option.label === search);
-      if (!found) {
-        selectOptions.unshift({
-          label: search,
-          value: search,
-          isNewOption: true,
-        });
-      }
+    if (search && !multiSelect && !hasOption(search, selectOptions, true)) {
+      selectOptions.unshift({
+        label: search,
+        value: search,
+        isNewOption: true,
+      });
     }
     return selectOptions;
   }, [data, datatype, groupby, labelFormatter, multiSelect, search]);


### PR DESCRIPTION
### SUMMARY
Allows new values for single value filters. This feature already exists for multiple value filters.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://github.com/apache/superset/assets/70410625/3a77d3bb-3859-4d2d-8270-e773b7930a1c

### TESTING INSTRUCTIONS
Check that single value native filters allow free form text.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
