### PR TITLE
fix: Fixes #24391 (Problems with celery beat running with docker when the machine is rebooted suddenly)

### DIFF
--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -40,6 +40,7 @@ if [[ "${1}" == "worker" ]]; then
   celery --app=superset.tasks.celery_app:app worker -O fair -l INFO
 elif [[ "${1}" == "beat" ]]; then
   echo "Starting Celery beat..."
+  rm -f /tmp/celerybeat.pid
   celery --app=superset.tasks.celery_app:app beat --pidfile /tmp/celerybeat.pid -l INFO -s "${SUPERSET_HOME}"/celerybeat-schedule
 elif [[ "${1}" == "app" ]]; then
   echo "Starting web app..."


### PR DESCRIPTION
fix(celery beat): starts correctly after a reboot

### SUMMARY
Removing pidfile before to start the the service is required to start the service correctly. Using docker not remove other (wrong) pidfile.

### TESTING INSTRUCTIONS
1. Run apache superset using docker compose:
`docker compose -f docker-compose-non-dev.yml up`
2. With containers running, reboot the machine.

### ADDITIONAL INFORMATION
Fixes #24391
- [X] Has associated issue: #24391
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
