### PR TITLE
fix: fixing recent migration file downgrade lineage

### DIFF
--- a/superset/migrations/versions/2023-06-01_13-13_83e1abbe777f_drop_access_request.py
+++ b/superset/migrations/versions/2023-06-01_13-13_83e1abbe777f_drop_access_request.py
@@ -17,14 +17,14 @@
 """drop access_request
 
 Revision ID: 83e1abbe777f
-Revises: ae58e1e58e5c
+Revises: 4ea966691069
 Create Date: 2023-06-01 13:13:18.147362
 
 """
 
 # revision identifiers, used by Alembic.
 revision = "83e1abbe777f"
-down_revision = "ae58e1e58e5c"
+down_revision = "4ea966691069"
 
 import sqlalchemy as sa
 from alembic import op

--- a/superset/migrations/versions/2023-06-08_09-02_9ba2ce3086e5_migrate_pivot_table_v1_to_v2.py
+++ b/superset/migrations/versions/2023-06-08_09-02_9ba2ce3086e5_migrate_pivot_table_v1_to_v2.py
@@ -17,7 +17,7 @@
 """migrate-pivot-table-v1-to-v2
 
 Revision ID: 9ba2ce3086e5
-Revises: 4ea966691069
+Revises: 83e1abbe777f
 Create Date: 2023-08-06 09:02:10.148992
 
 """
@@ -25,7 +25,7 @@ from superset.migrations.shared.migrate_viz import MigratePivotTable
 
 # revision identifiers, used by Alembic.
 revision = "9ba2ce3086e5"
-down_revision = "4ea966691069"
+down_revision = "83e1abbe777f"
 
 
 def upgrade():


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
1. recently introduced migration file `drop_access_request` has a downgrade version in future migration file.
2. This PR should fix the order in order to unblock certain people from getting stuck on db migration.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
