### PR TITLE
chore: deprecate FLASK_ENV and improve conf.ENVIRONMENT_TAG_CONFIG

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 FLASK_APP="superset.app:create_app()"
-DEBUG=true
+FLASK_DEBUG=true

--- a/.flaskenv
+++ b/.flaskenv
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 FLASK_APP="superset.app:create_app()"
-FLASK_ENV="development"
+DEBUG=true

--- a/.github/workflows/superset-applitool-cypress.yml
+++ b/.github/workflows/superset-applitool-cypress.yml
@@ -28,7 +28,7 @@ jobs:
         browser: ["chrome"]
         node: [16]
     env:
-      FLASK_ENV: development
+      SUPERSET_ENV: development
       SUPERSET_CONFIG: tests.integration_tests.superset_test_config
       SUPERSET__SQLALCHEMY_DATABASE_URI: postgresql+psycopg2://superset:superset@127.0.0.1:15432/superset
       PYTHONPATH: ${{ github.workspace }}

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -26,7 +26,7 @@ jobs:
         containers: [1, 2, 3]
         browser: ["chrome"]
     env:
-      FLASK_ENV: development
+      SUPERSET_ENV: development
       SUPERSET_CONFIG: tests.integration_tests.superset_test_config
       SUPERSET__SQLALCHEMY_DATABASE_URI: postgresql+psycopg2://superset:superset@127.0.0.1:15432/superset
       PYTHONPATH: ${{ github.workspace }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -453,7 +453,7 @@ superset load-examples
 # Start the Flask dev web server from inside your virtualenv.
 # Note that your page may not have CSS at this point.
 # See instructions below how to build the front-end assets.
-FLASK_ENV=development superset run -p 8088 --with-threads --reload --debugger
+superset run -p 8088 --with-threads --reload --debugger --debug
 ```
 
 Or you can install via our Makefile
@@ -477,7 +477,7 @@ $ make pre-commit
 via `.flaskenv`, however if needed, it should be set to `superset.app:create_app()`**
 
 If you have made changes to the FAB-managed templates, which are not built the same way as the newer, React-powered front-end assets, you need to start the app without the `--with-threads` argument like so:
-`FLASK_ENV=development superset run -p 8088 --reload --debugger`
+`superset run -p 8088 --reload --debugger --debug`
 
 #### Dependencies
 
@@ -518,7 +518,7 @@ def FLASK_APP_MUTATOR(app):
 Then make sure you run your WSGI server using the right worker type:
 
 ```bash
-FLASK_ENV=development gunicorn "superset.app:create_app()" -k "geventwebsocket.gunicorn.workers.GeventWebSocketWorker" -b 127.0.0.1:8088 --reload
+gunicorn "superset.app:create_app()" -k "geventwebsocket.gunicorn.workers.GeventWebSocketWorker" -b 127.0.0.1:8088 --reload
 ```
 
 You can log anything to the browser console, including objects:
@@ -603,7 +603,7 @@ So a typical development workflow is the following:
 1. [run Superset locally](#flask-server) using Flask, on port `8088` — but don't access it directly,<br/>
    ```bash
    # Install Superset and dependencies, plus load your virtual environment first, as detailed above.
-   FLASK_ENV=development superset run -p 8088 --with-threads --reload --debugger
+   superset run -p 8088 --with-threads --reload --debugger --debug
    ```
 2. in parallel, run the Webpack dev server locally on port `9000`,<br/>
    ```bash
@@ -922,7 +922,7 @@ For debugging locally using VSCode, you can configure a launch configuration fil
             "module": "flask",
             "env": {
                 "FLASK_APP": "superset",
-                "FLASK_ENV": "development"
+                "SUPERSET_ENV": "development"
             },
             "args": [
                 "run",

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ FROM python:${PY_VER} AS lean
 
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
-    FLASK_ENV=production \
+    SUPERSET_ENV=production \
     FLASK_APP="superset.app:create_app()" \
     PYTHONPATH="/app/pythonpath" \
     SUPERSET_HOME="/app/superset_home" \

--- a/RELEASING/from_tarball_entrypoint.sh
+++ b/RELEASING/from_tarball_entrypoint.sh
@@ -38,5 +38,5 @@ superset init
 # Loading examples
 superset load-examples --force
 
-FLASK_ENV=development FLASK_APP="superset.app:create_app()" \
+SUPERSET_ENV=development FLASK_APP="superset.app:create_app()" \
 flask run -p 8088 --with-threads --reload --debugger --host=0.0.0.0

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -31,9 +31,12 @@ assists people when migrating to a new version.
 - [23652](https://github.com/apache/superset/pull/23652): Enables GENERIC_CHART_AXES feature flag by default.
 - [23226](https://github.com/apache/superset/pull/23226): Migrated endpoint `/estimate_query_cost/<int:database_id>` to `/api/v1/sqllab/estimate/`. Corresponding permissions are can estimate query cost on SQLLab. Make sure you add/replace the necessary permissions on any custom roles you may have.
 - [23890](https://github.com/apache/superset/pull/23890): Removes Python 3.8 support.
-- [24404](https://github.com/apache/superset/pull/24404) FLASK_ENV is getting deprecated, we recommend using SUPERSET_ENV and reviewing your
+- [24404](https://github.com/apache/superset/pull/24404): FLASK_ENV is getting
+  deprecated, we recommend using SUPERSET_ENV and reviewing your
   config for ENVIRONMENT_TAG_CONFIG, which enables adding a tag in the navbar to
-  make it more clear which envrionment your are in
+  make it more clear which envrionment your are in.
+  `SUPERSET_ENV=production` and `SUPERSET_ENV=development` are the two
+  supported switches based on the default config.
 
 ### Breaking Changes
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -31,7 +31,7 @@ assists people when migrating to a new version.
 - [23652](https://github.com/apache/superset/pull/23652): Enables GENERIC_CHART_AXES feature flag by default.
 - [23226](https://github.com/apache/superset/pull/23226): Migrated endpoint `/estimate_query_cost/<int:database_id>` to `/api/v1/sqllab/estimate/`. Corresponding permissions are can estimate query cost on SQLLab. Make sure you add/replace the necessary permissions on any custom roles you may have.
 - [23890](https://github.com/apache/superset/pull/23890): Removes Python 3.8 support.
-- []() FLASK_ENV is getting deprecated, we recommend using SUPERSET_ENV and reviewing your
+- [24404](https://github.com/apache/superset/pull/24404) FLASK_ENV is getting deprecated, we recommend using SUPERSET_ENV and reviewing your
   config for ENVIRONMENT_TAG_CONFIG, which enables adding a tag in the navbar to
   make it more clear which envrionment your are in
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -31,6 +31,9 @@ assists people when migrating to a new version.
 - [23652](https://github.com/apache/superset/pull/23652): Enables GENERIC_CHART_AXES feature flag by default.
 - [23226](https://github.com/apache/superset/pull/23226): Migrated endpoint `/estimate_query_cost/<int:database_id>` to `/api/v1/sqllab/estimate/`. Corresponding permissions are can estimate query cost on SQLLab. Make sure you add/replace the necessary permissions on any custom roles you may have.
 - [23890](https://github.com/apache/superset/pull/23890): Removes Python 3.8 support.
+- []() FLASK_ENV is getting deprecated, we recommend using SUPERSET_ENV and reviewing your
+  config for ENVIRONMENT_TAG_CONFIG, which enables adding a tag in the navbar to
+  make it more clear which envrionment your are in
 
 ### Breaking Changes
 

--- a/docker/.env
+++ b/docker/.env
@@ -39,7 +39,7 @@ PYTHONPATH=/app/pythonpath:/app/docker/pythonpath_dev
 REDIS_HOST=redis
 REDIS_PORT=6379
 
-FLASK_ENV=development
+SUPERSET_ENV=development
 SUPERSET_ENV=development
 SUPERSET_LOAD_EXAMPLES=yes
 CYPRESS_CONFIG=false

--- a/docker/.env-non-dev
+++ b/docker/.env-non-dev
@@ -39,7 +39,7 @@ PYTHONPATH=/app/pythonpath:/app/docker/pythonpath_dev
 REDIS_HOST=redis
 REDIS_PORT=6379
 
-FLASK_ENV=production
+SUPERSET_ENV=production
 SUPERSET_ENV=production
 SUPERSET_LOAD_EXAMPLES=yes
 SUPERSET_SECRET_KEY=TEST_NON_DEV_SECRET

--- a/docs/docs/contributing/local-backend.mdx
+++ b/docs/docs/contributing/local-backend.mdx
@@ -42,7 +42,7 @@ superset load-examples
 
 # Start the Flask dev web server from inside your virtualenv.
 # Note that your page may not have CSS at this point.
-FLASK_ENV=development superset run -p 8088 --with-threads --reload --debugger
+superset run -p 8088 --with-threads --reload --debugger --debug
 ```
 
 Or you can install via our Makefile
@@ -66,7 +66,7 @@ make pre-commit
 via `.flaskenv`, however if needed, it should be set to `superset.app:create_app()`**
 
 If you have made changes to the FAB-managed templates, which are not built the same way as the newer, React-powered front-end assets, you need to start the app without the `--with-threads` argument like so:
-`FLASK_ENV=development superset run -p 8088 --reload --debugger`
+`superset run -p 8088 --reload --debugger --debug`
 
 #### Dependencies
 
@@ -93,7 +93,7 @@ def FLASK_APP_MUTATOR(app):
 Then make sure you run your WSGI server using the right worker type:
 
 ```bash
-FLASK_ENV=development gunicorn "superset.app:create_app()" -k "geventwebsocket.gunicorn.workers.GeventWebSocketWorker" -b 127.0.0.1:8088 --reload
+SUPERSET_ENV=development gunicorn "superset.app:create_app()" -k "geventwebsocket.gunicorn.workers.GeventWebSocketWorker" -b 127.0.0.1:8088 --reload
 ```
 
 You can log anything to the browser console, including objects:

--- a/superset/config.py
+++ b/superset/config.py
@@ -1576,7 +1576,7 @@ elif importlib.util.find_spec("superset_config") and not is_test():
     try:
         # pylint: disable=import-error,wildcard-import,unused-wildcard-import
         import superset_config
-        from superset_config import *
+        from superset_config import *  # type: ignore
 
         print(f"Loaded your LOCAL configuration at [{superset_config.__file__}]")
     except Exception:

--- a/superset/config.py
+++ b/superset/config.py
@@ -246,6 +246,7 @@ WTF_CSRF_EXEMPT_LIST = [
 ]
 
 # Whether to run the web server in debug mode or not
+DEBUG = os.environ.get("FLASK_DEBUG")
 FLASK_USE_RELOAD = True
 
 # Enable profiling of Python calls. Turn this on and append ``?_instrument=1``

--- a/superset/config.py
+++ b/superset/config.py
@@ -246,7 +246,6 @@ WTF_CSRF_EXEMPT_LIST = [
 ]
 
 # Whether to run the web server in debug mode or not
-DEBUG = os.environ.get("FLASK_ENV") == "development"
 FLASK_USE_RELOAD = True
 
 # Enable profiling of Python calls. Turn this on and append ``?_instrument=1``
@@ -1507,8 +1506,12 @@ WELCOME_PAGE_LAST_TAB: (
 # Configuration for environment tag shown on the navbar. Setting 'text' to '' will hide the tag.
 # 'color' can either be a hex color code, or a dot-indexed theme color (e.g. error.base)
 ENVIRONMENT_TAG_CONFIG = {
-    "variable": "FLASK_ENV",
+    "variable": "SUPERSET_ENV",
     "values": {
+        "debug": {
+            "color": "error.base",
+            "text": "flask-debug",
+        },
         "development": {
             "color": "error.base",
             "text": "Development",
@@ -1572,7 +1575,7 @@ elif importlib.util.find_spec("superset_config") and not is_test():
     try:
         # pylint: disable=import-error,wildcard-import,unused-wildcard-import
         import superset_config
-        from superset_config import *  # type: ignore
+        from superset_config import *
 
         print(f"Loaded your LOCAL configuration at [{superset_config.__file__}]")
     except Exception:

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -335,25 +335,25 @@ class BaseSupersetView(BaseView):
 
 def get_environment_tag() -> dict[str, Any]:
     # Whether flask is in debug mode (--debug)
-    DEBUG = appbuilder.app.config.get("DEBUG")
+    debug = appbuilder.app.config.get("DEBUG")
 
     # Getting the configuration option for ENVIRONMENT_TAG_CONFIG
-    ENV_TAG_CONFIG = appbuilder.app.config.get("ENVIRONMENT_TAG_CONFIG")
+    env_tag_config = appbuilder.app.config.get("ENVIRONMENT_TAG_CONFIG")
 
     # These are the predefined templates define in the config
-    ENV_TAG_TEMPLATES = ENV_TAG_CONFIG.get("values")
+    env_tag_templates = env_tag_config.get("values")
 
     # This is the environment variable name from which to select the template
     # default is SUPERSET_ENV (from FLASK_ENV in previous versions)
-    ENV_ENVVAR = ENV_TAG_CONFIG.get("variable")
+    env_envvar = env_tag_config.get("variable")
 
     # this is the actual name we want to use
-    ENV_NAME = os.environ.get(ENV_ENVVAR) or ("debug" if DEBUG else None)
+    env_name = os.environ.get(env_envvar)
 
-    if not ENV_NAME or ENV_NAME not in ENV_TAG_TEMPLATES.keys():
-        ENV_NAME = "debug" if DEBUG else None
+    if not env_name or env_name not in env_tag_templates.keys():
+        env_name = "debug" if debug else None
 
-    env_tag = ENV_TAG_TEMPLATES.get(ENV_NAME)
+    env_tag = env_tag_templates.get(env_name)
     return env_tag or {}
 
 

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -346,17 +346,23 @@ def menu_data(user: User) -> dict[str, Any]:
     if callable(brand_text):
         brand_text = brand_text()
     build_number = appbuilder.app.config["BUILD_NUMBER"]
-    try:
-        environment_tag = (
-            appbuilder.app.config["ENVIRONMENT_TAG_CONFIG"]["values"][
-                os.environ.get(
-                    appbuilder.app.config["ENVIRONMENT_TAG_CONFIG"]["variable"]
-                )
-            ]
-            or {}
-        )
-    except KeyError:
-        environment_tag = {}
+
+    # Whether flask is in debug mode (--debug)
+    DEBUG = appbuilder.app.config.get("DEBUG")
+
+    # Getting the configuration option for ENVIRONMENT_TAG_CONFIG
+    ENV_TAG_CONFIG = appbuilder.app.config.get("ENVIRONMENT_TAG_CONFIG")
+
+    # These are the predefined templates define in the config
+    ENV_TAG_TEMPLATES = ENV_TAG_CONFIG.get("values")
+
+    # This is the environment variable name from which to select the template
+    # default is SUPERSET_ENV (from FLASK_ENV in previous versions)
+    ENV_ENVVAR = ENV_TAG_CONFIG.get("variable")
+
+    # this is the actual name we want to use
+    ENV_NAME = os.environ.get(ENV_ENVVAR) or "debug" if DEBUG else None
+    environment_tag = ENV_TAG_TEMPLATES.get(ENV_NAME) or {}
 
     return {
         "menu": menu,

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -333,20 +333,7 @@ class BaseSupersetView(BaseView):
         )
 
 
-def menu_data(user: User) -> dict[str, Any]:
-    menu = appbuilder.menu.get_data()
-
-    languages = {}
-    for lang in appbuilder.languages:
-        languages[lang] = {
-            **appbuilder.languages[lang],
-            "url": appbuilder.get_url_for_locale(lang),
-        }
-    brand_text = appbuilder.app.config["LOGO_RIGHT_TEXT"]
-    if callable(brand_text):
-        brand_text = brand_text()
-    build_number = appbuilder.app.config["BUILD_NUMBER"]
-
+def get_environment_tag() -> dict[str, Any]:
     # Whether flask is in debug mode (--debug)
     DEBUG = appbuilder.app.config.get("DEBUG")
 
@@ -362,7 +349,24 @@ def menu_data(user: User) -> dict[str, Any]:
 
     # this is the actual name we want to use
     ENV_NAME = os.environ.get(ENV_ENVVAR) or "debug" if DEBUG else None
-    environment_tag = ENV_TAG_TEMPLATES.get(ENV_NAME) or {}
+
+    env_tag = ENV_TAG_TEMPLATES.get(ENV_NAME)
+    return env_tag or {}
+
+
+def menu_data(user: User) -> dict[str, Any]:
+    menu = appbuilder.menu.get_data()
+
+    languages = {}
+    for lang in appbuilder.languages:
+        languages[lang] = {
+            **appbuilder.languages[lang],
+            "url": appbuilder.get_url_for_locale(lang),
+        }
+    brand_text = appbuilder.app.config["LOGO_RIGHT_TEXT"]
+    if callable(brand_text):
+        brand_text = brand_text()
+    build_number = appbuilder.app.config["BUILD_NUMBER"]
 
     return {
         "menu": menu,
@@ -373,7 +377,7 @@ def menu_data(user: User) -> dict[str, Any]:
             "tooltip": appbuilder.app.config["LOGO_TOOLTIP"],
             "text": brand_text,
         },
-        "environment_tag": environment_tag,
+        "environment_tag": get_environment_tag(),
         "navbar_right": {
             # show the watermark if the default app icon has been overridden
             "show_watermark": ("superset-logo-horiz" not in appbuilder.app_icon),

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -348,7 +348,10 @@ def get_environment_tag() -> dict[str, Any]:
     ENV_ENVVAR = ENV_TAG_CONFIG.get("variable")
 
     # this is the actual name we want to use
-    ENV_NAME = os.environ.get(ENV_ENVVAR) or "debug" if DEBUG else None
+    ENV_NAME = os.environ.get(ENV_ENVVAR) or ("debug" if DEBUG else None)
+
+    if not ENV_NAME or ENV_NAME not in ENV_TAG_TEMPLATES.keys():
+        ENV_NAME = "debug" if DEBUG else None
 
     env_tag = ENV_TAG_TEMPLATES.get(ENV_NAME)
     return env_tag or {}

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -335,10 +335,10 @@ class BaseSupersetView(BaseView):
 
 def get_environment_tag() -> dict[str, Any]:
     # Whether flask is in debug mode (--debug)
-    debug = appbuilder.app.config.get("DEBUG")
+    debug = appbuilder.app.config["DEBUG"]
 
     # Getting the configuration option for ENVIRONMENT_TAG_CONFIG
-    env_tag_config = appbuilder.app.config.get("ENVIRONMENT_TAG_CONFIG")
+    env_tag_config = appbuilder.app.config["ENVIRONMENT_TAG_CONFIG"]
 
     # These are the predefined templates define in the config
     env_tag_templates = env_tag_config.get("values")


### PR DESCRIPTION
Flask is deprecating FLASK_ENV, leading to this msg in the interpreter:
```
'FLASK_ENV' is deprecated and will not be used in Flask 2.3. Use 'FLASK_DEBUG' instead.
```

### SUMMARY
Moving away from using `FLASK_ENV` and creating a `SUPERSET_ENV` instead. Cleaning up the code around the configuration `ENVIRONMENT_TAG_CONFIG` too that relied on that.

Adding a note on `UPDATING.md` at it may affect some environments, mostly should just affect whether and how that warning tag in the navbar shows up.

## TESTED
- `export SUPERSET_ENV=development` leads to `Development` tag showing in navbar
- `export SUPERSET_ENV=production` leads to  no tag showing in navbar
- `unset SUPERSET_ENV` leads to `flask-debug` tag in navbar
- `export SUPERSET_ENV=giberrish` leads to `flask-debug` tag in navbar
- tested custom "amazing" config
```
ENVIRONMENT_TAG_CONFIG = {
    "variable": "SUPERSET_ENV",
    "values": {
        "debug": {
            "color": "error.base",
            "text": "flask-debug",
        },
        "amazing": {
            "color": "warning.base",
            "text": "AMAZING",
        },
    },
}
```
<img width="300" alt="Screen Shot 2023-06-14 at 4 09 29 PM" src="https://github.com/apache/superset/assets/487433/1f0a48a1-6f59-49d6-875a-01a3f8e83d03">


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="329" alt="Screen Shot 2023-06-14 at 1 47 46 PM" src="https://github.com/apache/superset/assets/487433/6995cb05-6fd8-4e4d-92de-b1c1370c84ba">
