### PR TITLE
fix: creating a new chart with dashboard time filters but filter can't apply again

### DIFF
--- a/superset-frontend/src/explore/actions/saveModalActions.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.js
@@ -83,6 +83,19 @@ export const getSlicePayload = (
     adhocFilters = extractAddHocFiltersFromFormData(formDataFromSlice);
   }
 
+  if (
+    isEmpty(adhocFilters?.adhoc_filters) &&
+    isEmpty(formDataFromSlice) &&
+    formDataWithNativeFilters.adhoc_filters.length > 0
+  ) {
+    adhocFilters.adhoc_filters = [
+      {
+        ...formDataWithNativeFilters.adhoc_filters[0],
+        comparator: 'No filter',
+      },
+    ];
+  }
+
   const formData = {
     ...formDataWithNativeFilters,
     ...adhocFilters,

--- a/superset-frontend/src/explore/actions/saveModalActions.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.js
@@ -86,7 +86,7 @@ export const getSlicePayload = (
   if (
     isEmpty(adhocFilters?.adhoc_filters) &&
     isEmpty(formDataFromSlice) &&
-    formDataWithNativeFilters.adhoc_filters.length > 0
+    formDataWithNativeFilters?.adhoc_filters?.length > 0
   ) {
     adhocFilters.adhoc_filters = [
       {


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
How to reproduce the bug
- Create a chart and add it to a dashboard.
- Add a time range filter to the dashboard.
- Apply any value to this filter.
- Access the chart from the dashboard.
- Save to to a new chart, and add it to the same dashboard. Explore would reload and the temporal filter would be removed (expected).
- Navigate back to the dashboard, and apply a temporal filter.

Expected results
The temporal filter gets applied to the new chart.

Actual results
The filter is not applied to the new chart.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![old](https://github.com/apache/superset/assets/5705598/a23b9c31-b380-4b3c-8887-e7bb08ec5bfc)

After:
![new](https://github.com/apache/superset/assets/5705598/0f0aea1b-d18a-4cd5-876d-37efbf18ee88)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
