### PR TITLE
fix: force data load on import examples

### DIFF
--- a/.github/workflows/docker-ephemeral-env.yml
+++ b/.github/workflows/docker-ephemeral-env.yml
@@ -22,6 +22,10 @@ jobs:
             secrets.AWS_SECRET_ACCESS_KEY != '' &&
             secrets.AWS_SECRET_ACCESS_KEY != '') || '' }}" ]; then
             echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+            echo "has secrets!"
+          else
+            echo "has-secrets=0" >> "$GITHUB_OUTPUT"
+            echo "no secrets!"
           fi
 
   docker_ephemeral_env:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,6 +20,10 @@ jobs:
         run: |
           if [ -n "${{ (secrets.DOCKERHUB_USER != '' && secrets.DOCKERHUB_TOKEN != '') || '' }}" ]; then
             echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+            echo "has secrets!"
+          else
+            echo "has-secrets=0" >> "$GITHUB_OUTPUT"
+            echo "no secrets!"
           fi
 
   docker-build:

--- a/RELEASING/from_tarball_entrypoint.sh
+++ b/RELEASING/from_tarball_entrypoint.sh
@@ -36,7 +36,7 @@ superset db upgrade
 superset init
 
 # Loading examples
-superset load-examples
+superset load-examples --force
 
 FLASK_ENV=development FLASK_APP="superset.app:create_app()" \
 flask run -p 8088 --with-threads --reload --debugger --host=0.0.0.0

--- a/docker/docker-init.sh
+++ b/docker/docker-init.sh
@@ -72,7 +72,7 @@ if [ "$SUPERSET_LOAD_EXAMPLES" = "yes" ]; then
         superset load_test_users
         superset load_examples --load-test-data
     else
-        superset load_examples
+        superset load_examples --force
     fi
     echo_step "4" "Complete" "Loading examples"
 fi

--- a/superset/datasets/commands/importers/v1/utils.py
+++ b/superset/datasets/commands/importers/v1/utils.py
@@ -167,9 +167,9 @@ def import_dataset(
     except Exception:  # pylint: disable=broad-except
         # MySQL doesn't play nice with GSheets table names
         logger.warning(
-            "Couldn't check if table %s exists, assuming it does", dataset.table_name
+            "Couldn't check if table %s exists, assuming it doesn't", dataset.table_name
         )
-        table_exists = True
+        table_exists = False
 
     if data_uri and (not table_exists or force_data):
         load_data(data_uri, dataset, dataset.database, session)

--- a/superset/datasets/commands/importers/v1/utils.py
+++ b/superset/datasets/commands/importers/v1/utils.py
@@ -167,9 +167,9 @@ def import_dataset(
     except Exception:  # pylint: disable=broad-except
         # MySQL doesn't play nice with GSheets table names
         logger.warning(
-            "Couldn't check if table %s exists, assuming it doesn't", dataset.table_name
+            "Couldn't check if table %s exists, assuming it does", dataset.table_name
         )
-        table_exists = False
+        table_exists = True
 
     if data_uri and (not table_exists or force_data):
         load_data(data_uri, dataset, dataset.database, session)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This attempts to fix some errors that we're seeing in current builds from pre 2.1 to master of ephemerals and docker tarball testing for releases. Some tables aren't loading into sqlite because the table is locked, so I'm passing in the force flag to reload the data if it was unsuccessful

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![Sales_Dashboard](https://github.com/apache/superset/assets/5186919/5282ab09-849e-4942-aabb-f7af986b4e96)

After:
![Sales_Dashboard](https://github.com/apache/superset/assets/5186919/4d974c10-b8bd-4b31-8950-3f5b450e4e9c)



### TESTING INSTRUCTIONS
Ephemeral environments should succeed in loading example data

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
