### PR TITLE
fix(dashboard): native filters do not preserve bigint

### DIFF
--- a/superset-frontend/src/filters/components/Select/buildQuery.test.ts
+++ b/superset-frontend/src/filters/components/Select/buildQuery.test.ts
@@ -122,4 +122,18 @@ describe('Select buildQuery', () => {
     const [query] = queryContext.queries;
     expect(query.filters).toEqual([{ col: 'my_col', op: '>=', val: 123 }]);
   });
+
+  it('should add big numeric search parameter to query filter', () => {
+    const queryContext = buildQuery(formData, {
+      ownState: {
+        search: '123436775936632786',
+        coltypeMap: { my_col: GenericDataType.NUMERIC },
+      },
+    });
+    expect(queryContext.queries.length).toEqual(1);
+    const [query] = queryContext.queries;
+    expect(query.filters).toEqual([
+      { col: 'my_col', op: '>=', val: '123436775936632786' },
+    ]);
+  });
 });

--- a/superset-frontend/src/filters/components/Select/buildQuery.ts
+++ b/superset-frontend/src/filters/components/Select/buildQuery.ts
@@ -49,12 +49,21 @@ const buildQuery: BuildQuery<PluginFilterSelectQueryFormData> = (
           coltypeMap[label] === GenericDataType.NUMERIC &&
           !Number.isNaN(Number(search))
         ) {
-          // for numeric columns we apply a >= where clause
-          extraFilters.push({
-            col: column,
-            op: '>=',
-            val: Number(search),
-          });
+          if (search === `${Number(search)}`) {
+            // for numeric columns we apply a >= where clause
+            extraFilters.push({
+              col: column,
+              op: '>=',
+              val: Number(search),
+            });
+          } else {
+            // for big number case
+            extraFilters.push({
+              col: column,
+              op: '>=',
+              val: search,
+            });
+          }
         }
       });
     }


### PR DESCRIPTION
### SUMMARY
There is an overflow issue when searching for bigint records in the native filters, i.e., the value passed to the backend is a rounded form of the specified UI value.
This hotfix handles the bigint value in a string form to preserve the value in JSON

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After:

<img width="688" alt="Screenshot 2023-06-15 at 4 26 17 PM" src="https://github.com/apache/superset/assets/1392866/f2ef3ace-e0a7-4747-8ce0-0b5bb6d04fa5">

Before:

<img width="592" alt="Screenshot 2023-06-15 at 4 34 39 PM" src="https://github.com/apache/superset/assets/1392866/cdf0c3ce-f1ed-4d9e-9f2c-d82852cc3993">

### TESTING INSTRUCTIONS

- Specs
- Go to dashboard and add a number field in a native filter
- type any big number and check the request payload

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
