### PR TITLE
chore: Remove obsolete Druid NoSQL REGEX operator

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -34,6 +34,7 @@ assists people when migrating to a new version.
 
 ### Breaking Changes
 
+- [24415](https://github.com/apache/superset/pull/24415): Removed the obsolete Druid NoSQL REGEX operator.
 - [24400](https://github.com/apache/superset/pull/24400): Removed deprecated APIs `/superset/recent_activity/...`, `/superset/fave_dashboards_by_username/...`, `/superset/fave_dashboards/...`, `/superset/created_dashboards/...`, `/superset/user_slices/`, `/superset/created_slices/...`, `/superset/fave_slices/...`, `/superset/favstar/...`,
 - [24401](https://github.com/apache/superset/pull/24401): Removes the deprecated `metrics` column (which was blossomed in [20732](https://github.com/apache/superset/pull/20732)) from the `/api/v1/dataset/` API.
 - [24375](https://github.com/apache/superset/pull/24375): Removed deprecated API `/superset/get_or_create_table/...`, `/superset/sqllab_viz`

--- a/superset-frontend/src/explore/constants.ts
+++ b/superset-frontend/src/explore/constants.ts
@@ -39,7 +39,6 @@ export enum Operators {
   NOT_IN = 'NOT_IN',
   LIKE = 'LIKE',
   ILIKE = 'ILIKE',
-  REGEX = 'REGEX',
   IS_NOT_NULL = 'IS_NOT_NULL',
   IS_NULL = 'IS_NULL',
   LATEST_PARTITION = 'LATEST_PARTITION',
@@ -75,7 +74,6 @@ export const OPERATOR_ENUM_TO_OPERATOR_TYPE: {
     display: t('Like (case insensitive)'),
     operation: 'ILIKE',
   },
-  [Operators.REGEX]: { display: t('Regex'), operation: 'REGEX' },
   [Operators.IS_NOT_NULL]: {
     display: t('Is not null'),
     operation: 'IS NOT NULL',

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -236,7 +236,6 @@ class FilterOperator(str, Enum):
     IS_NOT_NULL = "IS NOT NULL"
     IN = "IN"
     NOT_IN = "NOT IN"
-    REGEX = "REGEX"
     IS_TRUE = "IS TRUE"
     IS_FALSE = "IS FALSE"
     TEMPORAL_RANGE = "TEMPORAL_RANGE"
@@ -253,7 +252,6 @@ class FilterStringOperators(str, Enum):
     NOT_IN = ("NOT_IN",)
     ILIKE = ("ILIKE",)
     LIKE = ("LIKE",)
-    REGEX = ("REGEX",)
     IS_NOT_NULL = ("IS_NOT_NULL",)
     IS_NULL = ("IS_NULL",)
     LATEST_PARTITION = ("LATEST_PARTITION",)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Whilst reading over [this](https://github.com/apache/superset/blob/b44d20348de4199b4eaf3663ddb23650b21a3dd9/superset/models/helpers.py#L1785-L1800) code I realized that the `REGEX` filter operator is unused—a byproduct of the Druid NoSQL connector which has been removed. 

This PR removes the obsolete options from the UI controls to prevent erroneous backend errors.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE

<img width="317" alt="Screenshot 2023-06-15 at 8 52 53 PM" src="https://github.com/apache/superset/assets/4567245/967de2e2-2bad-44b4-8a91-dc1a4b635f58">

![Screenshot 2023-06-15 at 7 57 24 PM](https://github.com/apache/superset/assets/4567245/f66e1aef-2209-4319-8231-9650a5839188)

#### AFTER

<img width="319" alt="Screenshot 2023-06-15 at 8 52 26 PM" src="https://github.com/apache/superset/assets/4567245/1386d1ed-5931-4803-a1e9-d8abee8c54f1">

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
