### PR TITLE
fix: Native filter dynamic numeric search

### DIFF
--- a/superset-frontend/src/filters/components/Select/buildQuery.test.ts
+++ b/superset-frontend/src/filters/components/Select/buildQuery.test.ts
@@ -97,7 +97,7 @@ describe('Select buildQuery', () => {
     expect(query.orderby).toEqual([['my_col', false]]);
   });
 
-  it('should add text search parameter to query filter', () => {
+  it('should add text search parameter for string to query filter', () => {
     const queryContext = buildQuery(formData, {
       ownState: {
         search: 'abc',
@@ -111,7 +111,7 @@ describe('Select buildQuery', () => {
     ]);
   });
 
-  it('should add numeric search parameter to query filter', () => {
+  it('should add text search parameter for numeric to query filter', () => {
     const queryContext = buildQuery(formData, {
       ownState: {
         search: '123',
@@ -120,6 +120,8 @@ describe('Select buildQuery', () => {
     });
     expect(queryContext.queries.length).toEqual(1);
     const [query] = queryContext.queries;
-    expect(query.filters).toEqual([{ col: 'my_col', op: '>=', val: 123 }]);
+    expect(query.filters).toEqual([
+      { col: 'my_col', op: 'ILIKE', val: '%123%' },
+    ]);
   });
 });

--- a/superset-frontend/src/filters/components/Select/buildQuery.ts
+++ b/superset-frontend/src/filters/components/Select/buildQuery.ts
@@ -39,21 +39,15 @@ const buildQuery: BuildQuery<PluginFilterSelectQueryFormData> = (
     if (search) {
       columns.filter(isPhysicalColumn).forEach(column => {
         const label = getColumnLabel(column);
-        if (coltypeMap[label] === GenericDataType.STRING) {
+        if (
+          coltypeMap[label] === GenericDataType.STRING ||
+          (coltypeMap[label] === GenericDataType.NUMERIC &&
+            !Number.isNaN(Number(search)))
+        ) {
           extraFilters.push({
             col: column,
             op: 'ILIKE',
             val: `%${search}%`,
-          });
-        } else if (
-          coltypeMap[label] === GenericDataType.NUMERIC &&
-          !Number.isNaN(Number(search))
-        ) {
-          // for numeric columns we apply a >= where clause
-          extraFilters.push({
-            col: column,
-            op: '>=',
-            val: Number(search),
           });
         }
       });

--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -433,7 +433,14 @@ class BaseDatasource(
             if isinstance(value, str):
                 value = value.strip("\t\n")
 
-                if target_generic_type == utils.GenericDataType.NUMERIC:
+                if (
+                    target_generic_type == utils.GenericDataType.NUMERIC
+                    and operator
+                    not in {
+                        utils.FilterOperator.ILIKE,
+                        utils.FilterOperator.LIKE,
+                    }
+                ):
                     # For backwards compatibility and edge cases
                     # where a column data type might have changed
                     return utils.cast_to_num(value)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR provides a fix for https://github.com/apache/superset/pull/14710 in addition to being an alternative formulation for https://github.com/apache/superset/pull/24413. Additionally it provides `LIKE` and `ILIKE` operator support for SIMPLE ad-hoc filters irrespective of the column type, i.e., now all operators are valid.

This change came about give how https://github.com/apache/superset/pull/14710 implemented dynamic (backend) filtering of numerical values for native filters.

Hypothetically lets assume there was an `id` column which comprised of the set of integers from 0 to 100,000 and a user searched for `100`, then:

1. A backend query was sent with a SIMPLE filter of the form `{col: 'id', op: '>=', val: 100}`.
2. The result set (limited to 1,000) would contain the values: 100, 101, 102, ..., 1,097, 1,098, 1,099
3. The frontend select filter would filter out any result not match the `100` substring resulting in only 10 matches: 100, 1,001, 1,002, 1,003, 1,004, 1,005, 1,006, 1,007, 1,008, 1,009.
4. Numerous valid matches like 1,100, 2,100, 10,000, etc. aren't shown as they're not part of the corpus of 1,000 results fetched from the backend.

The right way to see if a number is contained within another number is to treat the numbers as a string and provide a filter of the form  `{col: 'id', op: 'ILIKE', val: '%100%'}`. This also remedies the BIGINT issue where in https://github.com/apache/superset/pull/24413 the numerical values were treated as a string.

The ad-hoc filters include the `ILIKE` and `LIKE` operator which work exclusively with `STRING` types. This PR simply provides "support" for using both these operators by casting the column (if necessary) to a `STRING`, i.e., it means that the `ILIKE` and `LIKE` operator work for all SIMPLE filters irrespective of the column type, which can then be leveraged by the native filter search functionality.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE

<img width="243" alt="Screenshot 2023-06-15 at 11 38 37 PM" src="https://github.com/apache/superset/assets/4567245/d634b453-232a-49f2-b11f-8a3f103fa24f">

#### AFTER 

<img width="242" alt="Screenshot 2023-06-15 at 11 40 02 PM" src="https://github.com/apache/superset/assets/4567245/11d01d6f-7347-49b7-9d33-80977f8e4806">

##### Dynamic casting

<img width="1440" alt="Screenshot 2023-06-15 at 11 11 06 PM" src="https://github.com/apache/superset/assets/4567245/b68a4a36-63c3-43f5-b647-df6af9640b46">

<img width="1440" alt="Screenshot 2023-06-15 at 11 53 34 PM" src="https://github.com/apache/superset/assets/4567245/cc092410-8dcc-4e1f-8c4d-37acbd06a95b">

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
