### PR TITLE
fix: FE call to changed recent_activity endpoint

### DIFF
--- a/superset-frontend/src/features/home/ActivityTable.tsx
+++ b/superset-frontend/src/features/home/ActivityTable.tsx
@@ -36,7 +36,7 @@ import EmptyState from './EmptyState';
 import { WelcomeTable } from './types';
 
 /**
- * Return result from /api/v1/log/recent_activity/{user_id}/
+ * Return result from /api/v1/log/recent_activity/
  */
 interface RecentActivity {
   action: string;

--- a/superset-frontend/src/pages/Home/index.tsx
+++ b/superset-frontend/src/pages/Home/index.tsx
@@ -160,7 +160,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
   const userid = user.userId;
   const id = userid!.toString(); // confident that user is not a guest user
   const params = rison.encode({ page_size: 6 });
-  const recent = `/api/v1/log/recent_activity/${user.userId}/?q=${params}`;
+  const recent = `/api/v1/log/recent_activity/?q=${params}`;
   const [activeChild, setActiveChild] = useState('Loading');
   const userKey = dangerouslyGetItemDoNotUse(id, null);
   let defaultChecked = false;

--- a/superset-frontend/src/profile/components/RecentActivity.tsx
+++ b/superset-frontend/src/profile/components/RecentActivity.tsx
@@ -48,7 +48,7 @@ export default function RecentActivity({ user }: RecentActivityProps) {
         className="table-condensed"
         mutator={mutator}
         sortable
-        dataEndpoint={`/api/v1/log/recent_activity/${user?.userId}/?q=${params}`}
+        dataEndpoint={`/api/v1/log/recent_activity/?q=${params}`}
         noDataText={t('No Data')}
       />
     </div>


### PR DESCRIPTION
### SUMMARY
Fixes a bug created on https://github.com/apache/superset/pull/24400. The frontend was not updated with the changed backend REST API endpoint.

The endpoint changed from `/api/v1/log/recent_activity/<user_id>/` to `/api/v1/log/recent_activity/`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
