### PR TITLE
fix(sql-lab): remove redundant onChange schema property

### DIFF
--- a/superset-frontend/src/SqlLab/components/SouthPane/SouthPane.test.jsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/SouthPane.test.jsx
@@ -61,7 +61,7 @@ const store = mockStore({
     queries: {
       LCly_kkIN: {
         cached: false,
-        changedOn: Date.now(),
+        changed_on: new Date().toISOString(),
         db: 'main',
         dbId: 1,
         id: 'LCly_kkIN',
@@ -71,7 +71,7 @@ const store = mockStore({
       },
       lXJa7F9_r: {
         cached: false,
-        changedOn: 1559238500401,
+        changed_on: new Date(1559238500401).toISOString(),
         db: 'main',
         dbId: 1,
         id: 'lXJa7F9_r',
@@ -80,7 +80,7 @@ const store = mockStore({
       },
       '2g2_iRFMl': {
         cached: false,
-        changedOn: 1559238506925,
+        changed_on: new Date(1559238506925).toISOString(),
         db: 'main',
         dbId: 1,
         id: '2g2_iRFMl',
@@ -89,7 +89,7 @@ const store = mockStore({
       },
       erWdqEWPm: {
         cached: false,
-        changedOn: 1559238516395,
+        changed_on: new Date(1559238516395).toISOString(),
         db: 'main',
         dbId: 1,
         id: 'erWdqEWPm',

--- a/superset-frontend/src/SqlLab/fixtures.ts
+++ b/superset-frontend/src/SqlLab/fixtures.ts
@@ -217,7 +217,6 @@ export const queries = [
     progress: 100,
     startDttm: 1476910566092.96,
     state: QueryState.SUCCESS,
-    changedOn: 1476910566000,
     tempTable: null,
     userId: 1,
     executedSql: null,
@@ -276,7 +275,6 @@ export const queries = [
     progress: 100,
     startDttm: 1476910570802.2,
     state: QueryState.SUCCESS,
-    changedOn: 1476910572000,
     tempTable: null,
     userId: 1,
     executedSql:
@@ -310,7 +308,6 @@ export const queryWithNoQueryLimit = {
   progress: 100,
   startDttm: 1476910566092.96,
   state: QueryState.SUCCESS,
-  changedOn: 1476910566000,
   tempTable: null,
   userId: 1,
   executedSql: null,

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -614,8 +614,9 @@ export default function sqlLabReducer(state = {}, action) {
           (state.queries[id].state !== QueryState.STOPPED &&
             state.queries[id].state !== QueryState.FAILED)
         ) {
-          if (changedQuery.changedOn > queriesLastUpdate) {
-            queriesLastUpdate = changedQuery.changedOn;
+          const changedOn = Date.parse(changedQuery.changed_on);
+          if (changedOn > queriesLastUpdate) {
+            queriesLastUpdate = changedOn;
           }
           const prevState = state.queries[id]?.state;
           const currentState = changedQuery.state;

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -164,7 +164,7 @@ class ChartEntityResponseSchema(Schema):
     id = fields.Integer(metadata={"description": id_description})
     slice_name = fields.String(metadata={"description": slice_name_description})
     cache_timeout = fields.Integer(metadata={"description": cache_timeout_description})
-    changed_on = fields.String(metadata={"description": changed_on_description})
+    changed_on = fields.DateTime(metadata={"description": changed_on_description})
     description = fields.String(metadata={"description": description_description})
     description_markeddown = fields.String(
         metadata={"description": description_markeddown_description}

--- a/superset/explore/schemas.py
+++ b/superset/explore/schemas.py
@@ -114,7 +114,7 @@ class SliceSchema(Schema):
     certified_by = fields.String(
         metadata={"description": "Person or group that has certified this dashboard."}
     )
-    changed_on = fields.String(
+    changed_on = fields.DateTime(
         metadata={"description": "Timestamp of the last modification."}
     )
     changed_on_humanized = fields.String(

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -135,7 +135,6 @@ class Query(
 
     def to_dict(self) -> dict[str, Any]:
         return {
-            "changedOn": self.changed_on,
             "changed_on": self.changed_on.isoformat(),
             "dbId": self.database_id,
             "db": self.database.database_name if self.database else None,

--- a/superset/sqllab/schemas.py
+++ b/superset/sqllab/schemas.py
@@ -58,8 +58,7 @@ class ExecutePayloadSchema(Schema):
 
 
 class QueryResultSchema(Schema):
-    changedOn = fields.DateTime()
-    changed_on = fields.String()
+    changed_on = fields.DateTime()
     dbId = fields.Integer()
     db = fields.String()  # pylint: disable=invalid-name
     endDttm = fields.Float()

--- a/tests/integration_tests/queries/api_tests.py
+++ b/tests/integration_tests/queries/api_tests.py
@@ -439,7 +439,6 @@ class TestQueryApi(SupersetTestCase):
         for key, value in data["result"][0].items():
             # We can't assert timestamp
             if key not in (
-                "changedOn",
                 "changed_on",
                 "end_time",
                 "start_running_time",


### PR DESCRIPTION
### SUMMARY
While creating a Java Client from the the Superset OpenAPI spec with the OpenAPI codegen, a collision between the `changedOn` and `changed_on` properties in the SQL Lab `QueryRestultSchema` caused an error. This happened because it automatically converts the snake_case property to a camelCase one. This type of overlap doesn't exist in other schemas. In addition, when checking other similar schemas, all the other ones are of type `fields.DateTime`, except `SliceSchema` and `ChartEntityResponseSchema`, which were `fields.String`. For this reason, the redundant `changedOn` property was removed from `QueryResultSchema`, and the type of `changed_on` was updated to `DateTime` for `QueryResultSchema`, `SliceSchema` and `ChartEntityResponseSchema`.

Furthermore, when looking at the SQL Lab code, I noticed inconsistencies in the test fixtures and the reducer:
- The `SouthPane` test didn't have `changed_on` in the fixture, only `changedOn`. Furthermore, the type was wrong - the fixture had an epoch, while the value is in fact an ISO8601 string (see screenshot).  These were updated.
- The `SqlLab` fixture also showed the `changedOn` property as an epoch. However, the `changed_on` property there was in correct format, i.e. ISO-8601 string. To comply with the updated schema, `changedOn` was removed.
- the SQL Lab reducer was comparing the ISO-8601 string value of `changedOn` with an epoch-valued `queriesLastUpdate`. I'm not sure what kind of results that resulted in, but to fix this, we now refer to `changed_on`, and convert it to epoch format first before doing the comparison.

This inconsistency in types has been verified on both a SQLite and Postgres metastore backend, so it shouldn't be affected by the metastore's temporal column logic.

### SCREENSHOTS
Currently on master, the values of `changedOn` and `changed_on` are identical in the query response:
![image](https://github.com/apache/superset/assets/33317356/ba5df2b0-bb96-4f48-8df0-869f642f86c1)

Notice how `queriesLastUpdate` is an epoch, but `changedOn` which it's being compared to in the reducer is an ISO-8601 string?

![image](https://github.com/apache/superset/assets/33317356/5ed2943a-b211-4fc9-91cf-65a0451cc829)
![image](https://github.com/apache/superset/assets/33317356/dee08ef5-3626-45fc-9e50-9d3a9a663b90)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
