### PR TITLE
chore: bump prophet and holidays (predictive forecasting)

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -57,8 +57,6 @@ colorama==0.4.6
     # via
     #   apache-superset
     #   flask-appbuilder
-convertdate==2.4.0
-    # via holidays
 cron-descriptor==1.2.24
     # via apache-superset
 croniter==1.0.15
@@ -128,9 +126,7 @@ gunicorn==20.1.0
     # via apache-superset
 hashids==1.3.1
     # via apache-superset
-hijri-converter==2.2.4
-    # via holidays
-holidays==0.23
+holidays==0.26
     # via apache-superset
 humanize==3.11.0
     # via apache-superset
@@ -154,8 +150,6 @@ jsonschema==4.17.3
     # via flask-appbuilder
 kombu==5.2.4
     # via celery
-korean-lunar-calendar==0.2.1
-    # via holidays
 limits==3.4.0
     # via flask-limiter
 mako==1.2.4
@@ -224,8 +218,6 @@ pyjwt==2.4.0
     #   apache-superset
     #   flask-appbuilder
     #   flask-jwt-extended
-pymeeus==0.5.11
-    # via convertdate
 pynacl==1.5.0
     # via paramiko
 pyparsing==3.0.6

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
         "geopy",
         "gunicorn>=20.1.0; sys_platform != 'win32'",
         "hashids>=1.3.1, <2",
-        "holidays>=0.23, <0.24",
+        "holidays>=0.26, <0.27",
         "humanize",
         "isodate",
         "Mako>=1.2.2",
@@ -175,7 +175,7 @@ setup(
         "postgres": ["psycopg2-binary==2.9.6"],
         "presto": ["pyhive[presto]>=0.6.5"],
         "trino": ["trino>=0.324.0"],
-        "prophet": ["prophet>=1.0.1, <1.1", "pystan<3.0"],
+        "prophet": ["prophet>=1.1.4, <1.2"],
         "redshift": ["sqlalchemy-redshift>=0.8.1, < 0.9"],
         "rockset": ["rockset>=0.8.10, <0.9"],
         "shillelagh": [


### PR DESCRIPTION
### SUMMARY
This PR bumps optional dependency `prophet` for the predictive forecasting feature. Prophet made huge performance gains in the last releases https://github.com/facebook/prophet/releases and dropped some dependencies. 

> Sped up .predict() by up to 10x by removing intermediate DataFrame creations.

Also bumped `holidays` as needed for prophet. https://github.com/dr-prodigy/python-holidays/releases

Note: Although prophet worked before and after the bump, their related integration tests still fail https://github.com/apache/superset/issues/24406. So this PR may be blocked by this issue.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://github.com/apache/superset/assets/112352529/0438c58e-a467-4ce3-a1ab-acedb30aa360)


### TESTING INSTRUCTIONS
- `pip install -e '.[prophet]'`
- Setup Line chart and enable predictive forecast

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
