### PR TITLE
fix: deck.gl Geojson path not visible

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Geojson/Geojson.jsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Geojson/Geojson.jsx
@@ -123,14 +123,15 @@ export function getLayer(formData, payload, onAddFilter, setTooltip) {
 
   return new GeoJsonLayer({
     id: `geojson-layer-${fd.slice_id}`,
-    filled: fd.filled,
     data: features,
-    stroked: fd.stroked,
     extruded: fd.extruded,
-    pointRadiusScale: fd.point_radius_scale,
+    filled: fd.filled,
+    stroked: fd.stroked,
     getFillColor,
-    getLineWidth: fd.line_width || 1,
     getLineColor,
+    getLineWidth: fd.line_width || 1,
+    pointRadiusScale: fd.point_radius_scale,
+    lineWidthUnits: fd.line_width_unit,
     ...commonLayerProps(fd, setTooltip, setTooltipContent),
   });
 }

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Geojson/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Geojson/controlPanel.ts
@@ -69,8 +69,23 @@ const config: ControlPanelConfig = {
       controlSetRows: [
         [fillColorPicker, strokeColorPicker],
         [filled, stroked],
-        [extruded, null],
-        [lineWidth, null],
+        [extruded],
+        [lineWidth],
+        [
+          {
+            name: 'line_width_unit',
+            config: {
+              type: 'SelectControl',
+              label: t('Line width unit'),
+              default: 'meters',
+              choices: [
+                ['meters', t('meters')],
+                ['pixels', t('pixels')],
+              ],
+              renderTrigger: true,
+            },
+          },
+        ],
         [
           {
             name: 'point_radius_scale',
@@ -83,7 +98,6 @@ const config: ControlPanelConfig = {
               choices: formatSelectOptions([0, 100, 200, 300, 500]),
             },
           },
-          null,
         ],
       ],
     },


### PR DESCRIPTION
### SUMMARY
When user created a deck.gl Geojson chart, the path was not visible. It turned out that it wasn't really a bug, but the default unit of line width was meters, and a path 1 meter wide was practically invisible on large scale maps. This PR introduces a new control - line width unit, which lets user select if the unit should be meters or pixels. I kept meters as default in order not to break existing charts where users figured out they need to put a large number as line width.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before (line width 1 meter):
<img width="1727" alt="image" src="https://github.com/apache/superset/assets/15073128/37a20d78-bf40-429a-99ff-30f3043b158a">

After (line width 1 pixel):
<img width="1728" alt="image" src="https://github.com/apache/superset/assets/15073128/bb01c056-5080-4c33-9611-45fee30185aa">

### TESTING INSTRUCTIONS
1. Go to SQL Lab and execute this query:
```
SELECT '{
"type": "FeatureCollection",
"features": [{"type":"Feature","properties":{},"geometry":{ "type": "LineString", "coordinates": [ [-100.01667, 37.75278], [-100.065519, 37.42567], [-100.21247875, 37.376076], [-100.3594385, 37.326482], [-100.50639825, 37.276888], [-100.653358, 37.227294], [-100.7684914375, 37.1557011875], [-100.883624875, 37.084108375], [-100.9987583125, 37.0125155625], [-101.11389175, 36.94092275], [-101.2290251875, 36.8693299375], [-101.344158625, 36.797737125], [-101.4592920625, 36.7261443125], [-101.5744255, 36.6545515], [-101.6895589375, 36.5829586875], [-101.804692375, 36.511365875], [-101.9198258125, 36.4397730625], [-102.03495925, 36.36818025], [-102.1500926875, 36.2965874375], [-102.265226125, 36.224994625], [-102.3803595625, 36.1534018125], [-102.495493, 36.081809], [-102.619302375, 35.98194875], [-102.74311175, 35.8820885], [-102.866921125, 35.78222825], [-102.9907305, 35.682368], [-103.114539875, 35.58250775], [-103.23834925, 35.4826475], [-103.362158625, 35.38278725], [-103.485968, 35.282927], [-103.6262395, 35.24297875], [-103.766511, 35.2030305], [-103.9067825, 35.16308225], [-104.047054, 35.123134], [-104.1873255, 35.08318575], [-104.327597, 35.0432375], [-104.4678685, 35.00328925], [-104.60814, 34.963341], [-104.821293625, 34.981918625], [-105.03444725, 35.00049625], [-105.247600875, 35.019073875], [-105.4607545, 35.0376515], [-105.673908125, 35.056229125], [-105.88706175, 35.07480675], [-106.100215375, 35.093384375], [-106.313369, 35.111962], [-106.54273675, 35.08211525], [-106.7721045, 35.0522685], [-107.00147225, 35.02242175], [-107.23084, 34.992575], [-107.4804235, 35.0298895], [-107.730007, 35.067204], [-107.8702405, 35.206383], [-108.010474, 35.345562], [-108.188277, 35.39252125], [-108.36608, 35.4394805], [-108.543883, 35.48643975], [-108.721686, 35.533399], [-108.911406875, 35.45564075], [-109.10112775, 35.3778825], [-109.290848625, 35.30012425], [-109.4805695, 35.222366], [-109.670290375, 35.14460775], [-109.86001125, 35.0668495], [-110.049732125, 34.98909125], [-110.239453, 34.911333], [-110.4053895, 34.949769625], [-110.571326, 34.98820625], [-110.7372625, 35.026642875], [-110.903199, 35.0650795], [-111.0691355, 35.103516125], [-111.235072, 35.14195275], [-111.4010085, 35.180389375], [-111.566945, 35.218826], [-111.739963625, 35.2314255], [-111.91298225, 35.244025], [-112.086000875, 35.2566245], [-112.2590195, 35.269224], [-112.432038125, 35.2818235], [-112.60505675, 35.294423], [-112.778075375, 35.3070225], [-112.951094, 35.319622], [-113.23180625, 35.28429025], [-113.5125185, 35.2489585], [-113.79323075, 35.21362675], [-114.073943, 35.178295], [-114.171265, 34.955191], [-114.268587, 34.732087], [-114.493718, 34.8092475], [-114.718849, 34.886408], [-114.901495625, 34.866216], [-115.08414225, 34.846024], [-115.266788875, 34.825832], [-115.4494355, 34.80564], [-115.632082125, 34.785448], [-115.81472875, 34.765256], [-115.997375375, 34.745064], [-116.180022, 34.724872], [-116.3809551875, 34.766996], [-116.581888375, 34.80912], [-116.7828215625, 34.851244], [-116.98375475, 34.893368], [-117.1846879375, 34.935492], [-117.385621125, 34.977616], [-117.5865543125, 35.01974], [-117.7874875, 35.061864], [-117.9884206875, 35.103988], [-118.189353875, 35.146112], [-118.3902870625, 35.188236], [-118.59122025, 35.23036], [-118.7921534375, 35.272484], [-118.993086625, 35.314608], [-119.1940198125, 35.356732], [-119.394953, 35.398856], [-119.548127375, 35.55356975], [-119.70130175, 35.7082835], [-119.854476125, 35.86299725], [-120.0076505, 36.017711], [-120.160824875, 36.17242475], [-120.31399925, 36.3271385], [-120.467173625, 36.48185225], [-120.620348, 36.636566], [-120.7679015, 36.85089675], [-120.915455, 37.0652275], [-121.0630085, 37.27955825], [-121.210562, 37.493889], [-121.404887, 37.6161845], [-121.599212, 37.73848], [-121.773222, 37.754419], [-121.947232, 37.770358], [-122.121242, 37.786297], [-122.295252, 37.802236], [-122.425259, 37.988482], [-122.555266, 38.174728], [-122.685273, 38.360974], [-122.81528, 38.54722] ] } }
]
}'
as json
```

2. Save it as dataset and use it to create deckgl GeoJSON chart
3. Change the unit to meters and verify that the path is rendered

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
