### PR TITLE
fix: Viz migration adjustments - 2

### DIFF
--- a/superset/migrations/shared/migrate_viz/processors.py
+++ b/superset/migrations/shared/migrate_viz/processors.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Any
+
 from .base import MigrateViz
 
 
@@ -21,6 +23,7 @@ class MigrateTreeMap(MigrateViz):
     source_viz_type = "treemap"
     target_viz_type = "treemap_v2"
     remove_keys = {"metrics"}
+    rename_keys = {"order_desc": "sort_by_metric"}
 
     def _pre_action(self) -> None:
         if (
@@ -105,3 +108,7 @@ class MigrateDualLine(MigrateViz):
         self.data["truncateYAxis"] = True
         self.data["metrics"] = [self.data.get("metric")]
         self.data["metrics_b"] = [self.data.get("metric_2")]
+
+    def _migrate_temporal_filter(self, rv_data: dict[str, Any]) -> None:
+        super()._migrate_temporal_filter(rv_data)
+        rv_data["adhoc_filters_b"] = rv_data.get("adhoc_filters") or []


### PR DESCRIPTION
### SUMMARY
Makes adjustments to the viz migrations to fix problems found during tests.

- Adjusts the TreeMap migration to preserve the Sort Descending checkbox value
- Adjusts the Dual Line migration to add the filters to both Query A and Query B

@jinghua-qa

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
