### PR TITLE
chore(ci): make eslint and jest run in --quiet mode

### DIFF
--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.check.outcome == 'failure'
         working-directory: ./superset-frontend
         run: |
-          npm run test -- --coverage
+          npm run test -- --coverage --silent
       # todo: remove this step when fix generator as a project in root jest.config.js
       - name: generator-superset unit tests
         if: steps.check.outcome == 'failure'

--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -41,7 +41,7 @@ jobs:
         if: steps.check.outcome == 'failure'
         working-directory: ./superset-frontend
         run: |
-          npm run lint
+          npm run lint -- --quiet
           npm run prettier-check
       - name: Build plugins packages
         if: steps.check.outcome == 'failure'


### PR DESCRIPTION
`npm run lint` and `npm run test` are VERY verbose, so much so that the log explorer window in github gets unusable. `--quiet` in CI should do the trick here

https://eslint.org/docs/latest/use/command-line-interface#:~:text=Handle%20Warnings-,%2D%2Dquiet,Argument%20Type%3A%20No%20argument.

<img width="992" alt="Screen Shot 2023-06-16 at 10 49 24 AM" src="https://github.com/apache/superset/assets/487433/9845d46b-306f-4fc2-a9f9-1ac970eff01c">
<img width="1096" alt="Screen Shot 2023-06-16 at 10 49 02 AM" src="https://github.com/apache/superset/assets/487433/24d2d513-a2ce-41bf-b368-c66028d428c1">


