### PR TITLE
feat: use Scarf Gateway for Superset npm downloads

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -577,6 +577,18 @@ cd superset-frontend
 npm ci
 ```
 
+Note that Superset uses [Scarf](https://docs.scarf.sh) to capture telemetry/analytics about versions being installed, including the `scarf-js` npm package. As noted elsewhere in this documentation, Scarf gathers aggregated stats for the sake of security/release strategy, and does not capture/retain PII. [You can read here](https://docs.scarf.sh/package-analytics/) about the package, and various means to opt out of it, but one easy way to opt out is to add this setting in `superset-frontent/package.json`:
+```json
+// your-package/package.json
+{
+  // ...
+  "scarfSettings": {
+    "enabled": false
+  }
+  // ...
+}
+```
+
 #### Build assets
 
 There are three types of assets you can build:

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -204,7 +204,7 @@
     "regenerator-runtime": "^0.13.5",
     "rimraf": "^3.0.2",
     "rison": "^0.1.1",
-    "scarf-js": "^1.1.1",
+    "@scarf/scarf": "^1.1.1",
     "scroll-into-view-if-needed": "^2.2.28",
     "shortid": "^2.2.6",
     "tinycolor2": "^1.4.2",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -204,6 +204,7 @@
     "regenerator-runtime": "^0.13.5",
     "rimraf": "^3.0.2",
     "rison": "^0.1.1",
+    "scarf-js": "^1.1.1",
     "scroll-into-view-if-needed": "^2.2.28",
     "shortid": "^2.2.6",
     "tinycolor2": "^1.4.2",
@@ -345,6 +346,9 @@
     "webpack-dev-server": "^4.15.1",
     "webpack-manifest-plugin": "^4.1.1",
     "webpack-sources": "^3.2.3"
+  },
+  "scarfSettings": {
+    "allowTopLevel": true
   },
   "engines": {
     "node": "^16.9.1",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -86,6 +86,7 @@
     "@emotion/styled": "^11.3.0",
     "@fontsource/inter": "^4.0.0",
     "@reduxjs/toolkit": "^1.9.3",
+    "@scarf/scarf": "^1.1.1",
     "@superset-ui/chart-controls": "file:./packages/superset-ui-chart-controls",
     "@superset-ui/core": "file:./packages/superset-ui-core",
     "@superset-ui/legacy-plugin-chart-calendar": "file:./plugins/legacy-plugin-chart-calendar",
@@ -204,7 +205,6 @@
     "regenerator-runtime": "^0.13.5",
     "rimraf": "^3.0.2",
     "rison": "^0.1.1",
-    "@scarf/scarf": "^1.1.1",
     "scroll-into-view-if-needed": "^2.2.28",
     "shortid": "^2.2.6",
     "tinycolor2": "^1.4.2",
@@ -347,9 +347,6 @@
     "webpack-manifest-plugin": "^4.1.1",
     "webpack-sources": "^3.2.3"
   },
-  "scarfSettings": {
-    "allowTopLevel": true
-  },
   "engines": {
     "node": "^16.9.1",
     "npm": "^7.5.4 || ^8.1.2"
@@ -361,5 +358,8 @@
     }
   },
   "readme": "ERROR: No README data found!",
+  "scarfSettings": {
+    "allowTopLevel": true
+  },
   "_id": "superset@0.0.0-dev"
 }


### PR DESCRIPTION
### SUMMARY
This PR updates the Superset configuration for npm by adding scarf-js as a dependency. This allows Superset maintainers to collect basic de-identified download and adoption metrics. These metrics include which versions of superset are being installed and the origin of installation (git, etc.). This does not have a runtime footprint and adds no additional dependencies beyond itself. 

This change was suggested by Superset maintainers in direct discussions. There is also a [pull request](https://github.com/apache/superset/pull/24432) for updating the Docker compose and helm charts installation methods to retrieve metrics from those pathways. 

Scarf purges PII and provides aggregated statistics. Superset users can easily opt out of analytics in various ways documented [here](https://docs.scarf.sh/gateway/#do-not-track) and [here](https://docs.scarf.sh/package-analytics/#as-a-user-of-a-package-using-scarf-js-how-can-i-opt-out-of-analytics). 

### TESTING INSTRUCTIONS
To test this, download Apache Superset using general npm methodology and verify that Apache Superset downloads without issue. 

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ x ] Introduces new feature or API
- [ ] Removes existing feature or API
