### PR TITLE
chore: add instructions and ability to create a dist package

### DIFF
--- a/RELEASING/README.md
+++ b/RELEASING/README.md
@@ -366,7 +366,49 @@ Once 3+ binding votes (by PMC members) have been cast and at
 least 72 hours have past, you can post a [RESULT] thread:
 https://lists.apache.org/thread.html/50a6b134d66b86b237d5d7bc89df1b567246d125a71394d78b45f9a8@%3Cdev.superset.apache.org%3E
 
-To easily send the result email, still on the `superset/RELEASING` directory:
+
+### Publish an RC testing Convenience Pre-Release to PyPI
+
+Extract the release to the `/tmp` folder to build the PiPY release. Files in the `/tmp` folder will be automatically deleted by the OS.
+
+```bash
+mkdir -p /tmp/superset_dev && cd /tmp/superset_dev
+tar xfvz ~/svn/superset_dev/${SUPERSET_VERSION_RC}/${SUPERSET_RELEASE_RC_TARBALL}
+```
+
+Create a virtual environment and install the dependencies
+
+```bash
+cd ${SUPERSET_RELEASE_RC}/
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements/base.txt
+pip install twine
+```
+
+Create the distribution
+
+```bash
+cd superset-frontend/
+npm ci && npm run build
+cd ../
+flask fab babel-compile --target superset/translations
+python setup.py sdist --version=${SUPERSET_VERSION_RC}
+```
+
+Publish to PyPI
+
+You may need to ask a fellow committer to grant
+you access to it if you don't have access already. Make sure to create
+an account first if you don't have one, and reference your username
+while requesting access to push packages.
+
+```bash
+twine upload dist/${SUPERSET_RELEASE_RC}.tar.gz
+```
+
+## Sending the result email
+To easily send the result email, on the `superset/RELEASING` directory:
 
 ```bash
 # Note: use Superset's virtualenv

--- a/RELEASING/README.md
+++ b/RELEASING/README.md
@@ -407,6 +407,10 @@ while requesting access to push packages.
 twine upload dist/${SUPERSET_RELEASE_RC}.tar.gz
 ```
 
+Set your username to `__token__`
+Set your password to the token value, including the `pypi-` prefix
+More information on https://pypi.org/help/#apitoken
+
 ## Sending the result email
 To easily send the result email, on the `superset/RELEASING` directory:
 

--- a/setup.py
+++ b/setup.py
@@ -16,15 +16,37 @@
 # under the License.
 import json
 import os
+import re
 import subprocess
+import sys
 
 from setuptools import find_packages, setup
 
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 PACKAGE_JSON = os.path.join(BASE_DIR, "superset-frontend", "package.json")
 
-with open(PACKAGE_JSON) as package_file:
-    version_string = json.load(package_file)["version"]
+parameters = {}
+
+# Regex pattern to match arguments in the form --param=value
+pattern = re.compile(r"^--(\w+)=(.+)$")
+
+# Check for custom parameters in sys.argv
+for arg in sys.argv:
+    match = pattern.match(arg)
+    if match:
+        key = match.group(1)
+        value = match.group(2)
+        parameters[key] = value
+
+# Access the passed parameters and their values
+version_string = parameters.get("version")
+
+# Remove custom parameters from sys.argv to allow other commands to be processed
+sys.argv = [arg for arg in sys.argv if not pattern.match(arg)]
+
+if not version_string:
+    with open(PACKAGE_JSON) as package_file:
+        version_string = json.load(package_file)["version"] or ""
 
 with open("README.md", encoding="utf-8") as f:
     long_description = f.read()

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,8 @@ parameters = {}
 # Regex pattern to match arguments in the form --param=value
 pattern = re.compile(r"^--(\w+)=(.+)$")
 
+non_custom_parameters = []
+
 # Check for custom parameters in sys.argv
 for arg in sys.argv:
     match = pattern.match(arg)
@@ -37,12 +39,13 @@ for arg in sys.argv:
         key = match.group(1)
         value = match.group(2)
         parameters[key] = value
+    else:
+        non_custom_parameters.append(arg)
 
 # Access the passed parameters and their values
 version_string = parameters.get("version")
 
-# Remove custom parameters from sys.argv to allow other commands to be processed
-sys.argv = [arg for arg in sys.argv if not pattern.match(arg)]
+sys.argv = non_custom_parameters
 
 if not version_string:
     with open(PACKAGE_JSON) as package_file:


### PR DESCRIPTION
add instructions and ability to create a dist package for a release candidate

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This PR adds some instructions for pushing a release candidate to Pypi for testing. I also added a param in the setup.py script that allows the release manager to pass the rc version to the script, since the current version that we use from the package.json file is the non-rc one. I'm still considering ways that we can put the rc version in the package.json file for each release. The difficulty is then that the voted release needs to be updated after it is voted on. This should suffice, though for now for the Pypi rc packages. 


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
