### PR TITLE
fix(translations): regularise the capitalisation of 'CSV' in en localisation 

### DIFF
--- a/superset/translations/en/LC_MESSAGES/messages.json
+++ b/superset/translations/en/LC_MESSAGES/messages.json
@@ -201,7 +201,7 @@
         ""
       ],
       "A timeout occurred while executing the query.": [""],
-      "A timeout occurred while generating a csv.": [""],
+      "A timeout occurred while generating a CSV.": [""],
       "A timeout occurred while generating a dataframe.": [""],
       "A timeout occurred while taking a screenshot.": [""],
       "A valid color scheme is required": [""],
@@ -346,7 +346,7 @@
       "Allow CREATE TABLE AS option in SQL Lab": [""],
       "Allow CREATE VIEW AS": [""],
       "Allow CREATE VIEW AS option in SQL Lab": [""],
-      "Allow Csv Upload": [""],
+      "Allow CSV Upload": [""],
       "Allow DML": [""],
       "Allow columns to be rearranged": [""],
       "Allow creation of new tables based on queries": [""],
@@ -1139,7 +1139,7 @@
       "Database \"%(database_name)s\" schema \"%(schema_name)s\" is not allowed for columnar uploads. Please contact your Superset Admin.": [
         ""
       ],
-      "Database \"%(database_name)s\" schema \"%(schema_name)s\" is not allowed for csv uploads. Please contact your Superset Admin.": [
+      "Database \"%(database_name)s\" schema \"%(schema_name)s\" is not allowed for CSV uploads. Please contact your Superset Admin.": [
         ""
       ],
       "Database \"%(database_name)s\" schema \"%(schema_name)s\" is not allowed for excel uploads. Please contact your Superset Admin.": [
@@ -1825,7 +1825,7 @@
       "If duplicate columns are not overridden, they will be presented as \"X.1, X.2 ...X.x\"": [
         ""
       ],
-      "If selected, please set the schemas allowed for csv upload in Extra.": [
+      "If selected, please set the schemas allowed for CSV upload in Extra.": [
         ""
       ],
       "If table exists do one of the following: Fail (do nothing), Replace (drop and recreate table) or Append (insert data).": [
@@ -2758,7 +2758,7 @@
       "Report Schedule could not be deleted.": [""],
       "Report Schedule could not be updated.": [""],
       "Report Schedule delete failed.": [""],
-      "Report Schedule execution failed when generating a csv.": [""],
+      "Report Schedule execution failed when generating a CSV.": [""],
       "Report Schedule execution failed when generating a dataframe.": [""],
       "Report Schedule execution failed when generating a screenshot.": [""],
       "Report Schedule execution got an unexpected error.": [""],
@@ -3513,10 +3513,10 @@
       "The number of hours, negative or positive, to shift the time column. This can be used to move UTC time to local time.": [
         ""
       ],
-      "The number of results displayed is limited to %(rows)d by the configuration DISPLAY_MAX_ROWS. Please add additional limits/filters or download to csv to see more rows up to the %(limit)d limit.": [
+      "The number of results displayed is limited to %(rows)d by the configuration DISPLAY_MAX_ROWS. Please add additional limits/filters or download to CSV to see more rows up to the %(limit)d limit.": [
         ""
       ],
-      "The number of results displayed is limited to %(rows)d. Please add additional limits/filters, download to csv, or contact an admin to see more rows up to the %(limit)d limit.": [
+      "The number of results displayed is limited to %(rows)d. Please add additional limits/filters, download to CSV, or contact an admin to see more rows up to the %(limit)d limit.": [
         ""
       ],
       "The number of rows displayed is limited to %(rows)d by the dropdown.": [
@@ -4424,7 +4424,7 @@
       "You don't have the rights to alter this title.": [""],
       "You don't have the rights to create a chart": [""],
       "You don't have the rights to create a dashboard": [""],
-      "You don't have the rights to download as csv": [""],
+      "You don't have the rights to download as CSV": [""],
       "You have no permission to approve this request": [""],
       "You have removed this filter.": [""],
       "You have unsaved changes.": [""],

--- a/superset/translations/en/LC_MESSAGES/messages.po
+++ b/superset/translations/en/LC_MESSAGES/messages.po
@@ -12973,7 +12973,7 @@ msgid ""
 msgstr ""
 
 #: superset-frontend/src/features/alerts/AlertReportModal.tsx:408
-msgid "Send as "
+msgid "Send as CSV"
 msgstr ""
 
 #: superset-frontend/src/features/alerts/AlertReportModal.tsx:407

--- a/superset/translations/en/LC_MESSAGES/messages.po
+++ b/superset/translations/en/LC_MESSAGES/messages.po
@@ -872,7 +872,7 @@ msgid "A timeout occurred while executing the query."
 msgstr ""
 
 #: superset/reports/commands/exceptions.py:238
-msgid "A timeout occurred while generating a csv."
+msgid "A timeout occurred while generating a CSV."
 msgstr ""
 
 #: superset/reports/commands/exceptions.py:243
@@ -1554,7 +1554,7 @@ msgid "Allow CREATE VIEW AS option in SQL Lab"
 msgstr ""
 
 #: superset/views/database/mixins.py:198
-msgid "Allow Csv Upload"
+msgid "Allow CSV Upload"
 msgstr ""
 
 #: superset-frontend/src/features/databases/DatabaseModal/ExtraOptions.tsx:164
@@ -4847,7 +4847,7 @@ msgstr ""
 #, python-format
 msgid ""
 "Database \"%(database_name)s\" schema \"%(schema_name)s\" is not allowed "
-"for csv uploads. Please contact your Superset Admin."
+"for CSV uploads. Please contact your Superset Admin."
 msgstr ""
 
 #: superset/views/database/views.py:321
@@ -7685,7 +7685,7 @@ msgid ""
 msgstr ""
 
 #: superset/views/database/mixins.py:177
-msgid "If selected, please set the schemas allowed for csv upload in Extra."
+msgid "If selected, please set the schemas allowed for CSV upload in Extra."
 msgstr ""
 
 #: superset/views/database/forms.py:328 superset/views/database/forms.py:459
@@ -11702,7 +11702,7 @@ msgid "Report Schedule delete failed."
 msgstr ""
 
 #: superset/reports/commands/exceptions.py:159
-msgid "Report Schedule execution failed when generating a csv."
+msgid "Report Schedule execution failed when generating a CSV."
 msgstr ""
 
 #: superset/reports/commands/exceptions.py:163
@@ -12973,7 +12973,7 @@ msgid ""
 msgstr ""
 
 #: superset-frontend/src/features/alerts/AlertReportModal.tsx:408
-msgid "Send as CSV"
+msgid "Send as "
 msgstr ""
 
 #: superset-frontend/src/features/alerts/AlertReportModal.tsx:407
@@ -14728,14 +14728,14 @@ msgstr ""
 msgid ""
 "The number of results displayed is limited to %(rows)d by the "
 "configuration DISPLAY_MAX_ROWS. Please add additional limits/filters or "
-"download to csv to see more rows up to the %(limit)d limit."
+"download to CSV to see more rows up to the %(limit)d limit."
 msgstr ""
 
 #: superset-frontend/src/SqlLab/components/ResultSet/index.tsx:307
 #, python-format
 msgid ""
 "The number of results displayed is limited to %(rows)d. Please add "
-"additional limits/filters, download to csv, or contact an admin to see "
+"additional limits/filters, download to CSV, or contact an admin to see "
 "more rows up to the %(limit)d limit."
 msgstr ""
 
@@ -17911,7 +17911,7 @@ msgid "You don't have the rights to create a dashboard"
 msgstr ""
 
 #: superset/views/core.py:649
-msgid "You don't have the rights to download as csv"
+msgid "You don't have the rights to download as CSV"
 msgstr ""
 
 #: superset/views/core.py:425


### PR DESCRIPTION

### SUMMARY
Regularise  capitalisation of 'CSV' in en localisation. Capitialisation was previous a mixture of 'csv', 'Csv' and 'CSV'

Filenames and function names have not been touched.

Translations I don't speak have not been touched (but show similar issues).

### ADDITIONAL INFORMATION
- [ x] Changes UI
