### PR TITLE
fix(charts): Fix chart load task error handling

### DIFF
--- a/superset/charts/data/commands/get_data_command.py
+++ b/superset/charts/data/commands/get_data_command.py
@@ -17,7 +17,7 @@
 import logging
 from typing import Any
 
-from flask_babel import lazy_gettext as _
+from flask_babel import gettext as _
 
 from superset.charts.commands.exceptions import (
     ChartDataCacheLoadError,

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -23,7 +23,7 @@ from typing import Any, ClassVar, TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
-from flask_babel import _
+from flask_babel import gettext as _
 from pandas import DateOffset
 from typing_extensions import TypedDict
 

--- a/superset/tasks/async_queries.py
+++ b/superset/tasks/async_queries.py
@@ -90,10 +90,10 @@ def load_chart_data_into_cache(
             raise ex
         except Exception as ex:
             # TODO: QueryContext should support SIP-40 style errors
-            error = (
+            error = str(
                 ex.message  # pylint: disable=no-member
                 if hasattr(ex, "message")
-                else str(ex)
+                else ex
             )
             errors = [{"message": error}]
             async_query_manager.update_job(

--- a/tests/unit_tests/tasks/test_async_queries.py
+++ b/tests/unit_tests/tasks/test_async_queries.py
@@ -1,0 +1,39 @@
+from unittest import mock
+
+import pytest
+from flask_babel import lazy_gettext as _
+
+from superset.charts.commands.exceptions import ChartDataQueryFailedError
+
+
+@mock.patch("superset.tasks.async_queries.security_manager")
+@mock.patch("superset.tasks.async_queries.async_query_manager")
+@mock.patch("superset.tasks.async_queries.ChartDataQueryContextSchema")
+def test_load_chart_data_into_cache_with_error(
+    mock_query_context_schema_cls, mock_async_query_manager, mock_security_manager
+):
+    """Test that the task is gracefully marked failed in event of error"""
+    from superset.tasks.async_queries import load_chart_data_into_cache
+
+    job_metadata = {"user_id": 1}
+    form_data = {}
+    err_message = "Something went wrong"
+    err = ChartDataQueryFailedError(_(err_message))
+
+    mock_user = mock.MagicMock()
+    mock_query_context_schema = mock.MagicMock()
+
+    mock_security_manager.get_user_by_id.return_value = mock_user
+    mock_async_query_manager.STATUS_ERROR = "error"
+    mock_query_context_schema_cls.return_value = mock_query_context_schema
+
+    mock_query_context_schema.load.side_effect = err
+
+    with pytest.raises(ChartDataQueryFailedError):
+        load_chart_data_into_cache(job_metadata, form_data)
+
+    expected_errors = [{"message": err_message}]
+
+    mock_async_query_manager.update_job.assert_called_once_with(
+        job_metadata, "error", errors=expected_errors
+    )


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The exceptions raised within this task are given internationalised messages (flask-babel), which means when the task tries to serialise the exception message to mark the job as failed, it needs to make sure they're rendered first. Cast to str to make that happen.

The underlying issue was using lazy_gettext when just using gettext would make more sense, so I've also adjusted the import in a couple of obvious places directly impacting this task to fix it at both ends.

I've left in the str cast fix as it'd require a much deeper dive to determine if any other edge cases would still result in a lazy message given the complexity of the task.

### TESTING INSTRUCTIONS
See associated issue for full details.

1. Configure `GLOBAL_ASYNC_QUERIES`
2. Create a virtual dataset from any query
3. Edit the dataset to have invalid SQL, e.g. a syntax error
4. Click through to the charts page

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #24446
- [x] Has associated issue: #24446
- [x] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
