### PR TITLE
chore(dao): Replace save/overwrite with create/update respectively

### DIFF
--- a/superset/annotation_layers/annotations/commands/create.py
+++ b/superset/annotation_layers/annotations/commands/create.py
@@ -42,11 +42,10 @@ class CreateAnnotationCommand(BaseCommand):
     def run(self) -> Model:
         self.validate()
         try:
-            annotation = AnnotationDAO.create(self._properties)
+            return AnnotationDAO.create(attributes=self._properties)
         except DAOCreateFailedError as ex:
             logger.exception(ex.exception)
             raise AnnotationCreateFailedError() from ex
-        return annotation
 
     def validate(self) -> None:
         exceptions: list[ValidationError] = []

--- a/superset/annotation_layers/commands/create.py
+++ b/superset/annotation_layers/commands/create.py
@@ -39,11 +39,10 @@ class CreateAnnotationLayerCommand(BaseCommand):
     def run(self) -> Model:
         self.validate()
         try:
-            annotation_layer = AnnotationLayerDAO.create(self._properties)
+            return AnnotationLayerDAO.create(attributes=self._properties)
         except DAOCreateFailedError as ex:
             logger.exception(ex.exception)
             raise AnnotationLayerCreateFailedError() from ex
-        return annotation_layer
 
     def validate(self) -> None:
         exceptions: list[ValidationError] = []

--- a/superset/charts/commands/create.py
+++ b/superset/charts/commands/create.py
@@ -47,11 +47,10 @@ class CreateChartCommand(CreateMixin, BaseCommand):
         try:
             self._properties["last_saved_at"] = datetime.now()
             self._properties["last_saved_by"] = g.user
-            chart = ChartDAO.create(self._properties)
+            return ChartDAO.create(attributes=self._properties)
         except DAOCreateFailedError as ex:
             logger.exception(ex.exception)
             raise ChartCreateFailedError() from ex
-        return chart
 
     def validate(self) -> None:
         exceptions = []

--- a/superset/daos/chart.py
+++ b/superset/daos/chart.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=arguments-renamed
 from __future__ import annotations
 
 import logging
@@ -53,18 +52,6 @@ class ChartDAO(BaseDAO[Slice]):
         except SQLAlchemyError as ex:
             db.session.rollback()
             raise ex
-
-    @staticmethod
-    def save(slc: Slice, commit: bool = True) -> None:
-        db.session.add(slc)
-        if commit:
-            db.session.commit()
-
-    @staticmethod
-    def overwrite(slc: Slice, commit: bool = True) -> None:
-        db.session.merge(slc)
-        if commit:
-            db.session.commit()
 
     @staticmethod
     def favorited_ids(charts: list[Slice]) -> list[FavStar]:

--- a/superset/daos/dataset.py
+++ b/superset/daos/dataset.py
@@ -150,26 +150,27 @@ class DatasetDAO(BaseDAO[SqlaTable]):  # pylint: disable=too-many-public-methods
     @classmethod
     def update(
         cls,
-        model: SqlaTable,
-        properties: dict[str, Any],
+        item: SqlaTable | None = None,
+        attributes: dict[str, Any] | None = None,
         commit: bool = True,
     ) -> SqlaTable:
         """
         Updates a Dataset model on the metadata DB
         """
 
-        if "columns" in properties:
-            cls.update_columns(
-                model,
-                properties.pop("columns"),
-                commit=commit,
-                override_columns=bool(properties.get("override_columns")),
-            )
+        if item and attributes:
+            if "columns" in attributes:
+                cls.update_columns(
+                    item,
+                    attributes.pop("columns"),
+                    commit=commit,
+                    override_columns=bool(attributes.get("override_columns")),
+                )
 
-        if "metrics" in properties:
-            cls.update_metrics(model, properties.pop("metrics"), commit=commit)
+            if "metrics" in attributes:
+                cls.update_metrics(item, attributes.pop("metrics"), commit=commit)
 
-        return super().update(model, properties, commit=commit)
+        return super().update(item, attributes, commit=commit)
 
     @classmethod
     def update_columns(
@@ -316,7 +317,7 @@ class DatasetDAO(BaseDAO[SqlaTable]):  # pylint: disable=too-many-public-methods
         """
         Creates a Dataset model on the metadata DB
         """
-        return DatasetColumnDAO.create(properties, commit=commit)
+        return DatasetColumnDAO.create(attributes=properties, commit=commit)
 
     @classmethod
     def delete_column(cls, model: TableColumn, commit: bool = True) -> None:
@@ -358,7 +359,7 @@ class DatasetDAO(BaseDAO[SqlaTable]):  # pylint: disable=too-many-public-methods
         """
         Creates a Dataset model on the metadata DB
         """
-        return DatasetMetricDAO.create(properties, commit=commit)
+        return DatasetMetricDAO.create(attributes=properties, commit=commit)
 
     @classmethod
     def delete(

--- a/superset/daos/exceptions.py
+++ b/superset/daos/exceptions.py
@@ -36,7 +36,7 @@ class DAOUpdateFailedError(DAOException):
     DAO Update failed
     """
 
-    message = "Updated failed"
+    message = "Update failed"
 
 
 class DAODeleteFailedError(DAOException):
@@ -45,14 +45,6 @@ class DAODeleteFailedError(DAOException):
     """
 
     message = "Delete failed"
-
-
-class DAOConfigError(DAOException):
-    """
-    DAO is miss configured
-    """
-
-    message = "DAO is not configured correctly missing model definition"
 
 
 class DatasourceTypeNotSupportedError(DAOException):

--- a/superset/dashboards/commands/create.py
+++ b/superset/dashboards/commands/create.py
@@ -40,7 +40,7 @@ class CreateDashboardCommand(CreateMixin, BaseCommand):
     def run(self) -> Model:
         self.validate()
         try:
-            dashboard = DashboardDAO.create(self._properties, commit=False)
+            dashboard = DashboardDAO.create(attributes=self._properties, commit=False)
             dashboard = DashboardDAO.update_charts_owners(dashboard, commit=True)
         except DAOCreateFailedError as ex:
             logger.exception(ex.exception)

--- a/superset/dashboards/filter_sets/commands/create.py
+++ b/superset/dashboards/filter_sets/commands/create.py
@@ -47,8 +47,7 @@ class CreateFilterSetCommand(BaseFilterSetCommand):
     def run(self) -> Model:
         self.validate()
         self._properties[DASHBOARD_ID_FIELD] = self._dashboard.id
-        filter_set = FilterSetDAO.create(self._properties, commit=True)
-        return filter_set
+        return FilterSetDAO.create(attributes=self._properties, commit=True)
 
     def validate(self) -> None:
         self._validate_filterset_dashboard_exists()

--- a/superset/databases/commands/create.py
+++ b/superset/databases/commands/create.py
@@ -77,7 +77,7 @@ class CreateDatabaseCommand(BaseCommand):
         )
 
         try:
-            database = DatabaseDAO.create(self._properties, commit=False)
+            database = DatabaseDAO.create(attributes=self._properties, commit=False)
             database.set_sqlalchemy_uri(database.sqlalchemy_uri)
 
             ssh_tunnel = None

--- a/superset/databases/ssh_tunnel/commands/create.py
+++ b/superset/databases/ssh_tunnel/commands/create.py
@@ -46,7 +46,7 @@ class CreateSSHTunnelCommand(BaseCommand):
             # test_do_not_create_database_if_ssh_tunnel_creation_fails test will fail
             db.session.begin_nested()
             self.validate()
-            tunnel = SSHTunnelDAO.create(self._properties, commit=False)
+            return SSHTunnelDAO.create(attributes=self._properties, commit=False)
         except DAOCreateFailedError as ex:
             # Rollback nested transaction
             db.session.rollback()
@@ -55,8 +55,6 @@ class CreateSSHTunnelCommand(BaseCommand):
             # Rollback nested transaction
             db.session.rollback()
             raise ex
-
-        return tunnel
 
     def validate(self) -> None:
         # TODO(hughhh): check to make sure the server port is not localhost

--- a/superset/datasets/commands/create.py
+++ b/superset/datasets/commands/create.py
@@ -44,7 +44,7 @@ class CreateDatasetCommand(CreateMixin, BaseCommand):
         self.validate()
         try:
             # Creates SqlaTable (Dataset)
-            dataset = DatasetDAO.create(self._properties, commit=False)
+            dataset = DatasetDAO.create(attributes=self._properties, commit=False)
 
             # Updates columns and metrics from the datase
             dataset.fetch_metadata(commit=False)

--- a/superset/datasets/commands/update.py
+++ b/superset/datasets/commands/update.py
@@ -66,8 +66,8 @@ class UpdateDatasetCommand(UpdateMixin, BaseCommand):
         if self._model:
             try:
                 dataset = DatasetDAO.update(
-                    model=self._model,
-                    properties=self._properties,
+                    self._model,
+                    attributes=self._properties,
                 )
                 return dataset
             except DAOUpdateFailedError as ex:

--- a/superset/reports/commands/create.py
+++ b/superset/reports/commands/create.py
@@ -52,11 +52,10 @@ class CreateReportScheduleCommand(CreateMixin, BaseReportScheduleCommand):
     def run(self) -> ReportSchedule:
         self.validate()
         try:
-            report_schedule = ReportScheduleDAO.create(self._properties)
+            return ReportScheduleDAO.create(attributes=self._properties)
         except DAOCreateFailedError as ex:
             logger.exception(ex.exception)
             raise ReportScheduleCreateFailedError() from ex
-        return report_schedule
 
     def validate(self) -> None:
         exceptions: list[ValidationError] = []

--- a/superset/reports/commands/update.py
+++ b/superset/reports/commands/update.py
@@ -49,6 +49,8 @@ class UpdateReportScheduleCommand(UpdateMixin, BaseReportScheduleCommand):
 
     def run(self) -> Model:
         self.validate()
+        assert self._model
+
         try:
             report_schedule = ReportScheduleDAO.update(self._model, self._properties)
         except DAOUpdateFailedError as ex:

--- a/superset/row_level_security/commands/create.py
+++ b/superset/row_level_security/commands/create.py
@@ -39,12 +39,10 @@ class CreateRLSRuleCommand(BaseCommand):
     def run(self) -> Any:
         self.validate()
         try:
-            rule = RLSDAO.create(self._properties)
+            return RLSDAO.create(attributes=self._properties)
         except DAOCreateFailedError as ex:
             logger.exception(ex.exception)
             raise ex
-
-        return rule
 
     def validate(self) -> None:
         roles = populate_roles(self._roles)

--- a/superset/sqllab/commands/execute.py
+++ b/superset/sqllab/commands/execute.py
@@ -177,7 +177,7 @@ class ExecuteSqlCommand(BaseCommand):
 
     def _save_new_query(self, query: Query) -> None:
         try:
-            self._query_dao.save(query)
+            self._query_dao.create(query)
         except DAOCreateFailedError as ex:
             raise SqlLabException(
                 self._execution_context,

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -695,11 +695,11 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         slc.query_context = query_context
 
         if action == "saveas" and slice_add_perm:
-            ChartDAO.save(slc)
+            ChartDAO.create(slc)
             msg = _("Chart [{}] has been saved").format(slc.slice_name)
             flash(msg, "success")
         elif action == "overwrite" and slice_overwrite_perm:
-            ChartDAO.overwrite(slc)
+            ChartDAO.update(slc)
             msg = _("Chart [{}] has been overwritten").format(slc.slice_name)
             flash(msg, "success")
 

--- a/tests/unit_tests/databases/ssh_tunnel/dao_tests.py
+++ b/tests/unit_tests/databases/ssh_tunnel/dao_tests.py
@@ -27,15 +27,16 @@ def test_create_ssh_tunnel():
 
     db = Database(id=1, database_name="my_database", sqlalchemy_uri="sqlite://")
 
-    properties = {
-        "database_id": db.id,
-        "server_address": "123.132.123.1",
-        "server_port": "3005",
-        "username": "foo",
-        "password": "bar",
-    }
-
-    result = SSHTunnelDAO.create(properties, commit=False)
+    result = SSHTunnelDAO.create(
+        attributes={
+            "database_id": db.id,
+            "server_address": "123.132.123.1",
+            "server_port": "3005",
+            "username": "foo",
+            "password": "bar",
+        },
+        commit=False,
+    )
 
     assert result is not None
     assert isinstance(result, SSHTunnel)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Per  [SIP-92 Proposal for restructuring the Python code base](https://github.com/apache/superset/issues/20630) https://github.com/apache/superset/pull/24331 organized all the DAOs to be housed within a shared folder—the result of which highlighted numerous inconsistencies, repetition, and inefficiencies.

This PR (one of many smaller bitesized PRs) replaces the `save` and `overwrite` methods with `create` and `update` methods respectively which removes a bunch of copypasta.

Note this PR required a fair amount of yak shaving as the `create` and `update` methods needed to be updated to support a combination of a instance and/or the attributes representing the instance.

Future fast follows intend to:

1. Remove the ability to defining properties/attributes when creating or updating.
2. Consolidating the `create` and `update` into an `upsert` method.
3. Provide a mechanism for bulk upsert.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/20630
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
