### PR TITLE
fix(translations): typo mistake (translation to Spanish)

### DIFF
--- a/superset/translations/es/LC_MESSAGES/messages.json
+++ b/superset/translations/es/LC_MESSAGES/messages.json
@@ -646,7 +646,7 @@
       "Cell content": ["Contenido de la celda"],
       "Certification details": [""],
       "Certified by": ["Certificado por"],
-      "Certified by %s": ["Certidicado por %s"],
+      "Certified by %s": ["Certificado por %s"],
       "Change order of columns.": [""],
       "Change order of rows.": [""],
       "Changed By": ["Cambiado por"],


### PR DESCRIPTION
Typo mistake (translation to Spanish)

<!---
fix(translations): fix typo mistake - translation to es
-->

### SUMMARY
Word 'certidicado' is changed to 'certificado'.


