### PR TITLE
feat: add celeryConfigOverrides to allow extension for CeleryConfig object inside superset-config template

### DIFF
--- a/helm/superset/templates/_helpers.tpl
+++ b/helm/superset/templates/_helpers.tpl
@@ -95,6 +95,14 @@ class CeleryConfig(object):
   CELERY_RESULT_BACKEND = f"redis://{env('REDIS_HOST')}:{env('REDIS_PORT')}/0"
   {{- end }}
 
+  {{ if .Values.celeryConfigOverrides }}
+  # Overrides
+  {{- range $key, $value := .Values.celeryConfigOverrides }}
+  # {{ $key }}
+  {{ tpl $value $ }}
+  {{- end }}
+  {{- end }}
+
 CELERY_CONFIG = CeleryConfig
 RESULTS_BACKEND = RedisCache(
       host=env('REDIS_HOST'),

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -171,6 +171,12 @@ configOverridesFiles: {}
   # extend_timeout: extend_timeout.py
   # enable_oauth: enable_oauth.py
 
+# -- A dictionary of overrides to append at the end of CeleryConfig in superset_config.py - the name does not matter
+# WARNING: the order is not guaranteed
+celeryConfigOverrides: {}
+#  beat_schedule: |
+#    CELERY_BEAT_SCHEDULE = {'reports.scheduler': {'task': 'reports.scheduler', 'schedule': crontab(minute='*', hour='*')},'reports.prune_log': {'task': 'reports.prune_log','schedule': crontab(minute=0, hour=0)}}
+
 configMountPath: "/app/pythonpath"
 
 extraConfigMountPath: "/app/configs"


### PR DESCRIPTION
### SUMMARY
We have an usecase to set up CeleryBeat for alerts and that need some configurations in CeleryConfig object. The current helm chart does not support extension to this. 

So we use a similar mechanism as configOverrides to allow adding extra config to CeleryConfig.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
Render Helm chart by --dry-run to see that config values are indeed added to CeleryConfig. Non-breaking changes. Does not affect anyone who doesn't use the config

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
