### PR TITLE
docs: fix for domain sharding results in failed requests with "Missing Authorization Header"

### DIFF
--- a/docs/docs/installation/networking-settings.mdx
+++ b/docs/docs/installation/networking-settings.mdx
@@ -33,14 +33,14 @@ Add the following setting in your `superset_config.py` file:
 
 - `SUPERSET_WEBSERVER_DOMAINS`: list of allowed hostnames for domain sharding feature.
 
-Please create your domain shards as subdomains of your main domain for authorization to 
-work properly on new domains . For Example: 
+Please create your domain shards as subdomains of your main domain for authorization to
+work properly on new domains . For Example:
 
 - `SUPERSET_WEBSERVER_DOMAINS=['dashboards.mydomain.com','1.dashboards.mydomain.com','2.dashboards.mydomain.com','3.dashboards.mydomain.com']`
 
 or add the following setting in your `superset_config.py` file if domain shards are not subdomains of main domain.
 
-- `SESSION_COOKIE_DOMAIN = 'mydomain.com'` 
+- `SESSION_COOKIE_DOMAIN = 'mydomain.com'`
 
 ### Middleware
 

--- a/docs/docs/installation/networking-settings.mdx
+++ b/docs/docs/installation/networking-settings.mdx
@@ -33,6 +33,15 @@ Add the following setting in your `superset_config.py` file:
 
 - `SUPERSET_WEBSERVER_DOMAINS`: list of allowed hostnames for domain sharding feature.
 
+Please create you domain shards as subdomain of your main domain like following for authorization to 
+work properly on new domains [Issues 23295] (https://github.com/apache/superset/issues/23295) . Example - 
+
+- `SUPERSET_WEBSERVER_DOMAINS=['dashboards.mydomain.com','1.dashboards.mydomain.com','2.dashboards.mydomain.com','3.dashboards.mydomain.com']`
+
+or Add the following setting in your `superset_config.py` file if domain shards are not subdomains of main domain.
+
+- `SESSION_COOKIE_DOMAIN = 'mydomain.com'` 
+
 ### Middleware
 
 Superset allows you to add your own middleware. To add your own middleware, update the

--- a/docs/docs/installation/networking-settings.mdx
+++ b/docs/docs/installation/networking-settings.mdx
@@ -33,12 +33,12 @@ Add the following setting in your `superset_config.py` file:
 
 - `SUPERSET_WEBSERVER_DOMAINS`: list of allowed hostnames for domain sharding feature.
 
-Please create you domain shards as subdomain of your main domain like following for authorization to 
-work properly on new domains [Issues 23295] (https://github.com/apache/superset/issues/23295) . Example - 
+Please create your domain shards as subdomains of your main domain for authorization to 
+work properly on new domains . For Example: 
 
 - `SUPERSET_WEBSERVER_DOMAINS=['dashboards.mydomain.com','1.dashboards.mydomain.com','2.dashboards.mydomain.com','3.dashboards.mydomain.com']`
 
-or Add the following setting in your `superset_config.py` file if domain shards are not subdomains of main domain.
+or add the following setting in your `superset_config.py` file if domain shards are not subdomains of main domain.
 
 - `SESSION_COOKIE_DOMAIN = 'mydomain.com'` 
 

--- a/docs/docs/installation/networking-settings.mdx
+++ b/docs/docs/installation/networking-settings.mdx
@@ -36,7 +36,7 @@ Add the following setting in your `superset_config.py` file:
 Please create your domain shards as subdomains of your main domain for authorization to
 work properly on new domains . For Example:
 
-- `SUPERSET_WEBSERVER_DOMAINS=['dashboards.mydomain.com','1.dashboards.mydomain.com','2.dashboards.mydomain.com','3.dashboards.mydomain.com']`
+- `SUPERSET_WEBSERVER_DOMAINS=['superset-1.mydomain.com','superset-2.mydomain.com','superset-3.mydomain.com','superset-4.mydomain.com']`
 
 or add the following setting in your `superset_config.py` file if domain shards are not subdomains of main domain.
 

--- a/docs/docs/installation/networking-settings.mdx
+++ b/docs/docs/installation/networking-settings.mdx
@@ -40,7 +40,7 @@ work properly on new domains . For Example:
 
 or add the following setting in your `superset_config.py` file if domain shards are not subdomains of main domain.
 
-- `SESSION_COOKIE_DOMAIN = 'mydomain.com'`
+- `SESSION_COOKIE_DOMAIN = '.mydomain.com'`
 
 ### Middleware
 

--- a/docs/docs/installation/networking-settings.mdx
+++ b/docs/docs/installation/networking-settings.mdx
@@ -34,7 +34,7 @@ Add the following setting in your `superset_config.py` file:
 - `SUPERSET_WEBSERVER_DOMAINS`: list of allowed hostnames for domain sharding feature.
 
 Please create your domain shards as subdomains of your main domain for authorization to
-work properly on new domains . For Example:
+work properly on new domains. For Example:
 
 - `SUPERSET_WEBSERVER_DOMAINS=['superset-1.mydomain.com','superset-2.mydomain.com','superset-3.mydomain.com','superset-4.mydomain.com']`
 


### PR DESCRIPTION
### SUMMARY
Fixes https://github.com/apache/superset/issues/23295

Same issue discussion on domain sharding feature implementation PR - https://github.com/apache/superset/pull/5039

After enabling the domain sharding as follows

    ENABLE_CORS = True
    CORS_OPTIONS = {
      'supports_credentials': True,
      'allow_headers': '*',
      'resources': '*',
      'origins': ['https://dashboards.mydomain.com','https://dashboards1.mydomain.com','https://dashboards2.mydomain.com','https://dashboards3.mydomain.com']
    }
    SUPERSET_WEBSERVER_DOMAINS=['dashboards.mydomain.com','dashboards1.mydomain.com','dashboards2.mydomain.com','dashboards3.mydomain.com']
All 4 webserver domains are set via DNS A record to the same IP address.

When navigating to a dashboard, I can see in the Edge devtools, that the /api/v1/chart/data requests are sent to all webserver domains. However, they all fail with "401" (unauthenticated). I can also see, that some of the requests have a response set to {"msg":"Missing Authorization Header"}.

### EXPECTED RESULT
Domain sharding uses the 4 configured webserver domains for requesting data - and uses the session cookie of original domain for authentication.

### ACTUAL RESULT
The authentication of the non-original webserver domains does not work and the requests are not authenticated.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Please verify changes from my fork. 
After setting the `SESSION_COOKIE_DOMAIN` to main domain in `superset_config.py` authrization should work on all the domain shards. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes https://github.com/apache/superset/issues/23295
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
