### PR TITLE
chore(sqllab): add extra_json on tabstate

### DIFF
--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -487,11 +487,6 @@ class TabState(Model, AuditMixinNullable, ExtraJSONMixin):
     saved_query = relationship("SavedQuery", foreign_keys=[saved_query_id])
 
     def to_dict(self) -> dict[str, Any]:
-        try:
-            extra_json = json.loads(self.extra_json)
-        except json.JSONDecodeError:
-            extra_json = None
-
         return {
             "id": self.id,
             "user_id": self.user_id,
@@ -507,7 +502,7 @@ class TabState(Model, AuditMixinNullable, ExtraJSONMixin):
             "template_params": self.template_params,
             "hide_left_bar": self.hide_left_bar,
             "saved_query": self.saved_query.to_dict() if self.saved_query else None,
-            "extra_json": extra_json,
+            "extra_json": self.extra,
         }
 
 

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -487,6 +487,11 @@ class TabState(Model, AuditMixinNullable, ExtraJSONMixin):
     saved_query = relationship("SavedQuery", foreign_keys=[saved_query_id])
 
     def to_dict(self) -> dict[str, Any]:
+        try:
+            extra_json = json.loads(self.extra_json)
+        except json.JSONDecodeError:
+            extra_json = None
+
         return {
             "id": self.id,
             "user_id": self.user_id,
@@ -502,6 +507,7 @@ class TabState(Model, AuditMixinNullable, ExtraJSONMixin):
             "template_params": self.template_params,
             "hide_left_bar": self.hide_left_bar,
             "saved_query": self.saved_query.to_dict() if self.saved_query else None,
+            "extra_json": extra_json,
         }
 
 


### PR DESCRIPTION
### SUMMARY
This commit includes the `extra_json` attribute on tabstate view in order to sync the latest async updated time used in  [SIP-93](https://github.com/apache/superset/issues/21385)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<img width="512" alt="Screenshot_2023-06-22_at_1_16_02_PM" src="https://github.com/apache/superset/assets/1392866/a6e27059-a6dd-4586-a684-ee5e7f3f0c19">

### TESTING INSTRUCTIONS
check the bootstrap data in sqllab including `extra_json`

### ADDITIONAL INFORMATION
- [x] Has associated issue: [SIP-93](https://github.com/apache/superset/issues/21385)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
