### PR TITLE
build(docker): pin the underlying debain base image

### DIFF
--- a/.github/workflows/docker_build_push.sh
+++ b/.github/workflows/docker_build_push.sh
@@ -63,7 +63,7 @@ docker build --target lean \
   -t "${REPO_NAME}:${SHA}-py310" \
   -t "${REPO_NAME}:${REFSPEC}-py310" \
   -t "${REPO_NAME}:${LATEST_TAG}-py310" \
-  --build-arg PY_VER="3.10-slim"\
+  --build-arg PY_VER="3.10-slim-bookworm"\
   --label "sha=${SHA}" \
   --label "built_at=$(date)" \
   --label "target=lean310" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 ######################################################################
 # Node stage to deal with static asset construction
 ######################################################################
-ARG PY_VER=3.9.16-slim
+ARG PY_VER=3.9-slim-bookworm
 
 # if BUILDPLATFORM is null, set it to 'amd64' (or leave as is otherwise).
 ARG BUILDPLATFORM=${BUILDPLATFORM:-amd64}


### PR DESCRIPTION
### SUMMARY

The `slim` Python images are based on the latest Debian release.

Debian 12 Bookworm was released two weeks ago and I've seen some projects break because the APT packages they relied on are not available anymore.

As Superset does use `apt-get` during the build, it's better to pin the underlying Debian base image. This probably won't be an issue for a long time though...

### TESTING INSTRUCTIONS

Manually build from the `Dockerfile`,

```
docker build --target lean -t superset .
```

In stdout, we should see that the image is built from `3.9-slim-bookworm`,

```
Sending build context to Docker daemon    127MB
Step 1/31 : ARG PY_VER=3.9-slim-bookworm
```

And the build should finish without error.

```
Successfully tagged superset:latest
```
