### PR TITLE
fix: sqllab results not rendering after runs (intermittently)

### DIFF
--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -614,10 +614,6 @@ export default function sqlLabReducer(state = {}, action) {
           (state.queries[id].state !== QueryState.STOPPED &&
             state.queries[id].state !== QueryState.FAILED)
         ) {
-          const changedOn = Date.parse(changedQuery.changed_on);
-          if (changedOn > queriesLastUpdate) {
-            queriesLastUpdate = changedOn;
-          }
           const prevState = state.queries[id]?.state;
           const currentState = changedQuery.state;
           newQueries[id] = {

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -614,6 +614,10 @@ export default function sqlLabReducer(state = {}, action) {
           (state.queries[id].state !== QueryState.STOPPED &&
             state.queries[id].state !== QueryState.FAILED)
         ) {
+          if (changedQuery.changedOn > queriesLastUpdate) {
+            queriesLastUpdate = changedQuery.changedOn;
+          }
+
           const prevState = state.queries[id]?.state;
           const currentState = changedQuery.state;
           newQueries[id] = {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
With [this commit](https://github.com/apache/superset/commit/20e00363365780c37fefe60311321c41a81c5ee9) sqllab intermittently don't return results back in the bottom pane. Looking at the code i saw this condition for setting the last query updated time and after removing the issue i solved. Still trying to understand the inner workings on why this intially put there, but using this PR as chance to investigate and improve this part of the code base


https://github.com/apache/superset/assets/27827808/ac8a5597-0848-4d5f-9363-677849e635ea


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
