### PR TITLE
fix: Native filter dynamic numeric search

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1852,13 +1852,13 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                     elif op == utils.FilterOperator.LESS_THAN_OR_EQUALS.value:
                         where_clause_and.append(sqla_col <= eq)
                     elif op in {
-                        utils.FilterOperator.ILIKE,
-                        utils.FilterOperator.LIKE,
+                        utils.FilterOperator.ILIKE.value,
+                        utils.FilterOperator.LIKE.value,
                     }:
                         if target_generic_type != GenericDataType.STRING:
                             sqla_col = sa.cast(sqla_col, sa.String)
 
-                        if utils.FilterOperator.LIKE.value:
+                        if op == utils.FilterOperator.LIKE.value:
                             where_clause_and.append(sqla_col.like(eq))
                         else:
                             where_clause_and.append(sqla_col.ilike(eq))


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Addresses an issue with https://github.com/apache/superset/pull/24418 with handling `LIKE` vs. `ILIKE`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
