### PR TITLE
docker (build) without DOCKER_BUILDKIT

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,7 +50,7 @@ jobs:
           mkdir -p ./build
           echo ${{ github.sha }} > ./build/SHA
           echo ${{ github.event.pull_request.number }} > ./build/PR-NUM
-          DOCKER_BUILDKIT=1 docker build --target ci -t ${{ github.sha }} -t "pr-${{ github.event.pull_request.number }}" .
+          docker build --target ci -t ${{ github.sha }} -t "pr-${{ github.event.pull_request.number }}" .
           docker save ${{ github.sha }} | gzip > ./build/${{ github.sha }}.tar.gz
 
       - name: Upload build artifacts


### PR DESCRIPTION
According to https://github.com/apache/superset/pull/24504 if you remove DOCKER_BUILDKIT=1 then this should not affect the build process

TESTING INSTRUCTIONS
Manually build from the Dockerfile,

docker build -t superset 

And the build should finish without error.

Successfully tagged superset:latest