### PR TITLE
fix(dashboard): increase json_metadata field

### DIFF
--- a/superset/migrations/versions/2023-06-28_19-49_bf646a0c1501_json_metadata.py
+++ b/superset/migrations/versions/2023-06-28_19-49_bf646a0c1501_json_metadata.py
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""json_metadata
+
+Revision ID: bf646a0c1501
+Revises: 83e1abbe777f
+Create Date: 2023-06-28 19:49:59.217255
+
+"""
+
+
+import sqlalchemy as sa
+from alembic import op
+
+from superset.utils.core import MediumText
+
+# revision identifiers, used by Alembic.
+revision = "bf646a0c1501"
+down_revision = "83e1abbe777f"
+
+
+def upgrade():
+    with op.batch_alter_table("dashboards") as batch_op:
+        batch_op.alter_column(
+            "json_metadata",
+            existing_type=sa.Text(),
+            type_=MediumText(),
+            existing_nullable=True,
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("dashboards") as batch_op:
+        batch_op.alter_column(
+            "json_metadata",
+            existing_type=MediumText(),
+            type_=sa.Text(),
+            existing_nullable=True,
+        )

--- a/superset/migrations/versions/2023-06-28_19-49_bf646a0c1501_json_metadata.py
+++ b/superset/migrations/versions/2023-06-28_19-49_bf646a0c1501_json_metadata.py
@@ -17,7 +17,7 @@
 """json_metadata
 
 Revision ID: bf646a0c1501
-Revises: 83e1abbe777f
+Revises: a23c6f8b1280
 Create Date: 2023-06-28 19:49:59.217255
 
 """
@@ -30,7 +30,7 @@ from superset.utils.core import MediumText
 
 # revision identifiers, used by Alembic.
 revision = "bf646a0c1501"
-down_revision = "83e1abbe777f"
+down_revision = "a23c6f8b1280"
 
 
 def upgrade():

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -141,7 +141,7 @@ class Dashboard(Model, AuditMixinNullable, ImportExportMixin):
     css = Column(Text)
     certified_by = Column(Text)
     certification_details = Column(Text)
-    json_metadata = Column(Text)
+    json_metadata = Column(utils.MediumText())
     slug = Column(String(255), unique=True)
     slices: list[Slice] = relationship(
         Slice, secondary=dashboard_slices, backref="dashboards"


### PR DESCRIPTION
### SUMMARY
- Data too long for column `json_metadata`
- Default column size is 65535, we need to increase column size for saving dashboard.
  - ⚒️ Migration DDL required
- position_json already changed to `utils.MediumText`
```
(MySQLdb._exceptions.DataError) (1406, "Data too long for column 'json_metadata' at row 1")
[SQL: UPDATE dashboards SET changed_on=%s, json_metadata=%s, changed_by_fk=%s WHERE dashboards.id = %s]
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
```sql
ALTER TABLE dashboards MODIFY json_metadata MEDIUMTEXT;
```
- After modifying the column, it works normally.

### ADDITIONAL INFORMATION
- [x] Has associated issue: https://github.com/apache/superset/issues/5532
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
