### PR TITLE
refactor: pkg_resources -> importlib.metadata

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -137,7 +137,9 @@ humanize==3.11.0
 idna==3.2
     # via email-validator
 importlib-metadata==6.6.0
-    # via flask
+    # via
+    #   apache-superset
+    #   flask
 importlib-resources==5.12.0
     # via limits
 isodate==0.6.0

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ setup(
         "hashids>=1.3.1, <2",
         "holidays>=0.23, <0.24",
         "humanize",
+        "importlib_metadata",
         "isodate",
         "Mako>=1.2.2",
         "markdown>=3.0",

--- a/superset/db_engine_specs/__init__.py
+++ b/superset/db_engine_specs/__init__.py
@@ -32,12 +32,12 @@ import logging
 import pkgutil
 from collections import defaultdict
 from importlib import import_module
-from importlib_metadata import entry_points
 from pathlib import Path
 from typing import Any, Optional
 
 import sqlalchemy.databases
 import sqlalchemy.dialects
+from importlib_metadata import entry_points
 from sqlalchemy.engine.default import DefaultDialect
 from sqlalchemy.engine.url import URL
 

--- a/superset/db_engine_specs/__init__.py
+++ b/superset/db_engine_specs/__init__.py
@@ -32,12 +32,12 @@ import logging
 import pkgutil
 from collections import defaultdict
 from importlib import import_module
+from importlib_metadata import entry_points
 from pathlib import Path
 from typing import Any, Optional
 
 import sqlalchemy.databases
 import sqlalchemy.dialects
-from pkg_resources import iter_entry_points
 from sqlalchemy.engine.default import DefaultDialect
 from sqlalchemy.engine.url import URL
 
@@ -74,7 +74,7 @@ def load_engine_specs() -> list[type[BaseEngineSpec]]:
             if is_engine_spec(getattr(module, attr))
         )
     # load additional engines from external modules
-    for ep in iter_entry_points("superset.db_engine_specs"):
+    for ep in entry_points(group="superset.db_engine_specs"):
         try:
             engine_spec = ep.load()
         except Exception:  # pylint: disable=broad-except
@@ -150,7 +150,7 @@ def get_available_engine_specs() -> dict[type[BaseEngineSpec], set[str]]:
                 drivers[attr].add(attribute.dialect.driver)
 
     # installed 3rd-party dialects
-    for ep in iter_entry_points("sqlalchemy.dialects"):
+    for ep in entry_points(group="sqlalchemy.dialects"):
         try:
             dialect = ep.load()
         except Exception as ex:  # pylint: disable=broad-except

--- a/tests/unit_tests/db_engine_specs/test_init.py
+++ b/tests/unit_tests/db_engine_specs/test_init.py
@@ -17,7 +17,6 @@
 
 
 import pytest
-from pkg_resources import EntryPoint
 from pytest_mock import MockFixture
 
 from superset.db_engine_specs import get_available_engine_specs


### PR DESCRIPTION
pkg_resources is in the process of being deprecated in favor of
importlib.metadata and importlib.resources

importlib.metadata has been available in the standard library since 3.8

And as of 3.10 the importlib.metadata API is no longer provisional

In order to support Python version older than 3.10, the
`importlib_metadata` backport is used instead of the actual
`importlib.metadata` API.