### PR TITLE
fix(native filter): undefined filter dependencies

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/useFilterDependencies.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/useFilterDependencies.ts
@@ -27,7 +27,9 @@ export const useFilterDependencies = (filter: Filter) => {
       return [];
     }
     return filterDependencyIds.reduce((acc: Filter[], filterDependencyId) => {
-      acc.push(state.nativeFilters.filters[filterDependencyId] as Filter);
+      if (state.nativeFilters.filters[filterDependencyId]) {
+        acc.push(state.nativeFilters.filters[filterDependencyId] as Filter);
+      }
       return acc;
     }, []);
   });


### PR DESCRIPTION
### SUMMARY
`useFilterDependencies` can include the `undefined` value when `filter.cascadeParentIds` value is corrupted because it always appends from `cascadeParentIds` set.

This commit adds the nullish check point for useFilterDependencies to avoid the unexpected error.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After:
No error thrown

Before:
<img width="468" alt="Screenshot 2023-06-26 at 3 13 00 PM" src="https://github.com/apache/superset/assets/1392866/3668ecd3-b640-4788-b435-9664cbf736d1">

<img width="434" alt="Screenshot 2023-06-26 at 3 18 50 PM" src="https://github.com/apache/superset/assets/1392866/33cd587d-f00a-4766-a05f-004e0bb9d894">

### TESTING INSTRUCTIONS
generate `cascadeParentIds` metadata with nonexistence filterId

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
