### PR TITLE
docker (feature and build) add dockerize image

### DIFF
--- a/.github/workflows/docker_build_push.sh
+++ b/.github/workflows/docker_build_push.sh
@@ -96,6 +96,17 @@ DOCKER_BUILDKIT=1 docker build --target dev \
   --label "build_actor=${GITHUB_ACTOR}" \
   .
 
+#
+# Build the dockerize image
+#
+DOCKER_BUILDKIT=1 docker build \
+  -t "${REPO_NAME}:dockerize" \
+  --label "sha=${SHA}" \
+  --label "built_at=$(date)" \
+  --label "build_actor=${GITHUB_ACTOR}" \
+  -f dockerize.Dockerfile \
+  .
+
 if [ -z "${DOCKERHUB_TOKEN}" ]; then
   # Skip if secrets aren't populated -- they're only visible for actions running in the repo (not on forks)
   echo "Skipping Docker push"

--- a/dockerize.Dockerfile
+++ b/dockerize.Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:latest
+
+ARG DOCKERIZE_VERSION=v0.6.1
+
+RUN apk update --no-cache \
+    && apk upgrade --no-cache \
+    && apk add --no-cache wget openssl \
+    && wget -O - wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz | tar xzf - -C /usr/local/bin \
+    && apk del wget
+
+USER 10001
+
+ENTRYPOINT ["dockerize"]
+CMD ["--help"]

--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -29,7 +29,7 @@ maintainers:
   - name: craig-rueda
     email: craig@craigrueda.com
     url: https://github.com/craig-rueda
-version: 0.10.2
+version: 0.10.3
 dependencies:
   - name: postgresql
     version: 12.1.6

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -183,8 +183,8 @@ image:
 imagePullSecrets: []
 
 initImage:
-  repository: jwilder/dockerize
-  tag: latest
+  repository: apache/superset
+  tag: dockerize
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
The Dockerezer image currently on the Helm Chart is too old and has critical vulnerabilities, for example:

`
busybox, 1.26.2-r5, CVE-2017-16544 (https://nvd.nist.gov/vuln/detail/CVE-2017-16544)
`

This pr is designed to solve this problem

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
