### PR TITLE
fix(sqllab): Add threshold for checking inactive queries

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -201,8 +201,8 @@ export function estimateQueryCost(queryEditor) {
   };
 }
 
-export function clearInactiveQueries() {
-  return { type: CLEAR_INACTIVE_QUERIES };
+export function clearInactiveQueries(interval) {
+  return { type: CLEAR_INACTIVE_QUERIES, interval };
 }
 
 export function startQuery(query) {

--- a/superset-frontend/src/SqlLab/components/QueryAutoRefresh/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryAutoRefresh/index.tsx
@@ -92,7 +92,7 @@ function QueryAutoRefresh({
                 }, {}) ?? {};
               dispatch(refreshQueries(queries));
             } else {
-              dispatch(clearInactiveQueries());
+              dispatch(clearInactiveQueries(QUERY_UPDATE_FREQ));
             }
           }
         })
@@ -102,7 +102,7 @@ function QueryAutoRefresh({
         });
     }
     if (!cleanInactiveRequestRef.current && !shouldRequestChecking) {
-      dispatch(clearInactiveQueries());
+      dispatch(clearInactiveQueries(QUERY_UPDATE_FREQ));
       cleanInactiveRequestRef.current = true;
     }
   };

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -646,6 +646,7 @@ export default function sqlLabReducer(state = {}, action) {
         Object.entries(queries).filter(([, query]) => {
           if (
             ['running', 'pending'].includes(query.state) &&
+            Date.now() - query.startDttm > action.interval &&
             query.progress === 0
           ) {
             return false;


### PR DESCRIPTION
### SUMMARY
There's a issue that triggered preview query has gone occasionally. It is because the CLEAR_INACTIVE_QUERIES trigger in a 2s batch time but some queries can be added at the time to verify the inactive queries.
This commit adds the threshold to check the inactive queries to fix the problem.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

After:

https://github.com/apache/superset/assets/1392866/9c551de3-f318-486d-9705-4fadc708d2d7

Before:

https://github.com/apache/superset/assets/1392866/b3e90125-b64e-42c8-a751-51c67c0651a7


### TESTING INSTRUCTIONS
Try to choose tables to make a preview query and open new tab for additional request for preview queries

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
