### PR TITLE
fix: Use Celery task ETA for alert/report schedule

### DIFF
--- a/superset/tasks/scheduler.py
+++ b/superset/tasks/scheduler.py
@@ -18,7 +18,6 @@ import logging
 
 from celery import Celery
 from celery.exceptions import SoftTimeLimitExceeded
-from dateutil import parser
 
 from superset import app, is_feature_enabled
 from superset.commands.exceptions import CommandException

--- a/tests/integration_tests/reports/scheduler_tests.py
+++ b/tests/integration_tests/reports/scheduler_tests.py
@@ -171,7 +171,7 @@ def test_execute_task(update_state_mock, command_mock, init_mock, owners):
         init_mock.return_value = None
         command_mock.side_effect = ReportScheduleUnexpectedError("Unexpected error")
         with freeze_time("2020-01-01T09:00:00Z"):
-            execute(report_schedule.id, "2020-01-01T09:00:00Z")
+            execute(report_schedule.id)
             update_state_mock.assert_called_with(state="FAILURE")
 
         db.session.delete(report_schedule)
@@ -199,7 +199,7 @@ def test_execute_task_with_command_exception(
         init_mock.return_value = None
         command_mock.side_effect = CommandException("Unexpected error")
         with freeze_time("2020-01-01T09:00:00Z"):
-            execute(report_schedule.id, "2020-01-01T09:00:00Z")
+            execute(report_schedule.id)
             update_state_mock.assert_called_with(state="FAILURE")
             logger_mock.exception.assert_called_with(
                 "A downstream exception occurred while generating a report: None. Unexpected error",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

After installing Superset with Celery to 5.3.0 (within the defined constraints) we started to notice an issue with Superset trying to parse a date/time string which was already of type `datetime`. 

```
...
  File "superset/tasks/scheduler.py", line 81, in execute
    scheduled_dttm_ = parser.parse(scheduled_dttm)
  File "/usr/local/lib/python3.9/dist-packages/dateutil/parser/_parser.py", line 1368, in parse
    return DEFAULTPARSER.parse(timestr, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/dateutil/parser/_parser.py", line 640, in parse
    res, skipped_tokens = self._parse(timestr, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/dateutil/parser/_parser.py", line 719, in _parse
    l = _timelex.split(timestr)         # Splits the timestr into tokens
  File "/usr/local/lib/python3.9/dist-packages/dateutil/parser/_parser.py", line 201, in split
    return list(cls(s))
  File "/usr/local/lib/python3.9/dist-packages/dateutil/parser/_parser.py", line 69, in __init__
    raise TypeError('Parser must be a string or character stream, not '
TypeError: Parser must be a string or character stream, not datetime
```

I've spent a good amount of time perusing the Celery changelog and couldn't find anything which would have caused the regression, given that it seems we're using JSON for serialization/deserialization and there was no mention of the decoder trying to decode temporal arguments.

I did notice that there was some "magical" handling for the request ETA which, per [here](https://github.com/celery/celery/blob/51b28461d0d8b2fdf7db8a7cd2368ba11222bb6d/celery/worker/request.py#L135), tries to coerce the JSON encoded date/time into a `datetime` object. Digging a little future there seems to be some redundancy in how we define our tasks, i.e., providing both an ETA and a schedule which equate to the same thing.

This PR circumvents the problem by simply removing specifying the schedule in addition to the ETA which removes redundancy the need to decode the schedule. Note an alternative would be to tighten the constraint on the upper bound of feasible Celery versions, but this approach seemed more accomodating.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
