### PR TITLE
chore: Constrain selenium version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ setup(
         "pyyaml>=5.4",
         "PyJWT>=2.4.0, <3.0",
         "redis>=4.5.4, <5.0",
-        "selenium>=3.141.0",
+        "selenium>=3.141.0, <4.10.0",
         "shortid",
         "sshtunnel>=0.4.0, <0.5",
         "simplejson>=3.15.0",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Per the [Selenium changelog](https://github.com/SeleniumHQ/selenium/blob/trunk/py/CHANGES#L8), https://github.com/SeleniumHQ/selenium/pull/12030 was included in 4.10.0 which removed deprecated code including the `firefox_profile` option we currently use. 

This PR places an upper bound on the `selenium` version to prevent errors of the form,

```
...
  File "superset/utils/webdriver.py", line 147, in create
    return driver_class(**kwargs)
TypeError: __init__() got an unexpected keyword argument 'firefox_profile'
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI and verified that the error was absent in 4.9.0 and present in 4.10.0. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
