### PR TITLE
fix(native-filters): Infinite load when filter with default first value is out of scope in horizontal bar

### DIFF
--- a/superset-frontend/src/components/DropdownContainer/index.tsx
+++ b/superset-frontend/src/components/DropdownContainer/index.tsx
@@ -104,6 +104,10 @@ export interface DropdownContainerProps {
    * Main container additional style properties.
    */
   style?: CSSProperties;
+  /**
+   * Force render popover content before it's first opened
+   */
+  forceRender?: boolean;
 }
 
 export type Ref = HTMLDivElement & { open: () => void };
@@ -120,6 +124,7 @@ const DropdownContainer = forwardRef(
       dropdownTriggerIcon,
       dropdownTriggerText = t('More'),
       dropdownTriggerTooltip = null,
+      forceRender,
       style,
     }: DropdownContainerProps,
     outerRef: RefObject<Ref>,
@@ -364,7 +369,7 @@ const DropdownContainer = forwardRef(
               visible={popoverVisible}
               onVisibleChange={visible => setPopoverVisible(visible)}
               placement="bottom"
-              destroyTooltipOnHide
+              forceRender={forceRender}
             >
               <Tooltip title={dropdownTriggerTooltip}>
                 <Button

--- a/superset-frontend/src/components/Popover/Popover.test.tsx
+++ b/superset-frontend/src/components/Popover/Popover.test.tsx
@@ -47,6 +47,11 @@ test('it should not render a title or content when not visible', () => {
   expect(title).not.toBeInTheDocument();
 });
 
+test('it should render content when not visible but forceRender=true', () => {
+  render(<Popover content="Content sample" forceRender />);
+  expect(screen.getByText('Content sample')).toBeInTheDocument();
+});
+
 test('renders with icon child', async () => {
   render(
     <Popover content="Content sample" title="Popover title">

--- a/superset-frontend/src/components/Popover/Popover.tsx
+++ b/superset-frontend/src/components/Popover/Popover.tsx
@@ -16,9 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-export type { PopoverProps } from 'antd/lib/popover';
-export type { TooltipPlacement } from 'antd/lib/tooltip';
 
-// Eventually Popover can be wrapped and customized in this file
-// for now we're just redirecting
-export { Popover as default } from './Popover';
+import React from 'react';
+import { Popover as AntdPopover } from 'antd';
+import type { PopoverProps as AntdPopoverProps } from 'antd/lib/popover';
+
+export interface PopoverProps extends AntdPopoverProps {
+  forceRender?: boolean;
+}
+
+export const Popover = (props: PopoverProps) => <AntdPopover {...props} />;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
@@ -277,6 +277,7 @@ const FilterControls: FC<FilterControlsProps> = ({
               )
             : undefined
         }
+        forceRender={hasRequiredFirst}
         ref={popoverRef}
         onOverflowingStateChange={({ overflowed: nextOverflowedIds }) => {
           if (


### PR DESCRIPTION
### SUMMARY
When user added a native filter with "Select first filter value by default" checked and set a scope to a PR that's initially out of scope, the dashboard won't load if the native filters bar is in horizontal mode.
This PR fixes it by setting `forceRender` on the dropdown content in horizontal bar if there is a filter with the option selected.

A similar error has been fixed in PR https://github.com/apache/superset/pull/23299 - however, it turned out that the fix worked only for filter bar in vertical mode.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://github.com/apache/superset/assets/15073128/24ac7bdf-561d-47d0-be13-75d8eb89e467


After:

https://github.com/apache/superset/assets/15073128/53d3b6b9-e00d-45f8-a05c-bcd4d50e4244



### TESTING INSTRUCTIONS
1. Create a dashboard and add two tabs to it
2. Add one chart to each tab, and a third chart under the Tabs element.
3. Create two dashboard filters with with "Select first filter value by default" option checked: one mapped to Tab 1 and the chart outside tabs and the other only mapped to Tab 2.
4. Save filter changes.
5. Change the filter bar orientation to Horizontal.
6. Navigate back to Dashboards and access it from the list.


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
