### PR TITLE
fix: Release scripts Python version

### DIFF
--- a/RELEASING/Dockerfile.from_local_tarball
+++ b/RELEASING/Dockerfile.from_local_tarball
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM python:3.8-buster
+FROM python:3.9-buster
 
 RUN useradd --user-group --create-home --no-log-init --shell /bin/bash superset
 

--- a/RELEASING/Dockerfile.from_svn_tarball
+++ b/RELEASING/Dockerfile.from_svn_tarball
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM python:3.8-buster
+FROM python:3.9-buster
 
 RUN useradd --user-group --create-home --no-log-init --shell /bin/bash superset
 

--- a/RELEASING/Dockerfile.make_docs
+++ b/RELEASING/Dockerfile.make_docs
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM python:3.8-buster
+FROM python:3.9-buster
 ARG VERSION
 
 RUN git clone --depth 1 --branch ${VERSION} https://github.com/apache/superset.git /superset

--- a/RELEASING/Dockerfile.make_tarball
+++ b/RELEASING/Dockerfile.make_tarball
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM python:3.8-buster
+FROM python:3.9-buster
 
 RUN apt-get update -y
 RUN apt-get install -y jq

--- a/RELEASING/README.md
+++ b/RELEASING/README.md
@@ -74,7 +74,7 @@ the repo directly from the main `apache/superset` repo to a new directory `super
 
 ```bash
 cd <MY PROJECTS PATH>
-git clone git@github.com:apache/superset.git superset-release
+git clone https://github.com/apache/superset.git superset-release
 cd superset-release
 ```
 
@@ -102,7 +102,7 @@ the same terminal session won't be used for crafting the release candidate and t
 final release. Therefore, it's a good idea to do the following every time you
 work on a new phase of the release process to make sure you aren't releasing
 the wrong files/using wrong names. There's a script to help you set correctly all the
-necessary environment variables. Change your current directory to `superset/RELEASING`
+necessary environment variables. Change your current directory to `RELEASING`
 and execute the `set_release_env.sh` script with the relevant parameters:
 
 Usage (MacOS/ZSH):

--- a/RELEASING/from_tarball_entrypoint.sh
+++ b/RELEASING/from_tarball_entrypoint.sh
@@ -19,7 +19,10 @@ set -ex
 
 echo "[WARNING] this entrypoint creates an admin/admin user"
 echo "[WARNING] it should only be used for lightweight testing/validation"
-if $SUPERSET_TESTENV then echo "SUPERSET IS RUNNING IN TEST MODE"
+
+if [ -z "${SUPERSET_TESTENV}" ]; then
+  echo "SUPERSET IS RUNNING IN TEST MODE"
+fi
 
 # Create an admin user (you will be prompted to set username, first and last name before setting a password)
 superset fab create-admin \


### PR DESCRIPTION
### SUMMARY
https://github.com/apache/superset/pull/23890 bumped the Python version to 3.9 but forgot to update the release scripts. This PR updates the scripts to use the same version and also fixes a problem in the docs.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
