### PR TITLE
fix: Revert enable strong session protection by default (#24256)

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -26,7 +26,6 @@ assists people when migrating to a new version.
 
 - [24335](https://github.com/apache/superset/pull/24335): Removed deprecated API `/superset/filter/<datasource_type>/<int:datasource_id>/<column>/`
 - [24185](https://github.com/apache/superset/pull/24185): `/api/v1/database/test_connection` and `api/v1/database/validate_parameters` permissions changed from `can_read` to `can_write`. Only Admin user's have access.
-- [24256](https://github.com/apache/superset/pull/24256): `Flask-Login` session validation is now set to `strong` by default. Previous setting was `basic`.
 - [24232](https://github.com/apache/superset/pull/24232): Enables ENABLE_TEMPLATE_REMOVE_FILTERS, DRILL_TO_DETAIL, DASHBOARD_CROSS_FILTERS by default, marks VERSIONED_EXPORT and ENABLE_TEMPLATE_REMOVE_FILTERS as deprecated.
 - [23652](https://github.com/apache/superset/pull/23652): Enables GENERIC_CHART_AXES feature flag by default.
 - [23226](https://github.com/apache/superset/pull/23226): Migrated endpoint `/estimate_query_cost/<int:database_id>` to `/api/v1/sqllab/estimate/`. Corresponding permissions are can estimate query cost on SQLLab. Make sure you add/replace the necessary permissions on any custom roles you may have.

--- a/docs/docs/security.mdx
+++ b/docs/docs/security.mdx
@@ -157,11 +157,6 @@ HTTPS if the cookie is marked “secure”. The application must be served over 
 
 `PERMANENT_SESSION_LIFETIME`: (default: "31 days") The lifetime of a permanent session as a `datetime.timedelta` object.
 
-- Relevant Flask-Login settings:
-
-`SESSION_PROTECTION`: The method used to protect the session from being stolen. [Documentation](https://flask-login.readthedocs.io/en/latest/#session-protection)
-Default: "strong"
-
 ### Content Security Policy (CSP)
 
 Superset uses the [Talisman](https://pypi.org/project/flask-talisman/) extension to enable implementation of a
@@ -182,29 +177,29 @@ It's extremely important to correctly configure a Content Security Policy when d
 prevent many types of attacks. Superset provides two variables in `config.py` for deploying a CSP:
 
 - `TALISMAN_ENABLED` defaults to `False`; set this to `True` in order to implement a CSP
-- `TALISMAN_CONFIG` holds the actual the policy definition (*see example below*) as well as any
-other arguments to be passed to Talisman.
+- `TALISMAN_CONFIG` holds the actual the policy definition (_see example below_) as well as any
+  other arguments to be passed to Talisman.
 
 When running in production mode, Superset will check at startup for the presence
-of a CSP.  If one is not found, it will issue a warning with the security risks. For environments
+of a CSP. If one is not found, it will issue a warning with the security risks. For environments
 where CSP policies are defined outside of Superset using other software, administrators can disable
 this warning using the `CONTENT_SECURITY_POLICY_WARNING` key in `config.py`.
 
 #### CSP Requirements
 
-* Superset needs both the `'unsafe-eval'` and `'unsafe-inline'` CSP keywords in order to operate.
+- Superset needs both the `'unsafe-eval'` and `'unsafe-inline'` CSP keywords in order to operate.
 
   ```
   default-src 'self' 'unsafe-eval' 'unsafe-inline'
   ```
 
-* Some dashboards load images using data URIs and require `data:` in their `img-src`
+- Some dashboards load images using data URIs and require `data:` in their `img-src`
 
   ```
   img-src 'self' data:
   ```
 
-* MapBox charts use workers and need to connect to MapBox servers in addition to the Superset origin
+- MapBox charts use workers and need to connect to MapBox servers in addition to the Superset origin
 
   ```
   worker-src 'self' blob:
@@ -231,12 +226,12 @@ TALISMAN_CONFIG = {
 
 Setting `TALISMAN_ENABLED = True` will invoke Talisman's protection with its default arguments,
 of which `content_security_policy` is only one. Those can be found in the
-[Talisman documentation](https://pypi.org/project/flask-talisman/) under *Options*.
+[Talisman documentation](https://pypi.org/project/flask-talisman/) under _Options_.
 These generally improve security, but administrators should be aware of their existence.
 
 In particular, the default option of `force_https = True` may break Superset's Alerts & Reports
 if workers are configured to access charts via a `WEBDRIVER_BASEURL` beginning
-with `http://`.  As long as a Superset deployment enforces https upstream, e.g.,
+with `http://`. As long as a Superset deployment enforces https upstream, e.g.,
 through a loader balancer or application gateway, it should be acceptable to set this
 option to `False`, like this:
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -1380,8 +1380,6 @@ TALISMAN_CONFIG = {
 SESSION_COOKIE_HTTPONLY = True  # Prevent cookie from being read by frontend JS?
 SESSION_COOKIE_SECURE = False  # Prevent cookie from being transmitted over non-tls?
 SESSION_COOKIE_SAMESITE: Literal["None", "Lax", "Strict"] | None = "Lax"
-# Accepts None, "basic" and "strong", more details on: https://flask-login.readthedocs.io/en/latest/#session-protection
-SESSION_PROTECTION = "strong"
 
 # Cache static resources.
 SEND_FILE_MAX_AGE_DEFAULT = int(timedelta(days=365).total_seconds())


### PR DESCRIPTION
### SUMMARY
This PR reverts https://github.com/apache/superset/pull/24256 due to problems with the login and Alerts & Reports found during 2.1.1 tests. It's not a complete revert because I preserved most of the documentation added to `security.mdx` and only reverted the part about `SESSION_PROTECTION`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
