### PR TITLE
fix: Error when searching for a dashboard in the chart list

### DIFF
--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -270,8 +270,8 @@ function ChartList(props: ChartListProps) {
       ? {
           filters: [
             {
-              col: 'dashboards',
-              opr: FilterOperator.relationManyMany,
+              col: 'dashboard_title',
+              opr: FilterOperator.startsWith,
               value: filterValue,
             },
           ],
@@ -287,9 +287,7 @@ function ChartList(props: ChartListProps) {
       ...filters,
     });
     const response: void | JsonResponse = await SupersetClient.get({
-      endpoint: !filterValue
-        ? `/api/v1/dashboard/?q=${queryParams}`
-        : `/api/v1/chart/?q=${queryParams}`,
+      endpoint: `/api/v1/dashboard/?q=${queryParams}`,
     }).catch(() =>
       addDangerToast(t('An error occurred while fetching dashboards')),
     );


### PR DESCRIPTION
### SUMMARY
https://github.com/apache/superset/pull/21760 added the cross-referenced dashboards feature which is really valuable to our users. As part of the changes, the function to fetch the dashboards was operating differently depending on the existence of a search text. When a search was present, it was invoking `/api/v1/chart` which brings only the dashboards associated to the charts and when no search was present it was invoking `/api/v1/dashboard` which ignores the charts relationship. 

This was causing some problems:
- There was an error when invoking `/api/v1/chart` related to the constructed query.
- There was a performance implication in scenarios where the number of charts is really high because the application needs to join the charts and dashboards tables to resolve the associations.
- The behavior was different than the Datasets filter which ignores the charts relationships.

This PR changes the logic to always query the `/api/v1/dashboard` endpoint and ignore the relationships with charts.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://github.com/apache/superset/assets/70410625/0bfb6af8-2fd4-4e9d-ad33-6f592b9a1997

https://github.com/apache/superset/assets/70410625/61e4c941-d08f-4009-bf30-2b09ff3a576d

### TESTING INSTRUCTIONS
Check the videos for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
