### PR TITLE
feat: screenshot reports with custom width

### DIFF
--- a/superset/migrations/versions/2023-06-29_18-38_240d23c7f86f_update_tag_model_w_description.py
+++ b/superset/migrations/versions/2023-06-29_18-38_240d23c7f86f_update_tag_model_w_description.py
@@ -17,14 +17,14 @@
 """update_tag_model_w_description
 
 Revision ID: 240d23c7f86f
-Revises: 6fbe660cac39
+Revises: 8e5b0fb85b9a
 Create Date: 2023-06-29 18:38:30.033529
 
 """
 
 # revision identifiers, used by Alembic.
 revision = "240d23c7f86f"
-down_revision = "6fbe660cac39"
+down_revision = "8e5b0fb85b9a"
 
 import sqlalchemy as sa
 from alembic import op

--- a/superset/reports/commands/execute.py
+++ b/superset/reports/commands/execute.py
@@ -206,18 +206,29 @@ class BaseReportState:
             model=self._report_schedule,
         )
         user = security_manager.find_user(username)
+
         if self._report_schedule.chart:
+            window_width, window_height = app.config["WEBDRIVER_WINDOW"]["slice"]
+            window_size = (
+                self._report_schedule.custom_width or window_width,
+                self._report_schedule.custom_height or window_height,
+            )
             screenshot: Union[ChartScreenshot, DashboardScreenshot] = ChartScreenshot(
                 url,
                 self._report_schedule.chart.digest,
-                window_size=app.config["WEBDRIVER_WINDOW"]["slice"],
+                window_size=window_size,
                 thumb_size=app.config["WEBDRIVER_WINDOW"]["slice"],
             )
         else:
+            window_width, window_height = app.config["WEBDRIVER_WINDOW"]["dashboard"]
+            window_size = (
+                self._report_schedule.custom_width or window_width,
+                self._report_schedule.custom_height or window_height,
+            )
             screenshot = DashboardScreenshot(
                 url,
                 self._report_schedule.dashboard.digest,
-                window_size=app.config["WEBDRIVER_WINDOW"]["dashboard"],
+                window_size=window_size,
                 thumb_size=app.config["WEBDRIVER_WINDOW"]["dashboard"],
             )
         try:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Follow up to https://github.com/apache/superset/pull/24547, use the stored `custom_width` and `custom_heigth` when generating report screenshots.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
