### PR TITLE
fix: Deque mutated during iteration

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -850,23 +850,23 @@ def pessimistic_connection_handling(some_engine: Engine) -> None:
             # restore 'close with result'
             connection.should_close_with_result = save_should_close_with_result
 
-        if some_engine.dialect.name == "sqlite":
+    if some_engine.dialect.name == "sqlite":
 
-            @event.listens_for(some_engine, "connect")
-            def set_sqlite_pragma(  # pylint: disable=unused-argument
-                connection: sqlite3.Connection,
-                *args: Any,
-            ) -> None:
-                r"""
-                Enable foreign key support for SQLite.
+        @event.listens_for(some_engine, "connect")
+        def set_sqlite_pragma(  # pylint: disable=unused-argument
+            connection: sqlite3.Connection,
+            *args: Any,
+        ) -> None:
+            r"""
+            Enable foreign key support for SQLite.
 
-                :param connection: The SQLite connection
-                :param \*args: Additional positional arguments
-                :see: https://docs.sqlalchemy.org/en/latest/dialects/sqlite.html
-                """
+            :param connection: The SQLite connection
+            :param \*args: Additional positional arguments
+            :see: https://docs.sqlalchemy.org/en/latest/dialects/sqlite.html
+            """
 
-                with closing(connection.cursor()) as cursor:
-                    cursor.execute("PRAGMA foreign_keys=ON")
+            with closing(connection.cursor()) as cursor:
+                cursor.execute("PRAGMA foreign_keys=ON")
 
 
 def send_email_smtp(  # pylint: disable=invalid-name,too-many-arguments,too-many-locals

--- a/tests/unit_tests/databases/ssh_tunnel/dao_tests.py
+++ b/tests/unit_tests/databases/ssh_tunnel/dao_tests.py
@@ -35,7 +35,7 @@ def test_create_ssh_tunnel():
         "password": "bar",
     }
 
-    result = SSHTunnelDAO.create(properties)
+    result = SSHTunnelDAO.create(properties, commit=False)
 
     assert result is not None
     assert isinstance(result, SSHTunnel)


### PR DESCRIPTION
### SUMMARY
Fix a bug introduced by https://github.com/apache/superset/pull/24488 that happens when running on SQL Lite. There was an event being registered inside another event and causing a `deque mutated during iteration error`. According to SQL Alchemy [docs](https://docs.sqlalchemy.org/en/20/core/event.html#sqlalchemy.event.listen):

> The [listen()](https://docs.sqlalchemy.org/en/20/core/event.html#sqlalchemy.event.listen) function cannot be called at the same time that the target event is being run. This has implications for thread safety, and also means an event cannot be added from inside the listener function for itself. The list of events to be run are present inside of a mutable collection that can’t be changed during iteration.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1785" alt="Screenshot 2023-06-29 at 09 35 53" src="https://github.com/apache/superset/assets/70410625/94a130fc-9ebd-4587-a34d-e54cd6b8202d">

### TESTING INSTRUCTIONS
- Check that the above error does not happen when accessing a dashboard on SQL Lite.
- Check that if a dataset is deleted, its associated columns and metrics are also deleted.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
