### PR TITLE
chore(sqllab): Log current local storage usage

### DIFF
--- a/superset-frontend/src/SqlLab/components/App/index.jsx
+++ b/superset-frontend/src/SqlLab/components/App/index.jsx
@@ -30,7 +30,10 @@ import {
 } from 'src/SqlLab/constants';
 import * as Actions from 'src/SqlLab/actions/sqlLab';
 import { logEvent } from 'src/logger/actions';
-import { LOG_ACTIONS_SQLLAB_WARN_LOCAL_STORAGE_USAGE } from 'src/logger/LogUtils';
+import {
+  LOG_ACTIONS_SQLLAB_WARN_LOCAL_STORAGE_USAGE,
+  LOG_ACTIONS_SQLLAB_MONITOR_LOCAL_STORAGE_USAGE,
+} from 'src/logger/LogUtils';
 import TabbedSqlEditors from '../TabbedSqlEditors';
 import QueryAutoRefresh from '../QueryAutoRefresh';
 
@@ -121,14 +124,27 @@ class App extends React.PureComponent {
   }
 
   componentDidUpdate() {
+    const { localStorageUsageInKilobytes, actions, queries } = this.props;
+    const queryCount = queries?.lenghth || 0;
     if (
-      this.props.localStorageUsageInKilobytes >=
+      localStorageUsageInKilobytes >=
       LOCALSTORAGE_WARNING_THRESHOLD * LOCALSTORAGE_MAX_USAGE_KB
     ) {
       this.showLocalStorageUsageWarning(
-        this.props.localStorageUsageInKilobytes,
-        this.props.queries?.lenghth || 0,
+        localStorageUsageInKilobytes,
+        queryCount,
       );
+    }
+    if (localStorageUsageInKilobytes > 0 && !this.hasLoggedLocalStorageUsage) {
+      const eventData = {
+        current_usage: localStorageUsageInKilobytes,
+        query_count: queryCount,
+      };
+      actions.logEvent(
+        LOG_ACTIONS_SQLLAB_MONITOR_LOCAL_STORAGE_USAGE,
+        eventData,
+      );
+      this.hasLoggedLocalStorageUsage = true;
     }
   }
 

--- a/superset-frontend/src/logger/LogUtils.ts
+++ b/superset-frontend/src/logger/LogUtils.ts
@@ -61,6 +61,8 @@ export const LOG_ACTIONS_FURTHER_DRILL_BY = 'further_drill_by';
 export const LOG_ACTIONS_DRILL_BY_EDIT_CHART = 'drill_by_edit_chart';
 export const LOG_ACTIONS_DRILL_BY_BREADCRUMB_CLICKED =
   'drill_by_breadcrumb_clicked';
+export const LOG_ACTIONS_SQLLAB_MONITOR_LOCAL_STORAGE_USAGE =
+  'sqllab_monitor_local_storage_usage';
 
 // Log event types --------------------------------------------------------------
 export const LOG_EVENT_TYPE_TIMING = new Set([


### PR DESCRIPTION
### SUMMARY
This commit adds a logging event for the current local storage size for monitoring purpose.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

After:
<img width="494" alt="Screenshot 2023-06-29 at 11 57 50 AM" src="https://github.com/apache/superset/assets/1392866/b5c474d9-e7ee-401a-b599-a44179179746">

Before: N/A

### TESTING INSTRUCTIONS
Go to SQLLab and check the network tab for the logging event

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
