### PR TITLE
fix: Metric is truncated in tooltip

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.tsx
@@ -31,6 +31,13 @@ const TooltipSectionWrapper = styled.div`
     &:not(:last-of-type) {
       margin-bottom: ${theme.gridUnit * 2}px;
     }
+    &:last-of-type {
+      display: -webkit-box;
+      -webkit-line-clamp: 40;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   `}
 `;
 

--- a/superset-frontend/src/components/Tooltip/index.tsx
+++ b/superset-frontend/src/components/Tooltip/index.tsx
@@ -45,6 +45,13 @@ export const Tooltip = (props: TooltipProps) => {
       />
       <AntdTooltip
         overlayStyle={{ fontSize: theme.typography.sizes.s, lineHeight: '1.6' }}
+        overlayInnerStyle={{
+          display: '-webkit-box',
+          overflow: 'hidden',
+          WebkitLineClamp: 40,
+          WebkitBoxOrient: 'vertical',
+          textOverflow: 'ellipsis',
+        }}
         color={`${theme.colors.grayscale.dark2}e6`}
         {...props}
       />

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetric.js
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetric.js
@@ -89,8 +89,7 @@ export default class AdhocMetric {
   }
 
   getDefaultLabel() {
-    const label = this.translateToSql({ useVerboseName: true });
-    return label.length < 43 ? label : `${label.substring(0, 40)}...`;
+    return this.translateToSql({ useVerboseName: true });
   }
 
   translateToSql(


### PR DESCRIPTION
### SUMMARY
Fixes a bug where the metric name is truncated when displayed in the tooltip. This creates a problem because the metric name might already be truncated in the control and the user wishes to see its full name. Now the tooltip will only truncate when it surpasses the max number of lines defined by the `Tooltip` component.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="301" alt="Screenshot 2023-06-29 at 14 29 27" src="https://github.com/apache/superset/assets/70410625/6924e5b4-4bca-4bab-97d0-c48666072696">
<img width="307" alt="Screenshot 2023-06-29 at 14 26 30" src="https://github.com/apache/superset/assets/70410625/5bd3c0bb-4c8e-4025-b78f-360012e46d05">

### TESTING INSTRUCTIONS
Make sure metric names are displayed without truncation in the tooltip if under the Tooltip max lines limit.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
