### PR TITLE
fix: set max version for pyocient

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -167,7 +167,7 @@ setup(
         "mysql": ["mysqlclient>=2.1.0, <3"],
         "ocient": [
             "sqlalchemy-ocient>=1.0.0",
-            "pyocient>=1.0.15",
+            "pyocient>=1.0.15, <3",
             "shapely",
             "geojson",
         ],

--- a/setup.py
+++ b/setup.py
@@ -167,7 +167,7 @@ setup(
         "mysql": ["mysqlclient>=2.1.0, <3"],
         "ocient": [
             "sqlalchemy-ocient>=1.0.0",
-            "pyocient>=1.0.15, <3",
+            "pyocient>=1.0.15, <2",
             "shapely",
             "geojson",
         ],


### PR DESCRIPTION
### SUMMARY
`pyocient` 2.x ad 3.x introduce a number of API changes that break Deck.gl chart integrations for point, linestring, and polygon data types. By setting a max range, we ensure Superset users do not pull in these breaking changes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
