### PR TITLE
chore(native filters): Expandable filter config modal

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/FilterCard.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/FilterCard.test.tsx
@@ -205,13 +205,6 @@ jest.mock('@superset-ui/core', () => ({
   }),
 }));
 
-jest.mock(
-  'src/components/Icons/Icon',
-  () =>
-    ({ fileName }: { fileName: string }) =>
-      <span role="img" aria-label={fileName.replace('_', '-')} />,
-);
-
 // extract text from embedded html tags
 // source: https://polvara.me/posts/five-things-you-didnt-know-about-testing-library
 const getTextInHTMLTags =

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTitleContainer.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTitleContainer.tsx
@@ -112,7 +112,13 @@ const FilterTitleContainer = forwardRef<HTMLDivElement, Props>(
           className={classNames.join(' ')}
         >
           <div css={{ display: 'flex', width: '100%' }}>
-            <div css={{ alignItems: 'center', display: 'flex' }}>
+            <div
+              css={{
+                alignItems: 'center',
+                display: 'flex',
+                wordBreak: 'break-all',
+              }}
+            >
               {isRemoved ? t('(Removed)') : getFilterTitle(id)}
             </div>
             {!removedFilters[id] && isErrored && (

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
@@ -62,17 +62,29 @@ import {
 } from './utils';
 import DividerConfigForm from './DividerConfigForm';
 
+const MODAL_MARGIN = 16;
+
 const StyledModalWrapper = styled(StyledModal)<{ expanded: boolean }>`
-  min-width: 700px;
-  width: ${({ expanded }) => (expanded ? '100% !important' : '70%')};
+  min-width: 880px;
+  width: ${({ expanded }) => (expanded ? '100%' : '70%')} !important;
+
+  @media (max-width: ${880 + MODAL_MARGIN * 2}px) {
+    width: 100% !important;
+    min-width: auto;
+  }
 
   .ant-modal-body {
     padding: 0px;
   }
+
   ${({ expanded }) =>
     expanded &&
     css`
       height: 100%;
+
+      .ant-modal-body {
+        flex: 1 1 auto;
+      }
       .ant-modal-content {
         height: 100%;
       }
@@ -92,6 +104,10 @@ export const StyledModalBody = styled.div<{ expanded: boolean }>`
 
 export const StyledForm = styled(AntdForm)`
   width: 100%;
+`;
+
+export const StyledExpandButtonWrapper = styled.div`
+  margin-left: ${({ theme }) => theme.gridUnit * 4}px;
 `;
 
 export const FILTERS_CONFIG_MODAL_TEST_ID = 'filters-config-modal';
@@ -604,23 +620,7 @@ function FiltersConfigModal({
     <StyledModalWrapper
       visible={isOpen}
       maskClosable={false}
-      title={
-        <div
-          css={css`
-            display: flex;
-            justify-content: space-between;
-            align-items: flex-end;
-            margin-right: 50px;
-          `}
-        >
-          <div>{t('Add and edit filters')}</div>
-          <ToggleIcon
-            iconSize="l"
-            iconColor={theme.colors.grayscale.base}
-            onClick={toggleExpand}
-          />
-        </div>
-      }
+      title={t('Add and edit filters')}
       expanded={expanded}
       destroyOnClose
       onCancel={handleCancel}
@@ -628,14 +628,29 @@ function FiltersConfigModal({
       centered
       data-test="filter-modal"
       footer={
-        <Footer
-          onDismiss={() => setSaveAlertVisible(false)}
-          onCancel={handleCancel}
-          handleSave={handleSave}
-          canSave={!erroredFilters.length}
-          saveAlertVisible={saveAlertVisible}
-          onConfirmCancel={handleConfirmCancel}
-        />
+        <div
+          css={css`
+            display: flex;
+            justify-content: flex-end;
+            align-items: flex-end;
+          `}
+        >
+          <Footer
+            onDismiss={() => setSaveAlertVisible(false)}
+            onCancel={handleCancel}
+            handleSave={handleSave}
+            canSave={!erroredFilters.length}
+            saveAlertVisible={saveAlertVisible}
+            onConfirmCancel={handleConfirmCancel}
+          />
+          <StyledExpandButtonWrapper>
+            <ToggleIcon
+              iconSize="l"
+              iconColor={theme.colors.grayscale.dark2}
+              onClick={toggleExpand}
+            />
+          </StyledExpandButtonWrapper>
+        </div>
       }
     >
       <ErrorBoundary>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
@@ -618,7 +618,7 @@ function FiltersConfigModal({
           />
         </div>
       }
-      width="50%"
+      width="70%"
       {...(expanded && { width: '100%', height: '100%' })}
       expanded={expanded}
       destroyOnClose

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
@@ -64,12 +64,15 @@ import DividerConfigForm from './DividerConfigForm';
 
 const StyledModalWrapper = styled(StyledModal)<{ expanded: boolean }>`
   min-width: 700px;
+  width: ${({ expanded }) => (expanded ? '100% !important' : '70%')};
+
   .ant-modal-body {
     padding: 0px;
   }
   ${({ expanded }) =>
     expanded &&
     css`
+      height: 100%;
       .ant-modal-content {
         height: 100%;
       }
@@ -618,8 +621,6 @@ function FiltersConfigModal({
           />
         </div>
       }
-      width="70%"
-      {...(expanded && { width: '100%', height: '100%' })}
       expanded={expanded}
       destroyOnClose
       onCancel={handleCancel}


### PR DESCRIPTION
### SUMMARY
The native filters modal width is unnecessarily narrow which results in a suboptimal UX—excessive scrolling—especially when either the filter names and/or datasets/column names are long.
This commit adds an option to make the  'Add and edit filters' modal wider.

<img width="1036" alt="Sales_Dashboard" src="https://github.com/apache/superset/assets/1392866/20cd78e8-7bd5-4c11-bf19-42d01a0c5bcd">


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

After:

https://github.com/apache/superset/assets/1392866/6027a46b-aa5f-4f1d-8656-52d7c33c9928

Before:

https://github.com/apache/superset/assets/1392866/7d6311ac-2fa8-4b9b-8656-1e0dd9b67f43


### TESTING INSTRUCTIONS
Go to dashboard and choose a dataset contains a long name column name

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
