### PR TITLE
docs: add notice not to use gevent worker with bigquery datasource

### DIFF
--- a/docs/docs/databases/bigquery.mdx
+++ b/docs/docs/databases/bigquery.mdx
@@ -87,3 +87,6 @@ You should then be able to connect to your BigQuery datasets.
 
 To be able to upload CSV or Excel files to BigQuery in Superset, you'll need to also add the
 [pandas_gbq](https://github.com/pydata/pandas-gbq) library.
+
+Currently, Google BigQuery python sdk is not compatible with `gevent`, due to some dynamic monkeypatching on python core library by `gevent`.
+So, when you deploy superset with `gunicorn` server, you have to use worker type except `gevent`.

--- a/docs/docs/databases/bigquery.mdx
+++ b/docs/docs/databases/bigquery.mdx
@@ -89,4 +89,4 @@ To be able to upload CSV or Excel files to BigQuery in Superset, you'll need to 
 [pandas_gbq](https://github.com/pydata/pandas-gbq) library.
 
 Currently, Google BigQuery python sdk is not compatible with `gevent`, due to some dynamic monkeypatching on python core library by `gevent`.
-So, when you deploy superset with `gunicorn` server, you have to use worker type except `gevent`.
+So, when you deploy Superset with `gunicorn` server, you have to use worker type except `gevent`.

--- a/docs/docs/installation/configuring-superset.mdx
+++ b/docs/docs/installation/configuring-superset.mdx
@@ -147,7 +147,7 @@ If you're not using Gunicorn, you may want to disable the use of `flask-compress
 `COMPRESS_REGISTER = False` in your `superset_config.py`.
 
 Currently, Google BigQuery python sdk is not compatible with `gevent`, due to some dynamic monkeypatching on python core library by `gevent`.
-So, when you use `BigQuery` datasource on superset, you have to use `gunicorn` worker type except `gevent`.
+So, when you use `BigQuery` datasource on Superset, you have to use `gunicorn` worker type except `gevent`.
 
 ### Configuration Behind a Load Balancer
 

--- a/docs/docs/installation/configuring-superset.mdx
+++ b/docs/docs/installation/configuring-superset.mdx
@@ -146,6 +146,9 @@ for production use._
 If you're not using Gunicorn, you may want to disable the use of `flask-compress` by setting
 `COMPRESS_REGISTER = False` in your `superset_config.py`.
 
+Currently, Google BigQuery python sdk is not compatible with `gevent`, due to some dynamic monkeypatching on python core library by `gevent`.
+So, when you use `BigQuery` datasource on superset, you have to use `gunicorn` worker type except `gevent`.
+
 ### Configuration Behind a Load Balancer
 
 If you are running superset behind a load balancer or reverse proxy (e.g. NGINX or ELB on AWS), you


### PR DESCRIPTION
### SUMMARY

- Currently, Google BigQuery python sdk is not compatible with `gevent`, due to some dynamic monkeypatching on python core library by `gevent`.
  - https://github.com/googleapis/python-bigquery/issues/697
  - https://github.com/gevent/gevent/issues/1797
  - https://github.com/grpc/grpc/issues/4629
- Even though enabling `GLOBAL_ASYNC_QUERIES` feature flag, some superset UI&API remain to be called on webserver, instead of celery worker. (ex: `force_refresh` UI on `v2.1.0`)
- So, it helps superset users, to notice `gunicorn` with `gevent` worker type is not compatible with `bigquery` data source.
- Related community links
  - https://github.com/apache/superset/issues/23979
  - https://apache-superset.slack.com/archives/C015WAZL0KH/p1686908792979199

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
- just docs update

### TESTING INSTRUCTIONS
- just docs update

### ADDITIONAL INFORMATION
- [x] Has associated issue: https://github.com/apache/superset/issues/23979
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
