### PR TITLE
fix: remove underscore from builtin_time_grains label

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -106,7 +106,7 @@ builtin_time_grains: dict[str | None, str] = {
     TimeGrainConstants.WEEK_STARTING_SUNDAY: __("Week starting Sunday"),
     TimeGrainConstants.WEEK_STARTING_MONDAY: __("Week starting Monday"),
     TimeGrainConstants.WEEK_ENDING_SATURDAY: __("Week ending Saturday"),
-    TimeGrainConstants.WEEK_ENDING_SUNDAY: __("Week_ending Sunday"),
+    TimeGrainConstants.WEEK_ENDING_SUNDAY: __("Week ending Sunday"),
 }
 
 


### PR DESCRIPTION
### SUMMARY
- remove underscore from builtin_time_grains label 
- ![image](https://github.com/apache/superset/assets/6916639/03fb75d1-cdf0-42d5-b9b0-233686f7874d)


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
