### PR TITLE
refactor: pkg_resources -> importlib.resources

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -33,6 +33,7 @@ import sys
 from collections import OrderedDict
 from datetime import timedelta
 from email.mime.multipart import MIMEMultipart
+from importlib.resources import files
 from typing import Any, Callable, Literal, TYPE_CHECKING, TypedDict
 
 import pkg_resources
@@ -82,12 +83,9 @@ else:
 # ---------------------------------------------------------
 # Superset specific config
 # ---------------------------------------------------------
-VERSION_INFO_FILE = pkg_resources.resource_filename(
-    "superset", "static/version_info.json"
-)
-PACKAGE_JSON_FILE = pkg_resources.resource_filename(
-    "superset", "static/assets/package.json"
-)
+VERSION_INFO_FILE = str(files("superset") / "static/version_info.json")
+PACKAGE_JSON_FILE = str(files("superset") / "static/assets/package.json")
+
 
 # Multiple favicons can be specified here. The "href" property
 # is mandatory, but "sizes," "type," and "rel" are optional.

--- a/superset/examples/utils.py
+++ b/superset/examples/utils.py
@@ -16,11 +16,11 @@
 # under the License.
 import logging
 import re
+from importlib.resources import files
 from pathlib import Path
 from typing import Any
 
 import yaml
-from pkg_resources import resource_isdir, resource_listdir, resource_stream
 
 from superset.commands.exceptions import CommandInvalidError
 from superset.commands.importers.v1.examples import ImportExamplesCommand
@@ -44,28 +44,30 @@ def load_examples_from_configs(
 
 def load_contents(load_test_data: bool = False) -> dict[str, Any]:
     """Traverse configs directory and load contents"""
-    root = Path("examples/configs")
-    resource_names = resource_listdir("superset", str(root))
-    queue = [root / resource_name for resource_name in resource_names]
+    root = files("superset") / "examples/configs"
+    resource_names = (files("superset") / str(root)).iterdir()
+    queue = [root / str(resource_name) for resource_name in resource_names]
 
     contents: dict[Path, str] = {}
     while queue:
         path_name = queue.pop()
         test_re = re.compile(r"\.test\.|metadata\.yaml$")
 
-        if resource_isdir("superset", str(path_name)):
+        if (files("superset") / str(path_name)).is_dir():
             queue.extend(
-                path_name / child_name
-                for child_name in resource_listdir("superset", str(path_name))
+                path_name / str(child_name)
+                for child_name in (files("superset") / str(path_name)).iterdir()
             )
-        elif path_name.suffix.lower() in YAML_EXTENSIONS:
+        elif Path(str(path_name)).suffix.lower() in YAML_EXTENSIONS:
             if load_test_data and test_re.search(str(path_name)) is None:
                 continue
-            contents[path_name] = (
-                resource_stream("superset", str(path_name)).read().decode("utf-8")
-            )
+            contents[Path(str(path_name))] = (
+                files("superset") / str(path_name)
+            ).read_text("utf-8")
 
-    return {str(path.relative_to(root)): content for path, content in contents.items()}
+    return {
+        str(path.relative_to(str(root))): content for path, content in contents.items()
+    }
 
 
 def load_configs_from_directory(

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -20,6 +20,7 @@ import logging
 import os
 import traceback
 from datetime import datetime
+from importlib.resources import files
 from typing import Any, Callable, cast, Optional, Union
 
 import simplejson as json
@@ -45,7 +46,6 @@ from flask_babel import get_locale, gettext as __, lazy_gettext as _
 from flask_jwt_extended.exceptions import NoAuthorizationError
 from flask_wtf.csrf import CSRFError
 from flask_wtf.form import FlaskForm
-from pkg_resources import resource_filename
 from sqlalchemy import exc
 from sqlalchemy.orm import Query
 from werkzeug.exceptions import HTTPException
@@ -504,7 +504,7 @@ def show_http_exception(ex: HTTPException) -> FlaskResponse:
         and not config["DEBUG"]
         and ex.code in {404, 500}
     ):
-        path = resource_filename("superset", f"static/assets/{ex.code}.html")
+        path = files("superset") / f"static/assets/{ex.code}.html"
         return send_file(path, max_age=0), ex.code
 
     return json_errors_response(
@@ -526,7 +526,7 @@ def show_http_exception(ex: HTTPException) -> FlaskResponse:
 def show_command_errors(ex: CommandException) -> FlaskResponse:
     logger.warning("CommandException", exc_info=True)
     if "text/html" in request.accept_mimetypes and not config["DEBUG"]:
-        path = resource_filename("superset", "static/assets/500.html")
+        path = files("superset") / "static/assets/500.html"
         return send_file(path, max_age=0), 500
 
     extra = ex.normalized_messages() if isinstance(ex, CommandInvalidError) else {}
@@ -548,7 +548,7 @@ def show_command_errors(ex: CommandException) -> FlaskResponse:
 def show_unexpected_exception(ex: Exception) -> FlaskResponse:
     logger.exception(ex)
     if "text/html" in request.accept_mimetypes and not config["DEBUG"]:
-        path = resource_filename("superset", "static/assets/500.html")
+        path = files("superset") / "static/assets/500.html"
         return send_file(path, max_age=0), 500
 
     return json_errors_response(


### PR DESCRIPTION
(Part 1 of 2)

setuptools' pkg_resources is in the process of being deprecated in favor
of importlib.resources and importlib.metadata (see also PR #24514)

importlib.resources has been available in the standard library since
Python 3.7

This change follows the importlib_resources migration guide and does not
perform any additional refactoring.

The last component that is using pkg_resources is
'superset.config.BASE_DIR'

'superset.config.BASE_DIR' is mainly used as the default file upload
directory in Flask and therefore requires special attention as this
directory needs to be writable and needs to exist for the full lifetime
of the Flask application.
