### PR TITLE
feat(database): Database Filtering via custom configuration

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -1582,6 +1582,21 @@ class ExtraRelatedQueryFilters(TypedDict, total=False):
 
 EXTRA_RELATED_QUERY_FILTERS: ExtraRelatedQueryFilters = {}
 
+# Extra dynamic database filter make it possible to limit which databases are shown
+# in the UI before any other filtering is applied. Useful for example when
+# considering to filter using Feature Flags along with regular role filters
+# that get applied by default in our base_filters.
+# For example, to only show a database starting with the letter "b"
+# in the "Database Connections" list, you could add the following in your config:
+# def initial_database_filter(query: Query, *args, *kwargs):
+#     from superset.models.core import Database
+#
+#     filter = Database.database_name.startswith('b')
+#     return query.filter(filter)
+#
+#  EXTRA_DYNAMIC_DATABASE_FILTER = initial_database_filter
+EXTRA_DYNAMIC_DATABASE_FILTER: Callable[[Query], Query] | None = None
+
 
 # -------------------------------------------------------------------
 # *                WARNING:  STOP EDITING  HERE                    *

--- a/superset/config.py
+++ b/superset/config.py
@@ -1582,7 +1582,8 @@ class ExtraRelatedQueryFilters(TypedDict, total=False):
 
 EXTRA_RELATED_QUERY_FILTERS: ExtraRelatedQueryFilters = {}
 
-# Extra dynamic database filter make it possible to limit which databases are shown
+
+# Extra dynamic query filters make it possible to limit which objects are shown
 # in the UI before any other filtering is applied. Useful for example when
 # considering to filter using Feature Flags along with regular role filters
 # that get applied by default in our base_filters.
@@ -1594,8 +1595,12 @@ EXTRA_RELATED_QUERY_FILTERS: ExtraRelatedQueryFilters = {}
 #     filter = Database.database_name.startswith('b')
 #     return query.filter(filter)
 #
-#  EXTRA_DYNAMIC_DATABASE_FILTER = initial_database_filter
-EXTRA_DYNAMIC_DATABASE_FILTER: Callable[[Query], Query] | None = None
+#  EXTRA_DYNAMIC_QUERY_FILTERS = {"database": initial_database_filter}
+class ExtraDynamicQueryFilters(TypedDict, total=False):
+    databases: Callable[[Query], Query]
+
+
+EXTRA_DYNAMIC_QUERY_FILTERS: ExtraDynamicQueryFilters = {}
 
 
 # -------------------------------------------------------------------

--- a/superset/databases/filters.py
+++ b/superset/databases/filters.py
@@ -49,8 +49,9 @@ class DatabaseFilter(BaseFilter):  # pylint: disable=too-few-public-methods
         filtering.
         """
 
-        if dynamic_filter := current_app.config["EXTRA_DYNAMIC_DATABASE_FILTER"]:
-            query = dynamic_filter(query)
+        if dynamic_filters := current_app.config["EXTRA_DYNAMIC_QUERY_FILTERS"]:
+            if dynamic_databases_filter := dynamic_filters.get("databases"):
+                query = dynamic_databases_filter(query)
 
         # We can proceed with default filtering now
         if security_manager.can_access_all_databases():

--- a/superset/databases/filters.py
+++ b/superset/databases/filters.py
@@ -41,11 +41,13 @@ class DatabaseFilter(BaseFilter):  # pylint: disable=too-few-public-methods
     # TODO(bogdan): consider caching.
 
     def apply(self, query: Query, value: Any) -> Query:
-        # Dynamic Filters need to be applied to the Query before we filter
-        # databases with anything else. This way you can show/hide databases using
-        # Feature Flags for example in conjuction with the regular role filtering.
-        # If not, if an user has access to all Databases it would skip this dynamic
-        # filtering.
+        """
+        Dynamic Filters need to be applied to the Query before we filter
+        databases with anything else. This way you can show/hide databases using
+        Feature Flags for example in conjuction with the regular role filtering.
+        If not, if an user has access to all Databases it would skip this dynamic
+        filtering.
+        """
 
         if dynamic_filter := current_app.config["EXTRA_DYNAMIC_DATABASE_FILTER"]:
             query = dynamic_filter(query)

--- a/superset/databases/filters.py
+++ b/superset/databases/filters.py
@@ -16,7 +16,7 @@
 # under the License.
 from typing import Any
 
-from flask import g
+from flask import current_app, g
 from flask_babel import lazy_gettext as _
 from sqlalchemy import or_
 from sqlalchemy.orm import Query
@@ -41,6 +41,16 @@ class DatabaseFilter(BaseFilter):  # pylint: disable=too-few-public-methods
     # TODO(bogdan): consider caching.
 
     def apply(self, query: Query, value: Any) -> Query:
+        # Dynamic Filters need to be applied to the Query before we filter
+        # databases with anything else. This way you can show/hide databases using
+        # Feature Flags for example in conjuction with the regular role filtering.
+        # If not, if an user has access to all Databases it would skip this dynamic
+        # filtering.
+
+        if dynamic_filter := current_app.config["EXTRA_DYNAMIC_DATABASE_FILTER"]:
+            query = dynamic_filter(query)
+
+        # We can proceed with default filtering now
         if security_manager.can_access_all_databases():
             return query
         database_perms = security_manager.user_view_menu_names("database_access")

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -3637,7 +3637,11 @@ class TestDatabaseApi(SupersetTestCase):
 
     def test_get_databases_with_extra_filters(self):
         """
-        API: Test get database with extra query filter
+        API: Test get database with extra query filter.
+        Here we are testing our default where all databases
+        must be returned if nothing is being set in the config.
+        Then, we're adding the patch for the config to add the filter function
+        and testing it's being applied.
         """
         self.login(username="admin")
         extra = {
@@ -3650,6 +3654,7 @@ class TestDatabaseApi(SupersetTestCase):
 
         if example_db.backend == "sqlite":
             return
+        # Create our two databases
         database_data = {
             "sqlalchemy_uri": example_db.sqlalchemy_uri_decrypted,
             "configuration_method": ConfigurationMethod.SQLALCHEMY_FORM,
@@ -3671,6 +3676,7 @@ class TestDatabaseApi(SupersetTestCase):
         second_response = json.loads(rv.data.decode("utf-8"))
         self.assertEqual(rv.status_code, 201)
 
+        # The filter function
         def _base_filter(query):
             from superset.models.core import Database
 
@@ -3683,16 +3689,20 @@ class TestDatabaseApi(SupersetTestCase):
         expected_names.sort()
 
         uri = f"api/v1/database/"
+        # Get the list of databases without filter in the config
         rv = self.client.get(uri)
         data = json.loads(rv.data.decode("utf-8"))
+        # All databases must be returned if no filter is present
         self.assertEqual(data["count"], len(dbs))
         database_names = [item["database_name"] for item in data["result"]]
         database_names.sort()
         # All Databases because we are an admin
         self.assertEqual(database_names, expected_names)
         assert rv.status_code == 200
+        # Our filter function wasn't get called
         base_filter_mock.assert_not_called()
 
+        # Now we patch the config to include our filter function
         with patch.dict(
             "superset.views.filters.current_app.config",
             {"EXTRA_DYNAMIC_QUERY_FILTERS": {"databases": base_filter_mock}},
@@ -3700,11 +3710,13 @@ class TestDatabaseApi(SupersetTestCase):
             uri = f"api/v1/database/"
             rv = self.client.get(uri)
             data = json.loads(rv.data.decode("utf-8"))
+            # Only one database start with dyntest
             self.assertEqual(data["count"], 1)
             database_names = [item["database_name"] for item in data["result"]]
             # Only the database that starts with tests, even if we are an admin
             self.assertEqual(database_names, ["dyntest-create-database-1"])
             assert rv.status_code == 200
+            # The filter function is called now that it's defined in our config
             base_filter_mock.assert_called()
 
         # Cleanup

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -3632,3 +3632,77 @@ class TestDatabaseApi(SupersetTestCase):
             return
         self.assertEqual(rv.status_code, 422)
         self.assertIn("Kaboom!", response["errors"][0]["message"])
+
+    def test_get_databases_with_extra_filters(self):
+        """
+        API: Test get database with extra query filter
+        """
+        self.login(username="admin")
+        extra = {
+            "metadata_params": {},
+            "engine_params": {},
+            "metadata_cache_timeout": {},
+            "schemas_allowed_for_file_upload": [],
+        }
+        example_db = get_example_database()
+
+        if example_db.backend == "sqlite":
+            return
+        database_data = {
+            "sqlalchemy_uri": example_db.sqlalchemy_uri_decrypted,
+            "configuration_method": ConfigurationMethod.SQLALCHEMY_FORM,
+            "server_cert": None,
+            "extra": json.dumps(extra),
+        }
+
+        uri = "api/v1/database/"
+        rv = self.client.post(
+            uri, json={**database_data, "database_name": "dyntest-create-database-1"}
+        )
+        first_response = json.loads(rv.data.decode("utf-8"))
+        self.assertEqual(rv.status_code, 201)
+
+        uri = "api/v1/database/"
+        rv = self.client.post(
+            uri, json={**database_data, "database_name": "create-database-2"}
+        )
+        second_response = json.loads(rv.data.decode("utf-8"))
+        self.assertEqual(rv.status_code, 201)
+        dbs = db.session.query(Database).all()
+        expected_names = [db.database_name for db in dbs]
+        expected_names.sort()
+
+        uri = f"api/v1/database/"
+        rv = self.client.get(uri)
+        data = json.loads(rv.data.decode("utf-8"))
+        self.assertEqual(data["count"], len(dbs))
+        database_names = [item["database_name"] for item in data["result"]]
+        database_names.sort()
+        # All Databases because we are an admin
+        self.assertEqual(database_names, expected_names)
+        assert rv.status_code == 200
+
+        def _base_filter(query):
+            from superset.models.core import Database
+
+            return query.filter(Database.database_name.startswith("dyntest"))
+
+        with patch.dict(
+            "superset.views.filters.current_app.config",
+            {"EXTRA_DYNAMIC_DATABASE_FILTER": _base_filter},
+        ):
+            uri = f"api/v1/database/"
+            rv = self.client.get(uri)
+            data = json.loads(rv.data.decode("utf-8"))
+            self.assertEqual(data["count"], 1)
+            database_names = [item["database_name"] for item in data["result"]]
+            # Only the database that starts with tests, even if we are an admin
+            self.assertEqual(database_names, ["dyntest-create-database-1"])
+            assert rv.status_code == 200
+
+        # Cleanup
+        first_model = db.session.query(Database).get(first_response.get("id"))
+        second_model = db.session.query(Database).get(second_response.get("id"))
+        db.session.delete(first_model)
+        db.session.delete(second_model)
+        db.session.commit()

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -3695,7 +3695,7 @@ class TestDatabaseApi(SupersetTestCase):
 
         with patch.dict(
             "superset.views.filters.current_app.config",
-            {"EXTRA_DYNAMIC_DATABASE_FILTER": base_filter_mock},
+            {"EXTRA_DYNAMIC_QUERY_FILTERS": {"databases": base_filter_mock}},
         ):
             uri = f"api/v1/database/"
             rv = self.client.get(uri)

--- a/tests/unit_tests/databases/api_test.py
+++ b/tests/unit_tests/databases/api_test.py
@@ -579,7 +579,7 @@ def test_apply_dynamic_database_filter(
         assert base_filter_mock.call_count == 0
 
         original_config = current_app.config.copy()
-        original_config["EXTRA_DYNAMIC_DATABASE_FILTER"] = base_filter_mock
+        original_config["EXTRA_DYNAMIC_QUERY_FILTERS"] = {"databases": base_filter_mock}
 
         mocker.patch("superset.views.filters.current_app.config", new=original_config)
         # Get filtered list

--- a/tests/unit_tests/databases/api_test.py
+++ b/tests/unit_tests/databases/api_test.py
@@ -507,7 +507,10 @@ def test_apply_dynamic_database_filter(
     full_api_access: None,
 ) -> None:
     """
-    Test that we can filter the list of databases
+    Test that we can filter the list of databases.
+    First test the default behavior without a filter and then
+    defining a filter function and patching the config to get
+    the filtered results.
     """
     with app.app_context():
         from superset.daos.database import DatabaseDAO


### PR DESCRIPTION
### SUMMARY
There might be scenarios where you want to perform custom filtering on the list of databases returned by the DatabaseRestApi, right now, there's no way besides monkey patching that you can do so. This PR adds a new config definition in our app and makes use of it in the `DatabaseFilter` which is applied to all searches so you can add custom filtering if needed via config, adding live filtering capabilities to our searches and easing customization.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Add a filtering function in your config file so all GET or GET list requests can make use of it and return a filtered result

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [X] Introduces new feature or API
- [ ] Removes existing feature or API
