### PR TITLE
fix: Clicking on a tag in the dashboard and charts lists does not work

### DIFF
--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -156,7 +156,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         from superset.sqllab.api import SqlLabRestApi
         from superset.tags.api import TagRestApi
         from superset.views.alerts import AlertView, ReportView
-        from superset.views.all_entities import TaggedObjectView
+        from superset.views.all_entities import TaggedObjectsModelView, TaggedObjectView
         from superset.views.annotations import AnnotationLayerView
         from superset.views.api import Api
         from superset.views.chart.views import SliceAsync, SliceModelView
@@ -320,6 +320,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         appbuilder.add_view_no_menu(TableSchemaView)
         appbuilder.add_view_no_menu(TabStateView)
         appbuilder.add_view_no_menu(TaggedObjectView)
+        appbuilder.add_view_no_menu(TaggedObjectsModelView)
         appbuilder.add_view_no_menu(TagView)
         appbuilder.add_view_no_menu(ReportView)
 


### PR DESCRIPTION
### SUMMARY
Fixes a bug when clicking on a tag in the dashboard and charts that lead to 404 error. The reason was that the all entities route was not registered on the server side leading to the error.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: Clicking on a tag pill led to a 404

<img width="1719" alt="Screenshot 2023-07-05 at 10 33 08" src="https://github.com/apache/superset/assets/70410625/dde06f73-25e0-4600-9296-6bf20d5b0bbc">

After: Clicking on a tag correctly shows the page

<img width="1000" alt="Screenshot 2023-07-05 at 11 20 31" src="https://github.com/apache/superset/assets/70410625/cda7ef24-f397-4886-bb72-80e1c8b17ae3">

### TESTING INSTRUCTIONS
1 - Enable TAGGING_SYSTEM feature flag.
2 - Edit a chart and tag it
3 - From the chart list, click on the tag pill
4 - It should show the tag page

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
