### PR TITLE
feat: Implement support for currencies in more charts

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/currency-format/index.ts
+++ b/superset-frontend/packages/superset-ui-core/src/currency-format/index.ts
@@ -19,3 +19,4 @@
 
 export { default as CurrencyFormatter } from './CurrencyFormatter';
 export * from './CurrencyFormatter';
+export * from './utils';

--- a/superset-frontend/packages/superset-ui-core/src/currency-format/utils.ts
+++ b/superset-frontend/packages/superset-ui-core/src/currency-format/utils.ts
@@ -34,10 +34,8 @@ export const buildCustomFormatters = (
 ) => {
   const metricsArray = ensureIsArray(metrics);
   return metricsArray.reduce((acc, metric) => {
-    const actualD3Format = isSavedMetric(metric)
-      ? columnFormats[metric] ?? d3Format
-      : d3Format;
     if (isSavedMetric(metric)) {
+      const actualD3Format = columnFormats[metric] ?? d3Format;
       return currencyFormats[metric]
         ? {
             ...acc,

--- a/superset-frontend/packages/superset-ui-core/src/currency-format/utils.ts
+++ b/superset-frontend/packages/superset-ui-core/src/currency-format/utils.ts
@@ -35,7 +35,7 @@ export const buildCustomFormatters = (
   const metricsArray = ensureIsArray(metrics);
   return metricsArray.reduce((acc, metric) => {
     if (isSavedMetric(metric)) {
-      const actualD3Format = columnFormats[metric] ?? d3Format;
+      const actualD3Format = d3Format ?? columnFormats[metric];
       return currencyFormats[metric]
         ? {
             ...acc,

--- a/superset-frontend/packages/superset-ui-core/src/currency-format/utils.ts
+++ b/superset-frontend/packages/superset-ui-core/src/currency-format/utils.ts
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 import {
   Currency,
   CurrencyFormatter,

--- a/superset-frontend/packages/superset-ui-core/test/currency-format/utils.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/currency-format/utils.test.ts
@@ -72,7 +72,7 @@ it('buildCustomFormatters with saved metrics returns custom formatters object', 
       {
         sum__num: { symbol: 'USD', symbolPosition: 'prefix' },
       },
-      {},
+      { sum__num: ',.2' },
       ',.1f',
     );
 
@@ -83,6 +83,33 @@ it('buildCustomFormatters with saved metrics returns custom formatters object', 
 
   expect(customFormatters.sum__num).toBeInstanceOf(CurrencyFormatter);
   expect(customFormatters.count).toBeInstanceOf(NumberFormatter);
+  expect((customFormatters.sum__num as CurrencyFormatter).d3Format).toEqual(
+    ',.1f',
+  );
+});
+
+it('buildCustomFormatters uses dataset d3 format if not provided in control panel', () => {
+  const customFormatters: Record<string, ValueFormatter> =
+    buildCustomFormatters(
+      [
+        {
+          expressionType: 'SIMPLE',
+          aggregate: 'COUNT',
+          column: { column_name: 'test' },
+        },
+        'sum__num',
+        'count',
+      ],
+      {
+        sum__num: { symbol: 'USD', symbolPosition: 'prefix' },
+      },
+      { sum__num: ',.2' },
+      undefined,
+    );
+
+  expect((customFormatters.sum__num as CurrencyFormatter).d3Format).toEqual(
+    ',.2',
+  );
 });
 
 it('getCustomFormatter', () => {

--- a/superset-frontend/packages/superset-ui-core/test/currency-format/utils.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/currency-format/utils.test.ts
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  buildCustomFormatters,
+  CurrencyFormatter,
+  getCustomFormatter,
+  getNumberFormatter,
+  getValueFormatter,
+  NumberFormatter,
+  ValueFormatter,
+} from '@superset-ui/core';
+
+it('buildCustomFormatters without saved metrics returns empty object', () => {
+  expect(
+    buildCustomFormatters(
+      [
+        {
+          expressionType: 'SIMPLE',
+          aggregate: 'COUNT',
+          column: { column_name: 'test' },
+        },
+      ],
+      {
+        sum__num: { symbol: 'USD', symbolPosition: 'prefix' },
+      },
+      {},
+      ',.1f',
+    ),
+  ).toEqual({});
+
+  expect(
+    buildCustomFormatters(
+      undefined,
+      {
+        sum__num: { symbol: 'USD', symbolPosition: 'prefix' },
+      },
+      {},
+      ',.1f',
+    ),
+  ).toEqual({});
+});
+
+it('buildCustomFormatters with saved metrics returns custom formatters object', () => {
+  const customFormatters: Record<string, ValueFormatter> =
+    buildCustomFormatters(
+      [
+        {
+          expressionType: 'SIMPLE',
+          aggregate: 'COUNT',
+          column: { column_name: 'test' },
+        },
+        'sum__num',
+        'count',
+      ],
+      {
+        sum__num: { symbol: 'USD', symbolPosition: 'prefix' },
+      },
+      {},
+      ',.1f',
+    );
+
+  expect(customFormatters).toEqual({
+    sum__num: expect.any(Function),
+    count: expect.any(Function),
+  });
+
+  expect(customFormatters.sum__num).toBeInstanceOf(CurrencyFormatter);
+  expect(customFormatters.count).toBeInstanceOf(NumberFormatter);
+});
+
+it('getCustomFormatter', () => {
+  const customFormatters = {
+    sum__num: new CurrencyFormatter({
+      currency: { symbol: 'USD', symbolPosition: 'prefix' },
+    }),
+    count: getNumberFormatter(),
+  };
+  expect(getCustomFormatter(customFormatters, 'count')).toEqual(
+    customFormatters.count,
+  );
+  expect(
+    getCustomFormatter(customFormatters, ['count', 'sum__num'], 'count'),
+  ).toEqual(customFormatters.count);
+  expect(getCustomFormatter(customFormatters, ['count', 'sum__num'])).toEqual(
+    undefined,
+  );
+});
+
+it('getValueFormatter', () => {
+  expect(
+    getValueFormatter(['count', 'sum__num'], {}, {}, ',.1f'),
+  ).toBeInstanceOf(NumberFormatter);
+
+  expect(
+    getValueFormatter(['count', 'sum__num'], {}, {}, ',.1f', 'count'),
+  ).toBeInstanceOf(NumberFormatter);
+
+  expect(
+    getValueFormatter(
+      ['count', 'sum__num'],
+      { count: { symbol: 'USD', symbolPosition: 'prefix' } },
+      {},
+      ',.1f',
+      'count',
+    ),
+  ).toBeInstanceOf(CurrencyFormatter);
+});

--- a/superset-frontend/plugins/legacy-plugin-chart-heatmap/src/Heatmap.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-heatmap/src/Heatmap.js
@@ -51,7 +51,7 @@ const propTypes = {
   leftMargin: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   metric: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   normalized: PropTypes.bool,
-  numberFormat: PropTypes.string,
+  valueFormatter: PropTypes.object,
   showLegend: PropTypes.bool,
   showPercentage: PropTypes.bool,
   showValues: PropTypes.bool,
@@ -90,7 +90,7 @@ function Heatmap(element, props) {
     leftMargin,
     metric,
     normalized,
-    numberFormat,
+    valueFormatter,
     showLegend,
     showPercentage,
     showValues,
@@ -114,8 +114,6 @@ function Heatmap(element, props) {
   let showX = true;
   const pixelsPerCharX = 4.5; // approx, depends on font size
   let pixelsPerCharY = 6; // approx, depends on font size
-
-  const valueFormatter = getNumberFormatter(numberFormat);
 
   // Dynamically adjusts  based on max x / y category lengths
   function adjustMargins() {

--- a/superset-frontend/plugins/legacy-plugin-chart-heatmap/src/transformProps.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-heatmap/src/transformProps.js
@@ -1,3 +1,5 @@
+import { getValueFormatter } from '@superset-ui/core';
+
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -17,7 +19,7 @@
  * under the License.
  */
 export default function transformProps(chartProps) {
-  const { width, height, formData, queriesData } = chartProps;
+  const { width, height, formData, queriesData, datasource } = chartProps;
   const {
     bottomMargin,
     canvasImageRendering,
@@ -37,7 +39,13 @@ export default function transformProps(chartProps) {
     yAxisBounds,
     yAxisFormat,
   } = formData;
-
+  const { columnFormats = {}, currencyFormats = {} } = datasource;
+  const valueFormatter = getValueFormatter(
+    metric,
+    currencyFormats,
+    columnFormats,
+    yAxisFormat,
+  );
   return {
     width,
     height,
@@ -50,7 +58,6 @@ export default function transformProps(chartProps) {
     leftMargin,
     metric,
     normalized,
-    numberFormat: yAxisFormat,
     showLegend,
     showPercentage: showPerc,
     showValues,
@@ -59,5 +66,6 @@ export default function transformProps(chartProps) {
     xScaleInterval: parseInt(xscaleInterval, 10),
     yScaleInterval: parseInt(yscaleInterval, 10),
     yAxisBounds,
+    valueFormatter,
   };
 }

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
@@ -21,7 +21,6 @@ import d3 from 'd3';
 import PropTypes from 'prop-types';
 import { extent as d3Extent } from 'd3-array';
 import {
-  getNumberFormatter,
   getSequentialSchemeRegistry,
   CategoricalColorNamespace,
 } from '@superset-ui/core';
@@ -47,9 +46,8 @@ const propTypes = {
   setDataMask: PropTypes.func,
   onContextMenu: PropTypes.func,
   emitCrossFilters: PropTypes.bool,
+  formatter: PropTypes.object,
 };
-
-const formatter = getNumberFormatter();
 
 function WorldMap(element, props) {
   const {
@@ -71,6 +69,7 @@ function WorldMap(element, props) {
     inContextMenu,
     filterState,
     emitCrossFilters,
+    formatter,
   } = props;
   const div = d3.select(element);
   div.classed('superset-legacy-chart-world-map', true);

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/transformProps.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/transformProps.js
@@ -17,11 +17,7 @@
  * under the License.
  */
 import { rgb } from 'd3-color';
-import {
-  getValueFormatter,
-  NumberFormats,
-  NumberFormatter,
-} from '@superset-ui/core';
+import { getValueFormatter } from '@superset-ui/core';
 
 export default function transformProps(chartProps) {
   const {

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/transformProps.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/transformProps.js
@@ -17,6 +17,11 @@
  * under the License.
  */
 import { rgb } from 'd3-color';
+import {
+  getValueFormatter,
+  NumberFormats,
+  NumberFormatter,
+} from '@superset-ui/core';
 
 export default function transformProps(chartProps) {
   const {
@@ -28,6 +33,7 @@ export default function transformProps(chartProps) {
     inContextMenu,
     filterState,
     emitCrossFilters,
+    datasource,
   } = chartProps;
   const { onContextMenu, setDataMask } = hooks;
   const {
@@ -40,8 +46,17 @@ export default function transformProps(chartProps) {
     colorBy,
     colorScheme,
     sliceId,
+    metric,
   } = formData;
   const { r, g, b } = colorPicker;
+  const { currencyFormats = {}, columnFormats = {} } = datasource;
+
+  const formatter = getValueFormatter(
+    metric,
+    currencyFormats,
+    columnFormats,
+    undefined,
+  );
 
   return {
     countryFieldtype,
@@ -61,5 +76,6 @@ export default function transformProps(chartProps) {
     inContextMenu,
     filterState,
     emitCrossFilters,
+    formatter,
   };
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.ts
@@ -26,11 +26,11 @@ import {
   getMetricLabel,
   extractTimegrain,
   QueryFormData,
+  getValueFormatter,
 } from '@superset-ui/core';
 import { BigNumberTotalChartProps, BigNumberVizProps } from '../types';
 import { getDateFormatter, parseMetricValue } from '../utils';
 import { Refs } from '../../types';
-import { getValueFormatter } from '../../utils/valueFormatter';
 
 export default function transformProps(
   chartProps: BigNumberTotalChartProps,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.ts
@@ -28,6 +28,7 @@ import {
   getXAxisLabel,
   Metric,
   ValueFormatter,
+  getValueFormatter,
 } from '@superset-ui/core';
 import { EChartsCoreOption, graphic } from 'echarts';
 import {
@@ -39,7 +40,6 @@ import {
 import { getDateFormatter, parseMetricValue } from '../utils';
 import { getDefaultTooltip } from '../../utils/tooltip';
 import { Refs } from '../../types';
-import { getValueFormatter } from '../../utils/valueFormatter';
 
 const defaultNumberFormatter = getNumberFormatter();
 export function renderTooltipFactory(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/transformProps.ts
@@ -24,6 +24,7 @@ import {
   NumberFormats,
   ValueFormatter,
   getColumnLabel,
+  getValueFormatter,
 } from '@superset-ui/core';
 import { CallbackDataParams } from 'echarts/types/src/util/types';
 import { EChartsCoreOption, FunnelSeriesOption } from 'echarts';
@@ -45,7 +46,6 @@ import { defaultGrid } from '../defaults';
 import { OpacityEnum, DEFAULT_LEGEND_FORM_DATA } from '../constants';
 import { getDefaultTooltip } from '../utils/tooltip';
 import { Refs } from '../types';
-import { getValueFormatter } from '../utils/valueFormatter';
 
 const percentFormatter = getNumberFormatter(NumberFormats.PERCENT_2_POINT);
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Gauge/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Gauge/transformProps.ts
@@ -23,6 +23,7 @@ import {
   DataRecord,
   getMetricLabel,
   getColumnLabel,
+  getValueFormatter,
 } from '@superset-ui/core';
 import { EChartsCoreOption, GaugeSeriesOption } from 'echarts';
 import { GaugeDataItemOption } from 'echarts/types/src/chart/gauge/GaugeSeries';
@@ -46,7 +47,6 @@ import { OpacityEnum } from '../constants';
 import { getDefaultTooltip } from '../utils/tooltip';
 import { Refs } from '../types';
 import { getColtypesMapping } from '../utils/series';
-import { getValueFormatter } from '../utils/valueFormatter';
 
 const setIntervalBoundsAndColors = (
   intervals: string,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -39,9 +39,6 @@ import {
   NumberFormatter,
   QueryFormMetric,
   getCustomFormatter,
-  NumberFormats,
-  isSavedMetric,
-  CurrencyFormatter,
 } from '@superset-ui/core';
 import { getOriginalSeries } from '@superset-ui/chart-controls';
 import { EChartsCoreOption, SeriesOption } from 'echarts';
@@ -91,6 +88,7 @@ import {
 } from '../Timeseries/transformers';
 import { TIMESERIES_CONSTANTS, TIMEGRAIN_TO_TIMESTAMP } from '../constants';
 import { getDefaultTooltip } from '../utils/tooltip';
+import { getYAxisFormatter } from '../utils/getYAxisFormatter';
 
 const getFormatter = (
   customFormatters: Record<string, ValueFormatter>,
@@ -106,32 +104,6 @@ const getFormatter = (
     getCustomFormatter(customFormatters, metrics, formatterKey) ??
     defaultFormatter
   );
-};
-
-const getYAxisFormatter = (
-  metrics: QueryFormMetric[],
-  forcePercentFormatter: boolean,
-  customFormatters: Record<string, ValueFormatter>,
-  yAxisFormat: string = NumberFormats.SMART_NUMBER,
-) => {
-  if (forcePercentFormatter) {
-    return getNumberFormatter(',.0%');
-  }
-  const metricsArray = ensureIsArray(metrics);
-  if (
-    metricsArray.every(isSavedMetric) &&
-    metricsArray
-      .map(metric => customFormatters[metric])
-      .every(
-        (formatter, _, formatters) =>
-          formatter instanceof CurrencyFormatter &&
-          (formatter as CurrencyFormatter)?.currency?.symbol ===
-            (formatters[0] as CurrencyFormatter)?.currency?.symbol,
-      )
-  ) {
-    return customFormatters[metricsArray[0]];
-  }
-  return getNumberFormatter(yAxisFormat);
 };
 
 export default function transformProps(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
@@ -25,6 +25,7 @@ import {
   NumberFormats,
   t,
   ValueFormatter,
+  getValueFormatter,
 } from '@superset-ui/core';
 import { CallbackDataParams } from 'echarts/types/src/util/types';
 import { EChartsCoreOption, PieSeriesOption } from 'echarts';
@@ -47,7 +48,6 @@ import { defaultGrid } from '../defaults';
 import { convertInteger } from '../utils/convertInteger';
 import { getDefaultTooltip } from '../utils/tooltip';
 import { Refs } from '../types';
-import { getValueFormatter } from '../utils/valueFormatter';
 
 const percentFormatter = getNumberFormatter(NumberFormats.PERCENT_2_POINT);
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -22,7 +22,6 @@ import {
   AnnotationLayer,
   AxisType,
   CategoricalColorNamespace,
-  CurrencyFormatter,
   ensureIsArray,
   GenericDataType,
   getMetricLabel,
@@ -33,13 +32,9 @@ import {
   isFormulaAnnotationLayer,
   isIntervalAnnotationLayer,
   isPhysicalColumn,
-  isSavedMetric,
   isTimeseriesAnnotationLayer,
-  NumberFormats,
-  QueryFormMetric,
   t,
   TimeseriesChartDataResponseResult,
-  ValueFormatter,
   buildCustomFormatters,
   getCustomFormatter,
 } from '@superset-ui/core';
@@ -99,32 +94,7 @@ import {
   TIMEGRAIN_TO_TIMESTAMP,
 } from '../constants';
 import { getDefaultTooltip } from '../utils/tooltip';
-
-const getYAxisFormatter = (
-  metrics: QueryFormMetric[],
-  forcePercentFormatter: boolean,
-  customFormatters: Record<string, ValueFormatter>,
-  yAxisFormat: string = NumberFormats.SMART_NUMBER,
-) => {
-  if (forcePercentFormatter) {
-    return getNumberFormatter(',.0%');
-  }
-  const metricsArray = ensureIsArray(metrics);
-  if (
-    metricsArray.every(isSavedMetric) &&
-    metricsArray
-      .map(metric => customFormatters[metric])
-      .every(
-        (formatter, _, formatters) =>
-          formatter instanceof CurrencyFormatter &&
-          (formatter as CurrencyFormatter)?.currency?.symbol ===
-            (formatters[0] as CurrencyFormatter)?.currency?.symbol,
-      )
-  ) {
-    return customFormatters[metricsArray[0]];
-  }
-  return getNumberFormatter(yAxisFormat);
-};
+import { getYAxisFormatter } from '../utils/getYAxisFormatter';
 
 export default function transformProps(
   chartProps: EchartsTimeseriesChartProps,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -40,6 +40,8 @@ import {
   t,
   TimeseriesChartDataResponseResult,
   ValueFormatter,
+  buildCustomFormatters,
+  getCustomFormatter,
 } from '@superset-ui/core';
 import {
   extractExtraMetrics,
@@ -97,10 +99,6 @@ import {
   TIMEGRAIN_TO_TIMESTAMP,
 } from '../constants';
 import { getDefaultTooltip } from '../utils/tooltip';
-import {
-  buildCustomFormatters,
-  getCustomFormatter,
-} from '../utils/valueFormatter';
 
 const getYAxisFormatter = (
   metrics: QueryFormMetric[],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/transformProps.ts
@@ -24,6 +24,7 @@ import {
   getTimeFormatter,
   NumberFormats,
   ValueFormatter,
+  getValueFormatter,
 } from '@superset-ui/core';
 import { TreemapSeriesNodeItemOption } from 'echarts/types/src/chart/treemap/TreemapSeries';
 import { EChartsCoreOption, TreemapSeriesOption } from 'echarts';
@@ -48,7 +49,6 @@ import { OpacityEnum } from '../constants';
 import { getDefaultTooltip } from '../utils/tooltip';
 import { Refs } from '../types';
 import { treeBuilder, TreeNode } from '../utils/treeBuilder';
-import { getValueFormatter } from '../utils/valueFormatter';
 
 export function formatLabel({
   params,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/getYAxisFormatter.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/getYAxisFormatter.ts
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  CurrencyFormatter,
+  ensureIsArray,
+  getNumberFormatter,
+  isSavedMetric,
+  NumberFormats,
+  QueryFormMetric,
+  ValueFormatter,
+} from '@superset-ui/core';
+
+export const getYAxisFormatter = (
+  metrics: QueryFormMetric[],
+  forcePercentFormatter: boolean,
+  customFormatters: Record<string, ValueFormatter>,
+  yAxisFormat: string = NumberFormats.SMART_NUMBER,
+) => {
+  if (forcePercentFormatter) {
+    return getNumberFormatter(',.0%');
+  }
+  const metricsArray = ensureIsArray(metrics);
+  if (
+    metricsArray.every(isSavedMetric) &&
+    metricsArray
+      .map(metric => customFormatters[metric])
+      .every(
+        (formatter, _, formatters) =>
+          formatter instanceof CurrencyFormatter &&
+          (formatter as CurrencyFormatter)?.currency?.symbol ===
+            (formatters[0] as CurrencyFormatter)?.currency?.symbol,
+      )
+  ) {
+    return customFormatters[metricsArray[0]];
+  }
+  return getNumberFormatter(yAxisFormat);
+};

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -518,7 +518,7 @@ export function getAxisType(dataType?: GenericDataType): AxisType {
 export function getOverMaxHiddenFormatter(
   config: {
     max?: number;
-    formatter?: NumberFormatter;
+    formatter?: ValueFormatter;
   } = {},
 ) {
   const { max, formatter } = config;


### PR DESCRIPTION
### SUMMARY
Continuation of https://github.com/apache/superset/pull/24517.
Implements support for currencies in WorldMap, Heatmap, Sunburst and Mixed Chart.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
Follow the instructions from https://github.com/apache/superset/pull/24517, verify that the feature works in listed viz types.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
