### PR TITLE
fix(datasets): Replace left panel layout by TableSelector

### DIFF
--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -133,6 +133,7 @@ export const TableOption = ({ table }: { table: Table }) => {
         <WarningIconWithTooltip
           warningMarkdown={extra.warning_markdown}
           size="l"
+          indentSize={0.5}
         />
       )}
       {value}

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -104,6 +104,7 @@ interface TableSelectorProps {
   tableValue?: string | string[];
   onTableSelectChange?: (value?: string | string[], schema?: string) => void;
   tableSelectMode?: 'single' | 'multiple';
+  customTableOptionLabelRenderer?: (table: Table) => JSX.Element;
 }
 
 export interface TableOption {
@@ -164,6 +165,7 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
   tableSelectMode = 'single',
   tableValue = undefined,
   onTableSelectChange,
+  customTableOptionLabelRenderer,
 }) => {
   const { addSuccessToast } = useToasts();
   const [currentSchema, setCurrentSchema] = useState<string | undefined>(
@@ -203,9 +205,12 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
             value: table.value,
             label: <TableOption table={table} />,
             text: table.value,
+            ...(customTableOptionLabelRenderer && {
+              customLabel: customTableOptionLabelRenderer(table),
+            }),
           }))
         : [],
-    [data],
+    [data, customTableOptionLabelRenderer],
   );
 
   useEffect(() => {

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -133,7 +133,7 @@ export const TableOption = ({ table }: { table: Table }) => {
         <WarningIconWithTooltip
           warningMarkdown={extra.warning_markdown}
           size="l"
-          indentSize={0.5}
+          marginRight={4}
         />
       )}
       {value}

--- a/superset-frontend/src/components/Tooltip/index.tsx
+++ b/superset-frontend/src/components/Tooltip/index.tsx
@@ -41,6 +41,9 @@ export const Tooltip = (props: TooltipProps) => {
               display: block;
             }
           }
+          .ant-tooltip-inner > p {
+            margin: 0;
+          }
         `}
       />
       <AntdTooltip

--- a/superset-frontend/src/components/WarningIconWithTooltip/index.tsx
+++ b/superset-frontend/src/components/WarningIconWithTooltip/index.tsx
@@ -39,7 +39,7 @@ function WarningIconWithTooltip({
       <Icons.AlertSolid
         iconColor={theme.colors.alert.base}
         iconSize={size}
-        css={{ marginRight: theme.gridUnit * 2 }}
+        css={{ marginRight: theme.gridUnit * 0.5 }}
       />
     </Tooltip>
   );

--- a/superset-frontend/src/components/WarningIconWithTooltip/index.tsx
+++ b/superset-frontend/src/components/WarningIconWithTooltip/index.tsx
@@ -24,11 +24,13 @@ import { Tooltip } from 'src/components/Tooltip';
 export interface WarningIconWithTooltipProps {
   warningMarkdown: string;
   size?: IconType['iconSize'];
+  indentSize?: number;
 }
 
 function WarningIconWithTooltip({
   warningMarkdown,
   size,
+  indentSize = 2,
 }: WarningIconWithTooltipProps) {
   const theme = useTheme();
   return (
@@ -39,7 +41,7 @@ function WarningIconWithTooltip({
       <Icons.AlertSolid
         iconColor={theme.colors.alert.base}
         iconSize={size}
-        css={{ marginRight: theme.gridUnit * 0.5 }}
+        css={{ marginRight: theme.gridUnit * indentSize }}
       />
     </Tooltip>
   );

--- a/superset-frontend/src/components/WarningIconWithTooltip/index.tsx
+++ b/superset-frontend/src/components/WarningIconWithTooltip/index.tsx
@@ -24,13 +24,13 @@ import { Tooltip } from 'src/components/Tooltip';
 export interface WarningIconWithTooltipProps {
   warningMarkdown: string;
   size?: IconType['iconSize'];
-  indentSize?: number;
+  marginRight?: number;
 }
 
 function WarningIconWithTooltip({
   warningMarkdown,
   size,
-  indentSize = 2,
+  marginRight,
 }: WarningIconWithTooltipProps) {
   const theme = useTheme();
   return (
@@ -41,7 +41,7 @@ function WarningIconWithTooltip({
       <Icons.AlertSolid
         iconColor={theme.colors.alert.base}
         iconSize={size}
-        css={{ marginRight: theme.gridUnit * indentSize }}
+        css={{ marginRight: marginRight ?? theme.gridUnit * 2 }}
       />
     </Tooltip>
   );

--- a/superset-frontend/src/features/datasets/AddDataset/LeftPanel/LeftPanel.test.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/LeftPanel/LeftPanel.test.tsx
@@ -27,122 +27,128 @@ const databasesEndpoint = 'glob:*/api/v1/database/?q*';
 const schemasEndpoint = 'glob:*/api/v1/database/*/schemas*';
 const tablesEndpoint = 'glob:*/api/v1/database/*/tables/?q*';
 
-fetchMock.get(databasesEndpoint, {
-  count: 2,
-  description_columns: {},
-  ids: [1, 2],
-  label_columns: {
-    allow_file_upload: 'Allow Csv Upload',
-    allow_ctas: 'Allow Ctas',
-    allow_cvas: 'Allow Cvas',
-    allow_dml: 'Allow Dml',
-    allow_multi_schema_metadata_fetch: 'Allow Multi Schema Metadata Fetch',
-    allow_run_async: 'Allow Run Async',
-    allows_cost_estimate: 'Allows Cost Estimate',
-    allows_subquery: 'Allows Subquery',
-    allows_virtual_table_explore: 'Allows Virtual Table Explore',
-    disable_data_preview: 'Disables SQL Lab Data Preview',
-    backend: 'Backend',
-    changed_on: 'Changed On',
-    changed_on_delta_humanized: 'Changed On Delta Humanized',
-    'created_by.first_name': 'Created By First Name',
-    'created_by.last_name': 'Created By Last Name',
-    database_name: 'Database Name',
-    explore_database_id: 'Explore Database Id',
-    expose_in_sqllab: 'Expose In Sqllab',
-    force_ctas_schema: 'Force Ctas Schema',
-    id: 'Id',
-  },
-  list_columns: [
-    'allow_file_upload',
-    'allow_ctas',
-    'allow_cvas',
-    'allow_dml',
-    'allow_multi_schema_metadata_fetch',
-    'allow_run_async',
-    'allows_cost_estimate',
-    'allows_subquery',
-    'allows_virtual_table_explore',
-    'disable_data_preview',
-    'backend',
-    'changed_on',
-    'changed_on_delta_humanized',
-    'created_by.first_name',
-    'created_by.last_name',
-    'database_name',
-    'explore_database_id',
-    'expose_in_sqllab',
-    'force_ctas_schema',
-    'id',
-  ],
-  list_title: 'List Database',
-  order_columns: [
-    'allow_file_upload',
-    'allow_dml',
-    'allow_run_async',
-    'changed_on',
-    'changed_on_delta_humanized',
-    'created_by.first_name',
-    'database_name',
-    'expose_in_sqllab',
-  ],
-  result: [
-    {
-      allow_file_upload: false,
-      allow_ctas: false,
-      allow_cvas: false,
-      allow_dml: false,
-      allow_multi_schema_metadata_fetch: false,
-      allow_run_async: false,
-      allows_cost_estimate: null,
-      allows_subquery: true,
-      allows_virtual_table_explore: true,
-      disable_data_preview: false,
-      backend: 'postgresql',
-      changed_on: '2021-03-09T19:02:07.141095',
-      changed_on_delta_humanized: 'a day ago',
-      created_by: null,
-      database_name: 'test-postgres',
-      explore_database_id: 1,
-      expose_in_sqllab: true,
-      force_ctas_schema: null,
-      id: 1,
+beforeEach(() => {
+  fetchMock.get(databasesEndpoint, {
+    count: 2,
+    description_columns: {},
+    ids: [1, 2],
+    label_columns: {
+      allow_file_upload: 'Allow Csv Upload',
+      allow_ctas: 'Allow Ctas',
+      allow_cvas: 'Allow Cvas',
+      allow_dml: 'Allow Dml',
+      allow_multi_schema_metadata_fetch: 'Allow Multi Schema Metadata Fetch',
+      allow_run_async: 'Allow Run Async',
+      allows_cost_estimate: 'Allows Cost Estimate',
+      allows_subquery: 'Allows Subquery',
+      allows_virtual_table_explore: 'Allows Virtual Table Explore',
+      disable_data_preview: 'Disables SQL Lab Data Preview',
+      backend: 'Backend',
+      changed_on: 'Changed On',
+      changed_on_delta_humanized: 'Changed On Delta Humanized',
+      'created_by.first_name': 'Created By First Name',
+      'created_by.last_name': 'Created By Last Name',
+      database_name: 'Database Name',
+      explore_database_id: 'Explore Database Id',
+      expose_in_sqllab: 'Expose In Sqllab',
+      force_ctas_schema: 'Force Ctas Schema',
+      id: 'Id',
     },
-    {
-      allow_csv_upload: false,
-      allow_ctas: false,
-      allow_cvas: false,
-      allow_dml: false,
-      allow_multi_schema_metadata_fetch: false,
-      allow_run_async: false,
-      allows_cost_estimate: null,
-      allows_subquery: true,
-      allows_virtual_table_explore: true,
-      disable_data_preview: false,
-      backend: 'mysql',
-      changed_on: '2021-03-09T19:02:07.141095',
-      changed_on_delta_humanized: 'a day ago',
-      created_by: null,
-      database_name: 'test-mysql',
-      explore_database_id: 1,
-      expose_in_sqllab: true,
-      force_ctas_schema: null,
-      id: 2,
-    },
-  ],
+    list_columns: [
+      'allow_file_upload',
+      'allow_ctas',
+      'allow_cvas',
+      'allow_dml',
+      'allow_multi_schema_metadata_fetch',
+      'allow_run_async',
+      'allows_cost_estimate',
+      'allows_subquery',
+      'allows_virtual_table_explore',
+      'disable_data_preview',
+      'backend',
+      'changed_on',
+      'changed_on_delta_humanized',
+      'created_by.first_name',
+      'created_by.last_name',
+      'database_name',
+      'explore_database_id',
+      'expose_in_sqllab',
+      'force_ctas_schema',
+      'id',
+    ],
+    list_title: 'List Database',
+    order_columns: [
+      'allow_file_upload',
+      'allow_dml',
+      'allow_run_async',
+      'changed_on',
+      'changed_on_delta_humanized',
+      'created_by.first_name',
+      'database_name',
+      'expose_in_sqllab',
+    ],
+    result: [
+      {
+        allow_file_upload: false,
+        allow_ctas: false,
+        allow_cvas: false,
+        allow_dml: false,
+        allow_multi_schema_metadata_fetch: false,
+        allow_run_async: false,
+        allows_cost_estimate: null,
+        allows_subquery: true,
+        allows_virtual_table_explore: true,
+        disable_data_preview: false,
+        backend: 'postgresql',
+        changed_on: '2021-03-09T19:02:07.141095',
+        changed_on_delta_humanized: 'a day ago',
+        created_by: null,
+        database_name: 'test-postgres',
+        explore_database_id: 1,
+        expose_in_sqllab: true,
+        force_ctas_schema: null,
+        id: 1,
+      },
+      {
+        allow_csv_upload: false,
+        allow_ctas: false,
+        allow_cvas: false,
+        allow_dml: false,
+        allow_multi_schema_metadata_fetch: false,
+        allow_run_async: false,
+        allows_cost_estimate: null,
+        allows_subquery: true,
+        allows_virtual_table_explore: true,
+        disable_data_preview: false,
+        backend: 'mysql',
+        changed_on: '2021-03-09T19:02:07.141095',
+        changed_on_delta_humanized: 'a day ago',
+        created_by: null,
+        database_name: 'test-mysql',
+        explore_database_id: 1,
+        expose_in_sqllab: true,
+        force_ctas_schema: null,
+        id: 2,
+      },
+    ],
+  });
+
+  fetchMock.get(schemasEndpoint, {
+    result: ['information_schema', 'public'],
+  });
+
+  fetchMock.get(tablesEndpoint, {
+    count: 3,
+    result: [
+      { value: 'Sheet1', type: 'table', extra: null },
+      { value: 'Sheet2', type: 'table', extra: null },
+      { value: 'Sheet3', type: 'table', extra: null },
+    ],
+  });
 });
 
-fetchMock.get(schemasEndpoint, {
-  result: ['information_schema', 'public'],
-});
-
-fetchMock.get(tablesEndpoint, {
-  count: 3,
-  result: [
-    { value: 'Sheet1', type: 'table', extra: null },
-    { value: 'Sheet2', type: 'table', extra: null },
-    { value: 'Sheet3', type: 'table', extra: null },
-  ],
+afterEach(() => {
+  fetchMock.reset();
 });
 
 const mockFun = jest.fn();
@@ -152,14 +158,16 @@ test('should render', async () => {
     useRedux: true,
   });
   expect(
-    await screen.findByText(/select database & schema/i),
+    await screen.findByText(/Select database or type to search databases/i),
   ).toBeInTheDocument();
 });
 
 test('should render schema selector, database selector container, and selects', async () => {
   render(<LeftPanel setDataset={mockFun} />, { useRedux: true });
 
-  expect(await screen.findByText(/select database & schema/i)).toBeVisible();
+  expect(
+    await screen.findByText(/Select database or type to search databases/i),
+  ).toBeVisible();
 
   const databaseSelect = screen.getByRole('combobox', {
     name: 'Select database or type to search databases',
@@ -175,7 +183,7 @@ test('does not render blank state if there is nothing selected', async () => {
   render(<LeftPanel setDataset={mockFun} />, { useRedux: true });
 
   expect(
-    await screen.findByText(/select database & schema/i),
+    await screen.findByText(/Select database or type to search databases/i),
   ).toBeInTheDocument();
   const emptyState = screen.queryByRole('img', { name: /empty/i });
   expect(emptyState).not.toBeInTheDocument();
@@ -218,66 +226,41 @@ test('searches for a table name', async () => {
   const schemaSelect = screen.getByRole('combobox', {
     name: /select schema or type to search schemas/i,
   });
+  const tableSelect = screen.getByRole('combobox', {
+    name: /select table or type to search tables/i,
+  });
 
   await waitFor(() => expect(schemaSelect).toBeEnabled());
 
   // Click 'public' schema to access tables
   userEvent.click(schemaSelect);
   userEvent.click(screen.getAllByText('public')[1]);
+  await waitFor(() => expect(fetchMock.calls(tablesEndpoint).length).toBe(1));
+  userEvent.click(tableSelect);
 
   await waitFor(() => {
-    expect(screen.getByText('Sheet1')).toBeInTheDocument();
-    expect(screen.getByText('Sheet2')).toBeInTheDocument();
-    expect(screen.getByText('Sheet3')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', {
+        name: /Sheet1/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', {
+        name: /Sheet2/i,
+      }),
+    ).toBeInTheDocument();
   });
 
-  userEvent.type(screen.getByRole('textbox'), 'Sheet2');
+  userEvent.type(tableSelect, 'Sheet2');
 
   await waitFor(() => {
-    expect(screen.queryByText('Sheet1')).not.toBeInTheDocument();
-    expect(screen.getByText('Sheet2')).toBeInTheDocument();
-    expect(screen.queryByText('Sheet3')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', { name: /Sheet1/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', {
+        name: /Sheet2/i,
+      }),
+    ).toBeInTheDocument();
   });
-});
-
-test('renders a warning icon when a table name has a pre-existing dataset', async () => {
-  render(
-    <LeftPanel
-      setDataset={mockFun}
-      dataset={exampleDataset[0]}
-      datasetNames={['Sheet2']}
-    />,
-    {
-      useRedux: true,
-    },
-  );
-
-  // Click 'test-postgres' database to access schemas
-  const databaseSelect = screen.getByRole('combobox', {
-    name: /select database or type to search databases/i,
-  });
-  userEvent.click(databaseSelect);
-  userEvent.click(await screen.findByText('test-postgres'));
-
-  const schemaSelect = screen.getByRole('combobox', {
-    name: /select schema or type to search schemas/i,
-  });
-
-  await waitFor(() => expect(schemaSelect).toBeEnabled());
-
-  // Warning icon should not show yet
-  expect(
-    screen.queryByRole('img', { name: 'warning' }),
-  ).not.toBeInTheDocument();
-
-  // Click 'public' schema to access tables
-  userEvent.click(schemaSelect);
-  userEvent.click(screen.getAllByText('public')[1]);
-
-  await waitFor(() => {
-    expect(screen.getByText('Sheet2')).toBeInTheDocument();
-  });
-
-  // Sheet2 should now show the warning icon
-  expect(screen.getByRole('img', { name: 'warning' })).toBeVisible();
 });

--- a/superset-frontend/src/features/datasets/AddDataset/LeftPanel/index.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/LeftPanel/index.tsx
@@ -16,36 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, {
-  useEffect,
-  useState,
-  SetStateAction,
-  Dispatch,
-  useCallback,
-} from 'react';
-import rison from 'rison';
-import {
-  SupersetClient,
-  t,
-  styled,
-  css,
-  useTheme,
-  logging,
-} from '@superset-ui/core';
-import { Input } from 'src/components/Input';
-import { Form } from 'src/components/Form';
-import Icons from 'src/components/Icons';
-import { TableOption } from 'src/components/TableSelector';
-import RefreshLabel from 'src/components/RefreshLabel';
-import { Table } from 'src/hooks/apiResources';
-import Loading from 'src/components/Loading';
-import DatabaseSelector, {
-  DatabaseObject,
-} from 'src/components/DatabaseSelector';
-import {
-  EmptyStateMedium,
-  emptyStateComponent,
-} from 'src/components/EmptyState';
+import React, { useEffect, SetStateAction, Dispatch, useCallback } from 'react';
+import { styled } from '@superset-ui/core';
+import TableSelector from 'src/components/TableSelector';
+import { DatabaseObject } from 'src/components/DatabaseSelector';
+import { emptyStateComponent } from 'src/components/EmptyState';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
 import { LocalStorageKeys, getItem } from 'src/utils/localStorageHelpers';
 import {
@@ -59,10 +34,6 @@ interface LeftPanelProps {
   datasetNames?: (string | null | undefined)[] | undefined;
 }
 
-const SearchIcon = styled(Icons.Search)`
-  color: ${({ theme }) => theme.colors.grayscale.light1};
-`;
-
 const LeftPanelStyle = styled.div`
   ${({ theme }) => `
     max-width: ${theme.gridUnit * 87.5}px;
@@ -73,14 +44,6 @@ const LeftPanelStyle = styled.div`
     .emptystate {
       height: auto;
       margin-top: ${theme.gridUnit * 17.5}px;
-    }
-    .refresh {
-      position: absolute;
-      top: ${theme.gridUnit * 38.75}px;
-      left: ${theme.gridUnit * 16.75}px;
-      span[role="button"]{
-        font-size: ${theme.gridUnit * 4.25}px;
-      }
     }
     .section-title {
       margin-top: ${theme.gridUnit * 5.5}px;
@@ -153,82 +116,29 @@ const LeftPanelStyle = styled.div`
 `}
 `;
 
-export default function LeftPanel({
-  setDataset,
-  dataset,
-  datasetNames,
-}: LeftPanelProps) {
-  const theme = useTheme();
-
-  const [tableOptions, setTableOptions] = useState<Array<TableOption>>([]);
-  const [resetTables, setResetTables] = useState(false);
-  const [loadTables, setLoadTables] = useState(false);
-  const [searchVal, setSearchVal] = useState('');
-  const [refresh, setRefresh] = useState(false);
-  const [selectedTable, setSelectedTable] = useState<number | null>(null);
-
+export default function LeftPanel({ setDataset, dataset }: LeftPanelProps) {
   const { addDangerToast } = useToasts();
 
   const setDatabase = useCallback(
     (db: Partial<DatabaseObject>) => {
       setDataset({ type: DatasetActionType.selectDatabase, payload: { db } });
-      setSelectedTable(null);
-      setResetTables(true);
     },
     [setDataset],
   );
-
-  const setTable = (tableName: string, index: number) => {
-    setSelectedTable(index);
-    setDataset({
-      type: DatasetActionType.selectTable,
-      payload: { name: 'table_name', value: tableName },
-    });
-  };
-
-  const getTablesList = useCallback(
-    (url: string) => {
-      SupersetClient.get({ url })
-        .then(({ json }) => {
-          const options: TableOption[] = json.result.map((table: Table) => {
-            const option: TableOption = {
-              value: table.value,
-              label: <TableOption table={table} />,
-              text: table.label,
-            };
-
-            return option;
-          });
-
-          setTableOptions(options);
-          setLoadTables(false);
-          setResetTables(false);
-          setRefresh(false);
-        })
-        .catch(error => {
-          addDangerToast(t('There was an error fetching tables'));
-          logging.error(t('There was an error fetching tables'), error);
-        });
-    },
-    [addDangerToast],
-  );
-
   const setSchema = (schema: string) => {
     if (schema) {
       setDataset({
         type: DatasetActionType.selectSchema,
         payload: { name: 'schema', value: schema },
       });
-      setLoadTables(true);
     }
-    setSelectedTable(null);
-    setResetTables(true);
   };
-
-  const encodedSchema = dataset?.schema
-    ? encodeURIComponent(dataset?.schema)
-    : undefined;
-
+  const setTable = (tableName: string) => {
+    setDataset({
+      type: DatasetActionType.selectTable,
+      payload: { name: 'table_name', value: tableName },
+    });
+  };
   useEffect(() => {
     const currentUserSelectedDb = getItem(
       LocalStorageKeys.db,
@@ -239,140 +149,18 @@ export default function LeftPanel({
     }
   }, [setDatabase]);
 
-  useEffect(() => {
-    if (loadTables) {
-      const params = rison.encode({
-        force: refresh,
-        schema_name: encodedSchema,
-      });
-
-      const endpoint = `/api/v1/database/${dataset?.db?.id}/tables/?q=${params}`;
-      getTablesList(endpoint);
-    }
-  }, [loadTables, dataset?.db?.id, encodedSchema, getTablesList, refresh]);
-
-  useEffect(() => {
-    if (resetTables) {
-      setTableOptions([]);
-      setResetTables(false);
-    }
-  }, [resetTables]);
-
-  const filteredOptions = tableOptions.filter(option =>
-    option?.value?.toLowerCase().includes(searchVal.toLowerCase()),
-  );
-
-  const Loader = (inline: string) => (
-    <div className="loading-container">
-      <Loading position="inline" />
-      <p>{inline}</p>
-    </div>
-  );
-
-  const SELECT_DATABASE_AND_SCHEMA_TEXT = t('Select database & schema');
-  const TABLE_LOADING_TEXT = t('Table loading');
-  const NO_TABLES_FOUND_TITLE = t('No database tables found');
-  const NO_TABLES_FOUND_DESCRIPTION = t('Try selecting a different schema');
-  const SELECT_DATABASE_TABLE_TEXT = t('Select database table');
-  const REFRESH_TABLE_LIST_TOOLTIP = t('Refresh table list');
-  const REFRESH_TABLES_TEXT = t('Refresh tables');
-  const SEARCH_TABLES_PLACEHOLDER_TEXT = t('Search tables');
-
-  const optionsList = document.getElementsByClassName('options-list');
-  const scrollableOptionsList =
-    optionsList[0]?.scrollHeight > optionsList[0]?.clientHeight;
-  const [emptyResultsWithSearch, setEmptyResultsWithSearch] = useState(false);
-
-  const onEmptyResults = (searchText?: string) => {
-    setEmptyResultsWithSearch(!!searchText);
-  };
-
   return (
     <LeftPanelStyle>
-      <p className="section-title db-schema">
-        {SELECT_DATABASE_AND_SCHEMA_TEXT}
-      </p>
-      <DatabaseSelector
-        db={dataset?.db}
+      <TableSelector
+        database={dataset?.db}
         handleError={addDangerToast}
+        emptyState={emptyStateComponent(false)}
         onDbChange={setDatabase}
         onSchemaChange={setSchema}
-        emptyState={emptyStateComponent(emptyResultsWithSearch)}
-        onEmptyResults={onEmptyResults}
+        onTableSelectChange={setTable}
+        sqlLabMode={false}
+        {...(dataset?.schema && { schema: dataset.schema })}
       />
-      {loadTables && !refresh && Loader(TABLE_LOADING_TEXT)}
-      {dataset?.schema && !loadTables && !tableOptions.length && !searchVal && (
-        <div className="emptystate">
-          <EmptyStateMedium
-            image="empty-table.svg"
-            title={NO_TABLES_FOUND_TITLE}
-            description={NO_TABLES_FOUND_DESCRIPTION}
-          />
-        </div>
-      )}
-
-      {dataset?.schema && (tableOptions.length > 0 || searchVal.length > 0) && (
-        <>
-          <Form>
-            <p className="table-title">{SELECT_DATABASE_TABLE_TEXT}</p>
-            <RefreshLabel
-              onClick={() => {
-                setLoadTables(true);
-                setRefresh(true);
-              }}
-              tooltipContent={REFRESH_TABLE_LIST_TOOLTIP}
-            />
-            {refresh && Loader(REFRESH_TABLES_TEXT)}
-            {!refresh && (
-              <Input
-                value={searchVal}
-                prefix={<SearchIcon iconSize="l" />}
-                onChange={evt => {
-                  setSearchVal(evt.target.value);
-                }}
-                className="table-form"
-                placeholder={SEARCH_TABLES_PLACEHOLDER_TEXT}
-                allowClear
-              />
-            )}
-          </Form>
-          <div className="options-list" data-test="options-list">
-            {!refresh &&
-              filteredOptions.map((option, i) => (
-                <div
-                  className={
-                    selectedTable === i
-                      ? scrollableOptionsList
-                        ? 'options-highlighted'
-                        : 'options-highlighted no-scrollbar'
-                      : scrollableOptionsList
-                      ? 'options'
-                      : 'options no-scrollbar'
-                  }
-                  key={i}
-                  role="button"
-                  tabIndex={0}
-                  onClick={() => setTable(option.value, i)}
-                >
-                  {option.label}
-                  {datasetNames?.includes(option.value) && (
-                    <Icons.Warning
-                      iconColor={
-                        selectedTable === i
-                          ? theme.colors.grayscale.light5
-                          : theme.colors.info.base
-                      }
-                      iconSize="m"
-                      css={css`
-                        margin-right: ${theme.gridUnit * 2}px;
-                      `}
-                    />
-                  )}
-                </div>
-              ))}
-          </div>
-        </>
-      )}
     </LeftPanelStyle>
   );
 }

--- a/superset-frontend/src/features/datasets/AddDataset/LeftPanel/index.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/LeftPanel/index.tsx
@@ -117,8 +117,6 @@ const LeftPanelStyle = styled.div`
 `}
 `;
 
-const divider = ':@:';
-
 export default function LeftPanel({
   setDataset,
   dataset,
@@ -156,13 +154,11 @@ export default function LeftPanel({
     }
   }, [setDatabase]);
 
-  const datasetNamesSet = datasetNames?.join(divider);
-
   const customTableOptionLabelRenderer = useCallback(
     (table: Table) => (
       <TableOption
         table={
-          datasetNamesSet?.split(divider)?.includes(table.value)
+          datasetNames?.includes(table.value)
             ? {
                 ...table,
                 extra: {
@@ -173,7 +169,7 @@ export default function LeftPanel({
         }
       />
     ),
-    [datasetNamesSet],
+    [datasetNames],
   );
 
   return (

--- a/superset-frontend/src/features/datasets/AddDataset/LeftPanel/index.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/LeftPanel/index.tsx
@@ -17,8 +17,8 @@
  * under the License.
  */
 import React, { useEffect, SetStateAction, Dispatch, useCallback } from 'react';
-import { styled } from '@superset-ui/core';
-import TableSelector from 'src/components/TableSelector';
+import { styled, t } from '@superset-ui/core';
+import TableSelector, { TableOption } from 'src/components/TableSelector';
 import { DatabaseObject } from 'src/components/DatabaseSelector';
 import { emptyStateComponent } from 'src/components/EmptyState';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
@@ -27,6 +27,7 @@ import {
   DatasetActionType,
   DatasetObject,
 } from 'src/features/datasets/AddDataset/types';
+import { Table } from 'src/hooks/apiResources';
 
 interface LeftPanelProps {
   setDataset: Dispatch<SetStateAction<object>>;
@@ -116,7 +117,13 @@ const LeftPanelStyle = styled.div`
 `}
 `;
 
-export default function LeftPanel({ setDataset, dataset }: LeftPanelProps) {
+const divider = ':@:';
+
+export default function LeftPanel({
+  setDataset,
+  dataset,
+  datasetNames,
+}: LeftPanelProps) {
   const { addDangerToast } = useToasts();
 
   const setDatabase = useCallback(
@@ -149,6 +156,26 @@ export default function LeftPanel({ setDataset, dataset }: LeftPanelProps) {
     }
   }, [setDatabase]);
 
+  const datasetNamesSet = datasetNames?.join(divider);
+
+  const customTableOptionLabelRenderer = useCallback(
+    (table: Table) => (
+      <TableOption
+        table={
+          datasetNamesSet?.split(divider)?.includes(table.value)
+            ? {
+                ...table,
+                extra: {
+                  warning_markdown: t('This table already has a dataset'),
+                },
+              }
+            : table
+        }
+      />
+    ),
+    [datasetNamesSet],
+  );
+
   return (
     <LeftPanelStyle>
       <TableSelector
@@ -159,6 +186,7 @@ export default function LeftPanel({ setDataset, dataset }: LeftPanelProps) {
         onSchemaChange={setSchema}
         onTableSelectChange={setTable}
         sqlLabMode={false}
+        customTableOptionLabelRenderer={customTableOptionLabelRenderer}
         {...(dataset?.schema && { schema: dataset.schema })}
       />
     </LeftPanelStyle>

--- a/superset-frontend/src/features/datasets/DatasetLayout/DatasetLayout.test.tsx
+++ b/superset-frontend/src/features/datasets/DatasetLayout/DatasetLayout.test.tsx
@@ -59,7 +59,7 @@ describe('DatasetLayout', () => {
     );
 
     expect(
-      await screen.findByText(/select database & schema/i),
+      await screen.findByText(/Select database or type to search databases/i),
     ).toBeInTheDocument();
     expect(LeftPanel).toBeTruthy();
   });

--- a/superset-frontend/src/features/datasets/hooks/useDatasetLists.ts
+++ b/superset-frontend/src/features/datasets/hooks/useDatasetLists.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { SupersetClient, logging, t } from '@superset-ui/core';
 import rison from 'rison';
 import { addDangerToast } from 'src/components/MessageToasts/actions';
@@ -83,7 +83,10 @@ const useDatasetsList = (
     }
   }, [db?.id, schema, encodedSchema, getDatasetsList]);
 
-  const datasetNames = datasets?.map(dataset => dataset.table_name);
+  const datasetNames = useMemo(
+    () => datasets?.map(dataset => dataset.table_name),
+    [datasets],
+  );
 
   return { datasets, datasetNames };
 };


### PR DESCRIPTION
### SUMMARY
Since new Dataset creation layout doesn't use virtualized list component for the table list, hard to operate the dataset creation with large table set (>10k). (mostly browser is frozen while scrolling down)

<img width="953" alt="superset-goalie_-_Airbnb_-_Slack" src="https://github.com/apache/superset/assets/1392866/775b0483-d9e3-4c7b-afaf-91b3ada67097">

Since the left panel layout designed for database/schema/table selection, we can reuse the  database/schema/table selector (which uses virtualized list) for the same functionality (except the warning icon. However the warning message will be shown as is once user selects a table. I think it won't be critical without the warning icon on the list)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

After:
<img width="873" alt="Screenshot 2023-07-05 at 2 43 20 PM" src="https://github.com/apache/superset/assets/1392866/c767afa8-92f4-4e49-b730-c201bdda9e1b">

Before:
<img width="874" alt="Screenshot 2023-07-05 at 2 34 43 PM" src="https://github.com/apache/superset/assets/1392866/d4716e07-3b63-423f-8a49-ab42a8371d67">

### TESTING INSTRUCTIONS
Go to datasets and create new dataset

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
