### PR TITLE
fix: change naming convention for count metric on Dataset creation

### DIFF
--- a/superset/datasets/commands/create.py
+++ b/superset/datasets/commands/create.py
@@ -48,7 +48,7 @@ class CreateDatasetCommand(CreateMixin, BaseCommand):
             dataset = DatasetDAO.create(self._properties, commit=False)
 
             # Updates columns and metrics from the dataset
-            dataset.metrics = [SqlMetric(metric_name="count", expression="COUNT(*)")]
+            dataset.metrics = [SqlMetric(metric_name="COUNT(*)", expression="COUNT(*)")]
 
             dataset.fetch_metadata(commit=False)
             db.session.commit()


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Change the name of the default metric to `COUNT(*)` instead of just `count`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
