### PR TITLE
fix(sqllab): missing column meta on autocomplete

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -666,7 +666,6 @@ const SqlEditor = ({
             onBlur={setQueryEditorAndSaveSql}
             onChange={onSqlChanged}
             queryEditorId={queryEditor.id}
-            extendedTables={tables}
             height={`${aceEditorHeight}px`}
             hotkeys={hotkeys}
           />

--- a/superset-frontend/src/hooks/apiResources/index.ts
+++ b/superset-frontend/src/hooks/apiResources/index.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
+export { skipToken } from '@reduxjs/toolkit/query/react';
 export {
   useApiResourceFullBody,
   useApiV1Resource,

--- a/superset-frontend/src/hooks/apiResources/tables.ts
+++ b/superset-frontend/src/hooks/apiResources/tables.ts
@@ -139,6 +139,7 @@ export const {
   useTablesQuery,
   useTableMetadataQuery,
   useTableExtendedMetadataQuery,
+  endpoints: tableEndpoints,
 } = tableApi;
 
 export function useTables(options: Params) {

--- a/superset-frontend/src/views/store.ts
+++ b/superset-frontend/src/views/store.ts
@@ -161,3 +161,4 @@ export function setupStore({
 }
 
 export const store: Store = setupStore();
+export type RootState = ReturnType<typeof store.getState>;


### PR DESCRIPTION
### SUMMARY

Hotfix for regression from #24371
After table extended metadata discarded from sqlLab state, columns are no longer exists within `extendedTables`.
This commit adds the logic to extract the columns metadata from rdk query selectors.
FYI: Since AceEditorWrapper is hard to test the autocomplete specs, I'm planning to add specs for this including other autocomplete items in the upcoming PRs that will refactor setWords by a hook

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

After:

https://github.com/apache/superset/assets/1392866/6da82118-36e8-403e-a634-504c3ba1192c

Before:

https://github.com/apache/superset/assets/1392866/54820b9b-43df-4eeb-9ff0-3a85025414a7

### TESTING INSTRUCTIONS

Enable autocomplete
Type some column name and check the autocomplete list including column names

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
