### PR TITLE
fix(report): edit without custom width

### DIFF
--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 from croniter import croniter
 from flask import current_app
@@ -220,7 +220,13 @@ class ReportSchedulePostSchema(Schema):
     )
 
     @validates("custom_width")
-    def validate_custom_width(self, value: int) -> None:  # pylint: disable=no-self-use
+    def validate_custom_width(  # pylint: disable=no-self-use
+        self,
+        value: Optional[int],
+    ) -> None:
+        if value is None:
+            return
+
         min_width = current_app.config["ALERT_REPORTS_MIN_CUSTOM_SCREENSHOT_WIDTH"]
         max_width = current_app.config["ALERT_REPORTS_MAX_CUSTOM_SCREENSHOT_WIDTH"]
         if not min_width <= value <= max_width:
@@ -344,7 +350,13 @@ class ReportSchedulePutSchema(Schema):
     )
 
     @validates("custom_width")
-    def validate_custom_width(self, value: int) -> None:  # pylint: disable=no-self-use
+    def validate_custom_width(  # pylint: disable=no-self-use
+        self,
+        value: Optional[int],
+    ) -> None:
+        if value is None:
+            return
+
         min_width = current_app.config["ALERT_REPORTS_MIN_CUSTOM_SCREENSHOT_WIDTH"]
         max_width = current_app.config["ALERT_REPORTS_MAX_CUSTOM_SCREENSHOT_WIDTH"]
         if not min_width <= value <= max_width:

--- a/tests/unit_tests/reports/__init__.py
+++ b/tests/unit_tests/reports/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/unit_tests/reports/schemas_test.py
+++ b/tests/unit_tests/reports/schemas_test.py
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+from marshmallow import ValidationError
+from pytest_mock import MockFixture
+
+from superset.reports.schemas import ReportSchedulePostSchema, ReportSchedulePutSchema
+
+
+def test_report_post_schema_custom_width_validation(mocker: MockFixture) -> None:
+    """
+    Test the custom width validation.
+    """
+    current_app = mocker.patch("superset.reports.schemas.current_app")
+    current_app.config = {
+        "ALERT_REPORTS_MIN_CUSTOM_SCREENSHOT_WIDTH": 100,
+        "ALERT_REPORTS_MAX_CUSTOM_SCREENSHOT_WIDTH": 200,
+    }
+
+    schema = ReportSchedulePostSchema()
+
+    schema.load(
+        {
+            "type": "Report",
+            "name": "A report",
+            "description": "My report",
+            "active": True,
+            "crontab": "* * * * *",
+            "timezone": "America/Los_Angeles",
+            "custom_width": 100,
+        }
+    )
+
+    # not required
+    schema.load(
+        {
+            "type": "Report",
+            "name": "A report",
+            "description": "My report",
+            "active": True,
+            "crontab": "* * * * *",
+            "timezone": "America/Los_Angeles",
+        }
+    )
+
+    with pytest.raises(ValidationError) as excinfo:
+        schema.load(
+            {
+                "type": "Report",
+                "name": "A report",
+                "description": "My report",
+                "active": True,
+                "crontab": "* * * * *",
+                "timezone": "America/Los_Angeles",
+                "custom_width": 1000,
+            }
+        )
+    assert excinfo.value.messages == {
+        "custom_width": ["Screenshot width must be between 100px and 200px"]
+    }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Allow passing an empty `custom_width` when configuring a report.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
