### PR TITLE
fix: Wrong positioning of filter tooltips on scroll

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
@@ -204,6 +204,7 @@ const DescriptionToolTip = ({ description }: { description: string }) => (
         WebkitBoxOrient: 'vertical',
         textOverflow: 'ellipsis',
       }}
+      getPopupContainer={trigger => trigger.parentElement as HTMLElement}
     >
       <i
         className="fa fa-info-circle text-muted"

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -365,7 +365,11 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
       }
       destroyTooltipOnHide
     >
-      <Tooltip placement="top" title={tooltipTitle}>
+      <Tooltip
+        placement="top"
+        title={tooltipTitle}
+        getPopupContainer={trigger => trigger.parentElement as HTMLElement}
+      >
         <DateLabel
           label={actualTimeRange}
           isActive={show}
@@ -379,7 +383,11 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
 
   const modalContent = (
     <>
-      <Tooltip placement="top" title={tooltipTitle}>
+      <Tooltip
+        placement="top"
+        title={tooltipTitle}
+        getPopupContainer={trigger => trigger.parentElement as HTMLElement}
+      >
         <DateLabel
           onClick={toggleOverlay}
           label={actualTimeRange}


### PR DESCRIPTION
### SUMMARY
Fixes the positioning of filter tooltips on scroll. Previously, the tooltips were unanchored to their elements and ended up in wrong positions when scrolling.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: Tooltips following the scroll

https://github.com/apache/superset/assets/70410625/89894d64-34ed-4bdf-ad7b-7b911b219194

After: Tooltips anchored to their elements

https://github.com/apache/superset/assets/70410625/ed888132-bd27-47eb-9600-01231d0f9d3d

### TESTING INSTRUCTIONS
Check the videos for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
