### PR TITLE
feat(csv-upload): Configurable max filesize

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -750,6 +750,9 @@ CSV_EXTENSIONS = {"csv", "tsv", "txt"}
 COLUMNAR_EXTENSIONS = {"parquet", "zip"}
 ALLOWED_EXTENSIONS = {*EXCEL_EXTENSIONS, *CSV_EXTENSIONS, *COLUMNAR_EXTENSIONS}
 
+# Optional maximum file size in bytes when uploading a CSV
+CSV_UPLOAD_MAX_SIZE = None
+
 # CSV Options: key/value pairs that will be passed as argument to DataFrame.to_csv
 # method.
 # note: index option should not be overridden

--- a/superset/forms.py
+++ b/superset/forms.py
@@ -16,10 +16,12 @@
 # under the License.
 """Contains the logic to create cohesive forms on the explore view"""
 import json
+import os
 from typing import Any, Optional
 
 from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
-from wtforms import Field
+from flask_babel import gettext as _
+from wtforms import Field, ValidationError
 
 
 class JsonListField(Field):
@@ -51,6 +53,27 @@ class CommaSeparatedListField(Field):
             self.data = [x.strip() for x in valuelist[0].split(",")]
         else:
             self.data = []
+
+
+class FileSizeLimit:  # pylint: disable=too-few-public-methods
+    """Imposes an optional maximum filesize limit for uploaded files"""
+
+    def __init__(self, max_size: Optional[int]):
+        self.max_size = max_size
+
+    def __call__(self, form: dict[str, Any], field: Any) -> None:
+        if self.max_size is None:
+            return
+
+        field.data.flush()
+        size = os.fstat(field.data.fileno()).st_size
+        if size > self.max_size:
+            raise ValidationError(
+                _(
+                    "File size must be less than or equal to %(max_size)s bytes",
+                    max_size=self.max_size,
+                )
+            )
 
 
 def filter_not_empty_values(values: Optional[list[Any]]) -> Optional[list[Any]]:

--- a/superset/views/database/forms.py
+++ b/superset/views/database/forms.py
@@ -33,6 +33,7 @@ from wtforms.validators import DataRequired, Length, NumberRange, Optional, Rege
 from superset import app, db, security_manager
 from superset.forms import (
     CommaSeparatedListField,
+    FileSizeLimit,
     filter_not_empty_values,
     JsonListField,
 )
@@ -109,6 +110,7 @@ class CsvToDatabaseForm(UploadToDatabaseForm):
         description=_("Select a file to be uploaded to the database"),
         validators=[
             FileRequired(),
+            FileSizeLimit(config["CSV_UPLOAD_MAX_SIZE"]),
             FileAllowed(
                 config["ALLOWED_EXTENSIONS"].intersection(config["CSV_EXTENSIONS"]),
                 _(

--- a/tests/unit_tests/forms_tests.py
+++ b/tests/unit_tests/forms_tests.py
@@ -1,0 +1,54 @@
+import contextlib
+import tempfile
+from typing import Optional
+
+import pytest
+from flask_wtf.file import FileField
+from wtforms import Form, ValidationError
+
+from superset.forms import FileSizeLimit
+
+
+def _get_test_form(size_limit: Optional[int]) -> Form:
+    class TestForm(Form):
+        test = FileField("test", validators=[FileSizeLimit(size_limit)])
+
+    return TestForm()
+
+
+@contextlib.contextmanager
+def _tempfile(contents: bytes):
+    with tempfile.NamedTemporaryFile() as f:
+        f.write(contents)
+        f.flush()
+
+        yield f
+
+
+def test_file_size_limit_pass() -> None:
+    """Permit files which do not exceed the size limit"""
+    limit = 100
+    form = _get_test_form(limit)
+
+    with _tempfile(b"." * limit) as f:
+        form.test.data = f
+        assert form.validate() is True
+
+
+def test_file_size_limit_fail() -> None:
+    """Reject files which are too large"""
+    limit = 100
+    form = _get_test_form(limit)
+
+    with _tempfile(b"." * (limit + 1)) as f:
+        form.test.data = f
+        assert form.validate() is False
+
+
+def test_file_size_limit_ignored_if_none() -> None:
+    """Permit files when there is no limit"""
+    form = _get_test_form(None)
+
+    with _tempfile(b"." * 200) as f:
+        form.test.data = f
+        assert form.validate() is True


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add a validation utility to validate maximum file size when uploading CSVs, and install it on the CsvToDatabaseForm, backed by an optional parameter in application config.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Configure a maximum upload size
2. Attempt to upload files of varying sizes

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
