### PR TITLE
chore: Re-enable some GitHub action workflows in draft mode

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -6,7 +6,6 @@ on:
 jobs:
   config:
     runs-on: "ubuntu-latest"
-    if: github.event.pull_request.draft == false
     outputs:
       has-secrets: ${{ steps.check.outputs.has-secrets }}
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,6 @@ on:
 jobs:
   config:
     runs-on: "ubuntu-latest"
-    if: github.event.pull_request.draft == false
     outputs:
       has-secrets: ${{ steps.check.outputs.has-secrets }}
     steps:

--- a/.github/workflows/embedded-sdk-test.yml
+++ b/.github/workflows/embedded-sdk-test.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   embedded-sdk-test:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     defaults:
       run:

--- a/.github/workflows/superset-cli.yml
+++ b/.github/workflows/superset-cli.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   test-load-examples:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -11,7 +11,6 @@ on:
 
 jobs:
   cypress-matrix:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     permissions:
       contents: read

--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   frontend-build:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"

--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   test-mysql:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -76,7 +75,6 @@ jobs:
           bash .github/workflows/codecov.sh -c -F python -F mysql
 
   test-postgres:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -143,7 +141,6 @@ jobs:
           bash .github/workflows/codecov.sh -c -F python -F postgres
 
   test-sqlite:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/superset-python-misc.yml
+++ b/.github/workflows/superset-python-misc.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   python-lint:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -50,7 +49,6 @@ jobs:
         run: pylint -j 0 superset
 
   pre-commit:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -91,7 +89,6 @@ jobs:
         run: pre-commit run --all-files
 
   babel-extract:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   test-postgres-presto:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -87,7 +86,6 @@ jobs:
           bash .github/workflows/codecov.sh -c -F python -F presto
 
   test-postgres-hive:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   unit-tests:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/superset-translations.yml
+++ b/.github/workflows/superset-translations.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   frontend-check:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
@@ -31,7 +30,6 @@ jobs:
           npm run check-translation
 
   babel-extract:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/superset-websocket.yml
+++ b/.github/workflows/superset-websocket.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   app-checks:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This is a partial revert of https://github.com/apache/superset/pull/12666 which was likely authored when Apache's CI was under heavy load. Specifically it reenables _all_ the workflows when a PR is in draft mode. This enables the author to iterate on fixing any issues prior to it being deemed eligible for review. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI and additionally ensured there were no references to `draft` in the GitHub actions, i.e., 

```
$ git grep draft .github
$
``` 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
