### PR TITLE
chore: turn off talisman for ephemeral environments in ci

### DIFF
--- a/.github/workflows/ecs-task-definition.json
+++ b/.github/workflows/ecs-task-definition.json
@@ -25,8 +25,12 @@
                     "value": "8080"
                 },
                 {
-                  "name": "SUPERSET_SECRET_KEY",
-                  "value": "super-secret-for-ephemerals"
+                    "name": "SUPERSET_SECRET_KEY",
+                    "value": "super-secret-for-ephemerals"
+                },
+                {
+                    "name": "TALISMAN_ENABLED",
+                    "value": "False"
                 }
             ],
             "mountPoints": [],


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Talisman is throwing a lot of blocking script-src errors in the ephemeral testing environment for CI, and it's blocking login to the application in CI. I'm disabling Talisman since the CSP rules aren't needed there, unless for testing. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
