### PR TITLE
chore(dao): Add explicit ON DELETE CASCADE for ownership

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -24,7 +24,8 @@ assists people when migrating to a new version.
 
 ## Next
 
-- [24488](https://github.com/apache/superset/pull/24488): Augments the foreign key constraints for the `sql_metrics`, `sqlatable_user`, and `table_columns` tables which reference the `tables` table to include an explicit CASCADE ON DELETE to ensure the relevant records are deleted when a dataset is deleted. Scheduled downtime may be advised.
+- [24628]https://github.com/apache/superset/pull/24628): Augments the foreign key constraints for the `dashboard_owner`, `report_schedule_owner`, and `slice_owner` tables to include an explicit CASCADE ON DELETE to ensure the relevant ownership records are deleted when a dataset is deleted. Scheduled downtime may be advised.
+- [24488](https://github.com/apache/superset/pull/24488): Augments the foreign key constraints for the `sql_metrics`, `sqlatable_user`, and `table_columns` tables to include an explicit CASCADE ON DELETE to ensure the relevant records are deleted when a dataset is deleted. Scheduled downtime may be advised.
 - [24335](https://github.com/apache/superset/pull/24335): Removed deprecated API `/superset/filter/<datasource_type>/<int:datasource_id>/<column>/`
 - [24185](https://github.com/apache/superset/pull/24185): `/api/v1/database/test_connection` and `api/v1/database/validate_parameters` permissions changed from `can_read` to `can_write`. Only Admin user's have access.
 - [24232](https://github.com/apache/superset/pull/24232): Enables ENABLE_TEMPLATE_REMOVE_FILTERS, DRILL_TO_DETAIL, DASHBOARD_CROSS_FILTERS by default, marks VERSIONED_EXPORT and ENABLE_TEMPLATE_REMOVE_FILTERS as deprecated.

--- a/superset/charts/commands/delete.py
+++ b/superset/charts/commands/delete.py
@@ -47,10 +47,6 @@ class DeleteChartCommand(BaseCommand):
         self._model = cast(Slice, self._model)
         try:
             Dashboard.clear_cache_for_slice(slice_id=self._model_id)
-            # Even though SQLAlchemy should in theory delete rows from the association
-            # table, sporadically Superset will error because the rows are not deleted.
-            # Let's do it manually here to prevent the error.
-            self._model.owners = []
             ChartDAO.delete(self._model)
         except DAODeleteFailedError as ex:
             logger.exception(ex.exception)

--- a/superset/daos/chart.py
+++ b/superset/daos/chart.py
@@ -44,7 +44,6 @@ class ChartDAO(BaseDAO[Slice]):
         item_ids = [item.id for item in get_iterable(items)]
         # bulk delete, first delete related data
         for item in get_iterable(items):
-            item.owners = []
             item.dashboards = []
             db.session.merge(item)
         # bulk delete itself

--- a/superset/daos/dashboard.py
+++ b/superset/daos/dashboard.py
@@ -189,7 +189,6 @@ class DashboardDAO(BaseDAO[Dashboard]):
         # bulk delete, first delete related data
         for item in get_iterable(items):
             item.slices = []
-            item.owners = []
             item.embedded = []
             db.session.merge(item)
         # bulk delete itself

--- a/superset/daos/report.py
+++ b/superset/daos/report.py
@@ -36,7 +36,7 @@ from superset.reports.models import (
     ReportScheduleType,
     ReportState,
 )
-from superset.utils.core import get_iterable, get_user_id
+from superset.utils.core import get_user_id
 
 logger = logging.getLogger(__name__)
 
@@ -94,30 +94,6 @@ class ReportScheduleDAO(BaseDAO[ReportSchedule]):
             .filter(ReportSchedule.database_id.in_(database_ids))
             .all()
         )
-
-    @classmethod
-    def delete(
-        cls,
-        items: ReportSchedule | list[ReportSchedule],
-        commit: bool = True,
-    ) -> None:
-        item_ids = [item.id for item in get_iterable(items)]
-        try:
-            # Clean owners secondary table
-            report_schedules = (
-                db.session.query(ReportSchedule)
-                .filter(ReportSchedule.id.in_(item_ids))
-                .all()
-            )
-            for report_schedule in report_schedules:
-                report_schedule.owners = []
-            for report_schedule in report_schedules:
-                db.session.delete(report_schedule)
-            if commit:
-                db.session.commit()
-        except SQLAlchemyError as ex:
-            db.session.rollback()
-            raise DAODeleteFailedError(str(ex)) from ex
 
     @staticmethod
     def validate_unique_creation_method(

--- a/superset/examples/birth_names.py
+++ b/superset/examples/birth_names.py
@@ -535,7 +535,6 @@ def create_dashboard(slices: list[Slice]) -> Dashboard:
     dash = db.session.query(Dashboard).filter_by(slug="births").first()
     if not dash:
         dash = Dashboard()
-        dash.owners = []
         db.session.add(dash)
 
     dash.published = True

--- a/superset/migrations/shared/constraints.py
+++ b/superset/migrations/shared/constraints.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from alembic import op
+from sqlalchemy.engine.reflection import Inspector
+
+from superset.utils.core import generic_find_fk_constraint_name
+
+
+@dataclass(frozen=True)
+class ForeignKey:
+    table: str
+    referent_table: str
+    local_cols: list[str]
+    remote_cols: list[str]
+
+    @property
+    def constraint_name(self) -> str:
+        return f"fk_{self.table}_{self.local_cols[0]}_{self.referent_table}"
+
+
+def redefine(
+    foreign_key: ForeignKey,
+    on_delete: str | None = None,
+    on_update: str | None = None,
+) -> None:
+    """
+    Redefine the foreign key constraint to include the ON DELETE and ON UPDATE
+    constructs for cascading purposes.
+
+    :params foreign_key: The foreign key constraint
+    :param ondelete: If set, emit ON DELETE <value> when issuing DDL operations
+    :param onupdate: If set, emit ON UPDATE <value> when issuing DDL operations
+    """
+
+    bind = op.get_bind()
+    insp = Inspector.from_engine(bind)
+    conv = {"fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s"}
+
+    with op.batch_alter_table(foreign_key.table, naming_convention=conv) as batch_op:
+        if constraint := generic_find_fk_constraint_name(
+            table=foreign_key.table,
+            columns=set(foreign_key.remote_cols),
+            referenced=foreign_key.referent_table,
+            insp=insp,
+        ):
+            batch_op.drop_constraint(constraint, type_="foreignkey")
+
+        batch_op.create_foreign_key(
+            constraint_name=foreign_key.constraint_name,
+            referent_table=foreign_key.referent_table,
+            local_cols=foreign_key.local_cols,
+            remote_cols=foreign_key.remote_cols,
+            ondelete=on_delete,
+            onupdate=on_update,
+        )

--- a/superset/migrations/versions/2023-07-07_15-51_6d05b0a70c89_add_on_delete_cascade_for_owners_references.py
+++ b/superset/migrations/versions/2023-07-07_15-51_6d05b0a70c89_add_on_delete_cascade_for_owners_references.py
@@ -17,14 +17,14 @@
 """add on delete cascade for owners references
 
 Revision ID: 6d05b0a70c89
-Revises: 240d23c7f86f
+Revises: f92a3124dd66
 Create Date: 2023-07-07 15:51:57.964635
 
 """
 
 # revision identifiers, used by Alembic.
 revision = "6d05b0a70c89"
-down_revision = "240d23c7f86f"
+down_revision = "f92a3124dd66"
 
 from superset.migrations.shared.constraints import ForeignKey, redefine
 

--- a/superset/migrations/versions/2023-07-07_15-51_6d05b0a70c89_add_on_delete_cascade_for_owners_references.py
+++ b/superset/migrations/versions/2023-07-07_15-51_6d05b0a70c89_add_on_delete_cascade_for_owners_references.py
@@ -14,43 +14,55 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""add on delete cascade for tables references
+"""add on delete cascade for owners references
 
-Revision ID: 6fbe660cac39
-Revises: 90139bf715e4
-Create Date: 2023-06-22 13:39:47.989373
+Revision ID: 6d05b0a70c89
+Revises: 240d23c7f86f
+Create Date: 2023-07-07 15:51:57.964635
 
 """
 
 # revision identifiers, used by Alembic.
-revision = "6fbe660cac39"
-down_revision = "90139bf715e4"
+revision = "6d05b0a70c89"
+down_revision = "240d23c7f86f"
 
 from superset.migrations.shared.constraints import ForeignKey, redefine
 
 foreign_keys = [
     ForeignKey(
-        table="sql_metrics",
-        referent_table="tables",
-        local_cols=["table_id"],
-        remote_cols=["id"],
-    ),
-    ForeignKey(
-        table="table_columns",
-        referent_table="tables",
-        local_cols=["table_id"],
-        remote_cols=["id"],
-    ),
-    ForeignKey(
-        table="sqlatable_user",
+        table="dashboard_user",
         referent_table="ab_user",
         local_cols=["user_id"],
         remote_cols=["id"],
     ),
     ForeignKey(
-        table="sqlatable_user",
-        referent_table="tables",
-        local_cols=["table_id"],
+        table="dashboard_user",
+        referent_table="dashboards",
+        local_cols=["dashboard_id"],
+        remote_cols=["id"],
+    ),
+    ForeignKey(
+        table="report_schedule_user",
+        referent_table="ab_user",
+        local_cols=["user_id"],
+        remote_cols=["id"],
+    ),
+    ForeignKey(
+        table="report_schedule_user",
+        referent_table="report_schedule",
+        local_cols=["report_schedule_id"],
+        remote_cols=["id"],
+    ),
+    ForeignKey(
+        table="slice_user",
+        referent_table="ab_user",
+        local_cols=["user_id"],
+        remote_cols=["id"],
+    ),
+    ForeignKey(
+        table="slice_user",
+        referent_table="slices",
+        local_cols=["slice_id"],
         remote_cols=["id"],
     ),
 ]

--- a/superset/migrations/versions/2023-07-11_15-51_6d05b0a70c89_add_on_delete_cascade_for_owners_references.py
+++ b/superset/migrations/versions/2023-07-11_15-51_6d05b0a70c89_add_on_delete_cascade_for_owners_references.py
@@ -18,7 +18,7 @@
 
 Revision ID: 6d05b0a70c89
 Revises: f92a3124dd66
-Create Date: 2023-07-07 15:51:57.964635
+Create Date: 2023-07-11 15:51:57.964635
 
 """
 

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -115,8 +115,8 @@ dashboard_user = Table(
     "dashboard_user",
     metadata,
     Column("id", Integer, primary_key=True),
-    Column("user_id", Integer, ForeignKey("ab_user.id")),
-    Column("dashboard_id", Integer, ForeignKey("dashboards.id")),
+    Column("user_id", Integer, ForeignKey("ab_user.id", ondelete="CASCADE")),
+    Column("dashboard_id", Integer, ForeignKey("dashboards.id", ondelete="CASCADE")),
 )
 
 
@@ -146,7 +146,11 @@ class Dashboard(Model, AuditMixinNullable, ImportExportMixin):
     slices: list[Slice] = relationship(
         Slice, secondary=dashboard_slices, backref="dashboards"
     )
-    owners = relationship(security_manager.user_model, secondary=dashboard_user)
+    owners = relationship(
+        security_manager.user_model,
+        secondary=dashboard_user,
+        passive_deletes=True,
+    )
     tags = relationship(
         "Tag",
         overlaps="objects,tag,tags,tags",

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -58,8 +58,8 @@ slice_user = Table(
     "slice_user",
     metadata,
     Column("id", Integer, primary_key=True),
-    Column("user_id", Integer, ForeignKey("ab_user.id")),
-    Column("slice_id", Integer, ForeignKey("slices.id")),
+    Column("user_id", Integer, ForeignKey("ab_user.id", ondelete="CASCADE")),
+    Column("slice_id", Integer, ForeignKey("slices.id", ondelete="CASCADE")),
 )
 logger = logging.getLogger(__name__)
 
@@ -95,7 +95,11 @@ class Slice(  # pylint: disable=too-many-public-methods
     last_saved_by = relationship(
         security_manager.user_model, foreign_keys=[last_saved_by_fk]
     )
-    owners = relationship(security_manager.user_model, secondary=slice_user)
+    owners = relationship(
+        security_manager.user_model,
+        secondary=slice_user,
+        passive_deletes=True,
+    )
     tags = relationship(
         "Tag",
         secondary="tagged_object",

--- a/superset/reports/models.py
+++ b/superset/reports/models.py
@@ -91,9 +91,17 @@ report_schedule_user = Table(
     "report_schedule_user",
     metadata,
     Column("id", Integer, primary_key=True),
-    Column("user_id", Integer, ForeignKey("ab_user.id"), nullable=False),
     Column(
-        "report_schedule_id", Integer, ForeignKey("report_schedule.id"), nullable=False
+        "user_id",
+        Integer,
+        ForeignKey("ab_user.id", ondelete="CASCADE"),
+        nullable=False,
+    ),
+    Column(
+        "report_schedule_id",
+        Integer,
+        ForeignKey("report_schedule.id", ondelete="CASCADE"),
+        nullable=False,
     ),
     UniqueConstraint("user_id", "report_schedule_id"),
 )
@@ -132,7 +140,11 @@ class ReportSchedule(Model, AuditMixinNullable, ExtraJSONMixin):
     # (Alerts) M-O to database
     database_id = Column(Integer, ForeignKey("dbs.id"), nullable=True)
     database = relationship(Database, foreign_keys=[database_id])
-    owners = relationship(security_manager.user_model, secondary=report_schedule_user)
+    owners = relationship(
+        security_manager.user_model,
+        secondary=report_schedule_user,
+        passive_deletes=True,
+    )
 
     # (Alerts) Stamped last observations
     last_eval_dttm = Column(DateTime)

--- a/superset/tables/models.py
+++ b/superset/tables/models.py
@@ -53,12 +53,12 @@ table_column_association_table = sa.Table(
     Model.metadata,  # pylint: disable=no-member
     sa.Column(
         "table_id",
-        sa.ForeignKey("sl_tables.id", ondelete="cascade"),
+        sa.ForeignKey("sl_tables.id", ondelete="CASCADE"),
         primary_key=True,
     ),
     sa.Column(
         "column_id",
-        sa.ForeignKey("sl_columns.id", ondelete="cascade"),
+        sa.ForeignKey("sl_columns.id", ondelete="CASCADE"),
         primary_key=True,
     ),
 )

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -1503,7 +1503,6 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         chart = db.session.query(Slice).filter_by(uuid=chart_config["uuid"]).one()
         assert chart.table == dataset
 
-        chart.owners = []
         db.session.delete(chart)
         db.session.commit()
         db.session.delete(dataset)
@@ -1575,7 +1574,6 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         dataset = database.tables[0]
         chart = db.session.query(Slice).filter_by(uuid=chart_config["uuid"]).one()
 
-        chart.owners = []
         db.session.delete(chart)
         db.session.commit()
         db.session.delete(dataset)

--- a/tests/integration_tests/charts/commands_tests.py
+++ b/tests/integration_tests/charts/commands_tests.py
@@ -282,8 +282,6 @@ class TestImportChartsCommand(SupersetTestCase):
 
         assert chart.owners == [admin]
 
-        chart.owners = []
-        database.owners = []
         db.session.delete(chart)
         db.session.delete(dataset)
         db.session.delete(database)

--- a/tests/integration_tests/commands_test.py
+++ b/tests/integration_tests/commands_test.py
@@ -146,9 +146,6 @@ class TestImportAssetsCommand(SupersetTestCase):
 
         assert dashboard.owners == [self.user]
 
-        dashboard.owners = []
-        chart.owners = []
-        database.owners = []
         db.session.delete(dashboard)
         db.session.delete(chart)
         db.session.delete(dataset)
@@ -190,10 +187,6 @@ class TestImportAssetsCommand(SupersetTestCase):
         chart = dashboard.slices[0]
         dataset = chart.table
         database = dataset.database
-        dashboard.owners = []
-
-        chart.owners = []
-        database.owners = []
         db.session.delete(dashboard)
         db.session.delete(chart)
         db.session.delete(dataset)

--- a/tests/integration_tests/dashboard_tests.py
+++ b/tests/integration_tests/dashboard_tests.py
@@ -213,7 +213,6 @@ class TestDashboard(SupersetTestCase):
         hidden_dash.dashboard_title = "Not My Dashboard"
         hidden_dash.slug = not_my_dash_slug
         hidden_dash.slices = []
-        hidden_dash.owners = []
 
         db.session.add(dash)
         db.session.add(hidden_dash)

--- a/tests/integration_tests/dashboards/commands_tests.py
+++ b/tests/integration_tests/dashboards/commands_tests.py
@@ -573,9 +573,6 @@ class TestImportDashboardsCommand(SupersetTestCase):
 
         assert dashboard.owners == [admin]
 
-        dashboard.owners = []
-        chart.owners = []
-        database.owners = []
         db.session.delete(dashboard)
         db.session.delete(chart)
         db.session.delete(dataset)

--- a/tests/integration_tests/datasets/commands_tests.py
+++ b/tests/integration_tests/datasets/commands_tests.py
@@ -400,7 +400,6 @@ class TestImportDatasetsCommand(SupersetTestCase):
         assert column.description is None
         assert column.python_date_format is None
 
-        dataset.database.owners = []
         db.session.delete(dataset)
         db.session.delete(dataset.database)
         db.session.commit()
@@ -528,7 +527,6 @@ class TestImportDatasetsCommand(SupersetTestCase):
         )
         assert len(database.tables) == 1
 
-        database.owners = []
         db.session.delete(database.tables[0])
         db.session.delete(database)
         db.session.commit()


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Per  [SIP-92 Proposal for restructuring the Python code base](https://github.com/apache/superset/issues/20630) https://github.com/apache/superset/pull/24331 organized all the DAOs to be housed within a shared folder—the result of which highlighted numerous inconsistencies, repetition, and inefficiencies.

This PR is somewhat akin to https://github.com/apache/superset/pull/24488 where explicit `ON DELETE CASCADE` operations are set for the ownership associations.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/20630
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided:  Takes ~ 1 minute for Airbnb's instance w/o load.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
