### PR TITLE
chore: Drop rouge constraints and tables

### DIFF
--- a/superset/migrations/versions/2023-07-07_20-06_f92a3124dd66_drop_rouge_constraints_and_tables.py
+++ b/superset/migrations/versions/2023-07-07_20-06_f92a3124dd66_drop_rouge_constraints_and_tables.py
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""drop rouge constraints and tables
+
+Revision ID: f92a3124dd66
+Revises: 240d23c7f86f
+Create Date: 2023-07-07 20:06:22.659096
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "f92a3124dd66"
+down_revision = "240d23c7f86f"
+
+from alembic import op
+from sqlalchemy.engine.reflection import Inspector
+
+from superset.utils.core import generic_find_fk_constraint_name
+
+
+def upgrade():
+    bind = op.get_bind()
+    insp = Inspector.from_engine(bind)
+    tables = insp.get_table_names()
+    conv = {"fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s"}
+
+    if "datasources" in tables:
+        with op.batch_alter_table("slices", naming_convention=conv) as batch_op:
+            if constraint := generic_find_fk_constraint_name(
+                table="slices",
+                columns={"id"},
+                referenced="datasources",
+                insp=insp,
+            ):
+                batch_op.drop_constraint(constraint, type_="foreignkey")
+
+    for table in [  # Child tables are ordered first.
+        "alert_logs",
+        "alert_owner",
+        "sql_observations",
+        "alerts",
+        "columns",
+        "metrics",
+        "druiddatasource_user",
+        "datasources",
+        "clusters",
+        "dashboard_email_schedules",
+        "slice_email_schedules",
+    ]:
+        if table in tables:
+            op.drop_table(table)
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Looking at the current schema,

```
$ rm superset.db
$ FLASK_DEBUG=true superset db upgrade
$ sqlite3 superset.db
sqlite> .tables
ab_permission               metrics                   
ab_permission_view          query                     
ab_permission_view_role     report_execution_log      
ab_register_user            report_recipient          
ab_role                     report_schedule           
ab_user                     report_schedule_user      
ab_user_role                rls_filter_roles          
ab_view_menu                rls_filter_tables         
alembic_version             row_level_security_filters
alert_logs                  saved_query               
alert_owner                 sl_columns                
alerts                      sl_dataset_columns        
annotation                  sl_dataset_tables         
annotation_layer            sl_dataset_users          
cache_keys                  sl_datasets               
clusters                    sl_table_columns          
columns                     sl_tables                 
css_templates               slice_email_schedules     
dashboard_email_schedules   slice_user                
dashboard_roles             slices                    
dashboard_slices            sql_metrics               
dashboard_user              sql_observations          
dashboards                  sqlatable_user            
datasources                 ssh_tunnels               
dbs                         tab_state                 
druiddatasource_user        table_columns             
dynamic_plugin              table_schema              
embedded_dashboards         tables                    
favstar                     tag                       
filter_sets                 tagged_object             
key_value                   url                       
keyvalue                    user_attribute            
logs                      
sqlite> 
```

it became apparent that there were a number of rouge tables—those which technically were likely dropped in other migrations—but seem to remain in the database. I speculate maybe these were accidentally skipped when resolving a diamond dependency.

This PR adds a migration to drop these tables. Note that the downgrade is a no-op as there's no reference to the underlying schemas in the code pre-migration. I'm made sure the migration is atomic by first checking that the table exists prior to it being dropped. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided: < 5 seconds
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
