### PR TITLE
fix: Chart can be added to dashboard by non-owner via save as option

### DIFF
--- a/superset-frontend/src/explore/components/SaveModal.test.jsx
+++ b/superset-frontend/src/explore/components/SaveModal.test.jsx
@@ -164,7 +164,7 @@ test('disables overwrite option for new slice', () => {
 
 test('disables overwrite option for non-owner', () => {
   const wrapperForNonOwner = getWrapper();
-  wrapperForNonOwner.setProps({ userId: 2 });
+  wrapperForNonOwner.setProps({ user: { userId: 2 } });
   const overwriteRadio = wrapperForNonOwner.find('#overwrite-radio');
   expect(overwriteRadio).toHaveLength(1);
   expect(overwriteRadio.prop('disabled')).toBe(true);

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -41,8 +41,11 @@ import { Radio } from 'src/components/Radio';
 import Button from 'src/components/Button';
 import { AsyncSelect } from 'src/components';
 import Loading from 'src/components/Loading';
+import { canUserEditDashboard } from 'src/dashboard/util/permissionUtils';
 import { setSaveChartModalVisibility } from 'src/explore/actions/saveModalActions';
 import { SaveActionType } from 'src/explore/types';
+import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
+import { Dashboard } from 'src/types/Dashboard';
 
 // Session storage key for recent dashboard
 const SK_DASHBOARD_ID = 'save_chart_recent_dashboard';
@@ -51,7 +54,7 @@ interface SaveModalProps extends RouteComponentProps {
   addDangerToast: (msg: string) => void;
   actions: Record<string, any>;
   form_data?: Record<string, any>;
-  userId: number;
+  user: UserWithPermissionsAndRoles;
   alert?: string;
   sliceName?: string;
   slice?: Record<string, any>;
@@ -111,7 +114,7 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
 
   canOverwriteSlice(): boolean {
     return (
-      this.props.slice?.owners?.includes(this.props.userId) &&
+      this.props.slice?.owners?.includes(this.props.user.userId) &&
       !this.props.slice?.is_managed_externally
     );
   }
@@ -124,10 +127,8 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
     }
     if (dashboardId) {
       try {
-        const result = await this.loadDashboard(dashboardId);
-        if (
-          result?.owners.some((owner: any) => owner.id === this.props.userId)
-        ) {
+        const result = (await this.loadDashboard(dashboardId)) as Dashboard;
+        if (canUserEditDashboard(result, this.props.user)) {
           this.setState({
             dashboard: { label: result.dashboard_title, value: result.id },
           });
@@ -300,7 +301,7 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
         {
           col: 'owners',
           opr: 'rel_m_m',
-          value: this.props.userId,
+          value: this.props.user.userId,
         },
       ],
       page,
@@ -486,7 +487,7 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
 interface StateProps {
   datasource: any;
   slice: any;
-  userId: any;
+  user: UserWithPermissionsAndRoles;
   dashboards: any;
   alert: any;
   isVisible: boolean;
@@ -500,7 +501,7 @@ function mapStateToProps({
   return {
     datasource: explore.datasource,
     slice: explore.slice,
-    userId: user?.userId,
+    user: user,
     dashboards: saveModal.dashboards,
     alert: saveModal.saveModalAlert,
     isVisible: saveModal.isVisible,

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -125,7 +125,10 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
     if (dashboardId) {
       try {
         const result = await this.loadDashboard(dashboardId);
-        if (result) {
+        if (
+          result &&
+          result.owners.some((owner: any) => owner.id === this.props.userId)
+        ) {
           this.setState({
             dashboard: { label: result.dashboard_title, value: result.id },
           });

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -126,8 +126,7 @@ class SaveModal extends React.Component<SaveModalProps, SaveModalState> {
       try {
         const result = await this.loadDashboard(dashboardId);
         if (
-          result &&
-          result.owners.some((owner: any) => owner.id === this.props.userId)
+          result?.owners.some((owner: any) => owner.id === this.props.userId)
         ) {
           this.setState({
             dashboard: { label: result.dashboard_title, value: result.id },

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -501,7 +501,7 @@ function mapStateToProps({
   return {
     datasource: explore.datasource,
     slice: explore.slice,
-    user: user,
+    user,
     dashboards: saveModal.dashboards,
     alert: saveModal.saveModalAlert,
     isVisible: saveModal.isVisible,

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -43,6 +43,7 @@ from superset.charts.commands.exceptions import (
     ChartInvalidError,
     ChartNotFoundError,
     ChartUpdateFailedError,
+    DashboardsForbiddenError,
 )
 from superset.charts.commands.export import ExportChartsCommand
 from superset.charts.commands.importers.dispatcher import ImportChartsCommand
@@ -314,6 +315,8 @@ class ChartRestApi(BaseSupersetModelRestApi):
               $ref: '#/components/responses/400'
             401:
               $ref: '#/components/responses/401'
+            403:
+              $ref: '#/components/responses/403'
             422:
               $ref: '#/components/responses/422'
             500:
@@ -327,6 +330,8 @@ class ChartRestApi(BaseSupersetModelRestApi):
         try:
             new_model = CreateChartCommand(item).run()
             return self.response(201, id=new_model.id, result=item)
+        except DashboardsForbiddenError as ex:
+            return self.response(ex.status, message=ex.message)
         except ChartInvalidError as ex:
             return self.response_422(message=ex.normalized_messages())
         except ChartCreateFailedError as ex:

--- a/superset/charts/commands/create.py
+++ b/superset/charts/commands/create.py
@@ -22,9 +22,11 @@ from flask import g
 from flask_appbuilder.models.sqla import Model
 from marshmallow import ValidationError
 
+from superset import security_manager
 from superset.charts.commands.exceptions import (
     ChartCreateFailedError,
     ChartInvalidError,
+    DashboardsForbiddenError,
     DashboardsNotFoundValidationError,
 )
 from superset.commands.base import BaseCommand, CreateMixin
@@ -69,6 +71,9 @@ class CreateChartCommand(CreateMixin, BaseCommand):
         dashboards = DashboardDAO.find_by_ids(dashboard_ids)
         if len(dashboards) != len(dashboard_ids):
             exceptions.append(DashboardsNotFoundValidationError())
+        for dash in dashboards:
+            if not security_manager.is_owner(dash):
+                raise DashboardsForbiddenError()
         self._properties["dashboards"] = dashboards
 
         try:

--- a/superset/charts/commands/exceptions.py
+++ b/superset/charts/commands/exceptions.py
@@ -155,6 +155,10 @@ class ChartImportError(ImportFailedError):
     message = _("Import chart failed for an unknown reason")
 
 
+class DashboardsForbiddenError(ForbiddenError):
+    message = _("Changing one or more of these dashboards is forbidden")
+
+
 class WarmUpCacheChartNotFoundError(CommandException):
     status = 404
     message = _("Chart not found")


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes a bug that allowed a user to add a chart to a dashboard they had access to view, but did not own.  This was possible because the `POST /api/v1/chart` endpoint used to create new charts allows a list of dashboard id's to be passed that the new chart should be added to.  However, the endpoint did not validate whether the user was an owner of these dashboards, only if they could view the dashboard (via the filter on the `DashboardDAO`).

This PR patches this endpoint so that it now verifies the user is an owner of each dashboard they are trying to add the new chart to.  It also includes a fix to the explore frontend code so that the save modal dashboard dropdown only pre-populates if the user is an owner of the dashboard they came from.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before (logged in as alpha role but not owner of the dashboard):

![non_owner_save_as_before](https://github.com/apache/superset/assets/47196419/207098b2-40d7-4dfd-b629-e9821df8539c)

After (same user):

![non_owner_save_as_after](https://github.com/apache/superset/assets/47196419/685fad00-e54e-49c7-9d05-31f2f053ccfd)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
