### PR TITLE
docs(databases): correct the way of using use environment variables

### DIFF
--- a/docs/docs/databases/extra-settings.mdx
+++ b/docs/docs/databases/extra-settings.mdx
@@ -45,9 +45,9 @@ A common pattern is to use environment variables to make secrets available.
 
 ```python
 def example_password_as_env_var(url):
-# assuming the uri looks like
-# mysql://localhost?superset_user:{SUPERSET_PASSWORD}
-return url.password.format(os.environ)
+    # assuming the uri looks like
+    # mysql://localhost?superset_user:{SUPERSET_PASSWORD}
+    return url.password.format(**os.environ)
 
 SQLALCHEMY_CUSTOM_PASSWORD_STORE = example_password_as_env_var
 ```


### PR DESCRIPTION
Correct the way of using use environment variables in `example_password_as_env_var` example

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
