### PR TITLE
fix: Incorrect initial global scoping of cross filters

### DIFF
--- a/superset-frontend/src/dashboard/util/crossFilters.test.ts
+++ b/superset-frontend/src/dashboard/util/crossFilters.test.ts
@@ -175,7 +175,6 @@ test('Generate correct cross filters configuration without initial configuration
       chartsInScope: [1, 2],
     },
   });
-  metadataRegistryStub.restore();
 });
 
 test('Generate correct cross filters configuration with initial configuration', () => {
@@ -218,7 +217,6 @@ test('Generate correct cross filters configuration with initial configuration', 
       chartsInScope: [1, 2],
     },
   });
-  metadataRegistryStub.restore();
 });
 
 test('Return undefined if DASHBOARD_CROSS_FILTERS feature flag is disabled', () => {
@@ -233,4 +231,86 @@ test('Return undefined if DASHBOARD_CROSS_FILTERS feature flag is disabled', () 
       CHARTS,
     ),
   ).toEqual(undefined);
+});
+
+test('Recalculate charts in global filter scope when charts change', () => {
+  // @ts-ignore
+  global.featureFlags = {
+    [FeatureFlag.DASHBOARD_CROSS_FILTERS]: true,
+  };
+  expect(
+    getCrossFiltersConfiguration(
+      {
+        ...DASHBOARD_LAYOUT,
+        'CHART-3': {
+          children: [],
+          id: 'CHART-3',
+          meta: {
+            chartId: 3,
+            sliceName: 'Test chart 3',
+            height: 1,
+            width: 1,
+            uuid: '3',
+          },
+          parents: ['ROOT_ID', 'GRID_ID', 'ROW-6XUMf1rV76'],
+          type: 'CHART',
+        },
+      },
+      CHART_CONFIG_METADATA,
+      {
+        ...CHARTS,
+        '3': {
+          id: 3,
+          form_data: {
+            datasource: '3__table',
+            viz_type: 'echarts_timeseries_line',
+          },
+          chartAlert: null,
+          chartStatus: 'rendered' as const,
+          chartUpdateEndTime: 0,
+          chartUpdateStartTime: 0,
+          lastRendered: 0,
+          latestQueryFormData: {},
+          sliceFormData: {
+            datasource: '3__table',
+            viz_type: 'echarts_timeseries_line',
+          },
+          queryController: null,
+          queriesResponse: [{}],
+          triggerQuery: false,
+        },
+      },
+    ),
+  ).toEqual({
+    chartConfiguration: {
+      '1': {
+        id: 1,
+        crossFilters: {
+          scope: { rootPath: ['ROOT_ID'], excluded: [1, 2] },
+          chartsInScope: [3],
+        },
+      },
+      '2': {
+        id: 2,
+        crossFilters: {
+          scope: 'global',
+          chartsInScope: [1, 3],
+        },
+      },
+      '3': {
+        id: 3,
+        crossFilters: {
+          scope: 'global',
+          chartsInScope: [1, 2],
+        },
+      },
+    },
+    globalChartConfiguration: {
+      scope: {
+        excluded: [],
+        rootPath: ['ROOT_ID'],
+      },
+      chartsInScope: [1, 2, 3],
+    },
+  });
 });

--- a/superset-frontend/src/dashboard/util/crossFilters.ts
+++ b/superset-frontend/src/dashboard/util/crossFilters.ts
@@ -53,7 +53,14 @@ export const getCrossFiltersConfiguration = (
   }
 
   const globalChartConfiguration = metadata.global_chart_configuration
-    ? cloneDeep(metadata.global_chart_configuration)
+    ? {
+        scope: metadata.global_chart_configuration.scope,
+        chartsInScope: getChartIdsInFilterScope(
+          metadata.global_chart_configuration.scope,
+          Object.values(charts).map(chart => chart.id),
+          dashboardLayout,
+        ),
+      }
     : {
         scope: DEFAULT_CROSS_FILTER_SCOPING,
         chartsInScope: Object.values(charts).map(chart => chart.id),


### PR DESCRIPTION

### SUMMARY
When user first created a new dashboard, initially charts in global scope of cross filters was an empty array (since dashboard was empty). However, after adding new charts, we didn't update the chartsInScope array for global scoping. This PR fixes the bug.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF


### TESTING INSTRUCTIONS
1. Create a new dashboard
2. Populate with charts (Table chart, Line chart, etc).
3. Click on the Table’s cell to trigger the cross-filtering.
4. Verify that cross filtering from table was applied to other charts

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
