### PR TITLE
fix: Ensure metrics is an array in Mixed Chart

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -223,13 +223,13 @@ export default function transformProps(
     contributionMode ? ',.0%' : yAxisFormatSecondary,
   );
   const customFormatters = buildCustomFormatters(
-    [...metrics, ...metricsB],
+    [...ensureIsArray(metrics), ...ensureIsArray(metricsB)],
     currencyFormats,
     columnFormats,
     yAxisFormat,
   );
   const customFormattersSecondary = buildCustomFormatters(
-    [...metrics, ...metricsB],
+    [...ensureIsArray(metrics), ...ensureIsArray(metricsB)],
     currencyFormats,
     columnFormats,
     yAxisFormatSecondary,

--- a/superset/examples/birth_names.py
+++ b/superset/examples/birth_names.py
@@ -392,14 +392,16 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             params=get_slice_json(
                 defaults,
                 viz_type="mixed_timeseries",
-                metrics={
-                    "expressionType": "SIMPLE",
-                    "column": {"column_name": "num", "type": "BIGINT(20)"},
-                    "aggregate": "AVG",
-                    "label": "AVG(num)",
-                    "optionName": "metric_vgops097wej_g8uff99zhk7",
-                },
-                metrics_b="sum__num",
+                metrics=[
+                    {
+                        "expressionType": "SIMPLE",
+                        "column": {"column_name": "num", "type": "BIGINT(20)"},
+                        "aggregate": "AVG",
+                        "label": "AVG(num)",
+                        "optionName": "metric_vgops097wej_g8uff99zhk7",
+                    }
+                ],
+                metrics_b=["sum__num"],
                 granularity_sqla="ds",
                 yAxisIndex=0,
                 yAxisIndexB=1,


### PR DESCRIPTION

### SUMMARY
In a Mixed Chart metadata from examples db (Average and Sum Trends), `metrics` and `metrics_b` is a single value instead of an array. This PR fixes that + adds failsafe in Mixed Chart metrics array spreading

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
Add Average and Sum Trends chart to a dashboard, make sure it loads correctly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
