### PR TITLE
fix(dataset-import): support empty strings for extra fields

### DIFF
--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -204,8 +204,13 @@ class ImportV1DatasetSchema(Schema):
         """
         Fix for extra initially being exported as a string.
         """
-        if isinstance(data.get("extra"), str):
-            data["extra"] = json.loads(data["extra"])
+        if "extra" in data:
+            extra = data["extra"]
+            if isinstance(extra, str):
+                if extra.strip():
+                    data["extra"] = json.loads(extra)
+                else:
+                    data["extra"] = {}
 
         return data
 

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -204,13 +204,12 @@ class ImportV1DatasetSchema(Schema):
         """
         Fix for extra initially being exported as a string.
         """
-        if "extra" in data:
-            extra = data["extra"]
-            if isinstance(extra, str):
-                if extra.strip():
-                    data["extra"] = json.loads(extra)
-                else:
-                    data["extra"] = {}
+        if isinstance(data.get("extra"), str):
+            try:
+                extra = data["extra"]
+                data["extra"] = json.loads(extra) if extra.strip() else None
+            except ValueError:
+                data["extra"] = None
 
         return data
 

--- a/tests/unit_tests/datasets/commands/importers/v1/import_test.py
+++ b/tests/unit_tests/datasets/commands/importers/v1/import_test.py
@@ -419,7 +419,7 @@ def test_import_dataset_extra_empty_string(
     dataset_config["database_id"] = database.id
     sqla_table = import_dataset(session, dataset_config)
 
-    assert sqla_table.extra == "{}"
+    assert sqla_table.extra == None
 
 
 @patch("superset.datasets.commands.importers.v1.utils.request")

--- a/tests/unit_tests/datasets/commands/importers/v1/import_test.py
+++ b/tests/unit_tests/datasets/commands/importers/v1/import_test.py
@@ -359,6 +359,69 @@ def test_import_column_extra_is_string(mocker: MockFixture, session: Session) ->
     assert sqla_table.extra == '{"warning_markdown": "*WARNING*"}'
 
 
+def test_import_dataset_extra_empty_string(
+    mocker: MockFixture, session: Session
+) -> None:
+    """
+    Test importing a dataset when the extra field is an empty string.
+    """
+    from superset import security_manager
+    from superset.connectors.sqla.models import SqlaTable
+    from superset.datasets.commands.importers.v1.utils import import_dataset
+    from superset.datasets.schemas import ImportV1DatasetSchema
+    from superset.models.core import Database
+
+    mocker.patch.object(security_manager, "can_access", return_value=True)
+
+    engine = session.get_bind()
+    SqlaTable.metadata.create_all(engine)  # pylint: disable=no-member
+
+    database = Database(database_name="my_database", sqlalchemy_uri="sqlite://")
+    session.add(database)
+    session.flush()
+
+    dataset_uuid = uuid.uuid4()
+    yaml_config: dict[str, Any] = {
+        "version": "1.0.0",
+        "table_name": "my_table",
+        "main_dttm_col": "ds",
+        "schema": "my_schema",
+        "sql": None,
+        "params": {
+            "remote_id": 64,
+            "database_name": "examples",
+            "import_time": 1606677834,
+        },
+        "extra": " ",
+        "uuid": dataset_uuid,
+        "metrics": [
+            {
+                "metric_name": "cnt",
+                "expression": "COUNT(*)",
+            }
+        ],
+        "columns": [
+            {
+                "column_name": "profit",
+                "is_dttm": False,
+                "is_active": True,
+                "type": "INTEGER",
+                "groupby": False,
+                "filterable": False,
+                "expression": "revenue-expenses",
+            }
+        ],
+        "database_uuid": database.uuid,
+    }
+
+    schema = ImportV1DatasetSchema()
+    dataset_config = schema.load(yaml_config)
+    dataset_config["database_id"] = database.id
+    sqla_table = import_dataset(session, dataset_config)
+
+    assert sqla_table.extra == "{}"
+
+
 @patch("superset.datasets.commands.importers.v1.utils.request")
 def test_import_column_allowed_data_url(
     request: Mock,


### PR DESCRIPTION
### SUMMARY
During the import process, the `extra` value for datasets is loaded as a dictionary. This operation fails in case the `extra` key has an empty string (`extra: ""`).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Edit an existing dataset.
2. Add any information to the `extra` value (in the UI).
3. Save changes.
4. Modify the dataset again.
5. Remove your text changes. 
6. Save changes. The dataset now has `extra: ""`. 
7. Export the dataset.
8. Import it back.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #24662
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
