### PR TITLE
chore: Remove obsolete legacy visualizations

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1076,65 +1076,6 @@ class BulletViz(NVD3Viz):
         }
 
 
-class BigNumberViz(BaseViz):
-
-    """Put emphasis on a single metric with this big number viz"""
-
-    viz_type = "big_number"
-    verbose_name = _("Big Number with Trendline")
-    credits = 'a <a href="https://github.com/airbnb/superset">Superset</a> original'
-    is_timeseries = True
-
-    @deprecated(deprecated_in="3.0")
-    def query_obj(self) -> QueryObjectDict:
-        query_obj = super().query_obj()
-        metric = self.form_data.get("metric")
-        if not metric:
-            raise QueryObjectValidationError(_("Pick a metric!"))
-        query_obj["metrics"] = [self.form_data.get("metric")]
-        self.form_data["metric"] = metric
-        return query_obj
-
-    @deprecated(deprecated_in="3.0")
-    def get_data(self, df: pd.DataFrame) -> VizData:
-        if df.empty:
-            return None
-
-        df = df.pivot_table(
-            index=DTTM_ALIAS,
-            columns=[],
-            values=self.metric_labels,
-            dropna=False,
-            aggfunc=np.min,  # looking for any (only) value, preserving `None`
-        )
-        df = self.apply_rolling(df)
-        df[DTTM_ALIAS] = df.index
-        return super().get_data(df)
-
-
-class BigNumberTotalViz(BaseViz):
-
-    """Put emphasis on a single metric with this big number viz"""
-
-    viz_type = "big_number_total"
-    verbose_name = _("Big Number")
-    credits = 'a <a href="https://github.com/airbnb/superset">Superset</a> original'
-    is_timeseries = False
-
-    @deprecated(deprecated_in="3.0")
-    def query_obj(self) -> QueryObjectDict:
-        query_obj = super().query_obj()
-        metric = self.form_data.get("metric")
-        if not metric:
-            raise QueryObjectValidationError(_("Pick a metric!"))
-        query_obj["metrics"] = [self.form_data.get("metric")]
-        self.form_data["metric"] = metric
-
-        # Limiting rows is not required as only one cell is returned
-        query_obj["row_limit"] = None
-        return query_obj
-
-
 class NVD3TimeSeriesViz(NVD3Viz):
 
     """A rich line chart component with tons of options"""

--- a/tests/integration_tests/viz_tests.py
+++ b/tests/integration_tests/viz_tests.py
@@ -1311,7 +1311,7 @@ class TestTimeSeriesViz(SupersetTestCase):
             data={"y": [1.0, 2.0, 3.0, 4.0]},
         )
         self.assertEqual(
-            viz.BigNumberViz(
+            viz.NVD3TimeSeriesViz(
                 datasource,
                 {
                     "metrics": ["y"],
@@ -1325,7 +1325,7 @@ class TestTimeSeriesViz(SupersetTestCase):
             [1.0, 3.0, 6.0, 10.0],
         )
         self.assertEqual(
-            viz.BigNumberViz(
+            viz.NVD3TimeSeriesViz(
                 datasource,
                 {
                     "metrics": ["y"],
@@ -1339,7 +1339,7 @@ class TestTimeSeriesViz(SupersetTestCase):
             [1.0, 3.0, 5.0, 7.0],
         )
         self.assertEqual(
-            viz.BigNumberViz(
+            viz.NVD3TimeSeriesViz(
                 datasource,
                 {
                     "metrics": ["y"],
@@ -1361,7 +1361,7 @@ class TestTimeSeriesViz(SupersetTestCase):
             ),
             data={"y": [1.0, 2.0, 3.0, 4.0]},
         )
-        test_viz = viz.BigNumberViz(
+        test_viz = viz.NVD3TimeSeriesViz(
             datasource,
             {
                 "metrics": ["y"],
@@ -1372,34 +1372,6 @@ class TestTimeSeriesViz(SupersetTestCase):
         )
         with pytest.raises(QueryObjectValidationError):
             test_viz.apply_rolling(df)
-
-
-class TestBigNumberViz(SupersetTestCase):
-    def test_get_data(self):
-        datasource = self.get_datasource_mock()
-        df = pd.DataFrame(
-            data={
-                DTTM_ALIAS: pd.to_datetime(
-                    ["2019-01-01", "2019-01-02", "2019-01-05", "2019-01-07"]
-                ),
-                "y": [1.0, 2.0, 3.0, 4.0],
-            }
-        )
-        data = viz.BigNumberViz(datasource, {"metrics": ["y"]}).get_data(df)
-        self.assertEqual(data[2], {DTTM_ALIAS: pd.Timestamp("2019-01-05"), "y": 3})
-
-    def test_get_data_with_none(self):
-        datasource = self.get_datasource_mock()
-        df = pd.DataFrame(
-            data={
-                DTTM_ALIAS: pd.to_datetime(
-                    ["2019-01-01", "2019-01-02", "2019-01-05", "2019-01-07"]
-                ),
-                "y": [1.0, 2.0, None, 4.0],
-            }
-        )
-        data = viz.BigNumberViz(datasource, {"metrics": ["y"]}).get_data(df)
-        assert np.isnan(data[2]["y"])
 
 
 class TestFilterBoxViz(SupersetTestCase):


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This is a rehash of https://github.com/apache/superset/pull/24675 without the deprecation of the `TableViz` as sadly the legacy visualization is deeply entangled with the annotation layers. Specifically this PR removes the following obsolete chart types:

- `BigNumberViz`
- `BigNumberTotalViz`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
