### PR TITLE
fix: import database engine validation

### DIFF
--- a/superset/databases/commands/importers/v1/utils.py
+++ b/superset/databases/commands/importers/v1/utils.py
@@ -18,12 +18,16 @@
 import json
 from typing import Any
 
+from sqlalchemy.engine.url import make_url
 from sqlalchemy.orm import Session
 
 from superset import security_manager
 from superset.commands.exceptions import ImportFailedError
 from superset.databases.ssh_tunnel.models import SSHTunnel
+from superset.databases.utils import make_url_safe
+from superset.exceptions import SupersetSecurityException
 from superset.models.core import Database
+from superset.security.analytics_db_safety import check_sqlalchemy_uri
 
 
 def import_database(
@@ -45,7 +49,11 @@ def import_database(
         raise ImportFailedError(
             "Database doesn't exist and user doesn't have permission to create databases"
         )
-
+    # Check if this URI is allowed
+    try:
+        check_sqlalchemy_uri(make_url_safe(config["sqlalchemy_uri"]))
+    except SupersetSecurityException as e:
+        raise ImportFailedError(e.message)
     # https://github.com/apache/superset/pull/16756 renamed ``csv`` to ``file``.
     config["allow_file_upload"] = config.pop("allow_csv_upload")
     if "schemas_allowed_for_csv_upload" in config["extra"]:

--- a/tests/integration_tests/databases/commands_tests.py
+++ b/tests/integration_tests/databases/commands_tests.py
@@ -421,7 +421,7 @@ class TestImportDatabasesCommand(SupersetTestCase):
         assert database.database_name == "imported_database"
         assert database.expose_in_sqllab
         assert database.extra == "{}"
-        assert database.sqlalchemy_uri == "sqlite:///test.db"
+        assert database.sqlalchemy_uri == "someengine://user:pass@host1"
 
         db.session.delete(database)
         db.session.commit()
@@ -460,7 +460,7 @@ class TestImportDatabasesCommand(SupersetTestCase):
         assert database.database_name == "imported_database"
         assert database.expose_in_sqllab
         assert database.extra == '{"schemas_allowed_for_file_upload": ["upload"]}'
-        assert database.sqlalchemy_uri == "sqlite:///test.db"
+        assert database.sqlalchemy_uri == "someengine://user:pass@host1"
 
         db.session.delete(database)
         db.session.commit()
@@ -716,7 +716,7 @@ class TestImportDatabasesCommand(SupersetTestCase):
         assert database.database_name == "imported_database"
         assert database.expose_in_sqllab
         assert database.extra == "{}"
-        assert database.sqlalchemy_uri == "sqlite:///test.db"
+        assert database.sqlalchemy_uri == "someengine://user:pass@host1"
 
         model_ssh_tunnel = (
             db.session.query(SSHTunnel)
@@ -761,7 +761,7 @@ class TestImportDatabasesCommand(SupersetTestCase):
         assert database.database_name == "imported_database"
         assert database.expose_in_sqllab
         assert database.extra == "{}"
-        assert database.sqlalchemy_uri == "sqlite:///test.db"
+        assert database.sqlalchemy_uri == "someengine://user:pass@host1"
 
         model_ssh_tunnel = (
             db.session.query(SSHTunnel)

--- a/tests/integration_tests/fixtures/importexport.py
+++ b/tests/integration_tests/fixtures/importexport.py
@@ -386,7 +386,7 @@ database_with_ssh_tunnel_config_private_key: dict[str, Any] = {
     "database_name": "imported_database",
     "expose_in_sqllab": True,
     "extra": {},
-    "sqlalchemy_uri": "sqlite:///test.db",
+    "sqlalchemy_uri": "someengine://user:pass@host1",
     "uuid": "b8a1ccd3-779d-4ab7-8ad8-9ab119d7fe89",
     "ssh_tunnel": {
         "server_address": "localhost",
@@ -408,7 +408,7 @@ database_with_ssh_tunnel_config_password: dict[str, Any] = {
     "database_name": "imported_database",
     "expose_in_sqllab": True,
     "extra": {},
-    "sqlalchemy_uri": "sqlite:///test.db",
+    "sqlalchemy_uri": "someengine://user:pass@host1",
     "uuid": "b8a1ccd3-779d-4ab7-8ad8-9ab119d7fe89",
     "ssh_tunnel": {
         "server_address": "localhost",

--- a/tests/integration_tests/fixtures/importexport.py
+++ b/tests/integration_tests/fixtures/importexport.py
@@ -346,7 +346,7 @@ saved_queries_metadata_config: dict[str, Any] = {
     "type": "SavedQuery",
     "timestamp": "2021-03-30T20:37:54.791187+00:00",
 }
-database_config: dict[str, Any] = {
+database_config_sqlite: dict[str, Any] = {
     "allow_csv_upload": True,
     "allow_ctas": True,
     "allow_cvas": True,
@@ -361,7 +361,7 @@ database_config: dict[str, Any] = {
     "version": "1.0.0",
 }
 
-database_config_non_sqlite: dict[str, Any] = {
+database_config: dict[str, Any] = {
     "allow_csv_upload": True,
     "allow_ctas": True,
     "allow_cvas": True,

--- a/tests/integration_tests/fixtures/importexport.py
+++ b/tests/integration_tests/fixtures/importexport.py
@@ -361,6 +361,21 @@ database_config: dict[str, Any] = {
     "version": "1.0.0",
 }
 
+database_config_non_sqlite: dict[str, Any] = {
+    "allow_csv_upload": True,
+    "allow_ctas": True,
+    "allow_cvas": True,
+    "allow_dml": True,
+    "allow_run_async": False,
+    "cache_timeout": None,
+    "database_name": "imported_database",
+    "expose_in_sqllab": True,
+    "extra": {},
+    "sqlalchemy_uri": "someengine://user:pass@host1",
+    "uuid": "b8a1ccd3-779d-4ab7-8ad8-9ab119d7fe89",
+    "version": "1.0.0",
+}
+
 database_with_ssh_tunnel_config_private_key: dict[str, Any] = {
     "allow_csv_upload": True,
     "allow_ctas": True,

--- a/tests/unit_tests/databases/commands/importers/v1/import_test.py
+++ b/tests/unit_tests/databases/commands/importers/v1/import_test.py
@@ -32,14 +32,14 @@ def test_import_database(mocker: MockFixture, session: Session) -> None:
     from superset import security_manager
     from superset.databases.commands.importers.v1.utils import import_database
     from superset.models.core import Database
-    from tests.integration_tests.fixtures.importexport import database_config_non_sqlite
+    from tests.integration_tests.fixtures.importexport import database_config
 
     mocker.patch.object(security_manager, "can_access", return_value=True)
 
     engine = session.get_bind()
     Database.metadata.create_all(engine)  # pylint: disable=no-member
 
-    config = copy.deepcopy(database_config_non_sqlite)
+    config = copy.deepcopy(database_config)
     database = import_database(session, config)
     assert database.database_name == "imported_database"
     assert database.sqlalchemy_uri == "someengine://user:pass@host1"
@@ -57,7 +57,7 @@ def test_import_database(mocker: MockFixture, session: Session) -> None:
 
     # ``allow_dml`` was initially not exported; the import should work if the field is
     # missing
-    config = copy.deepcopy(database_config_non_sqlite)
+    config = copy.deepcopy(database_config)
     del config["allow_dml"]
     session.delete(database)
     session.flush()
@@ -72,7 +72,7 @@ def test_import_database_sqlite_invalid(mocker: MockFixture, session: Session) -
     from superset import app, security_manager
     from superset.databases.commands.importers.v1.utils import import_database
     from superset.models.core import Database
-    from tests.integration_tests.fixtures.importexport import database_config
+    from tests.integration_tests.fixtures.importexport import database_config_sqlite
 
     app.config["PREVENT_UNSAFE_DB_CONNECTIONS"] = True
     mocker.patch.object(security_manager, "can_access", return_value=True)
@@ -80,7 +80,7 @@ def test_import_database_sqlite_invalid(mocker: MockFixture, session: Session) -
     engine = session.get_bind()
     Database.metadata.create_all(engine)  # pylint: disable=no-member
 
-    config = copy.deepcopy(database_config)
+    config = copy.deepcopy(database_config_sqlite)
     with pytest.raises(ImportFailedError) as excinfo:
         _ = import_database(session, config)
     assert (
@@ -101,14 +101,14 @@ def test_import_database_managed_externally(
     from superset import security_manager
     from superset.databases.commands.importers.v1.utils import import_database
     from superset.models.core import Database
-    from tests.integration_tests.fixtures.importexport import database_config_non_sqlite
+    from tests.integration_tests.fixtures.importexport import database_config
 
     mocker.patch.object(security_manager, "can_access", return_value=True)
 
     engine = session.get_bind()
     Database.metadata.create_all(engine)  # pylint: disable=no-member
 
-    config = copy.deepcopy(database_config_non_sqlite)
+    config = copy.deepcopy(database_config)
     config["is_managed_externally"] = True
     config["external_url"] = "https://example.org/my_database"
 
@@ -127,14 +127,14 @@ def test_import_database_without_permission(
     from superset import security_manager
     from superset.databases.commands.importers.v1.utils import import_database
     from superset.models.core import Database
-    from tests.integration_tests.fixtures.importexport import database_config_non_sqlite
+    from tests.integration_tests.fixtures.importexport import database_config
 
     mocker.patch.object(security_manager, "can_access", return_value=False)
 
     engine = session.get_bind()
     Database.metadata.create_all(engine)  # pylint: disable=no-member
 
-    config = copy.deepcopy(database_config_non_sqlite)
+    config = copy.deepcopy(database_config)
 
     with pytest.raises(ImportFailedError) as excinfo:
         import_database(session, config)

--- a/tests/unit_tests/databases/commands/importers/v1/import_test.py
+++ b/tests/unit_tests/databases/commands/importers/v1/import_test.py
@@ -69,11 +69,12 @@ def test_import_database_sqlite_invalid(mocker: MockFixture, session: Session) -
     """
     Test importing a database.
     """
-    from superset import security_manager
+    from superset import app, security_manager
     from superset.databases.commands.importers.v1.utils import import_database
     from superset.models.core import Database
     from tests.integration_tests.fixtures.importexport import database_config
 
+    app.config["PREVENT_UNSAFE_DB_CONNECTIONS"] = True
     mocker.patch.object(security_manager, "can_access", return_value=True)
 
     engine = session.get_bind()
@@ -86,6 +87,8 @@ def test_import_database_sqlite_invalid(mocker: MockFixture, session: Session) -
         str(excinfo.value)
         == "SQLiteDialect_pysqlite cannot be used as a data source for security reasons."
     )
+    # restore app config
+    app.config["PREVENT_UNSAFE_DB_CONNECTIONS"] = True
 
 
 def test_import_database_managed_externally(


### PR DESCRIPTION
### SUMMARY
Fixes improves URI validation when importing databases, will work for importing datasets also.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
