### PR TITLE
fix: Select onChange is being fired without explicit selection

### DIFF
--- a/superset-frontend/src/components/ListView/ListView.test.jsx
+++ b/superset-frontend/src/components/ListView/ListView.test.jsx
@@ -470,7 +470,7 @@ describe('ListView', () => {
     });
 
     await act(async () => {
-      wrapper2.find('[aria-label="Sort"]').first().props().onChange({
+      wrapper2.find('[aria-label="Sort"]').first().props().onSelect({
         desc: false,
         id: 'something',
         label: 'Alphabetical',

--- a/superset-frontend/src/components/Select/AsyncSelect.test.tsx
+++ b/superset-frontend/src/components/Select/AsyncSelect.test.tsx
@@ -522,7 +522,7 @@ test('changes the selected item in single mode', async () => {
       label: firstOption.label,
       value: firstOption.value,
     }),
-    firstOption,
+    expect.objectContaining(firstOption),
   );
   expect(await findSelectValue()).toHaveTextContent(firstOption.label);
   userEvent.click(await findSelectOption(secondOption.label));
@@ -531,7 +531,7 @@ test('changes the selected item in single mode', async () => {
       label: secondOption.label,
       value: secondOption.value,
     }),
-    secondOption,
+    expect.objectContaining(secondOption),
   );
   expect(await findSelectValue()).toHaveTextContent(secondOption.label);
 });
@@ -802,6 +802,25 @@ test('Renders only an overflow tag if dropdown is open in oneLine mode', async (
   expect(withinSelector.queryByText(OPTIONS[1].label)).not.toBeInTheDocument();
   expect(withinSelector.queryByText(OPTIONS[2].label)).not.toBeInTheDocument();
   expect(withinSelector.getByText('+ 2 ...')).toBeVisible();
+});
+
+test('does not fire onChange when searching but no selection', async () => {
+  const onChange = jest.fn();
+  render(
+    <div role="main">
+      <AsyncSelect
+        {...defaultProps}
+        onChange={onChange}
+        mode="multiple"
+        allowNewOptions
+      />
+    </div>,
+  );
+  await open();
+  await type('Joh');
+  userEvent.click(await findSelectOption('John'));
+  userEvent.click(screen.getByRole('main'));
+  expect(onChange).toHaveBeenCalledTimes(1);
 });
 
 /*

--- a/superset-frontend/src/components/Select/AsyncSelect.tsx
+++ b/superset-frontend/src/components/Select/AsyncSelect.tsx
@@ -28,7 +28,7 @@ import React, {
   useCallback,
   useImperativeHandle,
 } from 'react';
-import { ensureIsArray, t } from '@superset-ui/core';
+import { ensureIsArray, t, usePrevious } from '@superset-ui/core';
 import { LabeledValue as AntdLabeledValue } from 'antd/lib/select';
 import debounce from 'lodash/debounce';
 import { isEqual } from 'lodash';
@@ -47,6 +47,7 @@ import {
   getSuffixIcon,
   dropDownRenderHelper,
   handleFilterOptionHelper,
+  mapOptions,
 } from './utils';
 import {
   AsyncSelectProps,
@@ -54,6 +55,7 @@ import {
   SelectOptionsPagePromise,
   SelectOptionsType,
   SelectOptionsTypePage,
+  SelectProps,
 } from './types';
 import {
   StyledCheckOutlined,
@@ -113,10 +115,13 @@ const AsyncSelect = forwardRef(
       mode = 'single',
       name,
       notFoundContent,
+      onBlur,
       onError,
       onChange,
       onClear,
       onDropdownVisibleChange,
+      onDeselect,
+      onSelect,
       optionFilterProps = ['label', 'value'],
       options,
       pageSize = DEFAULT_PAGE_SIZE,
@@ -150,9 +155,15 @@ const AsyncSelect = forwardRef(
       ? 'tags'
       : 'multiple';
     const allowFetch = !fetchOnlyOnSearch || inputValue;
-
     const [maxTagCount, setMaxTagCount] = useState(
       propsMaxTagCount ?? MAX_TAG_COUNT,
+    );
+    const [onChangeCount, setOnChangeCount] = useState(0);
+    const previousChangeCount = usePrevious(onChangeCount, 0);
+
+    const fireOnChange = useCallback(
+      () => setOnChangeCount(onChangeCount + 1),
+      [onChangeCount],
     );
 
     useEffect(() => {
@@ -209,9 +220,7 @@ const AsyncSelect = forwardRef(
         : selectOptions;
     }, [selectOptions, selectValue]);
 
-    const handleOnSelect = (
-      selectedItem: string | number | AntdLabeledValue | undefined,
-    ) => {
+    const handleOnSelect: SelectProps['onSelect'] = (selectedItem, option) => {
       if (isSingleMode) {
         setSelectValue(selectedItem);
       } else {
@@ -229,11 +238,11 @@ const AsyncSelect = forwardRef(
         });
       }
       setInputValue('');
+      fireOnChange();
+      onSelect?.(selectedItem, option);
     };
 
-    const handleOnDeselect = (
-      value: string | number | AntdLabeledValue | undefined,
-    ) => {
+    const handleOnDeselect: SelectProps['onDeselect'] = (value, option) => {
       if (Array.isArray(selectValue)) {
         if (isLabeledValue(value)) {
           const array = selectValue as AntdLabeledValue[];
@@ -246,6 +255,8 @@ const AsyncSelect = forwardRef(
         }
       }
       setInputValue('');
+      fireOnChange();
+      onDeselect?.(value, option);
     };
 
     const internalOnError = useCallback(
@@ -425,7 +436,50 @@ const AsyncSelect = forwardRef(
       if (onClear) {
         onClear();
       }
+      fireOnChange();
     };
+
+    const handleOnBlur = (event: React.FocusEvent<HTMLElement>) => {
+      const tagsMode = !isSingleMode && allowNewOptions;
+      const searchValue = inputValue.trim();
+      // Searched values will be autoselected during onBlur events when in tags mode.
+      // We want to make sure a value is only selected if the user has actually selected it
+      // by pressing Enter or clicking on it.
+      if (
+        tagsMode &&
+        searchValue &&
+        !hasOption(searchValue, selectValue, true)
+      ) {
+        // The search value will be added so we revert to the previous value
+        setSelectValue(selectValue || []);
+      }
+      onBlur?.(event);
+    };
+
+    useEffect(() => {
+      if (onChangeCount !== previousChangeCount) {
+        const set = new Set();
+        const array = ensureIsArray(selectValue);
+        array.forEach(item => set.add(getValue(item)));
+        const options = mapOptions(
+          fullSelectOptions.filter(opt => set.has(opt.value)),
+        );
+        if (isSingleMode) {
+          // @ts-ignore
+          onChange?.(selectValue, options[0]);
+        } else {
+          // @ts-ignore
+          onChange?.(array, options);
+        }
+      }
+    }, [
+      fullSelectOptions,
+      isSingleMode,
+      onChange,
+      onChangeCount,
+      previousChangeCount,
+      selectValue,
+    ]);
 
     useEffect(() => {
       // when `options` list is updated from component prop, reset states
@@ -494,13 +548,13 @@ const AsyncSelect = forwardRef(
           maxTagCount={maxTagCount}
           mode={mappedMode}
           notFoundContent={isLoading ? t('Loading...') : notFoundContent}
+          onBlur={handleOnBlur}
           onDeselect={handleOnDeselect}
           onDropdownVisibleChange={handleOnDropdownVisibleChange}
           onPopupScroll={handlePagination}
           onSearch={showSearch ? handleOnSearch : undefined}
           onSelect={handleOnSelect}
           onClear={handleClear}
-          onChange={onChange}
           options={
             hasCustomLabels(fullSelectOptions) ? undefined : fullSelectOptions
           }

--- a/superset-frontend/src/components/Select/AsyncSelect.tsx
+++ b/superset-frontend/src/components/Select/AsyncSelect.tsx
@@ -238,7 +238,6 @@ const AsyncSelect = forwardRef(
           return previousState;
         });
       }
-      setInputValue('');
       fireOnChange();
       onSelect?.(selectedItem, option);
     };
@@ -255,7 +254,6 @@ const AsyncSelect = forwardRef(
           setSelectValue(array.filter(element => element !== value));
         }
       }
-      setInputValue('');
       fireOnChange();
       onDeselect?.(value, option);
     };

--- a/superset-frontend/src/components/Select/AsyncSelect.tsx
+++ b/superset-frontend/src/components/Select/AsyncSelect.tsx
@@ -458,9 +458,8 @@ const AsyncSelect = forwardRef(
 
     useEffect(() => {
       if (onChangeCount !== previousChangeCount) {
-        const set = new Set();
         const array = ensureIsArray(selectValue);
-        array.forEach(item => set.add(getValue(item)));
+        const set = new Set(array.map(getValue));
         const options = mapOptions(
           fullSelectOptions.filter(opt => set.has(opt.value)),
         );

--- a/superset-frontend/src/components/Select/AsyncSelect.tsx
+++ b/superset-frontend/src/components/Select/AsyncSelect.tsx
@@ -104,6 +104,7 @@ const AsyncSelect = forwardRef(
       allowClear,
       allowNewOptions = false,
       ariaLabel,
+      autoClearSearchValue = false,
       fetchOnlyOnSearch,
       filterOption = true,
       header = null,
@@ -535,7 +536,7 @@ const AsyncSelect = forwardRef(
         <StyledSelect
           allowClear={!isLoading && allowClear}
           aria-label={ariaLabel || name}
-          autoClearSearchValue={false}
+          autoClearSearchValue={autoClearSearchValue}
           dropdownRender={dropdownRender}
           filterOption={handleFilterOption}
           filterSort={sortComparatorWithSearch}

--- a/superset-frontend/src/components/Select/Select.stories.tsx
+++ b/superset-frontend/src/components/Select/Select.stories.tsx
@@ -208,6 +208,8 @@ InteractiveSelect.args = {
   autoFocus: true,
   allowNewOptions: false,
   allowClear: false,
+  autoClearSearchValue: false,
+  allowSelectAll: true,
   showSearch: true,
   disabled: false,
   invertSelection: false,

--- a/superset-frontend/src/components/Select/Select.test.tsx
+++ b/superset-frontend/src/components/Select/Select.test.tsx
@@ -890,6 +890,25 @@ test('"Select All" does not affect disabled options', async () => {
   expect(await findSelectValue()).not.toHaveTextContent(options[1].label);
 });
 
+test('does not fire onChange when searching but no selection', async () => {
+  const onChange = jest.fn();
+  render(
+    <div role="main">
+      <Select
+        {...defaultProps}
+        onChange={onChange}
+        mode="multiple"
+        allowNewOptions
+      />
+    </div>,
+  );
+  await open();
+  await type('Joh');
+  userEvent.click(await findSelectOption('John'));
+  userEvent.click(screen.getByRole('main'));
+  expect(onChange).toHaveBeenCalledTimes(1);
+});
+
 /*
  TODO: Add tests that require scroll interaction. Needs further investigation.
  - Fetches more data when scrolling and more data is available

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -493,9 +493,8 @@ const Select = forwardRef(
 
     useEffect(() => {
       if (onChangeCount !== previousChangeCount) {
-        const set = new Set();
         const array = ensureIsArray(selectValue);
-        array.forEach(item => set.add(getValue(item)));
+        const set = new Set(array.map(getValue));
         const options = mapOptions(
           fullSelectOptions.filter(opt => set.has(opt.value)),
         );

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -87,6 +87,7 @@ const Select = forwardRef(
       allowNewOptions = false,
       allowSelectAll = true,
       ariaLabel,
+      autoClearSearchValue = false,
       filterOption = true,
       header = null,
       headerPosition = 'top',
@@ -328,7 +329,7 @@ const Select = forwardRef(
           : cleanSelectOptions;
         setSelectOptions(newOptions);
       }
-      setInputValue(search);
+      setInputValue(searchValue);
     };
 
     const handleFilterOption = (search: string, option: AntdLabeledValue) =>
@@ -535,7 +536,7 @@ const Select = forwardRef(
         <StyledSelect
           allowClear={!isLoading && allowClear}
           aria-label={ariaLabel || name}
-          autoClearSearchValue={false}
+          autoClearSearchValue={autoClearSearchValue}
           dropdownRender={dropdownRender}
           filterOption={handleFilterOption}
           filterSort={sortComparatorWithSearch}

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -262,7 +262,6 @@ const Select = forwardRef(
           return previousState;
         });
       }
-      setInputValue('');
       fireOnChange();
       onSelect?.(selectedItem, option);
     };
@@ -307,7 +306,6 @@ const Select = forwardRef(
           setSelectValue(array);
         }
       }
-      setInputValue('');
       fireOnChange();
       onDeselect?.(value, option);
     };
@@ -520,13 +518,25 @@ const Select = forwardRef(
       [selectAllEnabled, options],
     );
 
-    const customMaxTagPlaceholder = () => {
+    const omittedCount = useMemo(() => {
       const num_selected = ensureIsArray(selectValue).length;
       const num_shown = maxTagCount as number;
-      return selectAllMode
-        ? `+ ${num_selected - num_shown - 1} ...`
-        : `+ ${num_selected - num_shown} ...`;
-    };
+      return num_selected - num_shown - (selectAllMode ? 1 : 0);
+    }, [maxTagCount, selectAllMode, selectValue]);
+
+    const customMaxTagPlaceholder = () =>
+      `+ ${omittedCount > 0 ? omittedCount : 1} ...`;
+
+    // We can't remove the + tag so when Select All
+    // is the only item omitted, we subtract one from maxTagCount
+    let actualMaxTagCount = maxTagCount;
+    if (
+      actualMaxTagCount !== 'responsive' &&
+      omittedCount === 0 &&
+      selectAllMode
+    ) {
+      actualMaxTagCount -= 1;
+    }
 
     return (
       <StyledContainer headerPosition={headerPosition}>
@@ -545,7 +555,7 @@ const Select = forwardRef(
           }
           headerPosition={headerPosition}
           labelInValue={labelInValue}
-          maxTagCount={maxTagCount}
+          maxTagCount={actualMaxTagCount}
           maxTagPlaceholder={customMaxTagPlaceholder}
           mode={mappedMode}
           notFoundContent={isLoading ? t('Loading...') : notFoundContent}

--- a/superset-frontend/src/components/Select/types.ts
+++ b/superset-frontend/src/components/Select/types.ts
@@ -40,6 +40,7 @@ export type AntdProps = AntdSelectProps<AntdSelectValue>;
 export type AntdExposedProps = Pick<
   AntdProps,
   | 'allowClear'
+  | 'autoClearSearchValue'
   | 'autoFocus'
   | 'disabled'
   | 'filterOption'

--- a/superset-frontend/src/components/Select/utils.tsx
+++ b/superset-frontend/src/components/Select/utils.tsx
@@ -218,7 +218,7 @@ export const mapOptions = (values: SelectOptionsType) =>
   values.map(opt => ({
     children: opt.label,
     key: opt.value,
-    value: opt.value,
     label: opt.label,
     disabled: opt.disabled,
+    ...opt,
   }));

--- a/superset-frontend/src/components/Select/utils.tsx
+++ b/superset-frontend/src/components/Select/utils.tsx
@@ -218,7 +218,5 @@ export const mapOptions = (values: SelectOptionsType) =>
   values.map(opt => ({
     children: opt.label,
     key: opt.value,
-    label: opt.label,
-    disabled: opt.disabled,
     ...opt,
   }));

--- a/superset-frontend/src/features/alerts/AlertReportModal.test.jsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.test.jsx
@@ -341,7 +341,7 @@ describe('AlertReportModal', () => {
         .find('[data-test="select-delivery-method"]')
         .last()
         .props()
-        .onChange('Email');
+        .onSelect('Email');
     });
     await waitForComponentToPaint(wrapper);
     expect(wrapper.find('textarea[name="recipients"]')).toHaveLength(1);


### PR DESCRIPTION
### SUMMARY
This PR fixes a bug in the `Select` component related to searched values that were automatically being selected without an explicit selection from the user. This happens because the [onChange](https://ant.design/components/select#select-props) event is called when a value selection is made or when the input changes. This was only perceived with the introduction of `autoClearSearchValue={false}` in https://github.com/apache/superset/pull/23869. This PR changes the logic to only fire the `onChange` event when there's an actual selection by the user.

### TESTING INSTRUCTIONS
I added a test to the component but we need to check the general use of selects in the application because there are wrappers that override the component behavior such as `SelectControl` and `SelectFilterPlugin`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
