### PR TITLE
feat: migrate charts on import

### DIFF
--- a/superset/charts/commands/importers/v1/utils.py
+++ b/superset/charts/commands/importers/v1/utils.py
@@ -26,7 +26,7 @@ from sqlalchemy.orm import Session
 from superset import security_manager
 from superset.commands.exceptions import ImportFailedError
 from superset.migrations.shared.migrate_viz import processors
-from superset.migrations.shared.migrate_viz.base import ChartMigratorStatus, MigrateViz
+from superset.migrations.shared.migrate_viz.base import MigrateViz
 from superset.models.slice import Slice
 
 
@@ -72,7 +72,8 @@ def migrate_chart(config: dict[str, Any]) -> dict[str, Any]:
         for class_ in processors.__dict__.values()
         if isclass(class_)
         and issubclass(class_, MigrateViz)
-        and class_.status == ChartMigratorStatus.COMPLETE
+        and hasattr(class_, "source_viz_type")
+        and class_ != processors.MigrateAreaChart  # incomplete
     }
 
     output = copy.deepcopy(config)

--- a/superset/charts/commands/importers/v1/utils.py
+++ b/superset/charts/commands/importers/v1/utils.py
@@ -26,7 +26,7 @@ from sqlalchemy.orm import Session
 from superset import security_manager
 from superset.commands.exceptions import ImportFailedError
 from superset.migrations.shared.migrate_viz import processors
-from superset.migrations.shared.migrate_viz.base import MigrateViz
+from superset.migrations.shared.migrate_viz.base import ChartMigratorStatus, MigrateViz
 from superset.models.slice import Slice
 
 
@@ -70,7 +70,9 @@ def migrate_chart(config: dict[str, Any]) -> dict[str, Any]:
     migrators = {
         class_.source_viz_type: class_
         for class_ in processors.__dict__.values()
-        if isclass(class_) and issubclass(class_, MigrateViz) and class_ != MigrateViz
+        if isclass(class_)
+        and issubclass(class_, MigrateViz)
+        and class_.status == ChartMigratorStatus.COMPLETE
     }
 
     output = copy.deepcopy(config)

--- a/superset/charts/commands/importers/v1/utils.py
+++ b/superset/charts/commands/importers/v1/utils.py
@@ -15,7 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import copy
 import json
+from inspect import isclass
 from typing import Any
 
 from flask import g
@@ -23,6 +25,8 @@ from sqlalchemy.orm import Session
 
 from superset import security_manager
 from superset.commands.exceptions import ImportFailedError
+from superset.migrations.shared.migrate_viz import processors
+from superset.migrations.shared.migrate_viz.base import MigrateViz
 from superset.models.slice import Slice
 
 
@@ -46,6 +50,9 @@ def import_chart(
     # TODO (betodealmeida): move this logic to import_from_dict
     config["params"] = json.dumps(config["params"])
 
+    # migrate old viz types to new ones
+    config = migrate_chart(config)
+
     chart = Slice.import_from_dict(session, config, recursive=False)
     if chart.id is None:
         session.flush()
@@ -54,3 +61,44 @@ def import_chart(
         chart.owners.append(g.user)
 
     return chart
+
+
+def migrate_chart(config: dict[str, Any]) -> dict[str, Any]:
+    """
+    Used to migrate old viz types to new ones.
+    """
+    migrators = {
+        class_.source_viz_type: class_
+        for class_ in processors.__dict__.values()
+        if isclass(class_) and issubclass(class_, MigrateViz) and class_ != MigrateViz
+    }
+
+    output = copy.deepcopy(config)
+    if config["viz_type"] not in migrators:
+        return output
+
+    migrator = migrators[config["viz_type"]](output["params"])
+    # pylint: disable=protected-access
+    migrator._pre_action()
+    migrator._migrate()
+    migrator._post_action()
+    params = migrator.data
+
+    params["viz_type"] = migrator.target_viz_type
+    output.update(
+        {
+            "params": json.dumps(params),
+            "viz_type": migrator.target_viz_type,
+        }
+    )
+
+    # also update `query_context`
+    try:
+        query_context = json.loads(output.get("query_context", "{}"))
+    except json.decoder.JSONDecodeError:
+        query_context = {}
+    if "form_data" in query_context:
+        query_context["form_data"] = output["params"]
+        output["query_context"] = json.dumps(query_context)
+
+    return output

--- a/superset/migrations/shared/migrate_viz/base.py
+++ b/superset/migrations/shared/migrate_viz/base.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import copy
 import json
+from enum import Enum
 from typing import Any
 
 from alembic import op
@@ -29,6 +30,12 @@ from superset.constants import TimeGrain
 from superset.migrations.shared.utils import paginated_update, try_load_json
 
 Base = declarative_base()
+
+
+class ChartMigratorStatus(Enum):
+    NOT_IMPLEMENTED = "NOT_IMPLEMENTED"
+    INCOMPLETE = "INCOMPLETE"
+    COMPLETE = "COMPLETE"
 
 
 class Slice(Base):  # type: ignore
@@ -50,6 +57,9 @@ class MigrateViz:
     source_viz_type: str
     target_viz_type: str
     has_x_axis_control: bool = False
+
+    # specific migrations need to override this
+    status = ChartMigratorStatus.NOT_IMPLEMENTED
 
     def __init__(self, form_data: str) -> None:
         self.data = try_load_json(form_data)

--- a/superset/migrations/shared/migrate_viz/base.py
+++ b/superset/migrations/shared/migrate_viz/base.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import copy
 import json
-from enum import Enum
 from typing import Any
 
 from alembic import op
@@ -30,12 +29,6 @@ from superset.constants import TimeGrain
 from superset.migrations.shared.utils import paginated_update, try_load_json
 
 Base = declarative_base()
-
-
-class ChartMigratorStatus(Enum):
-    NOT_IMPLEMENTED = "NOT_IMPLEMENTED"
-    INCOMPLETE = "INCOMPLETE"
-    COMPLETE = "COMPLETE"
 
 
 class Slice(Base):  # type: ignore
@@ -57,9 +50,6 @@ class MigrateViz:
     source_viz_type: str
     target_viz_type: str
     has_x_axis_control: bool = False
-
-    # specific migrations need to override this
-    status = ChartMigratorStatus.NOT_IMPLEMENTED
 
     def __init__(self, form_data: str) -> None:
         self.data = try_load_json(form_data)

--- a/superset/migrations/shared/migrate_viz/processors.py
+++ b/superset/migrations/shared/migrate_viz/processors.py
@@ -51,6 +51,9 @@ class MigrateAreaChart(MigrateViz):
             self.data["show_extra_controls"] = True
             self.data["stack"] = stacked_map.get(stacked)
 
+        if x_axis := self.data.get("granularity_sqla"):
+            self.data["x_axis"] = x_axis
+
         if x_axis_label := self.data.get("x_axis_label"):
             self.data["x_axis_title"] = x_axis_label
             self.data["x_axis_title_margin"] = 30

--- a/superset/migrations/shared/migrate_viz/processors.py
+++ b/superset/migrations/shared/migrate_viz/processors.py
@@ -16,7 +16,7 @@
 # under the License.
 from typing import Any
 
-from .base import MigrateViz
+from .base import ChartMigratorStatus, MigrateViz
 
 
 class MigrateTreeMap(MigrateViz):
@@ -38,6 +38,8 @@ class MigrateAreaChart(MigrateViz):
     source_viz_type = "area"
     target_viz_type = "echarts_area"
     remove_keys = {"contribution", "stacked_style", "x_axis_label"}
+
+    status = ChartMigratorStatus.INCOMPLETE
 
     def _pre_action(self) -> None:
         if self.data.get("contribution"):
@@ -83,6 +85,8 @@ class MigratePivotTable(MigrateViz):
         "var": "Sample Variance",
     }
 
+    status = ChartMigratorStatus.COMPLETE
+
     def _pre_action(self) -> None:
         if pivot_margins := self.data.get("pivot_margins"):
             self.data["colTotals"] = pivot_margins
@@ -103,6 +107,8 @@ class MigrateDualLine(MigrateViz):
         "y_axis_2_bounds": "y_axis_bounds_secondary",
     }
     remove_keys = {"metric", "metric_2"}
+
+    status = ChartMigratorStatus.COMPLETE
 
     def _pre_action(self) -> None:
         self.data["yAxisIndex"] = 0

--- a/superset/migrations/shared/migrate_viz/processors.py
+++ b/superset/migrations/shared/migrate_viz/processors.py
@@ -16,7 +16,7 @@
 # under the License.
 from typing import Any
 
-from .base import ChartMigratorStatus, MigrateViz
+from .base import MigrateViz
 
 
 class MigrateTreeMap(MigrateViz):
@@ -35,11 +35,18 @@ class MigrateTreeMap(MigrateViz):
 
 
 class MigrateAreaChart(MigrateViz):
+    """
+    Migrate area charts.
+
+    This migration is incomplete, see https://github.com/apache/superset/pull/24703#discussion_r1265222611
+    for more details. If you fix this migration, please update the ``migrate_chart``
+    function in ``superset/charts/commands/importers/v1/utils.py`` so that it gets
+    applied in chart imports.
+    """
+
     source_viz_type = "area"
     target_viz_type = "echarts_area"
     remove_keys = {"contribution", "stacked_style", "x_axis_label"}
-
-    status = ChartMigratorStatus.INCOMPLETE
 
     def _pre_action(self) -> None:
         if self.data.get("contribution"):
@@ -85,8 +92,6 @@ class MigratePivotTable(MigrateViz):
         "var": "Sample Variance",
     }
 
-    status = ChartMigratorStatus.COMPLETE
-
     def _pre_action(self) -> None:
         if pivot_margins := self.data.get("pivot_margins"):
             self.data["colTotals"] = pivot_margins
@@ -107,8 +112,6 @@ class MigrateDualLine(MigrateViz):
         "y_axis_2_bounds": "y_axis_bounds_secondary",
     }
     remove_keys = {"metric", "metric_2"}
-
-    status = ChartMigratorStatus.COMPLETE
 
     def _pre_action(self) -> None:
         self.data["yAxisIndex"] = 0

--- a/tests/unit_tests/charts/commands/importers/v1/utils_test.py
+++ b/tests/unit_tests/charts/commands/importers/v1/utils_test.py
@@ -1,0 +1,118 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import json
+
+from superset.charts.commands.importers.v1.utils import migrate_chart
+
+
+def test_migrate_chart() -> None:
+    """
+    Test the ``migrate_chart`` command when importing a chart.
+    """
+    chart_config = {
+        "slice_name": "Birth names by state",
+        "description": None,
+        "certified_by": None,
+        "certification_details": None,
+        "viz_type": "area",
+        "params": json.dumps(
+            {
+                "datasource": "21__table",
+                "viz_type": "area",
+                "granularity_sqla": "ds",
+                "time_grain_sqla": "P1D",
+                "time_range": "No filter",
+                "metrics": ["count"],
+                "adhoc_filters": [],
+                "groupby": ["state"],
+                "order_desc": True,
+                "row_limit": 10000,
+                "show_brush": "auto",
+                "show_legend": True,
+                "line_interpolation": "linear",
+                "stacked_style": "stack",
+                "color_scheme": "supersetColors",
+                "rich_tooltip": True,
+                "bottom_margin": "auto",
+                "x_ticks_layout": "auto",
+                "x_axis_format": "smart_date",
+                "y_axis_format": "SMART_NUMBER",
+                "y_axis_bounds": [None, None],
+                "rolling_type": "None",
+                "comparison_type": "values",
+                "annotation_layers": [],
+                "extra_form_data": {},
+                "dashboards": [],
+            }
+        ),
+        "cache_timeout": None,
+        "uuid": "ffd15af2-2188-425c-b6b4-df28aac45872",
+        "version": "1.0.0",
+        "dataset_uuid": "a18b9cb0-b8d3-42ed-bd33-0f0fadbf0f6d",
+    }
+
+    new_config = migrate_chart(chart_config)
+    assert new_config == {
+        "slice_name": "Birth names by state",
+        "description": None,
+        "certified_by": None,
+        "certification_details": None,
+        "viz_type": "echarts_area",
+        "params": json.dumps(
+            {
+                "datasource": "21__table",
+                "viz_type": "echarts_area",
+                "time_grain_sqla": "P1D",
+                "metrics": ["count"],
+                "adhoc_filters": [
+                    {
+                        "clause": "WHERE",
+                        "subject": "ds",
+                        "operator": "TEMPORAL_RANGE",
+                        "comparator": "No filter",
+                        "expressionType": "SIMPLE",
+                    }
+                ],
+                "groupby": ["state"],
+                "order_desc": True,
+                "row_limit": 10000,
+                "show_brush": "auto",
+                "show_legend": True,
+                "line_interpolation": "linear",
+                "color_scheme": "supersetColors",
+                "rich_tooltip": True,
+                "bottom_margin": "auto",
+                "x_ticks_layout": "auto",
+                "x_axis_format": "smart_date",
+                "y_axis_format": "SMART_NUMBER",
+                "y_axis_bounds": [None, None],
+                "rolling_type": "None",
+                "comparison_type": "values",
+                "annotation_layers": [],
+                "extra_form_data": {},
+                "dashboards": [],
+                "show_extra_controls": True,
+                "stack": "Stack",
+                "x_axis": "ds",
+            }
+        ),
+        "cache_timeout": None,
+        "uuid": "ffd15af2-2188-425c-b6b4-df28aac45872",
+        "version": "1.0.0",
+        "dataset_uuid": "a18b9cb0-b8d3-42ed-bd33-0f0fadbf0f6d",
+    }

--- a/tests/unit_tests/charts/commands/importers/v1/utils_test.py
+++ b/tests/unit_tests/charts/commands/importers/v1/utils_test.py
@@ -20,9 +20,11 @@ import json
 from superset.charts.commands.importers.v1.utils import migrate_chart
 
 
-def test_migrate_chart() -> None:
+def test_migrate_chart_area() -> None:
     """
-    Test the ``migrate_chart`` command when importing a chart.
+    Test the ``migrate_chart`` command when importing an area chart.
+
+    This is currently a no-op since the migration is not complete.
     """
     chart_config = {
         "slice_name": "Birth names by state",
@@ -32,32 +34,32 @@ def test_migrate_chart() -> None:
         "viz_type": "area",
         "params": json.dumps(
             {
-                "datasource": "21__table",
-                "viz_type": "area",
-                "granularity_sqla": "ds",
-                "time_grain_sqla": "P1D",
-                "time_range": "No filter",
-                "metrics": ["count"],
                 "adhoc_filters": [],
+                "annotation_layers": [],
+                "bottom_margin": "auto",
+                "color_scheme": "supersetColors",
+                "comparison_type": "values",
+                "dashboards": [],
+                "datasource": "21__table",
+                "extra_form_data": {},
+                "granularity_sqla": "ds",
                 "groupby": ["state"],
+                "line_interpolation": "linear",
+                "metrics": ["count"],
                 "order_desc": True,
+                "rich_tooltip": True,
+                "rolling_type": "None",
                 "row_limit": 10000,
                 "show_brush": "auto",
                 "show_legend": True,
-                "line_interpolation": "linear",
                 "stacked_style": "stack",
-                "color_scheme": "supersetColors",
-                "rich_tooltip": True,
-                "bottom_margin": "auto",
-                "x_ticks_layout": "auto",
+                "time_grain_sqla": "P1D",
+                "time_range": "No filter",
+                "viz_type": "area",
                 "x_axis_format": "smart_date",
-                "y_axis_format": "SMART_NUMBER",
+                "x_ticks_layout": "auto",
                 "y_axis_bounds": [None, None],
-                "rolling_type": "None",
-                "comparison_type": "values",
-                "annotation_layers": [],
-                "extra_form_data": {},
-                "dashboards": [],
+                "y_axis_format": "SMART_NUMBER",
             }
         ),
         "cache_timeout": None,
@@ -67,18 +69,84 @@ def test_migrate_chart() -> None:
     }
 
     new_config = migrate_chart(chart_config)
-    assert new_config == {
-        "slice_name": "Birth names by state",
+    assert new_config == chart_config
+
+
+def test_migrate_pivot_table() -> None:
+    """
+    Test the ``migrate_chart`` command when importing an old pivot table.
+    """
+    chart_config = {
+        "slice_name": "Pivot Table",
         "description": None,
         "certified_by": None,
         "certification_details": None,
-        "viz_type": "echarts_area",
+        "viz_type": "pivot_table",
         "params": json.dumps(
             {
-                "datasource": "21__table",
-                "viz_type": "echarts_area",
-                "time_grain_sqla": "P1D",
-                "metrics": ["count"],
+                "columns": ["state"],
+                "compare_lag": "10",
+                "compare_suffix": "o10Y",
+                "granularity_sqla": "ds",
+                "groupby": ["name"],
+                "limit": "25",
+                "markup_type": "markdown",
+                "metrics": [
+                    {
+                        "aggregate": "SUM",
+                        "column": {
+                            "column_name": "num",
+                            "type": "BIGINT",
+                        },
+                        "expressionType": "SIMPLE",
+                        "label": "Births",
+                        "optionName": "metric_11",
+                    },
+                ],
+                "row_limit": 50000,
+                "since": "100 years ago",
+                "time_range": "No filter",
+                "time_range_endpoints": ["inclusive", "exclusive"],
+                "until": "now",
+                "viz_type": "pivot_table",
+            },
+        ),
+        "cache_timeout": None,
+        "uuid": "ffd15af2-2188-425c-b6b4-df28aac45872",
+        "version": "1.0.0",
+        "dataset_uuid": "a18b9cb0-b8d3-42ed-bd33-0f0fadbf0f6d",
+    }
+
+    new_config = migrate_chart(chart_config)
+    assert new_config == {
+        "slice_name": "Pivot Table",
+        "description": None,
+        "certified_by": None,
+        "certification_details": None,
+        "viz_type": "pivot_table_v2",
+        "params": json.dumps(
+            {
+                "groupbyColumns": ["state"],
+                "compare_lag": "10",
+                "compare_suffix": "o10Y",
+                "groupbyRows": ["name"],
+                "limit": "25",
+                "markup_type": "markdown",
+                "metrics": [
+                    {
+                        "aggregate": "SUM",
+                        "column": {"column_name": "num", "type": "BIGINT"},
+                        "expressionType": "SIMPLE",
+                        "label": "Births",
+                        "optionName": "metric_11",
+                    }
+                ],
+                "series_limit": 50000,
+                "since": "100 years ago",
+                "time_range_endpoints": ["inclusive", "exclusive"],
+                "until": "now",
+                "viz_type": "pivot_table_v2",
+                "rowOrder": "value_z_to_a",
                 "adhoc_filters": [
                     {
                         "clause": "WHERE",
@@ -88,27 +156,6 @@ def test_migrate_chart() -> None:
                         "expressionType": "SIMPLE",
                     }
                 ],
-                "groupby": ["state"],
-                "order_desc": True,
-                "row_limit": 10000,
-                "show_brush": "auto",
-                "show_legend": True,
-                "line_interpolation": "linear",
-                "color_scheme": "supersetColors",
-                "rich_tooltip": True,
-                "bottom_margin": "auto",
-                "x_ticks_layout": "auto",
-                "x_axis_format": "smart_date",
-                "y_axis_format": "SMART_NUMBER",
-                "y_axis_bounds": [None, None],
-                "rolling_type": "None",
-                "comparison_type": "values",
-                "annotation_layers": [],
-                "extra_form_data": {},
-                "dashboards": [],
-                "show_extra_controls": True,
-                "stack": "Stack",
-                "x_axis": "ds",
             }
         ),
         "cache_timeout": None,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When importing a chart, migrate it to a new visualization type if possible.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

A legacy area chart:

![Screenshot 2023-07-14 at 15-54-49 Preset](https://github.com/apache/superset/assets/1534870/9534ef20-87d5-4019-a84a-094863d67b34)

When exported and imported into Superset running this branch we get a new echarts area chart:

![Screenshot 2023-07-14 at 15-56-33 Superset](https://github.com/apache/superset/assets/1534870/ef6ae293-46f6-4ed1-8e31-21e456f6870a)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
