### PR TITLE
chore(deps): bump pandas >=2.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -192,7 +192,7 @@ packaging==23.1
     #   deprecation
     #   limits
     #   marshmallow
-pandas==2.0.0
+pandas==2.0.3
     # via apache-superset
 paramiko==2.11.0
     # via sshtunnel
@@ -290,6 +290,8 @@ typing-extensions==4.4.0
     #   apache-superset
     #   flask-limiter
     #   limits
+tzdata==2023.3
+    # via pandas
 urllib3==1.26.6
     # via selenium
 vine==5.0.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -192,7 +192,7 @@ packaging==23.1
     #   deprecation
     #   limits
     #   marshmallow
-pandas==1.5.3
+pandas==2.0.0
     # via apache-superset
 paramiko==2.11.0
     # via sshtunnel

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -148,8 +148,6 @@ tqdm==4.65.0
     #   prophet
 trino==0.324.0
     # via apache-superset
-tzdata==2023.3
-    # via pytz-deprecation-shim
 tzlocal==4.3
     # via trino
 websocket-client==1.5.1

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
         "nh3>=0.2.11, <0.3",
         "numpy==1.23.5",
         "packaging",
-        "pandas>=2.0.0, <2.0.1",
+        "pandas>=2.0.3, <2.1",
         "parsedatetime",
         "pgsanity",
         "polyline>=2.0.0, <3.0",

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
         "nh3>=0.2.11, <0.3",
         "numpy==1.23.5",
         "packaging",
-        "pandas>=1.5.3, <1.6",
+        "pandas>=2.0.0, <2.0.1",
         "parsedatetime",
         "pgsanity",
         "polyline>=2.0.0, <3.0",

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -134,7 +134,7 @@ class QueryContextProcessor:
 
         if query_obj and cache_key and not cache.is_loaded:
             try:
-                invalid_columns = [
+                if invalid_columns := [
                     col
                     for col in get_column_names_from_columns(query_obj.columns)
                     + get_column_names_from_metrics(query_obj.metrics or [])
@@ -142,9 +142,7 @@ class QueryContextProcessor:
                         col not in self._qc_datasource.column_names
                         and col != DTTM_ALIAS
                     )
-                ]
-
-                if invalid_columns:
+                ]:
                     raise QueryObjectValidationError(
                         _(
                             "Columns missing in dataset: %(invalid_columns)s",
@@ -570,7 +568,7 @@ class QueryContextProcessor:
                     df, index=include_index, **config["CSV_EXPORT"]
                 )
             elif self._query_context.result_format == ChartDataResultFormat.XLSX:
-                result = excel.df_to_excel(df, **config["EXCEL_EXPORT"])
+                result = excel.df_to_excel(df)
             return result or ""
 
         return df.to_dict(orient="records")

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -568,7 +568,7 @@ class QueryContextProcessor:
                     df, index=include_index, **config["CSV_EXPORT"]
                 )
             elif self._query_context.result_format == ChartDataResultFormat.XLSX:
-                result = excel.df_to_excel(df)
+                result = excel.df_to_excel(df, **config["EXCEL_EXPORT"])
             return result or ""
 
         return df.to_dict(orient="records")

--- a/superset/config.py
+++ b/superset/config.py
@@ -758,11 +758,6 @@ CSV_UPLOAD_MAX_SIZE = None
 # note: index option should not be overridden
 CSV_EXPORT = {"encoding": "utf-8"}
 
-# Excel Options: key/value pairs that will be passed as argument to DataFrame.to_excel
-# method.
-# note: index option should not be overridden
-EXCEL_EXPORT = {"encoding": "utf-8"}
-
 # ---------------------------------------------------
 # Time grain configurations
 # ---------------------------------------------------

--- a/superset/config.py
+++ b/superset/config.py
@@ -758,6 +758,11 @@ CSV_UPLOAD_MAX_SIZE = None
 # note: index option should not be overridden
 CSV_EXPORT = {"encoding": "utf-8"}
 
+# Excel Options: key/value pairs that will be passed as argument to DataFrame.to_excel
+# method.
+# note: index option should not be overridden
+EXCEL_EXPORT: dict[str, Any] = {}
+
 # ---------------------------------------------------
 # Time grain configurations
 # ---------------------------------------------------

--- a/superset/reports/notifications/slack.py
+++ b/superset/reports/notifications/slack.py
@@ -21,6 +21,7 @@ from io import IOBase
 from typing import Union
 
 import backoff
+import pandas as pd
 from flask_babel import gettext as __
 from slack_sdk import WebClient
 from slack_sdk.errors import (
@@ -121,8 +122,9 @@ Error: %(text)s
         # need to truncate the data
         for i in range(len(df) - 1):
             truncated_df = df[: i + 1].fillna("")
-            truncated_df = truncated_df.append(
-                {k: "..." for k in df.columns}, ignore_index=True
+            truncated_row = pd.Series({k: "..." for k in df.columns})
+            truncated_df = pd.concat(
+                [truncated_df, truncated_row.to_frame().T], ignore_index=True
             )
             tabulated = df.to_markdown()
             table = f"```\n{tabulated}\n```\n\n(table was truncated)"
@@ -130,8 +132,9 @@ Error: %(text)s
             if len(message) > MAXIMUM_MESSAGE_SIZE:
                 # Decrement i and build a message that is under the limit
                 truncated_df = df[:i].fillna("")
-                truncated_df = truncated_df.append(
-                    {k: "..." for k in df.columns}, ignore_index=True
+                truncated_row = pd.Series({k: "..." for k in df.columns})
+                truncated_df = pd.concat(
+                    [truncated_df, truncated_row.to_frame().T], ignore_index=True
                 )
                 tabulated = df.to_markdown()
                 table = (

--- a/superset/views/database/views.py
+++ b/superset/views/database/views.py
@@ -343,7 +343,6 @@ class ExcelToDatabaseView(SimpleFormView):
                 index_col=form.index_col.data,
                 io=form.excel_file.data,
                 keep_default_na=not form.null_values.data,
-                mangle_dupe_cols=form.mangle_dupe_cols.data,
                 na_values=form.null_values.data if form.null_values.data else None,
                 parse_dates=form.parse_dates.data,
                 skiprows=form.skiprows.data,

--- a/superset/views/database/views.py
+++ b/superset/views/database/views.py
@@ -201,7 +201,6 @@ class CsvToDatabaseView(CustomFormView):
                     infer_datetime_format=form.infer_datetime_format.data,
                     iterator=True,
                     keep_default_na=not form.null_values.data,
-                    mangle_dupe_cols=form.overwrite_duplicate.data,
                     usecols=form.use_cols.data if form.use_cols.data else None,
                     na_values=form.null_values.data if form.null_values.data else None,
                     nrows=form.nrows.data,

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -2849,7 +2849,7 @@ class PartitionViz(NVD3TimeSeriesViz):
         for i in range(0, len(groups) + 1):
             agg_df = df.groupby(groups[:i]) if i else df
             levels[i] = (
-                agg_df.mean()
+                agg_df.mean(numeric_only=True)
                 if time_op == "agg_mean"
                 else agg_df.sum(numeric_only=True)
             )
@@ -2874,7 +2874,7 @@ class PartitionViz(NVD3TimeSeriesViz):
                 lambda a, b, fill_value: a / float(b) - 1,
             ],
         }[time_op]
-        agg_df = df.groupby(DTTM_ALIAS).sum()
+        agg_df = df.groupby(DTTM_ALIAS).sum(numeric_only=True)
         levels = {
             0: pd.Series(
                 {
@@ -2884,7 +2884,7 @@ class PartitionViz(NVD3TimeSeriesViz):
             )
         }
         for i in range(1, len(groups) + 1):
-            agg_df = df.groupby([DTTM_ALIAS] + groups[:i]).sum()
+            agg_df = df.groupby([DTTM_ALIAS] + groups[:i]).sum(numeric_only=True)
             levels[i] = pd.DataFrame(
                 {
                     m: func[0](agg_df[m][until], agg_df[m][since], fill_value=0)
@@ -2900,7 +2900,7 @@ class PartitionViz(NVD3TimeSeriesViz):
         procs = {}
         for i in range(0, len(groups) + 1):
             self.form_data["groupby"] = groups[:i]
-            df_drop = df.drop(groups[i:], 1)
+            df_drop = df.drop(groups[i:], axis=1)
             procs[i] = self.process_data(df_drop, aggregate=True)
         self.form_data["groupby"] = groups
         return procs

--- a/tests/integration_tests/viz_tests.py
+++ b/tests/integration_tests/viz_tests.py
@@ -894,7 +894,7 @@ class TestPartitionViz(SupersetTestCase):
         metrics = ["metric1", "metric2", "metric3"]
         procs = {}
         for i in range(0, 4):
-            df_drop = df.drop(groups[i:], 1)
+            df_drop = df.drop(groups[i:], axis=1)
             pivot = df_drop.pivot_table(
                 index=DTTM_ALIAS, columns=groups[:i], values=metrics
             )

--- a/tests/unit_tests/pandas_postprocessing/test_rolling.py
+++ b/tests/unit_tests/pandas_postprocessing/test_rolling.py
@@ -162,8 +162,8 @@ def test_rolling_after_pivot_with_single_metric():
         pd.DataFrame(
             data={
                 "dttm": pd.to_datetime(["2019-01-01", "2019-01-02"]),
-                FLAT_COLUMN_SEPARATOR.join(["sum_metric", "UK"]): [5.0, 12.0],
-                FLAT_COLUMN_SEPARATOR.join(["sum_metric", "US"]): [6.0, 14.0],
+                FLAT_COLUMN_SEPARATOR.join(["sum_metric", "UK"]): [5, 12],
+                FLAT_COLUMN_SEPARATOR.join(["sum_metric", "US"]): [6, 14],
             }
         )
     )
@@ -213,10 +213,10 @@ def test_rolling_after_pivot_with_multiple_metrics():
         pd.DataFrame(
             data={
                 "dttm": pd.to_datetime(["2019-01-01", "2019-01-02"]),
-                FLAT_COLUMN_SEPARATOR.join(["count_metric", "UK"]): [1.0, 4.0],
-                FLAT_COLUMN_SEPARATOR.join(["count_metric", "US"]): [2.0, 6.0],
-                FLAT_COLUMN_SEPARATOR.join(["sum_metric", "UK"]): [5.0, 12.0],
-                FLAT_COLUMN_SEPARATOR.join(["sum_metric", "US"]): [6.0, 14.0],
+                FLAT_COLUMN_SEPARATOR.join(["count_metric", "UK"]): [1, 4],
+                FLAT_COLUMN_SEPARATOR.join(["count_metric", "US"]): [2, 6],
+                FLAT_COLUMN_SEPARATOR.join(["sum_metric", "UK"]): [5, 12],
+                FLAT_COLUMN_SEPARATOR.join(["sum_metric", "US"]): [6, 14],
             }
         )
     )

--- a/tests/unit_tests/pandas_postprocessing/test_rolling.py
+++ b/tests/unit_tests/pandas_postprocessing/test_rolling.py
@@ -149,14 +149,14 @@ def test_rolling_after_pivot_with_single_metric():
                sum_metric
     country            UK    US
     dttm
-    2019-01-01        5.0   6.0
-    2019-01-02       12.0  14.0
+    2019-01-01          5     6
+    2019-01-02         12    14
     """
     flat_df = pp.flatten(rolling_df)
     """
             dttm  sum_metric, UK  sum_metric, US
-    0 2019-01-01             5.0             6.0
-    1 2019-01-02            12.0            14.0
+    0 2019-01-01               5               6
+    1 2019-01-02              12              14
     """
     assert flat_df.equals(
         pd.DataFrame(
@@ -200,14 +200,14 @@ def test_rolling_after_pivot_with_multiple_metrics():
                count_metric      sum_metric
     country              UK   US         UK    US
     dttm
-    2019-01-01          1.0  2.0        5.0   6.0
-    2019-01-02          4.0  6.0       12.0  14.0
+    2019-01-01            1    2          5     6
+    2019-01-02            4    6         12    14
     """
     flat_df = pp.flatten(rolling_df)
     """
             dttm  count_metric, UK  count_metric, US  sum_metric, UK  sum_metric, US
-    0 2019-01-01               1.0               2.0             5.0             6.0
-    1 2019-01-02               4.0               6.0            12.0            14.0
+    0 2019-01-01                 1                 2               5               6
+    1 2019-01-02                 4                 6              12              14
     """
     assert flat_df.equals(
         pd.DataFrame(


### PR DESCRIPTION
### SUMMARY
In Pandas 2.0 installing the optional but recommended performance dependencies is now possible via pip extras, [reference](https://pandas.pydata.org/docs/whatsnew/v2.0.0.html#installing-optional-dependencies-with-pip-extras). These deps are also available in 1.5.3 but with the help of pip extras and pip-compile-multi, it should be much cleaner and more obvious as why these deps are installed. I think `pandas[performance]` should be installed in a separate follow-up PR.
This PR bumps dependency pandas from `1.5.3` to latest stable version `2.0.3` to be able to add these optional dependencies.

With Pandas 2.0 we could also potentially
- leverage new pandas features
- mitigate bugs
- improve performance

Changes in 2.0: https://pandas.pydata.org/docs/whatsnew/v2.0.0.html

### TESTING INSTRUCTIONS
- `scripts/tests/run.sh --module tests/integration_tests/`
- `pytest ./tests/unit_tests/`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
