### PR TITLE
fix(chore): dashboard requests to database equal the number of slices it has

### DIFF
--- a/superset/daos/dashboard.py
+++ b/superset/daos/dashboard.py
@@ -67,7 +67,7 @@ class DashboardDAO(BaseDAO[Dashboard]):
                 .outerjoin(Dashboard.roles)
             )
             # Apply dashboard base filters
-            query = DashboardAccessFilter("id", SQLAInterface(Dashboard, db.session)).apply(
+            query = cls.base_filter("id", SQLAInterface(Dashboard, db.session)).apply(
                 query, None
             )
             dashboard = query.one_or_none()

--- a/superset/daos/dashboard.py
+++ b/superset/daos/dashboard.py
@@ -23,7 +23,6 @@ from typing import Any
 
 from flask import g
 from flask_appbuilder.models.sqla import Model
-from flask_appbuilder.models.sqla.interface import SQLAInterface
 from sqlalchemy.exc import SQLAlchemyError
 
 from superset import security_manager

--- a/superset/daos/dashboard.py
+++ b/superset/daos/dashboard.py
@@ -41,7 +41,7 @@ from superset.dashboards.filter_sets.consts import (
 from superset.dashboards.filters import DashboardAccessFilter, is_uuid
 from superset.extensions import db
 from superset.models.core import FavStar, FavStarClassName
-from superset.models.dashboard import Dashboard, id_or_slug_filter
+from superset.models.dashboard import Dashboard, is_int, is_slug
 from superset.models.embedded_dashboard import EmbeddedDashboard
 from superset.models.filter_set import FilterSet
 from superset.models.slice import Slice

--- a/superset/daos/dashboard.py
+++ b/superset/daos/dashboard.py
@@ -38,10 +38,10 @@ from superset.dashboards.filter_sets.consts import (
     OWNER_ID_FIELD,
     OWNER_TYPE_FIELD,
 )
-from superset.dashboards.filters import DashboardAccessFilter, is_uuid
+from superset.dashboards.filters import DashboardAccessFilter
 from superset.extensions import db
 from superset.models.core import FavStar, FavStarClassName
-from superset.models.dashboard import Dashboard, is_int, is_slug
+from superset.models.dashboard import Dashboard
 from superset.models.embedded_dashboard import EmbeddedDashboard
 from superset.models.filter_set import FilterSet
 from superset.models.slice import Slice
@@ -56,10 +56,8 @@ class DashboardDAO(BaseDAO[Dashboard]):
 
     @classmethod
     def get_by_id_or_slug(cls, id_or_slug: int | str) -> Dashboard:
-        if is_uuid(id_or_slug) or is_int(id_or_slug) or is_slug(id_or_slug):
-            # just get dashboard if it's uuid
-            dashboard = Dashboard.get(id_or_slug)
-        else:
+        dashboard = Dashboard.get(id_or_slug)
+        if dashboard is None:
             raise DashboardNotFoundError()
 
         # make sure we still have basic access check from security manager

--- a/superset/daos/dashboard.py
+++ b/superset/daos/dashboard.py
@@ -56,24 +56,10 @@ class DashboardDAO(BaseDAO[Dashboard]):
 
     @classmethod
     def get_by_id_or_slug(cls, id_or_slug: int | str) -> Dashboard:
-        if is_uuid(id_or_slug):
+        if is_uuid(id_or_slug) or is_int(id_or_slug) or is_slug(id_or_slug):
             # just get dashboard if it's uuid
             dashboard = Dashboard.get(id_or_slug)
         else:
-            query = (
-                db.session.query(Dashboard)
-                .filter(id_or_slug_filter(id_or_slug))
-                .outerjoin(Slice, Dashboard.slices)
-                .outerjoin(Slice.table)
-                .outerjoin(Dashboard.owners)
-                .outerjoin(Dashboard.roles)
-            )
-            # Apply dashboard base filters
-            query = cls.base_filter("id", SQLAInterface(Dashboard, db.session)).apply(
-                query, None
-            )
-            dashboard = query.one_or_none()
-        if not dashboard:
             raise DashboardNotFoundError()
 
         # make sure we still have basic access check from security manager

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -463,12 +463,6 @@ def is_int(value: str | int) -> bool:
         return False
 
 
-def is_slug(value: str) -> bool:
-    if type(value) == str and not is_uuid(value):
-        return True
-    return False
-
-
 def id_or_slug_filter(id_or_slug: int | str) -> BinaryExpression:
     if is_int(id_or_slug):
         return Dashboard.id == int(id_or_slug)

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -463,6 +463,12 @@ def is_int(value: str | int) -> bool:
         return False
 
 
+def is_slug(value: str) -> bool:
+    if type(value) == str and not is_uuid(value):
+        return True
+    return False
+
+
 def id_or_slug_filter(id_or_slug: int | str) -> BinaryExpression:
     if is_int(id_or_slug):
         return Dashboard.id == int(id_or_slug)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Hello!
Superset 2.1.0 has an issue where the requests made when getting a dashboard repeat the same number of times as the number of slices. This is a significant problem because, for example, if the dashboard size is 1MB and it contains 100 slices, each user opening this dashboard generates 100MB of requests. Considering logs, endpoint checks, etc., it can reach 500-1000MB per user!

I have fixed this issue by retrieving the dashboard using id, uuid, or slug, and checking the access using the `raise_for_dashboard_access` function, which verifies access to the data sources.

### TESTING INSTRUCTIONS
1. Create a dashboard with 2 slices.
2. Set the sqlalchemy logs level to DEBUG.
3. Make a request to dashboard/<id or slug>/charts/.
4. Observe that the dashboard requests are repeated for each slice.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
