### PR TITLE
fix: add format for timestamp in crdb to correctly use times values

### DIFF
--- a/superset/db_engine_specs/cockroachdb.py
+++ b/superset/db_engine_specs/cockroachdb.py
@@ -21,6 +21,7 @@ from sqlalchemy import types
 
 from superset.db_engine_specs.postgres import PostgresEngineSpec
 
+
 class CockroachDbEngineSpec(PostgresEngineSpec):
     engine = "cockroachdb"
     engine_name = "CockroachDB"

--- a/superset/db_engine_specs/cockroachdb.py
+++ b/superset/db_engine_specs/cockroachdb.py
@@ -14,12 +14,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from superset.db_engine_specs.postgres import PostgresEngineSpec
-
 from datetime import datetime
 from typing import Any, Optional
 
 from sqlalchemy import types
+
+from superset.db_engine_specs.postgres import PostgresEngineSpec
 
 class CockroachDbEngineSpec(PostgresEngineSpec):
     engine = "cockroachdb"

--- a/superset/db_engine_specs/cockroachdb.py
+++ b/superset/db_engine_specs/cockroachdb.py
@@ -16,8 +16,21 @@
 # under the License.
 from superset.db_engine_specs.postgres import PostgresEngineSpec
 
+from datetime import datetime
+from typing import Any, Optional
+
+from sqlalchemy import types
 
 class CockroachDbEngineSpec(PostgresEngineSpec):
     engine = "cockroachdb"
     engine_name = "CockroachDB"
-    default_driver = ""
+
+    @classmethod
+    def convert_dttm(
+        cls, target_type: str, dttm: datetime, db_extra: Optional[dict[str, Any]] = None
+    ) -> Optional[str]:
+        sqla_type = cls.get_sqla_column_type(target_type)
+
+        if isinstance(sqla_type, (types.String, types.DateTime)):
+            return f"""'{dttm.isoformat(sep=" ", timespec="seconds")}'"""
+        return None

--- a/tests/unit_tests/db_engine_specs/test_crdb.py
+++ b/tests/unit_tests/db_engine_specs/test_crdb.py
@@ -33,7 +33,7 @@ from tests.unit_tests.fixtures.common import dttm
     ],
 )
 def test_convert_dttm(
-    target_type: str, expected_result: Optional[str]
+    target_type: str, expected_result: Optional[str], dttm: datetime
 ) -> None:
     from superset.db_engine_specs.cockroachdb import CockroachDbEngineSpec as spec
 

--- a/tests/unit_tests/db_engine_specs/test_crdb.py
+++ b/tests/unit_tests/db_engine_specs/test_crdb.py
@@ -33,7 +33,7 @@ from tests.unit_tests.fixtures.common import dttm
     ],
 )
 def test_convert_dttm(
-    target_type: str, expected_result: Optional[str], dttm: datetime
+    target_type: str, expected_result: Optional[str]
 ) -> None:
     from superset.db_engine_specs.cockroachdb import CockroachDbEngineSpec as spec
 

--- a/tests/unit_tests/db_engine_specs/test_crdb.py
+++ b/tests/unit_tests/db_engine_specs/test_crdb.py
@@ -20,7 +20,6 @@ from typing import Optional
 
 import pytest
 
-from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from tests.unit_tests.db_engine_specs.utils import assert_convert_dttm
 from tests.unit_tests.fixtures.common import dttm
 
@@ -39,4 +38,3 @@ def test_convert_dttm(
     from superset.db_engine_specs.cockroachdb import CockroachDbEngineSpec as spec
 
     assert_convert_dttm(spec, target_type, expected_result, dttm)
-

--- a/tests/unit_tests/db_engine_specs/test_crdb.py
+++ b/tests/unit_tests/db_engine_specs/test_crdb.py
@@ -14,24 +14,29 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from superset.db_engine_specs.postgres import PostgresEngineSpec
-
+# pylint: disable=unused-argument, import-outside-toplevel, protected-access
 from datetime import datetime
-from typing import Any, Optional
+from typing import Optional
 
-from sqlalchemy import types
+import pytest
 
-class CockroachDbEngineSpec(PostgresEngineSpec):
-    engine = "cockroachdb"
-    engine_name = "CockroachDB"
+from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
+from tests.unit_tests.db_engine_specs.utils import assert_convert_dttm
+from tests.unit_tests.fixtures.common import dttm
 
-    @classmethod
-    def convert_dttm(
-        cls, target_type: str, dttm: datetime, db_extra: Optional[dict[str, Any]] = None
-    ) -> Optional[str]:
-        sqla_type = cls.get_sqla_column_type(target_type)
-        if isinstance(sqla_type, types.Date):
-            return f"'{dttm.date().isoformat()}'"
-        if isinstance(sqla_type, (types.String, types.DateTime)):
-            return f"""'{dttm.isoformat(sep=" ", timespec="seconds")}'"""
-        return None
+
+@pytest.mark.parametrize(
+    "target_type,expected_result",
+    [
+        ("Date", "'2019-01-02'"),
+        ("TimeStamp", "'2019-01-02 03:04:05'"),
+        ("UnknownType", None),
+    ],
+)
+def test_convert_dttm(
+    target_type: str, expected_result: Optional[str], dttm: datetime
+) -> None:
+    from superset.db_engine_specs.cockroachdb import CockroachDbEngineSpec as spec
+
+    assert_convert_dttm(spec, target_type, expected_result, dttm)
+


### PR DESCRIPTION
### SUMMARY
This PR fixes #15825 

### TESTING INSTRUCTIONS
To test this, the following steps can be taken
- Add db connection for cockroach db. 
- Create a dataset that includes a table with a timestamp or timestampz column, this will be used as the temporal value when creating charts. 
- Create a chart that leverages a temporal value
- Inspect the generated query to see if the date format matches as expected. 

This has been tested in master and version 2.1.0 with python 3.11. 

In version 2.1.0 there were code changes needed to the `dict` type, this is due to a python version that was being used in the docker images of version 2.1.0. 

### ADDITIONAL INFORMATION
- [ x] Has associated issue: #15825 


