### PR TITLE
chore: update deprecated arguments in schema

### DIFF
--- a/superset/row_level_security/schemas.py
+++ b/superset/row_level_security/schemas.py
@@ -50,52 +50,54 @@ class TablesSchema(Schema):
 
 
 class RLSListSchema(Schema):
-    id = fields.Integer(description=id_description)
-    name = fields.String(description=name_description)
+    id = fields.Integer(metadata={"description": "id_description"})
+    name = fields.String(metadata={"description": "name_description"})
     filter_type = fields.String(
-        description=filter_type_description,
+        metadata={"description": "filter_type_description"},
         validate=OneOf(
             [filter_type.value for filter_type in RowLevelSecurityFilterType]
         ),
     )
     roles = fields.List(fields.Nested(RolesSchema))
     tables = fields.List(fields.Nested(TablesSchema))
-    clause = fields.String(description=clause_description)
+    clause = fields.String(metadata={"description": "clause_description"})
     changed_on_delta_humanized = fields.Function(
         RowLevelSecurityFilter.created_on_delta_humanized
     )
-    group_key = fields.String(description=group_key_description)
-    description = fields.String(description=description_description)
+    group_key = fields.String(metadata={"description": "group_key_description"})
+    description = fields.String(metadata={"description": "description_description"})
 
 
 class RLSShowSchema(Schema):
-    id = fields.Integer(description=id_description)
-    name = fields.String(description=name_description)
+    id = fields.Integer(metadata={"description": "id_description"})
+    name = fields.String(metadata={"description": "name_description"})
     filter_type = fields.String(
-        description=filter_type_description,
+        metadata={"description": "filter_type_description"},
         validate=OneOf(
             [filter_type.value for filter_type in RowLevelSecurityFilterType]
         ),
     )
     roles = fields.List(fields.Nested(RolesSchema))
     tables = fields.List(fields.Nested(TablesSchema))
-    clause = fields.String(description=clause_description)
-    group_key = fields.String(description=group_key_description)
-    description = fields.String(description=description_description)
+    clause = fields.String(metadata={"description": "clause_description"})
+    group_key = fields.String(metadata={"description": "group_key_description"})
+    description = fields.String(metadata={"description": "description_description"})
 
 
 class RLSPostSchema(Schema):
     name = fields.String(
-        description=name_description,
+        metadata={"description": "name_description"},
         required=True,
         allow_none=False,
         validate=Length(1, 255),
     )
     description = fields.String(
-        description=description_description, required=False, allow_none=True
+        metadata={"description": "description_description"},
+        required=False,
+        allow_none=True,
     )
     filter_type = fields.String(
-        description=filter_type_description,
+        metadata={"description": "filter_type_description"},
         required=True,
         allow_none=False,
         validate=OneOf(
@@ -104,34 +106,41 @@ class RLSPostSchema(Schema):
     )
     tables = fields.List(
         fields.Integer(),
-        description=tables_description,
+        metadata={"description": "tables_description"},
         required=True,
         allow_none=False,
         validate=Length(1),
     )
     roles = fields.List(
-        fields.Integer(), description=roles_description, required=True, allow_none=False
+        fields.Integer(),
+        metadata={"description": "roles_description"},
+        required=True,
+        allow_none=False,
     )
     group_key = fields.String(
-        description=group_key_description, required=False, allow_none=True
+        metadata={"description": "group_key_description"},
+        required=False,
+        allow_none=True,
     )
     clause = fields.String(
-        description=clause_description, required=True, allow_none=False
+        metadata={"description": "clause_description"}, required=True, allow_none=False
     )
 
 
 class RLSPutSchema(Schema):
     name = fields.String(
-        description=name_description,
+        metadata={"description": "name_description"},
         required=False,
         allow_none=False,
         validate=Length(1, 255),
     )
     description = fields.String(
-        description=description_description, required=False, allow_none=True
+        metadata={"description": "description_description"},
+        required=False,
+        allow_none=True,
     )
     filter_type = fields.String(
-        description=filter_type_description,
+        metadata={"description": "filter_type_description"},
         required=False,
         allow_none=False,
         validate=OneOf(
@@ -140,19 +149,21 @@ class RLSPutSchema(Schema):
     )
     tables = fields.List(
         fields.Integer(),
-        description=tables_description,
+        metadata={"description": "tables_description"},
         required=False,
         allow_none=False,
     )
     roles = fields.List(
         fields.Integer(),
-        description=roles_description,
+        metadata={"description": "roles_description"},
         required=False,
         allow_none=False,
     )
     group_key = fields.String(
-        description=group_key_description, required=False, allow_none=True
+        metadata={"description": "group_key_description"},
+        required=False,
+        allow_none=True,
     )
     clause = fields.String(
-        description=clause_description, required=False, allow_none=False
+        metadata={"description": "clause_description"}, required=False, allow_none=False
     )


### PR DESCRIPTION
### SUMMARY
[Since marshmallow 3.10](https://marshmallow.readthedocs.io/en/latest/changelog.html#id15) passing field metadata via keyword arguments is deprecated.

To search and replace I used the following regex:
- `description=(.*)\)`
- `metadata={"description": "$1"})
`
### TESTING INSTRUCTIONS
`pytest` or `./scripts/tests/run.sh
`
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
