### PR TITLE
fix(range-slider): removed localization of metric key

### DIFF
--- a/superset-frontend/src/filters/components/Range/buildQuery.ts
+++ b/superset-frontend/src/filters/components/Range/buildQuery.ts
@@ -20,7 +20,6 @@ import {
   buildQueryContext,
   GenericDataType,
   QueryFormData,
-  t,
 } from '@superset-ui/core';
 
 /**
@@ -55,7 +54,7 @@ export default function buildQuery(formData: QueryFormData) {
           },
           expressionType: 'SIMPLE',
           hasCustomLabel: true,
-          label: t('min'),
+          label: 'min',
         },
         {
           aggregate: 'MAX',
@@ -66,7 +65,7 @@ export default function buildQuery(formData: QueryFormData) {
           },
           expressionType: 'SIMPLE',
           hasCustomLabel: true,
-          label: t('max'),
+          label: 'max',
         },
       ],
     },


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Due to the this localization, the Range Slider is not functioning properly because we are unable to retrieve the `min` and `max` variables from the data because it was translated.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Example with a russian localization
#### Before

<img width="1280" alt="Screenshot_59" src="https://github.com/apache/superset/assets/66589759/53f27e2a-9309-4884-810a-c4b9c3ee9131">
<i>Message in english: a non-numeric column is selected</i>

#### After
<img width="1280" alt="Screenshot_61" src="https://github.com/apache/superset/assets/66589759/47ae212f-4f96-4286-80d7-ff0c83944a69">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
