### PR TITLE
docs: Specify correct postgresql yaml  for overriding default passwords

### DIFF
--- a/docs/docs/installation/running-on-kubernetes.mdx
+++ b/docs/docs/installation/running-on-kubernetes.mdx
@@ -89,7 +89,10 @@ Default security settings and passwords are included but you **SHOULD** override
 
 ```yaml
 postgresql:
-  postgresqlPassword: superset
+  auth:
+    postgresPassword: superset
+    password: superset
+supersetNode.connections.db_pass: superset
 ```
 
 Make sure, you set a unique strong complex alphanumeric string for your SECRET_KEY and use a tool to help you generate


### PR DESCRIPTION
### SUMMARY
The existing yaml for setting the admin postgresql password  is incorrect, just set up on a new kubernetes instance with the following yaml specified in PR. Also added the superset postgres user password as well, so that it could be changed as well.

