### PR TITLE
fix(druid): Delete obsolete Druid NoSQL slice parameters

### DIFF
--- a/superset/migrations/versions/2023-07-18_15-30_863adcf72773_delete_obsolete_druid_nosql_slice_parameters.py
+++ b/superset/migrations/versions/2023-07-18_15-30_863adcf72773_delete_obsolete_druid_nosql_slice_parameters.py
@@ -1,0 +1,103 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""delete obsolete Druid NoSQL slice parameters
+
+Revision ID: 863adcf72773
+Revises: 6d05b0a70c89
+Create Date: 2023-07-18 15:30:43.695135
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "863adcf72773"
+down_revision = "6d05b0a70c89"
+
+import json
+import logging
+
+from alembic import op
+from sqlalchemy import Column, Integer, Text
+from sqlalchemy.ext.declarative import declarative_base
+
+from superset import db
+
+Base = declarative_base()
+
+
+class Slice(Base):
+    __tablename__ = "slices"
+
+    id = Column(Integer, primary_key=True)
+    params = Column(Text)
+    query_context = Column(Text)
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    for slc in session.query(Slice).all():
+        if slc.params:
+            updated = False
+
+            try:
+                params = json.loads(slc.params)
+
+                for key in ["druid_time_origin", "granularity"]:
+                    if key in params:
+                        del params[key]
+                        updated = True
+
+                if updated:
+                    slc.params = json.dumps(params)
+            except Exception:
+                logging.exception(f"Unable to parse params for slice {slc.id}")
+
+        if slc.query_context:
+            updated = False
+
+            try:
+                query_context = json.loads(slc.query_context)
+
+                if form_data := query_context.get("form_data"):
+                    for key in ["druid_time_origin", "granularity"]:
+                        if key in form_data:
+                            del form_data[key]
+                            updated = True
+
+                for query in query_context.get("queries", []):
+                    for key in ["druid_time_origin", "granularity"]:
+                        if key in query:
+                            del query[key]
+                            updated = True
+
+                    if extras := query.get("extras"):
+                        if "having_druid" in extras:
+                            del extras["having_druid"]
+                            updated = True
+
+                if updated:
+                    slc.query_context = json.dumps(query_context)
+            except Exception:
+                logging.exception(f"Unable to parse query context for slice {slc.id}")
+
+    session.commit()
+    session.close()
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR addresses an issue raised by @padbk in https://github.com/apache/superset/discussions/24581#discussioncomment-6425918 related to sending an alert/revert via a CSV. The actual error was rather cryptic:

```
Error: Failed generating csv HTTP Error 400: BAD REQUEST
```

Specifically the RESTful `/api/v1/chart/{pk}/data/?format=csv` API endpoint was failing with the following error, 

```
{
  "message": "Request is incorrect: {'queries': {0: {'extras': {'having_druid': ['Unknown field.']}}}}"
}
```

which turned out to be related to https://github.com/apache/superset/pull/23997, i.e., the referenced PR (which I authored) didn't remove the now obsolete parameters from the `slices` table. This PR remedies said issue.

I used Airbnb's vast corpus (consisting of ~ 150k charts) to identify if/where the following form-data key were persisted to the database:

- `druid_time_origin`
- `having_druid`
- `having_filters`
- `granularity`

I wasn't able to find `having_filters` anywhere, but it was somewhat 😢 to see that the `druid_time_origin` and `granularity` fields were actually present in three separate places:

1. In the `slices.params` column
2. In the `form_data` field of the `slices.query_context` column.
3. In the `queries` field of the `slices.query_context` column.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI and added/tested the DB migration. After running the migration I then confirmed that that I was successfully able to generate a report sent as a CSV.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided << 5 minutes at Airbnb with ~ 150k charts
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
