### PR TITLE
fix: `search_path` in RDS

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1103,8 +1103,8 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     @classmethod
     def get_prequeries(
         cls,
-        catalog: str | None = None,
-        schema: str | None = None,
+        catalog: str | None = None,  # pylint: disable=unused-argument
+        schema: str | None = None,  # pylint: disable=unused-argument
     ) -> list[str]:
         """
         Return pre-session queries.

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1082,21 +1082,44 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
 
         For some databases (like MySQL, Presto, Snowflake) this requires modifying the
         SQLAlchemy URI before creating the connection. For others (like Postgres), it
-        requires additional parameters in ``connect_args``.
+        requires additional parameters in ``connect_args`` or running pre-session
+        queries with ``set`` parameters.
 
-        When a DB engine spec implements this method it should also have the attribute
-        ``supports_dynamic_schema`` set to true, so that Superset knows in which schema a
-        given query is running in order to enforce permissions (see #23385 and #23401).
+        When a DB engine spec implements this method or ``get_prequeries`` (see below) it
+        should also have the attribute ``supports_dynamic_schema`` set to true, so that
+        Superset knows in which schema a given query is running in order to enforce
+        permissions (see #23385 and #23401).
 
         Currently, changing the catalog is not supported. The method accepts a catalog so
         that when catalog support is added to Superset the interface remains the same.
         This is important because DB engine specs can be installed from 3rd party
-        packages.
+        packages, so we want to keep these methods as stable as possible.
         """
         return uri, {
             **connect_args,
             **cls.enforce_uri_query_params.get(uri.get_driver_name(), {}),
         }
+
+    @classmethod
+    def get_prequeries(
+        cls,
+        catalog: str | None = None,
+        schema: str | None = None,
+    ) -> list[str]:
+        """
+        Return pre-session queries.
+
+        These are currently used as an alternative to ``adjust_engine_params`` for
+        databases where the selected schema cannot be specified in the SQLAlchemy URI or
+        connection arguments.
+
+        For example, in order to specify a default schema in RDS we need to run a query
+        at the beggining of the session:
+
+            sql> set search_path = my_schema;
+
+        """
+        return []
 
     @classmethod
     def patch(cls) -> None:

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -270,7 +270,7 @@ class PostgresEngineSpec(PostgresBaseEngineSpec, BasicParametersMixin):
         be anything, and we would have to block users from running any queries
         referencing tables without an explicit schema.
         """
-        return [f'set search_path = "{schema}"']
+        return [f'set search_path = "{schema}"'] if schema else []
 
     @classmethod
     def get_allow_cost_estimate(cls, extra: dict[str, Any]) -> bool:

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -16,6 +16,9 @@
 # under the License.
 # pylint: disable=line-too-long,too-many-lines
 """A collection of ORM sqlalchemy models for Superset"""
+
+from __future__ import annotations
+
 import builtins
 import enum
 import json
@@ -26,7 +29,7 @@ from contextlib import closing, contextmanager, nullcontext
 from copy import deepcopy
 from datetime import datetime
 from functools import lru_cache
-from typing import Any, Callable, Optional, TYPE_CHECKING
+from typing import Any, Callable, TYPE_CHECKING
 
 import numpy
 import pandas as pd
@@ -270,7 +273,7 @@ class Database(
         return self.url_object.get_driver_name()
 
     @property
-    def masked_encrypted_extra(self) -> Optional[str]:
+    def masked_encrypted_extra(self) -> str | None:
         return self.db_engine_spec.mask_encrypted_extra(self.encrypted_extra)
 
     @property
@@ -315,7 +318,7 @@ class Database(
         return "schema_cache_timeout" in self.metadata_cache_timeout
 
     @property
-    def schema_cache_timeout(self) -> Optional[int]:
+    def schema_cache_timeout(self) -> int | None:
         return self.metadata_cache_timeout.get("schema_cache_timeout")
 
     @property
@@ -323,7 +326,7 @@ class Database(
         return "table_cache_timeout" in self.metadata_cache_timeout
 
     @property
-    def table_cache_timeout(self) -> Optional[int]:
+    def table_cache_timeout(self) -> int | None:
         return self.metadata_cache_timeout.get("table_cache_timeout")
 
     @property
@@ -364,7 +367,7 @@ class Database(
         conn = conn.set(password=PASSWORD_MASK if conn.password else None)
         self.sqlalchemy_uri = str(conn)  # hides the password
 
-    def get_effective_user(self, object_url: URL) -> Optional[str]:
+    def get_effective_user(self, object_url: URL) -> str | None:
         """
         Get the effective user, especially during impersonation.
 
@@ -383,10 +386,10 @@ class Database(
     @contextmanager
     def get_sqla_engine_with_context(
         self,
-        schema: Optional[str] = None,
+        schema: str | None = None,
         nullpool: bool = True,
-        source: Optional[utils.QuerySource] = None,
-        override_ssh_tunnel: Optional["SSHTunnel"] = None,
+        source: utils.QuerySource | None = None,
+        override_ssh_tunnel: SSHTunnel | None = None,
     ) -> Engine:
         from superset.daos.database import (  # pylint: disable=import-outside-toplevel
             DatabaseDAO,
@@ -425,10 +428,10 @@ class Database(
 
     def _get_sqla_engine(
         self,
-        schema: Optional[str] = None,
+        schema: str | None = None,
         nullpool: bool = True,
-        source: Optional[utils.QuerySource] = None,
-        sqlalchemy_uri: Optional[str] = None,
+        source: utils.QuerySource | None = None,
+        sqlalchemy_uri: str | None = None,
     ) -> Engine:
         sqlalchemy_url = make_url_safe(
             sqlalchemy_uri if sqlalchemy_uri else self.sqlalchemy_uri_decrypted
@@ -513,17 +516,23 @@ class Database(
     @contextmanager
     def get_raw_connection(
         self,
-        schema: Optional[str] = None,
+        schema: str | None = None,
         nullpool: bool = True,
-        source: Optional[utils.QuerySource] = None,
+        source: utils.QuerySource | None = None,
     ) -> Connection:
         with self.get_sqla_engine_with_context(
             schema=schema, nullpool=nullpool, source=source
         ) as engine:
             with closing(engine.raw_connection()) as conn:
+                # pre-session queries are used to set the selected schema and, in the
+                # future, the selected catalog
+                for prequery in self.db_engine_spec.get_prequeries(schema=schema):
+                    cursor = conn.cursor()
+                    cursor.execute(prequery)
+
                 yield conn
 
-    def get_default_schema_for_query(self, query: "Query") -> Optional[str]:
+    def get_default_schema_for_query(self, query: Query) -> str | None:
         """
         Return the default schema for a given query.
 
@@ -550,8 +559,8 @@ class Database(
     def get_df(  # pylint: disable=too-many-locals
         self,
         sql: str,
-        schema: Optional[str] = None,
-        mutator: Optional[Callable[[pd.DataFrame], None]] = None,
+        schema: str | None = None,
+        mutator: Callable[[pd.DataFrame], None] | None = None,
     ) -> pd.DataFrame:
         sqls = self.db_engine_spec.parse_sql(sql)
         engine = self._get_sqla_engine(schema)
@@ -614,7 +623,7 @@ class Database(
 
             return df
 
-    def compile_sqla_query(self, qry: Select, schema: Optional[str] = None) -> str:
+    def compile_sqla_query(self, qry: Select, schema: str | None = None) -> str:
         engine = self._get_sqla_engine(schema=schema)
 
         sql = str(qry.compile(engine, compile_kwargs={"literal_binds": True}))
@@ -628,12 +637,12 @@ class Database(
     def select_star(  # pylint: disable=too-many-arguments
         self,
         table_name: str,
-        schema: Optional[str] = None,
+        schema: str | None = None,
         limit: int = 100,
         show_cols: bool = False,
         indent: bool = True,
         latest_partition: bool = False,
-        cols: Optional[list[ResultSetColumnType]] = None,
+        cols: list[ResultSetColumnType] | None = None,
     ) -> str:
         """Generates a ``select *`` statement in the proper dialect"""
         eng = self._get_sqla_engine(schema=schema, source=utils.QuerySource.SQL_LAB)
@@ -672,7 +681,7 @@ class Database(
         self,
         schema: str,
         cache: bool = False,
-        cache_timeout: Optional[int] = None,
+        cache_timeout: int | None = None,
         force: bool = False,
     ) -> set[tuple[str, str]]:
         """Parameters need to be passed as keyword arguments.
@@ -708,7 +717,7 @@ class Database(
         self,
         schema: str,
         cache: bool = False,
-        cache_timeout: Optional[int] = None,
+        cache_timeout: int | None = None,
         force: bool = False,
     ) -> set[tuple[str, str]]:
         """Parameters need to be passed as keyword arguments.
@@ -737,7 +746,7 @@ class Database(
 
     @contextmanager
     def get_inspector_with_context(
-        self, ssh_tunnel: Optional["SSHTunnel"] = None
+        self, ssh_tunnel: SSHTunnel | None = None
     ) -> Inspector:
         with self.get_sqla_engine_with_context(
             override_ssh_tunnel=ssh_tunnel
@@ -751,9 +760,9 @@ class Database(
     def get_all_schema_names(  # pylint: disable=unused-argument
         self,
         cache: bool = False,
-        cache_timeout: Optional[int] = None,
+        cache_timeout: int | None = None,
         force: bool = False,
-        ssh_tunnel: Optional["SSHTunnel"] = None,
+        ssh_tunnel: SSHTunnel | None = None,
     ) -> list[str]:
         """Parameters need to be passed as keyword arguments.
 
@@ -818,7 +827,7 @@ class Database(
     def update_params_from_encrypted_extra(self, params: dict[str, Any]) -> None:
         self.db_engine_spec.update_params_from_encrypted_extra(self, params)
 
-    def get_table(self, table_name: str, schema: Optional[str] = None) -> Table:
+    def get_table(self, table_name: str, schema: str | None = None) -> Table:
         extra = self.get_extra()
         meta = MetaData(**extra.get("metadata_params", {}))
         with self.get_sqla_engine_with_context() as engine:
@@ -831,13 +840,13 @@ class Database(
             )
 
     def get_table_comment(
-        self, table_name: str, schema: Optional[str] = None
-    ) -> Optional[str]:
+        self, table_name: str, schema: str | None = None
+    ) -> str | None:
         with self.get_inspector_with_context() as inspector:
             return self.db_engine_spec.get_table_comment(inspector, table_name, schema)
 
     def get_columns(
-        self, table_name: str, schema: Optional[str] = None
+        self, table_name: str, schema: str | None = None
     ) -> list[ResultSetColumnType]:
         with self.get_inspector_with_context() as inspector:
             return self.db_engine_spec.get_columns(inspector, table_name, schema)
@@ -845,19 +854,19 @@ class Database(
     def get_metrics(
         self,
         table_name: str,
-        schema: Optional[str] = None,
+        schema: str | None = None,
     ) -> list[MetricType]:
         with self.get_inspector_with_context() as inspector:
             return self.db_engine_spec.get_metrics(self, inspector, table_name, schema)
 
     def get_indexes(
-        self, table_name: str, schema: Optional[str] = None
+        self, table_name: str, schema: str | None = None
     ) -> list[dict[str, Any]]:
         with self.get_inspector_with_context() as inspector:
             return self.db_engine_spec.get_indexes(self, inspector, table_name, schema)
 
     def get_pk_constraint(
-        self, table_name: str, schema: Optional[str] = None
+        self, table_name: str, schema: str | None = None
     ) -> dict[str, Any]:
         with self.get_inspector_with_context() as inspector:
             pk_constraint = inspector.get_pk_constraint(table_name, schema) or {}
@@ -871,7 +880,7 @@ class Database(
             return {key: _convert(value) for key, value in pk_constraint.items()}
 
     def get_foreign_keys(
-        self, table_name: str, schema: Optional[str] = None
+        self, table_name: str, schema: str | None = None
     ) -> list[dict[str, Any]]:
         with self.get_inspector_with_context() as inspector:
             return inspector.get_foreign_keys(table_name, schema)
@@ -926,7 +935,7 @@ class Database(
         with self.get_sqla_engine_with_context() as engine:
             return engine.has_table(table.table_name, table.schema or None)
 
-    def has_table_by_name(self, table_name: str, schema: Optional[str] = None) -> bool:
+    def has_table_by_name(self, table_name: str, schema: str | None = None) -> bool:
         with self.get_sqla_engine_with_context() as engine:
             return engine.has_table(table_name, schema)
 
@@ -936,7 +945,7 @@ class Database(
         conn: Connection,
         dialect: Dialect,
         view_name: str,
-        schema: Optional[str] = None,
+        schema: str | None = None,
     ) -> bool:
         view_names: list[str] = []
         try:
@@ -945,11 +954,11 @@ class Database(
             logger.warning("Has view failed", exc_info=True)
         return view_name in view_names
 
-    def has_view(self, view_name: str, schema: Optional[str] = None) -> bool:
+    def has_view(self, view_name: str, schema: str | None = None) -> bool:
         engine = self._get_sqla_engine()
         return engine.run_callable(self._has_view, engine.dialect, view_name, schema)
 
-    def has_view_by_name(self, view_name: str, schema: Optional[str] = None) -> bool:
+    def has_view_by_name(self, view_name: str, schema: str | None = None) -> bool:
         return self.has_view(view_name=view_name, schema=schema)
 
     def get_dialect(self) -> Dialect:
@@ -957,7 +966,7 @@ class Database(
         return sqla_url.get_dialect()()
 
     def make_sqla_column_compatible(
-        self, sqla_col: ColumnElement, label: Optional[str] = None
+        self, sqla_col: ColumnElement, label: str | None = None
     ) -> ColumnElement:
         """Takes a sqlalchemy column object and adds label info if supported by engine.
         :param sqla_col: sqlalchemy column instance

--- a/tests/unit_tests/db_engine_specs/test_postgres.py
+++ b/tests/unit_tests/db_engine_specs/test_postgres.py
@@ -133,25 +133,13 @@ def test_get_schema_from_engine_params() -> None:
     )
 
 
-def test_adjust_engine_params() -> None:
+def test_get_prequeries() -> None:
     """
-    Test the ``adjust_engine_params`` method.
+    Test the ``get_prequeries`` method.
     """
     from superset.db_engine_specs.postgres import PostgresEngineSpec
 
-    uri = make_url("postgres://user:password@host/catalog")
-
-    assert PostgresEngineSpec.adjust_engine_params(uri, {}, None, "secret") == (
-        uri,
-        {"options": "-csearch_path=secret"},
-    )
-
-    assert PostgresEngineSpec.adjust_engine_params(
-        uri,
-        {"foo": "bar", "options": "-csearch_path=default -c debug=1"},
-        None,
-        "secret",
-    ) == (
-        uri,
-        {"foo": "bar", "options": "-csearch_path=secret -cdebug=1"},
-    )
+    assert PostgresEngineSpec.get_prequeries() == []
+    assert PostgresEngineSpec.get_prequeries(schema="test") == [
+        'set search_path = "test"'
+    ]

--- a/tests/unit_tests/models/core_test.py
+++ b/tests/unit_tests/models/core_test.py
@@ -212,3 +212,21 @@ def test_dttm_sql_literal(
 def test_table_column_database() -> None:
     database = Database(database_name="db")
     assert TableColumn(database=database).database is database
+
+
+def test_get_prequeries(mocker: MockFixture) -> None:
+    """
+    Tests for ``get_prequeries``.
+    """
+    mocker.patch.object(
+        Database,
+        "get_sqla_engine_with_context",
+    )
+    db_engine_spec = mocker.patch.object(Database, "db_engine_spec")
+    db_engine_spec.get_prequeries.return_value = ["set a=1", "set b=2"]
+
+    database = Database(database_name="db")
+    with database.get_raw_connection() as conn:
+        conn.cursor().execute.assert_has_calls(
+            [mocker.call("set a=1"), mocker.call("set b=2")]
+        )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

(See https://github.com/apache/superset/issues/24684 for more context.)

For security reasons, we need to be able to run SQL Lab queries in user-specified schemas. For example, in SQL Lab, when a user selects the schema `foo` from the dropdown and runs the following query:

```sql
SELECT * FROM some_table;
```

Since `some_table` is not fully qualified (it has no schema), we need to:

1. Ensure the query runs in the `foo` schema, so that the right table is queried.
2. Ensure that the user has permission to query `foo.some_table` (eg, by having access to the `foo` schema).

[Note that if (1) is not true, we can't do (2), since we don't know the schema of `some_table`.]

For Postgres, the way we currently do (1) is by setting `options=-csearch_path=foo` in the connection arguments every time the user runs a query. The problem is that the Postgres DB engine spec **and** the Postgres SQLAlchemy dialect are also used by RDS, which does not support options to be passed this way. In 3.0 RC1 it's not possible to query RDS because the search path is set for every query.

Fortunately there's a way that works for both Postgres and RDS (and hopefully, other databases using the Postgres client): by running the query `set search_path=foo` when the connection is first created.

This PR introduces the concept of "pre queries", ie, queries that are run as soon as a raw connection is created. This ensures ensure that the schema (and in the future, catalog) can be set per query correctly for Postgres and potentially other databases (the implementation is per DB-engine spec).

Note that if DML is enabled it's still possible for users to run `set search_path=bar` in SQL Lab. This could lead to security issues where:

1. User selects `foo` as the schema in SQL Lab.
2. User runs the query `set search_path=bar; SELECT * FROM some_table`.
3. Superset's security manager will check if the user has access to `some_table`. Since the table name is not fully qualified and the dropdown is set to `foo`, Superset will check for access to `foo.some_table`, even though the table is actually `bar.some_table`.

This would allow a malicious user that has access to a given schema (say, `foo`) to query tables in **any** schema by simply choosing `foo` from the schema dropdown in SQL Lab and specifying the search path in the query.

To fix this problem (at least for Postgres), I extended the `get_default_schema_for_query` to check for `set search_path` and raise an exception if it's there:

![Screenshot 2023-07-19 at 19-01-35 Superset](https://github.com/apache/superset/assets/1534870/0d2fcdf2-9a5c-4868-8749-be9fe66321f5)

Ideally, instead of raising an exception we would parse the query to figure out the schema, but this is not trivial. Consider, eg, the following query:

```sql
set search_path = foo;
SELECT * FROM some_table;
set search_path = bar;
SELECT * FROM some_other_table;
```

Because of the complexity of figuring out the correct schema for table in a query with multiple statements, I opted to raise an exception for now, hoping that in the future we can improve this.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Added new unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
