### PR TITLE
chore: make antd table font size same as data table

### DIFF
--- a/superset-frontend/src/components/Table/VirtualTable.tsx
+++ b/superset-frontend/src/components/Table/VirtualTable.tsx
@@ -61,8 +61,11 @@ const StyledTable = styled(AntTable)<{ height?: number }>(
 
     .ant-pagination-item-active {
       border-color: ${theme.colors.primary.base};
+      }
     }
-  }
+    .ant-table.ant-table-small {
+      font-size: ${theme.typography.sizes.s}px;
+    }
 `,
 );
 

--- a/superset-frontend/src/components/Table/index.tsx
+++ b/superset-frontend/src/components/Table/index.tsx
@@ -184,6 +184,10 @@ const StyledTable = styled(AntTable)<{ height?: number }>(
     .ant-pagination-item-active {
       border-color: ${theme.colors.primary.base};
     }
+
+    .ant-table.ant-table-small {
+      font-size: ${theme.typography.sizes.s}px;
+    }
   `,
 );
 const StyledVirtualTable = styled(VirtualTable)(


### PR DESCRIPTION
### SUMMARY
"Drill to details" uses normal font-size (14px) where all other data tables in Superset use small font size (12px). This sets our Table component based on AntD to use our `typography.sizes.s` while the table is set to a small size.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### after
<img width="980" alt="Screen Shot 2023-07-18 at 6 25 53 PM" src="https://github.com/apache/superset/assets/487433/8c1951fd-d38b-423d-a3b1-d8cc563a4756">

#### before
<img width="943" alt="Screen Shot 2023-07-18 at 6 30 25 PM" src="https://github.com/apache/superset/assets/487433/6fa24c51-6762-460a-bd2f-2c79ec1dc822">
