### PR TITLE
fix: Dashboard time grain in Table

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
@@ -52,10 +52,15 @@ const buildQuery: BuildQuery<TableChartFormData> = (
   formData: TableChartFormData,
   options,
 ) => {
-  const { percent_metrics: percentMetrics, order_desc: orderDesc = false } =
-    formData;
+  const {
+    percent_metrics: percentMetrics,
+    order_desc: orderDesc = false,
+    extra_form_data,
+  } = formData;
   const queryMode = getQueryMode(formData);
   const sortByMetric = ensureIsArray(formData.timeseries_limit_metric)[0];
+  const time_grain_sqla =
+    extra_form_data?.time_grain_sqla || formData.time_grain_sqla;
   let formDataCopy = formData;
   // never include time in raw records mode
   if (queryMode === QueryMode.raw) {
@@ -102,12 +107,12 @@ const buildQuery: BuildQuery<TableChartFormData> = (
       columns = columns.map(col => {
         if (
           isPhysicalColumn(col) &&
-          formData.time_grain_sqla &&
+          time_grain_sqla &&
           hasGenericChartAxes &&
           formData?.temporal_columns_lookup?.[col]
         ) {
           return {
-            timeGrain: formData.time_grain_sqla,
+            timeGrain: time_grain_sqla,
             columnType: 'BASE_AXIS',
             sqlExpression: col,
             label: col,


### PR DESCRIPTION
### SUMMARY
Fixes a bug in the `Table` chart when reacting to dashboard Time Grain changes.

Follow-up of https://github.com/apache/superset/pull/24665

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: The time grain is incorrectly calculated and you can see duplicated quarters.

https://github.com/apache/superset/assets/70410625/e2c71aba-bdb3-45c4-894c-d3e4e17f4ecd

After: The time grain is applied correctly and there's no duplication anymore.

https://github.com/apache/superset/assets/70410625/57e67c83-5e7f-44b4-a99f-4aa48fd1f085

### TESTING INSTRUCTIONS
Make sure Table charts works as expected when reacting to dashboard Time Grain changes.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
