### PR TITLE
fix: update svgr webpack config to use svg dimensions

### DIFF
--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -421,6 +421,9 @@ const config = {
             options: {
               titleProp: true,
               ref: true,
+              // this is the default value for the icon. Using other values
+              // here will replace width and height in svg with 1em
+              icon: false,
             },
           },
         ],

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -419,11 +419,6 @@ const config = {
           {
             loader: '@svgr/webpack',
             options: {
-              icon: true,
-              svgo: false,
-              svgoConfig: {
-                plugins: [{ removeViewBox: false }],
-              },
               titleProp: true,
               ref: true,
             },


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This fix from a breaking change/regression after bumping the svgr/webpack package enables us to continue to use the width/height dimensions from the svg image itself. Ref: https://react-svgr.com/docs/options/#icon

Changes: https://github.com/apache/superset/pull/24648/files#diff-3834c36280e1af5685801f3357578aaec5a110699a2b8eb97844c56b4400c091


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: 
![Preset](https://github.com/apache/superset/assets/5186919/cd55bd75-dd50-4ba5-a486-3ebad4c01891)
<img width="276" alt="Screenshot_7_19_23__11_15_AM" src="https://github.com/apache/superset/assets/5186919/803ee46c-0168-4799-bd91-57947db39922">


After:
![_DEV__Superset](https://github.com/apache/superset/assets/5186919/576fc5d0-6f57-4c3a-b41b-586b89dfe4f6)
<img width="284" alt="Screenshot_7_19_23__11_13_AM" src="https://github.com/apache/superset/assets/5186919/cae3b2bc-d225-4e0d-92ae-6cab519117af">


### TESTING INSTRUCTIONS
Load a chart with icons. There may be other places in the application that were affected that haven't yet been identified, but by doing a code search for svg images with width and height we should be able to find others. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
