### PR TITLE
feat: Add line width unit control in deckgl Polygon and Path

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Geojson/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Geojson/controlPanel.ts
@@ -77,7 +77,7 @@ const config: ControlPanelConfig = {
             config: {
               type: 'SelectControl',
               label: t('Line width unit'),
-              default: 'meters',
+              default: 'pixels',
               choices: [
                 ['meters', t('meters')],
                 ['pixels', t('pixels')],

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Path/Path.jsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Path/Path.jsx
@@ -64,6 +64,7 @@ export function getLayer(formData, payload, onAddFilter, setTooltip) {
     data,
     rounded: true,
     widthScale: 1,
+    widthUnits: fd.line_width_unit,
     ...commonLayerProps(fd, setTooltip, setTooltipContent),
   });
 }

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Path/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Path/controlPanel.ts
@@ -68,8 +68,25 @@ const config: ControlPanelConfig = {
       expanded: true,
       controlSetRows: [
         [mapboxStyle, viewport],
-        ['color_picker', lineWidth],
-        [reverseLongLat, autozoom],
+        ['color_picker'],
+        [lineWidth],
+        [
+          {
+            name: 'line_width_unit',
+            config: {
+              type: 'SelectControl',
+              label: t('Line width unit'),
+              default: 'pixels',
+              choices: [
+                ['meters', t('meters')],
+                ['pixels', t('pixels')],
+              ],
+              renderTrigger: true,
+            },
+          },
+        ],
+        [reverseLongLat],
+        [autozoom],
       ],
     },
     {

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Polygon/Polygon.jsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Polygon/Polygon.jsx
@@ -143,7 +143,7 @@ export function getLayer(
     getLineColor: [sc.r, sc.g, sc.b, 255 * sc.a],
     getLineWidth: fd.line_width,
     extruded: fd.extruded,
-    lineWidthUnits: 'pixels',
+    lineWidthUnits: fd.line_width_unit,
     getElevation: d => getElevation(d, colorScaler),
     elevationScale: fd.multiplier,
     fp64: true,

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Polygon/Polygon.jsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Polygon/Polygon.jsx
@@ -143,6 +143,7 @@ export function getLayer(
     getLineColor: [sc.r, sc.g, sc.b, 255 * sc.a],
     getLineWidth: fd.line_width,
     extruded: fd.extruded,
+    lineWidthUnits: 'pixels',
     getElevation: d => getElevation(d, colorScaler),
     elevationScale: fd.multiplier,
     fp64: true,

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Polygon/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Polygon/controlPanel.ts
@@ -97,10 +97,7 @@ const config: ControlPanelConfig = {
     {
       label: t('Map'),
       expanded: true,
-      controlSetRows: [
-        [mapboxStyle, viewport],
-        [autozoom, null],
-      ],
+      controlSetRows: [[mapboxStyle], [viewport], [autozoom]],
     },
     {
       label: t('Polygon Settings'),
@@ -108,10 +105,26 @@ const config: ControlPanelConfig = {
       controlSetRows: [
         [fillColorPicker, strokeColorPicker],
         [filled, stroked],
-        [extruded, multiplier],
-        [lineWidth, null],
+        [extruded],
+        [multiplier],
+        [lineWidth],
         [
-          'linear_color_scheme',
+          {
+            name: 'line_width_unit',
+            config: {
+              type: 'SelectControl',
+              label: t('Line width unit'),
+              default: 'pixels',
+              choices: [
+                ['meters', t('meters')],
+                ['pixels', t('pixels')],
+              ],
+              renderTrigger: true,
+            },
+          },
+        ],
+        ['linear_color_scheme'],
+        [
           {
             name: 'opacity',
             config: {
@@ -140,6 +153,8 @@ const config: ControlPanelConfig = {
               renderTrigger: true,
             },
           },
+        ],
+        [
           {
             name: 'break_points',
             config: {
@@ -166,6 +181,8 @@ const config: ControlPanelConfig = {
               description: t('Whether to apply filter when items are clicked'),
             },
           },
+        ],
+        [
           {
             name: 'toggle_polygons',
             config: {
@@ -179,7 +196,8 @@ const config: ControlPanelConfig = {
             },
           },
         ],
-        [legendPosition, legendFormat],
+        [legendPosition],
+        [legendFormat],
       ],
     },
     {

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.jsx
@@ -210,7 +210,7 @@ export const lineWidth = {
     label: t('Line width'),
     renderTrigger: true,
     isInt: true,
-    default: 10,
+    default: 1,
     description: t('The width of the lines'),
   },
 };

--- a/superset/examples/deck.py
+++ b/superset/examples/deck.py
@@ -388,6 +388,7 @@ def load_deck_dash() -> None:  # pylint: disable=too-many-statements
         "extruded": True,
         "multiplier": 0.1,
         "line_width": 10,
+        "line_width_unit": "meters",
         "point_radius_fixed": {
             "type": "metric",
             "value": {

--- a/superset/examples/deck.py
+++ b/superset/examples/deck.py
@@ -387,6 +387,7 @@ def load_deck_dash() -> None:  # pylint: disable=too-many-statements
         "stroked": False,
         "extruded": True,
         "multiplier": 0.1,
+        "line_width": 10,
         "point_radius_fixed": {
             "type": "metric",
             "value": {

--- a/superset/migrations/versions/2023-07-19_17-54_ee179a490af9_deckgl_path_width_units.py
+++ b/superset/migrations/versions/2023-07-19_17-54_ee179a490af9_deckgl_path_width_units.py
@@ -49,7 +49,11 @@ def upgrade():
     bind = op.get_bind()
     session = db.Session(bind=bind)
     for slc in session.query(Slice).filter(
-        or_(Slice.viz_type == "deck_path", Slice.viz_type == "deck_geojson")
+        or_(
+            Slice.viz_type == "deck_path",
+            Slice.viz_type == "deck_geojson",
+            Slice.viz_type == "deck_polygon",
+        )
     ):
         params = json.loads(slc.params)
         if not params.get("line_width_unit"):
@@ -61,15 +65,4 @@ def upgrade():
 
 
 def downgrade():
-    bind = op.get_bind()
-    session = db.Session(bind=bind)
-    for slc in session.query(Slice).filter(
-        or_(Slice.viz_type == "deck_path", Slice.viz_type == "deck_geojson")
-    ):
-        params = json.loads(slc.params)
-        if params.get("line_width_unit"):
-            del params["line_width_unit"]
-        slc.params = json.dumps(params)
-        session.merge(slc)
-        session.commit()
-    session.close()
+    pass

--- a/superset/migrations/versions/2023-07-19_17-54_ee179a490af9_deckgl_path_width_units.py
+++ b/superset/migrations/versions/2023-07-19_17-54_ee179a490af9_deckgl_path_width_units.py
@@ -17,7 +17,7 @@
 """deckgl-path-width-units
 
 Revision ID: ee179a490af9
-Revises: 6d05b0a70c89
+Revises: 863adcf72773
 Create Date: 2023-07-19 17:54:06.752360
 
 """
@@ -32,7 +32,7 @@ from superset import db
 
 # revision identifiers, used by Alembic.
 revision = "ee179a490af9"
-down_revision = "6d05b0a70c89"
+down_revision = "863adcf72773"
 
 
 Base = declarative_base()

--- a/superset/migrations/versions/2023-07-19_17-54_ee179a490af9_deckgl_path_width_units.py
+++ b/superset/migrations/versions/2023-07-19_17-54_ee179a490af9_deckgl_path_width_units.py
@@ -17,7 +17,7 @@
 """deckgl-path-width-units
 
 Revision ID: ee179a490af9
-Revises: 863adcf72773
+Revises: a23c6f8b1280
 Create Date: 2023-07-19 17:54:06.752360
 
 """
@@ -32,7 +32,7 @@ from superset import db
 
 # revision identifiers, used by Alembic.
 revision = "ee179a490af9"
-down_revision = "863adcf72773"
+down_revision = "a23c6f8b1280"
 
 
 Base = declarative_base()

--- a/superset/migrations/versions/2023-07-19_17-54_ee179a490af9_deckgl_path_width_units.py
+++ b/superset/migrations/versions/2023-07-19_17-54_ee179a490af9_deckgl_path_width_units.py
@@ -22,8 +22,8 @@ Create Date: 2023-07-19 17:54:06.752360
 
 """
 import json
+import logging
 
-import sqlalchemy as sa
 from alembic import op
 from sqlalchemy import Column, Integer, or_, String, Text
 from sqlalchemy.ext.declarative import declarative_base
@@ -55,12 +55,14 @@ def upgrade():
             Slice.viz_type == "deck_polygon",
         )
     ):
-        params = json.loads(slc.params)
-        if not params.get("line_width_unit"):
-            params["line_width_unit"] = "meters"
-        slc.params = json.dumps(params)
-        session.merge(slc)
-        session.commit()
+        try:
+            params = json.loads(slc.params)
+            if not params.get("line_width_unit"):
+                params["line_width_unit"] = "meters"
+                slc.params = json.dumps(params)
+        except Exception:
+            logging.exception(f"Unable to parse params for slice {slc.id}")
+    session.commit()
     session.close()
 
 

--- a/superset/migrations/versions/2023-07-19_17-54_ee179a490af9_deckgl_path_width_units.py
+++ b/superset/migrations/versions/2023-07-19_17-54_ee179a490af9_deckgl_path_width_units.py
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""deckgl-path-width-units
+
+Revision ID: ee179a490af9
+Revises: 6d05b0a70c89
+Create Date: 2023-07-19 17:54:06.752360
+
+"""
+import json
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import Column, Integer, or_, String, Text
+from sqlalchemy.ext.declarative import declarative_base
+
+from superset import db
+
+# revision identifiers, used by Alembic.
+revision = "ee179a490af9"
+down_revision = "6d05b0a70c89"
+
+
+Base = declarative_base()
+
+
+class Slice(Base):
+    __tablename__ = "slices"
+    id = Column(Integer, primary_key=True)
+    viz_type = Column(String(250))
+    params = Column(Text)
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+    for slc in session.query(Slice).filter(
+        or_(Slice.viz_type == "deck_path", Slice.viz_type == "deck_geojson")
+    ):
+        params = json.loads(slc.params)
+        if not params.get("line_width_unit"):
+            params["line_width_unit"] = "meters"
+        slc.params = json.dumps(params)
+        session.merge(slc)
+        session.commit()
+    session.close()
+
+
+def downgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+    for slc in session.query(Slice).filter(
+        or_(Slice.viz_type == "deck_path", Slice.viz_type == "deck_geojson")
+    ):
+        params = json.loads(slc.params)
+        if params.get("line_width_unit"):
+            del params["line_width_unit"]
+        slc.params = json.dumps(params)
+        session.merge(slc)
+        session.commit()
+    session.close()


### PR DESCRIPTION
### SUMMARY
Currently the default unit of line width in deckgl Path and Polygon charts is meter. That leads to some confusion, especially in large scale maps, because users might think that the line is not drawn at all - while in reality it's simply too thin to be visible. This PR addresses that problem by changing the default unit from meters to pixels.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://github.com/apache/superset/assets/15073128/dc590943-062b-4071-9d97-2d3edf85211e

### TESTING INSTRUCTIONS
1. Create a deckgl Path chart
2. Verify that the default line width unit is pixels and default line width is 1 and that drawn line is visible
3. Verify a deckgl Polygons chart
4. Check "Stroked" and uncheck "Extruded"
5. Verify that line between polygons is visible
6. Verify that existing charts still use meters unit

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided
Current: 0.12 s
10+: 0.12 s
100+: 0.21 s
1000+: 0.13 s
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
