### PR TITLE
fix: Tooltip no longer highlights hovered data series

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/EchartsMixedTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/EchartsMixedTimeseries.tsx
@@ -45,6 +45,7 @@ export default function EchartsMixedTimeseries({
   emitCrossFilters,
   seriesBreakdown,
   onContextMenu,
+  onFocusedSeries,
   xValueFormatter,
   xAxis,
   refs,
@@ -122,6 +123,12 @@ export default function EchartsMixedTimeseries({
     click: props => {
       const { seriesName, seriesIndex } = props;
       handleChange(seriesName, seriesIndex);
+    },
+    mouseout: () => {
+      onFocusedSeries(null);
+    },
+    mouseover: params => {
+      onFocusedSeries(params.seriesName);
     },
     contextmenu: async eventParams => {
       if (onContextMenu) {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -120,8 +120,10 @@ export default function transformProps(
     theme,
     inContextMenu,
     emitCrossFilters,
-    ownState = {},
   } = chartProps;
+
+  let focusedSeries: string | null = null;
+
   const {
     verboseMap = {},
     currencyFormats = {},
@@ -577,7 +579,6 @@ export default function transformProps(
               ? tooltipFormatter
               : tooltipFormatterSecondary,
           });
-          const { focusedSeries } = ownState;
           const contentStyle =
             key === focusedSeries ? 'font-weight: 700' : 'opacity: 0.7';
           rows.push(`<span style="${contentStyle}">${content}</span>`);
@@ -632,7 +633,7 @@ export default function transformProps(
   };
 
   const onFocusedSeries = (seriesName: string | null) => {
-    ownState.focusedSeries = seriesName;
+    focusedSeries = seriesName;
   };
 
   return {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -578,11 +578,9 @@ export default function transformProps(
               : tooltipFormatterSecondary,
           });
           const { focusedSeries } = ownState;
-          if (key === focusedSeries) {
-            rows.push(`<span style="font-weight: 700">${content}</span>`);
-          } else {
-            rows.push(`<span style="opacity: 0.7">${content}</span>`);
-          }
+          const contentStyle =
+            key === focusedSeries ? 'font-weight: 700' : 'opacity: 0.7';
+          rows.push(`<span style="${contentStyle}">${content}</span>`);
         });
         return rows.join('<br />');
       },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -120,6 +120,7 @@ export default function transformProps(
     theme,
     inContextMenu,
     emitCrossFilters,
+    ownState = {},
   } = chartProps;
   const {
     verboseMap = {},
@@ -576,7 +577,12 @@ export default function transformProps(
               ? tooltipFormatter
               : tooltipFormatterSecondary,
           });
-          rows.push(`<span style="opacity: 0.7">${content}</span>`);
+          const { focusedSeries } = ownState;
+          if (key === focusedSeries) {
+            rows.push(`<span style="font-weight: 700">${content}</span>`);
+          } else {
+            rows.push(`<span style="opacity: 0.7">${content}</span>`);
+          }
         });
         return rows.join('<br />');
       },
@@ -627,6 +633,10 @@ export default function transformProps(
       : [],
   };
 
+  const onFocusedSeries = (seriesName: string | null) => {
+    ownState.focusedSeries = seriesName;
+  };
+
   return {
     formData,
     width,
@@ -641,6 +651,7 @@ export default function transformProps(
     seriesBreakdown: rawSeriesA.length,
     selectedValues: filterState.selectedValues || [],
     onContextMenu,
+    onFocusedSeries,
     xValueFormatter: tooltipFormatter,
     xAxis: {
       label: xAxisLabel,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
@@ -150,4 +150,5 @@ export type EchartsMixedTimeseriesChartTransformedProps =
         label: string;
         type: AxisType;
       };
+      onFocusedSeries: (series: string | null) => void;
     };

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -50,6 +50,7 @@ export default function EchartsTimeseries({
   legendData = [],
   onContextMenu,
   onLegendStateChanged,
+  onFocusedSeries,
   xValueFormatter,
   xAxis,
   refs,
@@ -145,6 +146,12 @@ export default function EchartsTimeseries({
         const { seriesName: name } = props;
         handleChange(name);
       }, TIMER_DURATION);
+    },
+    mouseout: () => {
+      onFocusedSeries(null);
+    },
+    mouseover: params => {
+      onFocusedSeries(params.seriesName);
     },
     legendselectchanged: payload => {
       onLegendStateChanged?.(payload.selected);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -111,8 +111,10 @@ export default function transformProps(
     theme,
     inContextMenu,
     emitCrossFilters,
-    ownState = {},
   } = chartProps;
+
+  let focusedSeries: string | null = null;
+
   const {
     verboseMap = {},
     columnFormats = {},
@@ -525,7 +527,6 @@ export default function transformProps(
               : getCustomFormatter(customFormatters, metrics, formatterKey) ??
                 defaultFormatter,
           });
-          const { focusedSeries } = ownState;
           const contentStyle =
             key === focusedSeries ? 'font-weight: 700' : 'opacity: 0.7';
           rows.push(`<span style="${contentStyle}">${content}</span>`);
@@ -576,7 +577,7 @@ export default function transformProps(
   };
 
   const onFocusedSeries = (seriesName: string | null) => {
-    ownState.focusedSeries = seriesName;
+    focusedSeries = seriesName;
   };
 
   return {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -111,6 +111,7 @@ export default function transformProps(
     theme,
     inContextMenu,
     emitCrossFilters,
+    ownState = {},
   } = chartProps;
   const {
     verboseMap = {},
@@ -524,7 +525,8 @@ export default function transformProps(
               : getCustomFormatter(customFormatters, metrics, formatterKey) ??
                 defaultFormatter,
           });
-          if (!legendState || legendState[key]) {
+          const { focusedSeries } = ownState;
+          if (key === focusedSeries) {
             rows.push(`<span style="font-weight: 700">${content}</span>`);
           } else {
             rows.push(`<span style="opacity: 0.7">${content}</span>`);
@@ -575,6 +577,10 @@ export default function transformProps(
       : [],
   };
 
+  const onFocusedSeries = (seriesName: string | null) => {
+    ownState.focusedSeries = seriesName;
+  };
+
   return {
     echartOptions,
     emitCrossFilters,
@@ -589,6 +595,7 @@ export default function transformProps(
     legendData,
     onContextMenu,
     onLegendStateChanged,
+    onFocusedSeries,
     xValueFormatter: tooltipFormatter,
     xAxis: {
       label: xAxisLabel,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -526,11 +526,9 @@ export default function transformProps(
                 defaultFormatter,
           });
           const { focusedSeries } = ownState;
-          if (key === focusedSeries) {
-            rows.push(`<span style="font-weight: 700">${content}</span>`);
-          } else {
-            rows.push(`<span style="opacity: 0.7">${content}</span>`);
-          }
+          const contentStyle =
+            key === focusedSeries ? 'font-weight: 700' : 'opacity: 0.7';
+          rows.push(`<span style="${contentStyle}">${content}</span>`);
         });
         if (stack) {
           rows.reverse();

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
@@ -107,4 +107,5 @@ export type TimeseriesChartTransformedProps =
         label: string;
         type: AxisType;
       };
+      onFocusedSeries: (series: string | null) => void;
     };


### PR DESCRIPTION
### SUMMARY
Fixes https://github.com/apache/superset/issues/24738.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1140" alt="Screenshot 2023-07-20 at 15 39 14" src="https://github.com/apache/superset/assets/70410625/ec14aae2-b348-47ab-88f3-5c48ce1e45cd">

<img width="1137" alt="Screenshot 2023-07-20 at 15 32 45" src="https://github.com/apache/superset/assets/70410625/39fa9380-8e6d-4ef3-9206-d40ee3124b03">

### TESTING INSTRUCTIONS
Check if hovered series are highlighted.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
