### PR TITLE
chore(view_api): return application/json as content-type for api/v1/form_data endpoint

### DIFF
--- a/superset/views/api.py
+++ b/superset/views/api.py
@@ -35,8 +35,7 @@ from superset.models.slice import Slice
 from superset.superset_typing import FlaskResponse
 from superset.utils import core as utils
 from superset.utils.date_parser import get_since_until
-from superset.views.base import api, handle_api_exception
-from superset.views.base_api import BaseSupersetApi
+from superset.views.base import api, BaseSupersetView, handle_api_exception
 
 if TYPE_CHECKING:
     from superset.common.query_context_factory import QueryContextFactory
@@ -44,7 +43,7 @@ if TYPE_CHECKING:
 get_time_range_schema = {"type": "string"}
 
 
-class Api(BaseSupersetApi):
+class Api(BaseSupersetView):
     query_context_factory = None
 
     @event_logger.log_this
@@ -87,7 +86,7 @@ class Api(BaseSupersetApi):
 
         update_time_range(form_data)
 
-        return self.response(200, **form_data)
+        return self.json_response(form_data)
 
     @api
     @handle_api_exception
@@ -104,9 +103,10 @@ class Api(BaseSupersetApi):
                 "until": until.isoformat() if until else "",
                 "timeRange": time_range,
             }
-            return self.response(200, result=result)
+            return self.json_response({"result": result})
         except (ValueError, TimeRangeParseFailError, TimeRangeAmbiguousError) as error:
-            return self.response_400(message=_("Unexpected time range: %s" % error))
+            error_msg = {"message": _("Unexpected time range: %s" % error)}
+            return self.json_response(error_msg, 400)
 
     def get_query_context_factory(self) -> QueryContextFactory:
         if self.query_context_factory is None:

--- a/superset/views/api.py
+++ b/superset/views/api.py
@@ -67,7 +67,7 @@ class Api(BaseSupersetApi):
         payload_json = result["queries"]
         return self.response(
             200,
-            result=json.dumps(
+            **json.dumps(
                 payload_json, default=utils.json_int_dttm_ser, ignore_nan=True
             ),
         )
@@ -90,7 +90,7 @@ class Api(BaseSupersetApi):
 
         update_time_range(form_data)
 
-        return self.response(200, result=json.dumps(form_data))
+        return self.response(200, **json.dumps(form_data))
 
     @api
     @handle_api_exception

--- a/superset/views/api.py
+++ b/superset/views/api.py
@@ -65,11 +65,8 @@ class Api(BaseSupersetApi):
         query_context.raise_for_access()
         result = query_context.get_payload()
         payload_json = result["queries"]
-        return self.response(
-            200,
-            **json.dumps(
-                payload_json, default=utils.json_int_dttm_ser, ignore_nan=True
-            ),
+        return json.dumps(
+            payload_json, default=utils.json_int_dttm_ser, ignore_nan=True
         )
 
     @event_logger.log_this
@@ -90,7 +87,7 @@ class Api(BaseSupersetApi):
 
         update_time_range(form_data)
 
-        return self.response(200, **json.dumps(form_data))
+        return self.response(200, **form_data)
 
     @api
     @handle_api_exception

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -1429,13 +1429,15 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         Chart API: Test query form data
         """
         self.login(username="admin")
-        slice_id = db.session.query(Slice).first().id
-        uri = f"api/v1/form_data/?slice_id={slice_id}"
+        slice = db.session.query(Slice).first()
+        uri = f"api/v1/form_data/?slice_id={slice.id if slice else None}"
         rv = self.client.get(uri)
         data = json.loads(rv.data.decode("utf-8"))
         self.assertEqual(rv.status_code, 200)
         self.assertEqual(rv.content_type, "application/json")
-        self.assertEqual(len(data), 12)
+        if slice:
+            self.assertEqual(data["slice_id"], slice.id)
+
 
     @pytest.mark.usefixtures(
         "load_unicode_dashboard_with_slice",

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -1438,7 +1438,6 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         if slice:
             self.assertEqual(data["slice_id"], slice.id)
 
-
     @pytest.mark.usefixtures(
         "load_unicode_dashboard_with_slice",
         "load_energy_table_with_slice",

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -1424,6 +1424,19 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
         self.assertEqual(rv.status_code, 200)
         self.assertEqual(len(data["result"]), 3)
 
+    def test_query_form_data(self):
+        """
+        Chart API: Test query form data
+        """
+        self.login(username="admin")
+        slice_id = db.session.query(Slice).first().id
+        uri = f"api/v1/form_data/?slice_id={slice_id}"
+        rv = self.client.get(uri)
+        data = json.loads(rv.data.decode("utf-8"))
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.content_type, "application/json")
+        self.assertEqual(len(data), 12)
+
     @pytest.mark.usefixtures(
         "load_unicode_dashboard_with_slice",
         "load_energy_table_with_slice",


### PR DESCRIPTION
…views/api

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
1. return content-type `application/json` for `api/v1/form_data` endpoint.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
