### PR TITLE
feat: add pandas performance dependencies

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -25,6 +25,8 @@ bcrypt==4.0.1
     # via paramiko
 billiard==3.6.4.0
     # via celery
+bottleneck==1.3.7
+    # via pandas
 brotli==1.0.9
     # via flask-compress
 cachelib==0.4.1
@@ -120,6 +122,8 @@ geographiclib==1.52
     # via geopy
 geopy==2.2.0
     # via apache-superset
+greenlet==2.0.2
+    # via sqlalchemy
 gunicorn==20.1.0
     # via apache-superset
 hashids==1.3.1
@@ -131,7 +135,9 @@ humanize==3.11.0
 idna==3.2
     # via email-validator
 importlib-metadata==6.6.0
-    # via apache-superset
+    # via
+    #   apache-superset
+    #   flask
 importlib-resources==5.12.0
     # via limits
 isodate==0.6.0
@@ -150,6 +156,8 @@ kombu==5.2.4
     # via celery
 limits==3.4.0
     # via flask-limiter
+llvmlite==0.40.1
+    # via numba
 mako==1.2.4
     # via
     #   alembic
@@ -176,9 +184,16 @@ msgpack==1.0.2
     # via apache-superset
 nh3==0.2.11
     # via apache-superset
+numba==0.57.1
+    # via pandas
+numexpr==2.8.4
+    # via pandas
 numpy==1.23.5
     # via
     #   apache-superset
+    #   bottleneck
+    #   numba
+    #   numexpr
     #   pandas
     #   pyarrow
 ordered-set==4.1.0
@@ -190,7 +205,7 @@ packaging==23.1
     #   deprecation
     #   limits
     #   marshmallow
-pandas==2.0.3
+pandas[performance]==2.0.3
     # via apache-superset
 paramiko==2.11.0
     # via sshtunnel
@@ -318,7 +333,9 @@ wtforms-json==0.3.5
 xlsxwriter==3.0.7
     # via apache-superset
 zipp==3.15.0
-    # via importlib-metadata
+    # via
+    #   importlib-metadata
+    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -10,8 +10,6 @@
     # via
     #   -r requirements/base.in
     #   -r requirements/development.in
-appnope==0.1.3
-    # via ipython
 astroid==2.6.6
     # via pylint
 asttokens==2.2.1

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -12,10 +12,6 @@
     #   -r requirements/docker.in
 gevent==22.10.2
     # via -r requirements/docker.in
-greenlet==2.0.2
-    # via
-    #   -r requirements/docker.in
-    #   gevent
 psycopg2-binary==2.9.6
     # via apache-superset
 zope-event==4.5.0

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
         "nh3>=0.2.11, <0.3",
         "numpy==1.23.5",
         "packaging",
-        "pandas>=2.0.3, <2.1",
+        "pandas[performance]>=2.0.3, <2.1",
         "parsedatetime",
         "pgsanity",
         "polyline>=2.0.0, <3.0",


### PR DESCRIPTION
### SUMMARY
This is a follow-up of https://github.com/apache/superset/pull/24705 that bumped pandas.

Pandas 2.0 [introduced](https://pandas.pydata.org/docs/getting_started/install.html#performance-dependencies-recommended) installing optional performance dependencies via pip extras. This PR adds these dependencies which are recommended.

> You are highly encouraged to install these libraries, as they provide speed improvements, especially when working with large data sets.

- added `[performance]` extra to `setup.py`
- `pip-install-multi --no-upgrade` to freeze packages


### TESTING INSTRUCTIONS
- `pytest ./tests/unit_tests/`
- `scripts/tests/run.sh --module tests/integration_tests/`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
