### PR TITLE
docs: update security policy and add CVE info

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+This is a project of the [Apache Software Foundation](https://apache.org) and follows the
+ASF [vulnerability handling process](https://apache.org/security/#vulnerability-handling).
+
+## Reporting Vulnerabilities
+
+**⚠️ Please do not file GitHub issues for security vulnerabilities as they are public! ⚠️**
+
+
+Apache Software Foundation takes a rigorous standpoint in annihilating the security issues
+in its software projects. Apache Superset is highly sensitive and forthcoming to issues 
+pertaining to its features and functionality.
+If you have any concern or believe you have found a vulnerability in Apache Superset,
+please get in touch with the Apache Security Team privately at
+e-mail address [security@apache.org](mailto:security@apache.org).
+
+More details can be found on the ASF website at
+[ASF vulnerability reporting process](https://apache.org/security/#reporting-a-vulnerability)
+
+We kindly ask you to include the following information in your report:
+- Apache Superset version that you are using
+- A sanitized copy of your `superset_config.py` file or any config overrides
+- Detailed steps to reproduce the vulnerability
+
+Note that Apache Superset is not responsible for any third-party dependencies that may 
+have security issues. Any vulnerabilities found in third-party dependencies should be 
+reported to the maintainers of those projects. Results from security scans of Apache 
+Superset dependencies found on its official Docker image can be remediated at release time
+by extending the image itself.
+
+**Your responsible disclosure and collaboration are invaluable.**
+
+## Extra Information
+
+ - [Apache Superset documentation](https://superset.apache.org/docs/security)
+ - [Common Vulnerabilities and Exposures by release](https://superset.apache.org/docs/security/cves)

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -9,7 +9,7 @@ ASF [vulnerability handling process](https://apache.org/security/#vulnerability-
 
 
 Apache Software Foundation takes a rigorous standpoint in annihilating the security issues
-in its software projects. Apache Superset is highly sensitive and forthcoming to issues 
+in its software projects. Apache Superset is highly sensitive and forthcoming to issues
 pertaining to its features and functionality.
 If you have any concern or believe you have found a vulnerability in Apache Superset,
 please get in touch with the Apache Security Team privately at
@@ -23,9 +23,9 @@ We kindly ask you to include the following information in your report:
 - A sanitized copy of your `superset_config.py` file or any config overrides
 - Detailed steps to reproduce the vulnerability
 
-Note that Apache Superset is not responsible for any third-party dependencies that may 
-have security issues. Any vulnerabilities found in third-party dependencies should be 
-reported to the maintainers of those projects. Results from security scans of Apache 
+Note that Apache Superset is not responsible for any third-party dependencies that may
+have security issues. Any vulnerabilities found in third-party dependencies should be
+reported to the maintainers of those projects. Results from security scans of Apache
 Superset dependencies found on its official Docker image can be remediated at release time
 by extending the image itself.
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -35,3 +35,4 @@ by extending the image itself.
 
  - [Apache Superset documentation](https://superset.apache.org/docs/security)
  - [Common Vulnerabilities and Exposures by release](https://superset.apache.org/docs/security/cves)
+ - [How Security Vulnerabilities are Reported & Handled in Apache Superset (Blog)](https://preset.io/blog/how-security-vulnerabilities-are-reported-and-handled-in-apache-superset/)

--- a/docs/docs/security/_category_.json
+++ b/docs/docs/security/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Security",
+  "position": 10
+}

--- a/docs/docs/security/cves.mdx
+++ b/docs/docs/security/cves.mdx
@@ -1,0 +1,27 @@
+---
+title: CVEs by release
+hide_title: true
+sidebar_position: 2
+---
+
+#### Version 2.1.0
+
+| CVE            | Title                                                                   | Affected          |
+| :------------- | :---------------------------------------------------------------------- | -----------------:|
+| CVE-2023-25504 | Possible SSRF on import datasets                                        | <= 2.1.0          |
+| CVE-2023-27524 | Session validation vulnerability when using provided default SECRET_KEY | <= 2.1.0          |
+| CVE-2023-27525 | Incorrect default permissions for Gamma role                            | <= 2.1.0          |
+| CVE-2023-30776 | Database connection password leak                                       | <= 2.1.0          |
+
+
+#### Version 2.0.1
+
+| CVE            | Title                                                       | Affected          |
+| :------------- | :---------------------------------------------------------- | -----------------:|
+| CVE-2022-41703 | SQL injection vulnerability in adhoc clauses                | < 2.0.1 or <1.5.2 |
+| CVE-2022-43717 | Cross-Site Scripting on dashboards                          | < 2.0.1 or <1.5.2 |
+| CVE-2022-43718 | Cross-Site Scripting vulnerability on upload forms          | < 2.0.1 or <1.5.2 |
+| CVE-2022-43719 | Cross Site Request Forgery (CSRF) on accept, request access | < 2.0.1 or <1.5.2 |
+| CVE-2022-43720 | Improper rendering of user input                            | < 2.0.1 or <1.5.2 |
+| CVE-2022-43721 | Open Redirect Vulnerability                                 | < 2.0.1 or <1.5.2 |
+| CVE-2022-45438 | Dashboard metadata information leak                         | < 2.0.1 or <1.5.2 |

--- a/docs/docs/security/security.mdx
+++ b/docs/docs/security/security.mdx
@@ -1,7 +1,7 @@
 ---
-title: Security
+title: Role based Access
 hide_title: true
-sidebar_position: 10
+sidebar_position: 1
 ---
 
 ### Roles


### PR DESCRIPTION
### SUMMARY

By Apache Foundation recommendation this PR adds a comprehensive list of currently public CVEs by release to our docs
Also updates our current security policy to make it more comprehensive and adds a link to the CVEs.

<img width="1103" alt="Screenshot 2023-07-21 at 14 07 51" src="https://github.com/apache/superset/assets/4025227/7cdbf6f6-3e7f-4f0d-b89e-ec6712b6471d">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
