### PR TITLE
fix(sqllab): Replace margin style by gap on query results

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -81,6 +81,12 @@ export interface ResultSetProps {
   defaultQueryLimit: number;
 }
 
+const ResultContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.gridUnit * 2}px;
+`;
+
 const ResultlessStyles = styled.div`
   position: relative;
   min-height: ${({ theme }) => theme.gridUnit * 25}px;
@@ -110,7 +116,6 @@ const ReturnedRows = styled.div`
 const ResultSetControls = styled.div`
   display: flex;
   justify-content: space-between;
-  padding: ${({ theme }) => 2 * theme.gridUnit}px 0;
 `;
 
 const ResultSetButtons = styled.div`
@@ -494,7 +499,7 @@ const ResultSet = ({
         ? results.expanded_columns.map(col => col.column_name)
         : [];
       return (
-        <>
+        <ResultContainer>
           {renderControls()}
           {renderRowsReturned()}
           {sql}
@@ -505,7 +510,7 @@ const ResultSet = ({
             filterText={searchText}
             expandedColumns={expandedColumns}
           />
-        </>
+        </ResultContainer>
       );
     }
     if (data && data.length === 0) {

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -84,7 +84,7 @@ export interface ResultSetProps {
 const ResultContainer = styled.div`
   display: flex;
   flex-direction: column;
-  gap: ${({ theme }) => theme.gridUnit * 2}px;
+  row-gap: ${({ theme }) => theme.gridUnit * 2}px;
 `;
 
 const ResultlessStyles = styled.div`

--- a/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
@@ -71,8 +71,6 @@ const StyledPane = styled.div<StyledPaneProps>`
     }
   }
   .ant-tabs-tabpane {
-    display: flex;
-    flex-direction: column;
     .scrollable {
       overflow-y: auto;
     }

--- a/superset-frontend/src/components/FilterableTable/index.tsx
+++ b/superset-frontend/src/components/FilterableTable/index.tsx
@@ -77,7 +77,6 @@ const StyledFilterableTable = styled.div`
   ${({ theme }) => `
     height: 100%;
     overflow: hidden;
-    margin-top: ${theme.gridUnit * 2}px;
 
     .ant-table-cell {
       font-weight: ${theme.typography.weights.bold};


### PR DESCRIPTION
### SUMMARY
The horizontal scrollbar in query results has been cut off due to the top margin. There's a bunch of redundant margin for adjustment which makes this kind of overflow hidden regression.
This commit replaces this margins by the upper wrapper's gap as well as removing the antd style overrides. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After:

<img width="908" alt="Screenshot 2023-07-21 at 1 14 32 PM" src="https://github.com/apache/superset/assets/1392866/cca384b2-0545-48b4-8138-48d85dc9d978">

Before:

<img width="910" alt="Screenshot 2023-07-21 at 1 09 07 PM" src="https://github.com/apache/superset/assets/1392866/e748bdd7-4a86-4c96-8c02-a1796128dcd3">

### TESTING INSTRUCTIONS
Go to sqllab and run a query that contains more than 20.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
