### PR TITLE
feat(sqllab): Show sql in the current result

### DIFF
--- a/superset-frontend/src/SqlLab/components/HighlightedSql/index.tsx
+++ b/superset-frontend/src/SqlLab/components/HighlightedSql/index.tsx
@@ -25,7 +25,7 @@ import ModalTrigger from 'src/components/ModalTrigger';
 
 SyntaxHighlighter.registerLanguage('sql', sql);
 
-interface HighlightedSqlProps {
+export interface HighlightedSqlProps {
   sql: string;
   rawSql?: string;
   maxWidth?: number;

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -363,14 +363,14 @@ const ResultSet = ({
           >
             <Label
               css={css`
-                line-height: 17px;
+                line-height: ${theme.typography.sizes.l}px;
               `}
             >
               {limitMessage && (
                 <Icons.ExclamationCircleOutlined
                   css={css`
-                    font-size: 12px;
-                    margin-right: 4px;
+                    font-size: ${theme.typography.sizes.m}px;
+                    margin-right: ${theme.gridUnit}px;
                   `}
                 />
               )}
@@ -542,7 +542,7 @@ const ResultSet = ({
                 css={[
                   css`
                     height: 28px;
-                    width: calc(100% - ${ROWS_CHIP_WIDTH - GAP}px);
+                    width: calc(100% - ${ROWS_CHIP_WIDTH + GAP}px);
                     code {
                       width: 100%;
                       overflow: hidden;

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -29,6 +29,7 @@ import {
   t,
   useTheme,
   usePrevious,
+  css,
 } from '@superset-ui/core';
 import ErrorMessageWithStackTrace from 'src/components/ErrorMessage/ErrorMessageWithStackTrace';
 import {
@@ -42,6 +43,7 @@ import { mountExploreUrl } from 'src/explore/exploreUtils';
 import { postFormData } from 'src/explore/exploreUtils/formData';
 import ProgressBar from 'src/components/ProgressBar';
 import Loading from 'src/components/Loading';
+import Card from 'src/components/Card';
 import FilterableTable from 'src/components/FilterableTable';
 import CopyToClipboard from 'src/components/CopyToClipboard';
 import { addDangerToast } from 'src/components/MessageToasts/actions';
@@ -76,6 +78,7 @@ export interface ResultSetProps {
   query: QueryResponse;
   search?: boolean;
   showSql?: boolean;
+  showSqlInline?: boolean;
   visualize?: boolean;
   user: UserWithPermissionsAndRoles;
   defaultQueryLimit: number;
@@ -138,6 +141,7 @@ const ResultSet = ({
   query,
   search = true,
   showSql = false,
+  showSqlInline = false,
   visualize = true,
   user,
   defaultQueryLimit,
@@ -413,7 +417,12 @@ const ResultSet = ({
   }
 
   if (showSql) {
-    sql = <HighlightedSql sql={query.sql} />;
+    sql = (
+      <HighlightedSql
+        sql={query.sql}
+        {...(showSqlInline && { maxLines: 1, maxWidth: 60 })}
+      />
+    );
   }
 
   if (query.state === QueryState.STOPPED) {
@@ -501,8 +510,33 @@ const ResultSet = ({
       return (
         <ResultContainer>
           {renderControls()}
-          {renderRowsReturned()}
-          {sql}
+          {showSql && showSqlInline ? (
+            <div
+              css={css`
+                display: flex;
+              `}
+            >
+              {renderRowsReturned()}
+              <Card
+                css={[
+                  css`
+                    position: absolute;
+                    width: 300px;
+                    height: 24px;
+                    right: 0px;
+                    overflow: hidden;
+                  `,
+                ]}
+              >
+                {sql}
+              </Card>
+            </div>
+          ) : (
+            <>
+              {renderRowsReturned()}
+              {sql}
+            </>
+          )}
           <FilterableTable
             data={data}
             orderedColumnKeys={results.columns.map(col => col.column_name)}

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -27,9 +27,11 @@ import {
   QueryState,
   styled,
   t,
+  tn,
   useTheme,
   usePrevious,
   css,
+  getNumberFormatter,
 } from '@superset-ui/core';
 import ErrorMessageWithStackTrace from 'src/components/ErrorMessage/ErrorMessageWithStackTrace';
 import {
@@ -44,6 +46,8 @@ import { postFormData } from 'src/explore/exploreUtils/formData';
 import ProgressBar from 'src/components/ProgressBar';
 import Loading from 'src/components/Loading';
 import Card from 'src/components/Card';
+import Label from 'src/components/Label';
+import { Tooltip } from 'src/components/Tooltip';
 import FilterableTable from 'src/components/FilterableTable';
 import CopyToClipboard from 'src/components/CopyToClipboard';
 import { addDangerToast } from 'src/components/MessageToasts/actions';
@@ -57,6 +61,7 @@ import {
   reRunQuery,
 } from 'src/SqlLab/actions/sqlLab';
 import { URL_PARAMS } from 'src/constants';
+import Icons from 'src/components/Icons';
 import ExploreCtasResultsButton from '../ExploreCtasResultsButton';
 import ExploreResultsButton from '../ExploreResultsButton';
 import HighlightedSql from '../HighlightedSql';
@@ -127,10 +132,8 @@ const ResultSetButtons = styled.div`
   padding-right: ${({ theme }) => 2 * theme.gridUnit}px;
 `;
 
-const LimitMessage = styled.span`
-  color: ${({ theme }) => theme.colors.secondary.light1};
-  margin-left: ${({ theme }) => theme.gridUnit * 2}px;
-`;
+const ROWS_CHIP_WIDTH = 100;
+const GAP = 8;
 
 const ResultSet = ({
   cache = false,
@@ -300,7 +303,7 @@ const ResultSet = ({
 
   const renderRowsReturned = () => {
     const { results, rows, queryLimit, limitingFactor } = query;
-    let limitMessage;
+    let limitMessage = '';
     const limitReached = results?.displayLimitReached;
     const limit = queryLimit || results.query.limit;
     const isAdmin = !!user?.roles?.Admin;
@@ -343,7 +346,7 @@ const ResultSet = ({
         { rows },
       );
     }
-
+    const formattedRowCount = getNumberFormatter()(rows);
     const rowsReturnedMessage = t('%(rows)d rows returned', {
       rows,
     });
@@ -353,10 +356,27 @@ const ResultSet = ({
     return (
       <ReturnedRows>
         {!limitReached && !shouldUseDefaultDropdownAlert && (
-          <span title={tooltipText}>
-            {rowsReturnedMessage}
-            <LimitMessage>{limitMessage}</LimitMessage>
-          </span>
+          <Tooltip
+            id="sqllab-rowcount-tooltip"
+            title={tooltipText}
+            placement="left"
+          >
+            <Label
+              css={css`
+                line-height: 17px;
+              `}
+            >
+              {limitMessage && (
+                <Icons.ExclamationCircleOutlined
+                  css={css`
+                    font-size: 12px;
+                    margin-right: 4px;
+                  `}
+                />
+              )}
+              {tn('%s row', '%s rows', rows, formattedRowCount)}
+            </Label>
+          </Tooltip>
         )}
         {!limitReached && shouldUseDefaultDropdownAlert && (
           <div ref={calculateAlertRefHeight}>
@@ -514,22 +534,28 @@ const ResultSet = ({
             <div
               css={css`
                 display: flex;
+                justify-content: space-between;
+                gap: ${GAP}px;
               `}
             >
-              {renderRowsReturned()}
               <Card
                 css={[
                   css`
-                    position: absolute;
-                    width: 300px;
-                    height: 24px;
-                    right: 0px;
-                    overflow: hidden;
+                    height: 28px;
+                    width: calc(100% - ${ROWS_CHIP_WIDTH - GAP}px);
+                    code {
+                      width: 100%;
+                      overflow: hidden;
+                      white-space: nowrap !important;
+                      text-overflow: ellipsis;
+                      display: block;
+                    }
                   `,
                 ]}
               >
                 {sql}
               </Card>
+              {renderRowsReturned()}
             </div>
           ) : (
             <>

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -118,7 +118,7 @@ const MonospaceDiv = styled.div`
 
 const ReturnedRows = styled.div`
   font-size: ${({ theme }) => theme.typography.sizes.s}px;
-  line-height: ${({ theme }) => theme.gridUnit * 6}px;
+  line-height: 1;
 `;
 
 const ResultSetControls = styled.div`

--- a/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
@@ -184,6 +184,8 @@ const SouthPane = ({
             database={databases[latestQuery.dbId]}
             displayLimit={displayLimit}
             defaultQueryLimit={defaultQueryLimit}
+            showSql
+            showSqlInline
           />
         );
       }


### PR DESCRIPTION
### SUMMARY
Following #24329, SQLLab can run a portion of the sql editor without highlighted. 
Like other 3rd party sql editor, it will be useful to display the current running sql in the result panel to identify the actual executed query.

<img width="523" alt="Screenshot_2023-07-24_at_3_46_19_PM" src="https://github.com/apache/superset/assets/1392866/285dbc71-de30-41a5-8baa-6e46ad93d6a7">

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

After:

https://github.com/apache/superset/assets/1392866/eda3ac07-3173-469f-9991-0a9587981917

Before:

https://github.com/apache/superset/assets/1392866/158f8a2d-0d8a-473c-982f-1e89c4b18414

### TESTING INSTRUCTIONS
Go to sqllab
Run a query and check the result panel

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
