### PR TITLE
fix(chore): switching between languages should be without timeout 60 seconds

### DIFF
--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -410,13 +410,12 @@ def menu_data(user: User) -> dict[str, Any]:
 
 
 @cache_manager.cache.memoize(timeout=60)
-def cached_common_bootstrap_data(user: User) -> dict[str, Any]:
+def cached_common_bootstrap_data(user: User, locale: str) -> dict[str, Any]:
     """Common data always sent to the client
 
     The function is memoized as the return value only changes when user permissions
     or configuration values change.
     """
-    locale = str(get_locale())
 
     # should not expose API TOKEN to frontend
     frontend_config = {
@@ -456,7 +455,7 @@ def cached_common_bootstrap_data(user: User) -> dict[str, Any]:
 
 def common_bootstrap_payload(user: User) -> dict[str, Any]:
     return {
-        **(cached_common_bootstrap_data(user)),
+        **cached_common_bootstrap_data(user, get_locale()),
         "flash_messages": get_flashed_messages(with_categories=True),
     }
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This is a fix for the problem of switching between languages. Currently, Superset has a 60-second timeout when switching languages due to using a memoized function. I added the locale as a dependency for that memoized function.

CC @bkyryliuk (https://github.com/apache/superset/commit/44654e5abcc70d1fd934529dc82d7fe1d1bb20ef)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
#### Before

https://github.com/apache/superset/assets/66589759/d0b43b3c-16e8-4c1c-9eec-efe911a18b7a


#### After
https://github.com/apache/superset/assets/66589759/d6ba6f8c-8d71-400d-aa13-569453939d30



### TESTING INSTRUCTIONS
1. Open Superset
2. Try to change the language twice
3. Notice that your second attempt doesn't changed language.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #23456 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
