### PR TITLE
fix: Filters alert width

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
@@ -63,7 +63,7 @@ import {
 import DividerConfigForm from './DividerConfigForm';
 
 const MODAL_MARGIN = 16;
-const MIN_WIDTH = 1000;
+const MIN_WIDTH = 880;
 
 const StyledModalWrapper = styled(StyledModal)<{ expanded: boolean }>`
   min-width: ${MIN_WIDTH}px;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
@@ -63,12 +63,13 @@ import {
 import DividerConfigForm from './DividerConfigForm';
 
 const MODAL_MARGIN = 16;
+const MIN_WIDTH = 1000;
 
 const StyledModalWrapper = styled(StyledModal)<{ expanded: boolean }>`
-  min-width: 880px;
-  width: ${({ expanded }) => (expanded ? '100%' : '70%')} !important;
+  min-width: ${MIN_WIDTH}px;
+  width: ${({ expanded }) => (expanded ? '100%' : MIN_WIDTH)} !important;
 
-  @media (max-width: ${880 + MODAL_MARGIN * 2}px) {
+  @media (max-width: ${MIN_WIDTH + MODAL_MARGIN * 2}px) {
     width: 100% !important;
     min-width: auto;
   }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/Footer/CancelConfirmationAlert.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/Footer/CancelConfirmationAlert.tsx
@@ -42,6 +42,7 @@ export function CancelConfirmationAlert({
       message={title}
       css={{
         textAlign: 'left',
+        flex: 1,
         '& .ant-alert-action': { alignSelf: 'center' },
       }}
       description={children}


### PR DESCRIPTION
### SUMMARY
Fixes the filters alert width and also changes the modal width.

Following @kasiazjc's [comment](https://github.com/apache/superset/pull/24559#issuecomment-1632099115) in https://github.com/apache/superset/pull/24559: 
>  I think in general we have to bump the width of the modal in the default mode to ~880px (and resize just after it not longer fits in the screen), so that everything is more visible.

I adjusted the modal to have a fixed base width instead of percent based one. I set it to 1000px instead of 880px as a middle ground.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1781" alt="Screenshot 2023-07-25 at 11 36 58" src="https://github.com/apache/superset/assets/70410625/015eb444-bd9d-42f0-8a03-f6a83f9f7c4e">
<img width="1770" alt="Screenshot 2023-07-25 at 11 46 35" src="https://github.com/apache/superset/assets/70410625/161d359c-63a1-4b47-93bc-a655c5d90934">

### TESTING INSTRUCTIONS
Make sure the the width of the filters' alert takes the available space.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
