### PR TITLE
fix: Dashboard aware RBAC "Save as" menu item

### DIFF
--- a/superset-frontend/src/dashboard/actions/hydrate.js
+++ b/superset-frontend/src/dashboard/actions/hydrate.js
@@ -24,7 +24,10 @@ import { getInitialState as getInitialNativeFilterState } from 'src/dashboard/re
 import { applyDefaultFormData } from 'src/explore/store';
 import { buildActiveFilters } from 'src/dashboard/util/activeDashboardFilters';
 import { findPermission } from 'src/utils/findPermission';
-import { canUserEditDashboard } from 'src/dashboard/util/permissionUtils';
+import {
+  canUserEditDashboard,
+  canUserSaveAsDashboard,
+} from 'src/dashboard/util/permissionUtils';
 import {
   getCrossFiltersConfiguration,
   isCrossFiltersEnabled,
@@ -336,7 +339,7 @@ export const hydrateDashboard =
           metadata,
           userId: user.userId ? String(user.userId) : null, // legacy, please use state.user instead
           dash_edit_perm: canEdit,
-          dash_save_perm: findPermission('can_write', 'Dashboard', roles),
+          dash_save_perm: canUserSaveAsDashboard(dashboard, user),
           dash_share_perm: findPermission(
             'can_share_dashboard',
             'Superset',

--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
@@ -196,7 +196,7 @@ test('should show the share actions', async () => {
   expect(screen.getByText('Share')).toBeInTheDocument();
 });
 
-test('should render the "Save Modal" when user can save', async () => {
+test('should render the "Save as" menu item when user can save', async () => {
   const mockedProps = createProps();
   const canSaveProps = {
     ...mockedProps,
@@ -206,7 +206,7 @@ test('should render the "Save Modal" when user can save', async () => {
   expect(screen.getByText('Save as')).toBeInTheDocument();
 });
 
-test('should NOT render the "Save Modal" menu item when user cannot save', async () => {
+test('should NOT render the "Save as" menu item when user cannot save', async () => {
   const mockedProps = createProps();
   setup(mockedProps);
   expect(screen.queryByText('Save as')).not.toBeInTheDocument();

--- a/superset-frontend/src/dashboard/components/SaveModal.tsx
+++ b/superset-frontend/src/dashboard/components/SaveModal.tsx
@@ -81,7 +81,7 @@ class SaveModal extends React.PureComponent<SaveModalProps, SaveModalState> {
     super(props);
     this.state = {
       saveType: props.saveType,
-      newDashName: props.dashboardTitle + t('[copy]'),
+      newDashName: `${props.dashboardTitle} ${t('[copy]')}`,
       duplicateSlices: false,
     };
 

--- a/superset-frontend/src/dashboard/util/permissionUtils.ts
+++ b/superset-frontend/src/dashboard/util/permissionUtils.ts
@@ -16,6 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { FeatureFlag } from '@superset-ui/core';
+import { isFeatureEnabled } from 'src/featureFlags';
 import {
   isUserWithPermissionsAndRoles,
   UndefinedUser,
@@ -63,3 +65,13 @@ export function canUserAccessSqlLab(
       ))
   );
 }
+
+export const canUserSaveAsDashboard = (
+  dashboard: Dashboard,
+  user?: UserWithPermissionsAndRoles | UndefinedUser | null,
+) =>
+  isUserWithPermissionsAndRoles(user) &&
+  findPermission('can_write', 'Dashboard', user?.roles) &&
+  (!isFeatureEnabled(FeatureFlag.DASHBOARD_RBAC) ||
+    isUserAdmin(user) ||
+    isUserDashboardOwner(dashboard, user));

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -1408,7 +1408,11 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         except ValidationError as error:
             return self.response_400(message=error.messages)
 
-        dash = DashboardDAO.copy_dashboard(original_dash, data)
+        try:
+            dash = DashboardDAO.copy_dashboard(original_dash, data)
+        except DashboardForbiddenError:
+            return self.response_403()
+
         return self.response(
             200,
             result={

--- a/tests/integration_tests/dashboards/security/security_rbac_tests.py
+++ b/tests/integration_tests/dashboards/security/security_rbac_tests.py
@@ -15,11 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 """Unit tests for Superset"""
+import json
 from unittest import mock
+from unittest.mock import patch
 
 import pytest
 
-from superset.utils.core import backend
+from superset.daos.dashboard import DashboardDAO
+from superset.dashboards.commands.exceptions import DashboardForbiddenError
+from superset.utils.core import backend, override_user
+from tests.integration_tests.conftest import with_feature_flags
 from tests.integration_tests.dashboards.dashboard_test_utils import *
 from tests.integration_tests.dashboards.security.base_case import (
     BaseTestDashboardSecurity,
@@ -36,6 +41,10 @@ from tests.integration_tests.fixtures.birth_names_dashboard import (
 )
 from tests.integration_tests.fixtures.public_role import public_role_like_gamma
 from tests.integration_tests.fixtures.query_context import get_query_context
+from tests.integration_tests.fixtures.world_bank_dashboard import (
+    load_world_bank_dashboard_with_slices,
+    load_world_bank_data,
+)
 
 CHART_DATA_URI = "api/v1/chart/data"
 
@@ -430,4 +439,83 @@ class TestDashboardRoleBasedSecurity(BaseTestDashboardSecurity):
         assert rv.status_code == 403
         # rollback changes
         db.session.delete(dashboard)
+        db.session.commit()
+
+    @with_feature_flags(DASHBOARD_RBAC=True)
+    @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
+    def test_copy_dashboard_via_api(self):
+        source = db.session.query(Dashboard).filter_by(slug="world_health").first()
+        source.roles = [self.get_role("Gamma")]
+
+        if not (published := source.published):
+            source.published = True  # Required per the DashboardAccessFilter for RBAC.
+
+        db.session.commit()
+
+        uri = f"api/v1/dashboard/{source.id}/copy/"
+
+        data = {
+            "dashboard_title": "copied dash",
+            "css": "<css>",
+            "duplicate_slices": False,
+            "json_metadata": json.dumps(
+                {
+                    "positions": source.position,
+                    "color_namespace": "Color Namespace Test",
+                    "color_scheme": "Color Scheme Test",
+                }
+            ),
+        }
+
+        self.login(username="gamma")
+        rv = self.client.post(uri, json=data)
+        self.assertEqual(rv.status_code, 403)
+        self.logout()
+
+        self.login(username="admin")
+        rv = self.client.post(uri, json=data)
+        self.assertEqual(rv.status_code, 200)
+        self.logout()
+        response = json.loads(rv.data.decode("utf-8"))
+
+        target = (
+            db.session.query(Dashboard)
+            .filter(Dashboard.id == response["result"]["id"])
+            .one()
+        )
+
+        db.session.delete(target)
+        source.roles = []
+
+        if not published:
+            source.published = False
+
+        db.session.commit()
+
+    @with_feature_flags(DASHBOARD_RBAC=True)
+    @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
+    def test_copy_dashboard_via_dao(self):
+        source = db.session.query(Dashboard).filter_by(slug="world_health").first()
+
+        data = {
+            "dashboard_title": "copied dash",
+            "css": "<css>",
+            "duplicate_slices": False,
+            "json_metadata": json.dumps(
+                {
+                    "positions": source.position,
+                    "color_namespace": "Color Namespace Test",
+                    "color_scheme": "Color Scheme Test",
+                }
+            ),
+        }
+
+        with override_user(security_manager.find_user("gamma")):
+            with pytest.raises(DashboardForbiddenError):
+                DashboardDAO.copy_dashboard(source, data)
+
+        with override_user(security_manager.find_user("admin")):
+            target = DashboardDAO.copy_dashboard(source, data)
+            db.session.delete(target)
+
         db.session.commit()


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR (alongside https://github.com/apache/superset/pull/24789) fixes https://github.com/apache/superset/issues/24782. 

Specifically (per https://github.com/apache/superset/issues/24782#issuecomment-1648726754) this PR ensures that the `Save as` menu item is not present when the `DASHBOARD_RBAC` feature is enabled and the user is neither an admin nor an owner. Note it's unclear whether a non-owner (irrespective of the feature flag setting) should ever be able to `Save as` a dashboard, though this PR simply preserves said behavior.

Regarding the backend logic he [DashboardRestApi.copy_dash](https://github.com/apache/superset/blob/554ef07eeda094f5bcc081e7a265e0b7408e0868/superset/dashboards/api.py#L1356-L1420) method invokes the [@with_dashboard](https://github.com/apache/superset/blob/554ef07eeda094f5bcc081e7a265e0b7408e0868/superset/dashboards/api.py#L106-L124) decorator which in turn calls [DashboardDAO.get_by_id_or_slug](https://github.com/apache/superset/blob/554ef07eeda094f5bcc081e7a265e0b7408e0868/superset/daos/dashboard.py#L58-L81) which has the necessary security checks to ensure ensure said user has access. The conundrum is, if you ask where the user has access to the dashboard the answer is "yes", even though we're stating they can't copy it. The solution to this seems to be to add logic within the dashboard DAO.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE

<img width="1440" alt="Screenshot 2023-07-25 at 5 22 36 PM" src="https://github.com/apache/superset/assets/4567245/d9e21578-2fe7-49f9-870b-dcb374a51859">

#### AFTER 

<img width="1440" alt="Screenshot 2023-07-25 at 3 50 50 PM" src="https://github.com/apache/superset/assets/4567245/e67296e3-0b41-4747-9a4c-0c9e06e19903">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @mdeshmu @sfirke