### PR TITLE
fix(embedded): adding logic to check dataset used by filters

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2064,15 +2064,22 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         )
 
         exists = db.session.query(query.exists()).scalar()
-        
+
         # check for datasets that are only used by filters
         if not exists:
-            dashboards_json = db.session.query(Dashboard.json_metadata).filter(Dashboard.id.in_(dashboard_ids)).all()
+            dashboards_json = (
+                db.session.query(Dashboard.json_metadata)
+                .filter(Dashboard.id.in_(dashboard_ids))
+                .all()
+            )
             for json_ in dashboards_json:
                 try:
                     json_metadata = json.loads(json_.json_metadata)
-                    for filter in json_metadata.get('native_filter_configuration', []):
-                        filter_dataset_ids = [target.get('datasetId') for target in filter.get('targets', [])]
+                    for filter in json_metadata.get("native_filter_configuration", []):
+                        filter_dataset_ids = [
+                            target.get("datasetId")
+                            for target in filter.get("targets", [])
+                        ]
                         if datasource.id in filter_dataset_ids:
                             exists = True
                 except ValueError:

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2063,6 +2063,16 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         )
 
         exists = db.session.query(query.exists()).scalar()
+        
+        # check for datasets that are only used by filters
+        if not exists:
+            dashboards_json = db.session.query(Dashboard.json_metadata).filter(Dashboard.id.in_(dashboard_ids)).all()
+            for json_ in dashboards_json:
+                json_metadata = json.loads(json_.json_metadata)
+                filter_dataset_ids = [target['datasetId'] for filter in json_metadata['native_filter_configuration'] for target in filter['targets']]
+                if datasource.id in filter_dataset_ids:
+                    exists = True
+
         return exists
 
     @staticmethod

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2063,10 +2063,11 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             .filter(Dashboard.id.in_(dashboard_ids))
         )
 
-        exists = db.session.query(query.exists()).scalar()
+        if db.session.query(query.exists()).scalar():
+            return True
 
         # check for datasets that are only used by filters
-        if not exists:
+        else:
             dashboards_json = (
                 db.session.query(Dashboard.json_metadata)
                 .filter(Dashboard.id.in_(dashboard_ids))
@@ -2081,11 +2082,11 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                             for target in filter_.get("targets", [])
                         ]
                         if datasource.id in filter_dataset_ids:
-                            exists = True
+                            return True
                 except ValueError:
                     pass
 
-        return exists
+        return False
 
     @staticmethod
     def _get_current_epoch_time() -> float:

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2067,24 +2067,22 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             return True
 
         # check for datasets that are only used by filters
-        else:
-            dashboards_json = (
-                db.session.query(Dashboard.json_metadata)
-                .filter(Dashboard.id.in_(dashboard_ids))
-                .all()
-            )
-            for json_ in dashboards_json:
-                try:
-                    json_metadata = json.loads(json_.json_metadata)
-                    for filter_ in json_metadata.get("native_filter_configuration", []):
-                        filter_dataset_ids = [
-                            target.get("datasetId")
-                            for target in filter_.get("targets", [])
-                        ]
-                        if datasource.id in filter_dataset_ids:
-                            return True
-                except ValueError:
-                    pass
+        dashboards_json = (
+            db.session.query(Dashboard.json_metadata)
+            .filter(Dashboard.id.in_(dashboard_ids))
+            .all()
+        )
+        for json_ in dashboards_json:
+            try:
+                json_metadata = json.loads(json_.json_metadata)
+                for filter_ in json_metadata.get("native_filter_configuration", []):
+                    filter_dataset_ids = [
+                        target.get("datasetId") for target in filter_.get("targets", [])
+                    ]
+                    if datasource.id in filter_dataset_ids:
+                        return True
+            except ValueError:
+                pass
 
         return False
 

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2075,10 +2075,10 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             for json_ in dashboards_json:
                 try:
                     json_metadata = json.loads(json_.json_metadata)
-                    for filter in json_metadata.get("native_filter_configuration", []):
+                    for filter_ in json_metadata.get("native_filter_configuration", []):
                         filter_dataset_ids = [
                             target.get("datasetId")
-                            for target in filter.get("targets", [])
+                            for target in filter_.get("targets", [])
                         ]
                         if datasource.id in filter_dataset_ids:
                             exists = True

--- a/tests/integration_tests/security/guest_token_security_tests.py
+++ b/tests/integration_tests/security/guest_token_security_tests.py
@@ -245,7 +245,7 @@ class TestGuestUserDashboardAccess(SupersetTestCase):
         test_dataset = SqlaTable(
             database_id=get_example_database().id,
             schema="main",
-            table_name="test_table",
+            table_name="test_table_embedded_filter",
         )
         db.session.add(test_dataset)
         db.session.commit()

--- a/tests/integration_tests/security/guest_token_security_tests.py
+++ b/tests/integration_tests/security/guest_token_security_tests.py
@@ -237,9 +237,10 @@ class TestGuestUserDashboardAccess(SupersetTestCase):
         db.session.delete(dash)
         db.session.commit()
 
-    def test_can_access_based_on_dashboard_with_filter(self):
+    def test_can_access_datasource_used_in_dashboard_filter(self):
         """
-        Test that a user can access a datasource used only by a filter in a dashboard.
+        Test that a user can access a datasource used only by a filter in a dashboard
+        they have access to.
         """
         # Create a test dataset
         test_dataset = SqlaTable(

--- a/tests/integration_tests/security/guest_token_security_tests.py
+++ b/tests/integration_tests/security/guest_token_security_tests.py
@@ -15,23 +15,27 @@
 # specific language governing permissions and limitations
 # under the License.
 """Unit tests for Superset"""
+import json
 from unittest import mock
 
 import pytest
 from flask import g
 
 from superset import db, security_manager
+from superset.connectors.sqla.models import SqlaTable
 from superset.daos.dashboard import EmbeddedDashboardDAO
 from superset.dashboards.commands.exceptions import DashboardAccessDeniedError
 from superset.exceptions import SupersetSecurityException
 from superset.models.dashboard import Dashboard
 from superset.security.guest_token import GuestTokenResourceType
 from superset.sql_parse import Table
+from superset.utils.database import get_example_database
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.birth_names_dashboard import (
     load_birth_names_dashboard_with_slices,
     load_birth_names_data,
 )
+from tests.integration_tests.fixtures.public_role import public_role_like_gamma
 
 
 @mock.patch.dict(
@@ -232,4 +236,49 @@ class TestGuestUserDashboardAccess(SupersetTestCase):
             security_manager.raise_for_dashboard_access(dash)
 
         db.session.delete(dash)
+        db.session.commit()
+
+    @pytest.mark.usefixtures("public_role_like_gamma")
+    def test_can_access_based_on_dashboard_with_filter(self):
+        """
+        Test that a user can access a datasource used only by a filter in a dashboard.
+        """
+        # Create a test dataset
+        test_dataset = SqlaTable(
+            database_id=get_example_database().id,
+            schema="main",
+            table_name="test_table",
+        )
+        db.session.add(test_dataset)
+        db.session.commit()
+
+        # Create an embedabble dashboard with a filter powered by the test dataset
+        test_dashboard = Dashboard()
+        test_dashboard.dashboard_title = "Test Embedded Dashboard"
+        test_dashboard.json_metadata = json.dumps(
+            {
+                "native_filter_configuration": [
+                    {"targets": [{"datasetId": test_dataset.id}]}
+                ]
+            }
+        )
+        test_dashboard.owners = []
+        test_dashboard.slices = []
+        test_dashboard.published = False
+        db.session.add(test_dashboard)
+        db.session.commit()
+        self.embedded = EmbeddedDashboardDAO.upsert(test_dashboard, [])
+
+        # grant access to the dashboad
+        self.authorized_guest.resources = [
+            {"type": "dashboard", "id": str(self.embedded.uuid)}
+        ] + self.authorized_guest.resources
+        self.authorized_guest.roles = [security_manager.get_public_role()]
+        g.user = self.authorized_guest
+
+        # The user should have access to the datasource via the dashboard
+        assert security_manager.can_access_based_on_dashboard(test_dataset) == True
+
+        db.session.delete(test_dashboard)
+        db.session.delete(test_dataset)
         db.session.commit()

--- a/tests/integration_tests/security/guest_token_security_tests.py
+++ b/tests/integration_tests/security/guest_token_security_tests.py
@@ -268,14 +268,12 @@ class TestGuestUserDashboardAccess(SupersetTestCase):
         self.embedded = EmbeddedDashboardDAO.upsert(test_dashboard, [])
 
         # grant access to the dashboad
-        self.authorized_guest.resources = [
-            {"type": "dashboard", "id": str(self.embedded.uuid)}
-        ] + self.authorized_guest.resources
-        self.authorized_guest.roles = [security_manager.get_public_role()]
         g.user = self.authorized_guest
+        g.user.resources = [{"type": "dashboard", "id": str(self.embedded.uuid)}]
+        g.user.roles = [security_manager.get_public_role()]
 
         # The user should have access to the datasource via the dashboard
-        assert security_manager.can_access_based_on_dashboard(test_dataset) == True
+        security_manager.raise_for_access(datasource=test_dataset)
 
         db.session.delete(test_dashboard)
         db.session.delete(test_dataset)

--- a/tests/integration_tests/security/guest_token_security_tests.py
+++ b/tests/integration_tests/security/guest_token_security_tests.py
@@ -35,7 +35,6 @@ from tests.integration_tests.fixtures.birth_names_dashboard import (
     load_birth_names_dashboard_with_slices,
     load_birth_names_data,
 )
-from tests.integration_tests.fixtures.public_role import public_role_like_gamma
 
 
 @mock.patch.dict(
@@ -238,7 +237,6 @@ class TestGuestUserDashboardAccess(SupersetTestCase):
         db.session.delete(dash)
         db.session.commit()
 
-    @pytest.mark.usefixtures("public_role_like_gamma")
     def test_can_access_based_on_dashboard_with_filter(self):
         """
         Test that a user can access a datasource used only by a filter in a dashboard.


### PR DESCRIPTION
### SUMMARY
When granting dashboard access to a guest user, it's only granted access to datasets used by its charts. If the dashboard has any native filters powered by datasets that aren't used by any chart, the filter wouldn't load with a permission error. This PR changes this logic to also allow access to datasets used by filters. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
#### Before
<img width="794" alt="image" src="https://github.com/apache/superset/assets/96086495/d6bb3d1d-04f3-44fc-ab4e-9a87163e5090">

#### After
<img width="800" alt="image" src="https://github.com/apache/superset/assets/96086495/c5e0e7ba-aa1c-4ed0-89f0-cffd99ec561d">

### TESTING INSTRUCTIONS
1. Create a chart using any dataset.
2. Save the chart and add it to a dashboard.
3. Create a virtual dataset for the same table (a `select * ...` would be enough).
4. Create a dashboard filter using the virtual dataset.
5. Enable embedded access for the dashboard.
6. Create a `guest_token` and grant access to this dashboard.
7. Access this dashboard in embedded mode.
8. Validate that the dashboard filter loads properly.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #24807
- [X] Required feature flags: `EMBEDDED_SUPERSET = True`
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
