### PR TITLE
fix: Removes unnecessary query on filters

### DIFF
--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
@@ -235,34 +235,33 @@ describe('SelectFilterPlugin', () => {
     });
   });
 
-  test('Add ownState with column types when search all options', async () => {
+  test('receives the correct filter when search all options', async () => {
     getWrapper({ searchAllOptions: true, multiSelect: false });
     userEvent.click(screen.getByRole('combobox'));
     expect(await screen.findByRole('combobox')).toBeInTheDocument();
     userEvent.click(screen.getByTitle('girl'));
-    expect(setDataMask).toHaveBeenCalledWith({
-      __cache: {
-        value: ['boy'],
-      },
-      extraFormData: {
-        filters: [
-          {
-            col: 'gender',
-            op: 'IN',
-            val: ['girl'],
-          },
-        ],
-      },
-      filterState: {
-        label: 'girl',
-        value: ['girl'],
-      },
-      ownState: {
-        coltypeMap: {
-          gender: 1,
+    expect(setDataMask).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        extraFormData: {
+          filters: [
+            {
+              col: 'gender',
+              op: 'IN',
+              val: ['girl'],
+            },
+          ],
         },
-        search: null,
-      },
-    });
+      }),
+    );
+  });
+  test('number of fired queries when searching', async () => {
+    getWrapper({ searchAllOptions: true });
+    userEvent.click(screen.getByRole('combobox'));
+    expect(await screen.findByRole('combobox')).toBeInTheDocument();
+    await userEvent.type(screen.getByRole('combobox'), 'a');
+    // Closes the select
+    userEvent.tab();
+    // One call for the search term and other for the empty search
+    expect(setDataMask).toHaveBeenCalledTimes(2);
   });
 });

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -185,23 +185,9 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
     [dispatchDataMask, initialColtypeMap, searchAllOptions],
   );
 
-  const clearSuggestionSearch = useCallback(() => {
-    setSearch('');
-    if (searchAllOptions) {
-      dispatchDataMask({
-        type: 'ownState',
-        ownState: {
-          coltypeMap: initialColtypeMap,
-          search: null,
-        },
-      });
-    }
-  }, [dispatchDataMask, initialColtypeMap, searchAllOptions]);
-
   const handleBlur = useCallback(() => {
-    clearSuggestionSearch();
     unsetFocusedFilter();
-  }, [clearSuggestionSearch, unsetFocusedFilter]);
+  }, [unsetFocusedFilter]);
 
   const handleChange = useCallback(
     (value?: SelectValue | number | string) => {
@@ -323,7 +309,6 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
           mode={multiSelect ? 'multiple' : 'single'}
           placeholder={placeholderText}
           onSearch={onSearch}
-          onSelect={clearSuggestionSearch}
           onBlur={handleBlur}
           onFocus={setFocusedFilter}
           onMouseEnter={setHoveredFilter}


### PR DESCRIPTION
### SUMMARY
This PR removes an unnecessary query that was being fired by filters with "Dynamically search all filter values" enabled. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://github.com/apache/superset/assets/70410625/7004d125-3875-4c04-94e7-47ab2046ff20

https://github.com/apache/superset/assets/70410625/48fcc814-5363-4c12-b938-d19348613be0

### TESTING INSTRUCTIONS
- Create a filter with "Dynamically search all filter values" enabled
- Check that the unnecessary query was removed

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
