### PR TITLE
fix: docs invalid client redirect

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -68,10 +68,6 @@ const config = {
             from: '/usertutorial.html',
           },
           {
-            to: '/docs/security',
-            from: '/security.html',
-          },
-          {
             to: '/docs/installation/sql-templating',
             from: '/sqllab.html',
           },

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -68,6 +68,10 @@ const config = {
             from: '/usertutorial.html',
           },
           {
+            to: '/docs/security/',
+            from: '/security.html',
+          },
+          {
             to: '/docs/installation/sql-templating',
             from: '/sqllab.html',
           },


### PR DESCRIPTION
### SUMMARY
docs `yarn build` was failing with:

```
Map(1) { '/docs/security' => false }
Error:  Unable to build website for locale en.
Error:  Error: You are trying to create client-side redirections to invalid paths.

These paths are redirected to but do not exist:
- /docs/security
```

This PR fixes it

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
