### PR TITLE
fix: Allow chart import to update the dataset an existing chart points to

### DIFF
--- a/superset/charts/commands/importers/v1/utils.py
+++ b/superset/charts/commands/importers/v1/utils.py
@@ -53,7 +53,9 @@ def import_chart(
     # migrate old viz types to new ones
     config = migrate_chart(config)
 
-    chart = Slice.import_from_dict(session, config, recursive=False)
+    chart = Slice.import_from_dict(
+        session, config, recursive=False, allow_reparenting=True
+    )
     if chart.id is None:
         session.flush()
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, attempting to overwrite a chart via import fails when the chart in the import file points to a dataset other than the one the chart currently points at.

This is because of the following filter which gets added to the query that checks if the chart being imported already exists:
```python
filters.extend([getattr(cls, k) == dict_rep.get(k) for k in parent_refs.keys()])
```
which for charts evalulates to
```python
filters.extend([Slice.datasource_id == dict_rep.get("datasource_id")])
```
When the chart's dataset has been changed, the query fails to find the chart even if a chart with the same UUID exists. It then attempts to create the chart since it thinks it doesn't exist, which obviously fails the UUID uniqueness constraint.

This PR allows for charts to be "re-parented" to another dataset on import by removing this filter for chart imports, which can be useful when importing and exporting assets between environments after making changes, or for managing assets as code.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Have a database connection with a dataset
2. Create a virtual dataset identical to the dataset (`SELECT * FROM <physical_dataset>`)
3. Create a chart for each dataset
4. Do a bulk export with both of these charts
5. Extract the export file 
6. Navigate to the charts folder and swap the `dataset_uuid` values for the charts
7. Compress the file
8. Import it back into the Superset instance
9. See the charts have swapped datasets

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/22506
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
