### PR TITLE
fix(dataset): resizable dataset layout left column

### DIFF
--- a/superset-frontend/src/features/datasets/AddDataset/LeftPanel/index.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/LeftPanel/index.tsx
@@ -37,7 +37,6 @@ interface LeftPanelProps {
 
 const LeftPanelStyle = styled.div`
   ${({ theme }) => `
-    max-width: ${theme.gridUnit * 87.5}px;
     padding: ${theme.gridUnit * 4}px;
     height: 100%;
     background-color: ${theme.colors.grayscale.light5};

--- a/superset-frontend/src/features/datasets/DatasetLayout/index.tsx
+++ b/superset-frontend/src/features/datasets/DatasetLayout/index.tsx
@@ -17,6 +17,9 @@
  * under the License.
  */
 import React, { ReactElement, JSXElementConstructor } from 'react';
+import { useTheme } from '@superset-ui/core';
+import ResizableSidebar from 'src/components/ResizableSidebar';
+
 import {
   StyledLayoutWrapper,
   LeftColumn,
@@ -46,14 +49,25 @@ export default function DatasetLayout({
   rightPanel,
   footer,
 }: DatasetLayoutProps) {
+  const theme = useTheme();
+
   return (
     <StyledLayoutWrapper data-test="dataset-layout-wrapper">
       {header && <StyledLayoutHeader>{header}</StyledLayoutHeader>}
       <OuterRow>
         {leftPanel && (
-          <LeftColumn>
-            <StyledLayoutLeftPanel>{leftPanel}</StyledLayoutLeftPanel>
-          </LeftColumn>
+          <ResizableSidebar
+            id="dataset"
+            initialWidth={theme.gridUnit * 80}
+            minWidth={theme.gridUnit * 80}
+            enable
+          >
+            {adjustedWidth => (
+              <LeftColumn width={adjustedWidth}>
+                <StyledLayoutLeftPanel>{leftPanel}</StyledLayoutLeftPanel>
+              </LeftColumn>
+            )}
+          </ResizableSidebar>
         )}
         <RightColumn>
           <PanelRow>

--- a/superset-frontend/src/features/datasets/styles.ts
+++ b/superset-frontend/src/features/datasets/styles.ts
@@ -25,22 +25,22 @@ export const StyledLayoutWrapper = styled.div`
   background-color: ${({ theme }) => theme.colors.grayscale.light5};
 `;
 
-const Column = styled.div`
+const Column = styled.div<{ width?: number }>`
   width: 100%;
   height: 100%;
   flex-direction: column;
 `;
 
 export const LeftColumn = styled(Column)`
-  width: ${({ theme }) => theme.gridUnit * 80}px;
+  width: ${({ theme, width }) => width ?? theme.gridUnit * 80}px;
   height: auto;
 `;
 
 export const RightColumn = styled(Column)`
+  width: auto;
   height: auto;
   display: flex;
-  flex: 1 0 auto;
-  width: calc(100% - ${({ theme }) => theme.gridUnit * 80}px);
+  flex: 1 1 auto;
 `;
 
 const Row = styled.div`
@@ -52,6 +52,7 @@ const Row = styled.div`
 
 export const OuterRow = styled(Row)`
   flex: 1 0 auto;
+  position: relative;
 `;
 
 export const PanelRow = styled(Row)`
@@ -87,7 +88,6 @@ export const StyledCreateDatasetTitle = styled.div`
 
 export const StyledLayoutLeftPanel = styled.div`
   ${({ theme }) => `
-  width: ${theme.gridUnit * 80}px;
   height: 100%;
   border-right: 1px solid ${theme.colors.grayscale.light2};
   `}

--- a/superset-frontend/src/features/datasets/styles.ts
+++ b/superset-frontend/src/features/datasets/styles.ts
@@ -25,22 +25,20 @@ export const StyledLayoutWrapper = styled.div`
   background-color: ${({ theme }) => theme.colors.grayscale.light5};
 `;
 
-const Column = styled.div<{ width?: number }>`
-  width: 100%;
-  height: 100%;
-  flex-direction: column;
-`;
-
-export const LeftColumn = styled(Column)`
+export const LeftColumn = styled.div<{ width?: number }>`
   width: ${({ theme, width }) => width ?? theme.gridUnit * 80}px;
+  max-width: ${({ theme, width }) => width ?? theme.gridUnit * 80}px;
   height: auto;
+  flex-direction: column;
+  flex: 1 0 auto;
 `;
 
-export const RightColumn = styled(Column)`
+export const RightColumn = styled.div`
   width: auto;
   height: auto;
   display: flex;
-  flex: 1 1 auto;
+  flex-direction: column;
+  flex-grow: 1;
 `;
 
 const Row = styled.div`

--- a/superset-frontend/src/features/datasets/styles.ts
+++ b/superset-frontend/src/features/datasets/styles.ts
@@ -28,14 +28,11 @@ export const StyledLayoutWrapper = styled.div`
 export const LeftColumn = styled.div<{ width?: number }>`
   width: ${({ theme, width }) => width ?? theme.gridUnit * 80}px;
   max-width: ${({ theme, width }) => width ?? theme.gridUnit * 80}px;
-  height: auto;
   flex-direction: column;
   flex: 1 0 auto;
 `;
 
 export const RightColumn = styled.div`
-  width: auto;
-  height: auto;
   display: flex;
   flex-direction: column;
   flex-grow: 1;


### PR DESCRIPTION
### SUMMARY
Since #24599 introduced the TableSelector in dataset left column, it also collapses the overflowing (long) table names like before [SQLLab editor.](https://github.com/apache/superset/pull/21300). This commit also introduces the Resizable Leftbar in dataset layout to fix the problem as SQL Lab does.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After:

https://github.com/apache/superset/assets/1392866/5c4dc304-9517-4c44-ad5a-71a574dd8ce4

Before:

https://github.com/apache/superset/assets/1392866/b73d2332-d45f-49db-842c-a324ec808f21

### TESTING INSTRUCTIONS
Go to "Add Dataset" and choose a schema which contains a long table name

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
