### PR TITLE
fix(migration): Ensure cascadeParentIds key exists

### DIFF
--- a/superset/migrations/versions/2023-07-19_16-48_a23c6f8b1280_cleanup_erroneous_parent_filter_ids.py
+++ b/superset/migrations/versions/2023-07-19_16-48_a23c6f8b1280_cleanup_erroneous_parent_filter_ids.py
@@ -61,14 +61,13 @@ def upgrade():
                     filter_ids = {fltr["id"] for fltr in filters}
 
                     for fltr in filters:
-                        for parent_id in fltr["cascadeParentIds"][:]:
+                        for parent_id in fltr.get("cascadeParentIds", [])[:]:
                             if parent_id not in filter_ids:
                                 fltr["cascadeParentIds"].remove(parent_id)
                                 updated = True
 
                 if updated:
                     dashboard.json_metadata = json.dumps(json_metadata)
-
             except Exception:
                 logging.exception(
                     f"Unable to parse JSON metadata for dashboard {dashboard.id}"


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Sorry this issue only surfaced whilst testing on a more recent corpus of Airbnb's data. It seems that there could be instances where the `cascadeParentIds` key does not exist for a given native dashboard filter. This change adds a safeguard for such an event.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
