### PR TITLE
fix: Alembic migration head

### DIFF
--- a/superset/migrations/versions/2023-07-19_17-54_ee179a490af9_deckgl_path_width_units.py
+++ b/superset/migrations/versions/2023-07-19_17-54_ee179a490af9_deckgl_path_width_units.py
@@ -17,7 +17,7 @@
 """deckgl-path-width-units
 
 Revision ID: ee179a490af9
-Revises: a23c6f8b1280
+Revises: e0f6f91c2055
 Create Date: 2023-07-19 17:54:06.752360
 
 """
@@ -32,7 +32,7 @@ from superset import db
 
 # revision identifiers, used by Alembic.
 revision = "ee179a490af9"
-down_revision = "a23c6f8b1280"
+down_revision = "e0f6f91c2055"
 
 
 Base = declarative_base()


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR fixes an issue where previously there were two Alembic heads.

#### BEFORE

```
$ FLASK_DEBUG=true superset db heads
e0f6f91c2055 (head)
ee179a490af9 (head)
```

i.e., the history of the two heads were:

```
e0f6f91c2055 <- bf646a0c1501 <- a23c6f8b1280 <- 863adcf72773
ee179a490af9 <- a23c6f8b1280
```

#### AFTER 

```
$ FLASK_DEBUG=true superset db heads
ee179a490af9 (head)
```

whereas after the change, i.e, making the down revision of `ee179a490af9` to be `e0f6f91c2055`  the history is:

```
ee179a490af9 <- e0f6f91c2055 <- bf646a0c1501 <- a23c6f8b1280 <- 863adcf72773
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
