### PR TITLE
docs(Kubernetes): Fix typos, clarify language re: Scarf

### DIFF
--- a/docs/docs/installation/running-on-kubernetes.mdx
+++ b/docs/docs/installation/running-on-kubernetes.mdx
@@ -122,7 +122,9 @@ init:
 ```
 
 :::note
-Superset uses [Scarf Gateway](https://about.scarf.sh/scarf-gateway) to collect telmetry data to better understand and support the need for patch versions of Sueprset. Scarf purges PII and provides aggregated statistics. Superset users can easily opt out of analytics in various ways documented [here](https://docs.scarf.sh/gateway/#do-not-track). However, if you wish to opt-out of this in your Helm-based installation, you can simply edit your `helm/superset/values.yaml` file and remove `apachesuperset.docker.scarf.sh/` from the `repository` field, so that it's simply pulling `apache/superset`
+Superset uses [Scarf Gateway](https://about.scarf.sh/scarf-gateway) to collect telemetry data.  Knowing the installation counts for different Superset versions informs the  project's decisions about patching and long-term support. Scarf purges personally identifiable information (PII) and provides only aggregated statistics.
+
+To opt-out of this data collection in your Helm-based installation, edit the `repository:` line in your `helm/superset/values.yaml` file, replacing `apachesuperset.docker.scarf.sh/apache/superset` with `apache/superset` to pull the image directly from Docker Hub.
 :::
 
 #### Dependencies
@@ -135,7 +137,7 @@ For production clusters it's recommended to build own image with this step done 
 Superset requires a Python DB-API database driver and a SQLAlchemy
 dialect to be installed for each datastore you want to connect to.
 
-See [Install Database Drivers](/docs/databases/installing-database-drivers) for more information
+See [Install Database Drivers](/docs/databases/installing-database-drivers) for more information.
 
 :::
 


### PR DESCRIPTION
### SUMMARY
closes BugHerd issue 61.  Someone pointed out that there were typos like "telmetry" and "Sueprset", I fixed those and rewrote the paragraph to make it clearer.