### PR TITLE
feat: allow database configuration via env variable

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -183,7 +183,7 @@ SQLALCHEMY_TRACK_MODIFICATIONS = False
 SECRET_KEY = os.environ.get("SUPERSET_SECRET_KEY") or CHANGE_ME_SECRET_KEY
 
 # The SQLAlchemy connection string.
-SQLALCHEMY_DATABASE_URI = "sqlite:///" + os.path.join(DATA_DIR, "superset.db")
+SQLALCHEMY_DATABASE_URI = os.environ.get("SUPERSET_DATABASE_URI") or "sqlite:///" + os.path.join(DATA_DIR, "superset.db")
 # SQLALCHEMY_DATABASE_URI = 'mysql://myapp@localhost/myapp'
 # SQLALCHEMY_DATABASE_URI = 'postgresql://root:password@localhost/myapp'
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Currently the only thing you can configure via the environment without separate configuration file is the Flask `SECRET_KEY`. This means when running superset as a docker image you pretty much always need to wrap it within your own docker image first. As running a docker image, which is supposed to be immutable, with an embedded sqlite db is also quite limited in its usefulness it would be great to at least be able to point the default docker image to some external db.

So this change allows to set a new ENV variable `SUPERSET_DATABASE_URI` which allows it to deploy a useful superset docker image directly. I followed the naming of `SUPERSET_SECRET_KEY` to stay consistent.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
