### PR TITLE
fix(sqllab): Add docText for long keyword

### DIFF
--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.test.ts
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.test.ts
@@ -267,3 +267,49 @@ test('returns column keywords among selected tables', async () => {
     ),
   );
 });
+
+test('returns long keywords with docText', async () => {
+  const expectLongKeywordDbId = 2;
+  const longKeyword = 'veryveryveryveryverylongtablename';
+  const dbFunctionNamesApiRoute = `glob:*/api/v1/database/${expectLongKeywordDbId}/function_names/`;
+  fetchMock.get(dbFunctionNamesApiRoute, { function_names: [] });
+
+  act(() => {
+    store.dispatch(
+      schemaApiUtil.upsertQueryData(
+        'schemas',
+        {
+          dbId: expectLongKeywordDbId,
+          forceRefresh: false,
+        },
+        ['short', longKeyword].map(value => ({
+          value,
+          label: value,
+          title: value,
+        })),
+      ),
+    );
+  });
+  const { result, waitFor } = renderHook(
+    () =>
+      useKeywords({
+        queryEditorId: 'testqueryid',
+        dbId: expectLongKeywordDbId,
+      }),
+    {
+      wrapper: createWrapper({
+        useRedux: true,
+        store,
+      }),
+    },
+  );
+  await waitFor(() =>
+    expect(result.current).toContainEqual(
+      expect.objectContaining({
+        name: longKeyword,
+        value: longKeyword,
+        docText: longKeyword,
+      }),
+    ),
+  );
+});

--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.ts
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.ts
@@ -50,6 +50,11 @@ const EMPTY_LIST = [] as typeof sqlKeywords;
 const { useQueryState: useSchemasQueryState } = schemaEndpoints.schemas;
 const { useQueryState: useTablesQueryState } = tableEndpoints.tables;
 
+const getHelperText = (value: string) =>
+  value.length > 30 && {
+    docText: value,
+  };
+
 export function useKeywords(
   { queryEditorId, dbId, schema }: Params,
   skip = false,
@@ -149,6 +154,7 @@ export function useKeywords(
         completer: {
           insertMatch,
         },
+        ...getHelperText(s.value),
       })),
     [schemaOptions, insertMatch],
   );
@@ -163,6 +169,7 @@ export function useKeywords(
         completer: {
           insertMatch,
         },
+        ...getHelperText(value),
       })),
     [tableData?.options, insertMatch],
   );
@@ -174,6 +181,7 @@ export function useKeywords(
         value: col,
         score: COLUMN_AUTOCOMPLETE_SCORE,
         meta: 'column',
+        ...getHelperText(col),
       })),
     [allColumns],
   );
@@ -188,6 +196,7 @@ export function useKeywords(
         completer: {
           insertMatch,
         },
+        ...getHelperText(func),
       })),
     [functionNames, insertMatch],
   );

--- a/superset-frontend/src/components/AsyncAceEditor/index.tsx
+++ b/superset-frontend/src/components/AsyncAceEditor/index.tsx
@@ -35,6 +35,8 @@ export interface AceCompleterKeywordData {
   value: string;
   score: number;
   meta: string;
+  docText?: string;
+  docHTML?: string;
 }
 
 export type TextMode = OrigTextMode & { $id: string };


### PR DESCRIPTION
### SUMMARY
Since the keyword tooltip is fixed size, a longer keyword name will be collapsed. This commit add `docText` for long keywords to enable the tooltip for the longer item.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After:

https://github.com/apache/superset/assets/1392866/cc936b09-9473-48d6-a465-4046e9b016ec

Before:

![Screenshot 2023-07-31 at 9 42 34 AM](https://github.com/apache/superset/assets/1392866/58c5de53-fd9c-4bbc-8a49-7b74997265fe)

### TESTING INSTRUCTIONS
Go to SQL Lab and enable autocomplete
Please select a schema including a long table name

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
