### PR TITLE
fix(legacy-chart): corrupted raw chart data

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/transformProps.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/transformProps.js
@@ -111,6 +111,7 @@ export default function transformProps(chartProps) {
   const data = Array.isArray(rawData)
     ? rawData.map(row => ({
         ...row,
+        values: row.values.map(value => ({ ...value })),
         key: formatLabel(row.key, datasource.verboseMap),
       }))
     : rawData;


### PR DESCRIPTION
### SUMMARY
In legacy charts, there's some logics mutating chartData which also corrupts the original raw data.
This makes the invalid chart results specially in the stacked chart which sums up the series values for the chart data.
This commit makes the copy of the rawData value to avoid the corruption.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After:
![Screenshot 2023-07-31 at 2 08 22 PM](https://github.com/apache/superset/assets/1392866/7caca115-70e6-475c-9949-8be1d6e3e70e)

https://github.com/apache/superset/assets/1392866/c42bcb63-3bf1-40fa-bec3-8ef4fb9b751d

Before:
![Screenshot 2023-07-31 at 2 08 46 PM](https://github.com/apache/superset/assets/1392866/6a26e440-8665-48fe-b3a9-d768b9858056)

https://github.com/apache/superset/assets/1392866/dca32a6e-a0dc-43d4-8125-3a0a01c9eb7f

### TESTING INSTRUCTIONS
- Create a area chart
- set stacked
- choose a Y A-axis format like `.3s`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
