### PR TITLE
fix: Ignores ResizeObserver errors in development mode

### DIFF
--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -512,7 +512,11 @@ if (isDevMode) {
       () => proxyConfig,
     ],
     client: {
-      overlay: { errors: true, warnings: false },
+      overlay: {
+        errors: true,
+        warnings: false,
+        runtimeErrors: error => !/ResizeObserver/.test(error.message),
+      },
       logging: 'error',
     },
     static: path.join(process.cwd(), '../static/assets'),


### PR DESCRIPTION
### SUMMARY
`webpack-dev-server` 4.12.0 added a new feature to [show runtime errors in the error overlay](https://github.com/webpack/webpack-dev-server/pull/4605) by default which resulted in  `ResizeObserver` errors when running Superset in development mode. 

<img width="1048" alt="Screenshot 2023-08-02 at 09 56 17" src="https://github.com/apache/superset/assets/70410625/895cbe9a-f46c-4a5b-8350-e3cd52a3f854">

We only have one use of `ResizeObserver` in our codebase and it's not the root cause for the error, so it must be coming from a third party dependency. Given that this type of error is [benign](https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded), we even have discussions to [downgrade it to a warning](https://github.com/w3c/csswg-drafts/issues/5023), this PR changes the Webpack [configuration](https://webpack.js.org/configuration/dev-server/#overlay) to ignore related error messages.

### TESTING INSTRUCTIONS
Make sure the referenced error does not happen when running the application in development mode.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
