### PR TITLE
fix: Ignores hot update files when generating the manifest

### DIFF
--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -98,11 +98,10 @@ const plugins = [
             .filter(x => x.endsWith('.css'))
             .map(x => `${output.publicPath}${x}`),
           js: chunks
-            .filter(x => x.endsWith('.js'))
+            .filter(x => x.endsWith('.js') && x.match(/(?<!hot-update).js$/))
             .map(x => `${output.publicPath}${x}`),
         };
       });
-
       return {
         ...seed,
         entrypoints: entryFiles,


### PR DESCRIPTION
### SUMMARY
Fixes the following error when running Superset with hot update enabled:

<img width="546" alt="Screenshot 2023-08-02 at 15 17 11" src="https://github.com/apache/superset/assets/70410625/caf93f6a-1484-47d5-a322-5ab996e69062">

<br>This happens because the manifest file was being generated with `[hash].hot-update.js` files. This PR [adds a filter to the Webpack config to ignore these files](https://github.com/webpack/webpack/discussions/14873#discussioncomment-3014164).

### TESTING INSTRUCTIONS
Make sure the console error does not appear when hot updating a file with `npm run dev-server`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
