### PR TITLE
fix(annotation): Address regression from #24694

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/query/types/AnnotationLayer.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/AnnotationLayer.ts
@@ -159,7 +159,6 @@ export function isTableAnnotationLayer(
 }
 
 export type RecordAnnotationResult = {
-  columns: string[];
   records: DataRecord[];
 };
 
@@ -181,7 +180,7 @@ export function isTimeseriesAnnotationResult(
 export function isRecordAnnotationResult(
   result: any,
 ): result is RecordAnnotationResult {
-  return Array.isArray(result?.columns) && Array.isArray(result?.records);
+  return Array.isArray(result?.records);
 }
 
 export type AnnotationData = { [key: string]: AnnotationResult };

--- a/superset-frontend/packages/superset-ui-core/test/query/types/AnnotationLayer.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/types/AnnotationLayer.test.ts
@@ -93,7 +93,6 @@ describe('AnnotationLayer type guards', () => {
     },
   ];
   const recordAnnotationResult: RecordAnnotationResult = {
-    columns: ['col1', 'col2'],
     records: [
       { a: 1, b: 2 },
       { a: 2, b: 3 },

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/annotation.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/annotation.test.ts
@@ -130,7 +130,6 @@ describe('extractAnnotationLabels', () => {
     ];
     const results: AnnotationData = {
       'My Interval': {
-        columns: ['col'],
         records: [{ col: 1 }],
       },
       'My Line': [


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR fixes a regression introduced in https://github.com/apache/superset/pull/24694. Specifically [previously](https://github.com/apache/superset/pull/24694/files#diff-359940b6f6470257ed49fa39b82361ccb50a826407072043843a36a0ed6ce4e9L842) the legacy `TableViz` returned both the records and the columns associated with the records, however per [here](https://github.com/apache/superset/pull/24694/files#diff-d3bf055ecf6a74aa0acbb0650d176b6c251aea7796543f77a2df3fd8b7e4c4b4R738) the new formulation only returned the records resulting in the annotation layer being [deemed](https://github.com/apache/superset/blob/b71541fb7fb1bdfd3e1eea59ee76de1f51e67e6b/superset-frontend/packages/superset-ui-core/src/query/types/AnnotationLayer.ts#L181-L185) invalid by the frontend.

Rather than also explicitly including the column names (which is also redundant as the names are included in the records) this PR simply removes them as they're superfluous and not used by the frontend anywhere.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI and ran an end-to-end test locally.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
