### PR TITLE
fix(explore): invalid "No Filter" applied

### DIFF
--- a/superset-frontend/src/explore/actions/saveModalActions.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.js
@@ -21,6 +21,7 @@ import { SupersetClient, t } from '@superset-ui/core';
 import { addSuccessToast } from 'src/components/MessageToasts/actions';
 import { isEmpty } from 'lodash';
 import { buildV1ChartDataPayload } from '../exploreUtils';
+import { Operators } from '../constants';
 
 const ADHOC_FILTER_REGEX = /^adhoc_filters/;
 
@@ -86,7 +87,8 @@ export const getSlicePayload = (
   if (
     isEmpty(adhocFilters?.adhoc_filters) &&
     isEmpty(formDataFromSlice) &&
-    formDataWithNativeFilters?.adhoc_filters?.length > 0
+    formDataWithNativeFilters?.adhoc_filters?.[0]?.operator ===
+      Operators.TEMPORAL_RANGE
   ) {
     adhocFilters.adhoc_filters = [
       {


### PR DESCRIPTION
### SUMMARY
When a legacy chart converted to the echart, there's a chance that non time range filter has been added in the adhoc_filters. This `No Filter` value has been introduced from https://github.com/apache/superset/pull/24405/files which always adds `No Filter` any given filter types. This commit adds the condition that `No Filter` added only for `TEMPORAL_RANGE`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After: `No filter` ignored

Before:
![Screenshot_2023-08-01_at_3_35_44_PM](https://github.com/apache/superset/assets/1392866/83a36888-731c-4cf2-8c14-7c54f26fa95a)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
