### PR TITLE
fix(explore): double resize triggered

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -20,7 +20,7 @@ import cx from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { styled, t, logging } from '@superset-ui/core';
-import { isEqual } from 'lodash';
+import { debounce, isEqual } from 'lodash';
 import { withRouter } from 'react-router-dom';
 
 import { exportChart, mountExploreUrl } from 'src/explore/exploreUtils';
@@ -142,7 +142,7 @@ class Chart extends React.Component {
     this.exportXLSX = this.exportXLSX.bind(this);
     this.exportFullXLSX = this.exportFullXLSX.bind(this);
     this.forceRefresh = this.forceRefresh.bind(this);
-    this.resize = this.resize.bind(this);
+    this.resize = debounce(this.resize, RESIZE_TIMEOUT).bind(this);
     this.setDescriptionRef = this.setDescriptionRef.bind(this);
     this.setHeaderRef = this.setHeaderRef.bind(this);
     this.getChartHeight = this.getChartHeight.bind(this);

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -142,7 +142,7 @@ class Chart extends React.Component {
     this.exportXLSX = this.exportXLSX.bind(this);
     this.exportFullXLSX = this.exportFullXLSX.bind(this);
     this.forceRefresh = this.forceRefresh.bind(this);
-    this.resize = debounce(this.resize, RESIZE_TIMEOUT).bind(this);
+    this.resize = debounce(this.resize.bind(this), RESIZE_TIMEOUT);
     this.setDescriptionRef = this.setDescriptionRef.bind(this);
     this.setHeaderRef = this.setHeaderRef.bind(this);
     this.getChartHeight = this.getChartHeight.bind(this);
@@ -222,7 +222,7 @@ class Chart extends React.Component {
   }
 
   componentWillUnmount() {
-    this.resize.cancel?.();
+    this.resize.cancel();
   }
 
   componentDidUpdate(prevProps) {

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -95,7 +95,7 @@ const defaultProps = {
 
 // we use state + shouldComponentUpdate() logic to prevent perf-wrecking
 // resizing across all slices on a dashboard on every update
-const RESIZE_TIMEOUT = 350;
+const RESIZE_TIMEOUT = 500;
 const SHOULD_UPDATE_ON_PROP_CHANGES = Object.keys(propTypes).filter(
   prop =>
     prop !== 'width' && prop !== 'height' && prop !== 'isComponentVisible',
@@ -178,8 +178,7 @@ class Chart extends React.Component {
       }
 
       if (nextProps.isFullSize !== this.props.isFullSize) {
-        clearTimeout(this.resizeTimeout);
-        this.resizeTimeout = setTimeout(this.resize, RESIZE_TIMEOUT);
+        this.resize();
         return false;
       }
 
@@ -189,8 +188,7 @@ class Chart extends React.Component {
         nextProps.width !== this.state.width ||
         nextProps.height !== this.state.height
       ) {
-        clearTimeout(this.resizeTimeout);
-        this.resizeTimeout = setTimeout(this.resize, RESIZE_TIMEOUT);
+        this.resize();
       }
 
       for (let i = 0; i < SHOULD_UPDATE_ON_PROP_CHANGES.length; i += 1) {
@@ -224,7 +222,7 @@ class Chart extends React.Component {
   }
 
   componentWillUnmount() {
-    clearTimeout(this.resizeTimeout);
+    this.unmounted = true;
   }
 
   componentDidUpdate(prevProps) {
@@ -269,6 +267,9 @@ class Chart extends React.Component {
   }
 
   resize() {
+    if (this.unmounted) {
+      return;
+    }
     const { width, height } = this.props;
     this.setState(() => ({ width, height }));
   }

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -222,7 +222,7 @@ class Chart extends React.Component {
   }
 
   componentWillUnmount() {
-    this.resize.cancel();
+    this.resize.cancel?.();
   }
 
   componentDidUpdate(prevProps) {

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -222,7 +222,7 @@ class Chart extends React.Component {
   }
 
   componentWillUnmount() {
-    this.unmounted = true;
+    this.resize.cancel();
   }
 
   componentDidUpdate(prevProps) {
@@ -267,9 +267,6 @@ class Chart extends React.Component {
   }
 
   resize() {
-    if (this.unmounted) {
-      return;
-    }
     const { width, height } = this.props;
     this.setState(() => ({ width, height }));
   }


### PR DESCRIPTION
### SUMMARY
Since the chart container triggers the resize handler by both props and state, it often tends to trigger rendering twice.
This commit debounces the resize function to prevent accidental duplicate resize calls.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After:

https://github.com/apache/superset/assets/1392866/adaa3871-d4e5-45fd-a31f-cbae02c39a63

https://github.com/apache/superset/assets/1392866/41632cac-fb10-4fbe-81d2-ed822101fe56

Before:

https://github.com/apache/superset/assets/1392866/48868a41-e750-4011-b654-f91a7f47b643

https://github.com/apache/superset/assets/1392866/e36c4784-e4dd-418f-a893-8334de57af8c


### TESTING INSTRUCTIONS
Go to dashboard and resize the window

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
