### PR TITLE
fix: revert "fix(embedded): adding logic to check dataset used by filters (#24808)

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -16,7 +16,6 @@
 # under the License.
 # pylint: disable=too-many-lines
 """A set of constants and methods to manage permissions and security"""
-import json
 import logging
 import re
 import time
@@ -2059,28 +2058,8 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             .filter(Dashboard.id.in_(dashboard_ids))
         )
 
-        if db.session.query(query.exists()).scalar():
-            return True
-
-        # check for datasets that are only used by filters
-        dashboards_json = (
-            db.session.query(Dashboard.json_metadata)
-            .filter(Dashboard.id.in_(dashboard_ids))
-            .all()
-        )
-        for json_ in dashboards_json:
-            try:
-                json_metadata = json.loads(json_.json_metadata)
-                for filter_ in json_metadata.get("native_filter_configuration", []):
-                    filter_dataset_ids = [
-                        target.get("datasetId") for target in filter_.get("targets", [])
-                    ]
-                    if datasource.id in filter_dataset_ids:
-                        return True
-            except ValueError:
-                pass
-
-        return False
+        exists = db.session.query(query.exists()).scalar()
+        return exists
 
     @staticmethod
     def _get_current_epoch_time() -> float:

--- a/tests/integration_tests/security/guest_token_security_tests.py
+++ b/tests/integration_tests/security/guest_token_security_tests.py
@@ -15,21 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 """Unit tests for Superset"""
-import json
 from unittest import mock
 
 import pytest
 from flask import g
 
 from superset import db, security_manager
-from superset.connectors.sqla.models import SqlaTable
 from superset.daos.dashboard import EmbeddedDashboardDAO
 from superset.dashboards.commands.exceptions import DashboardAccessDeniedError
 from superset.exceptions import SupersetSecurityException
 from superset.models.dashboard import Dashboard
 from superset.security.guest_token import GuestTokenResourceType
 from superset.sql_parse import Table
-from superset.utils.database import get_example_database
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.birth_names_dashboard import (
     load_birth_names_dashboard_with_slices,
@@ -235,47 +232,4 @@ class TestGuestUserDashboardAccess(SupersetTestCase):
             security_manager.raise_for_dashboard_access(dash)
 
         db.session.delete(dash)
-        db.session.commit()
-
-    def test_can_access_datasource_used_in_dashboard_filter(self):
-        """
-        Test that a user can access a datasource used only by a filter in a dashboard
-        they have access to.
-        """
-        # Create a test dataset
-        test_dataset = SqlaTable(
-            database_id=get_example_database().id,
-            schema="main",
-            table_name="test_table_embedded_filter",
-        )
-        db.session.add(test_dataset)
-        db.session.commit()
-
-        # Create an embedabble dashboard with a filter powered by the test dataset
-        test_dashboard = Dashboard()
-        test_dashboard.dashboard_title = "Test Embedded Dashboard"
-        test_dashboard.json_metadata = json.dumps(
-            {
-                "native_filter_configuration": [
-                    {"targets": [{"datasetId": test_dataset.id}]}
-                ]
-            }
-        )
-        test_dashboard.owners = []
-        test_dashboard.slices = []
-        test_dashboard.published = False
-        db.session.add(test_dashboard)
-        db.session.commit()
-        self.embedded = EmbeddedDashboardDAO.upsert(test_dashboard, [])
-
-        # grant access to the dashboad
-        g.user = self.authorized_guest
-        g.user.resources = [{"type": "dashboard", "id": str(self.embedded.uuid)}]
-        g.user.roles = [security_manager.get_public_role()]
-
-        # The user should have access to the datasource via the dashboard
-        security_manager.raise_for_access(datasource=test_dataset)
-
-        db.session.delete(test_dashboard)
-        db.session.delete(test_dataset)
         db.session.commit()


### PR DESCRIPTION


<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR reverts https://github.com/apache/superset/pull/24808. Regrettably @Vitor-Avila after further review I believe the logic outlined in your fix (per the integration test you added) exposes a security vulnerability, i.e., per this check in your test,

```python
security_manager.raise_for_access(datasource=test_dataset)
```

will mean said user will have access to the `test_dataset` datasource irrespective of the context. Thus by granting dashboard access to to a guest user you would be in fact (possibly unknowingly) granting full access to all datasources which are referenced within the native dashboard filters.

I think the right—context aware—solution is to change the `raise_for_access` caller to include the dashboard context. Note in https://github.com/apache/superset/pull/24804 I've refactored the dashboard security logic by folding `raise_for_dashboard_access` into `raise_for_access` so the later is (or can be dashboard aware).

The TL;DR is your change flexes to accommodate the need for the dashboard filters to function but is over generous in terms of the context in which the permissions are allowed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
