### PR TITLE
fix(logs): increase json field for logs table

### DIFF
--- a/superset/migrations/versions/2023-08-08_14-14_2e826adca42c_log_json.py
+++ b/superset/migrations/versions/2023-08-08_14-14_2e826adca42c_log_json.py
@@ -22,14 +22,15 @@ Create Date: 2023-08-08 14:14:23.381364
 
 """
 
-# revision identifiers, used by Alembic.
-revision = '2e826adca42c'
-down_revision = '0769ef90fddd'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 from superset.utils.core import MediumText
+
+# revision identifiers, used by Alembic.
+revision = "2e826adca42c"
+down_revision = "0769ef90fddd"
 
 
 def upgrade():

--- a/superset/migrations/versions/2023-08-08_14-14_2e826adca42c_log_json.py
+++ b/superset/migrations/versions/2023-08-08_14-14_2e826adca42c_log_json.py
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Fix schema for log
+
+Revision ID: 2e826adca42c
+Revises: 0769ef90fddd
+Create Date: 2023-08-08 14:14:23.381364
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '2e826adca42c'
+down_revision = '0769ef90fddd'
+
+from alembic import op
+import sqlalchemy as sa
+
+from superset.utils.core import MediumText
+
+
+def upgrade():
+    with op.batch_alter_table("logs") as batch_op:
+        batch_op.alter_column(
+            "json",
+            existing_type=sa.Text(),
+            type_=MediumText(),
+            existing_nullable=True,
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("logs") as batch_op:
+        batch_op.alter_column(
+            "json",
+            existing_type=MediumText(),
+            type_=sa.Text(),
+            existing_nullable=True,
+        )


### PR DESCRIPTION
### SUMMARY
- Increase json field for logs table. (Text to MediumText)
- When insert logs while imports a specific dashboard, An error occured.
```
(MySQLdb._exceptions.DataError) (1406, "Data too long for column 'json' at row 1")
[SQL: INSERT INTO logs (`action`, user_id, dashboard_id, slice_id, json, dttm, duration_ms, referrer) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)]
[parameters: ('copy_dash', '1', 9, 0, '{"path": "/superset/copy_dash/9/", "data": "{\\"certified_by\\":\\"\\",\\"certification_details\\":\\"\\",\\"css\\":\\"\\",\\"dashboard_title\\":\\"G ... (171666 characters truncated) ... BS\\"}},\\"filter_scopes\\":\\"{}\\"}", "url_rule": "/superset/copy_dash/<int:dashboard_id>/", "object_ref": "Superset.copy_dash", "dashboard_id": 9}', datetime.datetime(2023, 8, 7, 6, 50, 6, 897685), 6474, '[http://__/superset/dashboard/9/?native_filters_key=A27QtFLKT95Qdd0X-h4KkTLZTBhOslCg0Jshcisx4A8FM71hI_Ae6pBdTc4ac94f')](http://__/superset/dashboard/9/?native_filters_key=A27QtFLKT95Qdd0X-h4KkTLZTBhOslCg0Jshcisx4A8FM71hI_Ae6pBdTc4ac94f%27))]
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
```
0769ef90fddd -> 2e826adca42c (head), Fix schema for log
ee179a490af9 -> 0769ef90fddd, Fix schema perm for datasets
e0f6f91c2055 -> ee179a490af9, deckgl-path-width-units
bf646a0c1501 -> e0f6f91c2055, create_user_favorite_table
a23c6f8b1280 -> bf646a0c1501, json_metadata
```

### TESTING INSTRUCTIONS
```sql
ALTER TABLE logs MODIFY json MEDIUMTEXT;
Query OK, 556821 rows affected (5.10 sec)
```
- Estimate 100000 rows updated per 1 sec
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
