### PR TITLE
fix(trino): cancel_query doesn't abort query execution in Trino server

### DIFF
--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -135,6 +135,19 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
         return True
 
     @classmethod
+    def execute(cls, cursor: Cursor, query: str, **kwargs: Any) -> None:
+        opts = {}
+        if "async_" in kwargs:
+            opts["deferred_fetch"] = kwargs["async_"]
+        if cls.arraysize:
+            cursor.arraysize = cls.arraysize
+
+        try:
+            cursor.execute(query, **opts)
+        except Exception as ex:
+            raise cls.get_dbapi_mapped_exception(ex)
+
+    @classmethod
     def get_tracking_url(cls, cursor: Cursor) -> str | None:
         try:
             return cursor.info_uri
@@ -160,8 +173,8 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
 
         session.commit()
 
-        # if query cancelation was requested prior to the handle_cursor call, but
-        # the query was still executed, trigger the actual query cancelation now
+        # if query cancellation was requested prior to the handle_cursor call, but
+        # the query was still executed, trigger the actual query cancellation now
         if query.extra.get(QUERY_EARLY_CANCEL_KEY):
             cls.cancel_query(
                 cursor=cursor,
@@ -178,7 +191,7 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
             session.commit()
 
     @classmethod
-    def cancel_query(cls, cursor: Any, query: Query, cancel_query_id: str) -> bool:
+    def cancel_query(cls, cursor: Cursor, query: Query, cancel_query_id: str) -> bool:
         """
         Cancel query in the underlying database.
 
@@ -188,11 +201,12 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
         :return: True if query cancelled successfully, False otherwise
         """
         try:
+            # Can't use cursor.cancel() because
+            # cursor is new object created in sql_lab.cancel_query
             cursor.execute(
                 f"CALL system.runtime.kill_query(query_id => '{cancel_query_id}',"
                 "message => 'Query cancelled by Superset')"
             )
-            cursor.fetchall()  # needed to trigger the call
         except Exception:  # pylint: disable=broad-except
             return False
 


### PR DESCRIPTION
### SUMMARY
Fix #24858

This PR has 2 parts: Superset part - this PR, Trino part: trinodb/trino-python-client#400

Waiting for trinodb/trino-python-client#400 merge first and I'll bump the trino version

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

[Screencast from 08-08-2023 16:17:37.webm](https://github.com/apache/superset/assets/6848311/18003690-d8d4-469a-a1cf-ab6a3700530e)

After:

[Screencast from 08-08-2023 16:07:09.webm](https://github.com/apache/superset/assets/6848311/adebf3b7-7bb5-4e95-870f-1630e31dd1e5)




### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: #24858
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
