### PR TITLE
fix: Tooltip of area chart shows undefined total

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/utils.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/utils.js
@@ -191,19 +191,18 @@ export function generateAreaChartTooltipContent(
     '<tr class="tooltip-header"><td></td><td>Category</td><td>Value</td><td>% to total</td></tr>';
   d.series.forEach(series => {
     const key = getFormattedKey(series.key, true);
+    const isTotal = series.key === 'TOTAL';
     let trClass = '';
     if (series.highlight) {
       trClass = 'superset-legacy-chart-nvd3-tr-highlight';
-    } else if (series.key === 'TOTAL') {
+    } else if (isTotal) {
       trClass = 'superset-legacy-chart-nvd3-tr-total';
     }
     tooltip +=
       `<tr class="${trClass}" style="border-color: ${series.color}">` +
-      `<td style="color: ${series.color}">${
-        series.key === 'TOTAL' ? '' : '&#9724;'
-      }</td>` +
+      `<td style="color: ${series.color}">${isTotal ? '' : '&#9724;'}</td>` +
       `<td>${key}</td>` +
-      `<td>${valueFormatter(series?.point?.y)}</td>` +
+      `<td>${valueFormatter(isTotal ? total : series?.point?.y)}</td>` +
       `<td>${((100 * series.value) / total).toFixed(2)}%</td>` +
       '</tr>';
   });


### PR DESCRIPTION
### SUMMARY
Fixes a bug where the tooltip of the area chart displays `undefined` totals.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1129" alt="Screenshot 2023-08-08 at 11 38 30" src="https://github.com/apache/superset/assets/70410625/a820f01e-5e8f-4bb4-a77c-5ccaa35fe1b4">
<img width="1143" alt="Screenshot 2023-08-08 at 11 37 16" src="https://github.com/apache/superset/assets/70410625/c1d95a97-5a13-4c9a-80ca-831a064edb23">

### TESTING INSTRUCTIONS
Make sure the total are correctly calculated.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
