### PR TITLE
docs: jwks_uri addition to OAUTH provider

### DIFF
--- a/docs/docs/installation/configuring-superset.mdx
+++ b/docs/docs/installation/configuring-superset.mdx
@@ -196,7 +196,7 @@ OAUTH_PROVIDERS = [
             'access_token_params':{        # Additional parameters for calls to access_token_url
                 'client_id':'myClientId'
             },
-            'jwks_uri':'https://myAuthorizationServe/adfs/discovery/keys' # Required to generate token
+            'jwks_uri':'https://myAuthorizationServe/adfs/discovery/keys', # Required to generate token
             'access_token_headers':{    # Additional headers for calls to access_token_url
                 'Authorization': 'Basic Base64EncodedClientIdAndSecret'
             },

--- a/docs/docs/installation/configuring-superset.mdx
+++ b/docs/docs/installation/configuring-superset.mdx
@@ -196,7 +196,7 @@ OAUTH_PROVIDERS = [
             'access_token_params':{        # Additional parameters for calls to access_token_url
                 'client_id':'myClientId'
             },
-            'jwks_uri':'https://myAuthorizationServe/adfs/discovery/keys', # Required to generate token
+            'jwks_uri':'https://myAuthorizationServe/adfs/discovery/keys', # may be required to generate token
             'access_token_headers':{    # Additional headers for calls to access_token_url
                 'Authorization': 'Basic Base64EncodedClientIdAndSecret'
             },

--- a/docs/docs/installation/configuring-superset.mdx
+++ b/docs/docs/installation/configuring-superset.mdx
@@ -196,6 +196,7 @@ OAUTH_PROVIDERS = [
             'access_token_params':{        # Additional parameters for calls to access_token_url
                 'client_id':'myClientId'
             },
+            'jwks_uri':'https://myAuthorizationServe/adfs/discovery/keys' # Required to generate token
             'access_token_headers':{    # Additional headers for calls to access_token_url
                 'Authorization': 'Basic Base64EncodedClientIdAndSecret'
             },


### PR DESCRIPTION
jwks_uri token is needed by the OAUTH to fetch the key and create token needed to connect to sso provider.
This will enable the OAUTH to verify the request and process it further.
If this is missing , then sso request was failing to connect to the OPENID type SSO request and will give following error
`[Error] authorizing OAuth access token: Missing "jwks_uri" in metadata`

Reference: https://stackoverflow.com/questions/72035617/runtimeerror-missing-jwks-uri-in-metadata-for-flask-and-azure-ad-authlib