### PR TITLE
chore(dashboard import/export): include additional fields to export/import commands

### DIFF
--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -374,6 +374,9 @@ class ImportV1DashboardSchema(Schema):
     version = fields.String(required=True)
     is_managed_externally = fields.Boolean(allow_none=True, dump_default=False)
     external_url = fields.String(allow_none=True)
+    certified_by = fields.String(allow_none=True)
+    certification_details = fields.String(allow_none=True)
+    published = fields.Boolean(allow_none=True)
 
 
 class EmbeddedDashboardConfigSchema(Schema):

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -178,6 +178,9 @@ class Dashboard(Model, AuditMixinNullable, ImportExportMixin):
         "description",
         "css",
         "slug",
+        "certified_by",
+        "certification_details",
+        "published",
     ]
     extra_import_fields = ["is_managed_externally", "external_url"]
 

--- a/tests/integration_tests/dashboards/commands_tests.py
+++ b/tests/integration_tests/dashboards/commands_tests.py
@@ -92,6 +92,9 @@ class TestExportDashboardsCommand(SupersetTestCase):
             "description": None,
             "css": None,
             "slug": "world_health",
+            "certified_by": None,
+            "certification_details": None,
+            "published": False,
             "uuid": str(example_dashboard.uuid),
             "position": {
                 "CHART-36bfc934": {
@@ -279,6 +282,9 @@ class TestExportDashboardsCommand(SupersetTestCase):
             "description",
             "css",
             "slug",
+            "certified_by",
+            "certification_details",
+            "published",
             "uuid",
             "position",
             "metadata",

--- a/tests/integration_tests/import_export_tests.py
+++ b/tests/integration_tests/import_export_tests.py
@@ -117,6 +117,7 @@ class TestImportExport(SupersetTestCase):
             position_json='{"size_y": 2, "size_x": 2}',
             slug=f"{title.lower()}_imported",
             json_metadata=json.dumps(json_metadata),
+            published=False,
         )
 
     def create_table(self, name, schema=None, id=0, cols_names=[], metric_names=[]):


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Similar to https://github.com/apache/superset/pull/22471, this PR adds the fields below to the dashboard export/import flow:
* `published`
* `certified_by`
* `certification_details`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Create a dashboard.
2. Publish it and add certification information.
3. Export the dashboard.
4. Validate that `published` is set to `true` in the YAML, and also that certification info was exported.
5. Convert the dashboard to `draft` and remove certification info.
6. Import it. Validate that certification info and status were updated. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
