### PR TITLE
fix: timezone issue in Pandas 2

### DIFF
--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -168,7 +168,7 @@ class SupersetResultSet:
                             if sample.tzinfo:
                                 tz = sample.tzinfo
                                 series = pd.Series(array[column])
-                                series = pd.to_datetime(series).dt.tz_localize(None)
+                                series = pd.to_datetime(series)
                                 pa_data[i] = pa.Array.from_pandas(
                                     series,
                                     type=pa.timestamp("ns", tz=tz),

--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -167,12 +167,11 @@ class SupersetResultSet:
                         try:
                             if sample.tzinfo:
                                 tz = sample.tzinfo
-                                series = pd.Series(
-                                    array[column], dtype="datetime64[ns]"
-                                )
-                                series = pd.to_datetime(series).dt.tz_localize(tz)
+                                series = pd.Series(array[column])
+                                series = pd.to_datetime(series).dt.tz_localize(None)
                                 pa_data[i] = pa.Array.from_pandas(
-                                    series, type=pa.timestamp("ns", tz=tz)
+                                    series,
+                                    type=pa.timestamp("ns", tz=tz),
                                 )
                         except Exception as ex:  # pylint: disable=broad-except
                             logger.exception(ex)

--- a/tests/unit_tests/result_set_test.py
+++ b/tests/unit_tests/result_set_test.py
@@ -17,12 +17,15 @@
 
 # pylint: disable=import-outside-toplevel, unused-argument
 
+from datetime import datetime, timezone
 
 import numpy as np
 import pandas as pd
 from numpy.core.multiarray import array
+from pytest_mock import MockerFixture
 
-from superset.result_set import stringify_values
+from superset.db_engine_specs.base import BaseEngineSpec
+from superset.result_set import stringify_values, SupersetResultSet
 
 
 def test_column_names_as_bytes() -> None:
@@ -140,3 +143,24 @@ def test_stringify_with_null_timestamps():
     )
 
     assert np.array_equal(result_set, expected)
+
+
+def test_timezone_series(mocker: MockerFixture) -> None:
+    """
+    Test that we can handle timezone-aware datetimes correctly.
+
+    This covers a regression that happened when upgrading from Pandas 1.5.3 to 2.0.3.
+    """
+    logger = mocker.patch("superset.result_set.logger")
+
+    data = [[datetime(2023, 1, 1, tzinfo=timezone.utc)]]
+    description = [(b"__time", "datetime", None, None, None, None, False)]
+    result_set = SupersetResultSet(
+        data,
+        description,  # type: ignore
+        BaseEngineSpec,
+    )
+    assert result_set.to_pandas_df().values.tolist() == [
+        [pd.Timestamp("2023-01-01 00:00:00+0000", tz="UTC")]
+    ]
+    logger.exception.assert_not_called()


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Pandas 2.0 doesn't like when we create a series of type `datetime64[ns]` from a timezone-aware datetime:

```python
>>> from datetime import datetime, timezone
>>> import pandas as pd
>>> pd.__version__
'2.0.3'
>>> d = datetime.now(timezone.utc)
>>> pd.Series([d], dtype="datetime64[ns]")
Traceback (most recent call last):
  File "/Users/beto/.pyenv/versions/superset-3.9.2/lib/python3.9/site-packages/pandas/core/dtypes/cast.py", line 1243, in maybe_cast_to_datetime
    dta = DatetimeArray._from_sequence(value, dtype=dtype)
  File "/Users/beto/.pyenv/versions/superset-3.9.2/lib/python3.9/site-packages/pandas/core/arrays/datetimes.py", line 291, in _from_sequence
    return cls._from_sequence_not_strict(scalars, dtype=dtype, copy=copy)
  File "/Users/beto/.pyenv/versions/superset-3.9.2/lib/python3.9/site-packages/pandas/core/arrays/datetimes.py", line 343, in _from_sequence_not_strict
    _validate_tz_from_dtype(dtype, tz, explicit_tz_none)
  File "/Users/beto/.pyenv/versions/superset-3.9.2/lib/python3.9/site-packages/pandas/core/arrays/datetimes.py", line 2392, in _validate_tz_from_dtype
    raise ValueError(
ValueError: cannot supply both a tz and a timezone-naive dtype (i.e. datetime64[ns])

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/beto/.pyenv/versions/superset-3.9.2/lib/python3.9/site-packages/pandas/core/series.py", line 509, in __init__
    data = sanitize_array(data, index, dtype, copy)
  File "/Users/beto/.pyenv/versions/superset-3.9.2/lib/python3.9/site-packages/pandas/core/construction.py", line 599, in sanitize_array
    subarr = _try_cast(data, dtype, copy)
  File "/Users/beto/.pyenv/versions/superset-3.9.2/lib/python3.9/site-packages/pandas/core/construction.py", line 756, in _try_cast
    return maybe_cast_to_datetime(arr, dtype)
  File "/Users/beto/.pyenv/versions/superset-3.9.2/lib/python3.9/site-packages/pandas/core/dtypes/cast.py", line 1247, in maybe_cast_to_datetime
    raise ValueError(
ValueError: Cannot convert timezone-aware data to timezone-naive dtype. Use pd.Series(values).dt.tz_localize(None) instead.
```

This used to work fine in 1.5.3 (also tested in 1.3.4):

```python
>>> from datetime import datetime, timezone
>>> import pandas as pd
>>> pd.__version__
'1.5.3'
>>> d = datetime.now(timezone.utc)
>>> pd.Series([d], dtype="datetime64[ns]")
sys:1: FutureWarning: Data is timezone-aware. Converting timezone-aware data to timezone-naive by passing dtype='datetime64[ns]' to DataFrame or Series is deprecated and will raise in a future version. Use `pd.Series(values).dt.tz_localize(None)` instead.
0   2023-08-11 01:34:05.638490
dtype: datetime64[ns]
```

This PR fixes it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
