### PR TITLE
docs: Add wattbewerb to users list

### DIFF
--- a/RESOURCES/INTHEWILD.md
+++ b/RESOURCES/INTHEWILD.md
@@ -144,6 +144,7 @@ Join our growing community!
 - [DouroECI](https://www.douroeci.com/) [@nunohelibeires]
 - [Safaricom](https://www.safaricom.co.ke/) [@mmutiso]
 - [Scoot](https://scoot.co/) [@haaspt]
+- [Wattbewerb](https://wattbewerb.de/) [@wattbewerb]
 
 ### Healthcare
 - [Amino](https://amino.com) [@shkr]


### PR DESCRIPTION
### SUMMARY
This PR adds the volunteer organization [wattbewerb](https://wattbewerb.de/) to the users list.

### ADDITIONAL INFORMATION
Wattbewerb is a volunteer association pushing for accelerated PV installation and transition to green energy. We create a weekly updated ranking which compares the installed PV capacity per capita for each participating German municipality.

For each municipality, we provide a publicly available dashboard (via [this ranking page](https://plattform.wattbewerb.de/ranking)) to monitor the municipalities progress as well as data quality issues.

To improve readability for our German users, we contributed i.e. to superset's German translations.

