### PR TITLE
fix(gsheets): add column names on file upload

### DIFF
--- a/superset/db_engine_specs/gsheets.py
+++ b/superset/db_engine_specs/gsheets.py
@@ -410,10 +410,12 @@ class GSheetsEngineSpec(ShillelaghEngineSpec):
             spreadsheet_url = payload["spreadsheetUrl"]
 
         # insert data
+        data = df.fillna("").values.tolist()
+        data.insert(0, df.columns.values.tolist())
         body = {
             "range": range_,
             "majorDimension": "ROWS",
-            "values": df.fillna("").values.tolist(),
+            "values": data,
         }
         url = (
             "https://sheets.googleapis.com/v4/spreadsheets/"

--- a/tests/unit_tests/db_engine_specs/test_gsheets.py
+++ b/tests/unit_tests/db_engine_specs/test_gsheets.py
@@ -333,7 +333,7 @@ def test_upload_new(mocker: MockFixture) -> None:
     database = mocker.MagicMock()
     database.get_extra.return_value = {}
 
-    df = pd.DataFrame([1, "foo", 3.0])
+    df = pd.DataFrame({"col": [1, "foo", 3.0]})
     table = Table("sample_data")
 
     GSheetsEngineSpec.df_to_sql(database, table, df, {})
@@ -367,7 +367,7 @@ def test_upload_existing(mocker: MockFixture) -> None:
         "engine_params": {"catalog": {"sample_data": "https://docs.example.org"}}
     }
 
-    df = pd.DataFrame([1, "foo", 3.0])
+    df = pd.DataFrame({"col": [1, "foo", 3.0]})
     table = Table("sample_data")
 
     with pytest.raises(SupersetException) as excinfo:
@@ -392,7 +392,7 @@ def test_upload_existing(mocker: MockFixture) -> None:
                 json={
                     "range": "sheet0",
                     "majorDimension": "ROWS",
-                    "values": [[1], ["foo"], [3.0]],
+                    "values": [["col"], [1], ["foo"], [3.0]],
                 },
                 params={"valueInputOption": "USER_ENTERED"},
             ),


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Small fix to the GSheets file upload — the column names were not being added as the first row of the sheet.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
