### PR TITLE
fix(sqllab): scroll position after run current sql

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -343,6 +343,7 @@ const SqlEditor = ({
           const session = editor.getSession();
           const cursorPosition = editor.getCursorPosition();
           const totalLine = session.getLength();
+          const currentRow = editor.getFirstVisibleRow();
           let end = editor.find(';', {
             backwards: false,
             skipCurrent: true,
@@ -390,6 +391,7 @@ const SqlEditor = ({
           startQuery();
           editor.selection.clearSelection();
           editor.moveCursorToPosition(cursorPosition);
+          editor.scrollToRow(currentRow);
         },
       },
       {


### PR DESCRIPTION
### SUMMARY
The scroll position after run current sql(ctrl + shift + enter) moved to bottom when hit within the first paragraph. 
This commit fixes this bug by storing the current scroll after running the query.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After:

https://github.com/apache/superset/assets/1392866/549b2744-9b5e-4692-85c4-22444e01f58a

Before:

https://github.com/apache/superset/assets/1392866/fb0dace9-9d80-4ec7-8b86-ad2a15a82497

### TESTING INSTRUCTIONS

- type multiple sqls in the editor that makes scrollbars
- hit running current query in the first sql paragraph
- check the current position of the scrollbar after that

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
