### PR TITLE
chore(dao): Remove redundant convenience methods

### DIFF
--- a/superset/daos/dataset.py
+++ b/superset/daos/dataset.py
@@ -302,64 +302,12 @@ class DatasetDAO(BaseDAO[SqlaTable]):  # pylint: disable=too-many-public-methods
         )
 
     @classmethod
-    def update_column(
-        cls,
-        model: TableColumn,
-        properties: dict[str, Any],
-        commit: bool = True,
-    ) -> TableColumn:
-        return DatasetColumnDAO.update(model, properties, commit=commit)
-
-    @classmethod
-    def create_column(
-        cls, properties: dict[str, Any], commit: bool = True
-    ) -> TableColumn:
-        """
-        Creates a Dataset model on the metadata DB
-        """
-        return DatasetColumnDAO.create(attributes=properties, commit=commit)
-
-    @classmethod
-    def delete_column(cls, model: TableColumn, commit: bool = True) -> None:
-        """
-        Deletes a Dataset column
-        """
-        DatasetColumnDAO.delete(model, commit=commit)
-
-    @classmethod
     def find_dataset_metric(cls, dataset_id: int, metric_id: int) -> SqlMetric | None:
         # We want to apply base dataset filters
         dataset = DatasetDAO.find_by_id(dataset_id)
         if not dataset:
             return None
         return db.session.query(SqlMetric).get(metric_id)
-
-    @classmethod
-    def delete_metric(cls, model: SqlMetric, commit: bool = True) -> None:
-        """
-        Deletes a Dataset metric
-        """
-        DatasetMetricDAO.delete(model, commit=commit)
-
-    @classmethod
-    def update_metric(
-        cls,
-        model: SqlMetric,
-        properties: dict[str, Any],
-        commit: bool = True,
-    ) -> SqlMetric:
-        return DatasetMetricDAO.update(model, properties, commit=commit)
-
-    @classmethod
-    def create_metric(
-        cls,
-        properties: dict[str, Any],
-        commit: bool = True,
-    ) -> SqlMetric:
-        """
-        Creates a Dataset model on the metadata DB
-        """
-        return DatasetMetricDAO.create(attributes=properties, commit=commit)
 
     @classmethod
     def delete(

--- a/superset/datasets/columns/commands/delete.py
+++ b/superset/datasets/columns/commands/delete.py
@@ -20,7 +20,7 @@ from typing import Optional
 from superset import security_manager
 from superset.commands.base import BaseCommand
 from superset.connectors.sqla.models import TableColumn
-from superset.daos.dataset import DatasetDAO
+from superset.daos.dataset import DatasetColumnDAO, DatasetDAO
 from superset.daos.exceptions import DAODeleteFailedError
 from superset.datasets.columns.commands.exceptions import (
     DatasetColumnDeleteFailedError,
@@ -43,7 +43,7 @@ class DeleteDatasetColumnCommand(BaseCommand):
         assert self._model
 
         try:
-            DatasetDAO.delete_column(self._model)
+            DatasetColumnDAO.delete(self._model)
         except DAODeleteFailedError as ex:
             logger.exception(ex.exception)
             raise DatasetColumnDeleteFailedError() from ex

--- a/superset/datasets/metrics/commands/delete.py
+++ b/superset/datasets/metrics/commands/delete.py
@@ -20,7 +20,7 @@ from typing import Optional
 from superset import security_manager
 from superset.commands.base import BaseCommand
 from superset.connectors.sqla.models import SqlMetric
-from superset.daos.dataset import DatasetDAO
+from superset.daos.dataset import DatasetDAO, DatasetMetricDAO
 from superset.daos.exceptions import DAODeleteFailedError
 from superset.datasets.metrics.commands.exceptions import (
     DatasetMetricDeleteFailedError,
@@ -43,7 +43,7 @@ class DeleteDatasetMetricCommand(BaseCommand):
         assert self._model
 
         try:
-            DatasetDAO.delete_metric(self._model)
+            DatasetMetricDAO.delete(self._model)
         except DAODeleteFailedError as ex:
             logger.exception(ex.exception)
             raise DatasetMetricDeleteFailedError() from ex


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

The `DatasetDAO` has a a number of convenience methods which either weren't called, or likely should be called by the corresponding DAO which maps to the associated command (unless people feel strongly otherwise).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/20630
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
