### PR TITLE
chore(dao/command): Add transaction decorator to try to enforce "unit of work"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,6 +240,7 @@ ignore_basepython_conflict = true
 commands =
     superset db upgrade
     superset init
+    superset load-test-users
     # use -s to be able to use break pointers.
     # no args or tests/* can be passed as an argument to run all tests
     pytest -s {posargs}

--- a/scripts/permissions_cleanup.py
+++ b/scripts/permissions_cleanup.py
@@ -17,8 +17,10 @@
 from collections import defaultdict
 
 from superset import security_manager
+from superset.utils.decorators import transaction
 
 
+@transaction()
 def cleanup_permissions() -> None:
     # 1. Clean up duplicates.
     pvms = security_manager.get_session.query(
@@ -29,7 +31,6 @@ def cleanup_permissions() -> None:
     for pvm in pvms:
         pvms_dict[(pvm.permission, pvm.view_menu)].append(pvm)
     duplicates = [v for v in pvms_dict.values() if len(v) > 1]
-    len(duplicates)
 
     for pvm_list in duplicates:
         first_prm = pvm_list[0]
@@ -38,7 +39,6 @@ def cleanup_permissions() -> None:
             roles = roles.union(pvm.role)
             security_manager.get_session.delete(pvm)
         first_prm.roles = list(roles)
-    security_manager.get_session.commit()
 
     pvms = security_manager.get_session.query(
         security_manager.permissionview_model
@@ -52,7 +52,6 @@ def cleanup_permissions() -> None:
     for pvm in pvms:
         if not (pvm.view_menu and pvm.permission):
             security_manager.get_session.delete(pvm)
-    security_manager.get_session.commit()
 
     pvms = security_manager.get_session.query(
         security_manager.permissionview_model
@@ -63,7 +62,6 @@ def cleanup_permissions() -> None:
     roles = security_manager.get_session.query(security_manager.role_model).all()
     for role in roles:
         role.permissions = [p for p in role.permissions if p]
-    security_manager.get_session.commit()
 
     # 4. Delete empty roles from permission view menus
     pvms = security_manager.get_session.query(
@@ -71,7 +69,6 @@ def cleanup_permissions() -> None:
     ).all()
     for pvm in pvms:
         pvm.role = [r for r in pvm.role if r]
-    security_manager.get_session.commit()
 
 
 cleanup_permissions()

--- a/scripts/python_tests.sh
+++ b/scripts/python_tests.sh
@@ -29,6 +29,7 @@ echo "Superset config module: $SUPERSET_CONFIG"
 
 superset db upgrade
 superset init
+superset load-test-users
 
 echo "Running tests"
 

--- a/superset/cachekeys/api.py
+++ b/superset/cachekeys/api.py
@@ -113,8 +113,10 @@ class CacheRestApi(BaseSupersetModelRestApi):
                 delete_stmt = CacheKey.__table__.delete().where(  # pylint: disable=no-member
                     CacheKey.cache_key.in_(cache_keys)
                 )
-                db.session.execute(delete_stmt)
-                db.session.commit()
+
+                with db.session.begin_nested():
+                    db.session.execute(delete_stmt)
+
                 stats_logger_manager.instance.gauge(
                     "invalidated_cache", len(cache_keys)
                 )
@@ -125,7 +127,5 @@ class CacheRestApi(BaseSupersetModelRestApi):
                 )
             except SQLAlchemyError as ex:  # pragma: no cover
                 logger.error(ex, exc_info=True)
-                db.session.rollback()
                 return self.response_500(str(ex))
-            db.session.commit()
         return self.response(201)

--- a/superset/cli/examples.py
+++ b/superset/cli/examples.py
@@ -20,6 +20,7 @@ import click
 from flask.cli import with_appcontext
 
 import superset.utils.database as database_utils
+from superset.utils.decorators import transaction
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +90,7 @@ def load_examples_run(
 
 @click.command()
 @with_appcontext
+@transaction()
 @click.option("--load-test-data", "-t", is_flag=True, help="Load additional test data")
 @click.option("--load-big-data", "-b", is_flag=True, help="Load additional big data")
 @click.option(

--- a/superset/cli/main.py
+++ b/superset/cli/main.py
@@ -27,6 +27,7 @@ from flask.cli import FlaskGroup, with_appcontext
 from superset import app, appbuilder, cli, security_manager
 from superset.cli.lib import normalize_token
 from superset.extensions import db
+from superset.utils.decorators import transaction
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +61,7 @@ for load, module_name, is_pkg in pkgutil.walk_packages(
 
 @superset.command()
 @with_appcontext
+@transaction()
 def init() -> None:
     """Inits the Superset application"""
     appbuilder.add_permissions(update_perms=True)

--- a/superset/cli/test.py
+++ b/superset/cli/test.py
@@ -22,12 +22,14 @@ from flask.cli import with_appcontext
 
 import superset.utils.database as database_utils
 from superset import app, security_manager
+from superset.utils.decorators import transaction
 
 logger = logging.getLogger(__name__)
 
 
 @click.command()
 @with_appcontext
+@transaction()
 def load_test_users() -> None:
     """
     Loads admin, alpha, and gamma user for testing purposes
@@ -35,15 +37,7 @@ def load_test_users() -> None:
     Syncs permissions for those users/roles
     """
     print(Fore.GREEN + "Loading a set of users for unit tests")
-    load_test_users_run()
 
-
-def load_test_users_run() -> None:
-    """
-    Loads admin, alpha, and gamma user for testing purposes
-
-    Syncs permissions for those users/roles
-    """
     if app.config["TESTING"]:
         sm = security_manager
 
@@ -84,4 +78,3 @@ def load_test_users_run() -> None:
                     sm.find_role(role),
                     password="general",
                 )
-        sm.get_session.commit()

--- a/superset/cli/update.py
+++ b/superset/cli/update.py
@@ -30,6 +30,7 @@ from flask_appbuilder.api import BaseApi
 from flask_appbuilder.api.manager import resolver
 
 import superset.utils.database as database_utils
+from superset.utils.decorators import transaction
 from superset.utils.encrypt import SecretsMigrator
 
 logger = logging.getLogger(__name__)
@@ -37,6 +38,7 @@ logger = logging.getLogger(__name__)
 
 @click.command()
 @with_appcontext
+@transaction()
 @click.option("--database_name", "-d", help="Database name to change")
 @click.option("--uri", "-u", help="Database URI to change")
 @click.option(
@@ -53,6 +55,7 @@ def set_database_uri(database_name: str, uri: str, skip_create: bool) -> None:
 
 @click.command()
 @with_appcontext
+@transaction()
 def sync_tags() -> None:
     """Rebuilds special tags (owner, type, favorited by)."""
     # pylint: disable=no-member

--- a/superset/commands/annotation_layer/annotation/delete.py
+++ b/superset/commands/annotation_layer/annotation/delete.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
+from functools import partial
 from typing import Optional
 
 from superset.commands.annotation_layer.annotation.exceptions import (
@@ -23,8 +24,8 @@ from superset.commands.annotation_layer.annotation.exceptions import (
 )
 from superset.commands.base import BaseCommand
 from superset.daos.annotation_layer import AnnotationDAO
-from superset.daos.exceptions import DAODeleteFailedError
 from superset.models.annotations import Annotation
+from superset.utils.decorators import on_error, transaction
 
 logger = logging.getLogger(__name__)
 
@@ -34,15 +35,11 @@ class DeleteAnnotationCommand(BaseCommand):
         self._model_ids = model_ids
         self._models: Optional[list[Annotation]] = None
 
+    @transaction(on_error=partial(on_error, reraise=AnnotationDeleteFailedError))
     def run(self) -> None:
         self.validate()
         assert self._models
-
-        try:
-            AnnotationDAO.delete(self._models)
-        except DAODeleteFailedError as ex:
-            logger.exception(ex.exception)
-            raise AnnotationDeleteFailedError() from ex
+        AnnotationDAO.delete(self._models)
 
     def validate(self) -> None:
         # Validate/populate model exists

--- a/superset/commands/annotation_layer/annotation/update.py
+++ b/superset/commands/annotation_layer/annotation/update.py
@@ -16,6 +16,7 @@
 # under the License.
 import logging
 from datetime import datetime
+from functools import partial
 from typing import Any, Optional
 
 from flask_appbuilder.models.sqla import Model
@@ -31,8 +32,8 @@ from superset.commands.annotation_layer.annotation.exceptions import (
 from superset.commands.annotation_layer.exceptions import AnnotationLayerNotFoundError
 from superset.commands.base import BaseCommand
 from superset.daos.annotation_layer import AnnotationDAO, AnnotationLayerDAO
-from superset.daos.exceptions import DAOUpdateFailedError
 from superset.models.annotations import Annotation
+from superset.utils.decorators import on_error, transaction
 
 logger = logging.getLogger(__name__)
 
@@ -43,16 +44,11 @@ class UpdateAnnotationCommand(BaseCommand):
         self._properties = data.copy()
         self._model: Optional[Annotation] = None
 
+    @transaction(on_error=partial(on_error, reraise=AnnotationUpdateFailedError))
     def run(self) -> Model:
         self.validate()
         assert self._model
-
-        try:
-            annotation = AnnotationDAO.update(self._model, self._properties)
-        except DAOUpdateFailedError as ex:
-            logger.exception(ex.exception)
-            raise AnnotationUpdateFailedError() from ex
-        return annotation
+        return AnnotationDAO.update(self._model, self._properties)
 
     def validate(self) -> None:
         exceptions: list[ValidationError] = []

--- a/superset/commands/annotation_layer/create.py
+++ b/superset/commands/annotation_layer/create.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
+from functools import partial
 from typing import Any
 
 from flask_appbuilder.models.sqla import Model
@@ -27,7 +28,7 @@ from superset.commands.annotation_layer.exceptions import (
 )
 from superset.commands.base import BaseCommand
 from superset.daos.annotation_layer import AnnotationLayerDAO
-from superset.daos.exceptions import DAOCreateFailedError
+from superset.utils.decorators import on_error, transaction
 
 logger = logging.getLogger(__name__)
 
@@ -36,13 +37,10 @@ class CreateAnnotationLayerCommand(BaseCommand):
     def __init__(self, data: dict[str, Any]):
         self._properties = data.copy()
 
+    @transaction(on_error=partial(on_error, reraise=AnnotationLayerCreateFailedError))
     def run(self) -> Model:
         self.validate()
-        try:
-            return AnnotationLayerDAO.create(attributes=self._properties)
-        except DAOCreateFailedError as ex:
-            logger.exception(ex.exception)
-            raise AnnotationLayerCreateFailedError() from ex
+        return AnnotationLayerDAO.create(attributes=self._properties)
 
     def validate(self) -> None:
         exceptions: list[ValidationError] = []

--- a/superset/commands/chart/importers/v1/utils.py
+++ b/superset/commands/chart/importers/v1/utils.py
@@ -77,7 +77,7 @@ def import_chart(
     if chart.id is None:
         db.session.flush()
 
-    if user := get_user():
+    if (user := get_user()) and user not in chart.owners:
         chart.owners.append(user)
 
     return chart

--- a/superset/commands/dashboard/delete.py
+++ b/superset/commands/dashboard/delete.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
+from functools import partial
 from typing import Optional
 
 from flask_babel import lazy_gettext as _
@@ -28,10 +29,10 @@ from superset.commands.dashboard.exceptions import (
     DashboardNotFoundError,
 )
 from superset.daos.dashboard import DashboardDAO
-from superset.daos.exceptions import DAODeleteFailedError
 from superset.daos.report import ReportScheduleDAO
 from superset.exceptions import SupersetSecurityException
 from superset.models.dashboard import Dashboard
+from superset.utils.decorators import on_error, transaction
 
 logger = logging.getLogger(__name__)
 
@@ -41,15 +42,11 @@ class DeleteDashboardCommand(BaseCommand):
         self._model_ids = model_ids
         self._models: Optional[list[Dashboard]] = None
 
+    @transaction(on_error=partial(on_error, reraise=DashboardDeleteFailedError))
     def run(self) -> None:
         self.validate()
         assert self._models
-
-        try:
-            DashboardDAO.delete(self._models)
-        except DAODeleteFailedError as ex:
-            logger.exception(ex.exception)
-            raise DashboardDeleteFailedError() from ex
+        DashboardDAO.delete(self._models)
 
     def validate(self) -> None:
         # Validate/populate model exists

--- a/superset/commands/dashboard/importers/v0.py
+++ b/superset/commands/dashboard/importers/v0.py
@@ -36,6 +36,7 @@ from superset.utils.dashboard_filter_scopes_converter import (
     convert_filter_scopes,
     copy_filter_scopes,
 )
+from superset.utils.decorators import transaction
 
 logger = logging.getLogger(__name__)
 
@@ -311,7 +312,6 @@ def import_dashboards(
 
     for dashboard in data["dashboards"]:
         import_dashboard(dashboard, dataset_id_mapping, import_time=import_time)
-    db.session.commit()
 
 
 class ImportDashboardsCommand(BaseCommand):
@@ -329,6 +329,7 @@ class ImportDashboardsCommand(BaseCommand):
         self.contents = contents
         self.database_id = database_id
 
+    @transaction()
     def run(self) -> None:
         self.validate()
 

--- a/superset/commands/dashboard/importers/v1/utils.py
+++ b/superset/commands/dashboard/importers/v1/utils.py
@@ -188,7 +188,7 @@ def import_dashboard(
     if dashboard.id is None:
         db.session.flush()
 
-    if user := get_user():
+    if (user := get_user()) and user not in dashboard.owners:
         dashboard.owners.append(user)
 
     return dashboard

--- a/superset/commands/dashboard/permalink/create.py
+++ b/superset/commands/dashboard/permalink/create.py
@@ -15,18 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
+from functools import partial
 
 from sqlalchemy.exc import SQLAlchemyError
 
-from superset import db
 from superset.commands.dashboard.permalink.base import BaseDashboardPermalinkCommand
 from superset.commands.key_value.upsert import UpsertKeyValueCommand
 from superset.daos.dashboard import DashboardDAO
 from superset.dashboards.permalink.exceptions import DashboardPermalinkCreateFailedError
 from superset.dashboards.permalink.types import DashboardPermalinkState
-from superset.key_value.exceptions import KeyValueCodecEncodeException
+from superset.key_value.exceptions import (
+    KeyValueCodecEncodeException,
+    KeyValueUpsertFailedError,
+)
 from superset.key_value.utils import encode_permalink_key, get_deterministic_uuid
 from superset.utils.core import get_user_id
+from superset.utils.decorators import on_error, transaction
 
 logger = logging.getLogger(__name__)
 
@@ -47,29 +51,33 @@ class CreateDashboardPermalinkCommand(BaseDashboardPermalinkCommand):
         self.dashboard_id = dashboard_id
         self.state = state
 
+    @transaction(
+        on_error=partial(
+            on_error,
+            catches=(
+                KeyValueCodecEncodeException,
+                KeyValueUpsertFailedError,
+                SQLAlchemyError,
+            ),
+            reraise=DashboardPermalinkCreateFailedError,
+        ),
+    )
     def run(self) -> str:
         self.validate()
-        try:
-            dashboard = DashboardDAO.get_by_id_or_slug(self.dashboard_id)
-            value = {
-                "dashboardId": str(dashboard.uuid),
-                "state": self.state,
-            }
-            user_id = get_user_id()
-            key = UpsertKeyValueCommand(
-                resource=self.resource,
-                key=get_deterministic_uuid(self.salt, (user_id, value)),
-                value=value,
-                codec=self.codec,
-            ).run()
-            assert key.id  # for type checks
-            db.session.commit()
-            return encode_permalink_key(key=key.id, salt=self.salt)
-        except KeyValueCodecEncodeException as ex:
-            raise DashboardPermalinkCreateFailedError(str(ex)) from ex
-        except SQLAlchemyError as ex:
-            logger.exception("Error running create command")
-            raise DashboardPermalinkCreateFailedError() from ex
+        dashboard = DashboardDAO.get_by_id_or_slug(self.dashboard_id)
+        value = {
+            "dashboardId": str(dashboard.uuid),
+            "state": self.state,
+        }
+        user_id = get_user_id()
+        key = UpsertKeyValueCommand(
+            resource=self.resource,
+            key=get_deterministic_uuid(self.salt, (user_id, value)),
+            value=value,
+            codec=self.codec,
+        ).run()
+        assert key.id  # for type checks
+        return encode_permalink_key(key=key.id, salt=self.salt)
 
     def validate(self) -> None:
         pass

--- a/superset/commands/database/create.py
+++ b/superset/commands/database/create.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
+from functools import partial
 from typing import Any, Optional
 
 from flask import current_app
@@ -39,11 +40,11 @@ from superset.commands.database.ssh_tunnel.exceptions import (
 )
 from superset.commands.database.test_connection import TestConnectionDatabaseCommand
 from superset.daos.database import DatabaseDAO
-from superset.daos.exceptions import DAOCreateFailedError
 from superset.databases.ssh_tunnel.models import SSHTunnel
 from superset.exceptions import SupersetErrorsException
-from superset.extensions import db, event_logger, security_manager
+from superset.extensions import event_logger, security_manager
 from superset.models.core import Database
+from superset.utils.decorators import on_error, transaction
 
 logger = logging.getLogger(__name__)
 stats_logger = current_app.config["STATS_LOGGER"]
@@ -53,6 +54,7 @@ class CreateDatabaseCommand(BaseCommand):
     def __init__(self, data: dict[str, Any]):
         self._properties = data.copy()
 
+    @transaction(on_error=partial(on_error, reraise=DatabaseCreateFailedError))
     def run(self) -> Model:
         self.validate()
 
@@ -96,8 +98,6 @@ class CreateDatabaseCommand(BaseCommand):
                     database, ssh_tunnel_properties
                 ).run()
 
-            db.session.commit()
-
             # add catalog/schema permissions
             if database.db_engine_spec.supports_catalog:
                 catalogs = database.get_all_catalog_names(
@@ -121,14 +121,12 @@ class CreateDatabaseCommand(BaseCommand):
                 except Exception:  # pylint: disable=broad-except
                     logger.warning("Error processing catalog '%s'", catalog)
                     continue
-
         except (
             SSHTunnelInvalidError,
             SSHTunnelCreateFailedError,
             SSHTunnelingNotEnabledError,
             SSHTunnelDatabasePortError,
         ) as ex:
-            db.session.rollback()
             event_logger.log_with_context(
                 action=f"db_creation_failed.{ex.__class__.__name__}.ssh_tunnel",
                 engine=self._properties.get("sqlalchemy_uri", "").split(":")[0],
@@ -136,11 +134,9 @@ class CreateDatabaseCommand(BaseCommand):
             # So we can show the original message
             raise
         except (
-            DAOCreateFailedError,
             DatabaseInvalidError,
             Exception,
         ) as ex:
-            db.session.rollback()
             event_logger.log_with_context(
                 action=f"db_creation_failed.{ex.__class__.__name__}",
                 engine=database.db_engine_spec.__name__,
@@ -198,6 +194,6 @@ class CreateDatabaseCommand(BaseCommand):
             raise exception
 
     def _create_database(self) -> Database:
-        database = DatabaseDAO.create(attributes=self._properties, commit=False)
+        database = DatabaseDAO.create(attributes=self._properties)
         database.set_sqlalchemy_uri(database.sqlalchemy_uri)
         return database

--- a/superset/commands/database/ssh_tunnel/delete.py
+++ b/superset/commands/database/ssh_tunnel/delete.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
+from functools import partial
 from typing import Optional
 
 from superset import is_feature_enabled
@@ -25,8 +26,8 @@ from superset.commands.database.ssh_tunnel.exceptions import (
     SSHTunnelNotFoundError,
 )
 from superset.daos.database import SSHTunnelDAO
-from superset.daos.exceptions import DAODeleteFailedError
 from superset.databases.ssh_tunnel.models import SSHTunnel
+from superset.utils.decorators import on_error, transaction
 
 logger = logging.getLogger(__name__)
 
@@ -36,16 +37,13 @@ class DeleteSSHTunnelCommand(BaseCommand):
         self._model_id = model_id
         self._model: Optional[SSHTunnel] = None
 
+    @transaction(on_error=partial(on_error, reraise=SSHTunnelDeleteFailedError))
     def run(self) -> None:
         if not is_feature_enabled("SSH_TUNNELING"):
             raise SSHTunnelingNotEnabledError()
         self.validate()
         assert self._model
-
-        try:
-            SSHTunnelDAO.delete([self._model])
-        except DAODeleteFailedError as ex:
-            raise SSHTunnelDeleteFailedError() from ex
+        SSHTunnelDAO.delete([self._model])
 
     def validate(self) -> None:
         # Validate/populate model exists

--- a/superset/commands/database/update.py
+++ b/superset/commands/database/update.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import logging
+from functools import partial
 from typing import Any
 
 from flask_appbuilder.models.sqla import Model
@@ -34,16 +35,14 @@ from superset.commands.database.exceptions import (
 from superset.commands.database.ssh_tunnel.create import CreateSSHTunnelCommand
 from superset.commands.database.ssh_tunnel.delete import DeleteSSHTunnelCommand
 from superset.commands.database.ssh_tunnel.exceptions import (
-    SSHTunnelError,
     SSHTunnelingNotEnabledError,
 )
 from superset.commands.database.ssh_tunnel.update import UpdateSSHTunnelCommand
 from superset.daos.database import DatabaseDAO
 from superset.daos.dataset import DatasetDAO
-from superset.daos.exceptions import DAOCreateFailedError, DAOUpdateFailedError
 from superset.databases.ssh_tunnel.models import SSHTunnel
-from superset.extensions import db
 from superset.models.core import Database
+from superset.utils.decorators import on_error, transaction
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +55,7 @@ class UpdateDatabaseCommand(BaseCommand):
         self._model_id = model_id
         self._model: Database | None = None
 
+    @transaction(on_error=partial(on_error, reraise=DatabaseUpdateFailedError))
     def run(self) -> Model:
         self._model = DatabaseDAO.find_by_id(self._model_id)
 
@@ -76,21 +76,10 @@ class UpdateDatabaseCommand(BaseCommand):
         # since they're name based
         original_database_name = self._model.database_name
 
-        try:
-            database = DatabaseDAO.update(
-                self._model,
-                self._properties,
-                commit=False,
-            )
-            database.set_sqlalchemy_uri(database.sqlalchemy_uri)
-            ssh_tunnel = self._handle_ssh_tunnel(database)
-            self._refresh_catalogs(database, original_database_name, ssh_tunnel)
-        except SSHTunnelError:  # pylint: disable=try-except-raise
-            # allow exception to bubble for debugbing information
-            raise
-        except (DAOUpdateFailedError, DAOCreateFailedError) as ex:
-            raise DatabaseUpdateFailedError() from ex
-
+        database = DatabaseDAO.update(self._model, self._properties)
+        database.set_sqlalchemy_uri(database.sqlalchemy_uri)
+        ssh_tunnel = self._handle_ssh_tunnel(database)
+        self._refresh_catalogs(database, original_database_name, ssh_tunnel)
         return database
 
     def _handle_ssh_tunnel(self, database: Database) -> SSHTunnel | None:
@@ -101,7 +90,6 @@ class UpdateDatabaseCommand(BaseCommand):
             return None
 
         if not is_feature_enabled("SSH_TUNNELING"):
-            db.session.rollback()
             raise SSHTunnelingNotEnabledError()
 
         current_ssh_tunnel = DatabaseDAO.get_ssh_tunnel(database.id)
@@ -131,13 +119,13 @@ class UpdateDatabaseCommand(BaseCommand):
         This method captures a generic exception, since errors could potentially come
         from any of the 50+ database drivers we support.
         """
+
         try:
             return database.get_all_catalog_names(
                 force=True,
                 ssh_tunnel=ssh_tunnel,
             )
         except Exception as ex:
-            db.session.rollback()
             raise DatabaseConnectionFailedError() from ex
 
     def _get_schema_names(
@@ -152,6 +140,7 @@ class UpdateDatabaseCommand(BaseCommand):
         This method captures a generic exception, since errors could potentially come
         from any of the 50+ database drivers we support.
         """
+
         try:
             return database.get_all_schema_names(
                 force=True,
@@ -159,7 +148,6 @@ class UpdateDatabaseCommand(BaseCommand):
                 ssh_tunnel=ssh_tunnel,
             )
         except Exception as ex:
-            db.session.rollback()
             raise DatabaseConnectionFailedError() from ex
 
     def _refresh_catalogs(
@@ -224,8 +212,6 @@ class UpdateDatabaseCommand(BaseCommand):
                     catalog,
                     schemas,
                 )
-
-        db.session.commit()
 
     def _refresh_schemas(
         self,

--- a/superset/commands/database/uploaders/base.py
+++ b/superset/commands/database/uploaders/base.py
@@ -16,11 +16,11 @@
 # under the License.
 import logging
 from abc import abstractmethod
+from functools import partial
 from typing import Any, Optional, TypedDict
 
 import pandas as pd
 from flask_babel import lazy_gettext as _
-from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.datastructures import FileStorage
 
 from superset import db
@@ -37,6 +37,7 @@ from superset.daos.database import DatabaseDAO
 from superset.models.core import Database
 from superset.sql_parse import Table
 from superset.utils.core import get_user
+from superset.utils.decorators import on_error, transaction
 from superset.views.database.validators import schema_allows_file_upload
 
 logger = logging.getLogger(__name__)
@@ -144,6 +145,7 @@ class UploadCommand(BaseCommand):
         self._file = file
         self._reader = reader
 
+    @transaction(on_error=partial(on_error, reraise=DatabaseUploadSaveMetadataFailed))
     def run(self) -> None:
         self.validate()
         if not self._model:
@@ -171,12 +173,6 @@ class UploadCommand(BaseCommand):
             db.session.add(sqla_table)
 
         sqla_table.fetch_metadata()
-
-        try:
-            db.session.commit()
-        except SQLAlchemyError as ex:
-            db.session.rollback()
-            raise DatabaseUploadSaveMetadataFailed() from ex
 
     def validate(self) -> None:
         self._model = DatabaseDAO.find_by_id(self._model_id)

--- a/superset/commands/dataset/columns/delete.py
+++ b/superset/commands/dataset/columns/delete.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
+from functools import partial
 from typing import Optional
 
 from superset import security_manager
@@ -26,8 +27,8 @@ from superset.commands.dataset.columns.exceptions import (
 )
 from superset.connectors.sqla.models import TableColumn
 from superset.daos.dataset import DatasetColumnDAO, DatasetDAO
-from superset.daos.exceptions import DAODeleteFailedError
 from superset.exceptions import SupersetSecurityException
+from superset.utils.decorators import on_error, transaction
 
 logger = logging.getLogger(__name__)
 
@@ -38,15 +39,11 @@ class DeleteDatasetColumnCommand(BaseCommand):
         self._model_id = model_id
         self._model: Optional[TableColumn] = None
 
+    @transaction(on_error=partial(on_error, reraise=DatasetColumnDeleteFailedError))
     def run(self) -> None:
         self.validate()
         assert self._model
-
-        try:
-            DatasetColumnDAO.delete([self._model])
-        except DAODeleteFailedError as ex:
-            logger.exception(ex.exception)
-            raise DatasetColumnDeleteFailedError() from ex
+        DatasetColumnDAO.delete([self._model])
 
     def validate(self) -> None:
         # Validate/populate model exists

--- a/superset/commands/dataset/duplicate.py
+++ b/superset/commands/dataset/duplicate.py
@@ -15,12 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
+from functools import partial
 from typing import Any
 
 from flask_appbuilder.models.sqla import Model
 from flask_babel import gettext as __
 from marshmallow import ValidationError
-from sqlalchemy.exc import SQLAlchemyError
 
 from superset.commands.base import BaseCommand, CreateMixin
 from superset.commands.dataset.exceptions import (
@@ -32,12 +32,12 @@ from superset.commands.dataset.exceptions import (
 from superset.commands.exceptions import DatasourceTypeInvalidError
 from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn
 from superset.daos.dataset import DatasetDAO
-from superset.daos.exceptions import DAOCreateFailedError
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.exceptions import SupersetErrorException
 from superset.extensions import db
 from superset.models.core import Database
 from superset.sql_parse import ParsedQuery, Table
+from superset.utils.decorators import on_error, transaction
 
 logger = logging.getLogger(__name__)
 
@@ -47,66 +47,61 @@ class DuplicateDatasetCommand(CreateMixin, BaseCommand):
         self._base_model: SqlaTable = SqlaTable()
         self._properties = data.copy()
 
+    @transaction(on_error=partial(on_error, reraise=DatasetDuplicateFailedError))
     def run(self) -> Model:
         self.validate()
-        try:
-            database_id = self._base_model.database_id
-            table_name = self._properties["table_name"]
-            owners = self._properties["owners"]
-            database = db.session.query(Database).get(database_id)
-            if not database:
-                raise SupersetErrorException(
-                    SupersetError(
-                        message=__("The database was not found."),
-                        error_type=SupersetErrorType.DATABASE_NOT_FOUND_ERROR,
-                        level=ErrorLevel.ERROR,
-                    ),
-                    status=404,
-                )
-            table = SqlaTable(table_name=table_name, owners=owners)
-            table.database = database
-            table.schema = self._base_model.schema
-            table.template_params = self._base_model.template_params
-            table.normalize_columns = self._base_model.normalize_columns
-            table.always_filter_main_dttm = self._base_model.always_filter_main_dttm
-            table.is_sqllab_view = True
-            table.sql = ParsedQuery(
-                self._base_model.sql,
-                engine=database.db_engine_spec.engine,
-            ).stripped()
-            db.session.add(table)
-            cols = []
-            for config_ in self._base_model.columns:
-                column_name = config_.column_name
-                col = TableColumn(
-                    column_name=column_name,
-                    verbose_name=config_.verbose_name,
-                    expression=config_.expression,
-                    filterable=True,
-                    groupby=True,
-                    is_dttm=config_.is_dttm,
-                    type=config_.type,
-                    description=config_.description,
-                )
-                cols.append(col)
-            table.columns = cols
-            mets = []
-            for config_ in self._base_model.metrics:
-                metric_name = config_.metric_name
-                met = SqlMetric(
-                    metric_name=metric_name,
-                    verbose_name=config_.verbose_name,
-                    expression=config_.expression,
-                    metric_type=config_.metric_type,
-                    description=config_.description,
-                )
-                mets.append(met)
-            table.metrics = mets
-            db.session.commit()
-        except (SQLAlchemyError, DAOCreateFailedError) as ex:
-            logger.warning(ex, exc_info=True)
-            db.session.rollback()
-            raise DatasetDuplicateFailedError() from ex
+        database_id = self._base_model.database_id
+        table_name = self._properties["table_name"]
+        owners = self._properties["owners"]
+        database = db.session.query(Database).get(database_id)
+        if not database:
+            raise SupersetErrorException(
+                SupersetError(
+                    message=__("The database was not found."),
+                    error_type=SupersetErrorType.DATABASE_NOT_FOUND_ERROR,
+                    level=ErrorLevel.ERROR,
+                ),
+                status=404,
+            )
+        table = SqlaTable(table_name=table_name, owners=owners)
+        table.database = database
+        table.schema = self._base_model.schema
+        table.template_params = self._base_model.template_params
+        table.normalize_columns = self._base_model.normalize_columns
+        table.always_filter_main_dttm = self._base_model.always_filter_main_dttm
+        table.is_sqllab_view = True
+        table.sql = ParsedQuery(
+            self._base_model.sql,
+            engine=database.db_engine_spec.engine,
+        ).stripped()
+        db.session.add(table)
+        cols = []
+        for config_ in self._base_model.columns:
+            column_name = config_.column_name
+            col = TableColumn(
+                column_name=column_name,
+                verbose_name=config_.verbose_name,
+                expression=config_.expression,
+                filterable=True,
+                groupby=True,
+                is_dttm=config_.is_dttm,
+                type=config_.type,
+                description=config_.description,
+            )
+            cols.append(col)
+        table.columns = cols
+        mets = []
+        for config_ in self._base_model.metrics:
+            metric_name = config_.metric_name
+            met = SqlMetric(
+                metric_name=metric_name,
+                verbose_name=config_.verbose_name,
+                expression=config_.expression,
+                metric_type=config_.metric_type,
+                description=config_.description,
+            )
+            mets.append(met)
+        table.metrics = mets
         return table
 
     def validate(self) -> None:

--- a/superset/commands/dataset/importers/v0.py
+++ b/superset/commands/dataset/importers/v0.py
@@ -34,6 +34,7 @@ from superset.connectors.sqla.models import (
 )
 from superset.models.core import Database
 from superset.utils import json
+from superset.utils.decorators import transaction
 from superset.utils.dict_import_export import DATABASES_KEY
 
 logger = logging.getLogger(__name__)
@@ -211,7 +212,6 @@ def import_from_dict(data: dict[str, Any], sync: Optional[list[str]] = None) -> 
         logger.info("Importing %d %s", len(data.get(DATABASES_KEY, [])), DATABASES_KEY)
         for database in data.get(DATABASES_KEY, []):
             Database.import_from_dict(database, sync=sync)
-        db.session.commit()
     else:
         logger.info("Supplied object is not a dictionary.")
 
@@ -240,10 +240,10 @@ class ImportDatasetsCommand(BaseCommand):
         if kwargs.get("sync_metrics"):
             self.sync.append("metrics")
 
+    @transaction()
     def run(self) -> None:
         self.validate()
 
-        # TODO (betodealmeida): add rollback in case of error
         for file_name, config in self._configs.items():
             logger.info("Importing dataset from file %s", file_name)
             if isinstance(config, dict):
@@ -260,7 +260,6 @@ class ImportDatasetsCommand(BaseCommand):
                     )
                     dataset["database_id"] = database.id
                     SqlaTable.import_from_dict(dataset, sync=self.sync)
-                db.session.commit()
 
     def validate(self) -> None:
         # ensure all files are YAML

--- a/superset/commands/dataset/importers/v1/utils.py
+++ b/superset/commands/dataset/importers/v1/utils.py
@@ -178,7 +178,7 @@ def import_dataset(
     if data_uri and (not table_exists or force_data):
         load_data(data_uri, dataset, dataset.database)
 
-    if user := get_user():
+    if (user := get_user()) and user not in dataset.owners:
         dataset.owners.append(user)
 
     return dataset

--- a/superset/commands/dataset/refresh.py
+++ b/superset/commands/dataset/refresh.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
+from functools import partial
 from typing import Optional
 
 from flask_appbuilder.models.sqla import Model
@@ -29,6 +30,7 @@ from superset.commands.dataset.exceptions import (
 from superset.connectors.sqla.models import SqlaTable
 from superset.daos.dataset import DatasetDAO
 from superset.exceptions import SupersetSecurityException
+from superset.utils.decorators import on_error, transaction
 
 logger = logging.getLogger(__name__)
 
@@ -38,16 +40,12 @@ class RefreshDatasetCommand(BaseCommand):
         self._model_id = model_id
         self._model: Optional[SqlaTable] = None
 
+    @transaction(on_error=partial(on_error, reraise=DatasetRefreshFailedError))
     def run(self) -> Model:
         self.validate()
-        if self._model:
-            try:
-                self._model.fetch_metadata()
-                return self._model
-            except Exception as ex:
-                logger.exception(ex)
-                raise DatasetRefreshFailedError() from ex
-        raise DatasetRefreshFailedError()
+        assert self._model
+        self._model.fetch_metadata()
+        return self._model
 
     def validate(self) -> None:
         # Validate/populate model exists

--- a/superset/commands/explore/permalink/create.py
+++ b/superset/commands/explore/permalink/create.py
@@ -15,18 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
+from functools import partial
 from typing import Any, Optional
 
 from sqlalchemy.exc import SQLAlchemyError
 
-from superset import db
 from superset.commands.explore.permalink.base import BaseExplorePermalinkCommand
 from superset.commands.key_value.create import CreateKeyValueCommand
 from superset.explore.permalink.exceptions import ExplorePermalinkCreateFailedError
 from superset.explore.utils import check_access as check_chart_access
-from superset.key_value.exceptions import KeyValueCodecEncodeException
+from superset.key_value.exceptions import (
+    KeyValueCodecEncodeException,
+    KeyValueCreateFailedError,
+)
 from superset.key_value.utils import encode_permalink_key
 from superset.utils.core import DatasourceType
+from superset.utils.decorators import on_error, transaction
 
 logger = logging.getLogger(__name__)
 
@@ -37,35 +41,39 @@ class CreateExplorePermalinkCommand(BaseExplorePermalinkCommand):
         self.datasource: str = state["formData"]["datasource"]
         self.state = state
 
+    @transaction(
+        on_error=partial(
+            on_error,
+            catches=(
+                KeyValueCodecEncodeException,
+                KeyValueCreateFailedError,
+                SQLAlchemyError,
+            ),
+            reraise=ExplorePermalinkCreateFailedError,
+        ),
+    )
     def run(self) -> str:
         self.validate()
-        try:
-            d_id, d_type = self.datasource.split("__")
-            datasource_id = int(d_id)
-            datasource_type = DatasourceType(d_type)
-            check_chart_access(datasource_id, self.chart_id, datasource_type)
-            value = {
-                "chartId": self.chart_id,
-                "datasourceId": datasource_id,
-                "datasourceType": datasource_type.value,
-                "datasource": self.datasource,
-                "state": self.state,
-            }
-            command = CreateKeyValueCommand(
-                resource=self.resource,
-                value=value,
-                codec=self.codec,
-            )
-            key = command.run()
-            if key.id is None:
-                raise ExplorePermalinkCreateFailedError("Unexpected missing key id")
-            db.session.commit()
-            return encode_permalink_key(key=key.id, salt=self.salt)
-        except KeyValueCodecEncodeException as ex:
-            raise ExplorePermalinkCreateFailedError(str(ex)) from ex
-        except SQLAlchemyError as ex:
-            logger.exception("Error running create command")
-            raise ExplorePermalinkCreateFailedError() from ex
+        d_id, d_type = self.datasource.split("__")
+        datasource_id = int(d_id)
+        datasource_type = DatasourceType(d_type)
+        check_chart_access(datasource_id, self.chart_id, datasource_type)
+        value = {
+            "chartId": self.chart_id,
+            "datasourceId": datasource_id,
+            "datasourceType": datasource_type.value,
+            "datasource": self.datasource,
+            "state": self.state,
+        }
+        command = CreateKeyValueCommand(
+            resource=self.resource,
+            value=value,
+            codec=self.codec,
+        )
+        key = command.run()
+        if key.id is None:
+            raise ExplorePermalinkCreateFailedError("Unexpected missing key id")
+        return encode_permalink_key(key=key.id, salt=self.salt)
 
     def validate(self) -> None:
         pass

--- a/superset/commands/importers/v1/__init__.py
+++ b/superset/commands/importers/v1/__init__.py
@@ -32,6 +32,7 @@ from superset.commands.importers.v1.utils import (
 )
 from superset.daos.base import BaseDAO
 from superset.models.core import Database  # noqa: F401
+from superset.utils.decorators import transaction
 
 
 class ImportModelsCommand(BaseCommand):
@@ -67,18 +68,15 @@ class ImportModelsCommand(BaseCommand):
     def _get_uuids(cls) -> set[str]:
         return {str(model.uuid) for model in db.session.query(cls.dao.model_cls).all()}
 
+    @transaction()
     def run(self) -> None:
         self.validate()
 
-        # rollback to prevent partial imports
         try:
             self._import(self._configs, self.overwrite)
-            db.session.commit()
         except CommandException:
-            db.session.rollback()
             raise
         except Exception as ex:
-            db.session.rollback()
             raise self.import_error() from ex
 
     def validate(self) -> None:  # noqa: F811

--- a/superset/commands/importers/v1/examples.py
+++ b/superset/commands/importers/v1/examples.py
@@ -43,6 +43,7 @@ from superset.datasets.schemas import ImportV1DatasetSchema
 from superset.models.dashboard import dashboard_slices
 from superset.utils.core import get_example_default_schema
 from superset.utils.database import get_example_database
+from superset.utils.decorators import transaction
 
 
 class ImportExamplesCommand(ImportModelsCommand):
@@ -62,19 +63,17 @@ class ImportExamplesCommand(ImportModelsCommand):
         super().__init__(contents, *args, **kwargs)
         self.force_data = kwargs.get("force_data", False)
 
+    @transaction()
     def run(self) -> None:
         self.validate()
 
-        # rollback to prevent partial imports
         try:
             self._import(
                 self._configs,
                 self.overwrite,
                 self.force_data,
             )
-            db.session.commit()
         except Exception as ex:
-            db.session.rollback()
             raise self.import_error() from ex
 
     @classmethod

--- a/superset/commands/query/delete.py
+++ b/superset/commands/query/delete.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
+from functools import partial
 from typing import Optional
 
 from superset.commands.base import BaseCommand
@@ -22,9 +23,9 @@ from superset.commands.query.exceptions import (
     SavedQueryDeleteFailedError,
     SavedQueryNotFoundError,
 )
-from superset.daos.exceptions import DAODeleteFailedError
 from superset.daos.query import SavedQueryDAO
 from superset.models.dashboard import Dashboard
+from superset.utils.decorators import on_error, transaction
 
 logger = logging.getLogger(__name__)
 
@@ -34,15 +35,11 @@ class DeleteSavedQueryCommand(BaseCommand):
         self._model_ids = model_ids
         self._models: Optional[list[Dashboard]] = None
 
+    @transaction(on_error=partial(on_error, reraise=SavedQueryDeleteFailedError))
     def run(self) -> None:
         self.validate()
         assert self._models
-
-        try:
-            SavedQueryDAO.delete(self._models)
-        except DAODeleteFailedError as ex:
-            logger.exception(ex.exception)
-            raise SavedQueryDeleteFailedError() from ex
+        SavedQueryDAO.delete(self._models)
 
     def validate(self) -> None:
         # Validate/populate model exists

--- a/superset/commands/report/create.py
+++ b/superset/commands/report/create.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
+from functools import partial
 from typing import Any, Optional
 
 from flask_babel import gettext as _
@@ -31,7 +32,6 @@ from superset.commands.report.exceptions import (
     ReportScheduleNameUniquenessValidationError,
 )
 from superset.daos.database import DatabaseDAO
-from superset.daos.exceptions import DAOCreateFailedError
 from superset.daos.report import ReportScheduleDAO
 from superset.reports.models import (
     ReportCreationMethod,
@@ -40,6 +40,7 @@ from superset.reports.models import (
 )
 from superset.reports.types import ReportScheduleExtra
 from superset.utils import json
+from superset.utils.decorators import on_error, transaction
 
 logger = logging.getLogger(__name__)
 
@@ -48,13 +49,10 @@ class CreateReportScheduleCommand(CreateMixin, BaseReportScheduleCommand):
     def __init__(self, data: dict[str, Any]):
         self._properties = data.copy()
 
+    @transaction(on_error=partial(on_error, reraise=ReportScheduleCreateFailedError))
     def run(self) -> ReportSchedule:
         self.validate()
-        try:
-            return ReportScheduleDAO.create(attributes=self._properties)
-        except DAOCreateFailedError as ex:
-            logger.exception(ex.exception)
-            raise ReportScheduleCreateFailedError() from ex
+        return ReportScheduleDAO.create(attributes=self._properties)
 
     def validate(self) -> None:
         """

--- a/superset/commands/report/delete.py
+++ b/superset/commands/report/delete.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
+from functools import partial
 from typing import Optional
 
 from superset import security_manager
@@ -24,10 +25,10 @@ from superset.commands.report.exceptions import (
     ReportScheduleForbiddenError,
     ReportScheduleNotFoundError,
 )
-from superset.daos.exceptions import DAODeleteFailedError
 from superset.daos.report import ReportScheduleDAO
 from superset.exceptions import SupersetSecurityException
 from superset.reports.models import ReportSchedule
+from superset.utils.decorators import on_error, transaction
 
 logger = logging.getLogger(__name__)
 
@@ -37,15 +38,11 @@ class DeleteReportScheduleCommand(BaseCommand):
         self._model_ids = model_ids
         self._models: Optional[list[ReportSchedule]] = None
 
+    @transaction(on_error=partial(on_error, reraise=ReportScheduleDeleteFailedError))
     def run(self) -> None:
         self.validate()
         assert self._models
-
-        try:
-            ReportScheduleDAO.delete(self._models)
-        except DAODeleteFailedError as ex:
-            logger.exception(ex.exception)
-            raise ReportScheduleDeleteFailedError() from ex
+        ReportScheduleDAO.delete(self._models)
 
     def validate(self) -> None:
         # Validate/populate model exists

--- a/superset/commands/security/create.py
+++ b/superset/commands/security/create.py
@@ -23,9 +23,9 @@ from superset.commands.base import BaseCommand
 from superset.commands.exceptions import DatasourceNotFoundValidationError
 from superset.commands.utils import populate_roles
 from superset.connectors.sqla.models import SqlaTable
-from superset.daos.exceptions import DAOCreateFailedError
 from superset.daos.security import RLSDAO
 from superset.extensions import db
+from superset.utils.decorators import transaction
 
 logger = logging.getLogger(__name__)
 
@@ -36,13 +36,10 @@ class CreateRLSRuleCommand(BaseCommand):
         self._tables = self._properties.get("tables", [])
         self._roles = self._properties.get("roles", [])
 
+    @transaction()
     def run(self) -> Any:
         self.validate()
-        try:
-            return RLSDAO.create(attributes=self._properties)
-        except DAOCreateFailedError as ex:
-            logger.exception(ex.exception)
-            raise
+        return RLSDAO.create(attributes=self._properties)
 
     def validate(self) -> None:
         roles = populate_roles(self._roles)

--- a/superset/commands/security/update.py
+++ b/superset/commands/security/update.py
@@ -24,9 +24,9 @@ from superset.commands.exceptions import DatasourceNotFoundValidationError
 from superset.commands.security.exceptions import RLSRuleNotFoundError
 from superset.commands.utils import populate_roles
 from superset.connectors.sqla.models import RowLevelSecurityFilter, SqlaTable
-from superset.daos.exceptions import DAOUpdateFailedError
 from superset.daos.security import RLSDAO
 from superset.extensions import db
+from superset.utils.decorators import transaction
 
 logger = logging.getLogger(__name__)
 
@@ -39,17 +39,11 @@ class UpdateRLSRuleCommand(BaseCommand):
         self._roles = self._properties.get("roles", [])
         self._model: Optional[RowLevelSecurityFilter] = None
 
+    @transaction()
     def run(self) -> Any:
         self.validate()
         assert self._model
-
-        try:
-            rule = RLSDAO.update(self._model, self._properties)
-        except DAOUpdateFailedError as ex:
-            logger.exception(ex.exception)
-            raise
-
-        return rule
+        return RLSDAO.update(self._model, self._properties)
 
     def validate(self) -> None:
         self._model = RLSDAO.find_by_id(int(self._model_id))

--- a/superset/commands/sql_lab/execute.py
+++ b/superset/commands/sql_lab/execute.py
@@ -22,10 +22,11 @@ import logging
 from typing import Any, TYPE_CHECKING
 
 from flask_babel import gettext as __
+from sqlalchemy.exc import SQLAlchemyError
 
+from superset import db
 from superset.commands.base import BaseCommand
 from superset.common.db_query_status import QueryStatus
-from superset.daos.exceptions import DAOCreateFailedError
 from superset.errors import SupersetErrorType
 from superset.exceptions import (
     SupersetErrorException,
@@ -41,6 +42,7 @@ from superset.sqllab.exceptions import (
 )
 from superset.sqllab.execution_context_convertor import ExecutionContextConvertor
 from superset.sqllab.limiting_factor import LimitingFactor
+from superset.utils.decorators import transaction
 
 if TYPE_CHECKING:
     from superset.daos.database import DatabaseDAO
@@ -90,6 +92,7 @@ class ExecuteSqlCommand(BaseCommand):
     def validate(self) -> None:
         pass
 
+    @transaction()
     def run(  # pylint: disable=too-many-statements,useless-suppression
         self,
     ) -> CommandResult:
@@ -178,9 +181,22 @@ class ExecuteSqlCommand(BaseCommand):
             )
 
     def _save_new_query(self, query: Query) -> None:
+        """
+        Saves the new SQL Lab query.
+
+        Committing within a transaction violates the "unit of work" construct, but is
+        necessary for async querying. The Celery task is defined within the confines
+        of another command and needs to read a previously committed state given the
+        `READ COMMITTED` isolation level.
+
+        To mitigate said issue, ideally there would be a command to prepare said query
+        and another to execute it, either in a sync or async manner.
+
+        :param query: The SQL Lab query
+        """
         try:
             self._query_dao.create(query)
-        except DAOCreateFailedError as ex:
+        except SQLAlchemyError as ex:
             raise SqlLabException(
                 self._execution_context,
                 SupersetErrorType.GENERIC_DB_ENGINE_ERROR,
@@ -188,6 +204,8 @@ class ExecuteSqlCommand(BaseCommand):
                 ex,
                 "Please contact an administrator for further assistance or try again.",
             ) from ex
+
+        db.session.commit()  # pylint: disable=consider-using-transaction
 
     def _validate_access(self, query: Query) -> None:
         try:

--- a/superset/commands/tag/update.py
+++ b/superset/commands/tag/update.py
@@ -25,6 +25,7 @@ from superset.commands.tag.exceptions import TagInvalidError, TagNotFoundError
 from superset.commands.tag.utils import to_object_type
 from superset.daos.tag import TagDAO
 from superset.tags.models import Tag
+from superset.utils.decorators import transaction
 
 logger = logging.getLogger(__name__)
 
@@ -35,18 +36,17 @@ class UpdateTagCommand(UpdateMixin, BaseCommand):
         self._properties = data.copy()
         self._model: Optional[Tag] = None
 
+    @transaction()
     def run(self) -> Model:
         self.validate()
-        if self._model:
-            self._model.name = self._properties["name"]
-            TagDAO.create_tag_relationship(
-                objects_to_tag=self._properties.get("objects_to_tag", []),
-                tag=self._model,
-            )
-            self._model.description = self._properties.get("description")
-
-            db.session.add(self._model)
-            db.session.commit()
+        assert self._model
+        self._model.name = self._properties["name"]
+        TagDAO.create_tag_relationship(
+            objects_to_tag=self._properties.get("objects_to_tag", []),
+            tag=self._model,
+        )
+        self._model.description = self._properties.get("description")
+        db.session.add(self._model)
 
         return self._model
 

--- a/superset/commands/temporary_cache/delete.py
+++ b/superset/commands/temporary_cache/delete.py
@@ -16,12 +16,12 @@
 # under the License.
 import logging
 from abc import ABC, abstractmethod
-
-from sqlalchemy.exc import SQLAlchemyError
+from functools import partial
 
 from superset.commands.base import BaseCommand
 from superset.commands.temporary_cache.exceptions import TemporaryCacheDeleteFailedError
 from superset.commands.temporary_cache.parameters import CommandParameters
+from superset.utils.decorators import on_error, transaction
 
 logger = logging.getLogger(__name__)
 
@@ -30,12 +30,9 @@ class DeleteTemporaryCacheCommand(BaseCommand, ABC):
     def __init__(self, cmd_params: CommandParameters):
         self._cmd_params = cmd_params
 
+    @transaction(on_error=partial(on_error, reraise=TemporaryCacheDeleteFailedError))
     def run(self) -> bool:
-        try:
-            return self.delete(self._cmd_params)
-        except SQLAlchemyError as ex:
-            logger.exception("Error running delete command")
-            raise TemporaryCacheDeleteFailedError() from ex
+        return self.delete(self._cmd_params)
 
     def validate(self) -> None:
         pass

--- a/superset/commands/temporary_cache/update.py
+++ b/superset/commands/temporary_cache/update.py
@@ -16,13 +16,13 @@
 # under the License.
 import logging
 from abc import ABC, abstractmethod
+from functools import partial
 from typing import Optional
-
-from sqlalchemy.exc import SQLAlchemyError
 
 from superset.commands.base import BaseCommand
 from superset.commands.temporary_cache.exceptions import TemporaryCacheUpdateFailedError
 from superset.commands.temporary_cache.parameters import CommandParameters
+from superset.utils.decorators import on_error, transaction
 
 logger = logging.getLogger(__name__)
 
@@ -34,12 +34,9 @@ class UpdateTemporaryCacheCommand(BaseCommand, ABC):
     ):
         self._parameters = cmd_params
 
+    @transaction(on_error=partial(on_error, reraise=TemporaryCacheUpdateFailedError))
     def run(self) -> Optional[str]:
-        try:
-            return self.update(self._parameters)
-        except SQLAlchemyError as ex:
-            logger.exception("Error running update command")
-            raise TemporaryCacheUpdateFailedError() from ex
+        return self.update(self._parameters)
 
     def validate(self) -> None:
         pass

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1768,11 +1768,10 @@ class SqlaTable(
             )
         )
 
-    def fetch_metadata(self, commit: bool = True) -> MetadataResult:
+    def fetch_metadata(self) -> MetadataResult:
         """
         Fetches the metadata for the table and merges it in
 
-        :param commit: should the changes be committed or not.
         :return: Tuple with lists of added, removed and modified column names.
         """
         new_columns = self.external_metadata()
@@ -1850,8 +1849,6 @@ class SqlaTable(
         config["SQLA_TABLE_MUTATOR"](self)
 
         db.session.merge(self)
-        if commit:
-            db.session.commit()
         return results
 
     @classmethod

--- a/superset/daos/base.py
+++ b/superset/daos/base.py
@@ -21,13 +21,8 @@ from typing import Any, Generic, get_args, TypeVar
 from flask_appbuilder.models.filters import BaseFilter
 from flask_appbuilder.models.sqla import Model
 from flask_appbuilder.models.sqla.interface import SQLAInterface
-from sqlalchemy.exc import SQLAlchemyError, StatementError
+from sqlalchemy.exc import StatementError
 
-from superset.daos.exceptions import (
-    DAOCreateFailedError,
-    DAODeleteFailedError,
-    DAOUpdateFailedError,
-)
 from superset.extensions import db
 
 T = TypeVar("T", bound=Model)
@@ -127,15 +122,12 @@ class BaseDAO(Generic[T]):
         cls,
         item: T | None = None,
         attributes: dict[str, Any] | None = None,
-        commit: bool = True,
     ) -> T:
         """
         Create an object from the specified item and/or attributes.
 
         :param item: The object to create
         :param attributes: The attributes associated with the object to create
-        :param commit: Whether to commit the transaction
-        :raises DAOCreateFailedError: If the creation failed
         """
 
         if not item:
@@ -145,15 +137,7 @@ class BaseDAO(Generic[T]):
             for key, value in attributes.items():
                 setattr(item, key, value)
 
-        try:
-            db.session.add(item)
-
-            if commit:
-                db.session.commit()
-        except SQLAlchemyError as ex:  # pragma: no cover
-            db.session.rollback()
-            raise DAOCreateFailedError(exception=ex) from ex
-
+        db.session.add(item)
         return item  # type: ignore
 
     @classmethod
@@ -161,15 +145,12 @@ class BaseDAO(Generic[T]):
         cls,
         item: T | None = None,
         attributes: dict[str, Any] | None = None,
-        commit: bool = True,
     ) -> T:
         """
         Update an object from the specified item and/or attributes.
 
         :param item: The object to update
         :param attributes: The attributes associated with the object to update
-        :param commit: Whether to commit the transaction
-        :raises DAOUpdateFailedError: If the updating failed
         """
 
         if not item:
@@ -179,19 +160,13 @@ class BaseDAO(Generic[T]):
             for key, value in attributes.items():
                 setattr(item, key, value)
 
-        try:
-            db.session.merge(item)
-
-            if commit:
-                db.session.commit()
-        except SQLAlchemyError as ex:  # pragma: no cover
-            db.session.rollback()
-            raise DAOUpdateFailedError(exception=ex) from ex
+        if item not in db.session:
+            return db.session.merge(item)
 
         return item  # type: ignore
 
     @classmethod
-    def delete(cls, items: list[T], commit: bool = True) -> None:
+    def delete(cls, items: list[T]) -> None:
         """
         Delete the specified items including their associated relationships.
 
@@ -204,17 +179,8 @@ class BaseDAO(Generic[T]):
         post-deletion logic.
 
         :param items: The items to delete
-        :param commit: Whether to commit the transaction
-        :raises DAODeleteFailedError: If the deletion failed
         :see: https://docs.sqlalchemy.org/en/latest/orm/queryguide/dml.html
         """
 
-        try:
-            for item in items:
-                db.session.delete(item)
-
-            if commit:
-                db.session.commit()
-        except SQLAlchemyError as ex:
-            db.session.rollback()
-            raise DAODeleteFailedError(exception=ex) from ex
+        for item in items:
+            db.session.delete(item)

--- a/superset/daos/chart.py
+++ b/superset/daos/chart.py
@@ -62,7 +62,6 @@ class ChartDAO(BaseDAO[Slice]):
                     dttm=datetime.now(),
                 )
             )
-            db.session.commit()
 
     @staticmethod
     def remove_favorite(chart: Slice) -> None:
@@ -77,4 +76,3 @@ class ChartDAO(BaseDAO[Slice]):
         )
         if fav:
             db.session.delete(fav)
-            db.session.commit()

--- a/superset/daos/dashboard.py
+++ b/superset/daos/dashboard.py
@@ -179,8 +179,7 @@ class DashboardDAO(BaseDAO[Dashboard]):
         dashboard: Dashboard,
         data: dict[Any, Any],
         old_to_new_slice_ids: dict[int, int] | None = None,
-        commit: bool = False,
-    ) -> Dashboard:
+    ) -> None:
         new_filter_scopes = {}
         md = dashboard.params_dict
 
@@ -265,10 +264,6 @@ class DashboardDAO(BaseDAO[Dashboard]):
         md["cross_filters_enabled"] = data.get("cross_filters_enabled", True)
         dashboard.json_metadata = json.dumps(md)
 
-        if commit:
-            db.session.commit()
-        return dashboard
-
     @staticmethod
     def favorited_ids(dashboards: list[Dashboard]) -> list[FavStar]:
         ids = [dash.id for dash in dashboards]
@@ -321,7 +316,6 @@ class DashboardDAO(BaseDAO[Dashboard]):
         dash.params = original_dash.params
         cls.set_dash_metadata(dash, metadata, old_to_new_slice_ids)
         db.session.add(dash)
-        db.session.commit()
         return dash
 
     @staticmethod
@@ -336,7 +330,6 @@ class DashboardDAO(BaseDAO[Dashboard]):
                     dttm=datetime.now(),
                 )
             )
-            db.session.commit()
 
     @staticmethod
     def remove_favorite(dashboard: Dashboard) -> None:
@@ -351,7 +344,6 @@ class DashboardDAO(BaseDAO[Dashboard]):
         )
         if fav:
             db.session.delete(fav)
-            db.session.commit()
 
 
 class EmbeddedDashboardDAO(BaseDAO[EmbeddedDashboard]):
@@ -369,7 +361,6 @@ class EmbeddedDashboardDAO(BaseDAO[EmbeddedDashboard]):
         )
         embedded.allow_domain_list = ",".join(allowed_domains)
         dashboard.embedded = [embedded]
-        db.session.commit()
         return embedded
 
     @classmethod
@@ -377,7 +368,6 @@ class EmbeddedDashboardDAO(BaseDAO[EmbeddedDashboard]):
         cls,
         item: EmbeddedDashboardDAO | None = None,
         attributes: dict[str, Any] | None = None,
-        commit: bool = True,
     ) -> Any:
         """
         Use EmbeddedDashboardDAO.upsert() instead.

--- a/superset/daos/database.py
+++ b/superset/daos/database.py
@@ -42,7 +42,6 @@ class DatabaseDAO(BaseDAO[Database]):
         cls,
         item: Database | None = None,
         attributes: dict[str, Any] | None = None,
-        commit: bool = True,
     ) -> Database:
         """
         Unmask ``encrypted_extra`` before updating.
@@ -60,7 +59,7 @@ class DatabaseDAO(BaseDAO[Database]):
                 attributes["encrypted_extra"],
             )
 
-        return super().update(item, attributes, commit)
+        return super().update(item, attributes)
 
     @staticmethod
     def validate_uniqueness(database_name: str) -> bool:
@@ -174,7 +173,6 @@ class SSHTunnelDAO(BaseDAO[SSHTunnel]):
         cls,
         item: SSHTunnel | None = None,
         attributes: dict[str, Any] | None = None,
-        commit: bool = True,
     ) -> SSHTunnel:
         """
         Unmask ``password``, ``private_key`` and ``private_key_password`` before updating.
@@ -190,7 +188,7 @@ class SSHTunnelDAO(BaseDAO[SSHTunnel]):
             attributes.pop("id", None)
             attributes = unmask_password_info(attributes, item)
 
-        return super().update(item, attributes, commit)
+        return super().update(item, attributes)
 
 
 class DatabaseUserOAuth2TokensDAO(BaseDAO[DatabaseUserOAuth2Tokens]):

--- a/superset/daos/exceptions.py
+++ b/superset/daos/exceptions.py
@@ -23,30 +23,6 @@ class DAOException(SupersetException):
     """
 
 
-class DAOCreateFailedError(DAOException):
-    """
-    DAO Create failed
-    """
-
-    message = "Create failed"
-
-
-class DAOUpdateFailedError(DAOException):
-    """
-    DAO Update failed
-    """
-
-    message = "Update failed"
-
-
-class DAODeleteFailedError(DAOException):
-    """
-    DAO Delete failed
-    """
-
-    message = "Delete failed"
-
-
 class DatasourceTypeNotSupportedError(DAOException):
     """
     DAO datasource query source type is not supported

--- a/superset/daos/query.py
+++ b/superset/daos/query.py
@@ -53,7 +53,6 @@ class QueryDAO(BaseDAO[Query]):
             for saved_query in related_saved_queries:
                 saved_query.rows = query.rows
                 saved_query.last_run = datetime.now()
-            db.session.commit()
 
     @staticmethod
     def save_metadata(query: Query, payload: dict[str, Any]) -> None:
@@ -97,7 +96,6 @@ class QueryDAO(BaseDAO[Query]):
 
         query.status = QueryStatus.STOPPED
         query.end_time = now_as_float()
-        db.session.commit()
 
 
 class SavedQueryDAO(BaseDAO[SavedQuery]):

--- a/superset/daos/report.py
+++ b/superset/daos/report.py
@@ -20,10 +20,7 @@ import logging
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy.exc import SQLAlchemyError
-
 from superset.daos.base import BaseDAO
-from superset.daos.exceptions import DAODeleteFailedError
 from superset.extensions import db
 from superset.reports.filters import ReportScheduleFilter
 from superset.reports.models import (
@@ -137,15 +134,12 @@ class ReportScheduleDAO(BaseDAO[ReportSchedule]):
         cls,
         item: ReportSchedule | None = None,
         attributes: dict[str, Any] | None = None,
-        commit: bool = True,
     ) -> ReportSchedule:
         """
         Create a report schedule with nested recipients.
 
         :param item: The object to create
         :param attributes: The attributes associated with the object to create
-        :param commit: Whether to commit the transaction
-        :raises: DAOCreateFailedError: If the creation failed
         """
 
         # TODO(john-bodley): Determine why we need special handling for recipients.
@@ -165,22 +159,19 @@ class ReportScheduleDAO(BaseDAO[ReportSchedule]):
                     for recipient in recipients
                 ]
 
-        return super().create(item, attributes, commit)
+        return super().create(item, attributes)
 
     @classmethod
     def update(
         cls,
         item: ReportSchedule | None = None,
         attributes: dict[str, Any] | None = None,
-        commit: bool = True,
     ) -> ReportSchedule:
         """
         Update a report schedule with nested recipients.
 
         :param item: The object to update
         :param attributes: The attributes associated with the object to update
-        :param commit: Whether to commit the transaction
-        :raises: DAOUpdateFailedError: If the update failed
         """
 
         # TODO(john-bodley): Determine why we need special handling for recipients.
@@ -200,7 +191,7 @@ class ReportScheduleDAO(BaseDAO[ReportSchedule]):
                     for recipient in recipients
                 ]
 
-        return super().update(item, attributes, commit)
+        return super().update(item, attributes)
 
     @staticmethod
     def find_active() -> list[ReportSchedule]:
@@ -283,23 +274,12 @@ class ReportScheduleDAO(BaseDAO[ReportSchedule]):
         return last_error_email_log if not report_from_last_email else None
 
     @staticmethod
-    def bulk_delete_logs(
-        model: ReportSchedule,
-        from_date: datetime,
-        commit: bool = True,
-    ) -> int | None:
-        try:
-            row_count = (
-                db.session.query(ReportExecutionLog)
-                .filter(
-                    ReportExecutionLog.report_schedule == model,
-                    ReportExecutionLog.end_dttm < from_date,
-                )
-                .delete(synchronize_session="fetch")
+    def bulk_delete_logs(model: ReportSchedule, from_date: datetime) -> int | None:
+        return (
+            db.session.query(ReportExecutionLog)
+            .filter(
+                ReportExecutionLog.report_schedule == model,
+                ReportExecutionLog.end_dttm < from_date,
             )
-            if commit:
-                db.session.commit()
-            return row_count
-        except SQLAlchemyError as ex:
-            db.session.rollback()
-            raise DAODeleteFailedError(str(ex)) from ex
+            .delete(synchronize_session="fetch")
+        )

--- a/superset/daos/user.py
+++ b/superset/daos/user.py
@@ -40,4 +40,3 @@ class UserDAO(BaseDAO[User]):
             attrs = UserAttribute(avatar_url=url, user_id=user.id)
             user.extra_attributes = [attrs]
             db.session.add(attrs)
-            db.session.commit()

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -1410,7 +1410,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
             database_id=state["database_id"],
         )
         if existing:
-            DatabaseUserOAuth2TokensDAO.delete([existing], commit=True)
+            DatabaseUserOAuth2TokensDAO.delete([existing])
 
         # store tokens
         expiration = datetime.now() + timedelta(seconds=token_response["expires_in"])
@@ -1422,7 +1422,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
                 "access_token_expiration": expiration,
                 "refresh_token": token_response.get("refresh_token"),
             },
-            commit=True,
         )
 
         # return blank page that closes itself

--- a/superset/db_engine_specs/gsheets.py
+++ b/superset/db_engine_specs/gsheets.py
@@ -455,4 +455,4 @@ class GSheetsEngineSpec(ShillelaghEngineSpec):
         catalog[table.table] = spreadsheet_url
         database.extra = json.dumps(extra)
         db.session.add(database)
-        db.session.commit()
+        db.session.commit()  # pylint: disable=consider-using-transaction

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -408,7 +408,7 @@ class HiveEngineSpec(PrestoEngineSpec):
                         logger.info("Query %s: [%s] %s", str(query_id), str(job_id), l)
                     last_log_line = len(log_lines)
                 if needs_commit:
-                    db.session.commit()
+                    db.session.commit()  # pylint: disable=consider-using-transaction
             if sleep_interval := current_app.config.get("HIVE_POLL_INTERVAL"):
                 logger.warning(
                     "HIVE_POLL_INTERVAL is deprecated and will be removed in 3.0. Please use DB_POLL_INTERVAL_SECONDS instead"

--- a/superset/db_engine_specs/impala.py
+++ b/superset/db_engine_specs/impala.py
@@ -151,7 +151,7 @@ class ImpalaEngineSpec(BaseEngineSpec):
                         needs_commit = True
 
                     if needs_commit:
-                        db.session.commit()
+                        db.session.commit()  # pylint: disable=consider-using-transaction
                 sleep_interval = current_app.config["DB_POLL_INTERVAL_SECONDS"].get(
                     cls.engine, 5
                 )

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=too-many-lines
+# pylint: disable=consider-using-transaction,too-many-lines
 from __future__ import annotations
 
 import contextlib

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint: disable=consider-using-transaction
 from __future__ import annotations
 
 import contextlib

--- a/superset/examples/bart_lines.py
+++ b/superset/examples/bart_lines.py
@@ -65,5 +65,4 @@ def load_bart_lines(only_metadata: bool = False, force: bool = False) -> None:
     tbl.description = "BART lines"
     tbl.database = database
     tbl.filter_select_enabled = True
-    db.session.commit()
     tbl.fetch_metadata()

--- a/superset/examples/birth_names.py
+++ b/superset/examples/birth_names.py
@@ -111,8 +111,6 @@ def load_birth_names(
     _set_table_metadata(obj, database)
     _add_table_metrics(obj)
 
-    db.session.commit()
-
     slices, _ = create_slices(obj)
     create_dashboard(slices)
 
@@ -844,5 +842,4 @@ def create_dashboard(slices: list[Slice]) -> Dashboard:
     dash.dashboard_title = "USA Births Names"
     dash.position_json = json.dumps(pos, indent=4)
     dash.slug = "births"
-    db.session.commit()
     return dash

--- a/superset/examples/country_map.py
+++ b/superset/examples/country_map.py
@@ -88,7 +88,6 @@ def load_country_map_data(only_metadata: bool = False, force: bool = False) -> N
     if not any(col.metric_name == "avg__2004" for col in obj.metrics):
         col = str(column("2004").compile(db.engine))
         obj.metrics.append(SqlMetric(metric_name="avg__2004", expression=f"AVG({col})"))
-    db.session.commit()
     obj.fetch_metadata()
     tbl = obj
 

--- a/superset/examples/css_templates.py
+++ b/superset/examples/css_templates.py
@@ -52,7 +52,6 @@ def load_css_templates() -> None:
     """
     )
     obj.css = css
-    db.session.commit()
 
     obj = db.session.query(CssTemplate).filter_by(template_name="Courier Black").first()
     if not obj:
@@ -97,4 +96,3 @@ def load_css_templates() -> None:
     """
     )
     obj.css = css
-    db.session.commit()

--- a/superset/examples/deck.py
+++ b/superset/examples/deck.py
@@ -541,4 +541,3 @@ def load_deck_dash() -> None:  # pylint: disable=too-many-statements
     dash.dashboard_title = title
     dash.slug = slug
     dash.slices = slices
-    db.session.commit()

--- a/superset/examples/energy.py
+++ b/superset/examples/energy.py
@@ -14,8 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Loads datasets, dashboards and slices in a new superset instance"""
-
 import textwrap
 
 import pandas as pd
@@ -79,7 +77,6 @@ def load_energy(
             SqlMetric(metric_name="sum__value", expression=f"SUM({col})")
         )
 
-    db.session.commit()
     tbl.fetch_metadata()
 
     slc = Slice(

--- a/superset/examples/flights.py
+++ b/superset/examples/flights.py
@@ -66,6 +66,5 @@ def load_flights(only_metadata: bool = False, force: bool = False) -> None:
     tbl.description = "Random set of flights in the US"
     tbl.database = database
     tbl.filter_select_enabled = True
-    db.session.commit()
     tbl.fetch_metadata()
     print("Done loading table!")

--- a/superset/examples/helpers.py
+++ b/superset/examples/helpers.py
@@ -14,8 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Loads datasets, dashboards and slices in a new superset instance"""
-
 import os
 from typing import Any
 
@@ -62,7 +60,6 @@ def merge_slice(slc: Slice) -> None:
     if o:
         db.session.delete(o)
     db.session.add(slc)
-    db.session.commit()
 
 
 def get_slice_json(defaults: dict[Any, Any], **kwargs: Any) -> str:

--- a/superset/examples/long_lat.py
+++ b/superset/examples/long_lat.py
@@ -97,7 +97,6 @@ def load_long_lat_data(only_metadata: bool = False, force: bool = False) -> None
     obj.main_dttm_col = "datetime"
     obj.database = database
     obj.filter_select_enabled = True
-    db.session.commit()
     obj.fetch_metadata()
     tbl = obj
 

--- a/superset/examples/misc_dashboard.py
+++ b/superset/examples/misc_dashboard.py
@@ -140,4 +140,3 @@ def load_misc_dashboard() -> None:
     dash.position_json = json.dumps(pos, indent=4)
     dash.slug = DASH_SLUG
     dash.slices = slices
-    db.session.commit()

--- a/superset/examples/multiformat_time_series.py
+++ b/superset/examples/multiformat_time_series.py
@@ -102,7 +102,6 @@ def load_multiformat_time_series(  # pylint: disable=too-many-locals
         col.python_date_format = dttm_and_expr[0]
         col.database_expression = dttm_and_expr[1]
         col.is_dttm = True
-    db.session.commit()
     obj.fetch_metadata()
     tbl = obj
 

--- a/superset/examples/paris.py
+++ b/superset/examples/paris.py
@@ -62,5 +62,4 @@ def load_paris_iris_geojson(only_metadata: bool = False, force: bool = False) ->
     tbl.description = "Map of Paris"
     tbl.database = database
     tbl.filter_select_enabled = True
-    db.session.commit()
     tbl.fetch_metadata()

--- a/superset/examples/random_time_series.py
+++ b/superset/examples/random_time_series.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
 import pandas as pd
 from sqlalchemy import DateTime, inspect, String
 
@@ -72,7 +71,6 @@ def load_random_time_series_data(
     obj.main_dttm_col = "ds"
     obj.database = database
     obj.filter_select_enabled = True
-    db.session.commit()
     obj.fetch_metadata()
     tbl = obj
 

--- a/superset/examples/sf_population_polygons.py
+++ b/superset/examples/sf_population_polygons.py
@@ -64,5 +64,4 @@ def load_sf_population_polygons(
     tbl.description = "Population density of San Francisco"
     tbl.database = database
     tbl.filter_select_enabled = True
-    db.session.commit()
     tbl.fetch_metadata()

--- a/superset/examples/supported_charts_dashboard.py
+++ b/superset/examples/supported_charts_dashboard.py
@@ -14,9 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
 # pylint: disable=too-many-lines
-
 import textwrap
 
 from sqlalchemy import inspect
@@ -1274,4 +1272,3 @@ def load_supported_charts_dashboard() -> None:
     dash.dashboard_title = "Supported Charts Dashboard"
     dash.position_json = json.dumps(pos, indent=2)
     dash.slug = DASH_SLUG
-    db.session.commit()

--- a/superset/examples/tabbed_dashboard.py
+++ b/superset/examples/tabbed_dashboard.py
@@ -14,8 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Loads datasets, dashboards and slices in a new superset instance"""
-
 import textwrap
 
 from superset import db
@@ -558,4 +556,3 @@ def load_tabbed_dashboard(_: bool = False) -> None:
     dash.slices = slices
     dash.dashboard_title = "Tabbed Dashboard"
     dash.slug = slug
-    db.session.commit()

--- a/superset/examples/world_bank.py
+++ b/superset/examples/world_bank.py
@@ -14,8 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Loads datasets, dashboards and slices in a new superset instance"""
-
 import os
 
 import pandas as pd
@@ -41,7 +39,7 @@ from superset.utils import core as utils, json
 from superset.utils.core import DatasourceType
 
 
-def load_world_bank_health_n_pop(  # pylint: disable=too-many-locals, too-many-statements
+def load_world_bank_health_n_pop(  # pylint: disable=too-many-locals
     only_metadata: bool = False,
     force: bool = False,
     sample: bool = False,
@@ -110,7 +108,6 @@ def load_world_bank_health_n_pop(  # pylint: disable=too-many-locals, too-many-s
                 SqlMetric(metric_name=metric, expression=f"{aggr_func}({col})")
             )
 
-    db.session.commit()
     tbl.fetch_metadata()
 
     slices = create_slices(tbl)
@@ -134,7 +131,6 @@ def load_world_bank_health_n_pop(  # pylint: disable=too-many-locals, too-many-s
     dash.position_json = json.dumps(pos, indent=4)
     dash.slug = slug
     dash.slices = slices
-    db.session.commit()
 
 
 def create_slices(tbl: BaseDatasource) -> list[Slice]:

--- a/superset/extensions/metastore_cache.py
+++ b/superset/extensions/metastore_cache.py
@@ -22,7 +22,6 @@ from uuid import UUID, uuid3
 from flask import current_app, Flask, has_app_context
 from flask_caching import BaseCache
 
-from superset import db
 from superset.key_value.exceptions import KeyValueCreateFailedError
 from superset.key_value.types import (
     KeyValueCodec,
@@ -95,7 +94,6 @@ class SupersetMetastoreCache(BaseCache):
             codec=self.codec,
             expires_on=self._get_expiry(timeout),
         ).run()
-        db.session.commit()
         return True
 
     def add(self, key: str, value: Any, timeout: Optional[int] = None) -> bool:
@@ -111,7 +109,6 @@ class SupersetMetastoreCache(BaseCache):
                 key=self.get_key(key),
                 expires_on=self._get_expiry(timeout),
             ).run()
-            db.session.commit()
             return True
         except KeyValueCreateFailedError:
             return False
@@ -136,6 +133,4 @@ class SupersetMetastoreCache(BaseCache):
         # pylint: disable=import-outside-toplevel
         from superset.commands.key_value.delete import DeleteKeyValueCommand
 
-        ret = DeleteKeyValueCommand(resource=RESOURCE, key=self.get_key(key)).run()
-        db.session.commit()
-        return ret
+        return DeleteKeyValueCommand(resource=RESOURCE, key=self.get_key(key)).run()

--- a/superset/extensions/pylint.py
+++ b/superset/extensions/pylint.py
@@ -56,5 +56,22 @@ class JSONLibraryImportChecker(BaseChecker):
                 self.add_message("disallowed-import", node=node)
 
 
+class TransactionChecker(BaseChecker):
+    name = "consider-using-transaction"
+    msgs = {
+        "W0001": (
+            'Consider using the @transaction decorator when defining a "unit of work"',
+            "consider-using-transaction",
+            "Used when an explicit commit or rollback call is detected",
+        ),
+    }
+
+    def visit_call(self, node: nodes.Call) -> None:
+        if isinstance(node.func, nodes.Attribute):
+            if node.func.attrname in ("commit", "rollback"):
+                self.add_message("consider-using-transaction", node=node)
+
+
 def register(linter: PyLinter) -> None:
     linter.register_checker(JSONLibraryImportChecker(linter))
+    linter.register_checker(TransactionChecker(linter))

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -56,6 +56,7 @@ from superset.security import SupersetSecurityManager
 from superset.superset_typing import FlaskResponse
 from superset.tags.core import register_sqla_event_listeners
 from superset.utils.core import is_test, pessimistic_connection_handling
+from superset.utils.decorators import transaction
 from superset.utils.log import DBEventLogger, get_event_logger_from_cfg_value
 
 if TYPE_CHECKING:
@@ -513,6 +514,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
     def configure_feature_flags(self) -> None:
         feature_flag_manager.init_app(self.superset_app)
 
+    @transaction()
     def configure_fab(self) -> None:
         if self.config["SILENCE_FAB"]:
             logging.getLogger("flask_appbuilder").setLevel(logging.ERROR)

--- a/superset/key_value/shared_entries.py
+++ b/superset/key_value/shared_entries.py
@@ -18,7 +18,6 @@
 from typing import Any, Optional
 from uuid import uuid3
 
-from superset import db
 from superset.key_value.types import JsonKeyValueCodec, KeyValueResource, SharedKey
 from superset.key_value.utils import get_uuid_namespace, random_key
 
@@ -46,7 +45,6 @@ def set_shared_value(key: SharedKey, value: Any) -> None:
         key=uuid_key,
         codec=CODEC,
     ).run()
-    db.session.commit()
 
 
 def get_permalink_salt(key: SharedKey) -> str:

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -83,7 +83,7 @@ def copy_dashboard(_mapper: Mapper, _connection: Connection, target: Dashboard) 
         user_id=target.id, welcome_dashboard_id=dashboard.id
     )
     session.add(extra_attributes)
-    session.commit()
+    session.commit()  # pylint: disable=consider-using-transaction
 
 
 sqla.event.listen(User, "after_insert", copy_dashboard)

--- a/superset/queries/api.py
+++ b/superset/queries/api.py
@@ -231,8 +231,8 @@ class QueryRestApi(BaseSupersetModelRestApi):
         backoff.constant,
         Exception,
         interval=1,
-        on_backoff=lambda details: db.session.rollback(),
-        on_giveup=lambda details: db.session.rollback(),
+        on_backoff=lambda details: db.session.rollback(),  # pylint: disable=consider-using-transaction
+        on_giveup=lambda details: db.session.rollback(),  # pylint: disable=consider-using-transaction
         max_tries=5,
     )
     @requires_json

--- a/superset/row_level_security/api.py
+++ b/superset/row_level_security/api.py
@@ -23,6 +23,7 @@ from flask_appbuilder.api import expose, protect, rison, safe
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_babel import ngettext
 from marshmallow import ValidationError
+from sqlalchemy.exc import SQLAlchemyError
 
 from superset.commands.exceptions import (
     DatasourceNotFoundValidationError,
@@ -34,7 +35,6 @@ from superset.commands.security.exceptions import RLSRuleNotFoundError
 from superset.commands.security.update import UpdateRLSRuleCommand
 from superset.connectors.sqla.models import RowLevelSecurityFilter
 from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP, RouteMethod
-from superset.daos.exceptions import DAOCreateFailedError, DAOUpdateFailedError
 from superset.extensions import event_logger
 from superset.row_level_security.schemas import (
     get_delete_ids_schema,
@@ -205,7 +205,7 @@ class RLSRestApi(BaseSupersetModelRestApi):
                 exc_info=True,
             )
             return self.response_422(message=str(ex))
-        except DAOCreateFailedError as ex:
+        except SQLAlchemyError as ex:
             logger.error(
                 "Error creating RLS rule %s: %s",
                 self.__class__.__name__,
@@ -291,7 +291,7 @@ class RLSRestApi(BaseSupersetModelRestApi):
                 exc_info=True,
             )
             return self.response_422(message=str(ex))
-        except DAOUpdateFailedError as ex:
+        except SQLAlchemyError as ex:
             logger.error(
                 "Error updating RLS rule %s: %s",
                 self.__class__.__name__,

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1019,7 +1019,6 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         )
         if deleted_count := pvms.delete():
             logger.info("Deleted %i faulty permissions", deleted_count)
-        self.get_session.commit()
 
     def sync_role_definitions(self) -> None:
         """
@@ -1045,7 +1044,6 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                 self.auth_role_public,
                 merge=True,
             )
-
         self.create_missing_perms()
         self.clean_perms()
 
@@ -1119,7 +1117,6 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                 ):
                     role_from_permissions.append(permission_view)
         role_to.permissions = role_from_permissions
-        self.get_session.commit()
 
     def set_role(
         self,
@@ -1140,7 +1137,6 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             permission_view for permission_view in pvms if pvm_check(permission_view)
         ]
         role.permissions = role_pvms
-        self.get_session.commit()
 
     def _is_admin_only(self, pvm: PermissionView) -> bool:
         """

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint: disable=consider-using-transaction
 import dataclasses
 import logging
 import uuid
@@ -127,6 +128,7 @@ def handle_query_error(
 
 
 def get_query_backoff_handler(details: dict[Any, Any]) -> None:
+    print(details)
     query_id = details["kwargs"]["query_id"]
     logger.error(
         "Query with id `%s` could not be retrieved", str(query_id), exc_info=True

--- a/superset/sqllab/sql_json_executer.py
+++ b/superset/sqllab/sql_json_executer.py
@@ -90,6 +90,7 @@ class SynchronousSqlJsonExecutor(SqlJsonExecutorBase):
         rendered_query: str,
         log_params: dict[str, Any] | None,
     ) -> SqlJsonExecutionStatus:
+        print(">>> execute <<<")
         query_id = execution_context.query.id
         try:
             data = self._get_sql_results_with_timeout(
@@ -101,6 +102,7 @@ class SynchronousSqlJsonExecutor(SqlJsonExecutorBase):
             raise
         except Exception as ex:
             logger.exception("Query %i failed unexpectedly", query_id)
+            print(str(ex))
             raise SupersetGenericDBErrorException(
                 utils.error_msg_from_exception(ex)
             ) from ex
@@ -112,6 +114,7 @@ class SynchronousSqlJsonExecutor(SqlJsonExecutorBase):
                     [SupersetError(**params) for params in data["errors"]]  # type: ignore
                 )
             # old string-only error message
+            print(data)
             raise SupersetGenericDBErrorException(data["error"])  # type: ignore
 
         return SqlJsonExecutionStatus.HAS_RESULTS

--- a/superset/tags/models.py
+++ b/superset/tags/models.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint: disable=consider-using-transaction
 from __future__ import annotations
 
 import enum

--- a/superset/tasks/celery_app.py
+++ b/superset/tasks/celery_app.py
@@ -62,7 +62,7 @@ def teardown(  # pylint: disable=unused-argument
 
     if flask_app.config.get("SQLALCHEMY_COMMIT_ON_TEARDOWN"):
         if not isinstance(retval, Exception):
-            db.session.commit()
+            db.session.commit()  # pylint: disable=consider-using-transaction
 
     if not flask_app.config.get("CELERY_ALWAYS_EAGER"):
         db.session.remove()

--- a/superset/utils/database.py
+++ b/superset/utils/database.py
@@ -54,13 +54,12 @@ def get_or_create_db(
         )
         db.session.add(database)
         database.set_sqlalchemy_uri(sqlalchemy_uri)
-        db.session.commit()
 
     # todo: it's a bad idea to do an update in a get/create function
     if database and database.sqlalchemy_uri_decrypted != sqlalchemy_uri:
         database.set_sqlalchemy_uri(sqlalchemy_uri)
-        db.session.commit()
 
+    db.session.flush()
     return database
 
 
@@ -80,4 +79,4 @@ def remove_database(database: Database) -> None:
     from superset import db
 
     db.session.delete(database)
-    db.session.commit()
+    db.session.flush()

--- a/superset/utils/decorators.py
+++ b/superset/utils/decorators.py
@@ -20,10 +20,12 @@ import logging
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
+from functools import wraps
 from typing import Any, Callable, TYPE_CHECKING
 from uuid import UUID
 
 from flask import current_app, g, Response
+from sqlalchemy.exc import SQLAlchemyError
 
 from superset.utils import core as utils
 from superset.utils.dates import now_as_float
@@ -207,3 +209,64 @@ def suppress_logging(
         yield
     finally:
         target_logger.setLevel(original_level)
+
+
+def on_error(
+    ex: Exception,
+    catches: tuple[type[Exception], ...] = (SQLAlchemyError,),
+    reraise: type[Exception] | None = SQLAlchemyError,
+) -> None:
+    """
+    Default error handler whenever any exception is caught during a SQLAlchemy nested
+    transaction.
+
+    :param ex: The source exception
+    :param catches: The exception types the handler catches
+    :param reraise: The exception type the handler raises after catching
+    :raises Exception: If the exception is not swallowed
+    """
+
+    if isinstance(ex, catches):
+        if hasattr(ex, "exception"):
+            logger.exception(ex.exception)
+
+        if reraise:
+            raise reraise() from ex
+    else:
+        raise ex
+
+
+def transaction(  # pylint: disable=redefined-outer-name
+    on_error: Callable[..., Any] | None = on_error,
+) -> Callable[..., Any]:
+    """
+    Perform a "unit of work".
+
+    Note ideally this would leverage SQLAlchemy's nested transaction, however this
+    proved rather complicated, likely due to many architectural facets, and thus has
+    been left for a follow up exercise.
+
+    :param on_error: Callback invoked when an exception is caught
+    :see: https://github.com/apache/superset/issues/25108
+    """
+
+    def decorate(func: Callable[..., Any]) -> Callable[..., Any]:
+        @wraps(func)
+        def wrapped(*args: Any, **kwargs: Any) -> Any:
+            from superset import db  # pylint: disable=import-outside-toplevel
+
+            try:
+                result = func(*args, **kwargs)
+                db.session.commit()  # pylint: disable=consider-using-transaction
+                return result
+            except Exception as ex:
+                db.session.rollback()  # pylint: disable=consider-using-transaction
+
+                if on_error:
+                    return on_error(ex)
+
+                raise
+
+        return wrapped
+
+    return decorate

--- a/superset/utils/lock.py
+++ b/superset/utils/lock.py
@@ -24,7 +24,6 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta
 from typing import Any, cast, TypeVar, Union
 
-from superset import db
 from superset.exceptions import CreateKeyValueDistributedLockFailedException
 from superset.key_value.exceptions import KeyValueCreateFailedError
 from superset.key_value.types import JsonKeyValueCodec, KeyValueResource
@@ -72,7 +71,6 @@ def KeyValueDistributedLock(  # pylint: disable=invalid-name
     store.
 
     :param namespace: The namespace for which the lock is to be acquired.
-    :type namespace: str
     :param kwargs: Additional keyword arguments.
     :yields: A unique identifier (UUID) for the acquired lock (the KV key).
     :raises CreateKeyValueDistributedLockFailedException: If the lock is taken.
@@ -93,12 +91,10 @@ def KeyValueDistributedLock(  # pylint: disable=invalid-name
             value=True,
             expires_on=datetime.now() + LOCK_EXPIRATION,
         ).run()
-        db.session.commit()
 
         yield key
 
         DeleteKeyValueCommand(resource=KeyValueResource.LOCK, key=key).run()
-        db.session.commit()
         logger.debug("Removed lock on namespace %s for key %s", namespace, key)
     except KeyValueCreateFailedError as ex:
         raise CreateKeyValueDistributedLockFailedException(

--- a/superset/utils/log.py
+++ b/superset/utils/log.py
@@ -403,7 +403,7 @@ class DBEventLogger(AbstractEventLogger):
             logs.append(log)
         try:
             db.session.bulk_save_objects(logs)
-            db.session.commit()
+            db.session.commit()  # pylint: disable=consider-using-transaction
         except SQLAlchemyError as ex:
             logging.error("DBEventLogger failed to log event(s)")
             logging.exception(ex)

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -63,6 +63,7 @@ from superset import (
     app as superset_app,
     appbuilder,
     conf,
+    db,
     get_feature_flags,
     is_feature_enabled,
     security_manager,
@@ -698,7 +699,7 @@ class DeleteMixin:  # pylint: disable=too-few-public-methods
                 if view_menu:
                     security_manager.get_session.delete(view_menu)
 
-                security_manager.get_session.commit()
+                db.session.commit()  # pylint: disable=consider-using-transaction
 
             flash(*self.datamodel.message)
             self.update_redirect()

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -619,10 +619,12 @@ class Superset(BaseSupersetView):
 
         if action == "saveas" and slice_add_perm:
             ChartDAO.create(slc)
+            db.session.commit()  # pylint: disable=consider-using-transaction
             msg = _("Chart [{}] has been saved").format(slc.slice_name)
             flash(msg, "success")
         elif action == "overwrite" and slice_overwrite_perm:
             ChartDAO.update(slc)
+            db.session.commit()  # pylint: disable=consider-using-transaction
             msg = _("Chart [{}] has been overwritten").format(slc.slice_name)
             flash(msg, "success")
 
@@ -676,7 +678,7 @@ class Superset(BaseSupersetView):
 
         if dash and slc not in dash.slices:
             dash.slices.append(slc)
-            db.session.commit()
+            db.session.commit()  # pylint: disable=consider-using-transaction
 
         response = {
             "can_add": slice_add_perm,

--- a/superset/views/dashboard/views.py
+++ b/superset/views/dashboard/views.py
@@ -122,7 +122,7 @@ class Dashboard(BaseSupersetView):
             owners=[g.user],
         )
         db.session.add(new_dashboard)
-        db.session.commit()
+        db.session.commit()  # pylint: disable=consider-using-transaction
         return redirect(f"/superset/dashboard/{new_dashboard.id}/?edit=true")
 
     @expose("/<dashboard_id_or_slug>/embedded")

--- a/superset/views/datasource/views.py
+++ b/superset/views/datasource/views.py
@@ -116,7 +116,7 @@ class Datasource(BaseSupersetView):
             )
         orm_datasource.update_from_object(datasource_dict)
         data = orm_datasource.data
-        db.session.commit()
+        db.session.commit()  # pylint: disable=consider-using-transaction
 
         return self.json_response(sanitize_datasource_data(data))
 

--- a/superset/views/key_value.py
+++ b/superset/views/key_value.py
@@ -48,7 +48,7 @@ class KV(BaseSupersetView):
             value = request.form.get("data")
             obj = models.KeyValue(value=value)
             db.session.add(obj)
-            db.session.commit()
+            db.session.commit()  # pylint: disable=consider-using-transaction
         except Exception as ex:  # pylint: disable=broad-except
             return json_error_response(utils.error_msg_from_exception(ex))
         return Response(json.dumps({"id": obj.id}), status=200)

--- a/superset/views/sql_lab/views.py
+++ b/superset/views/sql_lab/views.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint: disable=consider-using-transaction
 import logging
 
 from flask import request, Response
@@ -272,6 +273,5 @@ class TableSchemaView(BaseSupersetView):
             .filter_by(id=table_schema_id)
             .update({"expanded": payload})
         )
-        db.session.commit()
         response = json.dumps({"id": table_schema_id, "expanded": payload})
         return json_success(response)

--- a/tests/integration_tests/base_tests.py
+++ b/tests/integration_tests/base_tests.py
@@ -203,8 +203,7 @@ class SupersetTestCase(TestCase):
         previous_g_user = g.user if hasattr(g, "user") else None
         try:
             if login:
-                resp = self.login(username=temp_user.username)
-                print(resp)
+                self.login(username=temp_user.username)
             else:
                 g.user = temp_user
             yield temp_user

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -1266,7 +1266,6 @@ class TestChartApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
         assert rv.status_code == 200
         assert data["count"] > 0
         for chart in data["result"]:
-            print(chart)
             assert (
                 "energy"
                 in " ".join(

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -1211,6 +1211,9 @@ class TestGetChartDataApi(BaseTestChartDataApi):
         """
         Chart data cache API: Test chart data async cache request (no login)
         """
+        if get_example_database().backend == "presto":
+            return
+
         app._got_first_request = False
         async_query_manager_factory.init_app(app)
         self.logout()

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -124,10 +124,6 @@ def setup_sample_data() -> Any:
     with app.app_context():
         setup_presto_if_needed()
 
-        from superset.cli.test import load_test_users_run
-
-        load_test_users_run()
-
         from superset.examples.css_templates import load_css_templates
 
         load_css_templates()

--- a/tests/integration_tests/core_tests.py
+++ b/tests/integration_tests/core_tests.py
@@ -814,7 +814,7 @@ class TestCore(SupersetTestCase):
         mock_cache.return_value = MockCache()
 
         rv = self.client.get("/superset/explore_json/data/valid-cache-key")
-        self.assertEqual(rv.status_code, 401)
+        self.assertEqual(rv.status_code, 403)
 
     def test_explore_json_data_invalid_cache_key(self):
         self.login(ADMIN_USERNAME)

--- a/tests/integration_tests/dashboard_tests.py
+++ b/tests/integration_tests/dashboard_tests.py
@@ -186,7 +186,11 @@ class TestDashboard(SupersetTestCase):
         # Cleanup
         self.revoke_public_access_to_table(table)
 
-    @pytest.mark.usefixtures("load_energy_table_with_slice", "load_dashboard")
+    @pytest.mark.usefixtures(
+        "public_role_like_gamma",
+        "load_energy_table_with_slice",
+        "load_dashboard",
+    )
     def test_users_can_list_published_dashboard(self):
         self.login(ALPHA_USERNAME)
         resp = self.get_resp("/api/v1/dashboard/")

--- a/tests/integration_tests/dashboards/commands_tests.py
+++ b/tests/integration_tests/dashboards/commands_tests.py
@@ -592,7 +592,6 @@ class TestImportDashboardsCommand(SupersetTestCase):
         }
         command = v1.ImportDashboardsCommand(contents, overwrite=True)
         command.run()
-        command.run()
 
         new_num_dashboards = db.session.query(Dashboard).count()
         assert new_num_dashboards == num_dashboards + 1

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -281,7 +281,6 @@ class TestDatabaseApi(SupersetTestCase):
             "server_cert": None,
             "extra": json.dumps(extra),
         }
-
         uri = "api/v1/database/"
         rv = self.client.post(uri, json=database_data)
         response = json.loads(rv.data.decode("utf-8"))
@@ -713,7 +712,6 @@ class TestDatabaseApi(SupersetTestCase):
             "sqlalchemy_uri": example_db.sqlalchemy_uri_decrypted,
             "ssh_tunnel": ssh_tunnel_properties,
         }
-
         uri = "api/v1/database/"
         rv = self.client.post(uri, json=database_data)
         response = json.loads(rv.data.decode("utf-8"))
@@ -839,16 +837,12 @@ class TestDatabaseApi(SupersetTestCase):
         db.session.delete(model)
         db.session.commit()
 
-    @mock.patch(
-        "superset.commands.database.test_connection.TestConnectionDatabaseCommand.run",
-    )
     @mock.patch("superset.models.core.Database.get_all_catalog_names")
     @mock.patch("superset.models.core.Database.get_all_schema_names")
     def test_if_ssh_tunneling_flag_is_not_active_it_raises_new_exception(
         self,
         mock_get_all_schema_names,
         mock_get_all_catalog_names,
-        mock_test_connection_database_command_run,
     ):
         """
         Database API: Test raises SSHTunneling feature flag not enabled
@@ -927,7 +921,6 @@ class TestDatabaseApi(SupersetTestCase):
             "server_cert": None,
             "extra": json.dumps(extra),
         }
-
         uri = "api/v1/database/"
         rv = self.client.post(uri, json=database_data)
         response = json.loads(rv.data.decode("utf-8"))

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -26,17 +26,13 @@ import prison
 import pytest
 import yaml
 from sqlalchemy import inspect
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import func
 
 from superset import app  # noqa: F401
 from superset.commands.dataset.exceptions import DatasetCreateFailedError
 from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn
-from superset.daos.exceptions import (
-    DAOCreateFailedError,
-    DAODeleteFailedError,
-    DAOUpdateFailedError,
-)
 from superset.extensions import db, security_manager
 from superset.models.core import Database
 from superset.models.slice import Slice
@@ -197,7 +193,6 @@ class TestDatasetApi(SupersetTestCase):
         def count_datasets():
             uri = "api/v1/chart/"
             rv = self.client.get(uri, "get_list")
-            print(rv.data)
             self.assertEqual(rv.status_code, 200)
             data = rv.get_json()
             return data["count"]
@@ -879,7 +874,7 @@ class TestDatasetApi(SupersetTestCase):
         Dataset API: Test create dataset sqlalchemy error
         """
 
-        mock_dao_create.side_effect = DAOCreateFailedError()
+        mock_dao_create.side_effect = SQLAlchemyError()
         self.login(ADMIN_USERNAME)
         main_db = get_main_database()
         dataset_data = {
@@ -1487,7 +1482,7 @@ class TestDatasetApi(SupersetTestCase):
         Dataset API: Test update dataset sqlalchemy error
         """
 
-        mock_dao_update.side_effect = DAOUpdateFailedError()
+        mock_dao_update.side_effect = SQLAlchemyError()
 
         dataset = self.insert_default_dataset()
         self.login(ADMIN_USERNAME)
@@ -1551,7 +1546,7 @@ class TestDatasetApi(SupersetTestCase):
         Dataset API: Test delete dataset sqlalchemy error
         """
 
-        mock_dao_delete.side_effect = DAODeleteFailedError()
+        mock_dao_delete.side_effect = SQLAlchemyError()
 
         dataset = self.insert_default_dataset()
         self.login(ADMIN_USERNAME)
@@ -1620,7 +1615,7 @@ class TestDatasetApi(SupersetTestCase):
         Dataset API: Test delete dataset column
         """
 
-        mock_dao_delete.side_effect = DAODeleteFailedError()
+        mock_dao_delete.side_effect = SQLAlchemyError()
         dataset = self.get_fixture_datasets()[0]
         column_id = dataset.columns[0].id
         self.login(ADMIN_USERNAME)
@@ -1692,7 +1687,7 @@ class TestDatasetApi(SupersetTestCase):
         Dataset API: Test delete dataset metric
         """
 
-        mock_dao_delete.side_effect = DAODeleteFailedError()
+        mock_dao_delete.side_effect = SQLAlchemyError()
         dataset = self.get_fixture_datasets()[0]
         column_id = dataset.metrics[0].id
         self.login(ADMIN_USERNAME)

--- a/tests/integration_tests/datasource_tests.py
+++ b/tests/integration_tests/datasource_tests.py
@@ -88,7 +88,6 @@ class TestDatasource(SupersetTestCase):
         )
 
     def test_always_filter_main_dttm(self):
-        self.login(ADMIN_USERNAME)
         database = get_example_database()
 
         sql = f"SELECT DATE() as default_dttm, DATE() as additional_dttm, 1 as metric;"  # noqa: F541
@@ -363,7 +362,6 @@ class TestDatasource(SupersetTestCase):
             elif k == "owners":
                 self.assertEqual([o["id"] for o in resp[k]], datasource_post["owners"])
             else:
-                print(k)
                 self.assertEqual(resp[k], datasource_post[k])
 
     def test_save_default_endpoint_validation_success(self):

--- a/tests/integration_tests/embedded/api_tests.py
+++ b/tests/integration_tests/embedded/api_tests.py
@@ -44,6 +44,7 @@ class TestEmbeddedDashboardApi(SupersetTestCase):
         self.login(ADMIN_USERNAME)
         self.dash = db.session.query(Dashboard).filter_by(slug="births").first()
         self.embedded = EmbeddedDashboardDAO.upsert(self.dash, [])
+        db.session.flush()
         uri = f"api/v1/{self.resource_name}/{self.embedded.uuid}"
         response = self.client.get(uri)
         self.assert200(response)

--- a/tests/integration_tests/embedded/dao_tests.py
+++ b/tests/integration_tests/embedded/dao_tests.py
@@ -34,17 +34,21 @@ class TestEmbeddedDashboardDAO(SupersetTestCase):
         dash = db.session.query(Dashboard).filter_by(slug="world_health").first()
         assert not dash.embedded
         EmbeddedDashboardDAO.upsert(dash, ["test.example.com"])
+        db.session.flush()
         assert dash.embedded
         self.assertEqual(dash.embedded[0].allowed_domains, ["test.example.com"])
         original_uuid = dash.embedded[0].uuid
         self.assertIsNotNone(original_uuid)
         EmbeddedDashboardDAO.upsert(dash, [])
+        db.session.flush()
         self.assertEqual(dash.embedded[0].allowed_domains, [])
         self.assertEqual(dash.embedded[0].uuid, original_uuid)
 
     @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
     def test_get_by_uuid(self):
         dash = db.session.query(Dashboard).filter_by(slug="world_health").first()
-        uuid = str(EmbeddedDashboardDAO.upsert(dash, ["test.example.com"]).uuid)
+        EmbeddedDashboardDAO.upsert(dash, ["test.example.com"])
+        db.session.flush()
+        uuid = str(dash.embedded[0].uuid)
         embedded = EmbeddedDashboardDAO.find_by_id(uuid)
         self.assertIsNotNone(embedded)

--- a/tests/integration_tests/embedded/test_view.py
+++ b/tests/integration_tests/embedded/test_view.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
 def test_get_embedded_dashboard(client: FlaskClient[Any]):  # noqa: F811
     dash = db.session.query(Dashboard).filter_by(slug="births").first()
     embedded = EmbeddedDashboardDAO.upsert(dash, [])
+    db.session.flush()
     uri = f"embedded/{embedded.uuid}"
     response = client.get(uri)
     assert response.status_code == 200
@@ -57,6 +58,7 @@ def test_get_embedded_dashboard(client: FlaskClient[Any]):  # noqa: F811
 def test_get_embedded_dashboard_referrer_not_allowed(client: FlaskClient[Any]):  # noqa: F811
     dash = db.session.query(Dashboard).filter_by(slug="births").first()
     embedded = EmbeddedDashboardDAO.upsert(dash, ["test.example.com"])
+    db.session.flush()
     uri = f"embedded/{embedded.uuid}"
     response = client.get(uri)
     assert response.status_code == 403

--- a/tests/integration_tests/fixtures/unicode_dashboard.py
+++ b/tests/integration_tests/fixtures/unicode_dashboard.py
@@ -114,7 +114,8 @@ def _create_and_commit_unicode_slice(table: SqlaTable, title: str):
 
 def _cleanup(dash: Dashboard, slice_name: str) -> None:
     db.session.delete(dash)
-    if slice_name:
-        slice = db.session.query(Slice).filter_by(slice_name=slice_name).one_or_none()
+    if slice_name and (
+        slice := db.session.query(Slice).filter_by(slice_name=slice_name).one_or_none()
+    ):
         db.session.delete(slice)
     db.session.commit()

--- a/tests/integration_tests/security/row_level_security_tests.py
+++ b/tests/integration_tests/security/row_level_security_tests.py
@@ -215,8 +215,6 @@ class TestRowLevelSecurity(SupersetTestCase):
             },
         )
         self.assertEqual(rv.status_code, 422)
-        data = json.loads(rv.data.decode("utf-8"))
-        assert "Create failed" in data["message"]
 
     @pytest.mark.usefixtures("create_dataset")
     def test_model_view_rls_add_tables_required(self):

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -543,8 +543,7 @@ class TestDatabaseModel(SupersetTestCase):
 
         # make sure the columns have been mapped properly
         assert len(table.columns) == 4
-        with db.session.no_autoflush:
-            table.fetch_metadata(commit=False)
+        table.fetch_metadata()
 
         # assert that the removed column has been dropped and
         # the physical and calculated columns are present

--- a/tests/integration_tests/sqllab_tests.py
+++ b/tests/integration_tests/sqllab_tests.py
@@ -73,7 +73,6 @@ class TestSqlLab(SupersetTestCase):
 
     def run_some_queries(self):
         db.session.query(Query).delete()
-        db.session.commit()
         self.run_sql(QUERY_1, client_id="client_id_1", username="admin")
         self.run_sql(QUERY_2, client_id="client_id_2", username="admin")
         self.run_sql(QUERY_3, client_id="client_id_3", username="gamma_sqllab")

--- a/tests/integration_tests/superset_test_config.py
+++ b/tests/integration_tests/superset_test_config.py
@@ -95,6 +95,7 @@ WTF_CSRF_ENABLED = False
 
 FAB_ROLES = {"TestRole": [["Security", "menu_access"], ["List Users", "menu_access"]]}
 
+PUBLIC_ROLE_LIKE = "Gamma"
 AUTH_ROLE_PUBLIC = "Public"
 EMAIL_NOTIFICATIONS = False
 REDIS_HOST = os.environ.get("REDIS_HOST", "localhost")  # noqa: F405

--- a/tests/integration_tests/tags/dao_tests.py
+++ b/tests/integration_tests/tags/dao_tests.py
@@ -18,7 +18,6 @@
 from operator import and_
 from unittest.mock import patch  # noqa: F401
 import pytest
-from superset.daos.exceptions import DAOCreateFailedError, DAOException  # noqa: F401
 from superset.models.slice import Slice
 from superset.models.sql_lab import SavedQuery  # noqa: F401
 from superset.daos.tag import TagDAO
@@ -188,6 +187,7 @@ class TestTagsDAO(SupersetTestCase):
                     TaggedObject.object_type == ObjectType.chart,
                 ),
             )
+            .join(Tag, TaggedObject.tag_id == Tag.id)
             .distinct(Slice.id)
             .count()
         )
@@ -200,6 +200,7 @@ class TestTagsDAO(SupersetTestCase):
                     TaggedObject.object_type == ObjectType.dashboard,
                 ),
             )
+            .join(Tag, TaggedObject.tag_id == Tag.id)
             .distinct(Dashboard.id)
             .count()
             + num_charts

--- a/tests/unit_tests/commands/databases/create_test.py
+++ b/tests/unit_tests/commands/databases/create_test.py
@@ -29,7 +29,6 @@ def database_with_catalog(mocker: MockerFixture) -> MagicMock:
     """
     Mock a database with catalogs and schemas.
     """
-    mocker.patch("superset.commands.database.create.db")
     mocker.patch("superset.commands.database.create.TestConnectionDatabaseCommand")
 
     database = mocker.MagicMock()
@@ -53,7 +52,6 @@ def database_without_catalog(mocker: MockerFixture) -> MagicMock:
     """
     Mock a database without catalogs.
     """
-    mocker.patch("superset.commands.database.create.db")
     mocker.patch("superset.commands.database.create.TestConnectionDatabaseCommand")
 
     database = mocker.MagicMock()

--- a/tests/unit_tests/commands/databases/update_test.py
+++ b/tests/unit_tests/commands/databases/update_test.py
@@ -29,8 +29,6 @@ def database_with_catalog(mocker: MockerFixture) -> MagicMock:
     """
     Mock a database with catalogs and schemas.
     """
-    mocker.patch("superset.commands.database.update.db")
-
     database = mocker.MagicMock()
     database.database_name = "my_db"
     database.db_engine_spec.__name__ = "test_engine"
@@ -50,8 +48,6 @@ def database_without_catalog(mocker: MockerFixture) -> MagicMock:
     """
     Mock a database without catalogs.
     """
-    mocker.patch("superset.commands.database.update.db")
-
     database = mocker.MagicMock()
     database.database_name = "my_db"
     database.db_engine_spec.__name__ = "test_engine"

--- a/tests/unit_tests/dao/tag_test.py
+++ b/tests/unit_tests/dao/tag_test.py
@@ -22,7 +22,6 @@ def test_user_favorite_tag(mocker):
     from superset.daos.tag import TagDAO
 
     # Mock the behavior of TagDAO and g
-    mock_session = mocker.patch("superset.daos.tag.db.session")
     mock_TagDAO = mocker.patch(
         "superset.daos.tag.TagDAO"
     )  # Replace with the actual path to TagDAO
@@ -40,14 +39,11 @@ def test_user_favorite_tag(mocker):
     # Check that users_favorited was updated correctly
     assert mock_TagDAO.find_by_id().users_favorited == [mock_g.user]
 
-    mock_session.commit.assert_called_once()
-
 
 def test_remove_user_favorite_tag(mocker):
     from superset.daos.tag import TagDAO
 
     # Mock the behavior of TagDAO and g
-    mock_session = mocker.patch("superset.daos.tag.db.session")
     mock_TagDAO = mocker.patch("superset.daos.tag.TagDAO")
     mock_tag = mocker.MagicMock(users_favorited=[])
     mock_TagDAO.find_by_id.return_value = mock_tag
@@ -67,9 +63,6 @@ def test_remove_user_favorite_tag(mocker):
 
     # Check that users_favorited no longer contains the user
     assert mock_user not in mock_tag.users_favorited
-
-    # Check that the db.session.was committed
-    mock_session.commit.assert_called_once()
 
 
 def test_remove_user_favorite_tag_no_user(mocker):

--- a/tests/unit_tests/dao/user_test.py
+++ b/tests/unit_tests/dao/user_test.py
@@ -90,4 +90,3 @@ def test_set_avatar_url_without_existing_attributes(mock_db_session):
     assert len(user.extra_attributes) == 1
     assert user.extra_attributes[0].avatar_url == new_url
     mock_db_session.add.assert_called()  # New attribute should be added
-    mock_db_session.commit.assert_called()

--- a/tests/unit_tests/databases/api_test.py
+++ b/tests/unit_tests/databases/api_test.py
@@ -115,7 +115,7 @@ def test_post_with_uuid(
     payload = response.json
     assert payload["result"]["uuid"] == "7c1b7880-a59d-47cd-8bf1-f1eb8d2863cb"
 
-    database = db.session.query(Database).one()
+    database = session.query(Database).one()
     assert database.uuid == UUID("7c1b7880-a59d-47cd-8bf1-f1eb8d2863cb")
 
 

--- a/tests/unit_tests/databases/ssh_tunnel/commands/create_test.py
+++ b/tests/unit_tests/databases/ssh_tunnel/commands/create_test.py
@@ -36,7 +36,7 @@ def test_create_ssh_tunnel_command() -> None:
     )
 
     properties = {
-        "database_id": database.id,
+        "database": database,
         "server_address": "123.132.123.1",
         "server_port": "3005",
         "username": "foo",

--- a/tests/unit_tests/databases/ssh_tunnel/dao_tests.py
+++ b/tests/unit_tests/databases/ssh_tunnel/dao_tests.py
@@ -31,7 +31,6 @@ def test_create_ssh_tunnel():
             "username": "foo",
             "password": "bar",
         },
-        commit=False,
     )
 
     assert result is not None

--- a/tests/unit_tests/security/manager_test.py
+++ b/tests/unit_tests/security/manager_test.py
@@ -413,7 +413,6 @@ def test_raise_for_access_chart_owner(
         owners=[alpha],
     )
     session.add(slice)
-    session.flush()
 
     with override_user(alpha):
         sm.raise_for_access(

--- a/tests/unit_tests/utils/lock_tests.py
+++ b/tests/unit_tests/utils/lock_tests.py
@@ -22,8 +22,8 @@ from uuid import UUID
 
 import pytest
 from freezegun import freeze_time
-from sqlalchemy.orm import Session, sessionmaker
 
+from superset import db
 from superset.exceptions import CreateKeyValueDistributedLockFailedException
 from superset.key_value.types import JsonKeyValueCodec
 from superset.utils.lock import get_key, KeyValueDistributedLock
@@ -32,56 +32,51 @@ MAIN_KEY = get_key("ns", a=1, b=2)
 OTHER_KEY = get_key("ns2", a=1, b=2)
 
 
-def _get_lock(key: UUID, session: Session) -> Any:
+def _get_lock(key: UUID) -> Any:
     from superset.key_value.models import KeyValueEntry
 
-    entry = session.query(KeyValueEntry).filter_by(uuid=key).first()
+    entry = db.session.query(KeyValueEntry).filter_by(uuid=key).first()
     if entry is None or entry.is_expired():
         return None
 
     return JsonKeyValueCodec().decode(entry.value)
 
 
-def _get_other_session() -> Session:
-    # This session is used to simulate what another worker will find in the metastore
-    # during the locking process.
-    from superset import db
-
-    bind = db.session.get_bind()
-    SessionMaker = sessionmaker(bind=bind)
-    return SessionMaker()
-
-
 def test_key_value_distributed_lock_happy_path() -> None:
     """
     Test successfully acquiring and returning the distributed lock.
+
+    Note we use a nested transaction to ensure that the cleanup from the outer context
+    manager is correctly invoked, otherwise a partial rollback would occur leaving the
+    database in a fractured state.
     """
-    session = _get_other_session()
 
     with freeze_time("2021-01-01"):
-        assert _get_lock(MAIN_KEY, session) is None
+        assert _get_lock(MAIN_KEY) is None
+
         with KeyValueDistributedLock("ns", a=1, b=2) as key:
             assert key == MAIN_KEY
-            assert _get_lock(key, session) is True
-            assert _get_lock(OTHER_KEY, session) is None
-            with pytest.raises(CreateKeyValueDistributedLockFailedException):
-                with KeyValueDistributedLock("ns", a=1, b=2):
-                    pass
+            assert _get_lock(key) is True
+            assert _get_lock(OTHER_KEY) is None
 
-        assert _get_lock(MAIN_KEY, session) is None
+            with db.session.begin_nested():
+                with pytest.raises(CreateKeyValueDistributedLockFailedException):
+                    with KeyValueDistributedLock("ns", a=1, b=2):
+                        pass
+
+        assert _get_lock(MAIN_KEY) is None
 
 
 def test_key_value_distributed_lock_expired() -> None:
     """
     Test expiration of the distributed lock
     """
-    session = _get_other_session()
 
-    with freeze_time("2021-01-01T"):
-        assert _get_lock(MAIN_KEY, session) is None
+    with freeze_time("2021-01-01"):
+        assert _get_lock(MAIN_KEY) is None
         with KeyValueDistributedLock("ns", a=1, b=2):
-            assert _get_lock(MAIN_KEY, session) is True
-            with freeze_time("2022-01-01T"):
-                assert _get_lock(MAIN_KEY, session) is None
+            assert _get_lock(MAIN_KEY) is True
+            with freeze_time("2022-01-01"):
+                assert _get_lock(MAIN_KEY) is None
 
-        assert _get_lock(MAIN_KEY, session) is None
+        assert _get_lock(MAIN_KEY) is None


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This is a PR I've had on the back-burner for many months, but have struggled with on numerous occasions—often in part due to the flakey/delicate tests (and their associated frameworks). The initial desire was to fulfill the approach outlined in [[SIP-99B] Proposal for (re)defining a "unit of work"](https://github.com/apache/superset/issues/25108), but alas I failed, in part due to the challenges trying to untangle Superset logic which inherently is not overly conducive to adhering to the construct that a command should serve as a "unit of work".

Why is that? It's complicated, but asynchronous logic does not help given that a Celery task running within the confines of another command needs to read a previously committed state given the `READ COMMITTED` isolation level. Issues like this could likely be overcome by having two commands—prepare and execute—as opposed to a single execute command. 

The TL;DR is this PR should likely be interpreted as the first phase of SIP-99B. The general framework holds, i.e., DAOs no longer commit and a `transaction` decorator is used to wrap any command which perform either an `INSERT`, `UPDATE`, or `DELETE`.

Finally, I apologize for the size of the PR. I struggled to downside the footprint, but once you start enforcing that DAOs should not commit, then the files which touched begins to snowball.

Regrettably my time (for now) working on Apache Superset is likely drawing to a close, so for completeness I thought there was merit in [sharing the incremental diff](https://github.com/john-bodley/superset/compare/john-bodley--dao-nested-session...john-bodley:superset:john-bodley--dao-nested-session-phase-2?expand=1) for what I was hoping to achieve in case @michael-s-molina @villebro et al. wanted to carry the baton on.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/25108
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
