### PR TITLE
fix: update permalink schema

### DIFF
--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -124,7 +124,11 @@
                         "type": "object"
                       },
                       "level": {
-                        "enum": ["info", "warning", "error"],
+                        "enum": [
+                          "info",
+                          "warning",
+                          "error"
+                        ],
                         "type": "string"
                       },
                       "message": {
@@ -206,7 +210,12 @@
         "properties": {
           "annotationType": {
             "description": "Type of annotation layer",
-            "enum": ["FORMULA", "INTERVAL", "EVENT", "TIME_SERIES"],
+            "enum": [
+              "FORMULA",
+              "INTERVAL",
+              "EVENT",
+              "TIME_SERIES"
+            ],
             "type": "string"
           },
           "color": {
@@ -237,7 +246,12 @@
           },
           "opacity": {
             "description": "Opacity of layer",
-            "enum": ["", "opacityLow", "opacityMedium", "opacityHigh"],
+            "enum": [
+              "",
+              "opacityLow",
+              "opacityMedium",
+              "opacityHigh"
+            ],
             "nullable": true,
             "type": "string"
           },
@@ -264,12 +278,22 @@
           },
           "sourceType": {
             "description": "Type of source for annotation data",
-            "enum": ["", "line", "NATIVE", "table"],
+            "enum": [
+              "",
+              "line",
+              "NATIVE",
+              "table"
+            ],
             "type": "string"
           },
           "style": {
             "description": "Line style. Only applies to time-series annotations",
-            "enum": ["dashed", "dotted", "solid", "longDashed"],
+            "enum": [
+              "dashed",
+              "dotted",
+              "solid",
+              "longDashed"
+            ],
             "type": "string"
           },
           "timeColumn": {
@@ -287,12 +311,16 @@
           },
           "width": {
             "description": "Width of annotation line",
-            "format": "float",
-            "minimum": 0,
+            "minimum": 0.0,
             "type": "number"
           }
         },
-        "required": ["name", "show", "showMarkers", "value"],
+        "required": [
+          "name",
+          "show",
+          "showMarkers",
+          "value"
+        ],
         "type": "object"
       },
       "AnnotationLayerRestApi.get": {
@@ -302,7 +330,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "name": {
@@ -316,7 +343,7 @@
       "AnnotationLayerRestApi.get_list": {
         "properties": {
           "changed_by": {
-            "$ref": "#/components/schemas/AnnotationLayerRestApi.get_list.User"
+            "$ref": "#/components/schemas/AnnotationLayerRestApi.get_list.User1"
           },
           "changed_on": {
             "format": "date-time",
@@ -327,7 +354,7 @@
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/AnnotationLayerRestApi.get_list.User1"
+            "$ref": "#/components/schemas/AnnotationLayerRestApi.get_list.User"
           },
           "created_on": {
             "format": "date-time",
@@ -339,7 +366,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "name": {
@@ -361,7 +387,10 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "AnnotationLayerRestApi.get_list.User1": {
@@ -375,7 +404,10 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "AnnotationLayerRestApi.post": {
@@ -392,7 +424,9 @@
             "type": "string"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "AnnotationLayerRestApi.put": {
@@ -418,7 +452,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "json_metadata": {
@@ -443,13 +476,14 @@
             "type": "string"
           }
         },
-        "required": ["layer"],
+        "required": [
+          "layer"
+        ],
         "type": "object"
       },
       "AnnotationRestApi.get.AnnotationLayer": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "name": {
@@ -463,13 +497,13 @@
       "AnnotationRestApi.get_list": {
         "properties": {
           "changed_by": {
-            "$ref": "#/components/schemas/AnnotationRestApi.get_list.User"
+            "$ref": "#/components/schemas/AnnotationRestApi.get_list.User1"
           },
           "changed_on_delta_humanized": {
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/AnnotationRestApi.get_list.User1"
+            "$ref": "#/components/schemas/AnnotationRestApi.get_list.User"
           },
           "end_dttm": {
             "format": "date-time",
@@ -477,7 +511,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "long_descr": {
@@ -504,11 +537,12 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
-        "required": ["first_name"],
+        "required": [
+          "first_name"
+        ],
         "type": "object"
       },
       "AnnotationRestApi.get_list.User1": {
@@ -518,11 +552,12 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
-        "required": ["first_name"],
+        "required": [
+          "first_name"
+        ],
         "type": "object"
       },
       "AnnotationRestApi.post": {
@@ -554,7 +589,11 @@
             "type": "string"
           }
         },
-        "required": ["end_dttm", "short_descr", "start_dttm"],
+        "required": [
+          "end_dttm",
+          "short_descr",
+          "start_dttm"
+        ],
         "type": "object"
       },
       "AnnotationRestApi.put": {
@@ -621,7 +660,6 @@
       "CacheRestApi.get": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
@@ -630,7 +668,6 @@
       "CacheRestApi.get_list": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
@@ -639,7 +676,6 @@
       "CacheRestApi.post": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
@@ -648,7 +684,6 @@
       "CacheRestApi.put": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
@@ -671,11 +706,67 @@
         },
         "type": "object"
       },
+      "ChartCacheWarmUpRequestSchema": {
+        "properties": {
+          "chart_id": {
+            "description": "The ID of the chart to warm up cache for",
+            "type": "integer"
+          },
+          "dashboard_id": {
+            "description": "The ID of the dashboard to get filters for when warming cache",
+            "type": "integer"
+          },
+          "extra_filters": {
+            "description": "Extra filters to apply when warming up cache",
+            "type": "string"
+          }
+        },
+        "required": [
+          "chart_id"
+        ],
+        "type": "object"
+      },
+      "ChartCacheWarmUpResponseSchema": {
+        "properties": {
+          "result": {
+            "description": "A list of each chart's warmup status and errors if any",
+            "items": {
+              "$ref": "#/components/schemas/ChartCacheWarmUpResponseSingle"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ChartCacheWarmUpResponseSingle": {
+        "properties": {
+          "chart_id": {
+            "description": "The ID of the chart the status belongs to",
+            "type": "integer"
+          },
+          "viz_error": {
+            "description": "Error that occurred when warming cache for chart",
+            "type": "string"
+          },
+          "viz_status": {
+            "description": "Status of the underlying query for the viz",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "ChartDataAdhocMetricSchema": {
         "properties": {
           "aggregate": {
-            "description": "Aggregation operator. Only required for simple expression types.",
-            "enum": ["AVG", "COUNT", "COUNT_DISTINCT", "MAX", "MIN", "SUM"],
+            "description": "Aggregation operator.Only required for simple expression types.",
+            "enum": [
+              "AVG",
+              "COUNT",
+              "COUNT_DISTINCT",
+              "MAX",
+              "MIN",
+              "SUM"
+            ],
             "type": "string"
           },
           "column": {
@@ -683,7 +774,10 @@
           },
           "expressionType": {
             "description": "Simple or SQL metric",
-            "enum": ["SIMPLE", "SQL"],
+            "enum": [
+              "SIMPLE",
+              "SQL"
+            ],
             "example": "SQL",
             "type": "string"
           },
@@ -697,12 +791,12 @@
             "type": "boolean"
           },
           "label": {
-            "description": "Label for the metric. Is automatically generated unless hasCustomLabel is true, in which case label must be defined.",
+            "description": "Label for the metric. Is automatically generated unlesshasCustomLabel is true, in which case label must be defined.",
             "example": "Weighted observations",
             "type": "string"
           },
           "optionName": {
-            "description": "Unique identifier. Can be any string value, as long as all metrics have a unique identifier. If undefined, a random name will be generated.",
+            "description": "Unique identifier. Can be any string value, as long as all metrics have a unique identifier. If undefined, a random namewill be generated.",
             "example": "metric_aec60732-fac0-4b17-b736-93f1a5c93e30",
             "type": "string"
           },
@@ -717,7 +811,9 @@
             "type": "string"
           }
         },
-        "required": ["expressionType"],
+        "required": [
+          "expressionType"
+        ],
         "type": "object"
       },
       "ChartDataAggregateOptionsSchema": {
@@ -782,16 +878,25 @@
           },
           "percentiles": {
             "description": "Upper and lower percentiles for percentile whisker type.",
-            "example": [1, 99]
+            "example": [
+              1,
+              99
+            ]
           },
           "whisker_type": {
             "description": "Whisker type. Any numpy function will work.",
-            "enum": ["tukey", "min/max", "percentile"],
+            "enum": [
+              "tukey",
+              "min/max",
+              "percentile"
+            ],
             "example": "tukey",
             "type": "string"
           }
         },
-        "required": ["whisker_type"],
+        "required": [
+          "whisker_type"
+        ],
         "type": "object"
       },
       "ChartDataColumn": {
@@ -813,19 +918,23 @@
         "properties": {
           "orientation": {
             "description": "Should cell values be calculated across the row or column.",
-            "enum": ["row", "column"],
+            "enum": [
+              "row",
+              "column"
+            ],
             "example": "row",
             "type": "string"
           }
         },
-        "required": ["orientation"],
+        "required": [
+          "orientation"
+        ],
         "type": "object"
       },
       "ChartDataDatasource": {
         "properties": {
           "id": {
             "description": "Datasource id",
-            "format": "int32",
             "type": "integer"
           },
           "type": {
@@ -841,7 +950,9 @@
             "type": "string"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "type": "object"
       },
       "ChartDataExtras": {
@@ -852,12 +963,18 @@
           },
           "relative_end": {
             "description": "End time for relative time deltas. Default: `config[\"DEFAULT_RELATIVE_START_TIME\"]`",
-            "enum": ["today", "now"],
+            "enum": [
+              "today",
+              "now"
+            ],
             "type": "string"
           },
           "relative_start": {
             "description": "Start time for relative time deltas. Default: `config[\"DEFAULT_RELATIVE_START_TIME\"]`",
-            "enum": ["today", "now"],
+            "enum": [
+              "today",
+              "now"
+            ],
             "type": "string"
           },
           "time_grain_sqla": {
@@ -881,7 +998,12 @@
               "1969-12-28T00:00:00Z/P1W",
               "1969-12-29T00:00:00Z/P1W",
               "P1W/1970-01-03T00:00:00Z",
-              "P1W/1970-01-04T00:00:00Z"
+              "P1W/1970-01-04T00:00:00Z",
+              "PT2H",
+              "PT4H",
+              "PT8H",
+              "PT10H",
+              "PT12H"
             ],
             "example": "P1D",
             "nullable": true,
@@ -924,7 +1046,6 @@
               "IS NOT NULL",
               "IN",
               "NOT IN",
-              "REGEX",
               "IS TRUE",
               "IS FALSE",
               "TEMPORAL_RANGE"
@@ -934,11 +1055,18 @@
           },
           "val": {
             "description": "The value or values to compare against. Can be a string, integer, decimal, None or list, depending on the operator.",
-            "example": ["China", "France", "Japan"],
+            "example": [
+              "China",
+              "France",
+              "Japan"
+            ],
             "nullable": true
           }
         },
-        "required": ["col", "op"],
+        "required": [
+          "col",
+          "op"
+        ],
         "type": "object"
       },
       "ChartDataGeodeticParseOptionsSchema": {
@@ -960,7 +1088,11 @@
             "type": "string"
           }
         },
-        "required": ["geodetic", "latitude", "longitude"],
+        "required": [
+          "geodetic",
+          "latitude",
+          "longitude"
+        ],
         "type": "object"
       },
       "ChartDataGeohashDecodeOptionsSchema": {
@@ -978,7 +1110,11 @@
             "type": "string"
           }
         },
-        "required": ["geohash", "latitude", "longitude"],
+        "required": [
+          "geohash",
+          "latitude",
+          "longitude"
+        ],
         "type": "object"
       },
       "ChartDataGeohashEncodeOptionsSchema": {
@@ -996,7 +1132,11 @@
             "type": "string"
           }
         },
-        "required": ["geohash", "latitude", "longitude"],
+        "required": [
+          "geohash",
+          "latitude",
+          "longitude"
+        ],
         "type": "object"
       },
       "ChartDataPivotOptionsSchema": {
@@ -1088,12 +1228,17 @@
                   }
                 }
               },
-              "groupby": ["country", "gender"]
+              "groupby": [
+                "country",
+                "gender"
+              ]
             },
             "type": "object"
           }
         },
-        "required": ["operation"],
+        "required": [
+          "operation"
+        ],
         "type": "object"
       },
       "ChartDataProphetOptionsSchema": {
@@ -1101,9 +1246,8 @@
           "confidence_interval": {
             "description": "Width of predicted confidence interval",
             "example": 0.8,
-            "format": "float",
-            "maximum": 1,
-            "minimum": 0,
+            "maximum": 1.0,
+            "minimum": 0.0,
             "type": "number"
           },
           "monthly_seasonality": {
@@ -1113,7 +1257,6 @@
           "periods": {
             "description": "Time periods (in units of `time_grain`) to predict into the future",
             "example": 7,
-            "format": "int32",
             "type": "integer"
           },
           "time_grain": {
@@ -1137,7 +1280,12 @@
               "1969-12-28T00:00:00Z/P1W",
               "1969-12-29T00:00:00Z/P1W",
               "P1W/1970-01-03T00:00:00Z",
-              "P1W/1970-01-04T00:00:00Z"
+              "P1W/1970-01-04T00:00:00Z",
+              "PT2H",
+              "PT4H",
+              "PT8H",
+              "PT10H",
+              "PT12H"
             ],
             "example": "P1D",
             "type": "string"
@@ -1151,14 +1299,17 @@
             "example": false
           }
         },
-        "required": ["confidence_interval", "periods", "time_grain"],
+        "required": [
+          "confidence_interval",
+          "periods",
+          "time_grain"
+        ],
         "type": "object"
       },
       "ChartDataQueryContextSchema": {
         "properties": {
           "custom_cache_timeout": {
             "description": "Override the default cache timeout",
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -1179,8 +1330,25 @@
             },
             "type": "array"
           },
-          "result_format": {},
-          "result_type": {}
+          "result_format": {
+            "enum": [
+              "csv",
+              "json",
+              "xlsx"
+            ]
+          },
+          "result_type": {
+            "enum": [
+              "columns",
+              "full",
+              "query",
+              "results",
+              "samples",
+              "timegrains",
+              "post_processed",
+              "drill_detail"
+            ]
+          }
         },
         "type": "object"
       },
@@ -1238,11 +1406,12 @@
             "type": "array"
           },
           "granularity": {
-            "description": "Name of temporal column used for time filtering.",
+            "description": "Name of temporal column used for time filtering. ",
             "nullable": true,
             "type": "string"
           },
           "granularity_sqla": {
+            "deprecated": true,
             "description": "Name of temporal column used for time filtering for SQL datasources. This field is deprecated, use `granularity` instead.",
             "nullable": true,
             "type": "string"
@@ -1254,6 +1423,7 @@
             "type": "array"
           },
           "having": {
+            "deprecated": true,
             "description": "HAVING clause to be added to aggregate queries using AND operator. This field is deprecated and should be passed to `extras`.",
             "nullable": true,
             "type": "string"
@@ -1282,8 +1452,14 @@
           "orderby": {
             "description": "Expects a list of lists where the first element is the column name which to sort by, and the second element is a boolean.",
             "example": [
-              ["my_col_1", false],
-              ["my_col_2", true]
+              [
+                "my_col_1",
+                false
+              ],
+              [
+                "my_col_2",
+                true
+              ]
             ],
             "items": {},
             "nullable": true,
@@ -1303,18 +1479,26 @@
             "type": "array"
           },
           "result_type": {
+            "enum": [
+              "columns",
+              "full",
+              "query",
+              "results",
+              "samples",
+              "timegrains",
+              "post_processed",
+              "drill_detail"
+            ],
             "nullable": true
           },
           "row_limit": {
             "description": "Maximum row count (0=disabled). Default: `config[\"ROW_LIMIT\"]`",
-            "format": "int32",
             "minimum": 0,
             "nullable": true,
             "type": "integer"
           },
           "row_offset": {
             "description": "Number of rows to skip. Default: `0`",
-            "format": "int32",
             "minimum": 0,
             "nullable": true,
             "type": "integer"
@@ -1327,7 +1511,6 @@
           },
           "series_limit": {
             "description": "Maximum number of series. Requires `series` and `series_limit_metric` to be set.",
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -1355,7 +1538,6 @@
           },
           "timeseries_limit": {
             "description": "Maximum row count for timeseries queries. This field is deprecated, use `series_limit` instead.Default: `0`",
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -1368,11 +1550,12 @@
               "description": "The value of the query parameter",
               "type": "string"
             },
-            "description": "Optional query parameters passed to a dashboard or Explore view",
+            "description": "Optional query parameters passed to a dashboard or Explore  view",
             "nullable": true,
             "type": "object"
           },
           "where": {
+            "deprecated": true,
             "description": "WHERE clause to be added to queries using AND operator.This field is deprecated and should be passed to `extras`.",
             "nullable": true,
             "type": "string"
@@ -1407,7 +1590,6 @@
           },
           "cache_timeout": {
             "description": "Cache timeout in following order: custom timeout, datasource timeout, cache default timeout, config default cache timeout.",
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -1426,7 +1608,6 @@
           "coltypes": {
             "description": "A list of generic data types of each column",
             "items": {
-              "format": "int32",
               "type": "integer"
             },
             "type": "array"
@@ -1445,7 +1626,6 @@
           },
           "from_dttm": {
             "description": "Start timestamp of time range",
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -1466,7 +1646,6 @@
           },
           "rowcount": {
             "description": "Amount of rows in result set",
-            "format": "int32",
             "type": "integer"
           },
           "stacktrace": {
@@ -1489,7 +1668,6 @@
           },
           "to_dttm": {
             "description": "End timestamp of time range",
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           }
@@ -1518,7 +1696,6 @@
       "ChartDataRestApi.get": {
         "properties": {
           "cache_timeout": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -1541,7 +1718,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "is_managed_externally": {
@@ -1562,6 +1738,9 @@
             "maxLength": 250,
             "nullable": true,
             "type": "string"
+          },
+          "tags": {
+            "$ref": "#/components/schemas/ChartDataRestApi.get.Tag"
           },
           "thumbnail_url": {
             "readOnly": true
@@ -1585,12 +1764,32 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "json_metadata": {
             "nullable": true,
             "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ChartDataRestApi.get.Tag": {
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "maxLength": 250,
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
           }
         },
         "type": "object"
@@ -1602,25 +1801,22 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "last_name": {
             "maxLength": 64,
             "type": "string"
-          },
-          "username": {
-            "maxLength": 64,
-            "type": "string"
           }
         },
-        "required": ["first_name", "last_name", "username"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ChartDataRestApi.get_list": {
         "properties": {
           "cache_timeout": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -1633,12 +1829,9 @@
             "type": "string"
           },
           "changed_by": {
-            "$ref": "#/components/schemas/ChartDataRestApi.get_list.User"
+            "$ref": "#/components/schemas/ChartDataRestApi.get_list.User3"
           },
           "changed_by_name": {
-            "readOnly": true
-          },
-          "changed_by_url": {
             "readOnly": true
           },
           "changed_on_delta_humanized": {
@@ -1651,12 +1844,9 @@
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/ChartDataRestApi.get_list.User2"
+            "$ref": "#/components/schemas/ChartDataRestApi.get_list.User"
           },
           "created_by_name": {
-            "readOnly": true
-          },
-          "created_by_url": {
             "readOnly": true
           },
           "created_on_delta_humanized": {
@@ -1666,7 +1856,6 @@
             "$ref": "#/components/schemas/ChartDataRestApi.get_list.Dashboard"
           },
           "datasource_id": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -1695,7 +1884,6 @@
             "readOnly": true
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "is_managed_externally": {
@@ -1707,10 +1895,10 @@
             "type": "string"
           },
           "last_saved_by": {
-            "$ref": "#/components/schemas/ChartDataRestApi.get_list.User1"
+            "$ref": "#/components/schemas/ChartDataRestApi.get_list.User2"
           },
           "owners": {
-            "$ref": "#/components/schemas/ChartDataRestApi.get_list.User3"
+            "$ref": "#/components/schemas/ChartDataRestApi.get_list.User1"
           },
           "params": {
             "nullable": true,
@@ -1726,6 +1914,9 @@
           },
           "table": {
             "$ref": "#/components/schemas/ChartDataRestApi.get_list.SqlaTable"
+          },
+          "tags": {
+            "$ref": "#/components/schemas/ChartDataRestApi.get_list.Tag"
           },
           "thumbnail_url": {
             "readOnly": true
@@ -1749,7 +1940,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
@@ -1766,7 +1956,30 @@
             "type": "string"
           }
         },
-        "required": ["table_name"],
+        "required": [
+          "table_name"
+        ],
+        "type": "object"
+      },
+      "ChartDataRestApi.get_list.Tag": {
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "maxLength": 250,
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
+          }
+        },
         "type": "object"
       },
       "ChartDataRestApi.get_list.User": {
@@ -1775,12 +1988,18 @@
             "maxLength": 64,
             "type": "string"
           },
+          "id": {
+            "type": "integer"
+          },
           "last_name": {
             "maxLength": 64,
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ChartDataRestApi.get_list.User1": {
@@ -1790,7 +2009,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "last_name": {
@@ -1798,7 +2016,10 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ChartDataRestApi.get_list.User2": {
@@ -1808,7 +2029,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "last_name": {
@@ -1816,7 +2036,10 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ChartDataRestApi.get_list.User3": {
@@ -1825,27 +2048,21 @@
             "maxLength": 64,
             "type": "string"
           },
-          "id": {
-            "format": "int32",
-            "type": "integer"
-          },
           "last_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
-          "username": {
             "maxLength": 64,
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name", "username"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ChartDataRestApi.post": {
         "properties": {
           "cache_timeout": {
             "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.",
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -1862,14 +2079,12 @@
           "dashboards": {
             "items": {
               "description": "A list of dashboards to include this new chart to.",
-              "format": "int32",
               "type": "integer"
             },
             "type": "array"
           },
           "datasource_id": {
             "description": "The id of the dataset/datasource this new chart will use. A complete datasource identification needs `datasouce_id` and `datasource_type`.",
-            "format": "int32",
             "type": "integer"
           },
           "datasource_name": {
@@ -1905,7 +2120,6 @@
           "owners": {
             "items": {
               "description": "Owner are users ids allowed to delete or change this chart. If left empty you will be one of the owners of the chart.",
-              "format": "int32",
               "type": "integer"
             },
             "type": "array"
@@ -1933,20 +2147,27 @@
           },
           "viz_type": {
             "description": "The type of chart visualization used.",
-            "example": ["bar", "area", "table"],
+            "example": [
+              "bar",
+              "area",
+              "table"
+            ],
             "maxLength": 250,
             "minLength": 0,
             "type": "string"
           }
         },
-        "required": ["datasource_id", "datasource_type", "slice_name"],
+        "required": [
+          "datasource_id",
+          "datasource_type",
+          "slice_name"
+        ],
         "type": "object"
       },
       "ChartDataRestApi.put": {
         "properties": {
           "cache_timeout": {
             "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.",
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -1963,14 +2184,12 @@
           "dashboards": {
             "items": {
               "description": "A list of dashboards to include this new chart to.",
-              "format": "int32",
               "type": "integer"
             },
             "type": "array"
           },
           "datasource_id": {
             "description": "The id of the dataset/datasource this new chart will use. A complete datasource identification needs `datasouce_id` and `datasource_type`.",
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -2003,7 +2222,6 @@
           "owners": {
             "items": {
               "description": "Owner are users ids allowed to delete or change this chart. If left empty you will be one of the owners of the chart.",
-              "format": "int32",
               "type": "integer"
             },
             "type": "array"
@@ -2030,9 +2248,19 @@
             "nullable": true,
             "type": "string"
           },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            },
+            "type": "array"
+          },
           "viz_type": {
             "description": "The type of chart visualization used.",
-            "example": ["bar", "area", "table"],
+            "example": [
+              "bar",
+              "area",
+              "table"
+            ],
             "maxLength": 250,
             "minLength": 0,
             "nullable": true,
@@ -2044,14 +2272,13 @@
       "ChartDataRollingOptionsSchema": {
         "properties": {
           "center": {
-            "description": "Should the label be at the center of the window. Default: `false`",
+            "description": "Should the label be at the center of the window.Default: `false`",
             "example": false,
             "type": "boolean"
           },
           "min_periods": {
             "description": "The minimum amount of periods required for a row to be included in the result set.",
             "example": 7,
-            "format": "int32",
             "type": "integer"
           },
           "rolling_type": {
@@ -2088,7 +2315,7 @@
             "type": "object"
           },
           "win_type": {
-            "description": "Type of window function. See [SciPy window functions](https://docs.scipy.org/doc/scipy/reference/signal.windows.html#module-scipy.signal.windows) for more details. Some window functions require passing additional parameters to `rolling_type_options`. For instance, to use `gaussian`, the parameter `std` needs to be provided.",
+            "description": "Type of window function. See [SciPy window functions](https://docs.scipy.org/doc/scipy/reference /signal.windows.html#module-scipy.signal.windows) for more details. Some window functions require passing additional parameters to `rolling_type_options`. For instance, to use `gaussian`, the parameter `std` needs to be provided.",
             "enum": [
               "boxcar",
               "triang",
@@ -2111,18 +2338,24 @@
           "window": {
             "description": "Size of the rolling window in days.",
             "example": 7,
-            "format": "int32",
             "type": "integer"
           }
         },
-        "required": ["rolling_type", "window"],
+        "required": [
+          "rolling_type",
+          "window"
+        ],
         "type": "object"
       },
       "ChartDataSelectOptionsSchema": {
         "properties": {
           "columns": {
             "description": "Columns which to select from the input data, in the desired order. If columns are renamed, the original column name should be referenced here.",
-            "example": ["country", "gender", "age"],
+            "example": [
+              "country",
+              "gender",
+              "age"
+            ],
             "items": {
               "type": "string"
             },
@@ -2130,7 +2363,9 @@
           },
           "exclude": {
             "description": "Columns to exclude from selection.",
-            "example": ["my_temp_column"],
+            "example": [
+              "my_temp_column"
+            ],
             "items": {
               "type": "string"
             },
@@ -2175,14 +2410,15 @@
             "type": "object"
           }
         },
-        "required": ["columns"],
+        "required": [
+          "columns"
+        ],
         "type": "object"
       },
       "ChartEntityResponseSchema": {
         "properties": {
           "cache_timeout": {
             "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.",
-            "format": "int32",
             "type": "integer"
           },
           "certification_details": {
@@ -2195,6 +2431,7 @@
           },
           "changed_on": {
             "description": "The ISO date that the chart was last changed.",
+            "format": "date-time",
             "type": "string"
           },
           "description": {
@@ -2211,7 +2448,6 @@
           },
           "id": {
             "description": "The id of the chart.",
-            "format": "int32",
             "type": "integer"
           },
           "slice_name": {
@@ -2229,7 +2465,6 @@
         "properties": {
           "id": {
             "description": "The Chart id",
-            "format": "int32",
             "type": "integer"
           },
           "value": {
@@ -2243,12 +2478,10 @@
         "properties": {
           "datasource_id": {
             "description": "The datasource identifier",
-            "format": "int32",
             "type": "integer"
           },
           "datasource_type": {
             "description": "The datasource type",
-            "format": "int32",
             "type": "integer"
           }
         },
@@ -2270,7 +2503,6 @@
         "properties": {
           "count": {
             "description": "The total number of datasources",
-            "format": "int32",
             "type": "integer"
           },
           "result": {
@@ -2282,7 +2514,6 @@
       "ChartRestApi.get": {
         "properties": {
           "cache_timeout": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -2305,7 +2536,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "is_managed_externally": {
@@ -2326,6 +2556,9 @@
             "maxLength": 250,
             "nullable": true,
             "type": "string"
+          },
+          "tags": {
+            "$ref": "#/components/schemas/ChartRestApi.get.Tag"
           },
           "thumbnail_url": {
             "readOnly": true
@@ -2349,12 +2582,32 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "json_metadata": {
             "nullable": true,
             "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ChartRestApi.get.Tag": {
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "maxLength": 250,
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
           }
         },
         "type": "object"
@@ -2366,25 +2619,22 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "last_name": {
             "maxLength": 64,
             "type": "string"
-          },
-          "username": {
-            "maxLength": 64,
-            "type": "string"
           }
         },
-        "required": ["first_name", "last_name", "username"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ChartRestApi.get_list": {
         "properties": {
           "cache_timeout": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -2397,12 +2647,9 @@
             "type": "string"
           },
           "changed_by": {
-            "$ref": "#/components/schemas/ChartRestApi.get_list.User"
+            "$ref": "#/components/schemas/ChartRestApi.get_list.User3"
           },
           "changed_by_name": {
-            "readOnly": true
-          },
-          "changed_by_url": {
             "readOnly": true
           },
           "changed_on_delta_humanized": {
@@ -2415,12 +2662,9 @@
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/ChartRestApi.get_list.User2"
+            "$ref": "#/components/schemas/ChartRestApi.get_list.User"
           },
           "created_by_name": {
-            "readOnly": true
-          },
-          "created_by_url": {
             "readOnly": true
           },
           "created_on_delta_humanized": {
@@ -2430,7 +2674,6 @@
             "$ref": "#/components/schemas/ChartRestApi.get_list.Dashboard"
           },
           "datasource_id": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -2459,7 +2702,6 @@
             "readOnly": true
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "is_managed_externally": {
@@ -2471,10 +2713,10 @@
             "type": "string"
           },
           "last_saved_by": {
-            "$ref": "#/components/schemas/ChartRestApi.get_list.User1"
+            "$ref": "#/components/schemas/ChartRestApi.get_list.User2"
           },
           "owners": {
-            "$ref": "#/components/schemas/ChartRestApi.get_list.User3"
+            "$ref": "#/components/schemas/ChartRestApi.get_list.User1"
           },
           "params": {
             "nullable": true,
@@ -2490,6 +2732,9 @@
           },
           "table": {
             "$ref": "#/components/schemas/ChartRestApi.get_list.SqlaTable"
+          },
+          "tags": {
+            "$ref": "#/components/schemas/ChartRestApi.get_list.Tag"
           },
           "thumbnail_url": {
             "readOnly": true
@@ -2513,7 +2758,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
@@ -2530,7 +2774,30 @@
             "type": "string"
           }
         },
-        "required": ["table_name"],
+        "required": [
+          "table_name"
+        ],
+        "type": "object"
+      },
+      "ChartRestApi.get_list.Tag": {
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "maxLength": 250,
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
+          }
+        },
         "type": "object"
       },
       "ChartRestApi.get_list.User": {
@@ -2539,12 +2806,18 @@
             "maxLength": 64,
             "type": "string"
           },
+          "id": {
+            "type": "integer"
+          },
           "last_name": {
             "maxLength": 64,
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ChartRestApi.get_list.User1": {
@@ -2554,7 +2827,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "last_name": {
@@ -2562,7 +2834,10 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ChartRestApi.get_list.User2": {
@@ -2572,7 +2847,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "last_name": {
@@ -2580,7 +2854,10 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ChartRestApi.get_list.User3": {
@@ -2589,27 +2866,21 @@
             "maxLength": 64,
             "type": "string"
           },
-          "id": {
-            "format": "int32",
-            "type": "integer"
-          },
           "last_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
-          "username": {
             "maxLength": 64,
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name", "username"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ChartRestApi.post": {
         "properties": {
           "cache_timeout": {
             "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.",
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -2626,14 +2897,12 @@
           "dashboards": {
             "items": {
               "description": "A list of dashboards to include this new chart to.",
-              "format": "int32",
               "type": "integer"
             },
             "type": "array"
           },
           "datasource_id": {
             "description": "The id of the dataset/datasource this new chart will use. A complete datasource identification needs `datasouce_id` and `datasource_type`.",
-            "format": "int32",
             "type": "integer"
           },
           "datasource_name": {
@@ -2669,7 +2938,6 @@
           "owners": {
             "items": {
               "description": "Owner are users ids allowed to delete or change this chart. If left empty you will be one of the owners of the chart.",
-              "format": "int32",
               "type": "integer"
             },
             "type": "array"
@@ -2697,20 +2965,27 @@
           },
           "viz_type": {
             "description": "The type of chart visualization used.",
-            "example": ["bar", "area", "table"],
+            "example": [
+              "bar",
+              "area",
+              "table"
+            ],
             "maxLength": 250,
             "minLength": 0,
             "type": "string"
           }
         },
-        "required": ["datasource_id", "datasource_type", "slice_name"],
+        "required": [
+          "datasource_id",
+          "datasource_type",
+          "slice_name"
+        ],
         "type": "object"
       },
       "ChartRestApi.put": {
         "properties": {
           "cache_timeout": {
             "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.",
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -2727,14 +3002,12 @@
           "dashboards": {
             "items": {
               "description": "A list of dashboards to include this new chart to.",
-              "format": "int32",
               "type": "integer"
             },
             "type": "array"
           },
           "datasource_id": {
             "description": "The id of the dataset/datasource this new chart will use. A complete datasource identification needs `datasouce_id` and `datasource_type`.",
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -2767,7 +3040,6 @@
           "owners": {
             "items": {
               "description": "Owner are users ids allowed to delete or change this chart. If left empty you will be one of the owners of the chart.",
-              "format": "int32",
               "type": "integer"
             },
             "type": "array"
@@ -2794,9 +3066,19 @@
             "nullable": true,
             "type": "string"
           },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            },
+            "type": "array"
+          },
           "viz_type": {
             "description": "The type of chart visualization used.",
-            "example": ["bar", "area", "table"],
+            "example": [
+              "bar",
+              "area",
+              "table"
+            ],
             "maxLength": 250,
             "minLength": 0,
             "nullable": true,
@@ -2815,7 +3097,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "template_name": {
@@ -2833,7 +3114,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "last_name": {
@@ -2841,19 +3121,22 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "CssTemplateRestApi.get_list": {
         "properties": {
           "changed_by": {
-            "$ref": "#/components/schemas/CssTemplateRestApi.get_list.User"
+            "$ref": "#/components/schemas/CssTemplateRestApi.get_list.User1"
           },
           "changed_on_delta_humanized": {
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/CssTemplateRestApi.get_list.User1"
+            "$ref": "#/components/schemas/CssTemplateRestApi.get_list.User"
           },
           "created_on": {
             "format": "date-time",
@@ -2865,7 +3148,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "template_name": {
@@ -2883,7 +3165,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "last_name": {
@@ -2891,7 +3172,10 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "CssTemplateRestApi.get_list.User1": {
@@ -2901,7 +3185,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "last_name": {
@@ -2909,7 +3192,10 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "CssTemplateRestApi.post": {
@@ -2940,10 +3226,36 @@
         },
         "type": "object"
       },
+      "DashboardCopySchema": {
+        "properties": {
+          "css": {
+            "description": "Override CSS for the dashboard.",
+            "type": "string"
+          },
+          "dashboard_title": {
+            "description": "A title for the dashboard.",
+            "maxLength": 500,
+            "minLength": 0,
+            "nullable": true,
+            "type": "string"
+          },
+          "duplicate_slices": {
+            "description": "Whether or not to also copy all charts on the dashboard",
+            "type": "boolean"
+          },
+          "json_metadata": {
+            "description": "This JSON object is generated dynamically when clicking the save or overwrite button in the dashboard view. It is exposed here for reference and for power users who may want to alter  specific parameters.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "json_metadata"
+        ],
+        "type": "object"
+      },
       "DashboardDatasetSchema": {
         "properties": {
           "cache_timeout": {
-            "format": "int32",
             "type": "integer"
           },
           "column_formats": {
@@ -2951,7 +3263,6 @@
           },
           "column_types": {
             "items": {
-              "format": "int32",
               "type": "integer"
             },
             "type": "array"
@@ -2961,6 +3272,9 @@
               "type": "object"
             },
             "type": "array"
+          },
+          "currency_formats": {
+            "type": "object"
           },
           "database": {
             "$ref": "#/components/schemas/Database"
@@ -2996,7 +3310,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "is_sqllab_view": {
@@ -3015,7 +3328,6 @@
             "type": "string"
           },
           "offset": {
-            "format": "int32",
             "type": "integer"
           },
           "order_by_choices": {
@@ -3094,9 +3406,6 @@
           "changed_by_name": {
             "type": "string"
           },
-          "changed_by_url": {
-            "type": "string"
-          },
           "changed_on": {
             "format": "date-time",
             "type": "string"
@@ -3120,7 +3429,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "is_managed_externally": {
@@ -3153,6 +3461,12 @@
           "slug": {
             "type": "string"
           },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/Tag1"
+            },
+            "type": "array"
+          },
           "thumbnail_url": {
             "type": "string"
           },
@@ -3162,7 +3476,7 @@
         },
         "type": "object"
       },
-      "DashboardPermalinkPostSchema": {
+      "DashboardPermalinkStateSchema": {
         "properties": {
           "activeTabs": {
             "description": "Current active dashboard tabs",
@@ -3197,7 +3511,6 @@
       "DashboardRestApi.get": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
@@ -3214,12 +3527,9 @@
             "type": "string"
           },
           "changed_by": {
-            "$ref": "#/components/schemas/DashboardRestApi.get_list.User"
+            "$ref": "#/components/schemas/DashboardRestApi.get_list.User2"
           },
           "changed_by_name": {
-            "readOnly": true
-          },
-          "changed_by_url": {
             "readOnly": true
           },
           "changed_on_delta_humanized": {
@@ -3229,7 +3539,7 @@
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/DashboardRestApi.get_list.User1"
+            "$ref": "#/components/schemas/DashboardRestApi.get_list.User"
           },
           "created_on_delta_humanized": {
             "readOnly": true
@@ -3244,7 +3554,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "is_managed_externally": {
@@ -3255,7 +3564,7 @@
             "type": "string"
           },
           "owners": {
-            "$ref": "#/components/schemas/DashboardRestApi.get_list.User2"
+            "$ref": "#/components/schemas/DashboardRestApi.get_list.User1"
           },
           "position_json": {
             "nullable": true,
@@ -3276,6 +3585,9 @@
           "status": {
             "readOnly": true
           },
+          "tags": {
+            "$ref": "#/components/schemas/DashboardRestApi.get_list.Tag"
+          },
           "thumbnail_url": {
             "readOnly": true
           },
@@ -3288,7 +3600,6 @@
       "DashboardRestApi.get_list.Role": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "name": {
@@ -3296,7 +3607,30 @@
             "type": "string"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "DashboardRestApi.get_list.Tag": {
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "maxLength": 250,
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
+          }
+        },
         "type": "object"
       },
       "DashboardRestApi.get_list.User": {
@@ -3306,19 +3640,17 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "last_name": {
             "maxLength": 64,
             "type": "string"
-          },
-          "username": {
-            "maxLength": 64,
-            "type": "string"
           }
         },
-        "required": ["first_name", "last_name", "username"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "DashboardRestApi.get_list.User1": {
@@ -3328,7 +3660,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "last_name": {
@@ -3336,33 +3667,30 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "DashboardRestApi.get_list.User2": {
         "properties": {
-          "email": {
-            "maxLength": 64,
-            "type": "string"
-          },
           "first_name": {
             "maxLength": 64,
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "last_name": {
             "maxLength": 64,
             "type": "string"
-          },
-          "username": {
-            "maxLength": 64,
-            "type": "string"
           }
         },
-        "required": ["email", "first_name", "last_name", "username"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "DashboardRestApi.post": {
@@ -3378,6 +3706,7 @@
             "type": "string"
           },
           "css": {
+            "description": "Override CSS for the dashboard.",
             "type": "string"
           },
           "dashboard_title": {
@@ -3402,7 +3731,6 @@
           "owners": {
             "items": {
               "description": "Owner are users ids allowed to delete or change this dashboard. If left empty you will be one of the owners of the dashboard.",
-              "format": "int32",
               "type": "integer"
             },
             "type": "array"
@@ -3418,7 +3746,6 @@
           "roles": {
             "items": {
               "description": "Roles is a list which defines access to the dashboard. These roles are always applied in addition to restrictions on dataset level access. If no roles defined then the dashboard is available to all roles.",
-              "format": "int32",
               "type": "integer"
             },
             "type": "array"
@@ -3473,7 +3800,6 @@
           "owners": {
             "items": {
               "description": "Owner are users ids allowed to delete or change this dashboard. If left empty you will be one of the owners of the dashboard.",
-              "format": "int32",
               "nullable": true,
               "type": "integer"
             },
@@ -3492,7 +3818,6 @@
           "roles": {
             "items": {
               "description": "Roles is a list which defines access to the dashboard. These roles are always applied in addition to restrictions on dataset level access. If no roles defined then the dashboard is available to all roles.",
-              "format": "int32",
               "nullable": true,
               "type": "integer"
             },
@@ -3526,11 +3851,9 @@
             "type": "boolean"
           },
           "explore_database_id": {
-            "format": "int32",
             "type": "integer"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "name": {
@@ -3542,6 +3865,125 @@
       "Database1": {
         "properties": {
           "database_name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "DatabaseConnectionSchema": {
+        "properties": {
+          "allow_ctas": {
+            "description": "Allow CREATE TABLE AS option in SQL Lab",
+            "type": "boolean"
+          },
+          "allow_cvas": {
+            "description": "Allow CREATE VIEW AS option in SQL Lab",
+            "type": "boolean"
+          },
+          "allow_dml": {
+            "description": "Allow users to run non-SELECT statements (UPDATE, DELETE, CREATE, ...) in SQL Lab",
+            "type": "boolean"
+          },
+          "allow_file_upload": {
+            "description": "Allow to upload CSV file data into this databaseIf selected, please set the schemas allowed for csv upload in Extra.",
+            "type": "boolean"
+          },
+          "allow_run_async": {
+            "description": "Operate the database in asynchronous mode, meaning that the queries are executed on remote workers as opposed to on the web server itself. This assumes that you have a Celery worker setup as well as a results backend. Refer to the installation docs for more information.",
+            "type": "boolean"
+          },
+          "backend": {
+            "description": "SQLAlchemy engine to use",
+            "nullable": true,
+            "type": "string"
+          },
+          "cache_timeout": {
+            "description": "Duration (in seconds) of the caching timeout for charts of this database. A timeout of 0 indicates that the cache never expires. Note this defaults to the global timeout if undefined.",
+            "nullable": true,
+            "type": "integer"
+          },
+          "configuration_method": {
+            "description": "Configuration_method is used on the frontend to inform the backend whether to explode parameters or to provide only a sqlalchemy_uri.",
+            "type": "string"
+          },
+          "database_name": {
+            "description": "A database name to identify this connection.",
+            "maxLength": 250,
+            "minLength": 1,
+            "nullable": true,
+            "type": "string"
+          },
+          "driver": {
+            "description": "SQLAlchemy driver to use",
+            "nullable": true,
+            "type": "string"
+          },
+          "engine_information": {
+            "additionalProperties": {},
+            "type": "object"
+          },
+          "expose_in_sqllab": {
+            "description": "Expose this database to SQLLab",
+            "type": "boolean"
+          },
+          "extra": {
+            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\" rel=\"noopener noreferrer\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\" rel=\"noopener noreferrer\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
+            "type": "string"
+          },
+          "force_ctas_schema": {
+            "description": "When allowing CREATE TABLE AS option in SQL Lab, this option forces the table to be created in this schema",
+            "maxLength": 250,
+            "minLength": 0,
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "description": "Database ID (for updates)",
+            "type": "integer"
+          },
+          "impersonate_user": {
+            "description": "If Presto, all the queries in SQL Lab are going to be executed as the currently logged on user who must have permission to run them.<br/>If Hive and hive.server2.enable.doAs is enabled, will run the queries as service account, but impersonate the currently logged on user via hive.server2.proxy.user property.",
+            "type": "boolean"
+          },
+          "is_managed_externally": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "masked_encrypted_extra": {
+            "description": "<p>JSON string containing additional connection configuration.<br>This is used to provide connection information for systems like Hive, Presto, and BigQuery, which do not conform to the username:password syntax normally used by SQLAlchemy.</p>",
+            "nullable": true,
+            "type": "string"
+          },
+          "parameters": {
+            "additionalProperties": {},
+            "description": "DB-specific parameters for configuration",
+            "type": "object"
+          },
+          "parameters_schema": {
+            "additionalProperties": {},
+            "description": "JSONSchema for configuring the database by parameters instead of SQLAlchemy URI",
+            "type": "object"
+          },
+          "server_cert": {
+            "description": "<p>Optional CA_BUNDLE contents to validate HTTPS requests. Only available on certain database engines.</p>",
+            "nullable": true,
+            "type": "string"
+          },
+          "sqlalchemy_uri": {
+            "description": "<p>Refer to the <a href=\"https://docs.sqlalchemy.org/en/rel_1_2/core/engines.html#database-urls\" rel=\"noopener noreferrer\">SqlAlchemy docs</a> for more information on how to structure your URI.</p>",
+            "maxLength": 1024,
+            "minLength": 1,
+            "type": "string"
+          },
+          "ssh_tunnel": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DatabaseSSHTunnel"
+              }
+            ],
+            "nullable": true
+          },
+          "uuid": {
             "type": "string"
           }
         },
@@ -3561,7 +4003,6 @@
       "DatabaseRelatedChart": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "slice_name": {
@@ -3577,7 +4018,6 @@
         "properties": {
           "count": {
             "description": "Chart count",
-            "format": "int32",
             "type": "integer"
           },
           "result": {
@@ -3593,7 +4033,6 @@
       "DatabaseRelatedDashboard": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "json_metadata": {
@@ -3612,7 +4051,6 @@
         "properties": {
           "count": {
             "description": "Dashboard count",
-            "format": "int32",
             "type": "integer"
           },
           "result": {
@@ -3662,7 +4100,6 @@
             "readOnly": true
           },
           "cache_timeout": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -3685,17 +4122,12 @@
             "nullable": true,
             "type": "boolean"
           },
-          "extra": {
-            "nullable": true,
-            "type": "string"
-          },
           "force_ctas_schema": {
             "maxLength": 250,
             "nullable": true,
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "impersonate_user": {
@@ -3705,30 +4137,15 @@
           "is_managed_externally": {
             "type": "boolean"
           },
-          "masked_encrypted_extra": {
-            "readOnly": true
-          },
-          "parameters": {
-            "readOnly": true
-          },
-          "parameters_schema": {
-            "readOnly": true
-          },
-          "server_cert": {
-            "nullable": true,
-            "type": "string"
-          },
-          "sqlalchemy_uri": {
-            "maxLength": 1024,
-            "type": "string"
-          },
           "uuid": {
             "format": "uuid",
             "nullable": true,
             "type": "string"
           }
         },
-        "required": ["database_name", "sqlalchemy_uri"],
+        "required": [
+          "database_name"
+        ],
         "type": "object"
       },
       "DatabaseRestApi.get_list": {
@@ -3803,7 +4220,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "uuid": {
@@ -3812,7 +4228,9 @@
             "type": "string"
           }
         },
-        "required": ["database_name"],
+        "required": [
+          "database_name"
+        ],
         "type": "object"
       },
       "DatabaseRestApi.get_list.User": {
@@ -3826,7 +4244,10 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "DatabaseRestApi.post": {
@@ -3853,13 +4274,16 @@
           },
           "cache_timeout": {
             "description": "Duration (in seconds) of the caching timeout for charts of this database. A timeout of 0 indicates that the cache never expires. Note this defaults to the global timeout if undefined.",
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
           "configuration_method": {
             "default": "sqlalchemy_form",
-            "description": "Configuration_method is used on the frontend to inform the backend whether to explode parameters or to provide only a sqlalchemy_uri."
+            "description": "Configuration_method is used on the frontend to inform the backend whether to explode parameters or to provide only a sqlalchemy_uri.",
+            "enum": [
+              "sqlalchemy_form",
+              "dynamic_form"
+            ]
           },
           "database_name": {
             "description": "A database name to identify this connection.",
@@ -3886,7 +4310,7 @@
             "type": "string"
           },
           "extra": {
-            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
+            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\" rel=\"noopener noreferrer\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\" rel=\"noopener noreferrer\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
             "type": "string"
           },
           "force_ctas_schema": {
@@ -3920,7 +4344,7 @@
             "type": "string"
           },
           "sqlalchemy_uri": {
-            "description": "<p>Refer to the <a href=\"https://docs.sqlalchemy.org/en/rel_1_2/core/engines.html#database-urls\">SqlAlchemy docs</a> for more information on how to structure your URI.</p>",
+            "description": "<p>Refer to the <a href=\"https://docs.sqlalchemy.org/en/rel_1_2/core/engines.html#database-urls\" rel=\"noopener noreferrer\">SqlAlchemy docs</a> for more information on how to structure your URI.</p>",
             "maxLength": 1024,
             "minLength": 1,
             "type": "string"
@@ -3937,7 +4361,9 @@
             "type": "string"
           }
         },
-        "required": ["database_name"],
+        "required": [
+          "database_name"
+        ],
         "type": "object"
       },
       "DatabaseRestApi.put": {
@@ -3964,13 +4390,16 @@
           },
           "cache_timeout": {
             "description": "Duration (in seconds) of the caching timeout for charts of this database. A timeout of 0 indicates that the cache never expires. Note this defaults to the global timeout if undefined.",
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
           "configuration_method": {
             "default": "sqlalchemy_form",
-            "description": "Configuration_method is used on the frontend to inform the backend whether to explode parameters or to provide only a sqlalchemy_uri."
+            "description": "Configuration_method is used on the frontend to inform the backend whether to explode parameters or to provide only a sqlalchemy_uri.",
+            "enum": [
+              "sqlalchemy_form",
+              "dynamic_form"
+            ]
           },
           "database_name": {
             "description": "A database name to identify this connection.",
@@ -3998,7 +4427,7 @@
             "type": "string"
           },
           "extra": {
-            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
+            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\" rel=\"noopener noreferrer\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\" rel=\"noopener noreferrer\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
             "type": "string"
           },
           "force_ctas_schema": {
@@ -4032,7 +4461,7 @@
             "type": "string"
           },
           "sqlalchemy_uri": {
-            "description": "<p>Refer to the <a href=\"https://docs.sqlalchemy.org/en/rel_1_2/core/engines.html#database-urls\">SqlAlchemy docs</a> for more information on how to structure your URI.</p>",
+            "description": "<p>Refer to the <a href=\"https://docs.sqlalchemy.org/en/rel_1_2/core/engines.html#database-urls\" rel=\"noopener noreferrer\">SqlAlchemy docs</a> for more information on how to structure your URI.</p>",
             "maxLength": 1024,
             "minLength": 0,
             "type": "string"
@@ -4044,6 +4473,9 @@
               }
             ],
             "nullable": true
+          },
+          "uuid": {
+            "type": "string"
           }
         },
         "type": "object"
@@ -4052,7 +4484,6 @@
         "properties": {
           "id": {
             "description": "SSH Tunnel ID (for updates)",
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -4069,7 +4500,6 @@
             "type": "string"
           },
           "server_port": {
-            "format": "int32",
             "type": "integer"
           },
           "username": {
@@ -4111,7 +4541,11 @@
         "properties": {
           "configuration_method": {
             "default": "sqlalchemy_form",
-            "description": "Configuration_method is used on the frontend to inform the backend whether to explode parameters or to provide only a sqlalchemy_uri."
+            "description": "Configuration_method is used on the frontend to inform the backend whether to explode parameters or to provide only a sqlalchemy_uri.",
+            "enum": [
+              "sqlalchemy_form",
+              "dynamic_form"
+            ]
           },
           "database_name": {
             "description": "A database name to identify this connection.",
@@ -4131,7 +4565,7 @@
             "type": "string"
           },
           "extra": {
-            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
+            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\" rel=\"noopener noreferrer\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\" rel=\"noopener noreferrer\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
             "type": "string"
           },
           "impersonate_user": {
@@ -4154,7 +4588,7 @@
             "type": "string"
           },
           "sqlalchemy_uri": {
-            "description": "<p>Refer to the <a href=\"https://docs.sqlalchemy.org/en/rel_1_2/core/engines.html#database-urls\">SqlAlchemy docs</a> for more information on how to structure your URI.</p>",
+            "description": "<p>Refer to the <a href=\"https://docs.sqlalchemy.org/en/rel_1_2/core/engines.html#database-urls\" rel=\"noopener noreferrer\">SqlAlchemy docs</a> for more information on how to structure your URI.</p>",
             "maxLength": 1024,
             "minLength": 1,
             "type": "string"
@@ -4180,7 +4614,11 @@
             "type": "object"
           },
           "configuration_method": {
-            "description": "Configuration_method is used on the frontend to inform the backend whether to explode parameters or to provide only a sqlalchemy_uri."
+            "description": "Configuration_method is used on the frontend to inform the backend whether to explode parameters or to provide only a sqlalchemy_uri.",
+            "enum": [
+              "sqlalchemy_form",
+              "dynamic_form"
+            ]
           },
           "database_name": {
             "description": "A database name to identify this connection.",
@@ -4199,12 +4637,11 @@
             "type": "string"
           },
           "extra": {
-            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
+            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\" rel=\"noopener noreferrer\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\" rel=\"noopener noreferrer\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
             "type": "string"
           },
           "id": {
             "description": "Database ID (for updates)",
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -4230,14 +4667,16 @@
             "type": "string"
           }
         },
-        "required": ["configuration_method", "engine"],
+        "required": [
+          "configuration_method",
+          "engine"
+        ],
         "type": "object"
       },
       "Dataset": {
         "properties": {
           "cache_timeout": {
             "description": "Duration (in seconds) of the caching timeout for this dataset.",
-            "format": "int32",
             "type": "integer"
           },
           "column_formats": {
@@ -4250,6 +4689,10 @@
               "type": "object"
             },
             "type": "array"
+          },
+          "currency_formats": {
+            "description": "Currency formats.",
+            "type": "object"
           },
           "database": {
             "description": "Database associated with the dataset.",
@@ -4303,7 +4746,6 @@
           },
           "id": {
             "description": "Dataset ID.",
-            "format": "int32",
             "type": "integer"
           },
           "is_sqllab_view": {
@@ -4327,7 +4769,6 @@
           },
           "offset": {
             "description": "Dataset offset.",
-            "format": "int32",
             "type": "integer"
           },
           "order_by_choices": {
@@ -4343,7 +4784,6 @@
           "owners": {
             "description": "List of owners identifiers",
             "items": {
-              "format": "int32",
               "type": "integer"
             },
             "type": "array"
@@ -4401,6 +4841,60 @@
         },
         "type": "object"
       },
+      "DatasetCacheWarmUpRequestSchema": {
+        "properties": {
+          "dashboard_id": {
+            "description": "The ID of the dashboard to get filters for when warming cache",
+            "type": "integer"
+          },
+          "db_name": {
+            "description": "The name of the database where the table is located",
+            "type": "string"
+          },
+          "extra_filters": {
+            "description": "Extra filters to apply when warming up cache",
+            "type": "string"
+          },
+          "table_name": {
+            "description": "The name of the table to warm up cache for",
+            "type": "string"
+          }
+        },
+        "required": [
+          "db_name",
+          "table_name"
+        ],
+        "type": "object"
+      },
+      "DatasetCacheWarmUpResponseSchema": {
+        "properties": {
+          "result": {
+            "description": "A list of each chart's warmup status and errors if any",
+            "items": {
+              "$ref": "#/components/schemas/DatasetCacheWarmUpResponseSingle"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "DatasetCacheWarmUpResponseSingle": {
+        "properties": {
+          "chart_id": {
+            "description": "The ID of the chart the status belongs to",
+            "type": "integer"
+          },
+          "viz_error": {
+            "description": "Error that occurred when warming cache for chart",
+            "type": "string"
+          },
+          "viz_status": {
+            "description": "Status of the underlying query for the viz",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "DatasetColumnsPut": {
         "properties": {
           "advanced_data_type": {
@@ -4433,13 +4927,14 @@
             "type": "boolean"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "is_active": {
+            "nullable": true,
             "type": "boolean"
           },
           "is_dttm": {
+            "nullable": true,
             "type": "boolean"
           },
           "python_date_format": {
@@ -4462,13 +4957,14 @@
             "type": "string"
           }
         },
-        "required": ["column_name"],
+        "required": [
+          "column_name"
+        ],
         "type": "object"
       },
       "DatasetColumnsRestApi.get": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
@@ -4477,7 +4973,6 @@
       "DatasetColumnsRestApi.get_list": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
@@ -4486,7 +4981,6 @@
       "DatasetColumnsRestApi.post": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
@@ -4495,7 +4989,6 @@
       "DatasetColumnsRestApi.put": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
@@ -4504,7 +4997,6 @@
       "DatasetDuplicateSchema": {
         "properties": {
           "base_model_id": {
-            "format": "int32",
             "type": "integer"
           },
           "table_name": {
@@ -4513,13 +5005,15 @@
             "type": "string"
           }
         },
-        "required": ["base_model_id", "table_name"],
+        "required": [
+          "base_model_id",
+          "table_name"
+        ],
         "type": "object"
       },
       "DatasetMetricRestApi.get": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
@@ -4528,7 +5022,6 @@
       "DatasetMetricRestApi.get_list": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
@@ -4537,7 +5030,6 @@
       "DatasetMetricRestApi.post": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
@@ -4546,7 +5038,6 @@
       "DatasetMetricRestApi.put": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
@@ -4554,6 +5045,12 @@
       },
       "DatasetMetricsPut": {
         "properties": {
+          "currency": {
+            "maxLength": 128,
+            "minLength": 1,
+            "nullable": true,
+            "type": "string"
+          },
           "d3format": {
             "maxLength": 128,
             "minLength": 1,
@@ -4572,7 +5069,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "metric_name": {
@@ -4600,13 +5096,15 @@
             "type": "string"
           }
         },
-        "required": ["expression", "metric_name"],
+        "required": [
+          "expression",
+          "metric_name"
+        ],
         "type": "object"
       },
       "DatasetRelatedChart": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "slice_name": {
@@ -4622,7 +5120,6 @@
         "properties": {
           "count": {
             "description": "Chart count",
-            "format": "int32",
             "type": "integer"
           },
           "result": {
@@ -4638,7 +5135,6 @@
       "DatasetRelatedDashboard": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "json_metadata": {
@@ -4657,7 +5153,6 @@
         "properties": {
           "count": {
             "description": "Dashboard count",
-            "format": "int32",
             "type": "integer"
           },
           "result": {
@@ -4684,12 +5179,11 @@
       "DatasetRestApi.get": {
         "properties": {
           "cache_timeout": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
           "changed_by": {
-            "$ref": "#/components/schemas/DatasetRestApi.get.User"
+            "$ref": "#/components/schemas/DatasetRestApi.get.User2"
           },
           "changed_on": {
             "format": "date-time",
@@ -4699,11 +5193,14 @@
           "changed_on_humanized": {
             "readOnly": true
           },
+          "column_formats": {
+            "readOnly": true
+          },
           "columns": {
             "$ref": "#/components/schemas/DatasetRestApi.get.TableColumn"
           },
           "created_by": {
-            "$ref": "#/components/schemas/DatasetRestApi.get.User1"
+            "$ref": "#/components/schemas/DatasetRestApi.get.User"
           },
           "created_on": {
             "format": "date-time",
@@ -4713,8 +5210,14 @@
           "created_on_humanized": {
             "readOnly": true
           },
+          "currency_formats": {
+            "readOnly": true
+          },
           "database": {
             "$ref": "#/components/schemas/DatasetRestApi.get.Database"
+          },
+          "datasource_name": {
+            "readOnly": true
           },
           "datasource_type": {
             "readOnly": true
@@ -4739,8 +5242,10 @@
             "nullable": true,
             "type": "boolean"
           },
+          "granularity_sqla": {
+            "readOnly": true
+          },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "is_managed_externally": {
@@ -4761,13 +5266,18 @@
           "metrics": {
             "$ref": "#/components/schemas/DatasetRestApi.get.SqlMetric"
           },
+          "name": {
+            "readOnly": true
+          },
           "offset": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
+          "order_by_choices": {
+            "readOnly": true
+          },
           "owners": {
-            "$ref": "#/components/schemas/DatasetRestApi.get.User2"
+            "$ref": "#/components/schemas/DatasetRestApi.get.User1"
           },
           "schema": {
             "maxLength": 255,
@@ -4789,11 +5299,25 @@
             "nullable": true,
             "type": "string"
           },
+          "time_grain_sqla": {
+            "readOnly": true
+          },
+          "uid": {
+            "readOnly": true
+          },
           "url": {
+            "readOnly": true
+          },
+          "verbose_map": {
             "readOnly": true
           }
         },
-        "required": ["columns", "database", "metrics", "table_name"],
+        "required": [
+          "columns",
+          "database",
+          "metrics",
+          "table_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.get.Database": {
@@ -4806,11 +5330,12 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
-        "required": ["database_name"],
+        "required": [
+          "database_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.get.SqlMetric": {
@@ -4822,6 +5347,11 @@
           },
           "created_on": {
             "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "currency": {
+            "maxLength": 128,
             "nullable": true,
             "type": "string"
           },
@@ -4842,7 +5372,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "metric_name": {
@@ -4864,7 +5393,10 @@
             "type": "string"
           }
         },
-        "required": ["expression", "metric_name"],
+        "required": [
+          "expression",
+          "metric_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.get.TableColumn": {
@@ -4909,7 +5441,6 @@
             "type": "boolean"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "is_active": {
@@ -4943,7 +5474,9 @@
             "type": "string"
           }
         },
-        "required": ["column_name"],
+        "required": [
+          "column_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.get.User": {
@@ -4957,7 +5490,10 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.get.User1": {
@@ -4966,12 +5502,18 @@
             "maxLength": 64,
             "type": "string"
           },
+          "id": {
+            "type": "integer"
+          },
           "last_name": {
             "maxLength": 64,
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.get.User2": {
@@ -4980,31 +5522,23 @@
             "maxLength": 64,
             "type": "string"
           },
-          "id": {
-            "format": "int32",
-            "type": "integer"
-          },
           "last_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
-          "username": {
             "maxLength": 64,
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name", "username"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.get_list": {
         "properties": {
           "changed_by": {
-            "$ref": "#/components/schemas/DatasetRestApi.get_list.User"
+            "$ref": "#/components/schemas/DatasetRestApi.get_list.User1"
           },
           "changed_by_name": {
-            "readOnly": true
-          },
-          "changed_by_url": {
             "readOnly": true
           },
           "changed_on_delta_humanized": {
@@ -5035,14 +5569,13 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "kind": {
             "readOnly": true
           },
           "owners": {
-            "$ref": "#/components/schemas/DatasetRestApi.get_list.User1"
+            "$ref": "#/components/schemas/DatasetRestApi.get_list.User"
           },
           "schema": {
             "maxLength": 255,
@@ -5058,7 +5591,10 @@
             "type": "string"
           }
         },
-        "required": ["database", "table_name"],
+        "required": [
+          "database",
+          "table_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.get_list.Database": {
@@ -5068,11 +5604,12 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
-        "required": ["database_name"],
+        "required": [
+          "database_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.get_list.User": {
@@ -5081,12 +5618,18 @@
             "maxLength": 64,
             "type": "string"
           },
-          "username": {
+          "id": {
+            "type": "integer"
+          },
+          "last_name": {
             "maxLength": 64,
             "type": "string"
           }
         },
-        "required": ["first_name", "username"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.get_list.User1": {
@@ -5095,26 +5638,20 @@
             "maxLength": 64,
             "type": "string"
           },
-          "id": {
-            "format": "int32",
-            "type": "integer"
-          },
           "last_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
-          "username": {
             "maxLength": 64,
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name", "username"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.post": {
         "properties": {
           "database": {
-            "format": "int32",
             "type": "integer"
           },
           "external_url": {
@@ -5127,7 +5664,6 @@
           },
           "owners": {
             "items": {
-              "format": "int32",
               "type": "integer"
             },
             "type": "array"
@@ -5135,6 +5671,7 @@
           "schema": {
             "maxLength": 250,
             "minLength": 0,
+            "nullable": true,
             "type": "string"
           },
           "sql": {
@@ -5147,13 +5684,15 @@
             "type": "string"
           }
         },
-        "required": ["database", "table_name"],
+        "required": [
+          "database",
+          "table_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.put": {
         "properties": {
           "cache_timeout": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -5164,7 +5703,6 @@
             "type": "array"
           },
           "database_id": {
-            "format": "int32",
             "type": "integer"
           },
           "default_endpoint": {
@@ -5212,13 +5750,11 @@
             "type": "array"
           },
           "offset": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
           "owners": {
             "items": {
-              "format": "int32",
               "type": "integer"
             },
             "type": "array"
@@ -5273,14 +5809,15 @@
             "type": "string"
           }
         },
-        "required": ["datasource_type"],
+        "required": [
+          "datasource_type"
+        ],
         "type": "object"
       },
       "DistincResponseSchema": {
         "properties": {
           "count": {
             "description": "The total number of distinct values",
-            "format": "int32",
             "type": "integer"
           },
           "result": {
@@ -5310,7 +5847,9 @@
             "type": "array"
           }
         },
-        "required": ["allowed_domains"],
+        "required": [
+          "allowed_domains"
+        ],
         "type": "object"
       },
       "EmbeddedDashboardResponseSchema": {
@@ -5322,7 +5861,7 @@
             "type": "array"
           },
           "changed_by": {
-            "$ref": "#/components/schemas/User"
+            "$ref": "#/components/schemas/User1"
           },
           "changed_on": {
             "format": "date-time",
@@ -5373,6 +5912,32 @@
         },
         "type": "object"
       },
+      "EstimateQueryCostSchema": {
+        "properties": {
+          "database_id": {
+            "description": "The database id",
+            "type": "integer"
+          },
+          "schema": {
+            "description": "The database schema",
+            "nullable": true,
+            "type": "string"
+          },
+          "sql": {
+            "description": "The SQL query to estimate",
+            "type": "string"
+          },
+          "template_params": {
+            "description": "The SQL query template params",
+            "type": "object"
+          }
+        },
+        "required": [
+          "database_id",
+          "sql"
+        ],
+        "type": "object"
+      },
       "ExecutePayloadSchema": {
         "properties": {
           "client_id": {
@@ -5384,7 +5949,6 @@
             "type": "string"
           },
           "database_id": {
-            "format": "int32",
             "type": "integer"
           },
           "expand_data": {
@@ -5396,7 +5960,6 @@
             "type": "boolean"
           },
           "queryLimit": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -5432,7 +5995,10 @@
             "type": "string"
           }
         },
-        "required": ["database_id", "sql"],
+        "required": [
+          "database_id",
+          "sql"
+        ],
         "type": "object"
       },
       "ExploreContextSchema": {
@@ -5454,7 +6020,7 @@
         },
         "type": "object"
       },
-      "ExplorePermalinkPostSchema": {
+      "ExplorePermalinkStateSchema": {
         "properties": {
           "formData": {
             "description": "Chart form data",
@@ -5470,13 +6036,14 @@
             "type": "array"
           }
         },
-        "required": ["formData"],
+        "required": [
+          "formData"
+        ],
         "type": "object"
       },
       "FilterSetRestApi.get": {
         "properties": {
           "dashboard_id": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -5485,7 +6052,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "name": {
@@ -5493,7 +6059,6 @@
             "type": "string"
           },
           "owner_id": {
-            "format": "int32",
             "type": "integer"
           },
           "owner_type": {
@@ -5504,13 +6069,16 @@
             "readOnly": true
           }
         },
-        "required": ["name", "owner_id", "owner_type"],
+        "required": [
+          "name",
+          "owner_id",
+          "owner_type"
+        ],
         "type": "object"
       },
       "FilterSetRestApi.get_list": {
         "properties": {
           "changed_by_fk": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -5520,7 +6088,6 @@
             "type": "string"
           },
           "created_by_fk": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -5530,7 +6097,6 @@
             "type": "string"
           },
           "dashboard_id": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -5539,7 +6105,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "name": {
@@ -5547,7 +6112,6 @@
             "type": "string"
           },
           "owner_id": {
-            "format": "int32",
             "type": "integer"
           },
           "owner_type": {
@@ -5558,7 +6122,11 @@
             "readOnly": true
           }
         },
-        "required": ["name", "owner_id", "owner_type"],
+        "required": [
+          "name",
+          "owner_id",
+          "owner_type"
+        ],
         "type": "object"
       },
       "FilterSetRestApi.post": {
@@ -5578,15 +6146,21 @@
             "type": "string"
           },
           "owner_id": {
-            "format": "int32",
             "type": "integer"
           },
           "owner_type": {
-            "enum": ["User", "Dashboard"],
+            "enum": [
+              "User",
+              "Dashboard"
+            ],
             "type": "string"
           }
         },
-        "required": ["json_metadata", "name", "owner_type"],
+        "required": [
+          "json_metadata",
+          "name",
+          "owner_type"
+        ],
         "type": "object"
       },
       "FilterSetRestApi.put": {
@@ -5605,7 +6179,9 @@
             "type": "string"
           },
           "owner_type": {
-            "enum": ["Dashboard"],
+            "enum": [
+              "Dashboard"
+            ],
             "type": "string"
           }
         },
@@ -5615,12 +6191,10 @@
         "properties": {
           "chart_id": {
             "description": "The chart ID",
-            "format": "int32",
             "type": "integer"
           },
           "datasource_id": {
             "description": "The datasource ID",
-            "format": "int32",
             "type": "integer"
           },
           "datasource_type": {
@@ -5640,19 +6214,21 @@
             "type": "string"
           }
         },
-        "required": ["datasource_id", "datasource_type", "form_data"],
+        "required": [
+          "datasource_id",
+          "datasource_type",
+          "form_data"
+        ],
         "type": "object"
       },
       "FormDataPutSchema": {
         "properties": {
           "chart_id": {
             "description": "The chart ID",
-            "format": "int32",
             "type": "integer"
           },
           "datasource_id": {
             "description": "The datasource ID",
-            "format": "int32",
             "type": "integer"
           },
           "datasource_type": {
@@ -5672,7 +6248,11 @@
             "type": "string"
           }
         },
-        "required": ["datasource_id", "datasource_type", "form_data"],
+        "required": [
+          "datasource_id",
+          "datasource_type",
+          "form_data"
+        ],
         "type": "object"
       },
       "GetFavStarIdsSchema": {
@@ -5685,6 +6265,34 @@
             "type": "array"
           }
         },
+        "type": "object"
+      },
+      "GetOrCreateDatasetSchema": {
+        "properties": {
+          "database_id": {
+            "description": "ID of database table belongs to",
+            "type": "integer"
+          },
+          "schema": {
+            "description": "The schema the table belongs to",
+            "maxLength": 250,
+            "minLength": 0,
+            "nullable": true,
+            "type": "string"
+          },
+          "table_name": {
+            "description": "Name of table",
+            "type": "string"
+          },
+          "template_params": {
+            "description": "Template params for the table",
+            "type": "string"
+          }
+        },
+        "required": [
+          "database_id",
+          "table_name"
+        ],
         "type": "object"
       },
       "GuestTokenCreate": {
@@ -5702,10 +6310,13 @@
             "type": "array"
           },
           "user": {
-            "$ref": "#/components/schemas/User1"
+            "$ref": "#/components/schemas/User2"
           }
         },
-        "required": ["resources", "rls"],
+        "required": [
+          "resources",
+          "rls"
+        ],
         "type": "object"
       },
       "LogRestApi.get": {
@@ -5716,7 +6327,6 @@
             "type": "string"
           },
           "dashboard_id": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -5726,7 +6336,6 @@
             "type": "string"
           },
           "duration_ms": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -5740,7 +6349,6 @@
             "type": "string"
           },
           "slice_id": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -5748,7 +6356,6 @@
             "$ref": "#/components/schemas/LogRestApi.get.User"
           },
           "user_id": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           }
@@ -5762,7 +6369,9 @@
             "type": "string"
           }
         },
-        "required": ["username"],
+        "required": [
+          "username"
+        ],
         "type": "object"
       },
       "LogRestApi.get_list": {
@@ -5773,7 +6382,6 @@
             "type": "string"
           },
           "dashboard_id": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -5783,7 +6391,6 @@
             "type": "string"
           },
           "duration_ms": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -5797,7 +6404,6 @@
             "type": "string"
           },
           "slice_id": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -5805,7 +6411,6 @@
             "$ref": "#/components/schemas/LogRestApi.get_list.User"
           },
           "user_id": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           }
@@ -5819,13 +6424,14 @@
             "type": "string"
           }
         },
-        "required": ["username"],
+        "required": [
+          "username"
+        ],
         "type": "object"
       },
       "LogRestApi.post": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
@@ -5877,7 +6483,6 @@
             "$ref": "#/components/schemas/QueryResult"
           },
           "query_id": {
-            "format": "int32",
             "type": "integer"
           },
           "selected_columns": {
@@ -5923,16 +6528,13 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "limit": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
           "progress": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -5942,7 +6544,6 @@
             "type": "string"
           },
           "rows": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -6004,13 +6605,15 @@
             "readOnly": true
           }
         },
-        "required": ["client_id", "database"],
+        "required": [
+          "client_id",
+          "database"
+        ],
         "type": "object"
       },
       "QueryRestApi.get.Database": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
@@ -6026,18 +6629,15 @@
             "$ref": "#/components/schemas/Database1"
           },
           "end_time": {
-            "format": "float",
             "type": "number"
           },
           "executed_sql": {
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "rows": {
-            "format": "int32",
             "type": "integer"
           },
           "schema": {
@@ -6050,7 +6650,6 @@
             "readOnly": true
           },
           "start_time": {
-            "format": "float",
             "type": "number"
           },
           "status": {
@@ -6074,7 +6673,6 @@
       "QueryRestApi.post": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
@@ -6083,7 +6681,6 @@
       "QueryRestApi.put": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
@@ -6091,11 +6688,8 @@
       },
       "QueryResult": {
         "properties": {
-          "changedOn": {
-            "format": "date-time",
-            "type": "string"
-          },
           "changed_on": {
+            "format": "date-time",
             "type": "string"
           },
           "ctas": {
@@ -6105,11 +6699,9 @@
             "type": "string"
           },
           "dbId": {
-            "format": "int32",
             "type": "integer"
           },
           "endDttm": {
-            "format": "float",
             "type": "number"
           },
           "errorMessage": {
@@ -6126,32 +6718,27 @@
             "type": "string"
           },
           "limit": {
-            "format": "int32",
             "type": "integer"
           },
           "limitingFactor": {
             "type": "string"
           },
           "progress": {
-            "format": "int32",
             "type": "integer"
           },
           "queryId": {
-            "format": "int32",
             "type": "integer"
           },
           "resultsKey": {
             "type": "string"
           },
           "rows": {
-            "format": "int32",
             "type": "integer"
           },
           "schema": {
             "type": "string"
           },
           "serverId": {
-            "format": "int32",
             "type": "integer"
           },
           "sql": {
@@ -6161,7 +6748,6 @@
             "type": "string"
           },
           "startDttm": {
-            "format": "float",
             "type": "number"
           },
           "state": {
@@ -6186,8 +6772,202 @@
             "type": "string"
           },
           "userId": {
-            "format": "int32",
             "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "RLSRestApi.get": {
+        "properties": {
+          "clause": {
+            "description": "clause_description",
+            "type": "string"
+          },
+          "description": {
+            "description": "description_description",
+            "type": "string"
+          },
+          "filter_type": {
+            "description": "filter_type_description",
+            "enum": [
+              "Regular",
+              "Base"
+            ],
+            "type": "string"
+          },
+          "group_key": {
+            "description": "group_key_description",
+            "type": "string"
+          },
+          "id": {
+            "description": "id_description",
+            "type": "integer"
+          },
+          "name": {
+            "description": "name_description",
+            "type": "string"
+          },
+          "roles": {
+            "items": {
+              "$ref": "#/components/schemas/Roles1"
+            },
+            "type": "array"
+          },
+          "tables": {
+            "items": {
+              "$ref": "#/components/schemas/Tables"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "RLSRestApi.get_list": {
+        "properties": {
+          "changed_on_delta_humanized": {
+            "readOnly": true
+          },
+          "clause": {
+            "description": "clause_description",
+            "type": "string"
+          },
+          "description": {
+            "description": "description_description",
+            "type": "string"
+          },
+          "filter_type": {
+            "description": "filter_type_description",
+            "enum": [
+              "Regular",
+              "Base"
+            ],
+            "type": "string"
+          },
+          "group_key": {
+            "description": "group_key_description",
+            "type": "string"
+          },
+          "id": {
+            "description": "id_description",
+            "type": "integer"
+          },
+          "name": {
+            "description": "name_description",
+            "type": "string"
+          },
+          "roles": {
+            "items": {
+              "$ref": "#/components/schemas/Roles1"
+            },
+            "type": "array"
+          },
+          "tables": {
+            "items": {
+              "$ref": "#/components/schemas/Tables"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "RLSRestApi.post": {
+        "properties": {
+          "clause": {
+            "description": "clause_description",
+            "type": "string"
+          },
+          "description": {
+            "description": "description_description",
+            "nullable": true,
+            "type": "string"
+          },
+          "filter_type": {
+            "description": "filter_type_description",
+            "enum": [
+              "Regular",
+              "Base"
+            ],
+            "type": "string"
+          },
+          "group_key": {
+            "description": "group_key_description",
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "description": "name_description",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "roles": {
+            "description": "roles_description",
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "tables": {
+            "description": "tables_description",
+            "items": {
+              "type": "integer"
+            },
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "clause",
+          "filter_type",
+          "name",
+          "roles",
+          "tables"
+        ],
+        "type": "object"
+      },
+      "RLSRestApi.put": {
+        "properties": {
+          "clause": {
+            "description": "clause_description",
+            "type": "string"
+          },
+          "description": {
+            "description": "description_description",
+            "nullable": true,
+            "type": "string"
+          },
+          "filter_type": {
+            "description": "filter_type_description",
+            "enum": [
+              "Regular",
+              "Base"
+            ],
+            "type": "string"
+          },
+          "group_key": {
+            "description": "group_key_description",
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "description": "name_description",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "roles": {
+            "description": "roles_description",
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "tables": {
+            "description": "tables_description",
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
           }
         },
         "type": "object"
@@ -6212,11 +6992,10 @@
           },
           "time": {
             "description": "Time of activity, in epoch milliseconds",
-            "format": "float",
             "type": "number"
           },
           "time_delta_humanized": {
-            "description": "Human-readable description of how long ago activity took place",
+            "description": "Human-readable description of how long ago activity took place.",
             "type": "string"
           }
         },
@@ -6254,11 +7033,10 @@
           },
           "time": {
             "description": "Time of activity, in epoch milliseconds",
-            "format": "float",
             "type": "number"
           },
           "time_delta_humanized": {
-            "description": "Human-readable description of how long ago activity took place",
+            "description": "Human-readable description of how long ago activity took place.",
             "type": "string"
           }
         },
@@ -6268,7 +7046,6 @@
         "properties": {
           "count": {
             "description": "The total number of related values",
-            "format": "int32",
             "type": "integer"
           },
           "result": {
@@ -6292,7 +7069,6 @@
           },
           "value": {
             "description": "The related item identifier",
-            "format": "int32",
             "type": "integer"
           }
         },
@@ -6310,7 +7086,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "scheduled_dttm": {
@@ -6332,7 +7107,6 @@
             "type": "string"
           },
           "value": {
-            "format": "float",
             "nullable": true,
             "type": "number"
           },
@@ -6341,7 +7115,10 @@
             "type": "string"
           }
         },
-        "required": ["scheduled_dttm", "state"],
+        "required": [
+          "scheduled_dttm",
+          "state"
+        ],
         "type": "object"
       },
       "ReportExecutionLogRestApi.get_list": {
@@ -6356,7 +7133,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "scheduled_dttm": {
@@ -6378,7 +7154,6 @@
             "type": "string"
           },
           "value": {
-            "format": "float",
             "nullable": true,
             "type": "number"
           },
@@ -6387,13 +7162,15 @@
             "type": "string"
           }
         },
-        "required": ["scheduled_dttm", "state"],
+        "required": [
+          "scheduled_dttm",
+          "state"
+        ],
         "type": "object"
       },
       "ReportExecutionLogRestApi.post": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
@@ -6402,7 +7179,6 @@
       "ReportExecutionLogRestApi.put": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
@@ -6415,11 +7191,16 @@
           },
           "type": {
             "description": "The recipient type, check spec for valid options",
-            "enum": ["Email", "Slack"],
+            "enum": [
+              "Email",
+              "Slack"
+            ],
             "type": "string"
           }
         },
-        "required": ["type"],
+        "required": [
+          "type"
+        ],
         "type": "object"
       },
       "ReportRecipientConfigJSON": {
@@ -6452,6 +7233,10 @@
             "maxLength": 1000,
             "type": "string"
           },
+          "custom_width": {
+            "nullable": true,
+            "type": "integer"
+          },
           "dashboard": {
             "$ref": "#/components/schemas/ReportScheduleRestApi.get.Dashboard"
           },
@@ -6470,12 +7255,10 @@
             "type": "boolean"
           },
           "grace_period": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "last_eval_dttm": {
@@ -6489,7 +7272,6 @@
             "type": "string"
           },
           "last_value": {
-            "format": "float",
             "nullable": true,
             "type": "number"
           },
@@ -6498,7 +7280,6 @@
             "type": "string"
           },
           "log_retention": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -6539,12 +7320,16 @@
             "type": "string"
           },
           "working_timeout": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           }
         },
-        "required": ["crontab", "name", "recipients", "type"],
+        "required": [
+          "crontab",
+          "name",
+          "recipients",
+          "type"
+        ],
         "type": "object"
       },
       "ReportScheduleRestApi.get.Dashboard": {
@@ -6555,7 +7340,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
@@ -6568,17 +7352,17 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
-        "required": ["database_name"],
+        "required": [
+          "database_name"
+        ],
         "type": "object"
       },
       "ReportScheduleRestApi.get.ReportRecipients": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "recipient_config_json": {
@@ -6590,13 +7374,14 @@
             "type": "string"
           }
         },
-        "required": ["type"],
+        "required": [
+          "type"
+        ],
         "type": "object"
       },
       "ReportScheduleRestApi.get.Slice": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "slice_name": {
@@ -6619,7 +7404,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "last_name": {
@@ -6627,7 +7411,10 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ReportScheduleRestApi.get_list": {
@@ -6637,7 +7424,7 @@
             "type": "boolean"
           },
           "changed_by": {
-            "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.User"
+            "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.User2"
           },
           "changed_on": {
             "format": "date-time",
@@ -6648,12 +7435,11 @@
             "readOnly": true
           },
           "chart_id": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
           "created_by": {
-            "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.User1"
+            "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.User"
           },
           "created_on": {
             "format": "date-time",
@@ -6673,7 +7459,6 @@
             "readOnly": true
           },
           "dashboard_id": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -6685,7 +7470,6 @@
             "readOnly": true
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "last_eval_dttm": {
@@ -6703,7 +7487,7 @@
             "type": "string"
           },
           "owners": {
-            "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.User2"
+            "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.User1"
           },
           "recipients": {
             "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.ReportRecipients"
@@ -6717,13 +7501,17 @@
             "type": "string"
           }
         },
-        "required": ["crontab", "name", "recipients", "type"],
+        "required": [
+          "crontab",
+          "name",
+          "recipients",
+          "type"
+        ],
         "type": "object"
       },
       "ReportScheduleRestApi.get_list.ReportRecipients": {
         "properties": {
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "type": {
@@ -6731,7 +7519,9 @@
             "type": "string"
           }
         },
-        "required": ["type"],
+        "required": [
+          "type"
+        ],
         "type": "object"
       },
       "ReportScheduleRestApi.get_list.User": {
@@ -6745,7 +7535,10 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ReportScheduleRestApi.get_list.User1": {
@@ -6754,12 +7547,18 @@
             "maxLength": 64,
             "type": "string"
           },
+          "id": {
+            "type": "integer"
+          },
           "last_name": {
             "maxLength": 64,
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ReportScheduleRestApi.get_list.User2": {
@@ -6768,16 +7567,15 @@
             "maxLength": 64,
             "type": "string"
           },
-          "id": {
-            "format": "int32",
-            "type": "integer"
-          },
           "last_name": {
             "maxLength": 64,
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ReportScheduleRestApi.post": {
@@ -6786,7 +7584,6 @@
             "type": "boolean"
           },
           "chart": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -6796,7 +7593,12 @@
             "type": "string"
           },
           "creation_method": {
-            "description": "Creation method is used to inform the frontend whether the report/alert was created in the dashboard, chart, or alerts and reports UI."
+            "description": "Creation method is used to inform the frontend whether the report/alert was created in the dashboard, chart, or alerts and reports UI.",
+            "enum": [
+              "charts",
+              "dashboards",
+              "alerts_reports"
+            ]
           },
           "crontab": {
             "description": "A CRON expression.[Crontab Guru](https://crontab.guru/) is a helpful resource that can help you craft a CRON expression.",
@@ -6805,13 +7607,17 @@
             "minLength": 1,
             "type": "string"
           },
+          "custom_width": {
+            "description": "Custom width of the screenshot in pixels",
+            "example": 1000,
+            "nullable": true,
+            "type": "integer"
+          },
           "dashboard": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
           "database": {
-            "format": "int32",
             "type": "integer"
           },
           "description": {
@@ -6829,14 +7635,12 @@
           "grace_period": {
             "description": "Once an alert is triggered, how long, in seconds, before Superset nags you again. (in seconds)",
             "example": 14400,
-            "format": "int32",
             "minimum": 1,
             "type": "integer"
           },
           "log_retention": {
             "description": "How long to keep the logs around for this report (in days)",
             "example": 90,
-            "format": "int32",
             "minimum": 1,
             "type": "integer"
           },
@@ -6850,7 +7654,6 @@
           "owners": {
             "items": {
               "description": "Owner are users ids allowed to delete or change this report. If left empty you will be one of the owners of the report.",
-              "format": "int32",
               "type": "integer"
             },
             "type": "array"
@@ -6862,12 +7665,15 @@
             "type": "array"
           },
           "report_format": {
-            "enum": ["PNG", "CSV", "TEXT"],
+            "enum": [
+              "PNG",
+              "CSV",
+              "TEXT"
+            ],
             "type": "string"
           },
           "selected_tabs": {
             "items": {
-              "format": "int32",
               "type": "integer"
             },
             "nullable": true,
@@ -7480,7 +8286,10 @@
           },
           "type": {
             "description": "The report schedule type",
-            "enum": ["Alert", "Report"],
+            "enum": [
+              "Alert",
+              "Report"
+            ],
             "type": "string"
           },
           "validator_config_json": {
@@ -7488,18 +8297,24 @@
           },
           "validator_type": {
             "description": "Determines when to trigger alert based off value from alert query. Alerts will be triggered with these validator types:\n- Not Null - When the return value is Not NULL, Empty, or 0\n- Operator - When `sql_return_value comparison_operator threshold` is True e.g. `50 <= 75`<br>Supports the comparison operators <, <=, >, >=, ==, and !=",
-            "enum": ["not null", "operator"],
+            "enum": [
+              "not null",
+              "operator"
+            ],
             "type": "string"
           },
           "working_timeout": {
             "description": "If an alert is staled at a working state, how long until it's state is reseted to error",
             "example": 3600,
-            "format": "int32",
             "minimum": 1,
             "type": "integer"
           }
         },
-        "required": ["crontab", "name", "type"],
+        "required": [
+          "crontab",
+          "name",
+          "type"
+        ],
         "type": "object"
       },
       "ReportScheduleRestApi.put": {
@@ -7508,7 +8323,6 @@
             "type": "boolean"
           },
           "chart": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -7519,6 +8333,11 @@
           },
           "creation_method": {
             "description": "Creation method is used to inform the frontend whether the report/alert was created in the dashboard, chart, or alerts and reports UI.",
+            "enum": [
+              "charts",
+              "dashboards",
+              "alerts_reports"
+            ],
             "nullable": true
           },
           "crontab": {
@@ -7527,13 +8346,17 @@
             "minLength": 1,
             "type": "string"
           },
+          "custom_width": {
+            "description": "Custom width of the screenshot in pixels",
+            "example": 1000,
+            "nullable": true,
+            "type": "integer"
+          },
           "dashboard": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
           "database": {
-            "format": "int32",
             "type": "integer"
           },
           "description": {
@@ -7551,14 +8374,12 @@
           "grace_period": {
             "description": "Once an alert is triggered, how long, in seconds, before Superset nags you again. (in seconds)",
             "example": 14400,
-            "format": "int32",
             "minimum": 1,
             "type": "integer"
           },
           "log_retention": {
             "description": "How long to keep the logs around for this report (in days)",
             "example": 90,
-            "format": "int32",
             "minimum": 1,
             "type": "integer"
           },
@@ -7571,7 +8392,6 @@
           "owners": {
             "items": {
               "description": "Owner are users ids allowed to delete or change this report. If left empty you will be one of the owners of the report.",
-              "format": "int32",
               "type": "integer"
             },
             "type": "array"
@@ -7583,7 +8403,11 @@
             "type": "array"
           },
           "report_format": {
-            "enum": ["PNG", "CSV", "TEXT"],
+            "enum": [
+              "PNG",
+              "CSV",
+              "TEXT"
+            ],
             "type": "string"
           },
           "sql": {
@@ -8194,7 +9018,10 @@
           },
           "type": {
             "description": "The report schedule type",
-            "enum": ["Alert", "Report"],
+            "enum": [
+              "Alert",
+              "Report"
+            ],
             "type": "string"
           },
           "validator_config_json": {
@@ -8202,14 +9029,16 @@
           },
           "validator_type": {
             "description": "Determines when to trigger alert based off value from alert query. Alerts will be triggered with these validator types:\n- Not Null - When the return value is Not NULL, Empty, or 0\n- Operator - When `sql_return_value comparison_operator threshold` is True e.g. `50 <= 75`<br>Supports the comparison operators <, <=, >, >=, ==, and !=",
-            "enum": ["not null", "operator"],
+            "enum": [
+              "not null",
+              "operator"
+            ],
             "nullable": true,
             "type": "string"
           },
           "working_timeout": {
             "description": "If an alert is staled at a working state, how long until it's state is reseted to error",
             "example": 3600,
-            "format": "int32",
             "minimum": 1,
             "nullable": true,
             "type": "integer"
@@ -8222,9 +9051,16 @@
           "id": {
             "type": "string"
           },
-          "type": {}
+          "type": {
+            "enum": [
+              "dashboard"
+            ]
+          }
         },
-        "required": ["id", "type"],
+        "required": [
+          "id",
+          "type"
+        ],
         "type": "object"
       },
       "RlsRule": {
@@ -8233,17 +9069,28 @@
             "type": "string"
           },
           "dataset": {
-            "format": "int32",
             "type": "integer"
           }
         },
-        "required": ["clause"],
+        "required": [
+          "clause"
+        ],
         "type": "object"
       },
       "Roles": {
         "properties": {
           "id": {
-            "format": "int32",
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Roles1": {
+        "properties": {
+          "id": {
             "type": "integer"
           },
           "name": {
@@ -8268,7 +9115,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "label": {
@@ -8302,11 +9148,12 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
-        "required": ["database_name"],
+        "required": [
+          "database_name"
+        ],
         "type": "object"
       },
       "SavedQueryRestApi.get.User": {
@@ -8316,7 +9163,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "last_name": {
@@ -8324,7 +9170,10 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "SavedQueryRestApi.get_list": {
@@ -8344,7 +9193,6 @@
             "$ref": "#/components/schemas/SavedQueryRestApi.get_list.Database"
           },
           "db_id": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -8356,7 +9204,6 @@
             "readOnly": true
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "label": {
@@ -8368,7 +9215,6 @@
             "readOnly": true
           },
           "rows": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -8383,6 +9229,9 @@
           },
           "sql_tables": {
             "readOnly": true
+          },
+          "tags": {
+            "$ref": "#/components/schemas/SavedQueryRestApi.get_list.Tag"
           }
         },
         "type": "object"
@@ -8394,11 +9243,33 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           }
         },
-        "required": ["database_name"],
+        "required": [
+          "database_name"
+        ],
+        "type": "object"
+      },
+      "SavedQueryRestApi.get_list.Tag": {
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "maxLength": 250,
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
+          }
+        },
         "type": "object"
       },
       "SavedQueryRestApi.get_list.User": {
@@ -8408,7 +9279,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "last_name": {
@@ -8416,13 +9286,15 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "SavedQueryRestApi.post": {
         "properties": {
           "db_id": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -8454,7 +9326,6 @@
       "SavedQueryRestApi.put": {
         "properties": {
           "db_id": {
-            "format": "int32",
             "nullable": true,
             "type": "integer"
           },
@@ -8508,7 +9379,6 @@
         "properties": {
           "cache_timeout": {
             "description": "Duration (in seconds) of the caching timeout for this chart.",
-            "format": "int32",
             "type": "integer"
           },
           "certification_details": {
@@ -8521,6 +9391,7 @@
           },
           "changed_on": {
             "description": "Timestamp of the last modification.",
+            "format": "date-time",
             "type": "string"
           },
           "changed_on_humanized": {
@@ -8558,7 +9429,6 @@
           "owners": {
             "description": "Owners identifiers.",
             "items": {
-              "format": "int32",
               "type": "integer"
             },
             "type": "array"
@@ -8569,7 +9439,6 @@
           },
           "slice_id": {
             "description": "The slice ID.",
-            "format": "int32",
             "type": "integer"
           },
           "slice_name": {
@@ -8636,7 +9505,7 @@
         "properties": {
           "column_names": {
             "items": {
-              "description": "A list of column names that compose the foreign key or index",
+              "description": "A list of column names that compose the foreign key or  index",
               "type": "string"
             },
             "type": "array"
@@ -8747,6 +9616,291 @@
         },
         "type": "object"
       },
+      "Tables": {
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "schema": {
+            "type": "string"
+          },
+          "table_name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Tag": {
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "Tag1": {
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "TagGetResponseSchema": {
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "TagRestApi.get": {
+        "properties": {
+          "changed_by": {
+            "$ref": "#/components/schemas/TagRestApi.get.User1"
+          },
+          "changed_on_delta_humanized": {
+            "readOnly": true
+          },
+          "created_by": {
+            "$ref": "#/components/schemas/TagRestApi.get.User"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "maxLength": 250,
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "TagRestApi.get.User": {
+        "properties": {
+          "active": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "changed_on": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "created_on": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "email": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "fail_login_count": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "last_login": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "login_count": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "password": {
+            "maxLength": 256,
+            "nullable": true,
+            "type": "string"
+          },
+          "username": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "email",
+          "first_name",
+          "last_name",
+          "username"
+        ],
+        "type": "object"
+      },
+      "TagRestApi.get.User1": {
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "last_name"
+        ],
+        "type": "object"
+      },
+      "TagRestApi.get_list": {
+        "properties": {
+          "changed_by": {
+            "$ref": "#/components/schemas/TagRestApi.get_list.User1"
+          },
+          "changed_on_delta_humanized": {
+            "readOnly": true
+          },
+          "created_by": {
+            "$ref": "#/components/schemas/TagRestApi.get_list.User"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "maxLength": 250,
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "TagRestApi.get_list.User": {
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "last_name"
+        ],
+        "type": "object"
+      },
+      "TagRestApi.get_list.User1": {
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "last_name"
+        ],
+        "type": "object"
+      },
+      "TagRestApi.post": {
+        "properties": {
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "TagRestApi.put": {
+        "properties": {
+          "id": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "TaggedObjectEntityResponseSchema": {
+        "properties": {
+          "changed_on": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "created_by": {
+            "$ref": "#/components/schemas/User"
+          },
+          "creator": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "TemporaryCachePostSchema": {
         "properties": {
           "value": {
@@ -8754,7 +9908,9 @@
             "type": "string"
           }
         },
-        "required": ["value"],
+        "required": [
+          "value"
+        ],
         "type": "object"
       },
       "TemporaryCachePutSchema": {
@@ -8764,7 +9920,9 @@
             "type": "string"
           }
         },
-        "required": ["value"],
+        "required": [
+          "value"
+        ],
         "type": "object"
       },
       "User": {
@@ -8773,7 +9931,20 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
+            "type": "integer"
+          },
+          "last_name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "User1": {
+        "properties": {
+          "first_name": {
+            "type": "string"
+          },
+          "id": {
             "type": "integer"
           },
           "last_name": {
@@ -8785,7 +9956,7 @@
         },
         "type": "object"
       },
-      "User1": {
+      "User2": {
         "properties": {
           "first_name": {
             "type": "string"
@@ -8808,7 +9979,6 @@
             "type": "string"
           },
           "id": {
-            "format": "int32",
             "type": "integer"
           },
           "is_active": {
@@ -8841,24 +10011,23 @@
             "type": "object"
           }
         },
-        "required": ["sql"],
+        "required": [
+          "sql"
+        ],
         "type": "object"
       },
       "ValidateSQLResponse": {
         "properties": {
           "end_column": {
-            "format": "int32",
             "type": "integer"
           },
           "line_number": {
-            "format": "int32",
             "type": "integer"
           },
           "message": {
             "type": "string"
           },
           "start_column": {
-            "format": "int32",
             "type": "integer"
           }
         },
@@ -8868,11 +10037,17 @@
         "properties": {
           "op": {
             "description": "The operation to compare with a threshold to apply to the SQL output\n",
-            "enum": ["<", "<=", ">", ">=", "==", "!="],
+            "enum": [
+              "<",
+              "<=",
+              ">",
+              ">=",
+              "==",
+              "!="
+            ],
             "type": "string"
           },
           "threshold": {
-            "format": "float",
             "type": "number"
           }
         },
@@ -8892,7 +10067,10 @@
             "type": "array"
           }
         },
-        "required": ["type", "values"],
+        "required": [
+          "type",
+          "values"
+        ],
         "type": "object"
       },
       "database_schemas_query_schema": {
@@ -8912,8 +10090,16 @@
             "type": "string"
           }
         },
-        "required": ["schema_name"],
+        "required": [
+          "schema_name"
+        ],
         "type": "object"
+      },
+      "delete_tags_schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
       },
       "get_delete_ids_schema": {
         "items": {
@@ -9039,7 +10225,11 @@
                   ]
                 }
               },
-              "required": ["col", "opr", "value"],
+              "required": [
+                "col",
+                "opr",
+                "value"
+              ],
               "type": "object"
             },
             "type": "array"
@@ -9062,7 +10252,10 @@
             "type": "string"
           },
           "order_direction": {
-            "enum": ["asc", "desc"],
+            "enum": [
+              "asc",
+              "desc"
+            ],
             "type": "string"
           },
           "page": {
@@ -9120,7 +10313,9 @@
             "type": "number"
           }
         },
-        "required": ["last_updated_ms"],
+        "required": [
+          "last_updated_ms"
+        ],
         "type": "object"
       },
       "screenshot_query_schema": {
@@ -9149,7 +10344,9 @@
             "type": "string"
           }
         },
-        "required": ["key"],
+        "required": [
+          "key"
+        ],
         "type": "object"
       },
       "thumbnail_query_schema": {
@@ -9226,7 +10423,9 @@
           }
         ],
         "summary": "Returns a AdvancedDataTypeResponse object populated with the passed in args.",
-        "tags": ["Advanced Data Type"]
+        "tags": [
+          "Advanced Data Type"
+        ]
       }
     },
     "/api/v1/advanced_data_type/types": {
@@ -9266,7 +10465,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Advanced Data Type"]
+        "tags": [
+          "Advanced Data Type"
+        ]
       }
     },
     "/api/v1/annotation_layer/": {
@@ -9319,7 +10520,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "tags": [
+          "Annotation Layers"
+        ]
       },
       "get": {
         "description": "Get a list of Annotation layers, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
@@ -9424,7 +10627,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "tags": [
+          "Annotation Layers"
+        ]
       },
       "post": {
         "description": "Create an Annotation layer",
@@ -9476,7 +10681,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "tags": [
+          "Annotation Layers"
+        ]
       }
     },
     "/api/v1/annotation_layer/_info": {
@@ -9560,7 +10767,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "tags": [
+          "Annotation Layers"
+        ]
       }
     },
     "/api/v1/annotation_layer/related/{column_name}": {
@@ -9615,7 +10824,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "tags": [
+          "Annotation Layers"
+        ]
       }
     },
     "/api/v1/annotation_layer/{pk}": {
@@ -9663,7 +10874,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "tags": [
+          "Annotation Layers"
+        ]
       },
       "get": {
         "description": "Get an Annotation layer",
@@ -9761,7 +10974,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "tags": [
+          "Annotation Layers"
+        ]
       },
       "put": {
         "description": "Update an Annotation layer",
@@ -9824,7 +11039,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "tags": [
+          "Annotation Layers"
+        ]
       }
     },
     "/api/v1/annotation_layer/{pk}/annotation/": {
@@ -9886,7 +11103,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "tags": [
+          "Annotation Layers"
+        ]
       },
       "get": {
         "description": "Get a list of Annotation layers, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
@@ -9961,7 +11180,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "tags": [
+          "Annotation Layers"
+        ]
       },
       "post": {
         "description": "Create an Annotation layer",
@@ -10024,7 +11245,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "tags": [
+          "Annotation Layers"
+        ]
       }
     },
     "/api/v1/annotation_layer/{pk}/annotation/{annotation_id}": {
@@ -10081,7 +11304,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "tags": [
+          "Annotation Layers"
+        ]
       },
       "get": {
         "description": "Get an Annotation layer",
@@ -10157,7 +11382,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "tags": [
+          "Annotation Layers"
+        ]
       },
       "put": {
         "description": "Update an Annotation layer",
@@ -10229,7 +11456,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "tags": [
+          "Annotation Layers"
+        ]
       }
     },
     "/api/v1/assets/export/": {
@@ -10262,7 +11491,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Import/export"]
+        "tags": [
+          "Import/export"
+        ]
       }
     },
     "/api/v1/assets/import/": {
@@ -10285,12 +11516,12 @@
                     "description": "JSON map of passwords for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
                     "type": "string"
                   },
-                  "ssh_tunnel_private_keys": {
-                    "description": "JSON map of private_keys for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the private_key should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_private_key\"}`.",
+                  "ssh_tunnel_private_key_passwords": {
+                    "description": "JSON map of private_key_passwords for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the private_key should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_private_key_password\"}`.",
                     "type": "string"
                   },
-                  "ssh_tunnel_private_keyspasswords": {
-                    "description": "JSON map of private_key_passwords for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the private_key_password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_private_key_password\"}`.",
+                  "ssh_tunnel_private_keys": {
+                    "description": "JSON map of private_keys for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the private_key should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_private_key\"}`.",
                     "type": "string"
                   }
                 },
@@ -10334,7 +11565,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Import/export"]
+        "tags": [
+          "Import/export"
+        ]
       }
     },
     "/api/v1/async_event/": {
@@ -10407,7 +11640,9 @@
             "jwt": []
           }
         ],
-        "tags": ["AsyncEventsRestApi"]
+        "tags": [
+          "AsyncEventsRestApi"
+        ]
       }
     },
     "/api/v1/available_domains/": {
@@ -10441,7 +11676,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Available Domains"]
+        "tags": [
+          "Available Domains"
+        ]
       }
     },
     "/api/v1/cachekey/invalidate": {
@@ -10474,7 +11711,9 @@
             "jwt": []
           }
         ],
-        "tags": ["CacheRestApi"]
+        "tags": [
+          "CacheRestApi"
+        ]
       }
     },
     "/api/v1/chart/": {
@@ -10530,7 +11769,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "tags": [
+          "Charts"
+        ]
       },
       "get": {
         "description": "Get a list of charts, use Rison or JSON query parameters for filtering, sorting, pagination and  for selecting specific columns and metadata.",
@@ -10635,7 +11876,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "tags": [
+          "Charts"
+        ]
       },
       "post": {
         "description": "Create a new Chart.",
@@ -10675,6 +11918,9 @@
           "401": {
             "$ref": "#/components/responses/401"
           },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
           "422": {
             "$ref": "#/components/responses/422"
           },
@@ -10687,7 +11933,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/chart/_info": {
@@ -10771,7 +12019,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/chart/data": {
@@ -10824,7 +12074,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/chart/data/{cache_key}": {
@@ -10872,7 +12124,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/chart/export/": {
@@ -10921,7 +12175,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/chart/favorite_status/": {
@@ -10969,7 +12225,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/chart/import/": {
@@ -10996,12 +12254,12 @@
                     "description": "JSON map of passwords for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
                     "type": "string"
                   },
-                  "ssh_tunnel_private_keys": {
-                    "description": "JSON map of private_keys for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the private_key should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_private_key\"}`.",
+                  "ssh_tunnel_private_key_passwords": {
+                    "description": "JSON map of private_key_passwords for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the private_key should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_private_key_password\"}`.",
                     "type": "string"
                   },
-                  "ssh_tunnel_private_keyspasswords": {
-                    "description": "JSON map of private_key_passwords for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the private_key_password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_private_key_password\"}`.",
+                  "ssh_tunnel_private_keys": {
+                    "description": "JSON map of private_keys for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the private_key should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_private_key\"}`.",
                     "type": "string"
                   }
                 },
@@ -11045,7 +12303,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/chart/related/{column_name}": {
@@ -11101,7 +12361,55 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "tags": [
+          "Charts"
+        ]
+      }
+    },
+    "/api/v1/chart/warm_up_cache": {
+      "put": {
+        "description": "Warms up the cache for the chart. Note for slices a force refresh occurs. In terms of the `extra_filters` these can be obtained from records in the JSON encoded `logs.json` column associated with the `explore_json` action.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChartCacheWarmUpRequestSchema"
+              }
+            }
+          },
+          "description": "Identifies the chart to warm up cache for, and any additional dashboard or filter context to use.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChartCacheWarmUpResponseSchema"
+                }
+              }
+            },
+            "description": "Each chart's warmup status"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Warms up the cache for the chart",
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/chart/{pk}": {
@@ -11154,7 +12462,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "tags": [
+          "Charts"
+        ]
       },
       "get": {
         "description": "Get a chart detail information.",
@@ -11252,7 +12562,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "tags": [
+          "Charts"
+        ]
       },
       "put": {
         "description": "Changes a Chart.",
@@ -11320,7 +12632,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/chart/{pk}/cache_screenshot/": {
@@ -11376,7 +12690,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/chart/{pk}/data/": {
@@ -11453,7 +12769,105 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "tags": [
+          "Charts"
+        ]
+      }
+    },
+    "/api/v1/chart/{pk}/favorites/": {
+      "delete": {
+        "description": "Remove the chart from the user favorite list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Chart removed from favorites"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Charts"
+        ]
+      },
+      "post": {
+        "description": "Marks the chart as favorite for the current user",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Chart added to favorites"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/chart/{pk}/screenshot/{digest}/": {
@@ -11507,7 +12921,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/chart/{pk}/thumbnail/{digest}/": {
@@ -11564,7 +12980,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/css_template/": {
@@ -11617,7 +13035,9 @@
             "jwt": []
           }
         ],
-        "tags": ["CSS Templates"]
+        "tags": [
+          "CSS Templates"
+        ]
       },
       "get": {
         "description": "Get a list of CSS templates, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
@@ -11722,7 +13142,9 @@
             "jwt": []
           }
         ],
-        "tags": ["CSS Templates"]
+        "tags": [
+          "CSS Templates"
+        ]
       },
       "post": {
         "description": "Create a CSS template",
@@ -11774,7 +13196,9 @@
             "jwt": []
           }
         ],
-        "tags": ["CSS Templates"]
+        "tags": [
+          "CSS Templates"
+        ]
       }
     },
     "/api/v1/css_template/_info": {
@@ -11858,7 +13282,9 @@
             "jwt": []
           }
         ],
-        "tags": ["CSS Templates"]
+        "tags": [
+          "CSS Templates"
+        ]
       }
     },
     "/api/v1/css_template/related/{column_name}": {
@@ -11913,7 +13339,9 @@
             "jwt": []
           }
         ],
-        "tags": ["CSS Templates"]
+        "tags": [
+          "CSS Templates"
+        ]
       }
     },
     "/api/v1/css_template/{pk}": {
@@ -11960,7 +13388,9 @@
             "jwt": []
           }
         ],
-        "tags": ["CSS Templates"]
+        "tags": [
+          "CSS Templates"
+        ]
       },
       "get": {
         "description": "Get a CSS template",
@@ -12058,7 +13488,9 @@
             "jwt": []
           }
         ],
-        "tags": ["CSS Templates"]
+        "tags": [
+          "CSS Templates"
+        ]
       },
       "put": {
         "description": "Update a CSS template",
@@ -12120,7 +13552,9 @@
             "jwt": []
           }
         ],
-        "tags": ["CSS Templates"]
+        "tags": [
+          "CSS Templates"
+        ]
       }
     },
     "/api/v1/dashboard/": {
@@ -12176,7 +13610,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "tags": [
+          "Dashboards"
+        ]
       },
       "get": {
         "description": "Get a list of dashboards, use Rison or JSON query parameters for filtering, sorting, pagination and  for selecting specific columns and metadata.",
@@ -12281,7 +13717,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "tags": [
+          "Dashboards"
+        ]
       },
       "post": {
         "description": "Create a new Dashboard.",
@@ -12333,7 +13771,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/dashboard/_info": {
@@ -12417,7 +13857,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/dashboard/export/": {
@@ -12468,7 +13910,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/dashboard/favorite_status/": {
@@ -12516,7 +13960,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/dashboard/import/": {
@@ -12543,12 +13989,12 @@
                     "description": "JSON map of passwords for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
                     "type": "string"
                   },
-                  "ssh_tunnel_private_keys": {
-                    "description": "JSON map of private_keys for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the private_key should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_private_key\"}`.",
+                  "ssh_tunnel_private_key_passwords": {
+                    "description": "JSON map of private_key_passwords for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the private_key should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_private_key_password\"}`.",
                     "type": "string"
                   },
-                  "ssh_tunnel_private_keyspasswords": {
-                    "description": "JSON map of private_key_passwords for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the private_key_password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_private_key_password\"}`.",
+                  "ssh_tunnel_private_keys": {
+                    "description": "JSON map of private_keys for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the private_key should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_private_key\"}`.",
                     "type": "string"
                   }
                 },
@@ -12592,7 +14038,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/dashboard/permalink/{key}": {
@@ -12646,7 +14094,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboard Permanent Link"]
+        "tags": [
+          "Dashboard Permanent Link"
+        ]
       }
     },
     "/api/v1/dashboard/related/{column_name}": {
@@ -12702,7 +14152,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/dashboard/{dashboard_id}/filtersets": {
@@ -12776,7 +14228,9 @@
             "jwt": []
           }
         ],
-        "tags": ["FilterSetRestApi"]
+        "tags": [
+          "FilterSetRestApi"
+        ]
       },
       "post": {
         "description": "Create a new Dashboard's Filter Set.",
@@ -12842,7 +14296,9 @@
             "jwt": []
           }
         ],
-        "tags": ["FilterSetRestApi"]
+        "tags": [
+          "FilterSetRestApi"
+        ]
       }
     },
     "/api/v1/dashboard/{dashboard_id}/filtersets/{pk}": {
@@ -12903,7 +14359,9 @@
             "jwt": []
           }
         ],
-        "tags": ["FilterSetRestApi"]
+        "tags": [
+          "FilterSetRestApi"
+        ]
       },
       "put": {
         "description": "Changes a Dashboard's Filter set.",
@@ -12979,7 +14437,9 @@
             "jwt": []
           }
         ],
-        "tags": ["FilterSetRestApi"]
+        "tags": [
+          "FilterSetRestApi"
+        ]
       }
     },
     "/api/v1/dashboard/{id_or_slug}": {
@@ -13030,7 +14490,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/dashboard/{id_or_slug}/charts": {
@@ -13083,7 +14545,78 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "tags": [
+          "Dashboards"
+        ]
+      }
+    },
+    "/api/v1/dashboard/{id_or_slug}/copy/": {
+      "post": {
+        "parameters": [
+          {
+            "description": "The dashboard id or slug",
+            "in": "path",
+            "name": "id_or_slug",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DashboardCopySchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "last_modified_time": {
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Id of new dashboard and last modified time"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Makes a copy of an existing dashboard",
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/dashboard/{id_or_slug}/datasets": {
@@ -13137,7 +14670,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/dashboard/{id_or_slug}/embedded": {
@@ -13182,7 +14717,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "tags": [
+          "Dashboards"
+        ]
       },
       "get": {
         "description": "Returns the dashboard's embedded configuration",
@@ -13225,7 +14762,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "tags": [
+          "Dashboards"
+        ]
       },
       "post": {
         "description": "Sets a dashboard's embedded configuration.",
@@ -13279,7 +14818,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "tags": [
+          "Dashboards"
+        ]
       },
       "put": {
         "description": "Sets a dashboard's embedded configuration.",
@@ -13333,7 +14874,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/dashboard/{pk}": {
@@ -13386,7 +14929,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "tags": [
+          "Dashboards"
+        ]
       },
       "put": {
         "description": "Changes a Dashboard.",
@@ -13457,7 +15002,105 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "tags": [
+          "Dashboards"
+        ]
+      }
+    },
+    "/api/v1/dashboard/{pk}/favorites/": {
+      "delete": {
+        "description": "Remove the dashboard from the user favorite list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Dashboard removed from favorites"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Dashboards"
+        ]
+      },
+      "post": {
+        "description": "Marks the dashboard as favorite for the current user",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Dashboard added to favorites"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/dashboard/{pk}/filter_state": {
@@ -13525,7 +15168,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboard Filter State"]
+        "tags": [
+          "Dashboard Filter State"
+        ]
       }
     },
     "/api/v1/dashboard/{pk}/filter_state/{key}": {
@@ -13588,7 +15233,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboard Filter State"]
+        "tags": [
+          "Dashboard Filter State"
+        ]
       },
       "get": {
         "description": "Retrives a value.",
@@ -13648,7 +15295,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboard Filter State"]
+        "tags": [
+          "Dashboard Filter State"
+        ]
       },
       "put": {
         "description": "Updates an existing value.",
@@ -13725,7 +15374,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboard Filter State"]
+        "tags": [
+          "Dashboard Filter State"
+        ]
       }
     },
     "/api/v1/dashboard/{pk}/permalink": {
@@ -13745,7 +15396,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/DashboardPermalinkPostSchema"
+                "$ref": "#/components/schemas/DashboardPermalinkStateSchema"
               }
             }
           },
@@ -13790,7 +15441,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboard Permanent Link"]
+        "tags": [
+          "Dashboard Permanent Link"
+        ]
       }
     },
     "/api/v1/dashboard/{pk}/thumbnail/{digest}/": {
@@ -13874,7 +15527,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/database/": {
@@ -13981,7 +15636,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "tags": [
+          "Database"
+        ]
       },
       "post": {
         "description": "Create a new Database.",
@@ -14033,7 +15690,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/_info": {
@@ -14117,7 +15776,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/available/": {
@@ -14196,7 +15857,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/export/": {
@@ -14242,7 +15905,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/import/": {
@@ -14269,12 +15934,12 @@
                     "description": "JSON map of passwords for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
                     "type": "string"
                   },
-                  "ssh_tunnel_private_keys": {
-                    "description": "JSON map of private_keys for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the private_key should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_private_key\"}`.",
+                  "ssh_tunnel_private_key_passwords": {
+                    "description": "JSON map of private_key_passwords for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the private_key should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_private_key_password\"}`.",
                     "type": "string"
                   },
-                  "ssh_tunnel_private_keyspasswords": {
-                    "description": "JSON map of private_key_passwords for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the private_key_password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_private_key_password\"}`.",
+                  "ssh_tunnel_private_keys": {
+                    "description": "JSON map of private_keys for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the private_key should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_private_key\"}`.",
                     "type": "string"
                   }
                 },
@@ -14318,7 +15983,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/test_connection/": {
@@ -14366,7 +16033,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/validate_parameters/": {
@@ -14414,7 +16083,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/{pk}": {
@@ -14467,7 +16138,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "tags": [
+          "Database"
+        ]
       },
       "get": {
         "description": "Get a database",
@@ -14511,7 +16184,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "tags": [
+          "Database"
+        ]
       },
       "put": {
         "description": "Changes a Database.",
@@ -14579,7 +16254,57 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "tags": [
+          "Database"
+        ]
+      }
+    },
+    "/api/v1/database/{pk}/connection": {
+      "get": {
+        "parameters": [
+          {
+            "description": "The database id",
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatabaseConnectionSchema"
+                }
+              }
+            },
+            "description": "Database with connection info"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Get a database connection info",
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/{pk}/function_names/": {
@@ -14621,7 +16346,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/{pk}/related_objects/": {
@@ -14663,7 +16390,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/{pk}/schemas/": {
@@ -14720,7 +16449,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/{pk}/schemas_access_for_file_upload/": {
@@ -14762,7 +16493,9 @@
           }
         ],
         "summary": "The list of the database schemas where to upload information",
-        "tags": ["Database"]
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/{pk}/select_star/{table_name}/": {
@@ -14829,7 +16562,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/{pk}/select_star/{table_name}/{schema_name}/": {
@@ -14896,7 +16631,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/{pk}/ssh_tunnel/": {
@@ -14949,7 +16686,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/{pk}/table/{table_name}/{schema_name}/": {
@@ -15016,7 +16755,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/{pk}/table_extra/{table_name}/{schema_name}/": {
@@ -15084,7 +16825,9 @@
           }
         ],
         "summary": "Get table extra metadata",
-        "tags": ["Database"]
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/{pk}/tables/": {
@@ -15156,7 +16899,9 @@
           }
         ],
         "summary": "Get a list of tables for given database",
-        "tags": ["Database"]
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/{pk}/validate_sql/": {
@@ -15222,7 +16967,9 @@
           }
         ],
         "summary": "Validates that arbitrary sql is acceptable for the given database",
-        "tags": ["Database"]
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/dataset/": {
@@ -15281,7 +17028,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "tags": [
+          "Datasets"
+        ]
       },
       "get": {
         "description": "Get a list of models",
@@ -15386,7 +17135,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "tags": [
+          "Datasets"
+        ]
       },
       "post": {
         "description": "Create a new Dataset",
@@ -15438,7 +17189,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "tags": [
+          "Datasets"
+        ]
       }
     },
     "/api/v1/dataset/_info": {
@@ -15522,7 +17275,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "tags": [
+          "Datasets"
+        ]
       }
     },
     "/api/v1/dataset/distinct/{column_name}": {
@@ -15577,7 +17332,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "tags": [
+          "Datasets"
+        ]
       }
     },
     "/api/v1/dataset/duplicate": {
@@ -15637,7 +17394,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "tags": [
+          "Datasets"
+        ]
       }
     },
     "/api/v1/dataset/export/": {
@@ -15685,7 +17444,66 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "tags": [
+          "Datasets"
+        ]
+      }
+    },
+    "/api/v1/dataset/get_or_create/": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetOrCreateDatasetSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "properties": {
+                        "table_id": {
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "The ID of the table"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Retrieve a table by name, or create it if it does not exist",
+        "tags": [
+          "Datasets"
+        ]
       }
     },
     "/api/v1/dataset/import/": {
@@ -15708,6 +17526,18 @@
                     "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
                     "type": "string"
                   },
+                  "ssh_tunnel_passwords": {
+                    "description": "JSON map of passwords for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
+                    "type": "string"
+                  },
+                  "ssh_tunnel_private_key_passwords": {
+                    "description": "JSON map of private_key_passwords for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the private_key should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_private_key_password\"}`.",
+                    "type": "string"
+                  },
+                  "ssh_tunnel_private_keys": {
+                    "description": "JSON map of private_keys for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the private_key should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_private_key\"}`.",
+                    "type": "string"
+                  },
                   "sync_columns": {
                     "description": "sync columns?",
                     "type": "boolean"
@@ -15715,18 +17545,6 @@
                   "sync_metrics": {
                     "description": "sync metrics?",
                     "type": "boolean"
-                  },
-                  "ssh_tunnel_passwords": {
-                    "description": "JSON map of passwords for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
-                    "type": "string"
-                  },
-                  "ssh_tunnel_private_keys": {
-                    "description": "JSON map of private_keys for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the private_key should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_private_key\"}`.",
-                    "type": "string"
-                  },
-                  "ssh_tunnel_private_keyspasswords": {
-                    "description": "JSON map of private_key_passwords for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the private_key_password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_private_key_password\"}`.",
-                    "type": "string"
                   }
                 },
                 "type": "object"
@@ -15769,7 +17587,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "tags": [
+          "Datasets"
+        ]
       }
     },
     "/api/v1/dataset/related/{column_name}": {
@@ -15824,7 +17644,55 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "tags": [
+          "Datasets"
+        ]
+      }
+    },
+    "/api/v1/dataset/warm_up_cache": {
+      "put": {
+        "description": "Warms up the cache for the table. Note for slices a force refresh occurs. In terms of the `extra_filters` these can be obtained from records in the JSON encoded `logs.json` column associated with the `explore_json` action.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DatasetCacheWarmUpRequestSchema"
+              }
+            }
+          },
+          "description": "Identifies the database and table to warm up cache for, and any additional dashboard or filter context to use.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetCacheWarmUpResponseSchema"
+                }
+              }
+            },
+            "description": "Each chart's warmup status"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Warms up the cache for each chart powered by the given table",
+        "tags": [
+          "Datasets"
+        ]
       }
     },
     "/api/v1/dataset/{pk}": {
@@ -15877,7 +17745,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "tags": [
+          "Datasets"
+        ]
       },
       "get": {
         "description": "Get an item model",
@@ -15975,7 +17845,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "tags": [
+          "Datasets"
+        ]
       },
       "put": {
         "description": "Changes a Dataset",
@@ -16050,7 +17922,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "tags": [
+          "Datasets"
+        ]
       }
     },
     "/api/v1/dataset/{pk}/column/{column_id}": {
@@ -16113,7 +17987,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "tags": [
+          "Datasets"
+        ]
       }
     },
     "/api/v1/dataset/{pk}/metric/{metric_id}": {
@@ -16176,7 +18052,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "tags": [
+          "Datasets"
+        ]
       }
     },
     "/api/v1/dataset/{pk}/refresh": {
@@ -16229,7 +18107,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "tags": [
+          "Datasets"
+        ]
       }
     },
     "/api/v1/dataset/{pk}/related_objects": {
@@ -16271,7 +18151,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "tags": [
+          "Datasets"
+        ]
       }
     },
     "/api/v1/datasource/{datasource_type}/{datasource_id}/column/{column_name}/values/": {
@@ -16362,7 +18244,9 @@
           }
         ],
         "summary": "Get possible values for a datasource column",
-        "tags": ["Datasources"]
+        "tags": [
+          "Datasources"
+        ]
       }
     },
     "/api/v1/embedded_dashboard/{uuid}": {
@@ -16410,7 +18294,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Embedded Dashboard"]
+        "tags": [
+          "Embedded Dashboard"
+        ]
       }
     },
     "/api/v1/explore/": {
@@ -16486,7 +18372,9 @@
           }
         ],
         "summary": "Assembles Explore related information (form_data, slice, dataset)\\n in a single endpoint.",
-        "tags": ["Explore"]
+        "tags": [
+          "Explore"
+        ]
       }
     },
     "/api/v1/explore/form_data": {
@@ -16546,7 +18434,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Explore Form Data"]
+        "tags": [
+          "Explore Form Data"
+        ]
       }
     },
     "/api/v1/explore/form_data/{key}": {
@@ -16601,7 +18491,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Explore Form Data"]
+        "tags": [
+          "Explore Form Data"
+        ]
       },
       "get": {
         "description": "Retrives a form_data.",
@@ -16653,7 +18545,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Explore Form Data"]
+        "tags": [
+          "Explore Form Data"
+        ]
       },
       "put": {
         "description": "Updates an existing form_data.",
@@ -16722,7 +18616,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Explore Form Data"]
+        "tags": [
+          "Explore Form Data"
+        ]
       }
     },
     "/api/v1/explore/permalink": {
@@ -16732,7 +18628,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ExplorePermalinkPostSchema"
+                "$ref": "#/components/schemas/ExplorePermalinkStateSchema"
               }
             }
           },
@@ -16777,7 +18673,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Explore Permanent Link"]
+        "tags": [
+          "Explore Permanent Link"
+        ]
       }
     },
     "/api/v1/explore/permalink/{key}": {
@@ -16831,7 +18729,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Explore Permanent Link"]
+        "tags": [
+          "Explore Permanent Link"
+        ]
       }
     },
     "/api/v1/log/": {
@@ -16938,7 +18838,9 @@
             "jwt": []
           }
         ],
-        "tags": ["LogRestApi"]
+        "tags": [
+          "LogRestApi"
+        ]
       },
       "post": {
         "requestBody": {
@@ -16989,10 +18891,12 @@
             "jwt": []
           }
         ],
-        "tags": ["LogRestApi"]
+        "tags": [
+          "LogRestApi"
+        ]
       }
     },
-    "/api/v1/log/recent_activity/{user_id}/": {
+    "/api/v1/log/recent_activity/": {
       "get": {
         "parameters": [
           {
@@ -17046,7 +18950,9 @@
           }
         ],
         "summary": "Get recent activity data for a user",
-        "tags": ["LogRestApi"]
+        "tags": [
+          "LogRestApi"
+        ]
       }
     },
     "/api/v1/log/{pk}": {
@@ -17146,7 +19052,9 @@
             "jwt": []
           }
         ],
-        "tags": ["LogRestApi"]
+        "tags": [
+          "LogRestApi"
+        ]
       }
     },
     "/api/v1/me/": {
@@ -17172,7 +19080,9 @@
             "$ref": "#/components/responses/401"
           }
         },
-        "tags": ["Current User"]
+        "tags": [
+          "Current User"
+        ]
       }
     },
     "/api/v1/me/roles/": {
@@ -17198,7 +19108,9 @@
             "$ref": "#/components/responses/401"
           }
         },
-        "tags": ["Current User"]
+        "tags": [
+          "Current User"
+        ]
       }
     },
     "/api/v1/menu/": {
@@ -17257,7 +19169,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Menu"]
+        "tags": [
+          "Menu"
+        ]
       }
     },
     "/api/v1/query/": {
@@ -17364,7 +19278,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/api/v1/query/distinct/{column_name}": {
@@ -17419,7 +19335,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/api/v1/query/related/{column_name}": {
@@ -17474,7 +19392,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/api/v1/query/stop": {
@@ -17525,7 +19445,9 @@
           }
         ],
         "summary": "Manually stop a query with client_id",
-        "tags": ["Queries"]
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/api/v1/query/updated_since": {
@@ -17582,7 +19504,9 @@
           }
         ],
         "summary": "Get a list of queries that changed after last_updated_ms",
-        "tags": ["Queries"]
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/api/v1/query/{pk}": {
@@ -17682,7 +19606,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/api/v1/report/": {
@@ -17738,7 +19664,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Report Schedules"]
+        "tags": [
+          "Report Schedules"
+        ]
       },
       "get": {
         "description": "Get a list of report schedules, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
@@ -17843,7 +19771,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Report Schedules"]
+        "tags": [
+          "Report Schedules"
+        ]
       },
       "post": {
         "description": "Create a report schedule",
@@ -17898,7 +19828,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Report Schedules"]
+        "tags": [
+          "Report Schedules"
+        ]
       }
     },
     "/api/v1/report/_info": {
@@ -17982,7 +19914,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Report Schedules"]
+        "tags": [
+          "Report Schedules"
+        ]
       }
     },
     "/api/v1/report/related/{column_name}": {
@@ -18037,7 +19971,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Report Schedules"]
+        "tags": [
+          "Report Schedules"
+        ]
       }
     },
     "/api/v1/report/{pk}": {
@@ -18088,7 +20024,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Report Schedules"]
+        "tags": [
+          "Report Schedules"
+        ]
       },
       "get": {
         "description": "Get a report schedule",
@@ -18186,7 +20124,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Report Schedules"]
+        "tags": [
+          "Report Schedules"
+        ]
       },
       "put": {
         "description": "Update a report schedule",
@@ -18255,7 +20195,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Report Schedules"]
+        "tags": [
+          "Report Schedules"
+        ]
       }
     },
     "/api/v1/report/{pk}/log/": {
@@ -18332,7 +20274,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Report Schedules"]
+        "tags": [
+          "Report Schedules"
+        ]
       }
     },
     "/api/v1/report/{pk}/log/{log_id}": {
@@ -18410,7 +20354,593 @@
             "jwt": []
           }
         ],
-        "tags": ["Report Schedules"]
+        "tags": [
+          "Report Schedules"
+        ]
+      }
+    },
+    "/api/v1/rowlevelsecurity/": {
+      "delete": {
+        "description": "Deletes multiple RLS rules in a bulk operation.",
+        "parameters": [
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_delete_ids_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "RLS Rule bulk delete"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Row Level Security"
+        ]
+      },
+      "get": {
+        "description": "Get a list of models",
+        "parameters": [
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_list_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "count": {
+                      "description": "The total record count on the backend",
+                      "type": "number"
+                    },
+                    "description_columns": {
+                      "properties": {
+                        "column_name": {
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "ids": {
+                      "description": "A list of item ids, useful when you don't know the column id",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "label_columns": {
+                      "properties": {
+                        "column_name": {
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "list_columns": {
+                      "description": "A list of columns",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "list_title": {
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "List Items",
+                      "type": "string"
+                    },
+                    "order_columns": {
+                      "description": "A list of allowed columns to sort",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "result": {
+                      "description": "The result from the get list query",
+                      "items": {
+                        "$ref": "#/components/schemas/RLSRestApi.get_list"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Items from Model"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Row Level Security"
+        ]
+      },
+      "post": {
+        "description": "Create a new RLS Rule",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RLSRestApi.post"
+              }
+            }
+          },
+          "description": "RLS schema",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/RLSRestApi.post"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "RLS Rule added"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Row Level Security"
+        ]
+      }
+    },
+    "/api/v1/rowlevelsecurity/_info": {
+      "get": {
+        "description": "Get metadata information about this API resource",
+        "parameters": [
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_info_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "add_columns": {
+                      "type": "object"
+                    },
+                    "edit_columns": {
+                      "type": "object"
+                    },
+                    "filters": {
+                      "properties": {
+                        "column_name": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "description": "The filter name. Will be translated by babel",
+                                "type": "string"
+                              },
+                              "operator": {
+                                "description": "The filter operation key to use on list filters",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "permissions": {
+                      "description": "The user permissions for this API resource",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Item from Model"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Row Level Security"
+        ]
+      }
+    },
+    "/api/v1/rowlevelsecurity/related/{column_name}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "column_name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_related_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RelatedResponseSchema"
+                }
+              }
+            },
+            "description": "Related column data"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Row Level Security"
+        ]
+      }
+    },
+    "/api/v1/rowlevelsecurity/{pk}": {
+      "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Item deleted"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Row Level Security"
+        ]
+      },
+      "get": {
+        "description": "Get an item model",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_item_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "description_columns": {
+                      "properties": {
+                        "column_name": {
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "id": {
+                      "description": "The item id",
+                      "type": "string"
+                    },
+                    "label_columns": {
+                      "properties": {
+                        "column_name": {
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/RLSRestApi.get"
+                    },
+                    "show_columns": {
+                      "description": "A list of columns",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "show_title": {
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "Show Item Details",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Item from Model"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Row Level Security"
+        ]
+      },
+      "put": {
+        "description": "Updates an RLS Rule",
+        "parameters": [
+          {
+            "description": "The Rule pk",
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RLSRestApi.put"
+              }
+            }
+          },
+          "description": "RLS schema",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/RLSRestApi.put"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Rule changed"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Row Level Security"
+        ]
       }
     },
     "/api/v1/saved_query/": {
@@ -18463,7 +20993,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "tags": [
+          "Queries"
+        ]
       },
       "get": {
         "description": "Get a list of saved queries, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
@@ -18568,7 +21100,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "tags": [
+          "Queries"
+        ]
       },
       "post": {
         "description": "Create a saved query",
@@ -18620,7 +21154,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/api/v1/saved_query/_info": {
@@ -18704,7 +21240,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/api/v1/saved_query/distinct/{column_name}": {
@@ -18759,7 +21297,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/api/v1/saved_query/export/": {
@@ -18808,7 +21348,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/api/v1/saved_query/import/": {
@@ -18835,12 +21377,12 @@
                     "description": "JSON map of passwords for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
                     "type": "string"
                   },
-                  "ssh_tunnel_private_keys": {
-                    "description": "JSON map of private_keys for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the private_key should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_private_key\"}`.",
+                  "ssh_tunnel_private_key_passwords": {
+                    "description": "JSON map of private_key_passwords for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the private_key should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_private_key_password\"}`.",
                     "type": "string"
                   },
-                  "ssh_tunnel_private_keyspasswords": {
-                    "description": "JSON map of private_key_passwords for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the private_key_password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_private_key_password\"}`.",
+                  "ssh_tunnel_private_keys": {
+                    "description": "JSON map of private_keys for each ssh_tunnel associated to a featured database in the ZIP file. If the ZIP includes a ssh_tunnel config in the path `databases/MyDatabase.yaml`, the private_key should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_private_key\"}`.",
                     "type": "string"
                   }
                 },
@@ -18884,7 +21426,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/api/v1/saved_query/related/{column_name}": {
@@ -18939,7 +21483,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/api/v1/saved_query/{pk}": {
@@ -18986,7 +21532,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "tags": [
+          "Queries"
+        ]
       },
       "get": {
         "description": "Get a saved query",
@@ -19084,7 +21632,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "tags": [
+          "Queries"
+        ]
       },
       "put": {
         "description": "Update a saved query",
@@ -19146,7 +21696,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/api/v1/security/csrf_token/": {
@@ -19180,7 +21732,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Security"]
+        "tags": [
+          "Security"
+        ]
       }
     },
     "/api/v1/security/guest_token/": {
@@ -19228,7 +21782,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Security"]
+        "tags": [
+          "Security"
+        ]
       }
     },
     "/api/v1/security/login": {
@@ -19246,7 +21802,10 @@
                   },
                   "provider": {
                     "description": "Choose an authentication provider",
-                    "enum": ["db", "ldap"],
+                    "enum": [
+                      "db",
+                      "ldap"
+                    ],
                     "example": "db",
                     "type": "string"
                   },
@@ -19296,7 +21855,9 @@
             "$ref": "#/components/responses/500"
           }
         },
-        "tags": ["Security"]
+        "tags": [
+          "Security"
+        ]
       }
     },
     "/api/v1/security/refresh": {
@@ -19331,7 +21892,62 @@
             "jwt_refresh": []
           }
         ],
-        "tags": ["Security"]
+        "tags": [
+          "Security"
+        ]
+      }
+    },
+    "/api/v1/sqllab/estimate/": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EstimateQueryCostSchema"
+              }
+            }
+          },
+          "description": "SQL query and params",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Query estimation result"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Estimates the SQL query execution cost",
+        "tags": [
+          "SQL Lab"
+        ]
       }
     },
     "/api/v1/sqllab/execute/": {
@@ -19390,7 +22006,9 @@
             "jwt": []
           }
         ],
-        "tags": ["SQL Lab"]
+        "tags": [
+          "SQL Lab"
+        ]
       }
     },
     "/api/v1/sqllab/export/{client_id}/": {
@@ -19439,7 +22057,9 @@
           }
         ],
         "summary": "Exports the SQL query results to a CSV",
-        "tags": ["SQL Lab"]
+        "tags": [
+          "SQL Lab"
+        ]
       }
     },
     "/api/v1/sqllab/results/": {
@@ -19493,7 +22113,933 @@
           }
         ],
         "summary": "Gets the result of a SQL query execution",
-        "tags": ["SQL Lab"]
+        "tags": [
+          "SQL Lab"
+        ]
+      }
+    },
+    "/api/v1/tag/": {
+      "delete": {
+        "description": "Deletes multiple Tags. This will remove all tagged objects with this tag",
+        "parameters": [
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/delete_tags_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Deletes multiple Tags"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Tags"
+        ]
+      },
+      "get": {
+        "description": "Get a list of tags, use Rison or JSON query parameters for filtering, sorting, pagination and  for selecting specific columns and metadata.",
+        "parameters": [
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_list_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "count": {
+                      "description": "The total record count on the backend",
+                      "type": "number"
+                    },
+                    "description_columns": {
+                      "properties": {
+                        "column_name": {
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "ids": {
+                      "description": "A list of item ids, useful when you don't know the column id",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "label_columns": {
+                      "properties": {
+                        "column_name": {
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "list_columns": {
+                      "description": "A list of columns",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "list_title": {
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "List Items",
+                      "type": "string"
+                    },
+                    "order_columns": {
+                      "description": "A list of allowed columns to sort",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "result": {
+                      "description": "The result from the get list query",
+                      "items": {
+                        "$ref": "#/components/schemas/TagRestApi.get_list"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Items from Model"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Tags"
+        ]
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TagRestApi.post"
+              }
+            }
+          },
+          "description": "Model schema",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/TagRestApi.post"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Item inserted"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Tags"
+        ]
+      }
+    },
+    "/api/v1/tag/_info": {
+      "get": {
+        "description": "Several metadata information about tag API endpoints.",
+        "parameters": [
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_info_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "add_columns": {
+                      "type": "object"
+                    },
+                    "edit_columns": {
+                      "type": "object"
+                    },
+                    "filters": {
+                      "properties": {
+                        "column_name": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "description": "The filter name. Will be translated by babel",
+                                "type": "string"
+                              },
+                              "operator": {
+                                "description": "The filter operation key to use on list filters",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "permissions": {
+                      "description": "The user permissions for this API resource",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Item from Model"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Tags"
+        ]
+      }
+    },
+    "/api/v1/tag/favorite_status/": {
+      "get": {
+        "description": "Check favorited dashboards for current user",
+        "parameters": [
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_fav_star_ids_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetFavStarIdsSchema"
+                }
+              }
+            },
+            "description": "None"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Tags"
+        ]
+      }
+    },
+    "/api/v1/tag/get_objects/": {
+      "get": {
+        "description": "Gets all objects associated with a Tag.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tag_id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "items": {
+                        "$ref": "#/components/schemas/TaggedObjectEntityResponseSchema"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "List of tagged objects associated with a Tag"
+          },
+          "302": {
+            "description": "Redirects to the current digest"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Tags"
+        ]
+      }
+    },
+    "/api/v1/tag/related/{column_name}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "column_name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_related_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RelatedResponseSchema"
+                }
+              }
+            },
+            "description": "Related column data"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Tags"
+        ]
+      }
+    },
+    "/api/v1/tag/{object_type}/{object_id}/": {
+      "post": {
+        "description": "Add tags to an object..",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "object_type",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "object_id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "tags": {
+                    "description": "list of tag names to add to object",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Tag schema",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Tag added"
+          },
+          "302": {
+            "description": "Redirects to the current digest"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Tags"
+        ]
+      }
+    },
+    "/api/v1/tag/{object_type}/{object_id}/{tag}/": {
+      "delete": {
+        "description": "Deletes a Tagged Object.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tag",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "object_type",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "object_id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Chart delete"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Tags"
+        ]
+      }
+    },
+    "/api/v1/tag/{pk}": {
+      "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Item deleted"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Tags"
+        ]
+      },
+      "get": {
+        "description": "Get a tag detail information.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_item_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "description_columns": {
+                      "properties": {
+                        "column_name": {
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "id": {
+                      "description": "The item id",
+                      "type": "string"
+                    },
+                    "label_columns": {
+                      "properties": {
+                        "column_name": {
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/TagRestApi.get"
+                    },
+                    "show_columns": {
+                      "description": "A list of columns",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "show_title": {
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "Show Item Details",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Item from Model"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Tags"
+        ]
+      },
+      "put": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TagRestApi.put"
+              }
+            }
+          },
+          "description": "Model schema",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "$ref": "#/components/schemas/TagRestApi.put"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Item changed"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Tags"
+        ]
+      }
+    },
+    "/api/v1/tag/{pk}/favorites/": {
+      "delete": {
+        "description": "Remove the tag from the user favorite list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Tag removed from favorites"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Tags"
+        ]
+      },
+      "post": {
+        "description": "Marks the tag as favorite for the current user",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Tag added to favorites"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "Tags"
+        ]
       }
     },
     "/api/{version}/_openapi": {
@@ -19532,7 +23078,9 @@
             "jwt": []
           }
         ],
-        "tags": ["OpenApi"]
+        "tags": [
+          "OpenApi"
+        ]
       }
     }
   },

--- a/superset/explore/permalink/api.py
+++ b/superset/explore/permalink/api.py
@@ -68,7 +68,7 @@ class ExplorePermalinkRestApi(BaseSupersetApi):
             content:
               application/json:
                 schema:
-                  $ref: '#/components/schemas/ExplorePermalinkPostSchema'
+                  $ref: '#/components/schemas/ExplorePermalinkStateSchema'
           responses:
             201:
               description: The permanent link was stored successfully.


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Small fix for https://github.com/apache/superset/pull/24586 to  update the schema to point to the new one. The PostSchema no longer exists, so it was failing a test in the 2.1.1 release. 

### TESTING INSTRUCTIONS
The test in master isn't failing with the Post schema, likely because of some regression with openapi-spec-validator==0.5.6 that @villebro is looking into 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
