### PR TITLE
fix(hive): Remove unused async arg from execute query func to get hive connector working

### DIFF
--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -542,11 +542,9 @@ class HiveEngineSpec(PrestoEngineSpec):
             connect_args["configuration"] = configuration
 
     @staticmethod
-    def execute(  # type: ignore
-        cursor, query: str, async_: bool = False
-    ):  # pylint: disable=arguments-differ
-        kwargs = {"async": async_}
-        cursor.execute(query, **kwargs)
+    def execute(cursor, query: str):  
+        # pylint: disable=arguments-differ
+        cursor.execute(query)
 
     @classmethod
     @cache_manager.cache.memoize()

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -542,7 +542,7 @@ class HiveEngineSpec(PrestoEngineSpec):
             connect_args["configuration"] = configuration
 
     @staticmethod
-    def execute(cursor, query: str):  
+    def execute(cursor, query: str):
         # pylint: disable=arguments-differ
         cursor.execute(query)
 


### PR DESCRIPTION
### SUMMARY
Fixes this issue: https://github.com/apache/superset/issues/24786

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
