### PR TITLE
fix: Calendar Heatmap day offset

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/src/vendor/cal-heatmap.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/src/vendor/cal-heatmap.js
@@ -296,8 +296,21 @@ var CalHeatMap = function () {
     // Used mainly to convert the datas if they're not formatted like expected
     // Takes the fetched "data" object as argument, must return a json object
     // formatted like {timestamp:count, timestamp2:count2},
-    afterLoadData: function (data) {
-      return data;
+    afterLoadData: function (timestamps) {
+      // See https://github.com/wa0x6e/cal-heatmap/issues/126#issuecomment-373301803
+      const stdTimezoneOffset = date => {
+        const jan = new Date(date.getFullYear(), 0, 1);
+        const jul = new Date(date.getFullYear(), 6, 1);
+        return Math.max(jan.getTimezoneOffset(), jul.getTimezoneOffset());
+      };
+      const offset = stdTimezoneOffset(new Date()) * 60;
+      let results = {};
+      for (let timestamp in timestamps) {
+        const value = timestamps[timestamp];
+        timestamp = parseInt(timestamp, 10);
+        results[timestamp + offset] = value;
+      }
+      return results;
     },
 
     // Callback triggered after calling and completing update().


### PR DESCRIPTION
### SUMMARY
This PR fixes a bug where the Calendar Heatmap was displaying data with an offset of one day due to timezone differences.

See https://github.com/wa0x6e/cal-heatmap/issues/126

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Results panel shows December 9 but Heatmap shows December 8
<img width="816" alt="Screenshot 2023-08-15 at 11 25 06" src="https://github.com/apache/superset/assets/70410625/c4778ef9-1c22-48ff-acd6-58af48211c8d">

Heatmap and the Results panel match
<img width="832" alt="Screenshot 2023-08-15 at 11 24 18" src="https://github.com/apache/superset/assets/70410625/4619b3e8-841e-42fc-b53a-84795ed40516">

### TESTING INSTRUCTIONS
Make sure the Heatmap matches the dates in the Results panel.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
