### PR TITLE
fix(mssql): avoid trying to return a resultset for DML queries with not resultset

### DIFF
--- a/superset/db_engine_specs/mssql.py
+++ b/superset/db_engine_specs/mssql.py
@@ -141,6 +141,8 @@ class MssqlEngineSpec(BaseEngineSpec):
     def fetch_data(
         cls, cursor: Any, limit: Optional[int] = None
     ) -> list[tuple[Any, ...]]:
+        if not cursor.description:
+            return []
         data = super().fetch_data(cursor, limit)
         # Lists of `pyodbc.Row` need to be unpacked further
         return cls.pyodbc_rows_to_tuples(data)

--- a/tests/unit_tests/db_engine_specs/test_mssql.py
+++ b/tests/unit_tests/db_engine_specs/test_mssql.py
@@ -157,6 +157,14 @@ def test_extract_error_message() -> None:
     assert expected_message == error_message
 
 
+def test_fetch_data_no_description() -> None:
+    from superset.db_engine_specs.mssql import MssqlEngineSpec
+
+    cursor = mock.MagicMock()
+    cursor.description = []
+    assert MssqlEngineSpec.fetch_data(cursor) == []
+
+
 def test_fetch_data() -> None:
     from superset.db_engine_specs.base import BaseEngineSpec
     from superset.db_engine_specs.mssql import MssqlEngineSpec
@@ -166,9 +174,10 @@ def test_fetch_data() -> None:
         "pyodbc_rows_to_tuples",
         return_value="converted",
     ) as mock_pyodbc_rows_to_tuples:
+        cursor = mock.MagicMock()
         data = [(1, "foo")]
         with mock.patch.object(BaseEngineSpec, "fetch_data", return_value=data):
-            result = MssqlEngineSpec.fetch_data(None, 0)
+            result = MssqlEngineSpec.fetch_data(cursor, 0)
             mock_pyodbc_rows_to_tuples.assert_called_once_with(data)
             assert result == "converted"
 


### PR DESCRIPTION
### SUMMARY
Unlike other db engines, the mssql one does not include a check to see if there is even a need to return a result set before trying to fetch the data, that's why we are failing on a non select queries with the Statement not executed or executed statement has no resultset error.
In order to see if there is any result to try and fetch, we should check if the cursor description is not None.

Just for a reference we can see that other db engines like oracle or postgres do have that check before trying to fetch:
Oracle
https://github.com/apache/superset/blob/85a7d5cb3ebe833cfc2980f0846f15bb7ce1dd01/superset/db_engine_specs/postgres.py#L176C1-L179

Postgres
https://github.com/apache/superset/blob/85a7d5cb3ebe833cfc2980f0846f15bb7ce1dd01/superset/db_engine_specs/postgres.py#L176C1-L179

The result is failure in running a DML queries due to **'mssql error: Statement not executed or executed statement has no resultset'**

So the fix is simply to add that check before calling the inherited fetch_data method.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![256207004-7bda88ad-7d0e-475b-8b0a-f7b441aade0f](https://github.com/apache/superset/assets/53703174/5c6648c7-bdbe-45aa-bf68-330791574dde)

### TESTING INSTRUCTIONS
Run a DML query via the SQL Lab on an mssql DB 

### ADDITIONAL INFORMATION
- [x] Has associated issue: https://github.com/apache/superset/issues/24810
