### PR TITLE
chore(sqllab): Relocate user in SqlLab to root

### DIFF
--- a/superset-frontend/src/SqlLab/App.jsx
+++ b/superset-frontend/src/SqlLab/App.jsx
@@ -78,12 +78,6 @@ const sqlLabPersistStateConfig = {
         }
       });
 
-      if (subset.sqlLab?.user) {
-        // Don't persist the user.
-        // User should really not be stored under the "sqlLab" field. Oh well.
-        delete subset.sqlLab.user;
-      }
-
       const data = JSON.stringify(subset);
       // 2 digit precision
       const currentSize =

--- a/superset-frontend/src/SqlLab/App.jsx
+++ b/superset-frontend/src/SqlLab/App.jsx
@@ -105,9 +105,6 @@ const sqlLabPersistStateConfig = {
           ...initialState.sqlLab,
         },
       };
-      // Filter out any user data that may have been persisted in an older version.
-      // Get user from bootstrap data instead, every time
-      result.sqlLab.user = initialState.sqlLab.user;
       return result;
     },
   },

--- a/superset-frontend/src/SqlLab/App.jsx
+++ b/superset-frontend/src/SqlLab/App.jsx
@@ -27,7 +27,7 @@ import {
   isFeatureEnabled,
 } from '@superset-ui/core';
 import { GlobalStyles } from 'src/GlobalStyles';
-import { setupStore } from 'src/views/store';
+import { setupStore, userReducer } from 'src/views/store';
 import setupExtensions from 'src/setup/setupExtensions';
 import getBootstrapData from 'src/utils/getBootstrapData';
 import { tableApiUtil } from 'src/hooks/apiResources/tables';
@@ -112,7 +112,7 @@ const sqlLabPersistStateConfig = {
 
 export const store = setupStore({
   initialState,
-  rootReducers: reducers,
+  rootReducers: { ...reducers, user: userReducer },
   ...(!isFeatureEnabled(FeatureFlag.SQLLAB_BACKEND_PERSISTENCE) && {
     enhancers: [
       persistState(

--- a/superset-frontend/src/SqlLab/components/QueryTable/QueryTable.test.jsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/QueryTable.test.jsx
@@ -41,7 +41,7 @@ describe('QueryTable', () => {
   it('renders a proper table', () => {
     const mockStore = configureStore([thunk]);
     const store = mockStore({
-      sqlLab: user,
+      user,
     });
 
     const wrapper = mount(

--- a/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
@@ -105,7 +105,7 @@ const QueryTable = ({
     [columns],
   );
 
-  const user = useSelector<SqlLabRootState, User>(state => state.sqlLab.user);
+  const user = useSelector<SqlLabRootState, User>(state => state.user);
 
   const data = useMemo(() => {
     const restoreSql = (query: QueryResponse) => {

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
@@ -42,8 +42,6 @@ import {
   DatasetRadioState,
   EXPLORE_CHART_DEFAULT,
   DatasetOwner,
-  SqlLabExploreRootState,
-  getInitialState,
   SqlLabRootState,
 } from 'src/SqlLab/types';
 import { mountExploreUrl } from 'src/explore/exploreUtils';
@@ -177,9 +175,7 @@ export const SaveDatasetModal = ({
   >(undefined);
   const [loading, setLoading] = useState<boolean>(false);
 
-  const user = useSelector<SqlLabExploreRootState, User>(user =>
-    getInitialState(user),
-  );
+  const user = useSelector<SqlLabRootState, User>(state => state.user);
   const dispatch = useDispatch<(dispatch: any) => Promise<JsonObject>>();
 
   const createWindow = (url: string) => {

--- a/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
@@ -107,8 +107,8 @@ const SouthPane = ({
   const dispatch = useDispatch();
 
   const { editorQueries, dataPreviewQueries, databases, offline, user } =
-    useSelector(({ sqlLab }: SqlLabRootState) => {
-      const { databases, offline, user, queries, tables } = sqlLab;
+    useSelector(({ user, sqlLab }: SqlLabRootState) => {
+      const { databases, offline, queries, tables } = sqlLab;
       const dataPreviewQueries = tables
         .filter(
           ({ dataPreviewQueryId, queryEditorId: qeId }) =>

--- a/superset-frontend/src/SqlLab/fixtures.ts
+++ b/superset-frontend/src/SqlLab/fixtures.ts
@@ -660,10 +660,10 @@ export const initialState = {
     workspaceQueries: [],
     queriesLastUpdate: 0,
     activeSouthPaneTab: 'Results',
-    user: { user },
     unsavedQueryEditor: {},
   },
   messageToasts: [],
+  user,
   common: {
     conf: {
       DEFAULT_SQLLAB_LIMIT: 1000,

--- a/superset-frontend/src/SqlLab/reducers/getInitialState.js
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.js
@@ -33,7 +33,6 @@ export default function getInitialState({
   tab_state_ids: tabStateIds = [],
   databases,
   queries: queries_,
-  requested_query: requestedQuery,
   user,
 }) {
   /**
@@ -203,7 +202,6 @@ export default function getInitialState({
       unsavedQueryEditor,
       queryCostEstimates: {},
     },
-    requestedQuery,
     messageToasts: getToastsFromPyFlashMessages(
       (common || {}).flash_messages || [],
     ),

--- a/superset-frontend/src/SqlLab/reducers/getInitialState.js
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.js
@@ -200,7 +200,6 @@ export default function getInitialState({
       tabHistory: dedupeTabHistory(tabHistory),
       tables: Object.values(tables),
       queriesLastUpdate: Date.now(),
-      user,
       unsavedQueryEditor,
       queryCostEstimates: {},
     },
@@ -213,5 +212,6 @@ export default function getInitialState({
       flash_messages: common.flash_messages,
       conf: common.conf,
     },
+    user,
   };
 }

--- a/superset-frontend/src/SqlLab/reducers/getInitialState.test.ts
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.test.ts
@@ -42,7 +42,7 @@ const apiDataWithTabState = {
 };
 describe('getInitialState', () => {
   it('should output the user that is passed in', () => {
-    expect(getInitialState(apiData).sqlLab.user.userId).toEqual(1);
+    expect(getInitialState(apiData).user.userId).toEqual(1);
   });
   it('should return undefined instead of null for templateParams', () => {
     expect(

--- a/superset-frontend/src/SqlLab/reducers/index.js
+++ b/superset-frontend/src/SqlLab/reducers/index.js
@@ -18,6 +18,7 @@
  */
 import { combineReducers } from 'redux';
 import messageToasts from 'src/components/MessageToasts/reducers';
+import { userReducer } from 'src/views/store';
 import sqlLab from './sqlLab';
 import localStorageUsageInKilobytes from './localStorageUsage';
 import common from './common';
@@ -27,6 +28,7 @@ export const reducers = {
   localStorageUsageInKilobytes,
   messageToasts,
   common,
+  user: userReducer,
 };
 
 export default combineReducers(reducers);

--- a/superset-frontend/src/SqlLab/reducers/index.js
+++ b/superset-frontend/src/SqlLab/reducers/index.js
@@ -18,7 +18,6 @@
  */
 import { combineReducers } from 'redux';
 import messageToasts from 'src/components/MessageToasts/reducers';
-import { userReducer } from 'src/views/store';
 import sqlLab from './sqlLab';
 import localStorageUsageInKilobytes from './localStorageUsage';
 import common from './common';
@@ -28,7 +27,6 @@ export const reducers = {
   localStorageUsageInKilobytes,
   messageToasts,
   common,
-  user: userReducer,
 };
 
 export default combineReducers(reducers);

--- a/superset-frontend/src/SqlLab/types.ts
+++ b/superset-frontend/src/SqlLab/types.ts
@@ -19,7 +19,6 @@
 import { JsonObject, QueryResponse } from '@superset-ui/core';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
 import { ToastType } from 'src/components/MessageToasts/types';
-import { RootState } from 'src/dashboard/types';
 import { DropdownButtonProps } from 'src/components/DropdownButton';
 import { ButtonProps } from 'src/components/Button';
 
@@ -69,6 +68,7 @@ export type SqlLabRootState = {
     errorMessage: string | null;
     unsavedQueryEditor: Partial<QueryEditor>;
     queryCostEstimates?: Record<string, QueryCostEstimate>;
+    editorTabLastUpdatedAt?: number;
   };
   localStorageUsageInKilobytes: number;
   messageToasts: toastState[];

--- a/superset-frontend/src/SqlLab/types.ts
+++ b/superset-frontend/src/SqlLab/types.ts
@@ -66,31 +66,17 @@ export type SqlLabRootState = {
     tabHistory: string[]; // default is activeTab ? [activeTab.id.toString()] : []
     tables: Record<string, any>[];
     queriesLastUpdate: number;
-    user: UserWithPermissionsAndRoles;
     errorMessage: string | null;
     unsavedQueryEditor: Partial<QueryEditor>;
     queryCostEstimates?: Record<string, QueryCostEstimate>;
   };
   localStorageUsageInKilobytes: number;
   messageToasts: toastState[];
+  user: UserWithPermissionsAndRoles;
   common: {
     flash_messages: string[];
     conf: JsonObject;
   };
-};
-
-export type SqlLabExploreRootState = SqlLabRootState | RootState;
-
-export const getInitialState = (state: SqlLabExploreRootState) => {
-  if (state.hasOwnProperty('sqlLab')) {
-    const {
-      sqlLab: { user },
-    } = state as SqlLabRootState;
-    return user;
-  }
-
-  const { user } = state as RootState;
-  return user as UserWithPermissionsAndRoles;
 };
 
 export enum DatasetRadioState {

--- a/superset-frontend/src/views/store.ts
+++ b/superset-frontend/src/views/store.ts
@@ -66,7 +66,7 @@ export type UserLoadedAction = {
   user: UserWithPermissionsAndRoles;
 };
 
-const userReducer = (
+export const userReducer = (
   user = bootstrapData.user || {},
   action: UserLoadedAction,
 ): BootstrapUser | UndefinedUser => {


### PR DESCRIPTION
### SUMMARY
As a part of [SQLLab SPA initiative](https://docs.google.com/document/d/1opyNuaw-CEAD9tG6fx_zqNcZwe3_soQgsnSJTP4mQkk/edit#heading=h.a232t31ftwzo), the SqlLab state will be consolidated into SPA redux store. In order to match the existing user state, this commit relocates the user property in SqlLab into root.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

After:

![Superset](https://github.com/apache/superset/assets/1392866/7ca1aaef-8877-4bd8-8c20-fe5707d316b9)

Before:

![Superset](https://github.com/apache/superset/assets/1392866/565b452f-1ec8-4c91-9563-50b170576d60)


### TESTING INSTRUCTIONS
Go to SQLLab and working without errors

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
