### PR TITLE
fix: CTE queries with non-SELECT statements

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -221,7 +221,7 @@ class ParsedQuery:
         # make sure we strip comments; prevents a bug with comments in the CTE
         parsed = sqlparse.parse(self.strip_comments())
 
-        if len(parsed[0]) > 0 and parsed[0][0].ttype == Keyword.CTE:
+        if parsed[0].is_group and parsed[0][0].ttype == Keyword.CTE:
             inner_cte = self.get_inner_cte_expression(parsed[0].tokens) or []
             if any(token.ttype == DDL for token in inner_cte) or any(
                 token.ttype == DML and token.normalized != "SELECT"

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -252,8 +252,9 @@ class ParsedQuery:
                         sqloxide_parse(self.strip_comments(), dialect="ansi")
                     ):
                         return False
-                except ValueError as ex:
-                    # sqloxide was not able to parse the query, so let's continue with sqlparse
+                except ValueError:
+                    # sqloxide was not able to parse the query, so let's continue with
+                    # sqlparse
                     pass
             inner_cte = self.get_inner_cte_expression(parsed[0].tokens) or []
             # Check if the inner CTE is a not a SELECT

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -221,8 +221,10 @@ class ParsedQuery:
         # make sure we strip comments; prevents a bug with comments in the CTE
         parsed = sqlparse.parse(self.strip_comments())
 
+        # Check if this is a CTE
         if parsed[0].is_group and parsed[0][0].ttype == Keyword.CTE:
             inner_cte = self.get_inner_cte_expression(parsed[0].tokens) or []
+            # Check if the inner CTE is a not a SELECT
             if any(token.ttype == DDL for token in inner_cte) or any(
                 token.ttype == DML and token.normalized != "SELECT"
                 for token in inner_cte

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -217,12 +217,44 @@ class ParsedQuery:
     def limit(self) -> Optional[int]:
         return self._limit
 
+    def _get_cte_tables(self, parsed: dict[str, Any]) -> list[dict[str, Any]]:
+        if "with" not in parsed:
+            return []
+        return parsed["with"].get("cte_tables", [])
+
+    def _check_cte_is_select(self, oxide_parse: list[dict[str, Any]]) -> bool:
+        """
+        Check if a oxide parsed CTE contains only SELECT statements
+
+        :param oxide_parse: parsed CTE
+        :return: True if CTE is a SELECT statement
+        """
+        for query in oxide_parse:
+            parsed_query = query["Query"]
+            cte_tables = self._get_cte_tables(parsed_query)
+            for cte_table in cte_tables:
+                is_select = all(
+                    key == "Select" for key in cte_table["query"]["body"].keys()
+                )
+                if not is_select:
+                    return False
+        return True
+
     def is_select(self) -> bool:
         # make sure we strip comments; prevents a bug with comments in the CTE
         parsed = sqlparse.parse(self.strip_comments())
 
         # Check if this is a CTE
         if parsed[0].is_group and parsed[0][0].ttype == Keyword.CTE:
+            if sqloxide_parse is not None:
+                try:
+                    if not self._check_cte_is_select(
+                        sqloxide_parse(self.strip_comments(), dialect="ansi")
+                    ):
+                        return False
+                except ValueError as ex:
+                    # sqloxide was not able to parse the query, so let's continue with sqlparse
+                    pass
             inner_cte = self.get_inner_cte_expression(parsed[0].tokens) or []
             # Check if the inner CTE is a not a SELECT
             if any(token.ttype == DDL for token in inner_cte) or any(

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -1029,6 +1029,42 @@ FROM foo f"""
     assert sql.is_select()
 
 
+def test_cte_insert_is_not_select() -> None:
+    """
+    Some CTEs with lowercase select are not correctly identified as SELECTS.
+    """
+    sql = ParsedQuery(
+        """WITH foo AS(
+        INSERT INTO foo (id) VALUES (1) RETURNING 1
+        ) select * FROM foo f"""
+    )
+    assert sql.is_select() is False
+
+
+def test_cte_delete_is_not_select() -> None:
+    """
+    Some CTEs with lowercase select are not correctly identified as SELECTS.
+    """
+    sql = ParsedQuery(
+        """WITH foo AS(
+        DELETE FROM foo RETURNING *
+        ) select * FROM foo f"""
+    )
+    assert sql.is_select() is False
+
+
+def test_cte_is_not_select_lowercase() -> None:
+    """
+    Some CTEs with lowercase select are not correctly identified as SELECTS.
+    """
+    sql = ParsedQuery(
+        """WITH foo AS(
+        insert into foo (id) values (1) RETURNING 1
+        ) select * FROM foo f"""
+    )
+    assert sql.is_select() is False
+
+
 def test_unknown_select() -> None:
     """
     Test that `is_select` works when sqlparse fails to identify the type.


### PR DESCRIPTION
### SUMMARY
Improves SQLLab parse check for non `SELECT` statements for CTE.

The following statement was being accepted as a valid `SELECT` statement:
``` sql
WITH a AS ( INSERT INTO foo (id) VALUES (1) RETURNING id ) SELECT * FROM a;
```
 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
