### PR TITLE
fix: Downgrades Prophet to 1.1.1 and Holidays to 0.23

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -59,6 +59,8 @@ colorama==0.4.6
     # via
     #   apache-superset
     #   flask-appbuilder
+convertdate==2.4.0
+    # via holidays
 cron-descriptor==1.2.24
     # via apache-superset
 croniter==1.0.15
@@ -128,7 +130,9 @@ gunicorn==20.1.0
     # via apache-superset
 hashids==1.3.1
     # via apache-superset
-holidays==0.28
+hijri-converter==2.3.1
+    # via holidays
+holidays==0.23
     # via apache-superset
 humanize==3.11.0
     # via apache-superset
@@ -154,6 +158,8 @@ jsonschema==4.17.3
     # via flask-appbuilder
 kombu==5.2.4
     # via celery
+korean-lunar-calendar==0.3.1
+    # via holidays
 limits==3.4.0
     # via flask-limiter
 llvmlite==0.40.1
@@ -230,6 +236,8 @@ pyjwt==2.4.0
     #   apache-superset
     #   flask-appbuilder
     #   flask-jwt-extended
+pymeeus==0.5.12
+    # via convertdate
 pynacl==1.5.0
     # via paramiko
 pyparsing==3.0.6

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -106,7 +106,7 @@ parameterized==0.9.0
     # via -r requirements/testing.in
 pathable==0.4.3
     # via jsonschema-spec
-prophet==1.1.3
+prophet==1.1.1
     # via apache-superset
 proto-plus==1.22.2
     # via
@@ -124,8 +124,6 @@ pydata-google-auth==1.7.0
     # via pandas-gbq
 pyfakefs==5.2.2
     # via -r requirements/testing.in
-pyhive[presto]==0.6.5
-    # via apache-superset
 pymeeus==0.5.12
     # via convertdate
 pytest==7.3.1
@@ -145,6 +143,8 @@ rfc3339-validator==0.1.4
     # via openapi-schema-validator
 rsa==4.9
     # via google-auth
+setuptools-git==1.2
+    # via prophet
 shillelagh[gsheetsapi]==1.2.6
     # via apache-superset
 sqlalchemy-bigquery==1.6.1

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -18,8 +18,6 @@ cmdstanpy==1.1.0
     # via prophet
 contourpy==1.0.7
     # via matplotlib
-convertdate==2.4.0
-    # via prophet
 coverage[toml]==7.2.5
     # via pytest-cov
 cycler==0.11.0
@@ -124,8 +122,8 @@ pydata-google-auth==1.7.0
     # via pandas-gbq
 pyfakefs==5.2.2
     # via -r requirements/testing.in
-pymeeus==0.5.12
-    # via convertdate
+pyhive[presto]==0.6.5
+    # via apache-superset
 pytest==7.3.1
     # via
     #   -r requirements/testing.in

--- a/setup.py
+++ b/setup.py
@@ -177,7 +177,7 @@ setup(
         "postgres": ["psycopg2-binary==2.9.6"],
         "presto": ["pyhive[presto]>=0.6.5"],
         "trino": ["trino>=0.324.0"],
-        "prophet": ["prophet>=1.1.0, <2.0.0"],
+        "prophet": ["prophet==1.1.1"],
         "redshift": ["sqlalchemy-redshift>=0.8.1, < 0.9"],
         "rockset": ["rockset-sqlalchemy>=0.0.1, <1.0.0"],
         "shillelagh": [

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
         "geopy",
         "gunicorn>=20.1.0; sys_platform != 'win32'",
         "hashids>=1.3.1, <2",
-        "holidays>=0.28, <1.0",
+        "holidays>=0.23, <0.24",
         "humanize",
         "importlib_metadata",
         "isodate",


### PR DESCRIPTION
### SUMMARY
https://github.com/apache/superset/pull/24129 bumped Prophet to 1.1.4 but there's a [nasty bug](https://github.com/facebook/prophet/issues/2354) affecting all versions following 1.1.1. This PR downgrades Prophet to 1.1.1 and pins the version in `setup.py`. We can relax the version constraint once that bug is fixed.

This PR also reverts the [holidays bump](https://github.com/apache/superset/pull/24647) given that version 0.28 is incompatible with `prophet` 1.1.1 even with a declared dependency of `holidays>=0.14.2`. I tried using version 0.28 but it broke CI.

### TESTING INSTRUCTIONS
CI should be sufficient.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
