### PR TITLE
fix(embedded sdk): Remove trailing slash from passed superset domain if there is one

### DIFF
--- a/superset-embedded-sdk/package-lock.json
+++ b/superset-embedded-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@superset-ui/embedded-sdk",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@superset-ui/embedded-sdk",
-      "version": "0.1.0-alpha.9",
+      "version": "0.1.0-alpha.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@superset-ui/switchboard": "^0.18.26-0",

--- a/superset-embedded-sdk/package.json
+++ b/superset-embedded-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/embedded-sdk",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "description": "SDK for embedding resources from Superset into your own application",
   "access": "public",
   "keywords": [

--- a/superset-embedded-sdk/src/index.ts
+++ b/superset-embedded-sdk/src/index.ts
@@ -89,6 +89,10 @@ export async function embedDashboard({
 
   log('embedding');
 
+  if (supersetDomain.endsWith("/")) {
+    supersetDomain = supersetDomain.slice(0, -1);
+  }
+
   function calculateConfig() {
     let configNumber = 0
     if(dashboardUiConfig) {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Without this change, passing a domain name with a trailing slash would result in the dashboard not loading with no error.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
