### PR TITLE
fix: Dashboard fullscreen is removing custom URL params

### DIFF
--- a/superset-frontend/src/dashboard/util/getDashboardUrl.test.js
+++ b/superset-frontend/src/dashboard/util/getDashboardUrl.test.js
@@ -73,6 +73,35 @@ describe('getChartIdsFromLayout', () => {
     );
   });
 
+  it('should encode filters with missing filters', () => {
+    const urlWithStandalone = getDashboardUrl({
+      pathname: 'path',
+      filters: undefined,
+      standalone: DashboardStandaloneMode.HIDE_NAV,
+    });
+    expect(urlWithStandalone).toBe(
+      `path?standalone=${DashboardStandaloneMode.HIDE_NAV}`,
+    );
+  });
+
+  it('should preserve unknown filters', () => {
+    const windowSpy = jest.spyOn(window, 'window', 'get');
+    windowSpy.mockImplementation(() => ({
+      location: {
+        origin: 'https://localhost',
+        search: '?unkown_param=value',
+      },
+    }));
+    const urlWithStandalone = getDashboardUrl({
+      pathname: 'path',
+      standalone: DashboardStandaloneMode.HIDE_NAV,
+    });
+    expect(urlWithStandalone).toBe(
+      `path?unkown_param=value&standalone=${DashboardStandaloneMode.HIDE_NAV}`,
+    );
+    windowSpy.mockRestore();
+  });
+
   it('should process native filters key', () => {
     const windowSpy = jest.spyOn(window, 'window', 'get');
     windowSpy.mockImplementation(() => ({
@@ -89,5 +118,6 @@ describe('getChartIdsFromLayout', () => {
     expect(urlWithNativeFilters).toBe(
       'path?preselect_filters=%7B%7D&native_filters_key=024380498jdkjf-2094838',
     );
+    windowSpy.mockRestore();
   });
 });

--- a/superset-frontend/src/dashboard/util/getDashboardUrl.ts
+++ b/superset-frontend/src/dashboard/util/getDashboardUrl.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { JsonObject } from '@superset-ui/core';
+import { isEmpty } from 'lodash';
 import { URL_PARAMS } from 'src/constants';
 import { getUrlParam } from 'src/utils/urlUtils';
 import serializeActiveFilterValues from './serializeActiveFilterValues';
@@ -32,18 +33,23 @@ export default function getDashboardUrl({
   hash: string;
   standalone?: number | null;
 }) {
-  const newSearchParams = new URLSearchParams();
+  const newSearchParams = new URLSearchParams(window.location.search);
 
-  // convert flattened { [id_column]: values } object
-  // to nested filter object
-  newSearchParams.set(
-    URL_PARAMS.preselectFilters.name,
-    JSON.stringify(serializeActiveFilterValues(filters)),
-  );
+  if (!isEmpty(filters)) {
+    // convert flattened { [id_column]: values } object
+    // to nested filter object
+    newSearchParams.set(
+      URL_PARAMS.preselectFilters.name,
+      JSON.stringify(serializeActiveFilterValues(filters)),
+    );
+  }
 
   if (standalone) {
     newSearchParams.set(URL_PARAMS.standalone.name, standalone.toString());
+  } else {
+    newSearchParams.delete(URL_PARAMS.standalone.name);
   }
+
   const dataMaskKey = getUrlParam(URL_PARAMS.nativeFiltersKey);
   if (dataMaskKey) {
     newSearchParams.set(


### PR DESCRIPTION
### SUMMARY
This PR changes the dashboard fullscreen feature to:
- Preserve custom URL parameters when toggling fullscreen
- Stop publishing empty `preselect_filters` param

Fixes https://github.com/apache/superset/issues/25024

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://github.com/apache/superset/assets/70410625/0e5808f2-267c-4f3a-9900-8dfd306f1758

https://github.com/apache/superset/assets/70410625/3fc49541-51f3-4fc1-aeb4-cfc51065c100

### TESTING INSTRUCTIONS
Check the videos for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
