### PR TITLE
fix: Native filter dashboard RBAC aware dataset permission

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/utils.ts
@@ -55,6 +55,7 @@ export const getFormData = ({
   granularity_sqla,
   type,
   dashboardId,
+  id,
 }: Partial<Filter> & {
   dashboardId: number;
   datasetId?: number;
@@ -94,6 +95,7 @@ export const getFormData = ({
     viz_type: filterType,
     type,
     dashboardId,
+    native_filter_id: id,
   };
 };
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Somewhat related to https://github.com/apache/superset/pull/25008, this PR ensures that access is granted to a datasource  (in the context of a dashboard native filter) when dashboard RBAC is enabled. Thanks to @michael-s-molina for https://github.com/apache/superset/pull/25025 which exposed the `dashboardId` in the client form data. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE

<img width="1440" alt="Screenshot 2023-08-18 at 11 38 14 AM" src="https://github.com/apache/superset/assets/4567245/d90a3e83-bad8-4299-b777-02f24f77b3f3">

#### AFTER

<img width="1440" alt="Screenshot 2023-08-18 at 11 37 21 AM" src="https://github.com/apache/superset/assets/4567245/8b7ee0c7-4959-40ed-a4f1-16bb23772255">

### TESTING INSTRUCTIONS

Added unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @jfrag1 