### PR TITLE
build(deps): Bump PyHive

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -85,7 +85,9 @@ ptyprocess==0.7.0
 pure-eval==0.2.2
     # via stack-data
 pure-sasl==0.6.2
-    # via thrift-sasl
+    # via
+    #   pyhive
+    #   thrift-sasl
 pyasn1==0.5.0
     # via
     #   pyasn1-modules
@@ -94,7 +96,7 @@ pyasn1-modules==0.3.0
     # via python-ldap
 pydruid==0.6.5
     # via apache-superset
-pyhive[hive]==0.6.5
+pyhive[hive_pure_sasl]==0.7.0
     # via apache-superset
 pyinstrument==4.4.0
     # via -r requirements/development.in
@@ -111,8 +113,6 @@ rfc3986==2.0.0
     # via tableschema
 s3transfer==0.6.1
     # via boto3
-sasl==0.3.1
-    # via pyhive
 sqloxide==0.1.33
     # via -r requirements/development.in
 stack-data==0.6.2

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -122,7 +122,7 @@ pydata-google-auth==1.7.0
     # via pandas-gbq
 pyfakefs==5.2.2
     # via -r requirements/testing.in
-pyhive[presto]==0.6.5
+pyhive[presto]==0.7.0
     # via apache-superset
 pytest==7.3.1
     # via

--- a/setup.py
+++ b/setup.py
@@ -165,7 +165,12 @@ setup(
         "firebolt": ["firebolt-sqlalchemy>=0.0.1"],
         "gsheets": ["shillelagh[gsheetsapi]>=1.2.6, <2"],
         "hana": ["hdbcli==2.4.162", "sqlalchemy_hana==0.4.0"],
-        "hive": ["pyhive[hive]>=0.6.5", "tableschema", "thrift>=0.14.1, <1.0.0"],
+        "hive": [
+            "pyhive[hive]>=0.6.5;python_version<'3.11'",
+            "pyhive[hive_pure_sasl]>=0.7.0",
+            "tableschema",
+            "thrift>=0.14.1, <1.0.0",
+        ],
         "impala": ["impyla>0.16.2, <0.17"],
         "kusto": ["sqlalchemy-kusto>=2.0.0, <3"],
         "kylin": ["kylinpy>=2.8.1, <2.9"],
@@ -189,7 +194,12 @@ setup(
             "shillelagh[datasetteapi,gsheetsapi,socrata,weatherapi]>=1.2.6,<2"
         ],
         "snowflake": ["snowflake-sqlalchemy>=1.2.4, <2"],
-        "spark": ["pyhive[hive]>=0.6.5", "tableschema", "thrift>=0.14.1, <1.0.0"],
+        "spark": [
+            "pyhive[hive]>=0.6.5;python_version<'3.11'",
+            "pyhive[hive_pure_sasl]>=0.7.0",
+            "tableschema",
+            "thrift>=0.14.1, <1.0.0",
+        ],
         "teradata": ["teradatasql>=16.20.0.23"],
         "thumbnails": ["Pillow>=9.5.0, <10.0.0"],
         "vertica": ["sqlalchemy-vertica-python>=0.5.9, < 0.6"],


### PR DESCRIPTION
### SUMMARY
PyHive added [support for Python 3.11](https://github.com/dropbox/PyHive/pull/454) and [SQLAlchemy 2.0](https://github.com/dropbox/PyHive/pull/457) recently. 

pure-sasl library is installed in all PY versions since it is a dependency of thrift-sasl, a dependency of PyHive.

PY < 3.11: sasl library will be installed and used as PyHive's code gives it first preference. 
PY >= 3.11 Only pure-sasl library will be installed and used.

`test-postgres-hive` CI test in this repo will always pure-sasl because PY 11 test cases fail if sasl is installed.

Note: `'pyhive[hive]'` extras uses [sasl](https://pypi.org/project/sasl/) that doesn't support Python 3.11, See https://github.com/cloudera/python-sasl/issues/30. Hence PyHive also supports [pure-sasl](https://pypi.org/project/pure-sasl/) via additional extras `'pyhive[hive_pure_sasl]'` which support Python 3.11 along with all previous Python versions.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TESTING INSTRUCTIONS
PY 3.11: https://github.com/apache/superset/actions/runs/5945658123/job/16125068727?pr=25030
PY 3.10: https://github.com/apache/superset/actions/runs/5945651721/job/16125052276?pr=25030
PY 3.9: https://github.com/apache/superset/actions/runs/5945685670/job/16125136349?pr=25030

cc: @EugeneTorap @bkyryliuk 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
