### PR TITLE
fix: Ensure SQLAlchemy sessions are closed

### DIFF
--- a/superset/tags/models.py
+++ b/superset/tags/models.py
@@ -170,17 +170,19 @@ class ObjectUpdater:
     ) -> None:
         session = Session(bind=connection)
 
-        # add `owner:` tags
-        cls._add_owners(session, target)
+        try:
+            # add `owner:` tags
+            cls._add_owners(session, target)
 
-        # add `type:` tags
-        tag = get_tag(f"type:{cls.object_type}", session, TagTypes.type)
-        tagged_object = TaggedObject(
-            tag_id=tag.id, object_id=target.id, object_type=cls.object_type
-        )
-        session.add(tagged_object)
-
-        session.commit()
+            # add `type:` tags
+            tag = get_tag(f"type:{cls.object_type}", session, TagTypes.type)
+            tagged_object = TaggedObject(
+                tag_id=tag.id, object_id=target.id, object_type=cls.object_type
+            )
+            session.add(tagged_object)
+            session.commit()
+        finally:
+            session.close()
 
     @classmethod
     def after_update(
@@ -191,25 +193,27 @@ class ObjectUpdater:
     ) -> None:
         session = Session(bind=connection)
 
-        # delete current `owner:` tags
-        query = (
-            session.query(TaggedObject.id)
-            .join(Tag)
-            .filter(
-                TaggedObject.object_type == cls.object_type,
-                TaggedObject.object_id == target.id,
-                Tag.type == TagTypes.owner,
+        try:
+            # delete current `owner:` tags
+            query = (
+                session.query(TaggedObject.id)
+                .join(Tag)
+                .filter(
+                    TaggedObject.object_type == cls.object_type,
+                    TaggedObject.object_id == target.id,
+                    Tag.type == TagTypes.owner,
+                )
             )
-        )
-        ids = [row[0] for row in query]
-        session.query(TaggedObject).filter(TaggedObject.id.in_(ids)).delete(
-            synchronize_session=False
-        )
+            ids = [row[0] for row in query]
+            session.query(TaggedObject).filter(TaggedObject.id.in_(ids)).delete(
+                synchronize_session=False
+            )
 
-        # add `owner:` tags
-        cls._add_owners(session, target)
-
-        session.commit()
+            # add `owner:` tags
+            cls._add_owners(session, target)
+            session.commit()
+        finally:
+            session.close()
 
     @classmethod
     def after_delete(
@@ -220,13 +224,16 @@ class ObjectUpdater:
     ) -> None:
         session = Session(bind=connection)
 
-        # delete row from `tagged_objects`
-        session.query(TaggedObject).filter(
-            TaggedObject.object_type == cls.object_type,
-            TaggedObject.object_id == target.id,
-        ).delete()
+        try:
+            # delete row from `tagged_objects`
+            session.query(TaggedObject).filter(
+                TaggedObject.object_type == cls.object_type,
+                TaggedObject.object_id == target.id,
+            ).delete()
 
-        session.commit()
+            session.commit()
+        finally:
+            session.close()
 
 
 class ChartUpdater(ObjectUpdater):
@@ -267,35 +274,40 @@ class FavStarUpdater:
         cls, _mapper: Mapper, connection: Connection, target: FavStar
     ) -> None:
         session = Session(bind=connection)
-        name = f"favorited_by:{target.user_id}"
-        tag = get_tag(name, session, TagTypes.favorited_by)
-        tagged_object = TaggedObject(
-            tag_id=tag.id,
-            object_id=target.obj_id,
-            object_type=get_object_type(target.class_name),
-        )
-        session.add(tagged_object)
-
-        session.commit()
+        try:
+            name = f"favorited_by:{target.user_id}"
+            tag = get_tag(name, session, TagTypes.favorited_by)
+            tagged_object = TaggedObject(
+                tag_id=tag.id,
+                object_id=target.obj_id,
+                object_type=get_object_type(target.class_name),
+            )
+            session.add(tagged_object)
+            session.commit()
+        finally:
+            session.close()
 
     @classmethod
     def after_delete(
         cls, _mapper: Mapper, connection: Connection, target: FavStar
     ) -> None:
         session = Session(bind=connection)
-        name = f"favorited_by:{target.user_id}"
-        query = (
-            session.query(TaggedObject.id)
-            .join(Tag)
-            .filter(
-                TaggedObject.object_id == target.obj_id,
-                Tag.type == TagTypes.favorited_by,
-                Tag.name == name,
+        try:
+            name = f"favorited_by:{target.user_id}"
+            query = (
+                session.query(TaggedObject.id)
+                .join(Tag)
+                .filter(
+                    TaggedObject.object_id == target.obj_id,
+                    Tag.type == TagTypes.favorited_by,
+                    Tag.name == name,
+                )
             )
-        )
-        ids = [row[0] for row in query]
-        session.query(TaggedObject).filter(TaggedObject.id.in_(ids)).delete(
-            synchronize_session=False
-        )
+            ids = [row[0] for row in query]
+            session.query(TaggedObject).filter(TaggedObject.id.in_(ids)).delete(
+                synchronize_session=False
+            )
 
-        session.commit()
+            session.commit()
+        finally:
+            session.close()

--- a/superset/tasks/cache.py
+++ b/superset/tasks/cache.py
@@ -95,7 +95,11 @@ class DummyStrategy(Strategy):  # pylint: disable=too-few-public-methods
 
     def get_payloads(self) -> list[dict[str, int]]:
         session = db.create_scoped_session()
-        charts = session.query(Slice).all()
+
+        try:
+            charts = session.query(Slice).all()
+        finally:
+            session.close()
 
         return [get_payload(chart) for chart in charts]
 
@@ -129,20 +133,24 @@ class TopNDashboardsStrategy(Strategy):  # pylint: disable=too-few-public-method
         payloads = []
         session = db.create_scoped_session()
 
-        records = (
-            session.query(Log.dashboard_id, func.count(Log.dashboard_id))
-            .filter(and_(Log.dashboard_id.isnot(None), Log.dttm >= self.since))
-            .group_by(Log.dashboard_id)
-            .order_by(func.count(Log.dashboard_id).desc())
-            .limit(self.top_n)
-            .all()
-        )
-        dash_ids = [record.dashboard_id for record in records]
-        dashboards = session.query(Dashboard).filter(Dashboard.id.in_(dash_ids)).all()
-        for dashboard in dashboards:
-            for chart in dashboard.slices:
-                payloads.append(get_payload(chart, dashboard))
-
+        try:
+            records = (
+                session.query(Log.dashboard_id, func.count(Log.dashboard_id))
+                .filter(and_(Log.dashboard_id.isnot(None), Log.dttm >= self.since))
+                .group_by(Log.dashboard_id)
+                .order_by(func.count(Log.dashboard_id).desc())
+                .limit(self.top_n)
+                .all()
+            )
+            dash_ids = [record.dashboard_id for record in records]
+            dashboards = (
+                session.query(Dashboard).filter(Dashboard.id.in_(dash_ids)).all()
+            )
+            for dashboard in dashboards:
+                for chart in dashboard.slices:
+                    payloads.append(get_payload(chart, dashboard))
+        finally:
+            session.close()
         return payloads
 
 
@@ -172,42 +180,46 @@ class DashboardTagsStrategy(Strategy):  # pylint: disable=too-few-public-methods
         payloads = []
         session = db.create_scoped_session()
 
-        tags = session.query(Tag).filter(Tag.name.in_(self.tags)).all()
-        tag_ids = [tag.id for tag in tags]
+        try:
+            tags = session.query(Tag).filter(Tag.name.in_(self.tags)).all()
+            tag_ids = [tag.id for tag in tags]
 
-        # add dashboards that are tagged
-        tagged_objects = (
-            session.query(TaggedObject)
-            .filter(
-                and_(
-                    TaggedObject.object_type == "dashboard",
-                    TaggedObject.tag_id.in_(tag_ids),
+            # add dashboards that are tagged
+            tagged_objects = (
+                session.query(TaggedObject)
+                .filter(
+                    and_(
+                        TaggedObject.object_type == "dashboard",
+                        TaggedObject.tag_id.in_(tag_ids),
+                    )
                 )
+                .all()
             )
-            .all()
-        )
-        dash_ids = [tagged_object.object_id for tagged_object in tagged_objects]
-        tagged_dashboards = session.query(Dashboard).filter(Dashboard.id.in_(dash_ids))
-        for dashboard in tagged_dashboards:
-            for chart in dashboard.slices:
+            dash_ids = [tagged_object.object_id for tagged_object in tagged_objects]
+            tagged_dashboards = session.query(Dashboard).filter(
+                Dashboard.id.in_(dash_ids)
+            )
+            for dashboard in tagged_dashboards:
+                for chart in dashboard.slices:
+                    payloads.append(get_payload(chart))
+
+            # add charts that are tagged
+            tagged_objects = (
+                session.query(TaggedObject)
+                .filter(
+                    and_(
+                        TaggedObject.object_type == "chart",
+                        TaggedObject.tag_id.in_(tag_ids),
+                    )
+                )
+                .all()
+            )
+            chart_ids = [tagged_object.object_id for tagged_object in tagged_objects]
+            tagged_charts = session.query(Slice).filter(Slice.id.in_(chart_ids))
+            for chart in tagged_charts:
                 payloads.append(get_payload(chart))
-
-        # add charts that are tagged
-        tagged_objects = (
-            session.query(TaggedObject)
-            .filter(
-                and_(
-                    TaggedObject.object_type == "chart",
-                    TaggedObject.tag_id.in_(tag_ids),
-                )
-            )
-            .all()
-        )
-        chart_ids = [tagged_object.object_id for tagged_object in tagged_objects]
-        tagged_charts = session.query(Slice).filter(Slice.id.in_(chart_ids))
-        for chart in tagged_charts:
-            payloads.append(get_payload(chart))
-
+        finally:
+            session.close()
         return payloads
 
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

At Airbnb we've been running into the infamous SQLAlchemy QueuePool issue which typically occurs when connections aren't being closed. Thankfully Flask-SQLAlchemy normally handles this for us, per [here](https://github.com/pallets-eco/flask-sqlalchemy/blob/e5bf821072de0d55ff92891432004322864a7265/src/flask_sqlalchemy/__init__.py#L872-L886), when the app context is torn down.

Grokking the code it seems like there are instances (for right or wrong) where we create our own sessions which aren't then explicitly closed. This PR ensures that either i) these sessions are now closed, or ii) the Flask-SQLAlchemy session is used.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
