### PR TITLE
docs: fix line break in Apache Druid page

### DIFF
--- a/docs/docs/databases/druid.mdx
+++ b/docs/docs/databases/druid.mdx
@@ -10,7 +10,7 @@ import useBaseUrl from "@docusaurus/useBaseUrl";
 ## Apache Druid
 
 A native connector to Druid ships with Superset (behind the `DRUID_IS_ACTIVE` flag) but this is
-slowly getting deprecated in favor of SQLAlchemy / DBAPI connector made available in the
+slowly getting deprecated in favor of the SQLAlchemy / DBAPI connector made available in the
 [pydruid library](https://pythonhosted.org/pydruid/).
 
 The connection string looks like:
@@ -20,10 +20,10 @@ druid://<User>:<password>@<Host>:<Port-default-9088>/druid/v2/sql
 ```
 Here's a breakdown of the key components of this connection string:
 
-`User`: username portion of the credentials needed to connect to your database  
-`Password`: password portion of the credentials needed to connect to your database  
-`Host`: IP address (or URL) of the host machine that's running your database  
-`Port`: specific port that's exposed on your host machine where your database is running  
+- `User`: username portion of the credentials needed to connect to your database
+- `Password`: password portion of the credentials needed to connect to your database
+- `Host`: IP address (or URL) of the host machine that's running your database
+- `Port`: specific port that's exposed on your host machine where your database is running
 
 ### Customizing Druid Connection
 

--- a/docs/docs/databases/druid.mdx
+++ b/docs/docs/databases/druid.mdx
@@ -20,10 +20,10 @@ druid://<User>:<password>@<Host>:<Port-default-9088>/druid/v2/sql
 ```
 Here's a breakdown of the key components of this connection string:
 
-User: username portion of the credentials needed to connect to your database
-Password: password portion of the credentials needed to connect to your database
-Host: IP address (or URL) of the host machine that's running your database
-Port: specific port that's exposed on your host machine where your database is running
+`User`: username portion of the credentials needed to connect to your database  
+`Password`: password portion of the credentials needed to connect to your database  
+`Host`: IP address (or URL) of the host machine that's running your database  
+`Port`: specific port that's exposed on your host machine where your database is running  
 
 ### Customizing Druid Connection
 


### PR DESCRIPTION
### SUMMARY
Added line breaks and highlighted using code formatting each keyword of the connection string

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://github.com/apache/superset/assets/62653082/ec8d4ba1-dbab-4b54-af53-da2d7440421b)

After:
![image](https://github.com/apache/superset/assets/62653082/c1d20903-66a1-4754-9f22-391f75f8dd1d)


### ADDITIONAL INFORMATION
Fixes #25033 
