### PR TITLE
chore(sqllab): typescript for getInitialState

### DIFF
--- a/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
@@ -117,7 +117,7 @@ const SouthPane = ({
             queries[dataPreviewQueryId],
         )
         .map(({ name, dataPreviewQueryId }) => ({
-          ...queries[dataPreviewQueryId],
+          ...queries[dataPreviewQueryId || ''],
           tableName: name,
         }));
       const editorQueries = Object.values(queries).filter(

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.jsx
@@ -225,7 +225,7 @@ const SqlEditor = ({
   const { database, latestQuery, hideLeftBar } = useSelector(
     ({ sqlLab: { unsavedQueryEditor, databases, queries } }) => {
       let { dbId, latestQueryId, hideLeftBar } = queryEditor;
-      if (unsavedQueryEditor.id === queryEditor.id) {
+      if (unsavedQueryEditor?.id === queryEditor.id) {
         dbId = unsavedQueryEditor.dbId || dbId;
         latestQueryId = unsavedQueryEditor.latestQueryId || latestQueryId;
         hideLeftBar = unsavedQueryEditor.hideLeftBar || hideLeftBar;

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
@@ -27,6 +27,7 @@ import React, {
 import { useDispatch } from 'react-redux';
 import querystring from 'query-string';
 
+import { Table } from 'src/SqlLab/types';
 import {
   queryEditorSetDb,
   addTable,
@@ -52,7 +53,7 @@ import {
   LocalStorageKeys,
   setItem,
 } from 'src/utils/localStorageHelpers';
-import TableElement, { Table } from '../TableElement';
+import TableElement from '../TableElement';
 
 interface ExtendedTable extends Table {
   expanded: boolean;

--- a/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/index.tsx
@@ -55,7 +55,7 @@ const SqlEditorTabHeader: React.FC<Props> = ({ queryEditor }) => {
   const qe = useSelector<SqlLabRootState, QueryEditor>(
     ({ sqlLab: { unsavedQueryEditor } }) => ({
       ...queryEditor,
-      ...(queryEditor.id === unsavedQueryEditor.id && unsavedQueryEditor),
+      ...(queryEditor.id === unsavedQueryEditor?.id && unsavedQueryEditor),
     }),
     shallowEqual,
   );

--- a/superset-frontend/src/SqlLab/components/TableElement/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TableElement/index.tsx
@@ -18,6 +18,7 @@
  */
 import React, { useState, useRef, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
+import type { Table } from 'src/SqlLab/types';
 import Collapse from 'src/components/Collapse';
 import Card from 'src/components/Card';
 import ButtonGroup from 'src/components/ButtonGroup';
@@ -47,16 +48,6 @@ export interface Column {
   name: string;
   keys?: { type: ColumnKeyTypeType }[];
   type: string;
-}
-
-export interface Table {
-  id: string;
-  dbId: number;
-  schema: string;
-  name: string;
-  dataPreviewQueryId?: string | null;
-  expanded?: boolean;
-  initialized?: boolean;
 }
 
 export interface TableElementProps {

--- a/superset-frontend/src/SqlLab/hooks/useQueryEditor/index.ts
+++ b/superset-frontend/src/SqlLab/hooks/useQueryEditor/index.ts
@@ -29,7 +29,7 @@ export default function useQueryEditor<T extends keyof QueryEditor>(
       pick(
         {
           ...queryEditors.find(({ id }) => id === sqlEditorId),
-          ...(sqlEditorId === unsavedQueryEditor.id && unsavedQueryEditor),
+          ...(sqlEditorId === unsavedQueryEditor?.id && unsavedQueryEditor),
         },
         ['id'].concat(attributes),
       ) as Pick<QueryEditor, T | 'id'>,

--- a/superset-frontend/src/SqlLab/reducers/getInitialState.test.ts
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.test.ts
@@ -47,6 +47,9 @@ const apiDataWithTabState = {
     database_id: 1,
     sql: '',
     table_schemas: [],
+    saved_query: null,
+    template_params: null,
+    latest_query: null,
   },
 };
 describe('getInitialState', () => {
@@ -182,6 +185,9 @@ describe('getInitialState', () => {
               },
             },
           ],
+          saved_query: null,
+          template_params: null,
+          latest_query: null,
         },
       }).sqlLab.tables;
       expect(initializedTables.map(({ id }) => id)).toEqual([1, 2, 6]);

--- a/superset-frontend/src/SqlLab/reducers/getInitialState.test.ts
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.test.ts
@@ -17,37 +17,46 @@
  * under the License.
  */
 
+import { DEFAULT_COMMON_BOOTSTRAP_DATA } from 'src/constants';
 import getInitialState, { dedupeTabHistory } from './getInitialState';
 
 const apiData = {
-  common: {
-    conf: {
-      DEFAULT_SQLLAB_LIMIT: 1,
-    },
-  },
-  active_tab: null,
+  common: DEFAULT_COMMON_BOOTSTRAP_DATA,
   tab_state_ids: [],
   databases: [],
-  queries: [],
-  requested_query: null,
+  queries: {},
   user: {
     userId: 1,
     username: 'some name',
+    isActive: true,
+    isAnonymous: false,
+    firstName: 'first name',
+    lastName: 'last name',
+    permissions: {},
+    roles: {},
   },
 };
 const apiDataWithTabState = {
   ...apiData,
-  tab_state_ids: [{ id: 1 }],
-  active_tab: { id: 1, table_schemas: [] },
+  tab_state_ids: [{ id: 1, label: 'test' }],
+  active_tab: {
+    id: 1,
+    user_id: 1,
+    label: 'editor1',
+    active: true,
+    database_id: 1,
+    sql: '',
+    table_schemas: [],
+  },
 };
 describe('getInitialState', () => {
   it('should output the user that is passed in', () => {
-    expect(getInitialState(apiData).user.userId).toEqual(1);
+    expect(getInitialState(apiData).user?.userId).toEqual(1);
   });
   it('should return undefined instead of null for templateParams', () => {
     expect(
-      getInitialState(apiDataWithTabState).sqlLab.queryEditors[0]
-        .templateParams,
+      getInitialState(apiDataWithTabState).sqlLab?.queryEditors?.[0]
+        ?.templateParams,
     ).toBeUndefined();
   });
 
@@ -55,13 +64,65 @@ describe('getInitialState', () => {
     it('should dedupe the tab history', () => {
       [
         { value: [], expected: [] },
-        { value: [12, 3, 4, 5, 6], expected: [12, 3, 4, 5, 6] },
-        { value: [1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2], expected: [1, 2] },
         {
-          value: [1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3],
-          expected: [1, 2, 3],
+          value: ['12', '3', '4', '5', '6'],
+          expected: ['12', '3', '4', '5', '6'],
         },
-        { value: [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3], expected: [2, 3] },
+        {
+          value: [
+            '1',
+            '2',
+            '2',
+            '2',
+            '2',
+            '2',
+            '2',
+            '2',
+            '2',
+            '2',
+            '2',
+            '2',
+            '2',
+          ],
+          expected: ['1', '2'],
+        },
+        {
+          value: [
+            '1',
+            '2',
+            '2',
+            '2',
+            '2',
+            '2',
+            '2',
+            '2',
+            '2',
+            '2',
+            '2',
+            '2',
+            '2',
+            '3',
+          ],
+          expected: ['1', '2', '3'],
+        },
+        {
+          value: [
+            '2',
+            '2',
+            '2',
+            '2',
+            '2',
+            '2',
+            '2',
+            '2',
+            '2',
+            '2',
+            '2',
+            '2',
+            '3',
+          ],
+          expected: ['2', '3'],
+        },
       ].forEach(({ value, expected }) => {
         expect(dedupeTabHistory(value)).toEqual(expected);
       });
@@ -92,6 +153,11 @@ describe('getInitialState', () => {
         ...apiData,
         active_tab: {
           id: 1,
+          user_id: 1,
+          label: 'editor1',
+          active: true,
+          database_id: 1,
+          sql: '',
           table_schemas: [
             {
               id: 1,

--- a/superset-frontend/src/SqlLab/reducers/getInitialState.ts
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.ts
@@ -28,10 +28,10 @@ import type {
 } from 'src/SqlLab/types';
 
 export function dedupeTabHistory(tabHistory: string[]) {
-  return tabHistory.reduce(
+  return tabHistory.reduce<string[]>(
     (result, tabId) =>
       result.slice(-1)[0] === tabId ? result : result.concat(tabId),
-    tabHistory.slice(0, 0),
+    [],
   );
 }
 

--- a/superset-frontend/src/SqlLab/reducers/getInitialState.ts
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.ts
@@ -61,6 +61,7 @@ export default function getInitialState({
     dbId: common.conf.SQLLAB_DEFAULT_DBID,
     queryLimit: common.conf.DEFAULT_SQLLAB_LIMIT,
     hideLeftBar: false,
+    remoteId: null,
   };
   let unsavedQueryEditor: UnsavedQueryEditor = {};
 
@@ -80,7 +81,7 @@ export default function getInitialState({
         latestQueryId: activeTab.latest_query
           ? activeTab.latest_query.id
           : null,
-        remoteId: activeTab.saved_query?.id,
+        remoteId: activeTab.saved_query?.id || null,
         autorun: Boolean(activeTab.autorun),
         templateParams: activeTab.template_params || undefined,
         dbId: activeTab.database_id,
@@ -147,7 +148,7 @@ export default function getInitialState({
       // migration was successful
       localStorage.removeItem('redux');
     } else {
-      unsavedQueryEditor = sqlLab.unsavedQueryEditor || {};
+      unsavedQueryEditor = sqlLab.unsavedQueryEditor || unsavedQueryEditor;
       // add query editors and tables to state with a special flag so they can
       // be migrated if the `SQLLAB_BACKEND_PERSISTENCE` feature flag is on
       sqlLab.queryEditors.forEach(qe => {
@@ -197,8 +198,8 @@ export default function getInitialState({
       tables: Object.values(tables),
       queriesLastUpdate: Date.now(),
       editorTabLastUpdatedAt,
-      unsavedQueryEditor,
       queryCostEstimates: {},
+      unsavedQueryEditor,
     },
     messageToasts: getToastsFromPyFlashMessages(
       (common || {})?.flash_messages || [],

--- a/superset-frontend/src/SqlLab/reducers/getInitialState.ts
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.ts
@@ -18,12 +18,20 @@
  */
 import { t } from '@superset-ui/core';
 import getToastsFromPyFlashMessages from 'src/components/MessageToasts/getToastsFromPyFlashMessages';
+import type { BootstrapData } from 'src/types/bootstrapTypes';
+import type { InitialState } from 'src/hooks/apiResources/sqlLab';
+import type {
+  QueryEditor,
+  UnsavedQueryEditor,
+  SqlLabRootState,
+  Table,
+} from 'src/SqlLab/types';
 
-export function dedupeTabHistory(tabHistory) {
+export function dedupeTabHistory(tabHistory: string[]) {
   return tabHistory.reduce(
     (result, tabId) =>
       result.slice(-1)[0] === tabId ? result : result.concat(tabId),
-    [],
+    tabHistory.slice(0, 0),
   );
 }
 
@@ -34,7 +42,7 @@ export default function getInitialState({
   databases,
   queries: queries_,
   user,
-}) {
+}: BootstrapData & Partial<InitialState>) {
   /**
    * Before YYYY-MM-DD, the state for SQL Lab was stored exclusively in the
    * browser's localStorage. The feature flag `SQLLAB_BACKEND_PERSISTENCE`
@@ -43,54 +51,41 @@ export default function getInitialState({
    * To allow for a transparent migration, the initial state is a combination
    * of the backend state (if any) with the browser state (if any).
    */
-  let queryEditors = {};
+  let queryEditors: Record<string, QueryEditor> = {};
   const defaultQueryEditor = {
-    id: null,
     loaded: true,
     name: t('Untitled query'),
     sql: 'SELECT *\nFROM\nWHERE',
-    selectedText: null,
     latestQueryId: null,
     autorun: false,
-    templateParams: null,
     dbId: common.conf.SQLLAB_DEFAULT_DBID,
     queryLimit: common.conf.DEFAULT_SQLLAB_LIMIT,
-    validationResult: {
-      id: null,
-      errors: [],
-      completed: false,
-    },
     hideLeftBar: false,
   };
-  let unsavedQueryEditor = {};
+  let unsavedQueryEditor: UnsavedQueryEditor = {};
 
   /**
    * Load state from the backend. This will be empty if the feature flag
    * `SQLLAB_BACKEND_PERSISTENCE` is off.
    */
   tabStateIds.forEach(({ id, label }) => {
-    let queryEditor;
+    let queryEditor: QueryEditor;
     if (activeTab && activeTab.id === id) {
       queryEditor = {
         id: id.toString(),
         loaded: true,
         name: activeTab.label,
-        sql: activeTab.sql || undefined,
+        sql: activeTab.sql || '',
         selectedText: undefined,
         latestQueryId: activeTab.latest_query
           ? activeTab.latest_query.id
           : null,
         remoteId: activeTab.saved_query?.id,
-        autorun: activeTab.autorun,
+        autorun: Boolean(activeTab.autorun),
         templateParams: activeTab.template_params || undefined,
         dbId: activeTab.database_id,
         schema: activeTab.schema,
         queryLimit: activeTab.query_limit,
-        validationResult: {
-          id: null,
-          errors: [],
-          completed: false,
-        },
         hideLeftBar: activeTab.hide_left_bar,
       };
     } else {
@@ -109,7 +104,8 @@ export default function getInitialState({
   });
 
   const tabHistory = activeTab ? [activeTab.id.toString()] : [];
-  let tables = {};
+  let tables = {} as Record<string, Table>;
+  const editorTabLastUpdatedAt = Date.now();
   if (activeTab) {
     activeTab.table_schemas
       .filter(tableSchema => tableSchema.description !== null)
@@ -140,11 +136,12 @@ export default function getInitialState({
    * hasn't used SQL Lab after it has been turned on, the state will be stored
    * in the browser's local storage.
    */
-  if (
-    localStorage.getItem('redux') &&
-    JSON.parse(localStorage.getItem('redux')).sqlLab
-  ) {
-    const { sqlLab } = JSON.parse(localStorage.getItem('redux'));
+  const localStorageData = localStorage.getItem('redux');
+  const sqlLabCacheData = localStorageData
+    ? (JSON.parse(localStorageData) as Pick<SqlLabRootState, 'sqlLab'>)
+    : undefined;
+  if (localStorageData && sqlLabCacheData?.sqlLab) {
+    const { sqlLab } = sqlLabCacheData;
 
     if (sqlLab.queryEditors.length === 0) {
       // migration was successful
@@ -199,11 +196,12 @@ export default function getInitialState({
       tabHistory: dedupeTabHistory(tabHistory),
       tables: Object.values(tables),
       queriesLastUpdate: Date.now(),
+      editorTabLastUpdatedAt,
       unsavedQueryEditor,
       queryCostEstimates: {},
     },
     messageToasts: getToastsFromPyFlashMessages(
-      (common || {}).flash_messages || [],
+      (common || {})?.flash_messages || [],
     ),
     localStorageUsageInKilobytes: 0,
     common: {

--- a/superset-frontend/src/SqlLab/types.ts
+++ b/superset-frontend/src/SqlLab/types.ts
@@ -33,16 +33,19 @@ export interface QueryEditor {
   id: string;
   dbId?: number;
   name: string;
-  schema: string;
+  title?: string; // keep in optional for backward compatibility
+  schema?: string;
   autorun: boolean;
   sql: string;
-  remoteId: number | null;
+  remoteId?: number | null;
   hideLeftBar?: boolean;
   latestQueryId?: string | null;
   templateParams?: string;
   selectedText?: string;
   queryLimit?: number;
   description?: string;
+  loaded?: boolean;
+  inLocalStorage?: boolean;
 }
 
 export type toastState = {
@@ -52,6 +55,21 @@ export type toastState = {
   duration: number;
   noDuplicate: boolean;
 };
+
+export type UnsavedQueryEditor = Partial<QueryEditor> & {
+  id?: QueryEditor['id'];
+};
+
+export interface Table {
+  id: string;
+  dbId: number;
+  schema: string;
+  name: string;
+  queryEditorId: QueryEditor['id'];
+  dataPreviewQueryId?: string | null;
+  expanded?: boolean;
+  initialized?: boolean;
+}
 
 export type SqlLabRootState = {
   sqlLab: {
@@ -63,10 +81,10 @@ export type SqlLabRootState = {
     queries: Record<string, QueryResponse>;
     queryEditors: QueryEditor[];
     tabHistory: string[]; // default is activeTab ? [activeTab.id.toString()] : []
-    tables: Record<string, any>[];
+    tables: Table[];
     queriesLastUpdate: number;
     errorMessage: string | null;
-    unsavedQueryEditor: Partial<QueryEditor>;
+    unsavedQueryEditor: UnsavedQueryEditor;
     queryCostEstimates?: Record<string, QueryCostEstimate>;
     editorTabLastUpdatedAt?: number;
   };

--- a/superset-frontend/src/SqlLab/types.ts
+++ b/superset-frontend/src/SqlLab/types.ts
@@ -33,11 +33,11 @@ export interface QueryEditor {
   id: string;
   dbId?: number;
   name: string;
-  title?: string; // keep in optional for backward compatibility
+  title?: string; // keep it optional for backward compatibility
   schema?: string;
   autorun: boolean;
   sql: string;
-  remoteId?: number | null;
+  remoteId: number | null;
   hideLeftBar?: boolean;
   latestQueryId?: string | null;
   templateParams?: string;
@@ -56,9 +56,7 @@ export type toastState = {
   noDuplicate: boolean;
 };
 
-export type UnsavedQueryEditor = Partial<QueryEditor> & {
-  id?: QueryEditor['id'];
-};
+export type UnsavedQueryEditor = Partial<QueryEditor>;
 
 export interface Table {
   id: string;
@@ -66,7 +64,7 @@ export interface Table {
   schema: string;
   name: string;
   queryEditorId: QueryEditor['id'];
-  dataPreviewQueryId?: string | null;
+  dataPreviewQueryId: string | null;
   expanded?: boolean;
   initialized?: boolean;
 }

--- a/superset-frontend/src/hooks/apiResources/queryApi.ts
+++ b/superset-frontend/src/hooks/apiResources/queryApi.ts
@@ -71,6 +71,7 @@ export const api = createApi({
     'DatabaseFunctions',
     'QueryValidations',
     'TableMetadatas',
+    'SqlLabInitialState',
   ],
   endpoints: () => ({}),
   baseQuery: supersetClientQuery,

--- a/superset-frontend/src/hooks/apiResources/sqlLab.test.ts
+++ b/superset-frontend/src/hooks/apiResources/sqlLab.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import fetchMock from 'fetch-mock';
+import { act, renderHook } from '@testing-library/react-hooks';
+import {
+  createWrapper,
+  defaultStore as store,
+} from 'spec/helpers/testing-library';
+import { api } from 'src/hooks/apiResources/queryApi';
+import { DEFAULT_COMMON_BOOTSTRAP_DATA } from 'src/constants';
+
+import { useSqlLabInitialStateQuery } from './sqlLab';
+
+const fakeApiResult = {
+  result: {
+    common: DEFAULT_COMMON_BOOTSTRAP_DATA,
+    tab_state_ids: [],
+    databases: [],
+    queries: {},
+    user: {
+      userId: 1,
+      username: 'some name',
+      isActive: true,
+      isAnonymous: false,
+      firstName: 'first name',
+      lastName: 'last name',
+      permissions: {},
+      roles: {},
+    },
+  },
+};
+
+const expectedResult = fakeApiResult.result;
+const sqlLabInitialStateApiRoute = `glob:*/api/v1/sqllab/`;
+
+afterEach(() => {
+  fetchMock.reset();
+  act(() => {
+    store.dispatch(api.util.resetApiState());
+  });
+});
+
+beforeEach(() => {
+  fetchMock.get(sqlLabInitialStateApiRoute, fakeApiResult);
+});
+
+test('returns api response mapping json result', async () => {
+  const { result, waitFor } = renderHook(() => useSqlLabInitialStateQuery(), {
+    wrapper: createWrapper({
+      useRedux: true,
+      store,
+    }),
+  });
+  await waitFor(() =>
+    expect(fetchMock.calls(sqlLabInitialStateApiRoute).length).toBe(1),
+  );
+  expect(result.current.data).toEqual(expectedResult);
+  expect(fetchMock.calls(sqlLabInitialStateApiRoute).length).toBe(1);
+  // clean up cache
+  act(() => {
+    store.dispatch(api.util.invalidateTags(['SqlLabInitialState']));
+  });
+  await waitFor(() =>
+    expect(fetchMock.calls(sqlLabInitialStateApiRoute).length).toBe(2),
+  );
+  expect(result.current.data).toEqual(expectedResult);
+});
+
+test('returns cached data without api request', async () => {
+  const { result, waitFor, rerender } = renderHook(
+    () => useSqlLabInitialStateQuery(),
+    {
+      wrapper: createWrapper({
+        store,
+        useRedux: true,
+      }),
+    },
+  );
+  await waitFor(() => expect(result.current.data).toEqual(expectedResult));
+  expect(fetchMock.calls(sqlLabInitialStateApiRoute).length).toBe(1);
+  rerender();
+  await waitFor(() => expect(result.current.data).toEqual(expectedResult));
+  expect(fetchMock.calls(sqlLabInitialStateApiRoute).length).toBe(1);
+});

--- a/superset-frontend/src/hooks/apiResources/sqlLab.test.ts
+++ b/superset-frontend/src/hooks/apiResources/sqlLab.test.ts
@@ -25,7 +25,7 @@ import {
 import { api } from 'src/hooks/apiResources/queryApi';
 import { DEFAULT_COMMON_BOOTSTRAP_DATA } from 'src/constants';
 
-import { useSqlLabInitialStateQuery } from './sqlLab';
+import { useSqlLabInitialState } from './sqlLab';
 
 const fakeApiResult = {
   result: {
@@ -61,7 +61,7 @@ beforeEach(() => {
 });
 
 test('returns api response mapping json result', async () => {
-  const { result, waitFor } = renderHook(() => useSqlLabInitialStateQuery(), {
+  const { result, waitFor } = renderHook(() => useSqlLabInitialState(), {
     wrapper: createWrapper({
       useRedux: true,
       store,
@@ -84,7 +84,7 @@ test('returns api response mapping json result', async () => {
 
 test('returns cached data without api request', async () => {
   const { result, waitFor, rerender } = renderHook(
-    () => useSqlLabInitialStateQuery(),
+    () => useSqlLabInitialState(),
     {
       wrapper: createWrapper({
         store,

--- a/superset-frontend/src/hooks/apiResources/sqlLab.ts
+++ b/superset-frontend/src/hooks/apiResources/sqlLab.ts
@@ -16,8 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { QueryResponse } from '@superset-ui/core';
-import { api, JsonResponse } from './queryApi';
+import type { QueryResponse } from '@superset-ui/core';
+import type { JsonResponse } from './queryApi';
+import { api } from './queryApi';
 
 export type InitialState = {
   active_tab: {
@@ -72,4 +73,5 @@ const queryValidationApi = api.injectEndpoints({
   }),
 });
 
-export const { useSqlLabInitialStateQuery } = queryValidationApi;
+export const { useSqlLabInitialStateQuery: useSqlLabInitialState } =
+  queryValidationApi;

--- a/superset-frontend/src/hooks/apiResources/sqlLab.ts
+++ b/superset-frontend/src/hooks/apiResources/sqlLab.ts
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { QueryResponse } from '@superset-ui/core';
+import { api, JsonResponse } from './queryApi';
+
+export type InitialState = {
+  active_tab: {
+    id: number;
+    user_id: number;
+    label: string;
+    active: boolean;
+    database_id: number;
+    schema?: string;
+    table_schemas: {
+      id: number;
+      table: string;
+      description: {
+        columns?: {
+          name: string;
+          type: string;
+        }[];
+        dataPreviewQueryId?: string;
+      } & Record<string, any>;
+      schema?: string;
+      tab_state_id: number;
+      database_id?: number;
+      expanded?: boolean;
+    }[];
+    sql: string;
+    query_limit?: number;
+    latest_query?: QueryResponse | null;
+    autorun?: boolean;
+    template_params?: string | null;
+    hide_left_bar?: boolean;
+    saved_query?: { id: number } | null;
+    extra_json?: object;
+  };
+  databases: object[];
+  queries: Record<string, QueryResponse & { inLocalStorage?: boolean }>;
+  tab_state_ids: {
+    id: number;
+    label: string;
+  }[];
+};
+
+const queryValidationApi = api.injectEndpoints({
+  endpoints: builder => ({
+    sqlLabInitialState: builder.query<InitialState, void>({
+      providesTags: ['SqlLabInitialState'],
+      query: () => ({
+        endpoint: `/api/v1/sqllab/`,
+        headers: { 'Content-Type': 'application/json' },
+        transformResponse: ({ json }: JsonResponse) => json.result,
+      }),
+    }),
+  }),
+});
+
+export const { useSqlLabInitialStateQuery } = queryValidationApi;

--- a/superset-frontend/src/hooks/apiResources/sqlLab.ts
+++ b/superset-frontend/src/hooks/apiResources/sqlLab.ts
@@ -44,11 +44,11 @@ export type InitialState = {
     }[];
     sql: string;
     query_limit?: number;
-    latest_query?: QueryResponse | null;
+    latest_query: QueryResponse | null;
     autorun?: boolean;
-    template_params?: string | null;
+    template_params: string | null;
     hide_left_bar?: boolean;
-    saved_query?: { id: number } | null;
+    saved_query: { id: number } | null;
     extra_json?: object;
   };
   databases: object[];


### PR DESCRIPTION
### SUMMARY
Part 2 of SQLLab SPA migration: [detail link](https://docs.google.com/document/d/1opyNuaw-CEAD9tG6fx_zqNcZwe3_soQgsnSJTP4mQkk/edit?usp=sharing)

This commit migrates the existing getInialState helper to typescript to be compatible with SPA entrypoint with `/api/v1/sqllab/`. (This commit also adjusts the existing SqlLab types and dependent types)
This commit also introduces `useSqlLabInitialStateQuery` which fetches `/api/v1/sqllab/` and will be used with the updated getInitialState helper in the next page component integration.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
npm run type
npm run test

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
