### PR TITLE
fix: docker-compose non-dev

### DIFF
--- a/docker-compose-non-dev.yml
+++ b/docker-compose-non-dev.yml
@@ -18,8 +18,8 @@ x-superset-image: &superset-image apachesuperset.docker.scarf.sh/apache/superset
 x-superset-depends-on: &superset-depends-on
   - db
   - redis
-x-superset-volumes: &superset-volumes
-  # /app/pythonpath_docker will be appended to the PYTHONPATH in the final container
+x-superset-volumes:
+  &superset-volumes # /app/pythonpath_docker will be appended to the PYTHONPATH in the final container
   - ./docker:/app/docker
   - superset_home:/app/superset_home
 
@@ -39,6 +39,7 @@ services:
     restart: unless-stopped
     volumes:
       - db_home:/var/lib/postgresql/data
+      - ./docker/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
 
   superset:
     env_file: docker/.env-non-dev
@@ -73,7 +74,11 @@ services:
     user: "root"
     volumes: *superset-volumes
     healthcheck:
-      test: ["CMD-SHELL", "celery -A superset.tasks.celery_app:app inspect ping -d celery@$$HOSTNAME"]
+      test:
+        [
+          "CMD-SHELL",
+          "celery -A superset.tasks.celery_app:app inspect ping -d celery@$$HOSTNAME",
+        ]
 
   superset-worker-beat:
     image: *superset-image

--- a/docker/.env-non-dev
+++ b/docker/.env-non-dev
@@ -21,11 +21,17 @@ DATABASE_DB=superset
 DATABASE_HOST=db
 DATABASE_PASSWORD=superset
 DATABASE_USER=superset
+DATABASE_PORT=5432
+DATABASE_DIALECT=postgresql
+
+EXAMPLES_DB=examples
+EXAMPLES_HOST=db
+EXAMPLES_USER=examples
+EXAMPLES_PASSWORD=examples
+EXAMPLES_PORT=5432
 
 # database engine specific environment variables
 # change the below if you prefer another database engine
-DATABASE_PORT=5432
-DATABASE_DIALECT=postgresql
 POSTGRES_DB=superset
 POSTGRES_USER=superset
 POSTGRES_PASSWORD=superset

--- a/docker/pythonpath_dev/superset_config.py
+++ b/docker/pythonpath_dev/superset_config.py
@@ -28,18 +28,18 @@ from celery.schedules import crontab
 
 logger = logging.getLogger()
 
-DATABASE_DIALECT = os.getenv("DATABASE_DIALECT", "postgresql")
-DATABASE_USER = os.getenv("DATABASE_USER", "superset")
-DATABASE_PASSWORD = os.getenv("DATABASE_PASSWORD", "superset")
-DATABASE_HOST = os.getenv("DATABASE_HOST", "db")
-DATABASE_PORT = os.getenv("DATABASE_PORT", "5432")
-DATABASE_DB = os.getenv("DATABASE_DB", "superset")
+DATABASE_DIALECT = os.getenv("DATABASE_DIALECT")
+DATABASE_USER = os.getenv("DATABASE_USER")
+DATABASE_PASSWORD = os.getenv("DATABASE_PASSWORD")
+DATABASE_HOST = os.getenv("DATABASE_HOST")
+DATABASE_PORT = os.getenv("DATABASE_PORT")
+DATABASE_DB = os.getenv("DATABASE_DB")
 
-EXAMPLES_USER = os.getenv("EXAMPLES_USER", "examples")
-EXAMPLES_PASSWORD = os.getenv("EXAMPLES_PASSWORD", "examples")
-EXAMPLES_HOST = os.getenv("EXAMPLES_HOST", "db")
-EXAMPLES_PORT = os.getenv("EXAMPLES_PORT", "5432")
-EXAMPLES_DB = os.getenv("EXAMPLES_DB", "examples")
+EXAMPLES_USER = os.getenv("EXAMPLES_USER")
+EXAMPLES_PASSWORD = os.getenv("EXAMPLES_PASSWORD")
+EXAMPLES_HOST = os.getenv("EXAMPLES_HOST")
+EXAMPLES_PORT = os.getenv("EXAMPLES_PORT")
+EXAMPLES_DB = os.getenv("EXAMPLES_DB")
 
 # The SQLAlchemy connection string.
 SQLALCHEMY_DATABASE_URI = (


### PR DESCRIPTION
### SUMMARY
Fixes `docker-compose -f docker-compose-non-dev.yml up` error reported [here](https://github.com/apache/superset/pull/25003#issuecomment-1683964516).

Follow-up of https://github.com/apache/superset/pull/25003

### TESTING INSTRUCTIONS
Make sure `docker-compose -f docker-compose-non-dev.yml up` is working.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
