### PR TITLE
fix: Error when using the legacy dataset editor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,12 +42,13 @@ repos:
     hooks:
       - id: mypy
         args: [--check-untyped-defs]
-        additional_dependencies:
-          [
+        additional_dependencies: [
             types-simplejson,
             types-python-dateutil,
             types-requests,
-            types-redis,
+            # types-redis 4.6.0.5 is failing mypy
+            # because of https://github.com/python/typeshed/pull/10531
+            types-redis==4.6.0.4,
             types-pytz,
             types-croniter,
             types-PyYAML,

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -411,7 +411,7 @@ class TableModelView(  # pylint: disable=too-many-ancestors
         "database": QuerySelectField(
             "Database",
             query_func=lambda: db.session.query(models.Database),
-            get_pk_func=lambda a: a.id,
+            get_pk_func=lambda item: item.id,
             widget=Select2Widget(extra_classes="readonly"),
         )
     }

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -411,6 +411,7 @@ class TableModelView(  # pylint: disable=too-many-ancestors
         "database": QuerySelectField(
             "Database",
             query_func=lambda: db.session.query(models.Database),
+            get_pk_func=lambda a: a.id,
             widget=Select2Widget(extra_classes="readonly"),
         )
     }


### PR DESCRIPTION
### SUMMARY
This PR fixes an error that was happening when using the legacy dataset editor:

```
File "python3.9/site-packages/flask_appbuilder/fields.py", line 128, in <genexpr>
    self._object_list = list((str(self.get_pk_func(obj)), obj) for obj in objs)
```

Using [git bisect](https://git-scm.com/docs/git-bisect), I was able to pinpoint https://github.com/apache/superset/pull/23680 as the root cause for the error.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: An error was thrown when accessing the legacy editor

<img width="1711" alt="Screenshot 2023-08-22 at 17 02 06" src="https://github.com/apache/superset/assets/70410625/0a755d7b-e841-4405-b324-3fd155c1efe5">

After: The editor rendered correctly

<img width="1509" alt="Screenshot 2023-08-22 at 17 01 35" src="https://github.com/apache/superset/assets/70410625/74327d63-19fd-4c2f-bb74-e4bd508fe9f7">

### TESTING INSTRUCTIONS
1 - Set `DISABLE_LEGACY_DATASOURCE_EDITOR` to `False`
2 - Edit a dataset using the legacy dataset editor
3 - It should render the legacy dataset editor

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
