### PR TITLE
feat: adding Scarf pixels to gather telemetry on readme and website

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,3 +184,6 @@ Understanding the Superset Points of View
   - [Why Apache Superset is Betting on Apache ECharts](https://preset.io/blog/2021-4-1-why-echarts/)
 
 - [Superset API](https://superset.apache.org/docs/rest-api)
+
+<!-- telemetry/analytics pixel: -->
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=bc1c90cd-bc04-4e11-8c7b-289fb2839492" />

--- a/README.md
+++ b/README.md
@@ -186,4 +186,4 @@ Understanding the Superset Points of View
 - [Superset API](https://superset.apache.org/docs/rest-api)
 
 <!-- telemetry/analytics pixel: -->
-<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=bc1c90cd-bc04-4e11-8c7b-289fb2839492" />
+![](https://static.scarf.sh/a.png?x-pxid=39ae6855-95fc-4566-86e5-360d542b0a68)

--- a/README.md
+++ b/README.md
@@ -186,4 +186,4 @@ Understanding the Superset Points of View
 - [Superset API](https://superset.apache.org/docs/rest-api)
 
 <!-- telemetry/analytics pixel: -->
-![](https://static.scarf.sh/a.png?x-pxid=39ae6855-95fc-4566-86e5-360d542b0a68)
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=bc1c90cd-bc04-4e11-8c7b-289fb2839492" />

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -253,6 +253,7 @@ const config = {
               <a href="https://apache.org/licenses/" target="_blank" rel="noreferrer">License</a>
             </small>
           </p>
+          <!-- telemetry/analytics pixel: -->
           <img referrerPolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=39ae6855-95fc-4566-86e5-360d542b0a68" />
           `,
       },

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -252,7 +252,9 @@ const config = {
               <a href="https://apache.org/events/current-event" target="_blank" rel="noreferrer">Events</a>&nbsp;|&nbsp;
               <a href="https://apache.org/licenses/" target="_blank" rel="noreferrer">License</a>
             </small>
-          </p>`,
+          </p>
+          <img referrerPolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=39ae6855-95fc-4566-86e5-360d542b0a68" />
+          `,
       },
       prism: {
         theme: lightCodeTheme,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds two distinct tracking pixels for telemetry, using the Scarf platform. One is added to the readme to capture analytics around visits to the repo, and one captures visits to the website/docs.

All of this data will be available to interested PMC members, and reported periodically in things like Superset Board Reports and Superset Town Hall events.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Log into Scarf and see the charts ticking!

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
