### PR TITLE
fix: Cross filters initial scope

### DIFF
--- a/superset-frontend/src/dashboard/constants.ts
+++ b/superset-frontend/src/dashboard/constants.ts
@@ -1,4 +1,4 @@
-import { DatasourceType } from '@superset-ui/core';
+import { DatasourceType, NativeFilterScope } from '@superset-ui/core';
 import { Datasource } from 'src/dashboard/types';
 import { DASHBOARD_ROOT_ID } from './util/constants';
 /**
@@ -44,7 +44,7 @@ export const FILTER_BAR_TABS_HEIGHT = 46;
 export const BUILDER_SIDEPANEL_WIDTH = 374;
 export const OVERWRITE_INSPECT_FIELDS = ['css', 'json_metadata.filter_scopes'];
 
-export const DEFAULT_CROSS_FILTER_SCOPING = {
+export const DEFAULT_CROSS_FILTER_SCOPING: NativeFilterScope = {
   rootPath: [DASHBOARD_ROOT_ID],
   excluded: [],
 };

--- a/superset-frontend/src/dashboard/util/crossFilters.ts
+++ b/superset-frontend/src/dashboard/util/crossFilters.ts
@@ -52,7 +52,7 @@ export const getCrossFiltersConfiguration = (
     return undefined;
   }
 
-  const globalChartConfiguration = metadata.global_chart_configuration
+  const globalChartConfiguration = metadata.global_chart_configuration?.scope
     ? {
         scope: metadata.global_chart_configuration.scope,
         chartsInScope: getChartIdsInFilterScope(


### PR DESCRIPTION
### SUMMARY
This PR fixes a bug in the initialization of cross filters scope. The algorithm was not considering dashboards that were created before `DASHBOARD_CROSS_FILTERS` was enabled. `metadata.global_chart_configuration.scope` might not exist and that was generating an error.

Fixes https://github.com/apache/superset/issues/25064

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1172" alt="Screenshot 2023-08-24 at 11 23 03" src="https://github.com/apache/superset/assets/70410625/454baabb-f7ab-41be-9e72-72f0062505ae">
<img width="1772" alt="Screenshot 2023-08-24 at 11 22 41" src="https://github.com/apache/superset/assets/70410625/8fd7b8c0-6900-4b18-8cd9-637c0b800e02">

### TESTING INSTRUCTIONS
- Create a dashboard with DASHBOARD_CROSS_FILTERS disabled
- Enable `DASHBOARD_CROSS_FILTERS`
- Navigate to the created dashboard
- It should not throw the mentioned error

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
