### PR TITLE
fix(assets import): Ensure old datasource ids are not referenced in imported charts

### DIFF
--- a/superset/commands/importers/v1/assets.py
+++ b/superset/commands/importers/v1/assets.py
@@ -110,7 +110,13 @@ class ImportAssetsCommand(BaseCommand):
         chart_ids: dict[str, int] = {}
         for file_name, config in configs.items():
             if file_name.startswith("charts/"):
-                config.update(dataset_info[config["dataset_uuid"]])
+                dataset_dict = dataset_info[config["dataset_uuid"]]
+                config.update(dataset_dict)
+                # pylint: disable=line-too-long
+                dataset_uid = f"{dataset_dict['datasource_id']}__{dataset_dict['datasource_type']}"
+                config["params"].update({"datasource": dataset_uid})
+                if "query_context" in config:
+                    del config["query_context"]
                 chart = import_chart(session, config, overwrite=True)
                 chart_ids[str(chart.uuid)] = chart.id
 

--- a/superset/commands/importers/v1/assets.py
+++ b/superset/commands/importers/v1/assets.py
@@ -79,6 +79,7 @@ class ImportAssetsCommand(BaseCommand):
         )
         self._configs: dict[str, Any] = {}
 
+    # pylint: disable=too-many-locals
     @staticmethod
     def _import(session: Session, configs: dict[str, Any]) -> None:
         # import databases first

--- a/tests/integration_tests/commands_test.py
+++ b/tests/integration_tests/commands_test.py
@@ -141,6 +141,9 @@ class TestImportAssetsCommand(SupersetTestCase):
         dataset = chart.table
         assert str(dataset.uuid) == dataset_config["uuid"]
 
+        assert chart.query_context is None
+        assert json.loads(chart.params)["datasource"] == dataset.uid
+
         database = dataset.database
         assert str(database.uuid) == database_config["uuid"]
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
https://github.com/apache/superset/pull/23582 fixed this exact same issue, but only for the dashboard import command.  I didn't realize at the time this also needed to be fixed for the assets import command (used by` /api/v1/assets/import`).  It turns out there's a good amount of duplicated code between the different import commands, so the same fix has to be copied here as well.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
