### PR TITLE
fix(sqllab): rendering performance regression by resultset

### DIFF
--- a/superset-frontend/src/SqlLab/components/SouthPane/SouthPane.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/SouthPane.test.tsx
@@ -20,11 +20,12 @@ import React from 'react';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { render, screen, waitFor } from 'spec/helpers/testing-library';
-import SouthPane from 'src/SqlLab/components/SouthPane';
+import SouthPane, { SouthPaneProps } from 'src/SqlLab/components/SouthPane';
 import '@testing-library/jest-dom/extend-expect';
 import { STATUS_OPTIONS } from 'src/SqlLab/constants';
 import { initialState, table, defaultQueryEditor } from 'src/SqlLab/fixtures';
 import { denormalizeTimestamp } from '@superset-ui/core';
+import { Store } from 'redux';
 
 const mockedProps = {
   queryEditorId: defaultQueryEditor.id,
@@ -41,6 +42,8 @@ const mockedEmptyProps = {
   displayLimit: 100,
   defaultQueryLimit: 100,
 };
+
+jest.mock('src/SqlLab/components/SqlEditorLeftBar', () => jest.fn());
 
 const latestQueryProgressMsg = 'LATEST QUERY MESSAGE - LCly_kkIN';
 
@@ -100,14 +103,14 @@ const store = mockStore({
     },
   },
 });
-const setup = (props, store) =>
+const setup = (props: SouthPaneProps, store: Store) =>
   render(<SouthPane {...props} />, {
     useRedux: true,
     ...(store && { store }),
   });
 
 describe('SouthPane', () => {
-  const renderAndWait = (props, store) =>
+  const renderAndWait = (props: SouthPaneProps, store: Store) =>
     waitFor(async () => setup(props, store));
 
   it('Renders an empty state for results', async () => {

--- a/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.jsx
@@ -212,10 +212,8 @@ describe('SqlEditor', () => {
   });
 
   it('render a SouthPane', async () => {
-    const { findByText } = setup(mockedProps, store);
-    expect(
-      await findByText(/run a query to display results/i),
-    ).toBeInTheDocument();
+    const { findByTestId } = setup(mockedProps, store);
+    expect(await findByTestId('mock-result-set')).toBeInTheDocument();
   });
 
   it('runs query action with ctas false', async () => {

--- a/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.jsx
@@ -30,6 +30,7 @@ import {
   defaultQueryEditor,
 } from 'src/SqlLab/fixtures';
 import SqlEditorLeftBar from 'src/SqlLab/components/SqlEditorLeftBar';
+import ResultSet from 'src/SqlLab/components/ResultSet';
 import { api } from 'src/hooks/apiResources/queryApi';
 import { getExtensionsRegistry } from '@superset-ui/core';
 import setupExtensions from 'src/setup/setupExtensions';
@@ -46,6 +47,7 @@ jest.mock('src/components/AsyncAceEditor', () => ({
   ),
 }));
 jest.mock('src/SqlLab/components/SqlEditorLeftBar', () => jest.fn());
+jest.mock('src/SqlLab/components/ResultSet', () => jest.fn());
 
 fetchMock.get('glob:*/api/v1/database/*/function_names/', {
   function_names: [],
@@ -56,10 +58,17 @@ fetchMock.post('glob:*/sqllab/execute/*', { result: [] });
 
 let store;
 let actions;
+const latestQuery = {
+  ...queries[0],
+  sqlEditorId: defaultQueryEditor.id,
+};
 const mockInitialState = {
   ...initialState,
   sqlLab: {
     ...initialState.sqlLab,
+    queries: {
+      [latestQuery.id]: { ...latestQuery, startDttm: new Date().getTime() },
+    },
     databases: {
       1991: {
         allow_ctas: false,
@@ -77,6 +86,7 @@ const mockInitialState = {
     unsavedQueryEditor: {
       id: defaultQueryEditor.id,
       dbId: 1991,
+      latestQueryId: latestQuery.id,
     },
   },
 };
@@ -107,7 +117,6 @@ const createStore = initState =>
 describe('SqlEditor', () => {
   const mockedProps = {
     queryEditor: initialState.sqlLab.queryEditors[0],
-    latestQuery: queries[0],
     tables: [table],
     getHeight: () => '100px',
     editorQueries: [],
@@ -125,6 +134,8 @@ describe('SqlEditor', () => {
     SqlEditorLeftBar.mockImplementation(() => (
       <div data-test="mock-sql-editor-left-bar" />
     ));
+    ResultSet.mockClear();
+    ResultSet.mockImplementation(() => <div data-test="mock-result-set" />);
   });
 
   afterEach(() => {
@@ -153,15 +164,18 @@ describe('SqlEditor', () => {
     expect(await findByTestId('react-ace')).toBeInTheDocument();
   });
 
-  it('avoids rerendering EditorLeftBar while typing', async () => {
+  it('avoids rerendering EditorLeftBar and ResultSet while typing', async () => {
     const { findByTestId } = setup(mockedProps, store);
     const editor = await findByTestId('react-ace');
     const sql = 'select *';
     const renderCount = SqlEditorLeftBar.mock.calls.length;
+    const renderCountForSouthPane = ResultSet.mock.calls.length;
     expect(SqlEditorLeftBar).toHaveBeenCalledTimes(renderCount);
+    expect(ResultSet).toHaveBeenCalledTimes(renderCountForSouthPane);
     fireEvent.change(editor, { target: { value: sql } });
     // Verify the rendering regression
     expect(SqlEditorLeftBar).toHaveBeenCalledTimes(renderCount);
+    expect(ResultSet).toHaveBeenCalledTimes(renderCountForSouthPane);
   });
 
   it('renders sql from unsaved change', async () => {

--- a/superset-frontend/src/views/store.ts
+++ b/superset-frontend/src/views/store.ts
@@ -141,7 +141,7 @@ const reducers = {
 export function setupStore({
   disableDebugger = false,
   initialState = {},
-  rootReducers = reducers,
+  rootReducers,
   ...overrides
 }: {
   disableDebugger?: boolean;
@@ -152,6 +152,7 @@ export function setupStore({
     preloadedState: initialState,
     reducer: {
       [api.reducerPath]: api.reducer,
+      ...reducers,
       ...rootReducers,
     },
     middleware: getMiddleware,

--- a/superset-frontend/src/views/store.ts
+++ b/superset-frontend/src/views/store.ts
@@ -141,7 +141,7 @@ const reducers = {
 export function setupStore({
   disableDebugger = false,
   initialState = {},
-  rootReducers,
+  rootReducers = reducers,
   ...overrides
 }: {
   disableDebugger?: boolean;
@@ -152,7 +152,6 @@ export function setupStore({
     preloadedState: initialState,
     reducer: {
       [api.reducerPath]: api.reducer,
-      ...reducers,
       ...rootReducers,
     },
     middleware: getMiddleware,


### PR DESCRIPTION
### SUMMARY
When ResultSet renders a large size of column record (i.e. preview of FCC 2018 Survey), rendering cost of VirtualizedTable is heavy. To avoid the lag of the typing editor, we should avoid the ResultSet rendering while typing.
This commit fixes the inefficient userSelector in ResultSet which triggers the re-rendering of FilterableTable anytime redux action triggered.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

After (no lag while typing):

https://github.com/apache/superset/assets/1392866/3e346d56-aa7c-4852-9a6a-db0f8a145e9b

Before (lagging after render the table resultset):

https://github.com/apache/superset/assets/1392866/1774e4e4-57bd-4765-a11f-3b881b7f5356

### TESTING INSTRUCTIONS
Load example db
Go to SQL Lab and select the 'FCC 20218 Survey' in the table schema
After the preview result loaded, type the sql in the editor to check the lagging

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
