### PR TITLE
feat: removing renderCard from Tags/index.tsc to remove cardview from Tags ListView

### DIFF
--- a/superset-frontend/src/pages/Tags/index.tsx
+++ b/superset-frontend/src/pages/Tags/index.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useMemo, useCallback, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { isFeatureEnabled, FeatureFlag, t } from '@superset-ui/core';
 import {
   createFetchRelated,
@@ -40,7 +40,6 @@ import { Link } from 'react-router-dom';
 import { deleteTags } from 'src/features/tags/tags';
 import { Tag as AntdTag } from 'antd';
 import { Tag } from 'src/views/CRUD/types';
-import TagCard from 'src/features/tags/TagCard';
 import TagModal from 'src/features/tags/TagModal';
 import FaveStar from 'src/components/FaveStar';
 

--- a/superset-frontend/src/pages/Tags/index.tsx
+++ b/superset-frontend/src/pages/Tags/index.tsx
@@ -297,36 +297,6 @@ function TagList(props: TagListProps) {
     },
   ];
 
-  const renderCard = useCallback(
-    (tag: Tag) => (
-      <TagCard
-        tag={tag}
-        hasPerm={hasPerm}
-        bulkSelectEnabled={bulkSelectEnabled}
-        refreshData={refreshData}
-        showThumbnails={
-          userKey
-            ? userKey.thumbnails
-            : isFeatureEnabled(FeatureFlag.THUMBNAILS)
-        }
-        userId={userId}
-        loading={loading}
-        addDangerToast={addDangerToast}
-        addSuccessToast={addSuccessToast}
-      />
-    ),
-    [
-      addDangerToast,
-      addSuccessToast,
-      bulkSelectEnabled,
-      hasPerm,
-      loading,
-      userId,
-      refreshData,
-      userKey,
-    ],
-  );
-
   const subMenuButtons: SubMenuProps['buttons'] = [];
 
   if (canDelete) {
@@ -400,7 +370,6 @@ function TagList(props: TagListProps) {
                     ? userKey.thumbnails
                     : isFeatureEnabled(FeatureFlag.THUMBNAILS)
                 }
-                renderCard={renderCard}
                 defaultViewMode={
                   isFeatureEnabled(FeatureFlag.LISTVIEWS_DEFAULT_CARD_VIEW)
                     ? 'card'


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Tags were being displayed with an option to view as cards. This was not part of the design of the tags feature.
To remove the cards from the ListView component, I removed the renderCard prop from from the TagList component to prevent card option settings from rendering in the ListView component.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![image](https://github.com/apache/superset/assets/41238731/9668ad25-b1c1-4e6b-82ca-e1afb52fd480)
After:
![image](https://github.com/apache/superset/assets/41238731/0ade2099-7238-4a7e-b211-d3b658873e66)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
