### PR TITLE
fix: preventing save button from flickering in SQL Lab

### DIFF
--- a/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.tsx
@@ -27,7 +27,7 @@ import { initialState, databases } from 'src/SqlLab/fixtures';
 const mockedProps = {
   queryEditorId: '123',
   animation: false,
-  database: databases.result[0],
+  database: { ...databases.result[0], allows_virtual_table_explore: false },
   onUpdate: () => {},
   onSave: () => {},
   saveQueryWarning: null,
@@ -61,6 +61,29 @@ const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
 
 describe('SavedQuery', () => {
+  it('doesnt render save button when allows_virtual_table_explore is undefined', async () => {
+    const noRenderProps = {
+      ...mockedProps,
+      database: {
+        ...mockedProps.database,
+        allows_virtual_table_explore: undefined,
+      },
+    };
+    render(<SaveQuery {...noRenderProps} />, {
+      useRedux: true,
+      store: mockStore(mockState),
+    });
+
+    try {
+      const saveBtn = screen.getByRole('button', { name: /save/i });
+      expect(saveBtn).not.toBeVisible();
+    } catch (err) {
+      expect(err.message).not.toContain('Received element is visible');
+      expect(err.message).toContain(
+        'Unable to find an accessible element with the role "button" and name `/save/i`',
+      );
+    }
+  });
   it('renders a non-split save button when allows_virtual_table_explore is not enabled', () => {
     render(<SaveQuery {...mockedProps} />, {
       useRedux: true,

--- a/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.tsx
@@ -73,17 +73,13 @@ describe('SavedQuery', () => {
       useRedux: true,
       store: mockStore(mockState),
     });
-
-    try {
-      const saveBtn = screen.getByRole('button', { name: /save/i });
-      expect(saveBtn).not.toBeVisible();
-    } catch (err) {
-      expect(err.message).not.toContain('Received element is visible');
-      expect(err.message).toContain(
-        'Unable to find an accessible element with the role "button" and name `/save/i`',
-      );
-    }
+    expect(() => {
+      screen.getByRole('button', { name: /save/i });
+    }).toThrow(
+      'Unable to find an accessible element with the role "button" and name `/save/i`',
+    );
   });
+
   it('renders a non-split save button when allows_virtual_table_explore is not enabled', () => {
     render(<SaveQuery {...mockedProps} />, {
       useRedux: true,

--- a/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
@@ -97,7 +97,7 @@ const SaveQuery = ({
   const [showSave, setShowSave] = useState<boolean>(false);
   const [showSaveDatasetModal, setShowSaveDatasetModal] = useState(false);
   const isSaved = !!query.remoteId;
-  const canExploreDatabase = database?.allows_virtual_table_explore ? true : null ;
+  const canExploreDatabase = !!database?.allows_virtual_table_explore;
 
   const overlayMenu = (
     <Menu>
@@ -180,12 +180,10 @@ const SaveQuery = ({
 
   return (
     <Styles className="SaveQuery">
-      {canExploreDatabase && (
-        <SaveDatasetActionButton
-          setShowSave={setShowSave}
-          overlayMenu={overlayMenu}
-        />
-      )}
+      <SaveDatasetActionButton
+        setShowSave={setShowSave}
+        overlayMenu={canExploreDatabase ? overlayMenu : null}
+      />
       <SaveDatasetModal
         visible={showSaveDatasetModal}
         onHide={() => setShowSaveDatasetModal(false)}

--- a/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
@@ -98,6 +98,8 @@ const SaveQuery = ({
   const [showSaveDatasetModal, setShowSaveDatasetModal] = useState(false);
   const isSaved = !!query.remoteId;
   const canExploreDatabase = !!database?.allows_virtual_table_explore;
+  const canShowSaveButton =
+    database?.allows_virtual_table_explore !== undefined;
 
   const overlayMenu = (
     <Menu>
@@ -180,7 +182,7 @@ const SaveQuery = ({
 
   return (
     <Styles className="SaveQuery">
-      {canExploreDatabase && (
+      {canShowSaveButton && (
         <SaveDatasetActionButton
           setShowSave={setShowSave}
           overlayMenu={canExploreDatabase ? overlayMenu : null}

--- a/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
@@ -98,7 +98,7 @@ const SaveQuery = ({
   const [showSaveDatasetModal, setShowSaveDatasetModal] = useState(false);
   const isSaved = !!query.remoteId;
   const canExploreDatabase = !!database?.allows_virtual_table_explore;
-  const canShowSaveButton =
+  const shouldShowSaveButton =
     database?.allows_virtual_table_explore !== undefined;
 
   const overlayMenu = (
@@ -182,7 +182,7 @@ const SaveQuery = ({
 
   return (
     <Styles className="SaveQuery">
-      {canShowSaveButton && (
+      {shouldShowSaveButton && (
         <SaveDatasetActionButton
           setShowSave={setShowSave}
           overlayMenu={canExploreDatabase ? overlayMenu : null}

--- a/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
@@ -97,7 +97,7 @@ const SaveQuery = ({
   const [showSave, setShowSave] = useState<boolean>(false);
   const [showSaveDatasetModal, setShowSaveDatasetModal] = useState(false);
   const isSaved = !!query.remoteId;
-  const canExploreDatabase = !!database?.allows_virtual_table_explore;
+  const canExploreDatabase = database?.allows_virtual_table_explore ? true : null ;
 
   const overlayMenu = (
     <Menu>
@@ -180,10 +180,12 @@ const SaveQuery = ({
 
   return (
     <Styles className="SaveQuery">
-      <SaveDatasetActionButton
-        setShowSave={setShowSave}
-        overlayMenu={canExploreDatabase ? overlayMenu : null}
-      />
+      {canExploreDatabase && (
+        <SaveDatasetActionButton
+          setShowSave={setShowSave}
+          overlayMenu={overlayMenu}
+        />
+      )}
       <SaveDatasetModal
         visible={showSaveDatasetModal}
         onHide={() => setShowSaveDatasetModal(false)}

--- a/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
@@ -180,10 +180,12 @@ const SaveQuery = ({
 
   return (
     <Styles className="SaveQuery">
-      <SaveDatasetActionButton
-        setShowSave={setShowSave}
-        overlayMenu={canExploreDatabase ? overlayMenu : null}
-      />
+      {canExploreDatabase && (
+        <SaveDatasetActionButton
+          setShowSave={setShowSave}
+          overlayMenu={canExploreDatabase ? overlayMenu : null}
+        />
+      )}
       <SaveDatasetModal
         visible={showSaveDatasetModal}
         onHide={() => setShowSaveDatasetModal(false)}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The save button was flickering from a non-split save button to a split save button due to a variable database.allows_virtual_table_explore being undefined after component mounts. Added logic to prevent this flickering behavior by blocking the save button from rendering while allows_virtual_table_explore is undefined. If allows_virtual_table_explore === false, then the non-split save button will still render.

Adjusted testsuite to test for this behavior.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before: 
https://www.loom.com/share/6eaf1679a6ac480daf675d367e561488

After:
https://www.loom.com/share/a378b25defda424689f9aa6a16ff3aed?sid=37b2a345-3d49-4ff2-9e8a-078ad6f92282

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
