### PR TITLE
fix: Date format when importing international timestamps

### DIFF
--- a/superset/templates/superset/form_view/csv_to_database_view/edit.html
+++ b/superset/templates/superset/form_view/csv_to_database_view/edit.html
@@ -1,142 +1,141 @@
-{#
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-#}
-{% extends "appbuilder/base.html" %}
-{% import 'appbuilder/general/lib.html' as lib %}
-{% import "superset/macros.html" as macros %}
-{% set begin_sep_label = '<td class="col-sm-2" style="border-left: 0; border-top: 0;">' %}
-  {% set end_sep_label = '</td>' %}
-{% set begin_sep_field = '<td style="border-right: 0; border-top: 0;">' %}
-  {% set end_sep_field = '</td>' %}
-{% import 'superset/form_view/database_schemas_selector.html' as schemas_selector %}
-{% import 'superset/form_view/csv_scripts.html' as csv_scripts %}
-{% import 'superset/form_view/csv_macros.html' as csv_macros %}
-{% block content %}
-{{ lib.panel_begin(title, "edit") }}
+{# Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements. See the NOTICE file distributed with this work
+for additional information regarding copyright ownership. The ASF licenses this
+file to you under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by
+applicable law or agreed to in writing, software distributed under the License
+is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. #} {% extends
+"appbuilder/base.html" %} {% import 'appbuilder/general/lib.html' as lib %} {%
+import "superset/macros.html" as macros %} {% set begin_sep_label = '
+<td class="col-sm-2" style="border-left: 0; border-top: 0">
+  ' %} {% set end_sep_label = '
+</td>
+' %} {% set begin_sep_field = '
+<td style="border-right: 0; border-top: 0">' %} {% set end_sep_field = '</td>
+' %} {% import 'superset/form_view/database_schemas_selector.html' as
+schemas_selector %} {% import 'superset/form_view/csv_scripts.html' as
+csv_scripts %} {% import 'superset/form_view/csv_macros.html' as csv_macros %}
+{% block content %} {{ lib.panel_begin(title, "edit") }}
 <div id="Home" class="tab-pane active">
   <form id="model_form" action="" method="post" enctype="multipart/form-data">
     {{form.hidden_tag()}}
     <div class="form-group">
-      <div class="col-md-12" style="padding: 0;">
+      <div class="col-md-12" style="padding: 0">
         <table class="table table-bordered">
           <tbody>
             <tr>
-              {{ lib.render_field(form.csv_file, begin_sep_label, end_sep_label, begin_sep_field, end_sep_field) }}
+              {{ lib.render_field(form.csv_file, begin_sep_label, end_sep_label,
+              begin_sep_field, end_sep_field) }}
             </tr>
             <tr>
-              {{ lib.render_field(form.table_name, begin_sep_label, end_sep_label, begin_sep_field, end_sep_field) }}
+              {{ lib.render_field(form.table_name, begin_sep_label,
+              end_sep_label, begin_sep_field, end_sep_field) }}
             </tr>
             <tr>
-              {{ lib.render_field(form.database, begin_sep_label, end_sep_label, begin_sep_field, end_sep_field) }}
+              {{ lib.render_field(form.database, begin_sep_label, end_sep_label,
+              begin_sep_field, end_sep_field) }}
             </tr>
             <tr>
-              {{ lib.render_field(form.schema, begin_sep_label, end_sep_label, begin_sep_field, end_sep_field) }}
+              {{ lib.render_field(form.schema, begin_sep_label, end_sep_label,
+              begin_sep_field, end_sep_field) }}
             </tr>
             <tr>
-              {{ csv_macros.render_delimiter_field(form.delimiter, begin_sep_label, end_sep_label, begin_sep_field, end_sep_field) }}
+              {{ csv_macros.render_delimiter_field(form.delimiter,
+              begin_sep_label, end_sep_label, begin_sep_field, end_sep_field) }}
             </tr>
           </tbody>
         </table>
       </div>
     </div>
-    {% call csv_macros.render_collapsable_form_group("accordion1", "File Settings") %}
-      <tr>
-        {{ lib.render_field(form.if_exists, begin_sep_label, end_sep_label, begin_sep_field,
-        end_sep_field) }}
-      </tr>
-      <tr>
-        {{ lib.render_field(form.skip_initial_space, begin_sep_label, end_sep_label, begin_sep_field,
-        end_sep_field) }}
-      </tr>
-      <tr>
-        {{ lib.render_field(form.skip_blank_lines, begin_sep_label, end_sep_label, begin_sep_field,
-        end_sep_field) }}
-      </tr>
-      <tr>
-        {{ lib.render_field(form.parse_dates, begin_sep_label, end_sep_label, begin_sep_field,
-        end_sep_field) }}
-      </tr>
-      <tr>
-        {{ lib.render_field(form.infer_datetime_format, begin_sep_label, end_sep_label, begin_sep_field,
-        end_sep_field) }}
-      </tr>
-      <tr>
-        {{ lib.render_field(form.decimal, begin_sep_label, end_sep_label, begin_sep_field,
-        end_sep_field) }}
-      </tr>
-      <tr>
-        {{ lib.render_field(form.null_values, begin_sep_label, end_sep_label, begin_sep_field,
-        end_sep_field) }}
-      </tr>
-    {% endcall %}
-    {% call csv_macros.render_collapsable_form_group("accordion2", "Columns") %}
-      <tr>
-        {{ lib.render_field(form.index_col, begin_sep_label, end_sep_label, begin_sep_field,
-        end_sep_field) }}
-      </tr>
-      <tr>
-        {{ lib.render_field(form.dataframe_index, begin_sep_label, end_sep_label, begin_sep_field,
-        end_sep_field) }}
-      </tr>
-      <tr>
-        {{ lib.render_field(form.index_label, begin_sep_label, end_sep_label, begin_sep_field,
-        end_sep_field) }}
-      </tr>
-      <tr>
-        {{ lib.render_field(form.use_cols, begin_sep_label, end_sep_label, begin_sep_field,
-        end_sep_field) }}
-      </tr>
-      <tr>
-        {{ lib.render_field(form.overwrite_duplicate, begin_sep_label, end_sep_label, begin_sep_field,
-        end_sep_field) }}
-      </tr>
-      <tr>
-        {{ lib.render_field(form.dtype, begin_sep_label, end_sep_label, begin_sep_field,
-        end_sep_field) }}
-      </tr>
-    {% endcall %}
-    {% call csv_macros.render_collapsable_form_group("accordion3", "Rows") %}
-      <tr>
-        {{ lib.render_field(form.header, begin_sep_label, end_sep_label, begin_sep_field, end_sep_field)
-        }}
-      </tr>
-      <tr>
-        {{ lib.render_field(form.nrows, begin_sep_label, end_sep_label, begin_sep_field, end_sep_field)
-        }}
-      </tr>
-      <tr>
-        {{ lib.render_field(form.skiprows, begin_sep_label, end_sep_label, begin_sep_field,
-        end_sep_field) }}
-      </tr>
+    {% call csv_macros.render_collapsable_form_group("accordion1", "File
+    Settings") %}
+    <tr>
+      {{ lib.render_field(form.if_exists, begin_sep_label, end_sep_label,
+      begin_sep_field, end_sep_field) }}
+    </tr>
+    <tr>
+      {{ lib.render_field(form.skip_initial_space, begin_sep_label,
+      end_sep_label, begin_sep_field, end_sep_field) }}
+    </tr>
+    <tr>
+      {{ lib.render_field(form.skip_blank_lines, begin_sep_label, end_sep_label,
+      begin_sep_field, end_sep_field) }}
+    </tr>
+    <tr>
+      {{ lib.render_field(form.parse_dates, begin_sep_label, end_sep_label,
+      begin_sep_field, end_sep_field) }}
+    </tr>
+    <tr>
+      {{ lib.render_field(form.infer_datetime_format, begin_sep_label,
+      end_sep_label, begin_sep_field, end_sep_field) }}
+    </tr>
+    <tr>
+      {{ lib.render_field(form.day_first, begin_sep_label, end_sep_label,
+      begin_sep_field, end_sep_field) }}
+    </tr>
+    <tr>
+      {{ lib.render_field(form.decimal, begin_sep_label, end_sep_label,
+      begin_sep_field, end_sep_field) }}
+    </tr>
+    <tr>
+      {{ lib.render_field(form.null_values, begin_sep_label, end_sep_label,
+      begin_sep_field, end_sep_field) }}
+    </tr>
+    {% endcall %} {% call csv_macros.render_collapsable_form_group("accordion2",
+    "Columns") %}
+    <tr>
+      {{ lib.render_field(form.index_col, begin_sep_label, end_sep_label,
+      begin_sep_field, end_sep_field) }}
+    </tr>
+    <tr>
+      {{ lib.render_field(form.dataframe_index, begin_sep_label, end_sep_label,
+      begin_sep_field, end_sep_field) }}
+    </tr>
+    <tr>
+      {{ lib.render_field(form.index_label, begin_sep_label, end_sep_label,
+      begin_sep_field, end_sep_field) }}
+    </tr>
+    <tr>
+      {{ lib.render_field(form.use_cols, begin_sep_label, end_sep_label,
+      begin_sep_field, end_sep_field) }}
+    </tr>
+    <tr>
+      {{ lib.render_field(form.overwrite_duplicate, begin_sep_label,
+      end_sep_label, begin_sep_field, end_sep_field) }}
+    </tr>
+    <tr>
+      {{ lib.render_field(form.dtype, begin_sep_label, end_sep_label,
+      begin_sep_field, end_sep_field) }}
+    </tr>
+    {% endcall %} {% call csv_macros.render_collapsable_form_group("accordion3",
+    "Rows") %}
+    <tr>
+      {{ lib.render_field(form.header, begin_sep_label, end_sep_label,
+      begin_sep_field, end_sep_field) }}
+    </tr>
+    <tr>
+      {{ lib.render_field(form.nrows, begin_sep_label, end_sep_label,
+      begin_sep_field, end_sep_field) }}
+    </tr>
+    <tr>
+      {{ lib.render_field(form.skiprows, begin_sep_label, end_sep_label,
+      begin_sep_field, end_sep_field) }}
+    </tr>
     {% endcall %}
     <div class="form-group">
-      <div class="col-xs-12" style="padding: 0;">
+      <div class="col-xs-12" style="padding: 0">
         {{ lib.render_form_controls() }}
       </div>
     </div>
   </form>
 </div>
-{% endblock %}
-{% block add_tail_js %}
-<script src="{{url_for('appbuilder.static',filename='js/ab_keep_tab.js')}}" nonce="{{ macros.get_nonce() }}"></script>
-{% endblock %}
-{% block tail_js %}
-  {{ super() }}
-  {{ schemas_selector }}
-  {{ csv_scripts }}
-{% endblock %}
+{% endblock %} {% block add_tail_js %}
+<script
+  src="{{url_for('appbuilder.static',filename='js/ab_keep_tab.js')}}"
+  nonce="{{ macros.get_nonce() }}"
+></script>
+{% endblock %} {% block tail_js %} {{ super() }} {{ schemas_selector }} {{
+csv_scripts }} {% endblock %}

--- a/superset/views/database/forms.py
+++ b/superset/views/database/forms.py
@@ -201,6 +201,10 @@ class CsvToDatabaseForm(UploadToDatabaseForm):
         _("Interpret Datetime Format Automatically"),
         description=_("Interpret the datetime format automatically"),
     )
+    day_first = BooleanField(
+        _("Day First"),
+        description=_("DD/MM format dates, international and European format"),
+    )
     decimal = StringField(
         _("Decimal Character"),
         default=".",

--- a/superset/views/database/views.py
+++ b/superset/views/database/views.py
@@ -168,6 +168,7 @@ class CsvToDatabaseView(CustomFormView):
         form.skip_initial_space.data = False
         form.skip_blank_lines.data = True
         form.infer_datetime_format.data = True
+        form.day_first.data = False
         form.decimal.data = "."
         form.if_exists.data = "fail"
 
@@ -199,6 +200,7 @@ class CsvToDatabaseView(CustomFormView):
                     header=form.header.data if form.header.data else 0,
                     index_col=form.index_col.data,
                     infer_datetime_format=form.infer_datetime_format.data,
+                    dayfirst=form.day_first.data,
                     iterator=True,
                     keep_default_na=not form.null_values.data,
                     usecols=form.use_cols.data if form.use_cols.data else None,


### PR DESCRIPTION
### SUMMARY
This PR fixes a problem when importing CSV data that contains international timestamps (days come before months). We use Pandas [read_csv](https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html) to handle this operation and this PR exposes the `dayfirst` configuration to address the issue.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: using the following CSV, we can see that the dates are not parsed correctly.

```
Date Time,Group,Team
01-08-2023 02:01:00,A,2
02-08-2023 02:01:00,A,2
03-08-2023 02:01:00,A,2
04-08-2023 02:01:00,A,2
05-08-2023 02:01:00,A,2
06-08-2023 02:01:00,B,1
07-08-2023 02:01:00,B,1
08-08-2023 02:01:00,B,1
09-08-2023 02:01:00,B,1
10-08-2023 02:01:00,B,1
11-08-2023 02:01:00,B,3
12-08-2023 02:01:00,B,3
13-08-2023 02:01:00,B,3
14-08-2023 02:01:00,A,4
15-08-2023 02:01:00,C,4
16-08-2023 02:01:00,C,4
17-08-2023 02:01:00,C,4
18-08-2023 02:01:00,C,4
19-08-2023 02:01:00,C,4
20-08-2023 02:01:00,C,4
21-08-2023 02:01:00,C,4
```

<img width="1778" alt="263803409-7206acb8-36a5-4e93-a1ee-a296ae52061d" src="https://github.com/apache/superset/assets/70410625/d5c99423-6af3-4aa2-bca6-421ae0081d84">

<br>After: We provide the `Day First` configuration for international formats.

<img width="1141" alt="Screenshot 2023-08-29 at 13 36 11" src="https://github.com/apache/superset/assets/70410625/1e2a3da4-39b2-48eb-bf7f-8c682214dd8f">

<img width="1777" alt="Screenshot 2023-08-29 at 13 23 21" src="https://github.com/apache/superset/assets/70410625/e39566a6-baff-470d-85c6-97b32d3874a6">

### TESTING INSTRUCTIONS
1 - Import the example CSV
2 - Check the Day First configuration
3 - Make sure data is imported correctly

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
