### PR TITLE
fix(sqllab): error while removing a referenced table

### DIFF
--- a/superset-frontend/src/SqlLab/components/TableElement/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TableElement/index.tsx
@@ -22,7 +22,7 @@ import type { Table } from 'src/SqlLab/types';
 import Collapse from 'src/components/Collapse';
 import Card from 'src/components/Card';
 import ButtonGroup from 'src/components/ButtonGroup';
-import { css, t, styled } from '@superset-ui/core';
+import { css, t, styled, useTheme } from '@superset-ui/core';
 import { debounce } from 'lodash';
 
 import {
@@ -102,6 +102,7 @@ const StyledCollapsePanel = styled(Collapse.Panel)`
 
 const TableElement = ({ table, ...props }: TableElementProps) => {
   const { dbId, schema, name, expanded } = table;
+  const theme = useTheme();
   const dispatch = useDispatch();
   const {
     data: tableMetadata,
@@ -253,7 +254,13 @@ const TableElement = ({ table, ...props }: TableElementProps) => {
       );
     }
     return (
-      <ButtonGroup className="ws-el-controls">
+      <ButtonGroup
+        css={css`
+          display: flex;
+          column-gap: ${theme.gridUnit * 1.5}px;
+          margin-right: ${theme.gridUnit}px;
+        `}
+      >
         {keyLink}
         <IconTooltip
           className={

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -184,6 +184,9 @@ export default function sqlLabReducer(state = {}, action) {
         if (action.query) {
           at.dataPreviewQueryId = action.query.id;
         }
+        if (existingTable.initialized) {
+          at.id = existingTable.id;
+        }
         return alterInArr(state, 'tables', existingTable, at);
       }
       // for new table, associate Id of query for data preview

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
@@ -248,6 +248,38 @@ describe('sqlLabReducer', () => {
       expect(newState.tables).toHaveLength(1);
       expect(newState.tables[0].extra).toBe(true);
     });
+    it('should overwrite table ID be ignored when the existing table is already initialized', () => {
+      const action = {
+        type: actions.MERGE_TABLE,
+        table: newTable,
+      };
+      newState = sqlLabReducer(newState, action);
+      expect(newState.tables).toHaveLength(1);
+      // Merging the initialized remote id
+      const remoteId = 1;
+      const syncAction = {
+        type: actions.MERGE_TABLE,
+        table: {
+          ...newTable,
+          id: remoteId,
+          initialized: true,
+        },
+      };
+      newState = sqlLabReducer(newState, syncAction);
+      expect(newState.tables).toHaveLength(1);
+      expect(newState.tables[0].initialized).toBe(true);
+      expect(newState.tables[0].id).toBe(remoteId);
+      const overwriteAction = {
+        type: actions.MERGE_TABLE,
+        table: {
+          id: 'rnd_new_id',
+          ...newTable,
+        },
+      };
+      newState = sqlLabReducer(newState, overwriteAction);
+      expect(newState.tables).toHaveLength(1);
+      expect(newState.tables[0].id).toBe(remoteId);
+    });
     it('should expand and collapse a table', () => {
       const collapseTableAction = {
         type: actions.COLLAPSE_TABLE,


### PR DESCRIPTION
### SUMMARY
Fixes https://github.com/apache/superset/issues/25111

When a table schema is already populated and synced with remote id, the autocomplete can trigger 'MERGE_TABLE' with the already referenced table. This action can overwrite the remote id by the auto-gen id.

This commit fixes this bug by skipping the overwrite the remote id. This commit also fixes the unexpected narrow gap between table control buttons due to the icon migration from font-awesome to antd icons 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

- After

https://github.com/apache/superset/assets/1392866/e214d538-6850-4b65-8058-1146f137c7fb

- Before

https://github.com/apache/superset/assets/1392866/0555a6e8-1f49-43d6-a951-f1d181e3930a

- icon gap update

|After|Before|Before under font-awesome|
|--|--|--|
|![Screenshot 2023-08-29 at 10 48 11 AM](https://github.com/apache/superset/assets/1392866/7e3c441a-695d-4f89-beae-c586d3feea92)|![Screenshot 2023-08-29 at 11 00 15 AM](https://github.com/apache/superset/assets/1392866/711a597a-4401-4185-9503-f5bcbfaca00c)|![Screenshot 2023-08-29 at 10 48 06 AM](https://github.com/apache/superset/assets/1392866/3fba0d4c-fb1f-4e76-8e93-723bfb66dbc8)|

### TESTING INSTRUCTIONS
set SQLLAB_BACKEND_PERSISTENCE True
Go to SQLLAB and enable autocomplete
Select a table in the table schema selector
Type some table name which is selected above
Click the same table from the autocomplete
Remove the table by the table action button
Check the error

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
