### PR TITLE
fix: Partially reverts #25007

### DIFF
--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -187,6 +187,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         from superset.views.redirects import R
         from superset.views.sql_lab.views import (
             SavedQueryView,
+            SavedQueryViewApi,
             SqlLab,
             TableSchemaView,
             TabStateView,
@@ -312,6 +313,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         appbuilder.add_view_no_menu(R)
         appbuilder.add_view_no_menu(ProfileView)
         appbuilder.add_view_no_menu(SavedQueryView)
+        appbuilder.add_view_no_menu(SavedQueryViewApi)
         appbuilder.add_view_no_menu(SliceAsync)
         appbuilder.add_view_no_menu(SqlLab)
         appbuilder.add_view_no_menu(SqlMetricInlineView)

--- a/superset/views/sql_lab/views.py
+++ b/superset/views/sql_lab/views.py
@@ -19,16 +19,23 @@ import logging
 import simplejson as json
 from flask import redirect, request, Response
 from flask_appbuilder import expose
+from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder.security.decorators import has_access, has_access_api
 from flask_babel import lazy_gettext as _
 from sqlalchemy import and_
 
 from superset import db
-from superset.models.sql_lab import Query, TableSchema, TabState
+from superset.constants import MODEL_VIEW_RW_METHOD_PERMISSION_MAP, RouteMethod
+from superset.models.sql_lab import Query, SavedQuery, TableSchema, TabState
 from superset.superset_typing import FlaskResponse
 from superset.utils import core as utils
 from superset.utils.core import get_user_id
-from superset.views.base import BaseSupersetView, json_success
+from superset.views.base import (
+    BaseSupersetView,
+    DeleteMixin,
+    json_success,
+    SupersetModelView,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +48,33 @@ class SavedQueryView(BaseSupersetView):
     @has_access
     def list(self) -> FlaskResponse:
         return super().render_app_template()
+
+
+class SavedQueryViewApi(
+    SupersetModelView, DeleteMixin
+):  # pylint: disable=too-many-ancestors
+    datamodel = SQLAInterface(SavedQuery)
+    include_route_methods = RouteMethod.CRUD_SET
+    route_base = "/savedqueryviewapi"
+    class_permission_name = "SavedQuery"
+
+    include_route_methods = {
+        RouteMethod.API_READ,
+        RouteMethod.API_CREATE,
+        RouteMethod.API_UPDATE,
+        RouteMethod.API_GET,
+    }
+
+    method_permission_name = MODEL_VIEW_RW_METHOD_PERMISSION_MAP
+
+    add_columns = ["label", "db_id", "schema", "description", "sql", "extra_json"]
+    edit_columns = add_columns
+    show_columns = add_columns + ["id"]
+
+    @has_access_api
+    @expose("show/<pk>")
+    def show(self, pk: int) -> FlaskResponse:
+        return super().show(pk)
 
 
 def _get_owner_id(tab_state_id: int) -> int:


### PR DESCRIPTION
### SUMMARY
This PR partially reverts #25007 and reintroduces a simplified version of `SavedQueryViewApi` that is used by the application and was removed in the original PR.

Fixes https://github.com/apache/superset/issues/25117. Hat tip to @sadpandajoe for discovering and creating the issue.

### TESTING INSTRUCTIONS
Check https://github.com/apache/superset/issues/25117 for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
