### PR TITLE
refactor(frontend): make "Search" box the first filter for charts and datasets

### DIFF
--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -590,6 +590,13 @@ function ChartList(props: ChartListProps) {
   const filters: Filters = useMemo(() => {
     const filters_list = [
       {
+        Header: t('Search'),
+        key: 'search',
+        id: 'slice_name',
+        input: 'search',
+        operator: FilterOperator.chartAllText,
+      },
+      {
         Header: t('Owner'),
         key: 'owner',
         id: 'owners',
@@ -705,13 +712,6 @@ function ChartList(props: ChartListProps) {
         fetchSelects: loadTags,
       });
     }
-    filters_list.push({
-      Header: t('Search'),
-      key: 'search',
-      id: 'slice_name',
-      input: 'search',
-      operator: FilterOperator.chartAllText,
-    });
     return filters_list;
   }, [addDangerToast, favoritesFilter, props.user]);
 

--- a/superset-frontend/src/pages/DatasetList/index.tsx
+++ b/superset-frontend/src/pages/DatasetList/index.tsx
@@ -522,6 +522,13 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
   const filterTypes: Filters = useMemo(
     () => [
       {
+        Header: t('Search'),
+        key: 'search',
+        id: 'table_name',
+        input: 'search',
+        operator: FilterOperator.contains,
+      },
+      {
         Header: t('Owner'),
         key: 'owner',
         id: 'owners',
@@ -597,13 +604,6 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
           { label: t('Yes'), value: true },
           { label: t('No'), value: false },
         ],
-      },
-      {
-        Header: t('Search'),
-        key: 'search',
-        id: 'table_name',
-        input: 'search',
-        operator: FilterOperator.contains,
       },
     ],
     [user],


### PR DESCRIPTION
### SUMMARY
Continues https://github.com/apache/superset/pull/19721, making that same change for Charts and Datasets for consistency.

Fixes https://github.com/apache/superset/issues/25128.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**BEFORE**

![image](https://github.com/apache/superset/assets/7569808/36cd9002-9dbc-4747-b6ef-c2e8e0d162e6)
![image](https://github.com/apache/superset/assets/7569808/ac5c6fe9-4bad-4513-9c1b-6022cecd16d0)

**AFTER**
![image](https://github.com/apache/superset/assets/7569808/eb279f4a-a77c-4cd8-8066-9584636603c3)
![image](https://github.com/apache/superset/assets/7569808/3439e0aa-81d4-4d80-9312-cd2f8348d40a)


### TESTING INSTRUCTIONS
Compare before & after.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
- [x] Has associated issue: fixes #25128
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API