### PR TITLE
fix(sqllab): Invalid start date

### DIFF
--- a/superset-frontend/src/SqlLab/components/QueryAutoRefresh/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryAutoRefresh/index.tsx
@@ -80,6 +80,7 @@ function QueryAutoRefresh({
       SupersetClient.get({
         endpoint: `/api/v1/query/updated_since?q=${params}`,
         timeout: QUERY_TIMEOUT_LIMIT,
+        parseMethod: 'json-bigint',
       })
         .then(({ json }) => {
           if (json) {

--- a/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
@@ -213,7 +213,7 @@ const QueryTable = ({
             {q.db}
           </Button>
         );
-        q.started = moment(q.startDttm).format('HH:mm:ss');
+        q.started = moment(q.startDttm).format('ll HH:mm:ss');
         q.querylink = (
           <Button
             buttonSize="small"

--- a/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
@@ -213,7 +213,7 @@ const QueryTable = ({
             {q.db}
           </Button>
         );
-        q.started = moment(q.startDttm).format('ll HH:mm:ss');
+        q.started = moment(q.startDttm).format('L HH:mm:ss');
         q.querylink = (
           <Button
             buttonSize="small"

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
@@ -161,7 +161,7 @@ export const SaveDatasetModal = ({
   );
 
   const getDefaultDatasetName = () =>
-    `${datasource?.name || UNTITLED} ${moment().format('MM/DD/YYYY HH:mm:ss')}`;
+    `${datasource?.name || UNTITLED} ${moment().format('L HH:mm:ss')}`;
   const [datasetName, setDatasetName] = useState(getDefaultDatasetName());
   const [newOrOverwrite, setNewOrOverwrite] = useState(
     DatasetRadioState.SAVE_NEW,

--- a/superset-frontend/src/SqlLab/reducers/getInitialState.ts
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.ts
@@ -130,7 +130,20 @@ export default function getInitialState({
       });
   }
 
-  const queries = { ...queries_ };
+  const queries = Object.fromEntries(
+    Object.entries(queries_ || {}).map(([queryId, query]) => [
+      queryId,
+      {
+        ...query,
+        ...(query.startDttm && {
+          startDttm: Number(query.startDttm),
+        }),
+        ...(query.endDttm && {
+          endDttm: Number(query.endDttm),
+        }),
+      },
+    ]),
+  );
 
   /**
    * If the `SQLLAB_BACKEND_PERSISTENCE` feature flag is off, or if the user

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -627,6 +627,12 @@ export default function sqlLabReducer(state = {}, action) {
           newQueries[id] = {
             ...state.queries[id],
             ...changedQuery,
+            ...(changedQuery.startDttm && {
+              startDttm: Number(changedQuery.startDttm),
+            }),
+            ...(changedQuery.endDttm && {
+              endDttm: Number(changedQuery.endDttm),
+            }),
             // race condition:
             // because of async behavior, sql lab may still poll a couple of seconds
             // when it started fetching or finished rendering results

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
@@ -364,16 +364,24 @@ describe('sqlLabReducer', () => {
       expect(Object.keys(newState.queries)).toHaveLength(0);
     });
     it('should refresh queries when polling returns new results', () => {
+      const startDttmInStr = '1693433503447.166992';
+      const endDttmInStr = '1693433503500.23132';
       newState = sqlLabReducer(
         {
           ...newState,
           queries: { abcd: {} },
         },
         actions.refreshQueries({
-          abcd: query,
+          abcd: {
+            ...query,
+            startDttm: startDttmInStr,
+            endDttm: endDttmInStr,
+          },
         }),
       );
       expect(newState.queries.abcd.changed_on).toBe(DENORMALIZED_CHANGED_ON);
+      expect(newState.queries.abcd.startDttm).toBe(Number(startDttmInStr));
+      expect(newState.queries.abcd.endDttm).toBe(Number(endDttmInStr));
       expect(newState.queriesLastUpdate).toBe(CHANGED_ON_TIMESTAMP);
     });
     it('should refresh queries when polling returns empty', () => {


### PR DESCRIPTION
### SUMMARY
Fixes #24790

Since /updated_since api migrate to v1 in #22611 , the startDttm format has been changed from a number to a string.

|api/v1|legacy api|
|--|--|
|![Superset](https://github.com/apache/superset/assets/1392866/0cad38ed-34bd-4b19-8502-2a1798774962)|![superset-dev_-_Airbnb_-_Slack](https://github.com/apache/superset/assets/1392866/58553b81-c9a3-4b62-98b7-e48d6eab84dd)|

Similar to #19605, it fails the conversion to a moment object. Since the Flask’s JSON serialization of decimals casts it to a string is actually correct as it preserves precision, so the frontend should expect strings.
This commit adds the extra parse logic in sqllab query sync to handle the floating value in the string format.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

After:

https://user-images.githubusercontent.com/1392866/264449407-c2015fe7-d1ef-48b4-9c98-60de6aa27c9c.png

Before:

https://user-images.githubusercontent.com/57723564/255794908-2b4a9005-00fc-4adc-95b0-d7a8a0fdee09.png

### TESTING INSTRUCTIONS
Go to SQLLab and run a query
Go to Query history and check the start date column

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
