### PR TITLE
fix: Handle Python date format for GENERIC_CHART_AXES feature

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -991,11 +991,13 @@ class SqlaTable(
         time_grain = col.get("timeGrain")
         has_timegrain = col.get("columnType") == "BASE_AXIS" and time_grain
         is_dttm = False
+        pdf = None
         if col_in_metadata := self.get_column(expression):
             sqla_column = col_in_metadata.get_sqla_col(
                 template_processor=template_processor
             )
             is_dttm = col_in_metadata.is_temporal
+            pdf = col_in_metadata.python_date_format
         else:
             sqla_column = literal_column(expression)
             if has_timegrain or force_type_check:
@@ -1012,7 +1014,7 @@ class SqlaTable(
         if is_dttm and has_timegrain:
             sqla_column = self.db_engine_spec.get_timestamp_expr(
                 col=sqla_column,
-                pdf=None,
+                pdf=pdf,
                 time_grain=time_grain,
             )
         return self.make_sqla_column_compatible(sqla_column, label)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Fixes https://github.com/apache/superset/issues/25134.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE

```sql
SELECT date_trunc('day', CAST(epoch_s AS TIMESTAMP)) AS epoch_s,
       COUNT(*) AS count
FROM
  (SELECT 123 AS epoch_s,
          12300 AS epoch_ms,
          '2023-01-01' AS ds) AS virtual_table
GROUP BY date_trunc('day', CAST(epoch_s AS TIMESTAMP))
ORDER BY count DESC
LIMIT 1000;
```

#### AFTER

```sql
SELECT date_trunc('day', CAST(from_unixtime(epoch_s) AS TIMESTAMP)) AS epoch_s,
       COUNT(*) AS count
FROM
  (SELECT 123 AS epoch_s,
          12300 AS epoch_ms,
          '2023-01-01' AS ds) AS virtual_table
GROUP BY date_trunc('day', CAST(from_unixtime(epoch_s) AS TIMESTAMP))
ORDER BY count DESC
LIMIT 1000;
```


### TESTING INSTRUCTIONS

Tested locally. Regrettably there's currently no unit testing for the entire `adhoc_column_to_sqla` function.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/25134
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
