### PR TITLE
fix(sqllab): invalid reducer key name

### DIFF
--- a/superset-frontend/src/views/store.ts
+++ b/superset-frontend/src/views/store.ts
@@ -123,7 +123,7 @@ const CombinedDatasourceReducers = (
 
 const reducers = {
   sqlLab: sqlLabReducer,
-  localStorageUsage: noopReducer(0),
+  localStorageUsageInKilobytes: noopReducer(0),
   messageToasts: messageToastReducer,
   common: noopReducer(bootstrapData.common),
   user: userReducer,


### PR DESCRIPTION
### SUMMARY
This commit fixes the invalid reducer key name (localStorageUsage).

FYI: it's not feature breaking (just warning from redux toolkit dev inspector). The warning from the header menu in SQL Lab which uses the separate SPA redux store and getInitialState() method passed the SQLLab reducer value for localStorageUsageInKilobytes which makes the noise.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![Screenshot 2023-08-31 at 12 10 38 PM](https://github.com/apache/superset/assets/1392866/6b4a649c-22bc-4172-a3a3-3ef2dcf9c442)

### TESTING INSTRUCTIONS
FeatureFlag.SQLLAB_BACKEND_PERSISTENCE disabled and go to SQLLab to check the warning message in console


### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
