### PR TITLE
fix: Applying Dashboard Time Range Filters to Overwritten Charts

### DIFF
--- a/superset-frontend/src/explore/actions/saveModalActions.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.js
@@ -79,19 +79,15 @@ export const getSlicePayload = (
     adhocFilters = extractAddHocFiltersFromFormData(formDataFromSlice);
   }
 
-  if (
-    isEmpty(adhocFilters?.adhoc_filters) &&
-    isEmpty(formDataFromSlice) &&
-    formDataWithNativeFilters?.adhoc_filters?.[0]?.operator ===
-      Operators.TEMPORAL_RANGE
-  ) {
-    adhocFilters.adhoc_filters = [
-      {
-        ...formDataWithNativeFilters.adhoc_filters[0],
-        comparator: 'No filter',
-      },
-    ];
-  }
+  // This loop iterates through the adhoc_filters array in formDataWithNativeFilters.
+  // If a filter is of type TEMPORAL_RANGE and isExtra, it sets its comparator to
+  // 'No filter' and adds the modified filter to the adhocFilters array. This ensures that all
+  // TEMPORAL_RANGE filters are converted to 'No filter' when saving a chart.
+  formDataWithNativeFilters?.adhoc_filters?.forEach(filter => {
+    if (filter.operator === Operators.TEMPORAL_RANGE && filter.isExtra) {
+      adhocFilters.adhoc_filters.push({ ...filter, comparator: 'No filter' });
+    }
+  });
 
   const formData = {
     ...formDataWithNativeFilters,

--- a/superset-frontend/src/explore/actions/saveModalActions.test.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.test.js
@@ -394,7 +394,6 @@ describe('getSlicePayload', () => {
       'viz_type',
       formDataWithAdhocFiltersWithExtra.viz_type,
     );
-    console.log(result.params.adhoc_filters);
     expect(result).toHaveProperty('datasource_id', 22);
     expect(result).toHaveProperty('datasource_type', 'table');
     expect(result).toHaveProperty('dashboards', dashboards);

--- a/superset-frontend/src/explore/actions/saveModalActions.test.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.test.js
@@ -302,7 +302,19 @@ describe('getSlicePayload', () => {
       formDataWithNativeFilters,
       dashboards,
       owners,
-      formDataFromSlice,
+      {
+        datasource: '22__table',
+        viz_type: 'pie',
+        adhoc_filters: [
+          {
+            clause: 'WHERE',
+            subject: 'year',
+            operator: 'TEMPORAL_RANGE',
+            comparator: 'No filter',
+            expressionType: 'SIMPLE',
+          },
+        ],
+      },
     );
     expect(result).toHaveProperty('params');
     expect(result).toHaveProperty('slice_name', sliceName);
@@ -366,7 +378,6 @@ describe('getSlicePayload', () => {
           operator: 'TEMPORAL_RANGE',
           comparator: 'No filter',
           expressionType: 'SIMPLE',
-          isExtra: true,
         },
       ],
     };
@@ -383,6 +394,7 @@ describe('getSlicePayload', () => {
       'viz_type',
       formDataWithAdhocFiltersWithExtra.viz_type,
     );
+    console.log(result.params.adhoc_filters);
     expect(result).toHaveProperty('datasource_id', 22);
     expect(result).toHaveProperty('datasource_type', 'table');
     expect(result).toHaveProperty('dashboards', dashboards);


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
When a chart was accessed from a dashboard, the dashboard configuration, including color palette and temporal filter, was carried over to the Chart Builder. If a temporal filter was carried over and the chart was subsequently overwritten, the temporal filter was not functioning correctly with the dashboard temporal filter.
![image](https://github.com/apache/superset/assets/5705598/ae8bab1c-c5f9-4d0f-8f6f-a246ec1c02b9)

**How to Reproduce the Bug:**
1. Create a chart and add it to a dashboard.
2. Add a time range filter to the dashboard and apply a value.
3. Click on the chart title to access it in the Chart Builder menu.
4. Add a new filter to the chart.
5. Overwrite the chart and return to the dashboard.
6. Apply any time range filter.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
