### PR TITLE
fix: Issue #24493; Resolved report selection menu in chart and dashboard page

### DIFF
--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
@@ -114,12 +114,12 @@ export const useExploreAdditionalActionsMenu = (
   onOpenPropertiesModal,
   ownState,
   dashboards,
+  ...rest
 ) => {
   const theme = useTheme();
   const { addDangerToast, addSuccessToast } = useToasts();
   const [showReportSubMenu, setShowReportSubMenu] = useState(null);
   const [isDropdownVisible, setIsDropdownVisible] = useState(false);
-  const [openSubmenus, setOpenSubmenus] = useState([]);
   const chart = useSelector(
     state => state.charts?.[getChartKey(state.explore)],
   );
@@ -204,23 +204,19 @@ export const useExploreAdditionalActionsMenu = (
         case MENU_KEYS.EXPORT_TO_CSV:
           exportCSV();
           setIsDropdownVisible(false);
-          setOpenSubmenus([]);
           break;
         case MENU_KEYS.EXPORT_TO_CSV_PIVOTED:
           exportCSVPivoted();
           setIsDropdownVisible(false);
-          setOpenSubmenus([]);
           break;
         case MENU_KEYS.EXPORT_TO_JSON:
           exportJson();
           setIsDropdownVisible(false);
-          setOpenSubmenus([]);
 
           break;
         case MENU_KEYS.EXPORT_TO_XLSX:
           exportExcel();
           setIsDropdownVisible(false);
-          setOpenSubmenus([]);
           break;
         case MENU_KEYS.DOWNLOAD_AS_IMAGE:
           downloadAsImage(
@@ -230,21 +226,17 @@ export const useExploreAdditionalActionsMenu = (
             true,
           )(domEvent);
           setIsDropdownVisible(false);
-          setOpenSubmenus([]);
           break;
         case MENU_KEYS.COPY_PERMALINK:
           copyLink();
           setIsDropdownVisible(false);
-          setOpenSubmenus([]);
           break;
         case MENU_KEYS.EMBED_CODE:
           setIsDropdownVisible(false);
-          setOpenSubmenus([]);
           break;
         case MENU_KEYS.SHARE_BY_EMAIL:
           shareByEmail();
           setIsDropdownVisible(false);
-          setOpenSubmenus([]);
           break;
         case MENU_KEYS.VIEW_QUERY:
           setIsDropdownVisible(false);
@@ -275,8 +267,7 @@ export const useExploreAdditionalActionsMenu = (
       <Menu
         onClick={handleMenuClick}
         selectable={false}
-        openKeys={openSubmenus}
-        onOpenChange={setOpenSubmenus}
+        {...rest}
       >
         <>
           {slice && (
@@ -423,7 +414,6 @@ export const useExploreAdditionalActionsMenu = (
       handleMenuClick,
       isDropdownVisible,
       latestQueryFormData,
-      openSubmenus,
       showReportSubMenu,
       slice,
       theme.gridUnit,

--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
@@ -264,11 +264,7 @@ export const useExploreAdditionalActionsMenu = (
 
   const menu = useMemo(
     () => (
-      <Menu
-        onClick={handleMenuClick}
-        selectable={false}
-        {...rest}
-      >
+      <Menu onClick={handleMenuClick} selectable={false} {...rest}>
         <>
           {slice && (
             <Menu.Item key={MENU_KEYS.EDIT_PROPERTIES}>

--- a/superset-frontend/src/features/reports/ReportModal/HeaderReportDropdown/index.tsx
+++ b/superset-frontend/src/features/reports/ReportModal/HeaderReportDropdown/index.tsx
@@ -114,6 +114,7 @@ export default function HeaderReportDropDown({
   setShowReportSubMenu,
   setIsDropdownVisible,
   isDropdownVisible,
+  ...rest
 }: HeaderReportProps) {
   const dispatch = useDispatch();
   const report = useSelector<any, AlertObject>(state => {
@@ -214,15 +215,18 @@ export default function HeaderReportDropDown({
 
   const textMenu = () =>
     isEmpty(report) ? (
-      <Menu selectable={false} css={onMenuHover}>
-        <Menu.Item onClick={handleShowMenu}>
+      <Menu selectable={false}>
+        <Menu.Item {...rest}>
           {DropdownItemExtension ? (
             <StyledDropdownItemWithIcon>
-              <div>{t('Set up an email report')}</div>
+              <div onClick={handleShowMenu}>{t('Set up an email report')}</div>
               <DropdownItemExtension />
             </StyledDropdownItemWithIcon>
           ) : (
-            t('Set up an email report')
+            <React.Fragment>
+              <div onClick={handleShowMenu} >{t('Set up an email report')}</div>
+            </React.Fragment>
+
           )}
         </Menu.Item>
         <Menu.Divider />

--- a/superset-frontend/src/features/reports/ReportModal/HeaderReportDropdown/index.tsx
+++ b/superset-frontend/src/features/reports/ReportModal/HeaderReportDropdown/index.tsx
@@ -223,9 +223,7 @@ export default function HeaderReportDropDown({
               <DropdownItemExtension />
             </StyledDropdownItemWithIcon>
           ) : (
-            <React.Fragment>
-              <div>{t('Set up an email report')}</div>
-            </React.Fragment>
+            t('Set up an email report')
           )}
         </Menu.Item>
         <Menu.Divider />

--- a/superset-frontend/src/features/reports/ReportModal/HeaderReportDropdown/index.tsx
+++ b/superset-frontend/src/features/reports/ReportModal/HeaderReportDropdown/index.tsx
@@ -215,7 +215,7 @@ export default function HeaderReportDropDown({
 
   const textMenu = () =>
     isEmpty(report) ? (
-      <Menu selectable={false} {...rest}>
+      <Menu selectable={false} {...rest} css={onMenuHover}>
         <Menu.Item onClick={handleShowMenu}>
           {DropdownItemExtension ? (
             <StyledDropdownItemWithIcon>

--- a/superset-frontend/src/features/reports/ReportModal/HeaderReportDropdown/index.tsx
+++ b/superset-frontend/src/features/reports/ReportModal/HeaderReportDropdown/index.tsx
@@ -215,18 +215,17 @@ export default function HeaderReportDropDown({
 
   const textMenu = () =>
     isEmpty(report) ? (
-      <Menu selectable={false}>
-        <Menu.Item {...rest}>
+      <Menu selectable={false} {...rest}>
+        <Menu.Item onClick={handleShowMenu}>
           {DropdownItemExtension ? (
             <StyledDropdownItemWithIcon>
-              <div onClick={handleShowMenu}>{t('Set up an email report')}</div>
+              <div>{t('Set up an email report')}</div>
               <DropdownItemExtension />
             </StyledDropdownItemWithIcon>
           ) : (
             <React.Fragment>
-              <div onClick={handleShowMenu} >{t('Set up an email report')}</div>
+              <div>{t('Set up an email report')}</div>
             </React.Fragment>
-
           )}
         </Menu.Item>
         <Menu.Divider />


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
When we used to click on Manage Email report and then select Setup Email report, a new dialogue used to open but the submenu remains in the DOM. To remove that I have added rest props. I have checked other functionalities as well and they were working as expected. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
#### Before
![image](https://github.com/apache/superset/assets/33354423/3de26335-764c-46de-9435-9023fd4c0b74)

#### After 
![image](https://github.com/apache/superset/assets/33354423/ee9f6147-2282-465a-8a1b-0e0157ac4f5c)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
