### PR TITLE
fix: Sunburst chart error when secondary metric is null

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1374,7 +1374,7 @@ class SunburstViz(BaseViz):
         metric = utils.get_metric_name(form_data["metric"])
         secondary_metric = (
             utils.get_metric_name(form_data["secondary_metric"])
-            if "secondary_metric" in form_data
+            if form_data.get("secondary_metric")
             else None
         )
         if metric == secondary_metric or secondary_metric is None:
@@ -1582,7 +1582,7 @@ class WorldMapViz(BaseViz):
         metric = utils.get_metric_name(self.form_data["metric"])
         secondary_metric = (
             utils.get_metric_name(self.form_data["secondary_metric"])
-            if "secondary_metric" in self.form_data
+            if self.form_data.get("secondary_metric")
             else None
         )
         columns = ["country", "m1", "m2"]


### PR DESCRIPTION
### SUMMARY
Fixes an error in legacy Sunburst charts that happened when the `secondary_metric` was `null`. There are no tests for this specific viz and I didn't add one because this code is deprecated and will be removed in the next major release.

Fixes https://github.com/apache/superset/issues/25154

### TESTING INSTRUCTIONS
Check the original issue for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
