### PR TITLE
fix: change constraint alters to non blocking for postgres

### DIFF
--- a/superset/migrations/versions/2023-08-09_14-17_8ace289026f3_add_on_delete_cascade_for_dashboard_slices.py
+++ b/superset/migrations/versions/2023-08-09_14-17_8ace289026f3_add_on_delete_cascade_for_dashboard_slices.py
@@ -26,8 +26,12 @@ Create Date: 2023-08-09 14:17:53.326191
 revision = "8ace289026f3"
 down_revision = "2e826adca42c"
 
+from alembic import op
+from sqlalchemy import create_engine
+from sqlalchemy.engine.reflection import Inspector
 
 from superset.migrations.shared.constraints import ForeignKey, redefine
+from superset.utils.core import generic_find_fk_constraint_name
 
 foreign_keys = [
     ForeignKey(
@@ -47,9 +51,90 @@ foreign_keys = [
 
 def upgrade():
     for foreign_key in foreign_keys:
-        redefine(foreign_key, on_delete="CASCADE")
+        bind = op.get_bind()
+        insp = Inspector.from_engine(bind)
+        db_dialect = bind.engine.url.drivername
+
+        if db_dialect == "postgresql":
+            if constraint := generic_find_fk_constraint_name(
+                table=foreign_key.table,
+                columns=set(foreign_key.remote_cols),
+                referenced=foreign_key.referent_table,
+                insp=insp,
+            ):
+                # rename the constraint so that we can drop it later- non-blocking
+                # this only works on postgres
+                op.execute(
+                    f"ALTER TABLE {foreign_key.table} RENAME CONSTRAINT {constraint} TO {foreign_key.constraint_name}_old"
+                )
+
+            # create the new constraint- uses a non-blocking ALTER TABLE Not Valid property
+            op.create_foreign_key(
+                constraint_name=foreign_key.constraint_name,
+                source_table=foreign_key.table,
+                referent_table=foreign_key.referent_table,
+                local_cols=foreign_key.local_cols,
+                remote_cols=foreign_key.remote_cols,
+                ondelete="CASCADE",
+                postgresql_not_valid=True,
+            )
+
+            # validate the constraint- non-blocking
+            op.execute(
+                f"ALTER TABLE {foreign_key.table} VALIDATE CONSTRAINT {foreign_key.constraint_name}"
+            )
+
+            # drop the old constraint which isn't needed anymore- non-blocking
+            if constraint:
+                op.drop_constraint(
+                    f"{foreign_key.constraint_name}_old",
+                    foreign_key.table,
+                    type_="foreignkey",
+                )
+        else:
+            redefine(foreign_key, on_delete="CASCADE")
 
 
 def downgrade():
     for foreign_key in foreign_keys:
-        redefine(foreign_key)
+        bind = op.get_bind()
+        insp = Inspector.from_engine(bind)
+        db_dialect = bind.engine.url.drivername
+
+        if db_dialect == "postgresql":
+            if constraint := generic_find_fk_constraint_name(
+                table=foreign_key.table,
+                columns=set(foreign_key.remote_cols),
+                referenced=foreign_key.referent_table,
+                insp=insp,
+            ):
+                # rename the constraint so that we can drop it later- non-blocking
+                # this only works on postgres
+                op.execute(
+                    f"ALTER TABLE {foreign_key.table} RENAME CONSTRAINT {constraint} TO {foreign_key.constraint_name}_old"
+                )
+
+            # create the new constraint- uses a non-blocking ALTER TABLE Not Valid property
+            op.create_foreign_key(
+                constraint_name=foreign_key.constraint_name,
+                source_table=foreign_key.table,
+                referent_table=foreign_key.referent_table,
+                local_cols=foreign_key.local_cols,
+                remote_cols=foreign_key.remote_cols,
+                postgresql_not_valid=True,
+            )
+
+            # validate the constraint- non-blocking
+            op.execute(
+                f"ALTER TABLE {foreign_key.table} VALIDATE CONSTRAINT {foreign_key.constraint_name}"
+            )
+
+            # drop the old constraint which isn't needed anymore- non-blocking
+            if constraint:
+                op.drop_constraint(
+                    f"{foreign_key.constraint_name}_old",
+                    foreign_key.table,
+                    type_="foreignkey",
+                )
+        else:
+            redefine(foreign_key)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This migration is marked as causing potential downtime, which we did see using a postgres db where it was locking the table while dropping the constraint and deadlocking with production db requests. I’m using two different techniques here to attempt to make this a more performant/non blocking migration so that we can run it without any downtime.  
1) instead of dropping the old constraint and creating a new one, I am renaming the old constraint which is a non-blocking action. Then creating the new constraint with the cascade on delete. 
2) utilizing postgres’ feature to not validate constraint updates. I’m using this on the subsequent drop constraint as again it is a way to drop the column in a non-blocking way. Then we validate the changes which also don’t block. 

I have run the benchmark scripts several times up to over 1m rows which is much more than the size of the table that we had issues with. Other than the tests locally, this hasn’t been validated in production yet. 

The other callout is that with renaming and then creating a new constraint, there is a period of time when there will be two constraints before the original one is dropped. From what I can tell it should work fine under these conditions but it has only been tested locally. 


These changes only affect migrations running on Postgres metadata databases. 

for the embedded table:
Results:

Current: 0.40 s
10+: 0.44 s
100+: 0.44 s
1000+: 0.26 s
10000+: 0.26 s


For the dashboard slices table:
Current: 0.30 s
10+: 0.45 s
100+: 0.45 s
1000+: 0.28 s

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
