### PR TITLE
fix: DML failures in SQL Lab

### DIFF
--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -272,7 +272,7 @@ def execute_sql_statement(  # pylint: disable=too-many-arguments,too-many-statem
         session.commit()
         with stats_timing("sqllab.query.time_executing_query", stats_logger):
             logger.debug("Query %d: Running query: %s", query.id, sql)
-            db_engine_spec.execute(cursor, sql, async_=False)
+            db_engine_spec.execute(cursor, sql)
             logger.debug("Query %d: Handling cursor", query.id)
             db_engine_spec.handle_cursor(cursor, query, session)
 

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -272,7 +272,7 @@ def execute_sql_statement(  # pylint: disable=too-many-arguments,too-many-statem
         session.commit()
         with stats_timing("sqllab.query.time_executing_query", stats_logger):
             logger.debug("Query %d: Running query: %s", query.id, sql)
-            db_engine_spec.execute(cursor, sql)
+            db_engine_spec.execute(cursor, sql, async_=True)
             logger.debug("Query %d: Handling cursor", query.id)
             db_engine_spec.handle_cursor(cursor, query, session)
 

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -516,10 +516,7 @@ def execute_sql_statements(
 
         # Commit the connection so CTA queries will create the table and any DML.
         should_commit = (
-            any(
-                not db_engine_spec.is_select_query(statement)
-                for statement in parsed_query.get_statements()
-            )
+            not db_engine_spec.is_select_query(parsed_query)  # check if query is DML
             or apply_ctas
         )
         if should_commit:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Main issue we discovered was connection not committing for DML statements in SQL Lab with all the proper permissions. To fix we've created a new variable called `should_commit` which will check if the current query statement needs to be properly committed

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
