### PR TITLE
docs: fix wrong type in PREFERRED_DATABASES example

### DIFF
--- a/docs/docs/databases/db-connection-ui.mdx
+++ b/docs/docs/databases/db-connection-ui.mdx
@@ -28,7 +28,7 @@ We added a new configuration option where the admin can define their preferred d
 # displayed prominently in the "Add Database" dialog. You should
 # use the "engine_name" attribute of the corresponding DB engine spec
 # in `superset/db_engine_specs/`.
-PREFERRED_DATABASES: List[str] = [
+PREFERRED_DATABASES: list[str] = [
     "PostgreSQL",
     "Presto",
     "MySQL",


### PR DESCRIPTION
### SUMMARY
The example is using `List` as type, but it is not being imported in `config.py`. Thus, if you follow the example, an error will happen during runtime.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Not applicable.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Not applicable. This is doc related.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
