### PR TITLE
test: simplify `integration_tests/charts/api_tests.py`

### DIFF
--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -1175,48 +1175,6 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
                 ).lower()
             )
 
-    @pytest.mark.usefixtures("create_certified_charts")
-    def test_gets_certified_charts_filter(self):
-        arguments = {
-            "filters": [
-                {
-                    "col": "id",
-                    "opr": "chart_is_certified",
-                    "value": True,
-                }
-            ],
-            "keys": ["none"],
-            "columns": ["slice_name"],
-        }
-        self.login(username="admin")
-
-        uri = f"api/v1/chart/?q={prison.dumps(arguments)}"
-        rv = self.get_assert_metric(uri, "get_list")
-        self.assertEqual(rv.status_code, 200)
-        data = json.loads(rv.data.decode("utf-8"))
-        self.assertEqual(data["count"], CHARTS_FIXTURE_COUNT)
-
-    @pytest.mark.usefixtures("create_charts")
-    def test_gets_not_certified_charts_filter(self):
-        arguments = {
-            "filters": [
-                {
-                    "col": "id",
-                    "opr": "chart_is_certified",
-                    "value": False,
-                }
-            ],
-            "keys": ["none"],
-            "columns": ["slice_name"],
-        }
-        self.login(username="admin")
-
-        uri = f"api/v1/chart/?q={prison.dumps(arguments)}"
-        rv = self.get_assert_metric(uri, "get_list")
-        self.assertEqual(rv.status_code, 200)
-        data = json.loads(rv.data.decode("utf-8"))
-        self.assertEqual(data["count"], 17)
-
     @pytest.mark.usefixtures("load_energy_charts")
     def test_user_gets_none_filtered_energy_slices(self):
         # test filtering on datasource_name
@@ -1673,9 +1631,24 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
             ]
         }
 
-    def test_gets_created_by_user_charts_filter(self):
+    @parameterized.expand(
+        [
+            # (filter_opr, filter_col, filter_value, expected_count)
+            ("chart_has_created_by", "id", True, 27),
+            ("chart_has_created_by", "id", False, 27),
+            ("chart_has_created_by", "id", "", 27),
+            ("chart_is_certified", "id", True, CHARTS_FIXTURE_COUNT),
+            ("chart_is_certified", "id", False, 17),
+            ("chart_is_certified", "id", "", 27),
+            ("chart_all_text", "slice_name", "", 27),
+        ]
+    )
+    @pytest.mark.usefixtures("create_charts", "create_certified_charts")
+    def test_gets_charts_filter(
+        self, filter_opr, filter_col, filter_value, expected_count
+    ):
         arguments = {
-            "filters": [{"col": "id", "opr": "chart_has_created_by", "value": True}],
+            "filters": [{"opr": filter_opr, "col": filter_col, "value": filter_value}],
             "keys": ["none"],
             "columns": ["slice_name"],
         }
@@ -1683,23 +1656,9 @@ class TestChartApi(SupersetTestCase, ApiOwnersTestCaseMixin, InsertChartMixin):
 
         uri = f"api/v1/chart/?q={prison.dumps(arguments)}"
         rv = self.get_assert_metric(uri, "get_list")
-        self.assertEqual(rv.status_code, 200)
+        assert rv.status_code == 200
         data = json.loads(rv.data.decode("utf-8"))
-        self.assertEqual(data["count"], 8)
-
-    def test_gets_not_created_by_user_charts_filter(self):
-        arguments = {
-            "filters": [{"col": "id", "opr": "chart_has_created_by", "value": False}],
-            "keys": ["none"],
-            "columns": ["slice_name"],
-        }
-        self.login(username="admin")
-
-        uri = f"api/v1/chart/?q={prison.dumps(arguments)}"
-        rv = self.get_assert_metric(uri, "get_list")
-        self.assertEqual(rv.status_code, 200)
-        data = json.loads(rv.data.decode("utf-8"))
-        self.assertEqual(data["count"], 8)
+        assert data["count"] == expected_count
 
     @pytest.mark.usefixtures("create_charts")
     def test_gets_owned_created_favorited_by_me_filter(self):


### PR DESCRIPTION
### SUMMARY
This PR simplifies `integration_tests/charts/api_tests.py` by parameterizing some tests that basically do the same.
Additional tests added to cover an empty filter value for `chart_all_text`, `chart_has_created_by` and `chart_is_certified`.

### TESTING INSTRUCTIONS
`scripts/tests/run.sh --module tests/integration_tests/charts/api_tests.py`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
