### PR TITLE
fix: Cypress test to force mouseover

### DIFF
--- a/superset-frontend/cypress-base/cypress/e2e/explore/chart.test.js
+++ b/superset-frontend/cypress-base/cypress/e2e/explore/chart.test.js
@@ -32,7 +32,7 @@ function openDashboardsAddedTo() {
   cy.getBySel('actions-trigger').click();
   cy.get('.ant-dropdown-menu-submenu-title')
     .contains('Dashboards added to')
-    .trigger('mouseover');
+    .trigger('mouseover', { force: true });
 }
 
 function closeDashboardsAddedTo() {


### PR DESCRIPTION
### SUMMARY
Fixes the following Cypress error:

```
1) Cross-referenced dashboards
      should show the cross-referenced dashboards:
         CypressError: Timed out retrying after 8000ms: `cy.trigger()` failed because this element:
  
         `<div class="ant-dropdown-menu-submenu-title" role="button" 
         aria-expanded="false" aria-haspopup="true" title="Dashboards added to">...</div>`
  
         has CSS `pointer-events: none`, inherited from this element:
```

### TESTING INSTRUCTIONS
CI.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
