### PR TITLE
chore(trino): remove unnecessary index checks

### DIFF
--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -527,7 +527,7 @@ class PrestoBaseEngineSpec(BaseEngineSpec, metaclass=ABCMeta):
 
     @classmethod
     @cache_manager.data_cache.memoize(timeout=60)
-    def latest_partition(
+    def latest_partition(  # pylint: disable=too-many-arguments
         cls,
         table_name: str,
         schema: str | None,

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -533,6 +533,7 @@ class PrestoBaseEngineSpec(BaseEngineSpec, metaclass=ABCMeta):
         schema: str | None,
         database: Database,
         show_first: bool = False,
+        indexes: list[dict[str, Any]] | None = None,
     ) -> tuple[list[str], list[str] | None]:
         """Returns col name and the latest (max) partition value for a table
 
@@ -542,12 +543,15 @@ class PrestoBaseEngineSpec(BaseEngineSpec, metaclass=ABCMeta):
         :type database: models.Database
         :param show_first: displays the value for the first partitioning key
           if there are many partitioning keys
+        :param indexes: indexes from the database
         :type show_first: bool
 
         >>> latest_partition('foo_table')
         (['ds'], ('2018-01-01',))
         """
-        indexes = database.get_indexes(table_name, schema)
+        if indexes is None:
+            indexes = database.get_indexes(table_name, schema)
+
         if not indexes:
             raise SupersetTemplateException(
                 f"Error getting partition for {schema}.{table_name}. "
@@ -1221,7 +1225,7 @@ class PrestoEngineSpec(PrestoBaseEngineSpec):
 
         if indexes := database.get_indexes(table_name, schema_name):
             col_names, latest_parts = cls.latest_partition(
-                table_name, schema_name, database, show_first=True
+                table_name, schema_name, database, show_first=True, indexes=indexes
             )
 
             if not latest_parts:

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -58,7 +58,11 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
 
         if indexes := database.get_indexes(table_name, schema_name):
             col_names, latest_parts = cls.latest_partition(
-                table_name, schema_name, database, show_first=True
+                table_name,
+                schema_name,
+                database,
+                show_first=True,
+                indexes=indexes,
             )
 
             if not latest_parts:


### PR DESCRIPTION
### SUMMARY
The `database.get_indexes` method, which in turn calls `inspector.get_indexes`, gets called twice on the `get_extra_table_metadata` call, which causes unnecessary query overhead. This PR adds an optional `indexes` argument to the `latest_partition` method to reuse the retrieved indexes when they're available.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
