### PR TITLE
fix: granularity_sqla and GENERIC_CHART_AXES

### DIFF
--- a/superset/legacy.py
+++ b/superset/legacy.py
@@ -17,10 +17,27 @@
 """Code related with dealing with legacy / change management"""
 from typing import Any
 
+from superset import is_feature_enabled
+
 
 def update_time_range(form_data: dict[str, Any]) -> None:
-    """Move since and until to time_range."""
+    """
+    Legacy adjustments to time range.
+
+        - Move `since` and `until` to `time_range`.
+        - Define `time_range` when `granularity_sqla` is set and unfiltered.
+
+    """
     if "since" in form_data or "until" in form_data:
-        form_data[
-            "time_range"
-        ] = f'{form_data.pop("since", "") or ""} : {form_data.pop("until", "") or ""}'
+        since = form_data.pop("since", "") or ""
+        until = form_data.pop("until", "") or ""
+        form_data["time_range"] = f"{since} : {until}"
+
+    if is_feature_enabled("GENERIC_CHART_AXES"):
+        if temporal_column := form_data.get("granularity_sqla"):
+            if any(
+                adhoc_filter.get("subject") == temporal_column
+                and adhoc_filter.get("comparator") == "No filter"
+                for adhoc_filter in form_data.get("adhoc_filters", [])
+            ):
+                form_data.setdefault("time_range", "No filter")

--- a/tests/unit_tests/legacy_tests.py
+++ b/tests/unit_tests/legacy_tests.py
@@ -22,6 +22,40 @@ from typing import Any
 from superset.legacy import update_time_range
 from tests.unit_tests.conftest import with_feature_flags
 
+original_form_data = {
+    "granularity_sqla": "order_date",
+    "datasource": "22__table",
+    "viz_type": "table",
+    "query_mode": "raw",
+    "groupby": [],
+    "time_grain_sqla": "P1D",
+    "temporal_columns_lookup": {"order_date": True},
+    "all_columns": ["order_date", "state", "product_code"],
+    "percent_metrics": [],
+    "adhoc_filters": [
+        {
+            "clause": "WHERE",
+            "subject": "order_date",
+            "operator": "TEMPORAL_RANGE",
+            "comparator": "No filter",
+            "expressionType": "SIMPLE",
+        }
+    ],
+    "order_by_cols": [],
+    "row_limit": 1000,
+    "server_page_length": 10,
+    "order_desc": True,
+    "table_timestamp_format": "smart_date",
+    "show_cell_bars": True,
+    "color_pn": True,
+    "extra_form_data": {},
+    "dashboards": [19],
+    "force": False,
+    "result_format": "json",
+    "result_type": "full",
+    "include_time": False,
+}
+
 
 def test_update_time_range_since_until() -> None:
     """
@@ -51,40 +85,6 @@ def test_update_time_range_granularity_sqla_no_feature_flag() -> None:
     """
     Tests for the unfiltered `granularity_sqla` when `GENERIC_CHART_AXES` is off.
     """
-    original_form_data = {
-        "granularity_sqla": "order_date",
-        "datasource": "22__table",
-        "viz_type": "table",
-        "query_mode": "raw",
-        "groupby": [],
-        "time_grain_sqla": "P1D",
-        "temporal_columns_lookup": {"order_date": True},
-        "all_columns": ["order_date", "state", "product_code"],
-        "percent_metrics": [],
-        "adhoc_filters": [
-            {
-                "clause": "WHERE",
-                "subject": "order_date",
-                "operator": "TEMPORAL_RANGE",
-                "comparator": "No filter",
-                "expressionType": "SIMPLE",
-            }
-        ],
-        "order_by_cols": [],
-        "row_limit": 1000,
-        "server_page_length": 10,
-        "order_desc": True,
-        "table_timestamp_format": "smart_date",
-        "show_cell_bars": True,
-        "color_pn": True,
-        "extra_form_data": {},
-        "dashboards": [19],
-        "force": False,
-        "result_format": "json",
-        "result_type": "full",
-        "include_time": False,
-    }
-
     form_data = copy.deepcopy(original_form_data)
     update_time_range(form_data)
     assert form_data == original_form_data
@@ -95,40 +95,6 @@ def test_update_time_range_granularity_sqla_with_feature_flag() -> None:
     """
     Tests for the unfiltered `granularity_sqla` when `GENERIC_CHART_AXES` is on.
     """
-    original_form_data = {
-        "granularity_sqla": "order_date",
-        "datasource": "22__table",
-        "viz_type": "table",
-        "query_mode": "raw",
-        "groupby": [],
-        "time_grain_sqla": "P1D",
-        "temporal_columns_lookup": {"order_date": True},
-        "all_columns": ["order_date", "state", "product_code"],
-        "percent_metrics": [],
-        "adhoc_filters": [
-            {
-                "clause": "WHERE",
-                "subject": "order_date",
-                "operator": "TEMPORAL_RANGE",
-                "comparator": "No filter",
-                "expressionType": "SIMPLE",
-            }
-        ],
-        "order_by_cols": [],
-        "row_limit": 1000,
-        "server_page_length": 10,
-        "order_desc": True,
-        "table_timestamp_format": "smart_date",
-        "show_cell_bars": True,
-        "color_pn": True,
-        "extra_form_data": {},
-        "dashboards": [19],
-        "force": False,
-        "result_format": "json",
-        "result_type": "full",
-        "include_time": False,
-    }
-
     form_data = copy.deepcopy(original_form_data)
     update_time_range(form_data)
     assert form_data["time_range"] == "No filter"

--- a/tests/unit_tests/legacy_tests.py
+++ b/tests/unit_tests/legacy_tests.py
@@ -1,0 +1,134 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name, use-implicit-booleaness-not-comparison
+
+import copy
+from typing import Any
+
+from superset.legacy import update_time_range
+from tests.unit_tests.conftest import with_feature_flags
+
+
+def test_update_time_range_since_until() -> None:
+    """
+    Tests for the old `since` and `until` parameters.
+    """
+    form_data: dict[str, Any]
+
+    form_data = {}
+    update_time_range(form_data)
+    assert form_data == {}
+
+    form_data = {"since": "yesterday"}
+    update_time_range(form_data)
+    assert form_data == {"time_range": "yesterday : "}
+
+    form_data = {"until": "tomorrow"}
+    update_time_range(form_data)
+    assert form_data == {"time_range": " : tomorrow"}
+
+    form_data = {"since": "yesterday", "until": "tomorrow"}
+    update_time_range(form_data)
+    assert form_data == {"time_range": "yesterday : tomorrow"}
+
+
+@with_feature_flags(GENERIC_CHART_AXES=False)
+def test_update_time_range_granularity_sqla_no_feature_flag() -> None:
+    """
+    Tests for the unfiltered `granularity_sqla` when `GENERIC_CHART_AXES` is off.
+    """
+    original_form_data = {
+        "granularity_sqla": "order_date",
+        "datasource": "22__table",
+        "viz_type": "table",
+        "query_mode": "raw",
+        "groupby": [],
+        "time_grain_sqla": "P1D",
+        "temporal_columns_lookup": {"order_date": True},
+        "all_columns": ["order_date", "state", "product_code"],
+        "percent_metrics": [],
+        "adhoc_filters": [
+            {
+                "clause": "WHERE",
+                "subject": "order_date",
+                "operator": "TEMPORAL_RANGE",
+                "comparator": "No filter",
+                "expressionType": "SIMPLE",
+            }
+        ],
+        "order_by_cols": [],
+        "row_limit": 1000,
+        "server_page_length": 10,
+        "order_desc": True,
+        "table_timestamp_format": "smart_date",
+        "show_cell_bars": True,
+        "color_pn": True,
+        "extra_form_data": {},
+        "dashboards": [19],
+        "force": False,
+        "result_format": "json",
+        "result_type": "full",
+        "include_time": False,
+    }
+
+    form_data = copy.deepcopy(original_form_data)
+    update_time_range(form_data)
+    assert form_data == original_form_data
+
+
+@with_feature_flags(GENERIC_CHART_AXES=True)
+def test_update_time_range_granularity_sqla_with_feature_flag() -> None:
+    """
+    Tests for the unfiltered `granularity_sqla` when `GENERIC_CHART_AXES` is on.
+    """
+    original_form_data = {
+        "granularity_sqla": "order_date",
+        "datasource": "22__table",
+        "viz_type": "table",
+        "query_mode": "raw",
+        "groupby": [],
+        "time_grain_sqla": "P1D",
+        "temporal_columns_lookup": {"order_date": True},
+        "all_columns": ["order_date", "state", "product_code"],
+        "percent_metrics": [],
+        "adhoc_filters": [
+            {
+                "clause": "WHERE",
+                "subject": "order_date",
+                "operator": "TEMPORAL_RANGE",
+                "comparator": "No filter",
+                "expressionType": "SIMPLE",
+            }
+        ],
+        "order_by_cols": [],
+        "row_limit": 1000,
+        "server_page_length": 10,
+        "order_desc": True,
+        "table_timestamp_format": "smart_date",
+        "show_cell_bars": True,
+        "color_pn": True,
+        "extra_form_data": {},
+        "dashboards": [19],
+        "force": False,
+        "result_format": "json",
+        "result_type": "full",
+        "include_time": False,
+    }
+
+    form_data = copy.deepcopy(original_form_data)
+    update_time_range(form_data)
+    assert form_data["time_range"] == "No filter"


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

New solution to https://github.com/apache/superset/pull/25196.

When `GENERIC_CHART_AXES` is enabled some charts that were saved with `granularity_sqla` might have an incorrectly applied filter. For example, notice that this chart has no temporal filter defined:

![Screenshot 2023-09-06 at 12-25-32 test](https://github.com/apache/superset/assets/1534870/4e401c96-7a87-4a46-9cb3-93eb6fc3a804)

![Screenshot 2023-09-06 at 12-25-39 test](https://github.com/apache/superset/assets/1534870/d3b72503-d16b-4860-acec-9ead565986a5)

But when loaded on a dashboard, a time filter is applied by default:

![Screenshot 2023-09-06 at 12-24-53 test](https://github.com/apache/superset/assets/1534870/a5da58c8-d50e-4977-884e-86e04f131b46)

With this fix, the query is generated correctly:

![Screenshot 2023-09-06 at 12-25-22 test](https://github.com/apache/superset/assets/1534870/af297a1b-9db8-4cd9-9d2a-f2b2f74792db)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

See above.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
