### PR TITLE
fix: inability to remove chart filter when dashboard time filter is applied

### DIFF
--- a/superset-frontend/src/explore/actions/saveModalActions.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.js
@@ -59,6 +59,13 @@ const extractAddHocFiltersFromFormData = formDataToHandle =>
     {},
   );
 
+const hasTemporalRangeFilter = formData => {
+  const { adhoc_filters = [] } = formData;
+  return adhoc_filters.some(
+    filter => filter.operator === Operators.TEMPORAL_RANGE,
+  );
+};
+
 export const getSlicePayload = (
   sliceName,
   formDataWithNativeFilters,
@@ -76,18 +83,24 @@ export const getSlicePayload = (
   // would end up as an extra filter and when overwriting the chart the original
   // time range adhoc_filter was lost
   if (isEmpty(adhocFilters?.adhoc_filters) && !isEmpty(formDataFromSlice)) {
-    adhocFilters = extractAddHocFiltersFromFormData(formDataFromSlice);
+    formDataFromSlice?.adhoc_filters?.forEach(filter => {
+      if (filter.operator === Operators.TEMPORAL_RANGE && filter.isExtra) {
+        adhocFilters.adhoc_filters.push({ ...filter, comparator: 'No filter' });
+      }
+    });
   }
 
   // This loop iterates through the adhoc_filters array in formDataWithNativeFilters.
   // If a filter is of type TEMPORAL_RANGE and isExtra, it sets its comparator to
   // 'No filter' and adds the modified filter to the adhocFilters array. This ensures that all
   // TEMPORAL_RANGE filters are converted to 'No filter' when saving a chart.
-  formDataWithNativeFilters?.adhoc_filters?.forEach(filter => {
-    if (filter.operator === Operators.TEMPORAL_RANGE && filter.isExtra) {
-      adhocFilters.adhoc_filters.push({ ...filter, comparator: 'No filter' });
-    }
-  });
+  if (!hasTemporalRangeFilter(adhocFilters)) {
+    formDataWithNativeFilters?.adhoc_filters?.forEach(filter => {
+      if (filter.operator === Operators.TEMPORAL_RANGE && filter.isExtra) {
+        adhocFilters.adhoc_filters.push({ ...filter, comparator: 'No filter' });
+      }
+    });
+  }
 
   const formData = {
     ...formDataWithNativeFilters,

--- a/superset-frontend/src/explore/actions/saveModalActions.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.js
@@ -59,12 +59,10 @@ const extractAddHocFiltersFromFormData = formDataToHandle =>
     {},
   );
 
-const hasTemporalRangeFilter = formData => {
-  const { adhoc_filters = [] } = formData;
-  return adhoc_filters.some(
+const hasTemporalRangeFilter = formData =>
+  (formData?.adhoc_filters || []).some(
     filter => filter.operator === Operators.TEMPORAL_RANGE,
   );
-};
 
 export const getSlicePayload = (
   sliceName,
@@ -73,7 +71,7 @@ export const getSlicePayload = (
   owners,
   formDataFromSlice = {},
 ) => {
-  let adhocFilters = extractAddHocFiltersFromFormData(
+  const adhocFilters = extractAddHocFiltersFromFormData(
     formDataWithNativeFilters,
   );
 
@@ -84,7 +82,7 @@ export const getSlicePayload = (
   // time range adhoc_filter was lost
   if (isEmpty(adhocFilters?.adhoc_filters) && !isEmpty(formDataFromSlice)) {
     formDataFromSlice?.adhoc_filters?.forEach(filter => {
-      if (filter.operator === Operators.TEMPORAL_RANGE && filter.isExtra) {
+      if (filter.operator === Operators.TEMPORAL_RANGE && !filter.isExtra) {
         adhocFilters.adhoc_filters.push({ ...filter, comparator: 'No filter' });
       }
     });

--- a/superset-frontend/src/explore/actions/saveModalActions.test.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.test.js
@@ -302,19 +302,7 @@ describe('getSlicePayload', () => {
       formDataWithNativeFilters,
       dashboards,
       owners,
-      {
-        datasource: '22__table',
-        viz_type: 'pie',
-        adhoc_filters: [
-          {
-            clause: 'WHERE',
-            subject: 'year',
-            operator: 'TEMPORAL_RANGE',
-            comparator: 'No filter',
-            expressionType: 'SIMPLE',
-          },
-        ],
-      },
+      formDataFromSlice,
     );
     expect(result).toHaveProperty('params');
     expect(result).toHaveProperty('slice_name', sliceName);


### PR DESCRIPTION


<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When a chart is added to a dashboard with a time range filter applied, adding an additional filter to the chart in Explore results in an issue where the added filter cannot be removed as expected.

Repro Steps:

1. Create a chart and add it to a dashboard. For example, a pie chart with video_game_sales, where the dimension is "genre" and the metric is "sum(global_sales)."
1. On the dashboard, apply a native filter for a time range, such as 1998-2023.
2. Click on the chart title to access it in Explore.
3. In Explore, add a new filter to the chart. In this case, add the filter "publisher in Nintendo"
4. Overwrite the chart and return to the dashboard.
5. Access the pie chart in Explore once more and attempt to remove the state filter. Overwrite the chart.

Expected Results:
The state filter should be removable from the chart after the second overwrite in step 5.

Actual Results:
Unfortunately, the state filter still persists, and it cannot be removed as expected.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![filter](https://github.com/apache/superset/assets/5705598/4c7ebe00-28ce-44da-bc42-c78d245d4fff)
After: 
![filter_a](https://github.com/apache/superset/assets/5705598/939befa4-c680-4c1f-8f8b-a1f7e4990526)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
