### PR TITLE
chore(read_csv): remove deprecated argument

### DIFF
--- a/superset/templates/superset/form_view/csv_to_database_view/edit.html
+++ b/superset/templates/superset/form_view/csv_to_database_view/edit.html
@@ -69,10 +69,6 @@ csv_scripts %} {% import 'superset/form_view/csv_macros.html' as csv_macros %}
       begin_sep_field, end_sep_field) }}
     </tr>
     <tr>
-      {{ lib.render_field(form.infer_datetime_format, begin_sep_label,
-      end_sep_label, begin_sep_field, end_sep_field) }}
-    </tr>
-    <tr>
       {{ lib.render_field(form.day_first, begin_sep_label, end_sep_label,
       begin_sep_field, end_sep_field) }}
     </tr>

--- a/superset/views/database/forms.py
+++ b/superset/views/database/forms.py
@@ -197,10 +197,6 @@ class CsvToDatabaseForm(UploadToDatabaseForm):
         ),
         filters=[filter_not_empty_values],
     )
-    infer_datetime_format = BooleanField(
-        _("Interpret Datetime Format Automatically"),
-        description=_("Interpret the datetime format automatically"),
-    )
     day_first = BooleanField(
         _("Day First"),
         description=_("DD/MM format dates, international and European format"),

--- a/superset/views/database/views.py
+++ b/superset/views/database/views.py
@@ -167,7 +167,6 @@ class CsvToDatabaseView(CustomFormView):
         form.overwrite_duplicate.data = True
         form.skip_initial_space.data = False
         form.skip_blank_lines.data = True
-        form.infer_datetime_format.data = True
         form.day_first.data = False
         form.decimal.data = "."
         form.if_exists.data = "fail"
@@ -199,7 +198,6 @@ class CsvToDatabaseView(CustomFormView):
                     filepath_or_buffer=form.csv_file.data,
                     header=form.header.data if form.header.data else 0,
                     index_col=form.index_col.data,
-                    infer_datetime_format=form.infer_datetime_format.data,
                     dayfirst=form.day_first.data,
                     iterator=True,
                     keep_default_na=not form.null_values.data,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

`infer_datetime_format` in `pandas.Dataframe.read_csv` (and other places) is deprecated and will be removed in the next major version. In Pandas 2.0.0 it's always true, so we don't need to pass it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Upload a CSV like this:

```csv
timestamp,value
12-01-2000 00:00:00,10
13-01-2000 00:00:00,20
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
