### PR TITLE
fix: Use RLS clause instead of ID for cache key

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2100,11 +2100,11 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         return [f.get("clause", "") for f in self.get_guest_rls_filters(table)]
 
     def get_rls_cache_key(self, datasource: "BaseDatasource") -> list[str]:
-        rls_clauses = []
+        rls_str = []
         if datasource.is_rls_supported:
-            rls_clauses = self.get_rls_filters_str(datasource)
+            rls_str = self.get_rls_filters_str(datasource)
         guest_rls = self.get_guest_rls_filters_str(datasource)
-        return guest_rls + rls_clauses
+        return guest_rls + rls_str
 
     @staticmethod
     def _get_current_epoch_time() -> float:

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2095,7 +2095,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         """
         filters = self.get_rls_filters(table)
         filters.sort(key=lambda f: f.clause)  # Combinations rather than permutations
-        return [f"{f.clause}{f.group_key or ''}" for f in filters]
+        return [f"{f.clause}-{f.group_key or ''}" for f in filters]
 
     def get_guest_rls_filters_str(self, table: "BaseDatasource") -> list[str]:
         return [f.get("clause", "") for f in self.get_guest_rls_filters(table)]

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2083,28 +2083,27 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         )
         return query.all()
 
-    def get_rls_ids(self, table: "BaseDatasource") -> list[int]:
+    def get_rls_filter_clauses(self, table: "BaseDatasource") -> list[int]:
         """
-        Retrieves the appropriate row level security filters IDs for the current user
+        Retrieves the appropriate row level security filters clauses for the current user
         and the passed table.
 
         :param table: The table to check against
-        :returns: A list of IDs
+        :returns: A list of clauses
         """
-        ids = [f.id for f in self.get_rls_filters(table)]
-        ids.sort()  # Combinations rather than permutations
-        return ids
+        clauses = [f.clause for f in self.get_rls_filters(table)]
+        clauses.sort()  # Combinations rather than permutations
+        return clauses
 
     def get_guest_rls_filters_str(self, table: "BaseDatasource") -> list[str]:
         return [f.get("clause", "") for f in self.get_guest_rls_filters(table)]
 
     def get_rls_cache_key(self, datasource: "BaseDatasource") -> list[str]:
-        rls_ids = []
+        rls_clauses = []
         if datasource.is_rls_supported:
-            rls_ids = self.get_rls_ids(datasource)
-        rls_str = [str(rls_id) for rls_id in rls_ids]
+            rls_clauses = self.get_rls_clauses(datasource)
         guest_rls = self.get_guest_rls_filters_str(datasource)
-        return guest_rls + rls_str
+        return guest_rls + rls_clauses
 
     @staticmethod
     def _get_current_epoch_time() -> float:

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2083,6 +2083,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         )
         return query.all()
 
+    # pylint: disable=invalid-name
     def get_rls_filters_clauses_with_group_key(
         self, table: "BaseDatasource"
     ) -> list[str]:

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2099,7 +2099,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         return [f.get("clause", "") for f in self.get_guest_rls_filters(table)]
 
     def get_rls_cache_key(self, datasource: "BaseDatasource") -> list[str]:
-        rls_clauses = []
+        rls_clauses_with_group_key = []
         if datasource.is_rls_supported:
             rls_clauses_with_group_key = [
                 f"{f.clause}-{f.group_key or ''}"

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2101,7 +2101,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
     def get_rls_cache_key(self, datasource: "BaseDatasource") -> list[str]:
         rls_clauses = []
         if datasource.is_rls_supported:
-            rls_clauses = self.get_rls_clauses(datasource)
+            rls_clauses = self.get_rls_filter_clauses(datasource)
         guest_rls = self.get_guest_rls_filters_str(datasource)
         return guest_rls + rls_clauses
 

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2083,7 +2083,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         )
         return query.all()
 
-    def get_rls_filter_clauses(self, table: "BaseDatasource") -> list[int]:
+    def get_rls_filter_clauses(self, table: "BaseDatasource") -> list[str]:
         """
         Retrieves the appropriate row level security filters clauses for the current user
         and the passed table.

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2083,28 +2083,27 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         )
         return query.all()
 
-    def get_rls_filters_str(self, table: "BaseDatasource") -> list[str]:
+    def get_rls_filters_clauses(self, table: "BaseDatasource") -> list[str]:
         """
-        Retrieves the appropriate row level security filters string representation
-        (id concat'ed with clause) for the current user and the passed table.
+        Retrieves the appropriate row level security filters clauses for the current user
+        and the passed table.
 
         :param table: The table to check against
-        :returns: A list of string representations of the user's RLS filters
+        :returns: A list of clauses
         """
-        filters = self.get_rls_filters(table)
-        filters.sort(key=lambda f: f.id)  # Combinations rather than permutations
-        str_reps = [f"{f.id}-{f.clause}" for f in filters]
-        return str_reps
+        clauses = [f.clause for f in self.get_rls_filters(table)]
+        clauses.sort()  # Combinations rather than permutations
+        return clauses
 
     def get_guest_rls_filters_str(self, table: "BaseDatasource") -> list[str]:
         return [f.get("clause", "") for f in self.get_guest_rls_filters(table)]
 
     def get_rls_cache_key(self, datasource: "BaseDatasource") -> list[str]:
-        rls_str = []
+        rls_clauses = []
         if datasource.is_rls_supported:
-            rls_str = self.get_rls_filters_str(datasource)
+            rls_clauses = self.get_rls_filters_clauses(datasource)
         guest_rls = self.get_guest_rls_filters_str(datasource)
-        return guest_rls + rls_str
+        return guest_rls + rls_clauses
 
     @staticmethod
     def _get_current_epoch_time() -> float:

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2101,7 +2101,10 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
     def get_rls_cache_key(self, datasource: "BaseDatasource") -> list[str]:
         rls_clauses = []
         if datasource.is_rls_supported:
-            rls_clauses_with_group_key = [f"{f.clause}-{f.group_key or ''}" for f in self.get_rls_sorted(datasource)]
+            rls_clauses_with_group_key = [
+                f"{f.clause}-{f.group_key or ''}"
+                for f in self.get_rls_sorted(datasource)
+            ]
         guest_rls = self.get_guest_rls_filters_str(datasource)
         return guest_rls + rls_clauses_with_group_key
 

--- a/tests/integration_tests/security/row_level_security_tests.py
+++ b/tests/integration_tests/security/row_level_security_tests.py
@@ -315,9 +315,9 @@ class TestRowLevelSecurity(SupersetTestCase):
         g.user = self.get_user(username="gamma")
         clauses = security_manager.get_rls_filters_clauses_with_group_key(tbl)
         assert clauses == [
-            "gender = 'boy'gender",
-            "name like 'A%' or name like 'B%'name",
-            "name like 'Q%'name",
+            "gender = 'boy'-gender",
+            "name like 'A%' or name like 'B%'-name",
+            "name like 'Q%'-name",
         ]
 
 

--- a/tests/integration_tests/security/row_level_security_tests.py
+++ b/tests/integration_tests/security/row_level_security_tests.py
@@ -305,6 +305,17 @@ class TestRowLevelSecurity(SupersetTestCase):
         assert not self.NAMES_Q_REGEX.search(sql)
         assert not self.BASE_FILTER_REGEX.search(sql)
 
+    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+    def test_get_rls_filter_clauses(self):
+        g.user = self.get_user(username="admin")
+        tbl = self.get_table(name="birth_names")
+        clauses = security_manager.get_rls_filters_str(tbl)
+        assert clauses == []
+
+        g.user = self.get_user(username="gamma")
+        clauses = security_manager.get_rls_filters_str(tbl)
+        assert clauses == [f"{self.rls_entry2.id}-name like 'A%' or name like 'B%'", f"{self.rls_entry3.id}-name like 'Q%'", f"{self.rls_entry4.id}-gender = 'boy'"]
+
 
 class TestRowLevelSecurityCreateAPI(SupersetTestCase):
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")

--- a/tests/integration_tests/security/row_level_security_tests.py
+++ b/tests/integration_tests/security/row_level_security_tests.py
@@ -306,18 +306,18 @@ class TestRowLevelSecurity(SupersetTestCase):
         assert not self.BASE_FILTER_REGEX.search(sql)
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
-    def test_get_rls_filter_clauses(self):
+    def test_get_rls_filter_clauses_with_group_key(self):
         g.user = self.get_user(username="admin")
         tbl = self.get_table(name="birth_names")
-        clauses = security_manager.get_rls_filters_clauses(tbl)
+        clauses = security_manager.get_rls_filters_clauses_with_group_key(tbl)
         assert clauses == []
 
         g.user = self.get_user(username="gamma")
-        clauses = security_manager.get_rls_filters_clauses(tbl)
+        clauses = security_manager.get_rls_filters_clauses_with_group_key(tbl)
         assert clauses == [
-            "gender = 'boy'",
-            "name like 'A%' or name like 'B%'",
-            "name like 'Q%'",
+            "gender = 'boy'gender",
+            "name like 'A%' or name like 'B%'name",
+            "name like 'Q%'name",
         ]
 
 

--- a/tests/integration_tests/security/row_level_security_tests.py
+++ b/tests/integration_tests/security/row_level_security_tests.py
@@ -309,15 +309,15 @@ class TestRowLevelSecurity(SupersetTestCase):
     def test_get_rls_filter_clauses(self):
         g.user = self.get_user(username="admin")
         tbl = self.get_table(name="birth_names")
-        clauses = security_manager.get_rls_filters_str(tbl)
+        clauses = security_manager.get_rls_filters_clauses(tbl)
         assert clauses == []
 
         g.user = self.get_user(username="gamma")
-        clauses = security_manager.get_rls_filters_str(tbl)
+        clauses = security_manager.get_rls_filters_clauses(tbl)
         assert clauses == [
-            f"{self.rls_entry2.id}-name like 'A%' or name like 'B%'",
-            f"{self.rls_entry3.id}-name like 'Q%'",
-            f"{self.rls_entry4.id}-gender = 'boy'",
+            "gender = 'boy'",
+            "name like 'A%' or name like 'B%'",
+            "name like 'Q%'",
         ]
 
 

--- a/tests/integration_tests/security/row_level_security_tests.py
+++ b/tests/integration_tests/security/row_level_security_tests.py
@@ -314,7 +314,11 @@ class TestRowLevelSecurity(SupersetTestCase):
 
         g.user = self.get_user(username="gamma")
         clauses = security_manager.get_rls_filters_str(tbl)
-        assert clauses == [f"{self.rls_entry2.id}-name like 'A%' or name like 'B%'", f"{self.rls_entry3.id}-name like 'Q%'", f"{self.rls_entry4.id}-gender = 'boy'"]
+        assert clauses == [
+            f"{self.rls_entry2.id}-name like 'A%' or name like 'B%'",
+            f"{self.rls_entry3.id}-name like 'Q%'",
+            f"{self.rls_entry4.id}-gender = 'boy'",
+        ]
 
 
 class TestRowLevelSecurityCreateAPI(SupersetTestCase):

--- a/tests/integration_tests/security/row_level_security_tests.py
+++ b/tests/integration_tests/security/row_level_security_tests.py
@@ -306,18 +306,18 @@ class TestRowLevelSecurity(SupersetTestCase):
         assert not self.BASE_FILTER_REGEX.search(sql)
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
-    def test_get_rls_filter_clauses_with_group_key(self):
+    def test_get_rls_cache_key(self):
         g.user = self.get_user(username="admin")
         tbl = self.get_table(name="birth_names")
-        clauses = security_manager.get_rls_filters_clauses_with_group_key(tbl)
+        clauses = security_manager.get_rls_cache_key(tbl)
         assert clauses == []
 
         g.user = self.get_user(username="gamma")
-        clauses = security_manager.get_rls_filters_clauses_with_group_key(tbl)
+        clauses = security_manager.get_rls_cache_key(tbl)
         assert clauses == [
-            "gender = 'boy'-gender",
             "name like 'A%' or name like 'B%'-name",
             "name like 'Q%'-name",
+            "gender = 'boy'-gender",
         ]
 
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, the cache key is only dependent on on the id’s of the RLS filters applied for the current user/table.  This means that if an existing RLS filter’s clause is updated, a user with that RLS will still be able to retrieve results that were cached before the RLS was updated since their RLS filter id’s are unchanged, so the cache key doesn’t change.  Therefore the user sees results based on the old RLS clause, ignoring the new clause.

This PR changes this behavior so that cache keys are instead dependent on the actual clauses of the RLS filters so that RLS rules apply correctly after an RLS clause is updated.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
