### PR TITLE
fix: Clearing the currency format has no effect on the chart

### DIFF
--- a/superset-frontend/src/explore/components/controls/CurrencyControl/CurrencyControl.tsx
+++ b/superset-frontend/src/explore/components/controls/CurrencyControl/CurrencyControl.tsx
@@ -107,6 +107,7 @@ export const CurrencyControl = ({
           onChange={(symbolPosition: string) => {
             onChange({ ...currency, symbolPosition });
           }}
+          onClear={() => onChange({ ...currency, symbolPosition: undefined })}
           value={currency?.symbolPosition}
           allowClear
           {...symbolSelectOverrideProps}
@@ -118,6 +119,7 @@ export const CurrencyControl = ({
           onChange={(symbol: string) => {
             onChange({ ...currency, symbol });
           }}
+          onClear={() => onChange({ ...currency, symbol: undefined })}
           value={currency?.symbol}
           allowClear
           allowNewOptions


### PR DESCRIPTION
### SUMMARY
Fixes a problem with the Currency Format control where clearing the control wouldn't have any effect on the chart.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://github.com/apache/superset/assets/70410625/101a4721-21c9-47c4-8743-a6a5db198281

https://github.com/apache/superset/assets/70410625/ab60d01d-ab4e-4d2c-8e61-cbcdda1d0357

### TESTING INSTRUCTIONS
Check the videos for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue: https://github.com/apache/superset/issues/25234
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
