### PR TITLE
fix: Improve the reliability of alerts & reports

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -914,6 +914,8 @@ DASHBOARD_AUTO_REFRESH_INTERVALS = [
     [86400, "24 hours"],
 ]
 
+CELERY_BEAT_SCHEDULER_EXPIRES = 60 * 60 * 24 * 7  # 1 week
+
 # Default celery config is to use SQLA as a broker, in a production setting
 # you'll want to use a proper broker as specified here:
 # https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/index.html
@@ -942,6 +944,7 @@ class CeleryConfig:  # pylint: disable=too-few-public-methods
         "reports.scheduler": {
             "task": "reports.scheduler",
             "schedule": crontab(minute="*", hour="*"),
+            "options": {"expires": CELERY_BEAT_SCHEDULER_EXPIRES},
         },
         "reports.prune_log": {
             "task": "reports.prune_log",

--- a/superset/config.py
+++ b/superset/config.py
@@ -914,6 +914,8 @@ DASHBOARD_AUTO_REFRESH_INTERVALS = [
     [86400, "24 hours"],
 ]
 
+# This is used as a workaround for the alerts & reports scheduler task to get the time
+# celery beat triggered it, see https://github.com/celery/celery/issues/6974 for details
 CELERY_BEAT_SCHEDULER_EXPIRES = timedelta(weeks=1)
 
 # Default celery config is to use SQLA as a broker, in a production setting

--- a/superset/config.py
+++ b/superset/config.py
@@ -914,7 +914,7 @@ DASHBOARD_AUTO_REFRESH_INTERVALS = [
     [86400, "24 hours"],
 ]
 
-CELERY_BEAT_SCHEDULER_EXPIRES = 60 * 60 * 24 * 7  # 1 week
+CELERY_BEAT_SCHEDULER_EXPIRES = timedelta(weeks=1)
 
 # Default celery config is to use SQLA as a broker, in a production setting
 # you'll want to use a proper broker as specified here:
@@ -944,7 +944,7 @@ class CeleryConfig:  # pylint: disable=too-few-public-methods
         "reports.scheduler": {
             "task": "reports.scheduler",
             "schedule": crontab(minute="*", hour="*"),
-            "options": {"expires": CELERY_BEAT_SCHEDULER_EXPIRES},
+            "options": {"expires": int(CELERY_BEAT_SCHEDULER_EXPIRES.total_seconds())},
         },
         "reports.prune_log": {
             "task": "reports.prune_log",

--- a/superset/tasks/cron_util.py
+++ b/superset/tasks/cron_util.py
@@ -17,7 +17,7 @@
 
 import logging
 from collections.abc import Iterator
-from datetime import datetime, timedelta, timezone as dt_timezone
+from datetime import datetime, timedelta
 
 from croniter import croniter
 from pytz import timezone as pytz_timezone, UnknownTimeZoneError

--- a/superset/tasks/cron_util.py
+++ b/superset/tasks/cron_util.py
@@ -27,10 +27,10 @@ from superset import app
 logger = logging.getLogger(__name__)
 
 
-def cron_schedule_window(cron: str, timezone: str) -> Iterator[datetime]:
+def cron_schedule_window(
+    triggered_at: datetime, cron: str, timezone: str
+) -> Iterator[datetime]:
     window_size = app.config["ALERT_REPORTS_CRON_WINDOW_SIZE"]
-    # create a time-aware datetime in utc
-    time_now = datetime.now(tz=dt_timezone.utc)
     try:
         tz = pytz_timezone(timezone)
     except UnknownTimeZoneError:
@@ -39,7 +39,7 @@ def cron_schedule_window(cron: str, timezone: str) -> Iterator[datetime]:
         logger.warning("Timezone %s was invalid. Falling back to 'UTC'", timezone)
     utc = pytz_timezone("UTC")
     # convert the current time to the user's local time for comparison
-    time_now = time_now.astimezone(tz)
+    time_now = triggered_at.astimezone(tz)
     start_at = time_now - timedelta(seconds=window_size / 2)
     stop_at = time_now + timedelta(seconds=window_size / 2)
     crons = croniter(cron, start_at)

--- a/superset/tasks/cron_util.py
+++ b/superset/tasks/cron_util.py
@@ -40,8 +40,8 @@ def cron_schedule_window(cron: str, timezone: str) -> Iterator[datetime]:
     utc = pytz_timezone("UTC")
     # convert the current time to the user's local time for comparison
     time_now = time_now.astimezone(tz)
-    start_at = time_now - timedelta(seconds=1)
-    stop_at = time_now + timedelta(seconds=window_size)
+    start_at = time_now - timedelta(seconds=window_size / 2)
+    stop_at = time_now + timedelta(seconds=window_size / 2)
     crons = croniter(cron, start_at)
     for schedule in crons.all_next(datetime):
         if schedule >= stop_at:

--- a/superset/tasks/scheduler.py
+++ b/superset/tasks/scheduler.py
@@ -14,8 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from datetime import datetime, timedelta
 import logging
+from datetime import datetime, timedelta
 
 from celery import Celery
 from celery.exceptions import SoftTimeLimitExceeded

--- a/superset/tasks/scheduler.py
+++ b/superset/tasks/scheduler.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from celery import Celery
 from celery.exceptions import SoftTimeLimitExceeded

--- a/superset/tasks/scheduler.py
+++ b/superset/tasks/scheduler.py
@@ -50,7 +50,7 @@ def scheduler() -> None:
         active_schedules = ReportScheduleDAO.find_active(session)
         triggered_at = (
             datetime.fromisoformat(scheduler.request.expires)
-            - timedelta(seconds=app.config["CELERY_BEAT_SCHEDULER_EXPIRES"])
+            - app.config["CELERY_BEAT_SCHEDULER_EXPIRES"]
             if scheduler.request.expires
             else datetime.utcnow()
         )

--- a/tests/unit_tests/tasks/test_cron_util.py
+++ b/tests/unit_tests/tasks/test_cron_util.py
@@ -14,11 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from datetime import datetime
 
 import pytest
-import pytz
-from dateutil import parser
-from freezegun import freeze_time
 from freezegun.api import FakeDatetime
 
 from superset.tasks.cron_util import cron_schedule_window
@@ -27,23 +25,28 @@ from superset.tasks.cron_util import cron_schedule_window
 @pytest.mark.parametrize(
     "current_dttm, cron, expected",
     [
-        ("2020-01-01T08:59:01Z", "0 1 * * *", []),
+        ("2020-01-01T08:59:01+00:00", "0 1 * * *", []),
         (
-            "2020-01-01T08:59:02Z",
+            "2020-01-01T08:59:32+00:00",
             "0 1 * * *",
             [FakeDatetime(2020, 1, 1, 9, 0).strftime("%A, %d %B %Y, %H:%M:%S")],
         ),
         (
-            "2020-01-01T08:59:59Z",
+            "2020-01-01T08:59:59+00:00",
             "0 1 * * *",
             [FakeDatetime(2020, 1, 1, 9, 0).strftime("%A, %d %B %Y, %H:%M:%S")],
         ),
         (
-            "2020-01-01T09:00:00Z",
+            "2020-01-01T09:00:00+00:00",
             "0 1 * * *",
             [FakeDatetime(2020, 1, 1, 9, 0).strftime("%A, %d %B %Y, %H:%M:%S")],
         ),
-        ("2020-01-01T09:00:01Z", "0 1 * * *", []),
+        (
+            "2020-01-01T09:00:01+00:00",
+            "0 1 * * *",
+            [FakeDatetime(2020, 1, 1, 9, 0).strftime("%A, %d %B %Y, %H:%M:%S")],
+        ),
+        ("2020-01-01T09:00:30+00:00", "0 1 * * *", []),
     ],
 )
 def test_cron_schedule_window_los_angeles(
@@ -53,34 +56,40 @@ def test_cron_schedule_window_los_angeles(
     Reports scheduler: Test cron schedule window for "America/Los_Angeles"
     """
 
-    with freeze_time(current_dttm):
-        datetimes = cron_schedule_window(cron, "America/Los_Angeles")
-        assert (
-            list(cron.strftime("%A, %d %B %Y, %H:%M:%S") for cron in datetimes)
-            == expected
-        )
+    datetimes = cron_schedule_window(
+        datetime.fromisoformat(current_dttm), cron, "America/Los_Angeles"
+    )
+    assert (
+        list(cron.strftime("%A, %d %B %Y, %H:%M:%S") for cron in datetimes) == expected
+    )
 
 
 @pytest.mark.parametrize(
     "current_dttm, cron, expected",
     [
-        ("2020-01-01T00:59:01Z", "0 1 * * *", []),
+        ("2020-01-01T00:59:01+00:00", "0 1 * * *", []),
+        ("2020-01-01T00:59:02+00:00", "0 1 * * *", []),
         (
-            "2020-01-01T00:59:02Z",
+            "2020-01-01T00:59:59+00:00",
             "0 1 * * *",
             [FakeDatetime(2020, 1, 1, 1, 0).strftime("%A, %d %B %Y, %H:%M:%S")],
         ),
         (
-            "2020-01-01T00:59:59Z",
+            "2020-01-01T01:00:00+00:00",
             "0 1 * * *",
             [FakeDatetime(2020, 1, 1, 1, 0).strftime("%A, %d %B %Y, %H:%M:%S")],
         ),
         (
-            "2020-01-01T01:00:00Z",
+            "2020-01-01T01:00:01+00:00",
             "0 1 * * *",
             [FakeDatetime(2020, 1, 1, 1, 0).strftime("%A, %d %B %Y, %H:%M:%S")],
         ),
-        ("2020-01-01T01:00:01Z", "0 1 * * *", []),
+        (
+            "2020-01-01T01:00:29+00:00",
+            "0 1 * * *",
+            [FakeDatetime(2020, 1, 1, 1, 0).strftime("%A, %d %B %Y, %H:%M:%S")],
+        ),
+        ("2020-01-01T01:00:30+00:00", "0 1 * * *", []),
     ],
 )
 def test_cron_schedule_window_invalid_timezone(
@@ -90,35 +99,41 @@ def test_cron_schedule_window_invalid_timezone(
     Reports scheduler: Test cron schedule window for "invalid timezone"
     """
 
-    with freeze_time(current_dttm):
-        datetimes = cron_schedule_window(cron, "invalid timezone")
-        # it should default to UTC
-        assert (
-            list(cron.strftime("%A, %d %B %Y, %H:%M:%S") for cron in datetimes)
-            == expected
-        )
+    datetimes = cron_schedule_window(
+        datetime.fromisoformat(current_dttm), cron, "invalid timezone"
+    )
+    # it should default to UTC
+    assert (
+        list(cron.strftime("%A, %d %B %Y, %H:%M:%S") for cron in datetimes) == expected
+    )
 
 
 @pytest.mark.parametrize(
     "current_dttm, cron, expected",
     [
-        ("2020-01-01T05:59:01Z", "0 1 * * *", []),
+        ("2020-01-01T05:59:01+00:00", "0 1 * * *", []),
+        ("2020-01-01T05:59:02+00:00", "0 1 * * *", []),
         (
-            "2020-01-01T05:59:02Z",
+            "2020-01-01T05:59:59+00:00",
             "0 1 * * *",
             [FakeDatetime(2020, 1, 1, 6, 0).strftime("%A, %d %B %Y, %H:%M:%S")],
         ),
         (
-            "2020-01-01T5:59:59Z",
+            "2020-01-01T06:00:00+00:00",
             "0 1 * * *",
             [FakeDatetime(2020, 1, 1, 6, 0).strftime("%A, %d %B %Y, %H:%M:%S")],
         ),
         (
-            "2020-01-01T6:00:00",
+            "2020-01-01T06:00:01+00:00",
             "0 1 * * *",
             [FakeDatetime(2020, 1, 1, 6, 0).strftime("%A, %d %B %Y, %H:%M:%S")],
         ),
-        ("2020-01-01T6:00:01Z", "0 1 * * *", []),
+        (
+            "2020-01-01T06:00:29+00:00",
+            "0 1 * * *",
+            [FakeDatetime(2020, 1, 1, 6, 0).strftime("%A, %d %B %Y, %H:%M:%S")],
+        ),
+        ("2020-01-01T06:00:30+00:00", "0 1 * * *", []),
     ],
 )
 def test_cron_schedule_window_new_york(
@@ -128,34 +143,40 @@ def test_cron_schedule_window_new_york(
     Reports scheduler: Test cron schedule window for "America/New_York"
     """
 
-    with freeze_time(current_dttm, tz_offset=0):
-        datetimes = cron_schedule_window(cron, "America/New_York")
-        assert (
-            list(cron.strftime("%A, %d %B %Y, %H:%M:%S") for cron in datetimes)
-            == expected
-        )
+    datetimes = cron_schedule_window(
+        datetime.fromisoformat(current_dttm), cron, "America/New_York"
+    )
+    assert (
+        list(cron.strftime("%A, %d %B %Y, %H:%M:%S") for cron in datetimes) == expected
+    )
 
 
 @pytest.mark.parametrize(
     "current_dttm, cron, expected",
     [
-        ("2020-01-01T06:59:01Z", "0 1 * * *", []),
+        ("2020-01-01T06:59:01+00:00", "0 1 * * *", []),
+        ("2020-01-01T06:59:02+00:00", "0 1 * * *", []),
         (
-            "2020-01-01T06:59:02Z",
+            "2020-01-01T06:59:59+00:00",
             "0 1 * * *",
             [FakeDatetime(2020, 1, 1, 7, 0).strftime("%A, %d %B %Y, %H:%M:%S")],
         ),
         (
-            "2020-01-01T06:59:59Z",
+            "2020-01-01T07:00:00+00:00",
             "0 1 * * *",
             [FakeDatetime(2020, 1, 1, 7, 0).strftime("%A, %d %B %Y, %H:%M:%S")],
         ),
         (
-            "2020-01-01T07:00:00",
+            "2020-01-01T07:00:01+00:00",
             "0 1 * * *",
             [FakeDatetime(2020, 1, 1, 7, 0).strftime("%A, %d %B %Y, %H:%M:%S")],
         ),
-        ("2020-01-01T07:00:01Z", "0 1 * * *", []),
+        (
+            "2020-01-01T07:00:29+00:00",
+            "0 1 * * *",
+            [FakeDatetime(2020, 1, 1, 7, 0).strftime("%A, %d %B %Y, %H:%M:%S")],
+        ),
+        ("2020-01-01T07:00:30+00:00", "0 1 * * *", []),
     ],
 )
 def test_cron_schedule_window_chicago(
@@ -165,34 +186,40 @@ def test_cron_schedule_window_chicago(
     Reports scheduler: Test cron schedule window for "America/Chicago"
     """
 
-    with freeze_time(current_dttm, tz_offset=0):
-        datetimes = cron_schedule_window(cron, "America/Chicago")
-        assert (
-            list(cron.strftime("%A, %d %B %Y, %H:%M:%S") for cron in datetimes)
-            == expected
-        )
+    datetimes = cron_schedule_window(
+        datetime.fromisoformat(current_dttm), cron, "America/Chicago"
+    )
+    assert (
+        list(cron.strftime("%A, %d %B %Y, %H:%M:%S") for cron in datetimes) == expected
+    )
 
 
 @pytest.mark.parametrize(
     "current_dttm, cron, expected",
     [
-        ("2020-07-01T05:59:01Z", "0 1 * * *", []),
+        ("2020-07-01T05:59:01+00:00", "0 1 * * *", []),
+        ("2020-07-01T05:59:02+00:00", "0 1 * * *", []),
         (
-            "2020-07-01T05:59:02Z",
+            "2020-07-01T05:59:59+00:00",
             "0 1 * * *",
             [FakeDatetime(2020, 7, 1, 6, 0).strftime("%A, %d %B %Y, %H:%M:%S")],
         ),
         (
-            "2020-07-01T05:59:59Z",
+            "2020-07-01T06:00:00+00:00",
             "0 1 * * *",
             [FakeDatetime(2020, 7, 1, 6, 0).strftime("%A, %d %B %Y, %H:%M:%S")],
         ),
         (
-            "2020-07-01T06:00:00",
+            "2020-07-01T06:00:01+00:00",
             "0 1 * * *",
             [FakeDatetime(2020, 7, 1, 6, 0).strftime("%A, %d %B %Y, %H:%M:%S")],
         ),
-        ("2020-07-01T06:00:01Z", "0 1 * * *", []),
+        (
+            "2020-07-01T06:00:29+00:00",
+            "0 1 * * *",
+            [FakeDatetime(2020, 7, 1, 6, 0).strftime("%A, %d %B %Y, %H:%M:%S")],
+        ),
+        ("2020-07-01T06:00:30+00:00", "0 1 * * *", []),
     ],
 )
 def test_cron_schedule_window_chicago_daylight(
@@ -202,9 +229,9 @@ def test_cron_schedule_window_chicago_daylight(
     Reports scheduler: Test cron schedule window for "America/Chicago"
     """
 
-    with freeze_time(current_dttm, tz_offset=0):
-        datetimes = cron_schedule_window(cron, "America/Chicago")
-        assert (
-            list(cron.strftime("%A, %d %B %Y, %H:%M:%S") for cron in datetimes)
-            == expected
-        )
+    datetimes = cron_schedule_window(
+        datetime.fromisoformat(current_dttm), cron, "America/Chicago"
+    )
+    assert (
+        list(cron.strftime("%A, %d %B %Y, %H:%M:%S") for cron in datetimes) == expected
+    )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The goal of this PR is to make the alerts & reports scheduler job more reliable.  See https://github.com/apache/superset/issues/25058 for a great description of one current reliability issue.

This PR includes two main changes to improve reliability
### Adjusts the center of the window used to check cron schedules.
Currently, the following logic defines the window:
```python
start_at = time_now - timedelta(seconds=1)
stop_at = time_now + timedelta(seconds=window_size) # window_size = 59
```
The consequence is that if more than a second had elapsed since the `scheduler` job was originally triggered, any alerts & reports supposed to be triggeredwould not be.  This PR moves the center of the window 30 seconds towards the past, giving more leeway for delayed jobs
### Reads current time based on when celery beat triggered the scheduler job, rather than having the scheduler job generate the current time.
As I was making the above change, I realized that if the celery queue was backed up, or there was any kind of delay between when celery beat placed the job into the queue and when it was executed, alerts & reports could be missed.  It would be preferable if we could simply use the time at which celery beat triggered the job.  I found that this was not currently [supported natively by celery](https://github.com/celery/celery/issues/6974), but there is a [workaround](https://stackoverflow.com/questions/40000663/get-celery-beat-trigger-time-on-task) using the `expires` option.  As [noted on the celery repo](https://github.com/celery/celery/issues/6974#issuecomment-977939822), this is not a perfect solution, but I see it as much more reliable than the current approach.

For example, if a report is supposed to be sent at 12:00, but the celery queue is backed up such that the scheduler job triggered by beat isn't executed until 12:02, this change will make it so that now the report will be triggered, whereas currently it would not be.

Fixes https://github.com/apache/superset/issues/25058
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
