### PR TITLE
fix: Currency formatting in Table raw mode

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -159,7 +159,7 @@ const processColumns = memoizeOne(function processColumns(
       } else if (isPercentMetric) {
         // percent metrics have a default format
         formatter = getNumberFormatter(numberFormat || PERCENT_3_POINT);
-      } else if (isMetric || (isNumber && numberFormat)) {
+      } else if (isMetric || (isNumber && (numberFormat || currency))) {
         formatter = currency
           ? new CurrencyFormatter({
               d3Format: numberFormat,

--- a/superset-frontend/plugins/plugin-chart-table/src/utils/isEqualColumns.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/utils/isEqualColumns.ts
@@ -39,6 +39,8 @@ export default function isEqualColumns(
     JSON.stringify(a.formData.extraFilters || null) ===
       JSON.stringify(b.formData.extraFilters || null) &&
     JSON.stringify(a.formData.extraFormData || null) ===
-      JSON.stringify(b.formData.extraFormData || null)
+      JSON.stringify(b.formData.extraFormData || null) &&
+    JSON.stringify(a.rawFormData.column_config || null) ===
+      JSON.stringify(b.rawFormData.column_config || null)
   );
 }

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -123,6 +123,47 @@ describe('plugin-chart-table', () => {
       expect(cells[4]).toHaveTextContent('$ 2.47k');
     });
 
+    it('render raw data', () => {
+      const props = transformProps({
+        ...testData.raw,
+        rawFormData: { ...testData.raw.rawFormData },
+      });
+      render(
+        ProviderWrapper({
+          children: <TableChart {...props} sticky={false} />,
+        }),
+      );
+      const cells = document.querySelectorAll('td');
+      expect(document.querySelectorAll('th')[0]).toHaveTextContent('num');
+      expect(cells[0]).toHaveTextContent('1234');
+      expect(cells[1]).toHaveTextContent('10000');
+      expect(cells[1]).toHaveTextContent('0');
+    });
+
+    it('render raw data with currencies', () => {
+      const props = transformProps({
+        ...testData.raw,
+        rawFormData: {
+          ...testData.raw.rawFormData,
+          column_config: {
+            num: {
+              currencyFormat: { symbol: 'USD', symbolPosition: 'prefix' },
+            },
+          },
+        },
+      });
+      render(
+        ProviderWrapper({
+          children: <TableChart {...props} sticky={false} />,
+        }),
+      );
+      const cells = document.querySelectorAll('td');
+      expect(document.querySelectorAll('th')[0]).toHaveTextContent('num');
+      expect(cells[0]).toHaveTextContent('$ 1.23k');
+      expect(cells[1]).toHaveTextContent('$ 10k');
+      expect(cells[2]).toHaveTextContent('$ 0');
+    });
+
     it('render empty data', () => {
       wrap.setProps({ ...transformProps(testData.empty), sticky: false });
       tree = wrap.render();

--- a/superset-frontend/plugins/plugin-chart-table/test/testData.ts
+++ b/superset-frontend/plugins/plugin-chart-table/test/testData.ts
@@ -21,6 +21,7 @@ import {
   ChartProps,
   DatasourceType,
   GenericDataType,
+  QueryMode,
   supersetTheme,
 } from '@superset-ui/core';
 import { TableChartProps, TableChartFormData } from '../src/types';
@@ -173,6 +174,33 @@ const advanced: TableChartProps = {
   ],
 };
 
+const raw = {
+  ...advanced,
+  rawFormData: {
+    ...advanced.rawFormData,
+    query_mode: QueryMode.raw,
+    columns: ['num'],
+  },
+  queriesData: [
+    {
+      ...basicQueryResult,
+      colnames: ['num'],
+      coltypes: [GenericDataType.NUMERIC],
+      data: [
+        {
+          num: 1234,
+        },
+        {
+          num: 10000,
+        },
+        {
+          num: 0,
+        },
+      ],
+    },
+  ],
+};
+
 const advancedWithCurrency = {
   ...advanced,
   datasource: {
@@ -198,4 +226,5 @@ export default {
   advanced,
   advancedWithCurrency,
   empty,
+  raw,
 };


### PR DESCRIPTION
### SUMMARY
In Table chart's raw mode, the currency formats would not be applied until user also selected a number formatter.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://github.com/apache/superset/assets/15073128/ca8b7d40-f6fa-4ec9-bc73-51b60a7b13f4

After:

https://github.com/apache/superset/assets/15073128/62be3fcc-e2f5-4cdb-84d2-719241bee745


### TESTING INSTRUCTIONS
1. Create a table chart and select raw mode
2. Add some numeric columns
3. Open "customize columns" popover
4. Select a currency without changing a number formatter first
5. Verify that currency is applied

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/pull/25248
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
