### PR TITLE
fix: Don't apply number formatting to the label in Treemap

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/transformProps.ts
@@ -168,7 +168,6 @@ export default function transformProps(
     treeNodes.map(treeNode => {
       const { name: nodeName, value, groupBy } = treeNode;
       const name = formatSeriesName(nodeName, {
-        numberFormatter,
         timeFormatter: getTimeFormatter(dateFormat),
         ...(coltypeMapping[groupBy] && {
           coltype: coltypeMapping[groupBy],


### PR DESCRIPTION
### SUMMARY
In Echarts Treemap, the value formatter (number and currency) was unnecessarily applied to labels when labels were numeric. That was both incorrect and inconsistent with other charts.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://github.com/apache/superset/assets/15073128/70280e33-ce07-4e0c-9483-8ea1fe10789e)

After:
<img width="1728" alt="image" src="https://github.com/apache/superset/assets/15073128/bbb6da6a-a80f-459b-89ee-266a4efca13a">


### TESTING INSTRUCTIONS
1. Create a Treemap chart
2. Use a numeric column as a dimension
3. Verify that only the metric value gets formatter and the label stays unformatted

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/pull/25248
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
