### PR TITLE
fix(dockefile): broken docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,10 @@ ARG BUILDPLATFORM=${BUILDPLATFORM:-amd64}
 FROM --platform=${BUILDPLATFORM} node:16-slim AS superset-node
 
 ARG NPM_BUILD_CMD="build"
+
+RUN apt-get update -q
+RUN apt-get install -yq python3 make gcc g++
+
 ENV BUILD_CMD=${NPM_BUILD_CMD} \
     PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 # NPM ci first, as to NOT invalidate previous steps except for when package.json changes

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,12 @@ FROM --platform=${BUILDPLATFORM} node:16-slim AS superset-node
 
 ARG NPM_BUILD_CMD="build"
 
-RUN apt-get update -q
-RUN apt-get install -yq python3 make gcc g++
+RUN apt-get update -q \
+    && apt-get install -yq --no-install-recommends \
+        python3 \
+        make \
+        gcc \
+        g++
 
 ENV BUILD_CMD=${NPM_BUILD_CMD} \
     PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true


### PR DESCRIPTION
### SUMMARY
The docker image was missing dependencies needed for the frontend build.

This commit installs the dependencies python3, make, gcc and g++.

### TESTING INSTRUCTIONS
`docker build . -t superset --no-cache`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
  - #25148 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
