### PR TITLE
fix: Add line height to metadata bar

### DIFF
--- a/superset-frontend/src/components/MetadataBar/MetadataBar.tsx
+++ b/superset-frontend/src/components/MetadataBar/MetadataBar.tsx
@@ -104,6 +104,7 @@ const StyledItem = styled.div<{
       text-overflow: ${collapsed ? 'unset' : 'ellipsis'};
       white-space: nowrap;
       text-decoration: ${onClick ? 'underline' : 'none'};
+      line-height: 1.4;
     }
   `}
 `;


### PR DESCRIPTION
### SUMMARY
Letters like "g" were cut off a bit in a metadata bar.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="1128" alt="image" src="https://github.com/apache/superset/assets/15073128/44b65a05-2d4e-445e-b9c0-1f216a242b3b">

After:

<img width="1044" alt="image" src="https://github.com/apache/superset/assets/15073128/b088786b-67c9-4f59-8ef2-909f3f0beabc">


### TESTING INSTRUCTIONS
Open a metadata bar which has text that contains letters like "g" (that go below the baseline) and verify they're not cut off

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
