### PR TITLE
chore(sqllab): Migrate tests to typescript

### DIFF
--- a/superset-frontend/src/SqlLab/components/HighlightedSql/HighlightedSql.test.tsx
+++ b/superset-frontend/src/SqlLab/components/HighlightedSql/HighlightedSql.test.tsx
@@ -21,35 +21,28 @@ import React from 'react';
 import HighlightedSql from 'src/SqlLab/components/HighlightedSql';
 import { fireEvent, render } from 'spec/helpers/testing-library';
 
-describe('HighlightedSql', () => {
-  const sql =
-    "SELECT * FROM test WHERE something='fkldasjfklajdslfkjadlskfjkldasjfkladsjfkdjsa'";
-  it('renders with props', () => {
-    expect(React.isValidElement(<HighlightedSql sql={sql} />)).toBe(true);
-  });
-  it('renders a ModalTrigger', () => {
-    const { getByTestId } = render(<HighlightedSql sql={sql} />);
-    expect(getByTestId('span-modal-trigger')).toBeInTheDocument();
-  });
-  it('renders a ModalTrigger while using shrink', () => {
-    const { getByTestId } = render(
-      <HighlightedSql sql={sql} shrink maxWidth={20} />,
-    );
-    expect(getByTestId('span-modal-trigger')).toBeInTheDocument();
-  });
-  it('renders two SyntaxHighlighter in modal', () => {
-    const { getByRole, queryByRole, getByTestId } = render(
-      <HighlightedSql
-        sql={sql}
-        rawSql="SELECT * FORM foo"
-        shrink
-        maxWidth={5}
-      />,
-    );
-    expect(queryByRole('dialog')).not.toBeInTheDocument();
-    fireEvent.click(getByTestId('span-modal-trigger'));
-    expect(queryByRole('dialog')).toBeInTheDocument();
-    const syntaxHighlighter = getByRole('dialog').getElementsByTagName('code');
-    expect(syntaxHighlighter.length).toEqual(2);
-  });
+const sql =
+  "SELECT * FROM test WHERE something='fkldasjfklajdslfkjadlskfjkldasjfkladsjfkdjsa'";
+test('renders with props', () => {
+  expect(React.isValidElement(<HighlightedSql sql={sql} />)).toBe(true);
+});
+test('renders a ModalTrigger', () => {
+  const { getByTestId } = render(<HighlightedSql sql={sql} />);
+  expect(getByTestId('span-modal-trigger')).toBeInTheDocument();
+});
+test('renders a ModalTrigger while using shrink', () => {
+  const { getByTestId } = render(
+    <HighlightedSql sql={sql} shrink maxWidth={20} />,
+  );
+  expect(getByTestId('span-modal-trigger')).toBeInTheDocument();
+});
+test('renders two SyntaxHighlighter in modal', () => {
+  const { getByRole, queryByRole, getByTestId } = render(
+    <HighlightedSql sql={sql} rawSql="SELECT * FORM foo" shrink maxWidth={5} />,
+  );
+  expect(queryByRole('dialog')).not.toBeInTheDocument();
+  fireEvent.click(getByTestId('span-modal-trigger'));
+  expect(queryByRole('dialog')).toBeInTheDocument();
+  const syntaxHighlighter = getByRole('dialog').getElementsByTagName('code');
+  expect(syntaxHighlighter.length).toEqual(2);
 });

--- a/superset-frontend/src/SqlLab/components/HighlightedSql/HighlightedSql.test.tsx
+++ b/superset-frontend/src/SqlLab/components/HighlightedSql/HighlightedSql.test.tsx
@@ -23,26 +23,26 @@ import { fireEvent, render } from 'spec/helpers/testing-library';
 
 const sql =
   "SELECT * FROM test WHERE something='fkldasjfklajdslfkjadlskfjkldasjfkladsjfkdjsa'";
-test('renders with props', () => {
+test('renders HighlightedSql component with sql prop', () => {
   expect(React.isValidElement(<HighlightedSql sql={sql} />)).toBe(true);
 });
-test('renders a ModalTrigger', () => {
+test('renders a ModalTrigger component', () => {
   const { getByTestId } = render(<HighlightedSql sql={sql} />);
   expect(getByTestId('span-modal-trigger')).toBeInTheDocument();
 });
-test('renders a ModalTrigger while using shrink', () => {
+test('renders a ModalTrigger component with shrink prop and maxWidth prop set to 20', () => {
   const { getByTestId } = render(
     <HighlightedSql sql={sql} shrink maxWidth={20} />,
   );
   expect(getByTestId('span-modal-trigger')).toBeInTheDocument();
 });
-test('renders two SyntaxHighlighter in modal', () => {
+test('renders two code elements in modal when rawSql prop is provided', () => {
   const { getByRole, queryByRole, getByTestId } = render(
     <HighlightedSql sql={sql} rawSql="SELECT * FORM foo" shrink maxWidth={5} />,
   );
   expect(queryByRole('dialog')).not.toBeInTheDocument();
   fireEvent.click(getByTestId('span-modal-trigger'));
   expect(queryByRole('dialog')).toBeInTheDocument();
-  const syntaxHighlighter = getByRole('dialog').getElementsByTagName('code');
-  expect(syntaxHighlighter.length).toEqual(2);
+  const codeElements = getByRole('dialog').getElementsByTagName('code');
+  expect(codeElements.length).toEqual(2);
 });

--- a/superset-frontend/src/SqlLab/components/HighlightedSql/HighlightedSql.test.tsx
+++ b/superset-frontend/src/SqlLab/components/HighlightedSql/HighlightedSql.test.tsx
@@ -17,12 +17,9 @@
  * under the License.
  */
 import React from 'react';
-import SyntaxHighlighter from 'react-syntax-highlighter';
-import { mount, shallow } from 'enzyme';
 
 import HighlightedSql from 'src/SqlLab/components/HighlightedSql';
-import ModalTrigger from 'src/components/ModalTrigger';
-import { supersetTheme, ThemeProvider } from '@superset-ui/core';
+import { fireEvent, render } from 'spec/helpers/testing-library';
 
 describe('HighlightedSql', () => {
   const sql =
@@ -31,34 +28,28 @@ describe('HighlightedSql', () => {
     expect(React.isValidElement(<HighlightedSql sql={sql} />)).toBe(true);
   });
   it('renders a ModalTrigger', () => {
-    const wrapper = shallow(<HighlightedSql sql={sql} />);
-    expect(wrapper.find(ModalTrigger)).toExist();
+    const { getByTestId } = render(<HighlightedSql sql={sql} />);
+    expect(getByTestId('span-modal-trigger')).toBeInTheDocument();
   });
   it('renders a ModalTrigger while using shrink', () => {
-    const wrapper = shallow(<HighlightedSql sql={sql} shrink maxWidth={20} />);
-    expect(wrapper.find(ModalTrigger)).toExist();
+    const { getByTestId } = render(
+      <HighlightedSql sql={sql} shrink maxWidth={20} />,
+    );
+    expect(getByTestId('span-modal-trigger')).toBeInTheDocument();
   });
   it('renders two SyntaxHighlighter in modal', () => {
-    const wrapper = mount(
+    const { getByRole, queryByRole, getByTestId } = render(
       <HighlightedSql
         sql={sql}
         rawSql="SELECT * FORM foo"
         shrink
         maxWidth={5}
       />,
-      {
-        wrappingComponent: ThemeProvider,
-        wrappingComponentProps: {
-          theme: supersetTheme,
-        },
-      },
     );
-    const pre = wrapper.find('pre');
-    expect(pre).toHaveLength(1);
-    pre.simulate('click');
-    setTimeout(() => {
-      const modalBody = mount(wrapper.state().modalBody);
-      expect(modalBody.find(SyntaxHighlighter)).toHaveLength(2);
-    }, 10);
+    expect(queryByRole('dialog')).not.toBeInTheDocument();
+    fireEvent.click(getByTestId('span-modal-trigger'));
+    expect(queryByRole('dialog')).toBeInTheDocument();
+    const syntaxHighlighter = getByRole('dialog').getElementsByTagName('code');
+    expect(syntaxHighlighter.length).toEqual(2);
   });
 });

--- a/superset-frontend/src/SqlLab/components/QueryStateLabel/QueryStateLabel.test.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryStateLabel/QueryStateLabel.test.tsx
@@ -23,19 +23,15 @@ import QueryStateLabel from '.';
 
 jest.mock('src/components/Label', () => () => <div data-test="mock-label" />);
 
-describe('SavedQuery', () => {
-  const mockedProps = {
-    query: {
-      state: 'running' as QueryState,
-    },
-  };
-  it('is valid', () => {
-    expect(React.isValidElement(<QueryStateLabel {...mockedProps} />)).toBe(
-      true,
-    );
-  });
-  it('has an Overlay and a Popover', () => {
-    const { getByTestId } = render(<QueryStateLabel {...mockedProps} />);
-    expect(getByTestId('mock-label')).toBeInTheDocument();
-  });
+const mockedProps = {
+  query: {
+    state: 'running' as QueryState,
+  },
+};
+test('is valid', () => {
+  expect(React.isValidElement(<QueryStateLabel {...mockedProps} />)).toBe(true);
+});
+test('has an Overlay and a Popover', () => {
+  const { getByTestId } = render(<QueryStateLabel {...mockedProps} />);
+  expect(getByTestId('mock-label')).toBeInTheDocument();
 });

--- a/superset-frontend/src/SqlLab/components/QueryStateLabel/QueryStateLabel.test.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryStateLabel/QueryStateLabel.test.tsx
@@ -17,14 +17,16 @@
  * under the License.
  */
 import React from 'react';
-import { styledMount as mount } from 'spec/helpers/theming';
-import Label from 'src/components/Label';
-import QueryStateLabel from 'src/SqlLab/components/QueryStateLabel';
+import type { QueryState } from '@superset-ui/core';
+import { render } from 'spec/helpers/testing-library';
+import QueryStateLabel from '.';
+
+jest.mock('src/components/Label', () => () => <div data-test="mock-label" />);
 
 describe('SavedQuery', () => {
   const mockedProps = {
     query: {
-      state: 'running',
+      state: 'running' as QueryState,
     },
   };
   it('is valid', () => {
@@ -33,7 +35,7 @@ describe('SavedQuery', () => {
     );
   });
   it('has an Overlay and a Popover', () => {
-    const wrapper = mount(<QueryStateLabel {...mockedProps} />);
-    expect(wrapper.find(Label)).toExist();
+    const { getByTestId } = render(<QueryStateLabel {...mockedProps} />);
+    expect(getByTestId('mock-label')).toBeInTheDocument();
   });
 });

--- a/superset-frontend/src/SqlLab/components/QueryStateLabel/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryStateLabel/index.tsx
@@ -22,7 +22,7 @@ import { STATE_TYPE_MAP, STATE_TYPE_MAP_LOCALIZED } from 'src/SqlLab/constants';
 import { styled, Query } from '@superset-ui/core';
 
 interface QueryStateLabelProps {
-  query: Query;
+  query: Pick<Query, 'state'>;
 }
 
 const StyledLabel = styled(Label)`

--- a/superset-frontend/src/SqlLab/components/QueryTable/QueryTable.test.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/QueryTable.test.tsx
@@ -24,11 +24,11 @@ import QueryTable from 'src/SqlLab/components/QueryTable';
 import TableView from 'src/components/TableView';
 import TableCollection from 'src/components/TableCollection';
 import { Provider } from 'react-redux';
-import { queries, user } from 'src/SqlLab/fixtures';
+import { runningQuery, successfulQuery, user } from 'src/SqlLab/fixtures';
 
 describe('QueryTable', () => {
   const mockedProps = {
-    queries,
+    queries: [runningQuery, successfulQuery],
     displayLimit: 100,
     latestQueryId: 'ryhMUZCGb',
   };

--- a/superset-frontend/src/SqlLab/components/QueryTable/QueryTable.test.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/QueryTable.test.tsx
@@ -26,34 +26,32 @@ import TableCollection from 'src/components/TableCollection';
 import { Provider } from 'react-redux';
 import { runningQuery, successfulQuery, user } from 'src/SqlLab/fixtures';
 
-describe('QueryTable', () => {
-  const mockedProps = {
-    queries: [runningQuery, successfulQuery],
-    displayLimit: 100,
-    latestQueryId: 'ryhMUZCGb',
-  };
-  it('is valid', () => {
-    expect(React.isValidElement(<QueryTable displayLimit={100} />)).toBe(true);
+const mockedProps = {
+  queries: [runningQuery, successfulQuery],
+  displayLimit: 100,
+  latestQueryId: 'ryhMUZCGb',
+};
+test('is valid', () => {
+  expect(React.isValidElement(<QueryTable displayLimit={100} />)).toBe(true);
+});
+test('is valid with props', () => {
+  expect(React.isValidElement(<QueryTable {...mockedProps} />)).toBe(true);
+});
+test('renders a proper table', () => {
+  const mockStore = configureStore([thunk]);
+  const store = mockStore({
+    user,
   });
-  it('is valid with props', () => {
-    expect(React.isValidElement(<QueryTable {...mockedProps} />)).toBe(true);
-  });
-  it('renders a proper table', () => {
-    const mockStore = configureStore([thunk]);
-    const store = mockStore({
-      user,
-    });
 
-    const wrapper = mount(
-      <Provider store={store}>
-        <QueryTable {...mockedProps} />
-      </Provider>,
-    );
-    const tableWrapper = wrapper.find(TableView).find(TableCollection);
+  const wrapper = mount(
+    <Provider store={store}>
+      <QueryTable {...mockedProps} />
+    </Provider>,
+  );
+  const tableWrapper = wrapper.find(TableView).find(TableCollection);
 
-    expect(wrapper.find(TableView)).toExist();
-    expect(tableWrapper.find('table')).toExist();
-    expect(tableWrapper.find('table').find('thead').find('tr')).toHaveLength(1);
-    expect(tableWrapper.find('table').find('tbody').find('tr')).toHaveLength(2);
-  });
+  expect(wrapper.find(TableView)).toExist();
+  expect(tableWrapper.find('table')).toExist();
+  expect(tableWrapper.find('table').find('thead').find('tr')).toHaveLength(1);
+  expect(tableWrapper.find('table').find('tbody').find('tr')).toHaveLength(2);
 });


### PR DESCRIPTION
### SUMMARY
Migrates legacy jsx tests to typescript including replacing enzyme by testing-library.

### TESTING INSTRUCTIONS
npm run type and test

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
