### PR TITLE
chore: Remove the ability to switch to filter-box chart when DASHBOARD_NATIVE_FILTERS feature is enabled

### DIFF
--- a/superset-frontend/src/explore/components/controls/VizTypeControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/index.tsx
@@ -23,6 +23,8 @@ import {
   getChartMetadataRegistry,
   styled,
   SupersetTheme,
+  isFeatureEnabled,
+  FeatureFlag,
 } from '@superset-ui/core';
 import { usePluginContext } from 'src/components/DynamicPlugins';
 import Modal from 'src/components/Modal';
@@ -45,6 +47,13 @@ interface VizTypeControlProps {
 const bootstrapData = getBootstrapData();
 const denyList: string[] = bootstrapData.common.conf.VIZ_TYPE_DENYLIST || [];
 const metadataRegistry = getChartMetadataRegistry();
+
+if (
+  isFeatureEnabled(FeatureFlag.DASHBOARD_NATIVE_FILTERS) &&
+  !denyList.includes('filter_box')
+) {
+  denyList.push('filter_box');
+}
 
 export const VIZ_TYPE_CONTROL_TEST_ID = 'viz-type-control';
 

--- a/superset-frontend/src/pages/ChartCreation/index.tsx
+++ b/superset-frontend/src/pages/ChartCreation/index.tsx
@@ -70,7 +70,7 @@ const denyList: string[] = bootstrapData.common.conf.VIZ_TYPE_DENYLIST || [];
 
 if (
   isFeatureEnabled(FeatureFlag.DASHBOARD_NATIVE_FILTERS) &&
-  !('filter_box' in denyList)
+  !denyList.includes('filter_box')
 ) {
   denyList.push('filter_box');
 }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR is a follow up to https://github.com/apache/superset/pull/23142. Previously I removed the ability to add a filter-box chart when the `DASHBOARD_NATIVE_FILTERS` feature was enabled, but neglected to take into account switching visualization types.

<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE

<img width="1053" alt="Screenshot 2023-09-12 at 11 11 49 AM" src="https://github.com/apache/superset/assets/4567245/a707d9dd-2d22-4367-a30b-b002879fc68c">

#### AFTER

<img width="1053" alt="Screenshot 2023-09-12 at 10 57 24 AM" src="https://github.com/apache/superset/assets/4567245/c3ffcc69-38ce-41fd-af9a-9b2a00b89bd2">

### TESTING INSTRUCTIONS

Manual testing.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
