### PR TITLE
fix(nativeFilters): Speed up native filters by removing unnecessary rerenders

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/chart/types/Base.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/types/Base.ts
@@ -58,6 +58,7 @@ export enum AppSection {
 export type FilterState = { value?: any; [key: string]: any };
 
 export type DataMask = {
+  __cache?: FilterState;
   extraFormData?: ExtraFormData;
   filterState?: FilterState;
   ownState?: JsonObject;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/state.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/state.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import { shallowEqual, useSelector } from 'react-redux';
 import {
   DataMaskStateWithId,
   ensureIsArray,
@@ -32,6 +32,7 @@ export function useFilterDependencies(
 ): ExtraFormData {
   const dependencyIds = useSelector<any, string[] | undefined>(
     state => state.nativeFilters.filters[id]?.cascadeParentIds,
+    shallowEqual,
   );
   return useMemo(() => {
     let dependencies = {};

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
@@ -220,7 +220,7 @@ const VerticalFilterBar: React.FC<VerticalBarProps> = ({
           />
         </FilterControlsWrapper>
       ),
-    [canEdit, dataMaskSelected, filterValues.length, onSelectionChange],
+    [canEdit, JSON.stringify(dataMaskSelected), filterValues.length, onSelectionChange],
   );
 
   const filterSetsTabs = useMemo(
@@ -267,7 +267,7 @@ const VerticalFilterBar: React.FC<VerticalBarProps> = ({
       </StyledTabs>
     ),
     [
-      dataMaskSelected,
+      JSON.stringify(dataMaskSelected),
       editFilterSetId,
       filterControls,
       filterSetFilterValues.length,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
@@ -222,7 +222,7 @@ const VerticalFilterBar: React.FC<VerticalBarProps> = ({
       ),
     [
       canEdit,
-      JSON.stringify(dataMaskSelected),
+      dataMaskSelected,
       filterValues.length,
       onSelectionChange,
     ],

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
@@ -221,11 +221,7 @@ const VerticalFilterBar: React.FC<VerticalBarProps> = ({
           />
         </FilterControlsWrapper>
       ),
-    [
-      canEdit,
-      filterValues.length,
-      onSelectionChange,
-    ],
+    [canEdit, filterValues.length, onSelectionChange],
   );
 
   const filterSetsTabs = useMemo(

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
@@ -159,7 +159,6 @@ const VerticalFilterBar: React.FC<VerticalBarProps> = ({
   width,
 }) => {
   const [editFilterSetId, setEditFilterSetId] = useState<number | null>(null);
-  const dataMaskSelectedRef = useRef(dataMaskSelected);
   const filterSets = useFilterSets();
   const filterSetFilterValues = Object.values(filterSets);
   const [tab, setTab] = useState(TabIds.AllFilters);
@@ -216,12 +215,17 @@ const VerticalFilterBar: React.FC<VerticalBarProps> = ({
       ) : (
         <FilterControlsWrapper>
           <FilterControls
-            dataMaskSelected={dataMaskSelectedRef.current}
+            dataMaskSelected={dataMaskSelected}
             onFilterSelectionChange={onSelectionChange}
           />
         </FilterControlsWrapper>
       ),
-    [canEdit, filterValues.length, onSelectionChange],
+    [
+      canEdit,
+      JSON.stringify(dataMaskSelected),
+      filterValues.length,
+      onSelectionChange,
+    ],
   );
 
   const filterSetsTabs = useMemo(

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
@@ -220,12 +220,7 @@ const VerticalFilterBar: React.FC<VerticalBarProps> = ({
           />
         </FilterControlsWrapper>
       ),
-    [
-      canEdit,
-      dataMaskSelected,
-      filterValues.length,
-      onSelectionChange,
-    ],
+    [canEdit, dataMaskSelected, filterValues.length, onSelectionChange],
   );
 
   const filterSetsTabs = useMemo(

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
@@ -220,7 +220,12 @@ const VerticalFilterBar: React.FC<VerticalBarProps> = ({
           />
         </FilterControlsWrapper>
       ),
-    [canEdit, JSON.stringify(dataMaskSelected), filterValues.length, onSelectionChange],
+    [
+      canEdit,
+      JSON.stringify(dataMaskSelected),
+      filterValues.length,
+      onSelectionChange,
+    ],
   );
 
   const filterSetsTabs = useMemo(

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
@@ -272,7 +272,7 @@ const VerticalFilterBar: React.FC<VerticalBarProps> = ({
       </StyledTabs>
     ),
     [
-      JSON.stringify(dataMaskSelected),
+      dataMaskSelected,
       editFilterSetId,
       filterControls,
       filterSetFilterValues.length,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
@@ -159,6 +159,7 @@ const VerticalFilterBar: React.FC<VerticalBarProps> = ({
   width,
 }) => {
   const [editFilterSetId, setEditFilterSetId] = useState<number | null>(null);
+  const dataMaskSelectedRef = useRef(dataMaskSelected);
   const filterSets = useFilterSets();
   const filterSetFilterValues = Object.values(filterSets);
   const [tab, setTab] = useState(TabIds.AllFilters);
@@ -215,14 +216,13 @@ const VerticalFilterBar: React.FC<VerticalBarProps> = ({
       ) : (
         <FilterControlsWrapper>
           <FilterControls
-            dataMaskSelected={dataMaskSelected}
+            dataMaskSelected={dataMaskSelectedRef.current}
             onFilterSelectionChange={onSelectionChange}
           />
         </FilterControlsWrapper>
       ),
     [
       canEdit,
-      JSON.stringify(dataMaskSelected),
       filterValues.length,
       onSelectionChange,
     ],

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -166,7 +166,7 @@ const FilterBar: React.FC<FiltersBarProps> = ({
         };
       });
     },
-    [dataMaskSelected, dispatch, setDataMaskSelected],
+    [JSON.stringify(dataMaskSelected), dispatch, setDataMaskSelected],
   );
 
   useEffect(() => {
@@ -222,7 +222,7 @@ const FilterBar: React.FC<FiltersBarProps> = ({
         dispatch(updateDataMask(filterId, dataMaskSelected[filterId]));
       }
     });
-  }, [dataMaskSelected, dispatch]);
+  }, [JSON.stringify(dataMaskSelected), dispatch]);
 
   const handleClearAll = useCallback(() => {
     const clearDataMaskIds: string[] = [];
@@ -244,7 +244,7 @@ const FilterBar: React.FC<FiltersBarProps> = ({
     if (dispatchAllowed) {
       clearDataMaskIds.forEach(id => dispatch(clearDataMask(id)));
     }
-  }, [dataMaskSelected, dispatch, filtersInScope, setDataMaskSelected]);
+  }, [JSON.stringify(dataMaskSelected), dispatch, filtersInScope, setDataMaskSelected]);
 
   useFilterUpdates(dataMaskSelected, setDataMaskSelected);
   const isApplyDisabled = checkIsApplyDisabled(

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -244,7 +244,12 @@ const FilterBar: React.FC<FiltersBarProps> = ({
     if (dispatchAllowed) {
       clearDataMaskIds.forEach(id => dispatch(clearDataMask(id)));
     }
-  }, [JSON.stringify(dataMaskSelected), dispatch, filtersInScope, setDataMaskSelected]);
+  }, [
+    JSON.stringify(dataMaskSelected),
+    dispatch,
+    filtersInScope,
+    setDataMaskSelected,
+  ]);
 
   useFilterUpdates(dataMaskSelected, setDataMaskSelected);
   const isApplyDisabled = checkIsApplyDisabled(

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -151,6 +151,7 @@ const FilterBar: React.FC<FiltersBarProps> = ({
   const [filtersInScope] = useSelectFiltersInScope(nativeFilterValues);
 
   const dataMaskSelectedRef = useRef(dataMaskSelected);
+  dataMaskSelectedRef.current = dataMaskSelected;
   const handleFilterSelectionChange = useCallback(
     (
       filter: Pick<Filter, 'id'> & Partial<Filter>,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -18,7 +18,13 @@
  */
 
 /* eslint-disable no-param-reassign */
-import React, { useEffect, useState, useCallback, createContext } from 'react';
+import React, {
+  useEffect,
+  useState,
+  useCallback,
+  createContext,
+  useRef,
+} from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   DataMaskStateWithId,
@@ -145,6 +151,8 @@ const FilterBar: React.FC<FiltersBarProps> = ({
 
   const [filtersInScope] = useSelectFiltersInScope(nativeFilterValues);
 
+  const dataMaskSelectedRef = useRef(dataMaskSelected);
+  // dataMaskSelectedRef.current = dataMaskSelected;
   const handleFilterSelectionChange = useCallback(
     (
       filter: Pick<Filter, 'id'> & Partial<Filter>,
@@ -155,19 +163,19 @@ const FilterBar: React.FC<FiltersBarProps> = ({
         if (
           // filterState.value === undefined - means that value not initialized
           dataMask.filterState?.value !== undefined &&
-          dataMaskSelected[filter.id]?.filterState?.value === undefined &&
+          dataMaskSelectedRef.current[filter.id]?.filterState?.value ===
+            undefined &&
           filter.requiredFirst
         ) {
           dispatch(updateDataMask(filter.id, dataMask));
         }
-
         draft[filter.id] = {
           ...(getInitialDataMask(filter.id) as DataMaskWithId),
           ...dataMask,
         };
       });
     },
-    [JSON.stringify(dataMaskSelected), dispatch, setDataMaskSelected],
+    [dispatch, setDataMaskSelected],
   );
 
   useEffect(() => {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -123,6 +123,7 @@ const FilterBar: React.FC<FiltersBarProps> = ({
   verticalConfig,
   hidden = false,
 }) => {
+  console.log('rerender');
   const history = useHistory();
   const dataMaskApplied: DataMaskStateWithId = useNativeFiltersDataMask();
   const [dataMaskSelected, setDataMaskSelected] =
@@ -222,7 +223,7 @@ const FilterBar: React.FC<FiltersBarProps> = ({
         dispatch(updateDataMask(filterId, dataMaskSelected[filterId]));
       }
     });
-  }, [JSON.stringify(dataMaskSelected), dispatch]);
+  }, [dataMaskSelected, dispatch]);
 
   const handleClearAll = useCallback(() => {
     const clearDataMaskIds: string[] = [];
@@ -244,12 +245,7 @@ const FilterBar: React.FC<FiltersBarProps> = ({
     if (dispatchAllowed) {
       clearDataMaskIds.forEach(id => dispatch(clearDataMask(id)));
     }
-  }, [
-    JSON.stringify(dataMaskSelected),
-    dispatch,
-    filtersInScope,
-    setDataMaskSelected,
-  ]);
+  }, [dataMaskSelected, dispatch, filtersInScope, setDataMaskSelected]);
 
   useFilterUpdates(dataMaskSelected, setDataMaskSelected);
   const isApplyDisabled = checkIsApplyDisabled(

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -151,7 +151,6 @@ const FilterBar: React.FC<FiltersBarProps> = ({
   const [filtersInScope] = useSelectFiltersInScope(nativeFilterValues);
 
   const dataMaskSelectedRef = useRef(dataMaskSelected);
-  // dataMaskSelectedRef.current = dataMaskSelected;
   const handleFilterSelectionChange = useCallback(
     (
       filter: Pick<Filter, 'id'> & Partial<Filter>,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -129,7 +129,6 @@ const FilterBar: React.FC<FiltersBarProps> = ({
   verticalConfig,
   hidden = false,
 }) => {
-  console.log('rerender');
   const history = useHistory();
   const dataMaskApplied: DataMaskStateWithId = useNativeFiltersDataMask();
   const [dataMaskSelected, setDataMaskSelected] =

--- a/superset-frontend/src/dataMask/reducer.ts
+++ b/superset-frontend/src/dataMask/reducer.ts
@@ -56,6 +56,7 @@ export function getInitialDataMask(
   }
   return {
     ...otherProps,
+    __cache: {},
     extraFormData: {},
     filterState: {},
     ownState: {},


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Currently, rendering 20+ filters takes not normal lot of time due to two issues:
1. The issue with the Select filter. After rendering, Select Filter adds the `__cache` key to the dataMask, and changing dataMask triggering a redraw of all filters again. This happens for each Select filter in sequence. This can be resolved by adding `__cache` to the default dataMask.
2. The issue with the `dataMaskSelected` in the hooks is that it is specified as an object, which always triggers a redraw. This can be resolved by setting `dataMaskSelected` to `JSON.stringify`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before
https://github.com/apache/superset/assets/66589759/4c3b4ff0-bb12-49eb-aa45-7ff1d8add39c

#### After
https://github.com/apache/superset/assets/66589759/db05070e-7dad-478f-a392-276a15848f63


### TESTING INSTRUCTIONS
1. Go to any dashboard
2. Add 30 select filters
3. Reload dashboard
4. See that filters take a lot of time for before render.
5 (optional). You can add console log to [FilterBarScrollContext](https://github.com/apache/superset/blob/master/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx#L120C1-L120C1) such as `console.log('rerendered filters bar!')` to see the number of times it logs.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
