### PR TITLE
fix: is_select with UNION

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -231,11 +231,8 @@ class ParsedQuery:
         """
 
         def is_body_select(body: dict[str, Any]) -> bool:
-            if "SetOperation" in body:
-                return is_body_select(body["SetOperation"]["left"]) and is_body_select(
-                    body["SetOperation"]["right"]
-                )
-
+            if op := body.get("SetOperation"):
+                return is_body_select(op["left"]) and is_body_select(op["right"])
             return all(key == "Select" for key in body.keys())
 
         for query in oxide_parse:

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -1623,3 +1623,13 @@ def test_is_select() -> None:
     Test `is_select`.
     """
     assert not ParsedQuery("SELECT 1; DROP DATABASE superset").is_select()
+    assert ParsedQuery(
+        "with base as(select id from table1 union all select id from table2) select * from base"
+    ).is_select()
+    assert ParsedQuery(
+        """
+WITH t AS (
+    SELECT 1 UNION ALL SELECT 2
+)
+SELECT * FROM t"""
+    ).is_select()


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Make sure `is_select` works with `UNION` when using sqloxide.

Fixes https://github.com/apache/superset/issues/25266 and https://github.com/apache/superset/issues/25278.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
