### PR TITLE
build(deps): bump redis version to match helm dependency chart and fix CVE-2022-24834 CVE-2021-32626

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -281,7 +281,7 @@ pyyaml==6.0.1
     # via
     #   apache-superset
     #   apispec
-redis==4.5.4
+redis==7.0.10
     # via apache-superset
 requests==2.31.0
     # via shillelagh


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Currently superset helm installation installs redis chart version 17.9.4 that installs redis version: 7.0.10, but superset installs version 4.x.x

that old version currently corrupting superset's container with 2 HIGH level vulnerabilities 
CVE-2022-24834 CVE-2021-32626


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
