### PR TITLE
feat: Adds CLI commands to execute viz migrations

### DIFF
--- a/superset/cli/viz_migrations.py
+++ b/superset/cli/viz_migrations.py
@@ -42,7 +42,7 @@ def viz_migrations() -> None:
     cls=RequiredMutuallyExclusiveOptionGroup,
 )
 @optgroup.option(
-    "--type",
+    "--viz_type",
     "-t",
     help=f"The viz type to migrate: {', '.join(list(VizTypes))}",
 )
@@ -58,7 +58,7 @@ def upgrade(viz_type: str) -> None:
     cls=RequiredMutuallyExclusiveOptionGroup,
 )
 @optgroup.option(
-    "--type",
+    "--viz_type",
     "-t",
     help=f"The viz type to migrate: {', '.join(list(VizTypes))}",
 )

--- a/superset/cli/viz_migrations.py
+++ b/superset/cli/viz_migrations.py
@@ -22,10 +22,10 @@ from flask.cli import with_appcontext
 
 
 class VizTypes(str, Enum):
-    treemap = "treemap"
-    dual_line = "dual_line"
-    area = "area"
-    pivot_table = "pivot_table"
+    TREEMAP = "treemap"
+    DUAL_LINE = "dual_line"
+    AREA = "area"
+    PIVOT_TABLE = "pivot_table"
 
 
 @click.group()
@@ -44,11 +44,11 @@ def viz_migrations() -> None:
 @optgroup.option(
     "--type",
     "-t",
-    help=f"The viz type to migrate: {', '.join([type for type in VizTypes])}",
+    help=f"The viz type to migrate: {', '.join(list(VizTypes))}",
 )
-def upgrade(type: str) -> None:
+def upgrade(viz_type: str) -> None:
     """Upgrade a viz to the latest version."""
-    migrate_viz(VizTypes(type))
+    migrate_viz(VizTypes(viz_type))
 
 
 @viz_migrations.command()
@@ -60,16 +60,16 @@ def upgrade(type: str) -> None:
 @optgroup.option(
     "--type",
     "-t",
-    help=f"The viz type to migrate: {', '.join([type for type in VizTypes])}",
+    help=f"The viz type to migrate: {', '.join(list(VizTypes))}",
 )
-def downgrade(type: str) -> None:
+def downgrade(viz_type: str) -> None:
     """Downgrades a viz to the previous version."""
-    migrate_viz(VizTypes(type), downgrade=True)
+    migrate_viz(VizTypes(viz_type), is_downgrade=True)
 
 
-def migrate_viz(type: VizTypes, downgrade: bool = False) -> None:
+def migrate_viz(viz_type: VizTypes, is_downgrade: bool = False) -> None:
     """Migrates a viz from one type to another."""
-    from superset.migrations.shared.migrate_viz.base import MigrateViz
+    # pylint: disable=import-outside-toplevel
     from superset.migrations.shared.migrate_viz.processors import (
         MigrateAreaChart,
         MigrateDualLine,
@@ -78,12 +78,12 @@ def migrate_viz(type: VizTypes, downgrade: bool = False) -> None:
     )
 
     migrations = {
-        VizTypes.treemap: MigrateTreeMap,
-        VizTypes.dual_line: MigrateDualLine,
-        VizTypes.area: MigrateAreaChart,
-        VizTypes.pivot_table: MigratePivotTable,
+        VizTypes.TREEMAP: MigrateTreeMap,
+        VizTypes.DUAL_LINE: MigrateDualLine,
+        VizTypes.AREA: MigrateAreaChart,
+        VizTypes.PIVOT_TABLE: MigratePivotTable,
     }
-    if downgrade:
-        migrations[type].downgrade()
+    if is_downgrade:
+        migrations[viz_type].downgrade()
     else:
-        migrations[type].upgrade()
+        migrations[viz_type].upgrade()

--- a/superset/cli/viz_migrations.py
+++ b/superset/cli/viz_migrations.py
@@ -20,6 +20,8 @@ import click
 from click_option_group import optgroup, RequiredMutuallyExclusiveOptionGroup
 from flask.cli import with_appcontext
 
+from superset import db
+
 
 class VizTypes(str, Enum):
     TREEMAP = "treemap"
@@ -84,6 +86,6 @@ def migrate_viz(viz_type: VizTypes, is_downgrade: bool = False) -> None:
         VizTypes.PIVOT_TABLE: MigratePivotTable,
     }
     if is_downgrade:
-        migrations[viz_type].downgrade()
+        migrations[viz_type].downgrade(db.session)
     else:
-        migrations[viz_type].upgrade()
+        migrations[viz_type].upgrade(db.session)

--- a/superset/cli/viz_migrations.py
+++ b/superset/cli/viz_migrations.py
@@ -23,7 +23,7 @@ from flask.cli import with_appcontext
 from superset import db
 
 
-class VizTypes(str, Enum):
+class VizType(str, Enum):
     TREEMAP = "treemap"
     DUAL_LINE = "dual_line"
     AREA = "area"
@@ -31,13 +31,13 @@ class VizTypes(str, Enum):
 
 
 @click.group()
-def viz_migrations() -> None:
+def migrate_viz() -> None:
     """
-    Migrates a viz from one type to another.
+    Migrate a viz from one type to another.
     """
 
 
-@viz_migrations.command()
+@migrate_viz.command()
 @with_appcontext
 @optgroup.group(
     "Grouped options",
@@ -46,14 +46,14 @@ def viz_migrations() -> None:
 @optgroup.option(
     "--viz_type",
     "-t",
-    help=f"The viz type to migrate: {', '.join(list(VizTypes))}",
+    help=f"The viz type to migrate: {', '.join(list(VizType))}",
 )
 def upgrade(viz_type: str) -> None:
     """Upgrade a viz to the latest version."""
-    migrate_viz(VizTypes(viz_type))
+    migrate(VizType(viz_type))
 
 
-@viz_migrations.command()
+@migrate_viz.command()
 @with_appcontext
 @optgroup.group(
     "Grouped options",
@@ -62,15 +62,15 @@ def upgrade(viz_type: str) -> None:
 @optgroup.option(
     "--viz_type",
     "-t",
-    help=f"The viz type to migrate: {', '.join(list(VizTypes))}",
+    help=f"The viz type to migrate: {', '.join(list(VizType))}",
 )
 def downgrade(viz_type: str) -> None:
-    """Downgrades a viz to the previous version."""
-    migrate_viz(VizTypes(viz_type), is_downgrade=True)
+    """Downgrade a viz to the previous version."""
+    migrate(VizType(viz_type), is_downgrade=True)
 
 
-def migrate_viz(viz_type: VizTypes, is_downgrade: bool = False) -> None:
-    """Migrates a viz from one type to another."""
+def migrate(viz_type: VizType, is_downgrade: bool = False) -> None:
+    """Migrate a viz from one type to another."""
     # pylint: disable=import-outside-toplevel
     from superset.migrations.shared.migrate_viz.processors import (
         MigrateAreaChart,
@@ -80,10 +80,10 @@ def migrate_viz(viz_type: VizTypes, is_downgrade: bool = False) -> None:
     )
 
     migrations = {
-        VizTypes.TREEMAP: MigrateTreeMap,
-        VizTypes.DUAL_LINE: MigrateDualLine,
-        VizTypes.AREA: MigrateAreaChart,
-        VizTypes.PIVOT_TABLE: MigratePivotTable,
+        VizType.TREEMAP: MigrateTreeMap,
+        VizType.DUAL_LINE: MigrateDualLine,
+        VizType.AREA: MigrateAreaChart,
+        VizType.PIVOT_TABLE: MigratePivotTable,
     }
     if is_downgrade:
         migrations[viz_type].downgrade(db.session)

--- a/superset/cli/viz_migrations.py
+++ b/superset/cli/viz_migrations.py
@@ -1,0 +1,89 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from enum import Enum
+
+import click
+from click_option_group import optgroup, RequiredMutuallyExclusiveOptionGroup
+from flask.cli import with_appcontext
+
+
+class VizTypes(str, Enum):
+    treemap = "treemap"
+    dual_line = "dual_line"
+    area = "area"
+    pivot_table = "pivot_table"
+
+
+@click.group()
+def viz_migrations() -> None:
+    """
+    Migrates a viz from one type to another.
+    """
+
+
+@viz_migrations.command()
+@with_appcontext
+@optgroup.group(
+    "Grouped options",
+    cls=RequiredMutuallyExclusiveOptionGroup,
+)
+@optgroup.option(
+    "--type",
+    "-t",
+    help=f"The viz type to migrate: {', '.join([type for type in VizTypes])}",
+)
+def upgrade(type: str) -> None:
+    """Upgrade a viz to the latest version."""
+    migrate_viz(VizTypes(type))
+
+
+@viz_migrations.command()
+@with_appcontext
+@optgroup.group(
+    "Grouped options",
+    cls=RequiredMutuallyExclusiveOptionGroup,
+)
+@optgroup.option(
+    "--type",
+    "-t",
+    help=f"The viz type to migrate: {', '.join([type for type in VizTypes])}",
+)
+def downgrade(type: str) -> None:
+    """Downgrades a viz to the previous version."""
+    migrate_viz(VizTypes(type), downgrade=True)
+
+
+def migrate_viz(type: VizTypes, downgrade: bool = False) -> None:
+    """Migrates a viz from one type to another."""
+    from superset.migrations.shared.migrate_viz.base import MigrateViz
+    from superset.migrations.shared.migrate_viz.processors import (
+        MigrateAreaChart,
+        MigrateDualLine,
+        MigratePivotTable,
+        MigrateTreeMap,
+    )
+
+    migrations = {
+        VizTypes.treemap: MigrateTreeMap,
+        VizTypes.dual_line: MigrateDualLine,
+        VizTypes.area: MigrateAreaChart,
+        VizTypes.pivot_table: MigratePivotTable,
+    }
+    if downgrade:
+        migrations[type].downgrade()
+    else:
+        migrations[type].upgrade()

--- a/superset/migrations/shared/migrate_viz/base.py
+++ b/superset/migrations/shared/migrate_viz/base.py
@@ -144,13 +144,7 @@ class MigrateViz:
     @classmethod
     def upgrade(cls) -> None:
         slices = db.session.query(Slice).filter(Slice.viz_type == cls.source_viz_type)
-        for slc in paginated_update(
-            query=slices,
-            print_page_progress=lambda current, total: print(
-                f"  Updating {current}/{total} charts", end="\r"
-            ),
-            session=db.session,
-        ):
+        for slc in slices:
             new_viz = cls.upgrade_slice(slc)
             db.session.merge(new_viz)
 
@@ -162,12 +156,6 @@ class MigrateViz:
                 Slice.params.like(f"%{FORM_DATA_BAK_FIELD_NAME}%"),
             )
         )
-        for slc in paginated_update(
-            query=slices,
-            print_page_progress=lambda current, total: print(
-                f"  Downgrading {current}/{total} charts", end="\r"
-            ),
-            session=db.session,
-        ):
+        for slc in slices:
             new_viz = cls.downgrade_slice(slc)
             db.session.merge(new_viz)

--- a/superset/migrations/shared/migrate_viz/base.py
+++ b/superset/migrations/shared/migrate_viz/base.py
@@ -20,12 +20,26 @@ import copy
 import json
 from typing import Any
 
-from sqlalchemy import and_
+from sqlalchemy import and_, Column, Integer, String, Text
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import Session
 
-from superset import conf, db, is_feature_enabled
+from superset import conf, is_feature_enabled
 from superset.constants import TimeGrain
 from superset.migrations.shared.utils import paginated_update, try_load_json
-from superset.models.slice import Slice
+
+Base = declarative_base()
+
+
+class Slice(Base):  # type: ignore
+    __tablename__ = "slices"
+
+    id = Column(Integer, primary_key=True)
+    slice_name = Column(String(250))
+    viz_type = Column(String(250))
+    params = Column(Text)
+    query_context = Column(Text)
+
 
 FORM_DATA_BAK_FIELD_NAME = "form_data_bak"
 
@@ -142,20 +156,30 @@ class MigrateViz:
         return slc
 
     @classmethod
-    def upgrade(cls) -> None:
-        slices = db.session.query(Slice).filter(Slice.viz_type == cls.source_viz_type)
-        for slc in slices:
+    def upgrade(cls, session: Session) -> None:
+        slices = session.query(Slice).filter(Slice.viz_type == cls.source_viz_type)
+        for slc in paginated_update(
+            slices,
+            lambda current, total: print(
+                f"  Updating {current}/{total} charts", end="\r"
+            ),
+        ):
             new_viz = cls.upgrade_slice(slc)
-            db.session.merge(new_viz)
+            session.merge(new_viz)
 
     @classmethod
-    def downgrade(cls) -> None:
-        slices = db.session.query(Slice).filter(
+    def downgrade(cls, session: Session) -> None:
+        slices = session.query(Slice).filter(
             and_(
                 Slice.viz_type == cls.target_viz_type,
                 Slice.params.like(f"%{FORM_DATA_BAK_FIELD_NAME}%"),
             )
         )
-        for slc in slices:
+        for slc in paginated_update(
+            slices,
+            lambda current, total: print(
+                f"  Downgrading {current}/{total} charts", end="\r"
+            ),
+        ):
             new_viz = cls.downgrade_slice(slc)
-            db.session.merge(new_viz)
+            session.merge(new_viz)

--- a/superset/migrations/shared/migrate_viz/base.py
+++ b/superset/migrations/shared/migrate_viz/base.py
@@ -145,10 +145,11 @@ class MigrateViz:
     def upgrade(cls) -> None:
         slices = db.session.query(Slice).filter(Slice.viz_type == cls.source_viz_type)
         for slc in paginated_update(
-            slices,
-            lambda current, total: print(
+            query=slices,
+            print_page_progress=lambda current, total: print(
                 f"  Updating {current}/{total} charts", end="\r"
             ),
+            session=db.session,
         ):
             new_viz = cls.upgrade_slice(slc)
             db.session.merge(new_viz)
@@ -162,10 +163,11 @@ class MigrateViz:
             )
         )
         for slc in paginated_update(
-            slices,
-            lambda current, total: print(
+            query=slices,
+            print_page_progress=lambda current, total: print(
                 f"  Downgrading {current}/{total} charts", end="\r"
             ),
+            session=db.session,
         ):
             new_viz = cls.downgrade_slice(slc)
             db.session.merge(new_viz)

--- a/superset/migrations/shared/utils.py
+++ b/superset/migrations/shared/utils.py
@@ -97,14 +97,17 @@ def paginated_update(
     query: Query,
     print_page_progress: Optional[Union[Callable[[int, int], None], bool]] = None,
     batch_size: int = DEFAULT_BATCH_SIZE,
+    session: Session = None,
 ) -> Iterator[Any]:
     """
     Update models in small batches so we don't have to load everything in memory.
     """
-
     total = query.count()
     processed = 0
-    session: Session = inspect(query).session
+
+    if not session:
+        session = inspect(query).session
+
     result = session.execute(query)
 
     if print_page_progress is None or print_page_progress is True:

--- a/superset/migrations/shared/utils.py
+++ b/superset/migrations/shared/utils.py
@@ -97,17 +97,14 @@ def paginated_update(
     query: Query,
     print_page_progress: Optional[Union[Callable[[int, int], None], bool]] = None,
     batch_size: int = DEFAULT_BATCH_SIZE,
-    session: Session = None,
 ) -> Iterator[Any]:
     """
     Update models in small batches so we don't have to load everything in memory.
     """
+
     total = query.count()
     processed = 0
-
-    if not session:
-        session = inspect(query).session
-
+    session: Session = inspect(query).session
     result = session.execute(query)
 
     if print_page_progress is None or print_page_progress is True:

--- a/superset/migrations/versions/2022-07-07_13-00_c747c78868b6_migrating_legacy_treemap.py
+++ b/superset/migrations/versions/2022-07-07_13-00_c747c78868b6_migrating_legacy_treemap.py
@@ -24,6 +24,7 @@ Create Date: 2022-06-30 22:04:17.686635
 from alembic import op
 from sqlalchemy.dialects.mysql.base import MySQLDialect
 
+from superset import db
 from superset.migrations.shared.migrate_viz import MigrateTreeMap
 
 # revision identifiers, used by Alembic.
@@ -32,16 +33,21 @@ down_revision = "cdcf3d64daf4"
 
 
 def upgrade():
+    bind = op.get_bind()
+
     # Ensure `slice.params` and `slice.query_context`` in MySQL is MEDIUMTEXT
     # before migration, as the migration will save a duplicate form_data backup
     # which may significantly increase the size of these fields.
-    if isinstance(op.get_bind().dialect, MySQLDialect):
+    if isinstance(bind.dialect, MySQLDialect):
         # If the columns are already MEDIUMTEXT, this is a no-op
         op.execute("ALTER TABLE slices MODIFY params MEDIUMTEXT")
         op.execute("ALTER TABLE slices MODIFY query_context MEDIUMTEXT")
 
-    MigrateTreeMap.upgrade()
+    session = db.Session(bind=bind)
+    MigrateTreeMap.upgrade(session)
 
 
 def downgrade():
-    MigrateTreeMap.downgrade()
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+    MigrateTreeMap.downgrade(session)

--- a/superset/migrations/versions/2022-07-07_14-00_06e1e70058c7_migrating_legacy_area.py
+++ b/superset/migrations/versions/2022-07-07_14-00_06e1e70058c7_migrating_legacy_area.py
@@ -21,6 +21,9 @@ Revises: c747c78868b6
 Create Date: 2022-06-13 14:17:51.872706
 
 """
+from alembic import op
+
+from superset import db
 from superset.migrations.shared.migrate_viz import MigrateAreaChart
 
 # revision identifiers, used by Alembic.
@@ -29,8 +32,12 @@ down_revision = "c747c78868b6"
 
 
 def upgrade():
-    MigrateAreaChart.upgrade()
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+    MigrateAreaChart.upgrade(session)
 
 
 def downgrade():
-    MigrateAreaChart.downgrade()
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+    MigrateAreaChart.downgrade(session)

--- a/superset/migrations/versions/2023-06-08_09-02_9ba2ce3086e5_migrate_pivot_table_v1_to_v2.py
+++ b/superset/migrations/versions/2023-06-08_09-02_9ba2ce3086e5_migrate_pivot_table_v1_to_v2.py
@@ -21,6 +21,9 @@ Revises: 4ea966691069
 Create Date: 2023-08-06 09:02:10.148992
 
 """
+from alembic import op
+
+from superset import db
 from superset.migrations.shared.migrate_viz import MigratePivotTable
 
 # revision identifiers, used by Alembic.
@@ -29,8 +32,12 @@ down_revision = "4ea966691069"
 
 
 def upgrade():
-    MigratePivotTable.upgrade()
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+    MigratePivotTable.upgrade(session)
 
 
 def downgrade():
-    MigratePivotTable.downgrade()
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+    MigratePivotTable.downgrade(session)

--- a/superset/migrations/versions/2023-06-08_10-22_4c5da39be729_migrate_treemap_chart.py
+++ b/superset/migrations/versions/2023-06-08_10-22_4c5da39be729_migrate_treemap_chart.py
@@ -24,6 +24,7 @@ Create Date: 2023-06-08 10:22:23.192064
 from alembic import op
 from sqlalchemy.dialects.mysql.base import MySQLDialect
 
+from superset import db
 from superset.migrations.shared.migrate_viz import MigrateTreeMap
 
 # revision identifiers, used by Alembic.
@@ -32,16 +33,21 @@ down_revision = "9ba2ce3086e5"
 
 
 def upgrade():
+    bind = op.get_bind()
+
     # Ensure `slice.params` and `slice.query_context`` in MySQL is MEDIUMTEXT
     # before migration, as the migration will save a duplicate form_data backup
     # which may significantly increase the size of these fields.
-    if isinstance(op.get_bind().dialect, MySQLDialect):
+    if isinstance(bind.dialect, MySQLDialect):
         # If the columns are already MEDIUMTEXT, this is a no-op
         op.execute("ALTER TABLE slices MODIFY params MEDIUMTEXT")
         op.execute("ALTER TABLE slices MODIFY query_context MEDIUMTEXT")
 
-    MigrateTreeMap.upgrade()
+    session = db.Session(bind=bind)
+    MigrateTreeMap.upgrade(session)
 
 
 def downgrade():
-    MigrateTreeMap.downgrade()
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+    MigrateTreeMap.downgrade(session)

--- a/superset/migrations/versions/2023-06-08_11-34_ae58e1e58e5c_migrate_dual_line_to_mixed_chart.py
+++ b/superset/migrations/versions/2023-06-08_11-34_ae58e1e58e5c_migrate_dual_line_to_mixed_chart.py
@@ -21,6 +21,9 @@ Revises: 4c5da39be729
 Create Date: 2023-06-08 11:34:36.241939
 
 """
+from alembic import op
+
+from superset import db
 
 # revision identifiers, used by Alembic.
 revision = "ae58e1e58e5c"
@@ -30,8 +33,12 @@ from superset.migrations.shared.migrate_viz.processors import MigrateDualLine
 
 
 def upgrade():
-    MigrateDualLine.upgrade()
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+    MigrateDualLine.upgrade(session)
 
 
 def downgrade():
-    MigrateDualLine.downgrade()
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+    MigrateDualLine.downgrade(session)


### PR DESCRIPTION
### SUMMARY
Adds a new CLI command called `viz-migrations` to allow users to migrate charts of a specific type. This command is particularly helpful to migrate visualizations to the latest version and at the same time disable their legacy versions with the [VIZ_TYPE_DENYLIST](https://github.com/apache/superset/blob/ec6191023263ac5f8292dd37f037805c3196e029/superset/config.py#L829) configuration.

```
Usage: superset viz-migrations [OPTIONS] COMMAND [ARGS]...

  Migrates a viz from one type to another.

Commands:
  downgrade  Downgrades a viz to the previous version.
  upgrade    Upgrade a viz to the latest version.

```

### TESTING INSTRUCTIONS
1 - Execute an upgrade of a particular viz type.
2 - Downgrade the previously upgraded viz type.
3 - Check the viz versions between these steps.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
