### PR TITLE
fix(sqllab): misplaced limit warning alert

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -301,7 +301,7 @@ const ResultSet = ({
     return <div />;
   };
 
-  const renderRowsReturned = () => {
+  const renderRowsReturned = (alertMessage: boolean) => {
     const { results, rows, queryLimit, limitingFactor } = query;
     let limitMessage = '';
     const limitReached = results?.displayLimitReached;
@@ -353,59 +353,70 @@ const ResultSet = ({
 
     const tooltipText = `${rowsReturnedMessage}. ${limitMessage}`;
 
+    if (alertMessage) {
+      return (
+        <>
+          {!limitReached && shouldUseDefaultDropdownAlert && (
+            <div ref={calculateAlertRefHeight}>
+              <Alert
+                type="warning"
+                message={t('%(rows)d rows returned', { rows })}
+                onClose={() => setAlertIsOpen(false)}
+                description={t(
+                  'The number of rows displayed is limited to %(rows)d by the dropdown.',
+                  { rows },
+                )}
+              />
+            </div>
+          )}
+          {limitReached && (
+            <div ref={calculateAlertRefHeight}>
+              <Alert
+                type="warning"
+                onClose={() => setAlertIsOpen(false)}
+                message={t('%(rows)d rows returned', { rows: rowsCount })}
+                description={
+                  isAdmin
+                    ? displayMaxRowsReachedMessage.withAdmin
+                    : displayMaxRowsReachedMessage.withoutAdmin
+                }
+              />
+            </div>
+          )}
+        </>
+      );
+    }
+    const showRowsReturned =
+      showSqlInline || (!limitReached && !shouldUseDefaultDropdownAlert);
+
     return (
-      <ReturnedRows>
-        {!limitReached && !shouldUseDefaultDropdownAlert && (
-          <Tooltip
-            id="sqllab-rowcount-tooltip"
-            title={tooltipText}
-            placement="left"
-          >
-            <Label
-              css={css`
-                line-height: ${theme.typography.sizes.l}px;
-              `}
+      <>
+        {showRowsReturned && (
+          <ReturnedRows>
+            <Tooltip
+              id="sqllab-rowcount-tooltip"
+              title={tooltipText}
+              placement="left"
             >
-              {limitMessage && (
-                <Icons.ExclamationCircleOutlined
-                  css={css`
-                    font-size: ${theme.typography.sizes.m}px;
-                    margin-right: ${theme.gridUnit}px;
-                  `}
-                />
-              )}
-              {tn('%s row', '%s rows', rows, formattedRowCount)}
-            </Label>
-          </Tooltip>
+              <Label
+                css={css`
+                  line-height: ${theme.typography.sizes.l}px;
+                `}
+              >
+                {limitMessage && (
+                  <Icons.ExclamationCircleOutlined
+                    css={css`
+                      font-size: ${theme.typography.sizes.m}px;
+                      margin-right: ${theme.gridUnit}px;
+                    `}
+                  />
+                )}
+                {tn('%s row', '%s rows', rows, formattedRowCount)}
+              </Label>
+            </Tooltip>
+          </ReturnedRows>
         )}
-        {!limitReached && shouldUseDefaultDropdownAlert && (
-          <div ref={calculateAlertRefHeight}>
-            <Alert
-              type="warning"
-              message={t('%(rows)d rows returned', { rows })}
-              onClose={() => setAlertIsOpen(false)}
-              description={t(
-                'The number of rows displayed is limited to %(rows)d by the dropdown.',
-                { rows },
-              )}
-            />
-          </div>
-        )}
-        {limitReached && (
-          <div ref={calculateAlertRefHeight}>
-            <Alert
-              type="warning"
-              onClose={() => setAlertIsOpen(false)}
-              message={t('%(rows)d rows returned', { rows: rowsCount })}
-              description={
-                isAdmin
-                  ? displayMaxRowsReachedMessage.withAdmin
-                  : displayMaxRowsReachedMessage.withoutAdmin
-              }
-            />
-          </div>
-        )}
-      </ReturnedRows>
+      </>
     );
   };
 
@@ -531,35 +542,39 @@ const ResultSet = ({
         <ResultContainer>
           {renderControls()}
           {showSql && showSqlInline ? (
-            <div
-              css={css`
-                display: flex;
-                justify-content: space-between;
-                gap: ${GAP}px;
-              `}
-            >
-              <Card
-                css={[
-                  css`
-                    height: 28px;
-                    width: calc(100% - ${ROWS_CHIP_WIDTH + GAP}px);
-                    code {
-                      width: 100%;
-                      overflow: hidden;
-                      white-space: nowrap !important;
-                      text-overflow: ellipsis;
-                      display: block;
-                    }
-                  `,
-                ]}
+            <>
+              <div
+                css={css`
+                  display: flex;
+                  justify-content: space-between;
+                  gap: ${GAP}px;
+                `}
               >
-                {sql}
-              </Card>
-              {renderRowsReturned()}
-            </div>
+                <Card
+                  css={[
+                    css`
+                      height: 28px;
+                      width: calc(100% - ${ROWS_CHIP_WIDTH + GAP}px);
+                      code {
+                        width: 100%;
+                        overflow: hidden;
+                        white-space: nowrap !important;
+                        text-overflow: ellipsis;
+                        display: block;
+                      }
+                    `,
+                  ]}
+                >
+                  {sql}
+                </Card>
+                {renderRowsReturned(false)}
+              </div>
+              {renderRowsReturned(true)}
+            </>
           ) : (
             <>
-              {renderRowsReturned()}
+              {renderRowsReturned(false)}
+              {renderRowsReturned(true)}
               {sql}
             </>
           )}

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -637,7 +637,11 @@ export default function sqlLabReducer(state = {}, action) {
             // when it started fetching or finished rendering results
             state:
               currentState === QueryState.SUCCESS &&
-              [QueryState.FETCHING, QueryState.SUCCESS].includes(prevState)
+              [
+                QueryState.FETCHING,
+                QueryState.SUCCESS,
+                QueryState.RUNNING,
+              ].includes(prevState)
                 ? prevState
                 : currentState,
           };


### PR DESCRIPTION
### SUMMARY
Hotfix for #25288

This commit fixes the displaced limit warning alert in the query result.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

|After|Before|
|--|--|
|![Screenshot 2023-09-14 at 11 14 24 AM](https://github.com/apache/superset/assets/1392866/c1e78da6-c059-435c-a17a-7364addd9a2b)|![Notification_Center](https://github.com/apache/superset/assets/1392866/aad66873-3380-4e95-a677-c4d227e67cba)|

### TESTING INSTRUCTIONS
1. Go to sql, run query without selecting the limit or set limit in query
2. Run query
3. Observe the the result section
4. See the yellow banner is to the right side of the query

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
