### PR TITLE
fix(sqllab): invalid persisted tab state

### DIFF
--- a/superset/sqllab/utils.py
+++ b/superset/sqllab/utils.py
@@ -79,19 +79,8 @@ def write_ipc_buffer(table: pa.Table) -> pa.Buffer:
 
 
 def bootstrap_sqllab_data(user_id: int | None) -> dict[str, Any]:
-    # send list of tab state ids
-    tabs_state = (
-        db.session.query(TabState.id, TabState.label).filter_by(user_id=user_id).all()
-    )
-    tab_state_ids = [str(tab_state[0]) for tab_state in tabs_state]
-    # return first active tab, or fallback to another one if no tab is active
-    active_tab = (
-        db.session.query(TabState)
-        .filter_by(user_id=user_id)
-        .order_by(TabState.active.desc())
-        .first()
-    )
-
+    tabs_state: list[Any] = []
+    active_tab: Any = None
     databases: dict[int, Any] = {}
     for database in DatabaseDAO.find_all():
         databases[database.id] = {
@@ -102,6 +91,20 @@ def bootstrap_sqllab_data(user_id: int | None) -> dict[str, Any]:
 
     # These are unnecessary if sqllab backend persistence is disabled
     if is_feature_enabled("SQLLAB_BACKEND_PERSISTENCE"):
+        # send list of tab state ids
+        tabs_state = (
+            db.session.query(TabState.id, TabState.label)
+            .filter_by(user_id=user_id)
+            .all()
+        )
+        tab_state_ids = [str(tab_state[0]) for tab_state in tabs_state]
+        # return first active tab, or fallback to another one if no tab is active
+        active_tab = (
+            db.session.query(TabState)
+            .filter_by(user_id=user_id)
+            .order_by(TabState.active.desc())
+            .first()
+        )
         # return all user queries associated with existing SQL editors
         user_queries = (
             db.session.query(Query)

--- a/tests/integration_tests/sql_lab/api_tests.py
+++ b/tests/integration_tests/sql_lab/api_tests.py
@@ -52,6 +52,22 @@ class TestSqlLabApi(SupersetTestCase):
     )
     def test_get_from_empty_bootsrap_data(self):
         self.login(username="gamma_sqllab_no_data")
+        resp = self.client.get("/api/v1/sqllab/")
+        assert resp.status_code == 200
+        data = json.loads(resp.data.decode("utf-8"))
+        result = data.get("result")
+        assert result["active_tab"] == None
+        assert result["queries"] == {}
+        assert result["tab_state_ids"] == []
+        self.assertEqual(len(result["databases"]), 0)
+
+    @mock.patch.dict(
+        "superset.extensions.feature_flag_manager._feature_flags",
+        {"SQLLAB_BACKEND_PERSISTENCE": False},
+        clear=True,
+    )
+    def test_get_from_bootstrap_data_for_non_persisted_tab_state(self):
+        self.login("admin")
         # create a tab
         data = {
             "queryEditor": json.dumps(

--- a/tests/integration_tests/sql_lab/api_tests.py
+++ b/tests/integration_tests/sql_lab/api_tests.py
@@ -52,6 +52,20 @@ class TestSqlLabApi(SupersetTestCase):
     )
     def test_get_from_empty_bootsrap_data(self):
         self.login(username="gamma_sqllab_no_data")
+        # create a tab
+        data = {
+            "queryEditor": json.dumps(
+                {
+                    "title": "Untitled Query 1",
+                    "dbId": 1,
+                    "schema": None,
+                    "autorun": False,
+                    "sql": "SELECT ...",
+                    "queryLimit": 1000,
+                }
+            )
+        }
+        self.get_json_resp("/tabstateview/", data=data)
         resp = self.client.get("/api/v1/sqllab/")
         assert resp.status_code == 200
         data = json.loads(resp.data.decode("utf-8"))

--- a/tests/integration_tests/sql_lab/api_tests.py
+++ b/tests/integration_tests/sql_lab/api_tests.py
@@ -89,7 +89,6 @@ class TestSqlLabApi(SupersetTestCase):
         assert result["active_tab"] == None
         assert result["queries"] == {}
         assert result["tab_state_ids"] == []
-        self.assertEqual(len(result["databases"]), 0)
 
     @mock.patch.dict(
         "superset.extensions.feature_flag_manager._feature_flags",


### PR DESCRIPTION
### SUMMARY
Fixes #25289

When PERSISTENCE_MODE sets back to false and the user has the previous persisted data, SQL Lab continuously propagates the previous persisted query editor data to NON persistence mode.

This commit updates the initial state logic to skip the persist data on non persistence mode.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

|After|Before|
|--|--|
|![Screenshot 2023-09-14 at 1 31 03 PM](https://github.com/apache/superset/assets/1392866/bca8ef1c-55d0-4bbc-92b7-d4dfb5fd5b03)|![Google Chrome - Superset 2023-09-13 at 3 41 20 PM](https://github.com/apache/superset/assets/105950525/44023d7d-2250-4be0-b138-e074b68f8e1b)|

### TESTING INSTRUCTIONS

1. Go to Sqllab, open a few tabs and run queries
2. Close all the tabs
3. Refresh page
4. See error

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
