### PR TITLE
docs: add snowflake-sqlalchemy in ./docker/requirements-local.txt 

### DIFF
--- a/docs/docs/databases/snowflake.mdx
+++ b/docs/docs/databases/snowflake.mdx
@@ -7,6 +7,18 @@ version: 1
 
 ## Snowflake
 
+If running Superset using Docker Compose, add the following to your `./docker/requirements-local.txt` file:
+
+```
+snowflake-sqlalchemy==version
+```
+
+example, If version is 1.5.0, then add the following to your `./docker/requirements-local.txt` file:
+
+```
+snowflake-sqlalchemy==1.5.0
+```
+
 The recommended connector library for Snowflake is
 [snowflake-sqlalchemy](https://pypi.org/project/snowflake-sqlalchemy/).
 

--- a/docs/docs/databases/snowflake.mdx
+++ b/docs/docs/databases/snowflake.mdx
@@ -7,7 +7,7 @@ version: 1
 
 ## Snowflake
 
-### Install BigQuery Driver
+### Install Snowflake Driver
 
 Follow the steps [here](/docs/databases/docker-add-drivers) about how to
 install new database drivers when setting up Superset locally via docker-compose.

--- a/docs/docs/databases/snowflake.mdx
+++ b/docs/docs/databases/snowflake.mdx
@@ -7,16 +7,13 @@ version: 1
 
 ## Snowflake
 
-If running Superset using Docker Compose, add the following to your `./docker/requirements-local.txt` file:
+### Install BigQuery Driver
+
+Follow the steps [here](/docs/databases/docker-add-drivers) about how to
+install new database drivers when setting up Superset locally via docker-compose.
 
 ```
-snowflake-sqlalchemy==version
-```
-
-example, If version is 1.5.0, then add the following to your `./docker/requirements-local.txt` file:
-
-```
-snowflake-sqlalchemy==1.5.0
+echo "snowflake-sqlalchemy" >> ./docker/requirements-local.txt
 ```
 
 The recommended connector library for Snowflake is


### PR DESCRIPTION
If using Docker Compose to run Superset, the snowflake-sqlalchemy library should be added to the./docker/requirements-local.txt file for Superset to recognise the Snowflake database connector.

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
