### PR TITLE
chore: bump gunicorn to v21

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -134,7 +134,7 @@ greenlet==2.0.2
     # via
     #   shillelagh
     #   sqlalchemy
-gunicorn==20.1.0
+gunicorn==21.2.0
     # via apache-superset
 hashids==1.3.1
     # via apache-superset

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
         "flask-wtf>=1.1.0, <2.0",
         "func_timeout",
         "geopy",
-        "gunicorn>=20.1.0; sys_platform != 'win32'",
+        "gunicorn>=21.2.0, <22.0; sys_platform != 'win32'",
         "hashids>=1.3.1, <2",
         "holidays>=0.23, <0.24",
         "humanize",


### PR DESCRIPTION
### SUMMARY
Gunicorn 21 fixes a few nasty bugs I ran into, namely:
- A deadlock that can choke workers: https://github.com/benoitc/gunicorn/issues/2917
- An annoying error that can be seen on logs sometimes: `ValueError: count must be a positive integer (got 0)`: https://github.com/benoitc/gunicorn/pull/2773

The latest patch release has been out for a few months now, and seems to work well based on my testing. Also, v 21 adds Support for Python 3.11 which we are mostly supporting now, and want to officially support soon.

The full changelog: https://docs.gunicorn.org/en/latest/news.html

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
