### PR TITLE
fix: Add explicit ON DELETE CASCADE for dashboard_roles

### DIFF
--- a/superset/migrations/versions/2023-08-09_15-39_4448fa6deeb1__dd_on_delete_cascade_for_embedded_dashboards.py.py
+++ b/superset/migrations/versions/2023-08-09_15-39_4448fa6deeb1__dd_on_delete_cascade_for_embedded_dashboards.py.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""add on delete cascade for embedded dashboards
+"""add on delete cascade for embedded_dashboards
 
 Revision ID: 4448fa6deeb1
 Revises: 8ace289026f3

--- a/superset/migrations/versions/2023-09-15_12-58_4b85906e5b91_add_on_delete_cascade_for_dashboard_roles.py
+++ b/superset/migrations/versions/2023-09-15_12-58_4b85906e5b91_add_on_delete_cascade_for_dashboard_roles.py
@@ -14,32 +14,32 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""add on delete cascade for dashboard_slices
+"""add on delete cascade for dashboard_roles
 
-Revision ID: 8ace289026f3
-Revises: 2e826adca42c
-Create Date: 2023-08-09 14:17:53.326191
+Revision ID: 4b85906e5b91
+Revises: 317970b4400c
+Create Date: 2023-09-15 12:58:26.772759
 
 """
 
 # revision identifiers, used by Alembic.
-revision = "8ace289026f3"
-down_revision = "2e826adca42c"
+revision = "4b85906e5b91"
+down_revision = "317970b4400c"
 
 
 from superset.migrations.shared.constraints import ForeignKey, redefine
 
 foreign_keys = [
     ForeignKey(
-        table="dashboard_slices",
+        table="dashboard_roles",
         referent_table="dashboards",
         local_cols=["dashboard_id"],
         remote_cols=["id"],
     ),
     ForeignKey(
-        table="dashboard_slices",
-        referent_table="slices",
-        local_cols=["slice_id"],
+        table="dashboard_roles",
+        referent_table="ab_role",
+        local_cols=["role_id"],
         remote_cols=["id"],
     ),
 ]

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -127,8 +127,20 @@ DashboardRoles = Table(
     "dashboard_roles",
     metadata,
     Column("id", Integer, primary_key=True),
-    Column("dashboard_id", Integer, ForeignKey("dashboards.id"), nullable=False),
-    Column("role_id", Integer, ForeignKey("ab_role.id"), nullable=False),
+    Column(
+        "dashboard_id",
+        Integer,
+        ForeignKey("dashboards.id"),
+        nullable=False,
+        on_delete="CASCADE",
+    ),
+    Column(
+        "role_id",
+        Integer,
+        ForeignKey("ab_role.id"),
+        nullable=False,
+        on_delete="CASCADE",
+    ),
 )
 
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Fixes https://github.com/apache/superset/issues/25305. See https://github.com/apache/superset/pull/24628 for more details.

I'm somewhat perplexes as to why the [test_cannot_get_draft_dashboard_with_roles_by_uuid](https://github.com/apache/superset/blob/06c0a5bba9c6c09ed8d0aba4616b33d46be18c77/tests/integration_tests/dashboards/security/security_rbac_tests.py#L424-L442) test didn't surface said issue, i.e., deleting a dashboard with a role associated with it. Note that the [`insert_dashboard`](https://github.com/apache/superset/blob/06c0a5bba9c6c09ed8d0aba4616b33d46be18c77/tests/integration_tests/base_tests.py#L480-L520) method does flush (and commit) to the dashboard.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/25305
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
