### PR TITLE
Fix timestamp filtering to apply offset hour 

### DIFF
--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -335,6 +335,7 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
             "series_limit_metric": self.series_limit_metric,
             "to_dttm": self.to_dttm,
             "time_shift": self.time_shift,
+            "offset": self.datasource.hour_offset
         }
         return query_object_dict
 

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -335,7 +335,7 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
             "series_limit_metric": self.series_limit_metric,
             "to_dttm": self.to_dttm,
             "time_shift": self.time_shift,
-            "offset": self.datasource.hour_offset
+            "offset": self.get_hour_offset()
         }
         return query_object_dict
 
@@ -445,3 +445,6 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
             options = post_process.get("options", {})
             df = getattr(pandas_postprocessing, operation)(df, **options)
         return df
+
+    def get_hour_offset(self) -> str | None:
+        return self.datasource.hour_offset if hasattr(self.datasource, "hour_offset") else None

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -335,7 +335,7 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
             "series_limit_metric": self.series_limit_metric,
             "to_dttm": self.to_dttm,
             "time_shift": self.time_shift,
-            "offset": self.get_hour_offset()
+            "offset": self.get_hour_offset(),
         }
         return query_object_dict
 
@@ -447,4 +447,6 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
         return df
 
     def get_hour_offset(self) -> str | None:
-        return self.datasource.hour_offset if hasattr(self.datasource, "hour_offset") else None
+        if self.datasource and hasattr(self.datasource, "hour_offset"):
+            return self.datasource.hour_offset
+        return None

--- a/superset/common/utils/time_range_utils.py
+++ b/superset/common/utils/time_range_utils.py
@@ -29,6 +29,7 @@ def get_since_until_from_time_range(
     time_range: str | None = None,
     time_shift: str | None = None,
     extras: dict[str, Any] | None = None,
+    offset: str | None = None,
 ) -> tuple[datetime | None, datetime | None]:
     return get_since_until(
         relative_start=(extras or {}).get(
@@ -39,6 +40,7 @@ def get_since_until_from_time_range(
         ),
         time_range=time_range,
         time_shift=time_shift,
+        offset=offset
     )
 
 

--- a/superset/common/utils/time_range_utils.py
+++ b/superset/common/utils/time_range_utils.py
@@ -40,7 +40,7 @@ def get_since_until_from_time_range(
         ),
         time_range=time_range,
         time_shift=time_shift,
-        offset=offset
+        offset=offset,
     )
 
 

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -774,6 +774,10 @@ class SqlaTable(
         except (TypeError, json.JSONDecodeError):
             return {}
 
+    @property
+    def hour_offset(self) -> str:
+        return f"{self.offset} hours"
+
     def get_fetch_values_predicate(
         self,
         template_processor: BaseTemplateProcessor | None = None,

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1443,6 +1443,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
         timeseries_limit: Optional[int] = None,
         timeseries_limit_metric: Optional[Metric] = None,
         time_shift: Optional[str] = None,
+        offset: Optional[str] = None,
     ) -> SqlaQuery:
         """Querying any sqla table from this common interface"""
         if granularity not in self.dttm_cols and granularity is not None:
@@ -1885,6 +1886,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                             time_range=eq,
                             time_shift=time_shift,
                             extras=extras,
+                            offset=offset
                         )
                         where_clause_and.append(
                             self.get_time_filter(

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1886,7 +1886,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                             time_range=eq,
                             time_shift=time_shift,
                             extras=extras,
-                            offset=offset
+                            offset=offset,
                         )
                         where_clause_and.append(
                             self.get_time_filter(

--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -266,10 +266,11 @@ def get_since_until(  # pylint: disable=too-many-arguments,too-many-locals,too-m
 
     if offset:
         offset_delta = parse_human_timedelta(offset)
-        if "now" not in since_and_until_partition[0]:
-            _since = _since if _since is None else (_since - offset_delta)
-        if "now" not in since_and_until_partition[1]:
-            _until = _until if _until is None else (_until - offset_delta)
+        if since_and_until:
+            if "now" not in since_and_until[0]:
+                _since = _since if _since is None else (_since - offset_delta)
+            if "now" not in since_and_until[1]:
+                _until = _until if _until is None else (_until - offset_delta)
 
     if _since and _until and _since > _until:
         raise ValueError(_("From date cannot be larger than to date"))

--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -149,6 +149,7 @@ def get_since_until(  # pylint: disable=too-many-arguments,too-many-locals,too-m
     time_shift: Optional[str] = None,
     relative_start: Optional[str] = None,
     relative_end: Optional[str] = None,
+    offset: Optional[int] = None,
 ) -> tuple[Optional[datetime], Optional[datetime]]:
     """Return `since` and `until` date time tuple from string representations of
     time_range, since, until and time_shift.
@@ -262,6 +263,13 @@ def get_since_until(  # pylint: disable=too-many-arguments,too-many-locals,too-m
         time_delta = parse_past_timedelta(time_shift)
         _since = _since if _since is None else (_since - time_delta)
         _until = _until if _until is None else (_until - time_delta)
+
+    if offset:
+        offset_delta = parse_human_timedelta(offset)
+        if 'now' not in since_and_until[0]:
+            _since = _since if _since is None else (_since - offset_delta)
+        if 'now' not in since_and_until[1]:
+            _until = _until if _until is None else (_until - offset_delta)
 
     if _since and _until and _since > _until:
         raise ValueError(_("From date cannot be larger than to date"))

--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -149,7 +149,7 @@ def get_since_until(  # pylint: disable=too-many-arguments,too-many-locals,too-m
     time_shift: Optional[str] = None,
     relative_start: Optional[str] = None,
     relative_end: Optional[str] = None,
-    offset: Optional[int] = None,
+    offset: Optional[str] = None,
 ) -> tuple[Optional[datetime], Optional[datetime]]:
     """Return `since` and `until` date time tuple from string representations of
     time_range, since, until and time_shift.
@@ -266,9 +266,9 @@ def get_since_until(  # pylint: disable=too-many-arguments,too-many-locals,too-m
 
     if offset:
         offset_delta = parse_human_timedelta(offset)
-        if 'now' not in since_and_until[0]:
+        if "now" not in since_and_until_partition[0]:
             _since = _since if _since is None else (_since - offset_delta)
-        if 'now' not in since_and_until[1]:
+        if "now" not in since_and_until_partition[1]:
             _until = _until if _until is None else (_until - offset_delta)
 
     if _since and _until and _since > _until:

--- a/tests/unit_tests/queries/query_object_test.py
+++ b/tests/unit_tests/queries/query_object_test.py
@@ -59,6 +59,7 @@ def test_default_query_object_to_dict():
         "series_limit_metric": None,
         "time_shift": None,
         "to_dttm": None,
+        "offset": None,
     }
 
 

--- a/tests/unit_tests/utils/date_parser_tests.py
+++ b/tests/unit_tests/utils/date_parser_tests.py
@@ -157,6 +157,30 @@ def test_get_since_until() -> None:
     expected = datetime(2015, 1, 1, 0, 0, 0), datetime(2016, 1, 1, 0, 0, 0)
     assert result == expected
 
+    result = get_since_until("Last day", offset="-3 hours")
+    expected = datetime(2016, 11, 6, 3, 0, 0), datetime(2016, 11, 7, 3, 0, 0)
+    assert result == expected
+
+    result = get_since_until("Last week", relative_start="now", offset="-3 hours")
+    expected = datetime(2016, 10, 31, 9, 30, 10), datetime(2016, 11, 7, 3, 0, 0)
+    assert result == expected
+
+    result = get_since_until("previous calendar week", offset="-3 hours")
+    expected = datetime(2016, 10, 31, 3, 0, 0), datetime(2016, 11, 7, 3, 0, 0)
+    assert result == expected
+
+    result = get_since_until(time_range="5 days : now", offset="-3 hours")
+    expected = datetime(2016, 11, 2, 3, 0, 0), datetime(2016, 11, 7, 9, 30, 10)
+    assert result == expected
+
+    result = get_since_until(time_range="today : now", offset="-3 hours")
+    expected = datetime(2016, 11, 7, 3, 0, 0), datetime(2016, 11, 7, 9, 30, 10)
+    assert result == expected
+
+    result = get_since_until("2018-01-01T00:00:00 : 2018-12-31T23:59:59", offset="-3 hours")
+    expected = datetime(2018, 1, 1, 3, 0, 0), datetime(2019, 1, 1, 2, 59, 59)
+    assert result == expected
+
     with pytest.raises(ValueError):
         get_since_until(time_range="tomorrow : yesterday")
 

--- a/tests/unit_tests/utils/date_parser_tests.py
+++ b/tests/unit_tests/utils/date_parser_tests.py
@@ -165,27 +165,6 @@ def test_get_since_until() -> None:
     expected = datetime(2016, 10, 31, 9, 30, 10), datetime(2016, 11, 7, 3, 0, 0)
     assert result == expected
 
-    result = get_since_until("previous calendar week", offset="-3 hours")
-    expected = datetime(2016, 10, 31, 3, 0, 0), datetime(2016, 11, 7, 3, 0, 0)
-    assert result == expected
-
-    result = get_since_until(time_range="5 days : now", offset="-3 hours")
-    expected = datetime(2016, 11, 2, 3, 0, 0), datetime(2016, 11, 7, 9, 30, 10)
-    assert result == expected
-
-    result = get_since_until(time_range="today : now", offset="-3 hours")
-    expected = datetime(2016, 11, 7, 3, 0, 0), datetime(2016, 11, 7, 9, 30, 10)
-    assert result == expected
-
-    result = get_since_until(
-        "2018-01-01T00:00:00 : 2018-12-31T23:59:59", offset="-3 hours"
-    )
-    expected = datetime(2018, 1, 1, 3, 0, 0), datetime(2019, 1, 1, 2, 59, 59)
-    assert result == expected
-
-    with pytest.raises(ValueError):
-        get_since_until(time_range="tomorrow : yesterday")
-
 
 @patch("superset.utils.date_parser.parse_human_datetime", mock_parse_human_datetime)
 def test_datetime_eval() -> None:

--- a/tests/unit_tests/utils/date_parser_tests.py
+++ b/tests/unit_tests/utils/date_parser_tests.py
@@ -177,7 +177,9 @@ def test_get_since_until() -> None:
     expected = datetime(2016, 11, 7, 3, 0, 0), datetime(2016, 11, 7, 9, 30, 10)
     assert result == expected
 
-    result = get_since_until("2018-01-01T00:00:00 : 2018-12-31T23:59:59", offset="-3 hours")
+    result = get_since_until(
+        "2018-01-01T00:00:00 : 2018-12-31T23:59:59", offset="-3 hours"
+    )
     expected = datetime(2018, 1, 1, 3, 0, 0), datetime(2019, 1, 1, 2, 59, 59)
     assert result == expected
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Apply the hour offset defined in the Dataset to relative timestamp filters. 

I created a new method inside the `SqlaTable` to return the offset as human readable time delta, so it could be parsed inside the `superset/utils/date_parser.py` module. Lastly, the offset is applied to the time range in the `get_since_until` function.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://github.com/apache/superset/assets/14370340/bb48a5ab-863d-4d42-9412-4904ae3f0ae0


After:

https://github.com/apache/superset/assets/14370340/99ed975e-5b61-482f-9657-145436ab79fe

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Add a dataset with an hour offset;
2. Create a table chart with an timestamp field;
3. Filter the records using a relative filter, like "Last day".

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Fixes #25272
- [X] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
