### PR TITLE
feat: Adds Sunburst chart migration logic

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-sunburst/src/Sunburst.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-sunburst/src/Sunburst.js
@@ -82,7 +82,8 @@ function buildHierarchy(rows) {
     let currentNode = root;
     for (let level = 0; level < levels.length; level += 1) {
       const children = currentNode.children || [];
-      const nodeName = levels[level].toString();
+      const node = levels[level];
+      const nodeName = node ? node.toString() : t('N/A');
       // If the next node has the name '0', it will
       const isLeafNode = level >= levels.length - 1 || levels[level + 1] === 0;
       let childNode;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
@@ -32,7 +32,7 @@ import {
 } from '@superset-ui/core';
 import { EChartsCoreOption } from 'echarts';
 import { CallbackDataParams } from 'echarts/types/src/util/types';
-import { OpacityEnum } from '../constants';
+import { NULL_STRING, OpacityEnum } from '../constants';
 import { defaultGrid } from '../defaults';
 import { Refs } from '../types';
 import { formatSeriesName, getColtypesMapping } from '../utils/series';
@@ -138,7 +138,10 @@ export function formatTooltip({
       color: ${theme.colors.grayscale.base}"
      >`,
     `<div style="font-weight: ${theme.typography.weights.bold}">
-      ${node.name}
+      ${(node.name || NULL_STRING)
+        .toString()
+        .replace('<', '&lt;')
+        .replace('>', '&gt;')}
      </div>`,
     `<div">
       ${absolutePercentage} of total

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
@@ -140,8 +140,8 @@ export function formatTooltip({
     `<div style="font-weight: ${theme.typography.weights.bold}">
       ${(node.name || NULL_STRING)
         .toString()
-        .replace('<', '&lt;')
-        .replace('>', '&gt;')}
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')}
      </div>`,
     `<div">
       ${absolutePercentage} of total

--- a/superset/cli/viz_migrations.py
+++ b/superset/cli/viz_migrations.py
@@ -28,6 +28,7 @@ class VizType(str, Enum):
     DUAL_LINE = "dual_line"
     AREA = "area"
     PIVOT_TABLE = "pivot_table"
+    SUNBURST = "sunburst"
 
 
 @click.group()
@@ -76,6 +77,7 @@ def migrate(viz_type: VizType, is_downgrade: bool = False) -> None:
         MigrateAreaChart,
         MigrateDualLine,
         MigratePivotTable,
+        MigrateSunburst,
         MigrateTreeMap,
     )
 
@@ -84,6 +86,7 @@ def migrate(viz_type: VizType, is_downgrade: bool = False) -> None:
         VizType.DUAL_LINE: MigrateDualLine,
         VizType.AREA: MigrateAreaChart,
         VizType.PIVOT_TABLE: MigratePivotTable,
+        VizType.SUNBURST: MigrateSunburst,
     }
     if is_downgrade:
         migrations[viz_type].downgrade(db.session)

--- a/superset/migrations/shared/migrate_viz/processors.py
+++ b/superset/migrations/shared/migrate_viz/processors.py
@@ -125,3 +125,9 @@ class MigrateDualLine(MigrateViz):
     def _migrate_temporal_filter(self, rv_data: dict[str, Any]) -> None:
         super()._migrate_temporal_filter(rv_data)
         rv_data["adhoc_filters_b"] = rv_data.get("adhoc_filters") or []
+
+
+class MigrateSunburst(MigrateViz):
+    source_viz_type = "sunburst"
+    target_viz_type = "sunburst_v2"
+    rename_keys = {"groupby": "columns"}


### PR DESCRIPTION
### SUMMARY
This PR adds the Sunburst chart migration logic (D3 ➡️ ECharts). Users can execute this migration using the https://github.com/apache/superset/pull/25304 CLI command and disable the legacy version with the [VIZ_TYPE_DENYLIST](https://github.com/apache/superset/blob/ec6191023263ac5f8292dd37f037805c3196e029/superset/config.py#L829) configuration.

@sadpandajoe @jinghua-qa

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1341" alt="Screenshot 2023-09-19 at 14 47 47" src="https://github.com/apache/superset/assets/70410625/7dbe218d-806f-42f2-8c19-13fd71b8adae">
<img width="1341" alt="Screenshot 2023-09-19 at 14 48 30" src="https://github.com/apache/superset/assets/70410625/1c9e58fe-95c0-4ca8-881f-338a3d45fc86">

### TESTING INSTRUCTIONS
1 - Upgrade a Sunburst chart using the CLI command
2 - Check the new chart
3 - Downgrade a Sunburst chart using the CLI command
4 - Check the legacy chart

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
