### PR TITLE
feat(sqllab): Format sql

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -1036,7 +1036,6 @@ export function queryEditorSetSql(queryEditor, sql) {
 export function formatQuery(queryEditor) {
   return function (dispatch, getState) {
     const { sql } = getUpToDateQuery(getState(), queryEditor);
-
     return SupersetClient.post({
       endpoint: `/api/v1/sqllab/format/`,
       body: JSON.stringify({ sql }),

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -1037,7 +1037,7 @@ export function formatQuery(queryEditor) {
   return function (dispatch, getState) {
     const { sql } = getUpToDateQuery(getState(), queryEditor);
     return SupersetClient.post({
-      endpoint: `/api/v1/sqllab/format/`,
+      endpoint: `/api/v1/sqllab/format_sql/`,
       body: JSON.stringify({ sql }),
       headers: { 'Content-Type': 'application/json' },
     }).then(({ json }) => {

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -1033,6 +1033,20 @@ export function queryEditorSetSql(queryEditor, sql) {
   return { type: QUERY_EDITOR_SET_SQL, queryEditor, sql };
 }
 
+export function formatQuery(queryEditor) {
+  return function (dispatch, getState) {
+    const { sql } = getUpToDateQuery(getState(), queryEditor);
+
+    return SupersetClient.post({
+      endpoint: `/api/v1/sqllab/format/`,
+      body: JSON.stringify({ sql }),
+      headers: { 'Content-Type': 'application/json' },
+    }).then(({ json }) => {
+      dispatch(queryEditorSetSql(queryEditor, json.result));
+    });
+  };
+}
+
 export function queryEditorSetAndSaveSql(targetQueryEditor, sql) {
   return function (dispatch, getState) {
     const queryEditor = getUpToDateQuery(getState(), targetQueryEditor);

--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.js
@@ -22,6 +22,7 @@ import fetchMock from 'fetch-mock';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import shortid from 'shortid';
+import { waitFor } from '@testing-library/react';
 import * as uiCore from '@superset-ui/core';
 import * as actions from 'src/SqlLab/actions/sqlLab';
 import { LOG_EVENT } from 'src/logger/actions';
@@ -124,6 +125,22 @@ describe('async actions', () => {
           expectedActionTypes,
         );
       });
+    });
+  });
+
+  describe('formatQuery', () => {
+    const formatQueryEndpoint = 'glob:*/api/v1/sqllab/format/';
+    const expectedSql = 'SELECT 1';
+    fetchMock.post(formatQueryEndpoint, { result: expectedSql });
+
+    test('posts to the correct url', async () => {
+      const store = mockStore(initialState);
+      store.dispatch(actions.formatQuery(query, queryId));
+      await waitFor(() =>
+        expect(fetchMock.calls(formatQueryEndpoint)).toHaveLength(1),
+      );
+      expect(store.getActions()[0].type).toBe(actions.QUERY_EDITOR_SET_SQL);
+      expect(store.getActions()[0].sql).toBe(expectedSql);
     });
   });
 

--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.js
@@ -129,7 +129,7 @@ describe('async actions', () => {
   });
 
   describe('formatQuery', () => {
-    const formatQueryEndpoint = 'glob:*/api/v1/sqllab/format/';
+    const formatQueryEndpoint = 'glob:*/api/v1/sqllab/format_sql/';
     const expectedSql = 'SELECT 1';
     fetchMock.post(formatQueryEndpoint, { result: expectedSql });
 

--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/index.tsx
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/index.tsx
@@ -146,8 +146,10 @@ const AceEditorWrapper = ({
   };
 
   const onChangeText = (text: string) => {
-    setSql(text);
-    onChange(text);
+    if (text !== sql) {
+      setSql(text);
+      onChange(text);
+    }
   };
 
   const { data: annotations } = useAnnotations({

--- a/superset-frontend/src/SqlLab/components/KeyboardShortcutButton/index.tsx
+++ b/superset-frontend/src/SqlLab/components/KeyboardShortcutButton/index.tsx
@@ -37,6 +37,7 @@ export enum KeyboardShortcut {
   CMD_OPT_F = 'cmd+opt+f',
   CTRL_F = 'ctrl+f',
   CTRL_H = 'ctrl+h',
+  CTRL_SHIFT_F = 'ctrl+shift+f',
 }
 
 export const KEY_MAP = {
@@ -49,6 +50,7 @@ export const KEY_MAP = {
   [KeyboardShortcut.CTRL_Q]: userOS === 'Windows' ? t('New tab') : undefined,
   [KeyboardShortcut.CTRL_T]: userOS !== 'Windows' ? t('New tab') : undefined,
   [KeyboardShortcut.CTRL_P]: t('Previous Line'),
+  [KeyboardShortcut.CTRL_SHIFT_F]: t('Format SQL'),
   // default ace editor shortcuts
   [KeyboardShortcut.CMD_F]: userOS === 'MacOS' ? t('Find') : undefined,
   [KeyboardShortcut.CTRL_F]: userOS !== 'MacOS' ? t('Find') : undefined,

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
@@ -72,6 +72,7 @@ import {
   scheduleQuery,
   setActiveSouthPaneTab,
   updateSavedQuery,
+  formatQuery,
 } from 'src/SqlLab/actions/sqlLab';
 import {
   STATE_TYPE_MAP,
@@ -92,6 +93,7 @@ import {
 } from 'src/utils/localStorageHelpers';
 import { EmptyStateBig } from 'src/components/EmptyState';
 import getBootstrapData from 'src/utils/getBootstrapData';
+import Badge from 'src/components/Badge';
 import { isEmpty } from 'lodash';
 import TemplateParamsEditor from '../TemplateParamsEditor';
 import SouthPane from '../SouthPane';
@@ -230,6 +232,8 @@ const elementStyle = (
   }px)`,
 });
 
+const KEYBOARD_SHORTCUT_FOR_FORMAT = 'ctrl+shift+f';
+
 const SqlEditor: React.FC<Props> = ({
   tables,
   queryEditor,
@@ -304,6 +308,10 @@ const SqlEditor: React.FC<Props> = ({
     },
     [ctas, database, defaultQueryLimit, dispatch, queryEditor],
   );
+
+  const formatCurrentQuery = useCallback(() => {
+    dispatch(formatQuery(queryEditor));
+  }, [dispatch, queryEditor]);
 
   const stopQuery = useCallback(() => {
     if (latestQuery && ['running', 'pending'].indexOf(latestQuery.state) >= 0) {
@@ -384,8 +392,16 @@ const SqlEditor: React.FC<Props> = ({
             }),
         func: stopQuery,
       },
+      {
+        name: 'formatQuery',
+        key: KEYBOARD_SHORTCUT_FOR_FORMAT,
+        descr: t('Format query'),
+        func: () => {
+          formatCurrentQuery();
+        },
+      },
     ];
-  }, [dispatch, queryEditor.sql, startQuery, stopQuery]);
+  }, [dispatch, queryEditor.sql, startQuery, stopQuery, formatCurrentQuery]);
 
   const hotkeys = useMemo(() => {
     // Get all hotkeys including ace editor hotkeys
@@ -602,7 +618,7 @@ const SqlEditor: React.FC<Props> = ({
       ? t('Schedule the query periodically')
       : t('You must run the query successfully first');
     return (
-      <Menu css={{ width: theme.gridUnit * 44 }}>
+      <Menu css={{ width: theme.gridUnit * 50 }}>
         <Menu.Item css={{ display: 'flex', justifyContent: 'space-between' }}>
           {' '}
           <span>{t('Autocomplete')}</span>{' '}
@@ -622,6 +638,17 @@ const SqlEditor: React.FC<Props> = ({
             />
           </Menu.Item>
         )}
+        <Menu.Item
+          onClick={formatCurrentQuery}
+          css={{ display: 'flex', justifyContent: 'space-between' }}
+        >
+          <span>{t('Format SQL')}</span>
+          <Badge
+            count={KEYBOARD_SHORTCUT_FOR_FORMAT}
+            color={theme.colors.grayscale.light2}
+            textColor={theme.colors.grayscale.dark1}
+          />
+        </Menu.Item>
         {!isEmpty(scheduledQueriesConf) && (
           <Menu.Item>
             <ScheduleQueryButton

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
@@ -93,7 +93,6 @@ import {
 } from 'src/utils/localStorageHelpers';
 import { EmptyStateBig } from 'src/components/EmptyState';
 import getBootstrapData from 'src/utils/getBootstrapData';
-import Badge from 'src/components/Badge';
 import { isEmpty } from 'lodash';
 import TemplateParamsEditor from '../TemplateParamsEditor';
 import SouthPane from '../SouthPane';
@@ -231,8 +230,6 @@ const elementStyle = (
     gutterSize + SQL_EDITOR_GUTTER_MARGIN
   }px)`,
 });
-
-const KEYBOARD_SHORTCUT_FOR_FORMAT = 'ctrl+shift+f';
 
 const SqlEditor: React.FC<Props> = ({
   tables,
@@ -394,8 +391,8 @@ const SqlEditor: React.FC<Props> = ({
       },
       {
         name: 'formatQuery',
-        key: KEYBOARD_SHORTCUT_FOR_FORMAT,
-        descr: t('Format query'),
+        key: KeyboardShortcut.CTRL_SHIFT_F,
+        descr: KEY_MAP[KeyboardShortcut.CTRL_SHIFT_F],
         func: () => {
           formatCurrentQuery();
         },
@@ -638,17 +635,7 @@ const SqlEditor: React.FC<Props> = ({
             />
           </Menu.Item>
         )}
-        <Menu.Item
-          onClick={formatCurrentQuery}
-          css={{ display: 'flex', justifyContent: 'space-between' }}
-        >
-          <span>{t('Format SQL')}</span>
-          <Badge
-            count={KEYBOARD_SHORTCUT_FOR_FORMAT}
-            color={theme.colors.grayscale.light2}
-            textColor={theme.colors.grayscale.dark1}
-          />
-        </Menu.Item>
+        <Menu.Item onClick={formatCurrentQuery}>{t('Format SQL')}</Menu.Item>
         {!isEmpty(scheduledQueriesConf) && (
           <Menu.Item>
             <ScheduleQueryButton

--- a/superset/sqllab/api.py
+++ b/superset/sqllab/api.py
@@ -231,7 +231,7 @@ class SqlLabRestApi(BaseSupersetApi):
         try:
             model = self.format_model_schema.load(request.json)
             result = sqlparse.format(
-                model.get("sql", ""), reindent=True, keyword_case="upper"
+                model["sql"], reindent=True, keyword_case="upper"
             )
             return self.response(200, result=result)
         except ValidationError as error:

--- a/superset/sqllab/api.py
+++ b/superset/sqllab/api.py
@@ -189,7 +189,7 @@ class SqlLabRestApi(BaseSupersetApi):
         result = command.run()
         return self.response(200, result=result)
 
-    @expose("/format/", methods=("POST",))
+    @expose("/format_sql/", methods=("POST",))
     @statsd_metrics
     @protect()
     @permission_name("read")
@@ -197,7 +197,7 @@ class SqlLabRestApi(BaseSupersetApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}" f".format",
         log_to_statsd=False,
     )
-    def format(self) -> FlaskResponse:
+    def format_sql(self) -> FlaskResponse:
         """Format the SQL query.
         ---
         post:

--- a/superset/sqllab/api.py
+++ b/superset/sqllab/api.py
@@ -208,7 +208,7 @@ class SqlLabRestApi(BaseSupersetApi):
             content:
               application/json:
                 schema:
-                  $ref: '#/components/schemas/EstimateQueryCostSchema'
+                  $ref: '#/components/schemas/FormatQueryPayloadSchema'
           responses:
             200:
               description: Format SQL result
@@ -230,12 +230,12 @@ class SqlLabRestApi(BaseSupersetApi):
         """
         try:
             model = self.format_model_schema.load(request.json)
+            result = sqlparse.format(
+                model.get("sql", ""), reindent=True, keyword_case="upper"
+            )
+            return self.response(200, result=result)
         except ValidationError as error:
             return self.response_400(message=error.messages)
-        result = sqlparse.format(
-            model.get("sql", ""), reindent=True, keyword_case="upper"
-        )
-        return self.response(200, result=result)
 
     @expose("/export/<string:client_id>/")
     @protect()

--- a/superset/sqllab/api.py
+++ b/superset/sqllab/api.py
@@ -230,9 +230,7 @@ class SqlLabRestApi(BaseSupersetApi):
         """
         try:
             model = self.format_model_schema.load(request.json)
-            result = sqlparse.format(
-                model["sql"], reindent=True, keyword_case="upper"
-            )
+            result = sqlparse.format(model["sql"], reindent=True, keyword_case="upper")
             return self.response(200, result=result)
         except ValidationError as error:
             return self.response_400(message=error.messages)

--- a/superset/sqllab/api.py
+++ b/superset/sqllab/api.py
@@ -198,6 +198,36 @@ class SqlLabRestApi(BaseSupersetApi):
         log_to_statsd=False,
     )
     def format(self) -> FlaskResponse:
+        """Format the SQL query.
+        ---
+        post:
+          summary: Format SQL code
+          requestBody:
+            description: SQL query
+            required: true
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/EstimateQueryCostSchema'
+          responses:
+            200:
+              description: Format SQL result
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      result:
+                        type: string
+            400:
+              $ref: '#/components/responses/400'
+            401:
+              $ref: '#/components/responses/401'
+            403:
+              $ref: '#/components/responses/403'
+            500:
+              $ref: '#/components/responses/500'
+        """
         try:
             model = self.format_model_schema.load(request.json)
         except ValidationError as error:

--- a/superset/sqllab/schemas.py
+++ b/superset/sqllab/schemas.py
@@ -42,6 +42,10 @@ class EstimateQueryCostSchema(Schema):
     )
 
 
+class FormatQueryPayloadSchema(Schema):
+    sql = fields.String(required=True)
+
+
 class ExecutePayloadSchema(Schema):
     database_id = fields.Integer(required=True)
     sql = fields.String(required=True)

--- a/tests/integration_tests/sql_lab/api_tests.py
+++ b/tests/integration_tests/sql_lab/api_tests.py
@@ -223,6 +223,19 @@ class TestSqlLabApi(SupersetTestCase):
         self.assertDictEqual(resp_data, success_resp)
         self.assertEqual(rv.status_code, 200)
 
+    def test_format_sql_request(self):
+        self.login()
+
+        data = {"sql": "select 1 from my_table"}
+        rv = self.client.post(
+            "/api/v1/sqllab/format/",
+            json=data,
+        )
+        success_resp = {"result": "SELECT 1\nFROM my_table"}
+        resp_data = json.loads(rv.data.decode("utf-8"))
+        self.assertDictEqual(resp_data, success_resp)
+        self.assertEqual(rv.status_code, 200)
+
     @mock.patch("superset.sqllab.commands.results.results_backend_use_msgpack", False)
     def test_execute_required_params(self):
         self.login()

--- a/tests/integration_tests/sql_lab/api_tests.py
+++ b/tests/integration_tests/sql_lab/api_tests.py
@@ -228,7 +228,7 @@ class TestSqlLabApi(SupersetTestCase):
 
         data = {"sql": "select 1 from my_table"}
         rv = self.client.post(
-            "/api/v1/sqllab/format/",
+            "/api/v1/sqllab/format_sql/",
             json=data,
         )
         success_resp = {"result": "SELECT 1\nFROM my_table"}


### PR DESCRIPTION
### SUMMARY
This commit adds "Format SQL" feature in sql editor which helps to format sql code in the sql editor.
This commit also adds a new shortcut (ctrl + shift + f) for this feature.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://github.com/apache/superset/assets/1392866/24a54a46-5b2c-494f-9c46-cfbf8f30a193

### TESTING INSTRUCTIONS
Go to SQL Lab and type a long-run sql
Hit Ctrl + Shift + f or click "Format SQL" in the action dropdown
Check the formatted sql

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
