### PR TITLE
fix: DashboardRoles cascade operation

### DIFF
--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -130,16 +130,14 @@ DashboardRoles = Table(
     Column(
         "dashboard_id",
         Integer,
-        ForeignKey("dashboards.id"),
+        ForeignKey("dashboards.id", on_delete="CASCADE"),
         nullable=False,
-        on_delete="CASCADE",
     ),
     Column(
         "role_id",
         Integer,
-        ForeignKey("ab_role.id"),
+        ForeignKey("ab_role.id", on_delete="CASCADE"),
         nullable=False,
-        on_delete="CASCADE",
     ),
 )
 


### PR DESCRIPTION
### SUMMARY
Follow-up of https://github.com/apache/superset/pull/25320 to apply the `CASCADE` on the foreign key instead of the column.

### TESTING INSTRUCTIONS
CI should be sufficient.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
