### PR TITLE
fix: fill NaN Values in cumsum function

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -229,7 +229,7 @@ class BaseViz:  # pylint: disable=too-many-public-methods
             elif rolling_type == "sum":
                 df = df.rolling(**kwargs).sum()
         elif rolling_type == "cumsum":
-            df = df.cumsum()
+            df = df.fillna(0).cumsum()
         if min_periods:
             df = df[min_periods:]
         if df.empty:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fill NaN Values before applying the cumsum function, to make the resulting lines continues.
Fixes https://github.com/apache/superset/issues/21093

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
