### PR TITLE
fix: Update correct version tag for 3.0.0 in Chart.yaml

### DIFF
--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 apiVersion: v2
-appVersion: "3.0"
+appVersion: "3.0.0"
 description: Apache Superset is a modern, enterprise-ready business intelligence web application
 name: superset
 icon: https://artifacthub.io/image/68c1d717-0e97-491f-b046-754e46f46922@2x


### PR DESCRIPTION
<!---

fix(helm version): helm version based on image tag 3.0.0
-->

### SUMMARY
It has incorrect default tag, that is making pods to crash. updating to 3.0.0 fixes the issue
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
