### PR TITLE
fix: Unable to sync columns when database or dataset name contains `+`

### DIFF
--- a/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
@@ -762,9 +762,7 @@ class DatasourceEditor extends React.PureComponent {
       database_name:
         datasource.database.database_name || datasource.database.name,
       schema_name: datasource.schema,
-      table_name: datasource.table_name
-        ? encodeURIComponent(datasource.table_name)
-        : datasource.table_name,
+      table_name: datasource.table_name,
       normalize_columns: datasource.normalize_columns,
       always_filter_main_dttm: datasource.always_filter_main_dttm,
     };
@@ -774,7 +772,7 @@ class DatasourceEditor extends React.PureComponent {
         params[key] = null;
       }
     });
-    const endpoint = `/datasource/external_metadata_by_name/?q=${rison.encode(
+    const endpoint = `/datasource/external_metadata_by_name/?q=${rison.encode_uri(
       params,
     )}`;
     this.setState({ metadataLoading: true });

--- a/superset-frontend/src/components/Datasource/DatasourceEditor.test.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceEditor.test.jsx
@@ -75,7 +75,7 @@ describe('DatasourceEditor', () => {
       setTimeout(() => {
         expect(fetchMock.calls(DATASOURCE_ENDPOINT)).toHaveLength(1);
         expect(fetchMock.calls(DATASOURCE_ENDPOINT)[0][0]).toContain(
-          'Vehicle%20Sales%20%2B%27',
+          'Vehicle+Sales%20%2B',
         );
         fetchMock.reset();
         done();


### PR DESCRIPTION
The `sync cloumns from source` use the api endpoint `/datasource/external_metadata_by_name/?q={rison}`.
If the databse_name or table_name contains special character, the API cannot correctly parse the values.
Because the query string encoding in frontend is incomplete.


### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Create a database naming 'Test (UTC+0)'.
2. Create a dataset.
3. Edit the dataset and nav to `columns`.
4. Click on `SYNC COLUMNS FROM SOURCE`.
5. Will alert the error 'Dataset does not exist'.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
