### PR TITLE
fix(sqllab): invalid persisted tab state (#25308)

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1025,21 +1025,8 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
     @staticmethod
     def _get_sqllab_tabs(user_id: int | None) -> dict[str, Any]:
-        # send list of tab state ids
-        tabs_state = (
-            db.session.query(TabState.id, TabState.label)
-            .filter_by(user_id=user_id)
-            .all()
-        )
-        tab_state_ids = [str(tab_state[0]) for tab_state in tabs_state]
-        # return first active tab, or fallback to another one if no tab is active
-        active_tab = (
-            db.session.query(TabState)
-            .filter_by(user_id=user_id)
-            .order_by(TabState.active.desc())
-            .first()
-        )
-
+        tabs_state: list[Any] = []
+        active_tab: Any = None
         databases: dict[int, Any] = {}
         for database in DatabaseDAO.find_all():
             databases[database.id] = {
@@ -1050,6 +1037,20 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
         # These are unnecessary if sqllab backend persistence is disabled
         if is_feature_enabled("SQLLAB_BACKEND_PERSISTENCE"):
+            # send list of tab state ids
+            tabs_state = (
+                db.session.query(TabState.id, TabState.label)
+                .filter_by(user_id=user_id)
+                .all()
+            )
+            tab_state_ids = [str(tab_state[0]) for tab_state in tabs_state]
+            # return first active tab, or fallback to another one if no tab is active
+            active_tab = (
+                db.session.query(TabState)
+                .filter_by(user_id=user_id)
+                .order_by(TabState.active.desc())
+                .first()
+            )
             # return all user queries associated with existing SQL editors
             user_queries = (
                 db.session.query(Query)

--- a/tests/integration_tests/core_tests.py
+++ b/tests/integration_tests/core_tests.py
@@ -1093,6 +1093,33 @@ class TestCore(SupersetTestCase, InsertChartMixin):
 
     @mock.patch.dict(
         "superset.extensions.feature_flag_manager._feature_flags",
+        {"SQLLAB_BACKEND_PERSISTENCE": False},
+        clear=True,
+    )
+    def test_get_from_bootstrap_data_for_non_persisted_tab_state(self):
+        username = "admin"
+        self.login(username)
+        user_id = security_manager.find_user(username).id
+        # create a tab
+        data = {
+            "queryEditor": json.dumps(
+                {
+                    "title": "Untitled Query 1",
+                    "dbId": 1,
+                    "schema": None,
+                    "autorun": False,
+                    "sql": "SELECT ...",
+                    "queryLimit": 1000,
+                }
+            )
+        }
+
+        payload = views.Superset._get_sqllab_tabs(user_id=user_id)
+        self.assertEqual(len(payload["queries"]), 0)
+        self.assertEqual(len(payload["tab_state_ids"]), 0)
+
+    @mock.patch.dict(
+        "superset.extensions.feature_flag_manager._feature_flags",
         {"SQLLAB_BACKEND_PERSISTENCE": True},
         clear=True,
     )


### PR DESCRIPTION
### SUMMARY
This PR is cherry-picking of #25308 for 3.0

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
