### PR TITLE
fix(RLS): Fix Info Tooltip + Button Alignment on RLS Modal

### DIFF
--- a/superset-frontend/src/features/rls/RowLevelSecurityModal.tsx
+++ b/superset-frontend/src/features/rls/RowLevelSecurityModal.tsx
@@ -39,10 +39,13 @@ import { FilterType, RLSObject, RoleObject, TableObject } from './types';
 
 const StyledModal = styled(Modal)`
   max-width: 1200px;
-  min-width: 352px;
+  min-width: min-content;
   width: 100%;
   .ant-modal-body {
     overflow: initial;
+  }
+  .ant-modal-footer {
+    white-space: nowrap;
   }
 `;
 const StyledIcon = (theme: SupersetTheme) => css`

--- a/superset-frontend/src/features/rls/RowLevelSecurityModal.tsx
+++ b/superset-frontend/src/features/rls/RowLevelSecurityModal.tsx
@@ -39,6 +39,7 @@ import { FilterType, RLSObject, RoleObject, TableObject } from './types';
 
 const StyledModal = styled(Modal)`
   max-width: 1200px;
+  min-width: 352px;
   width: 100%;
   .ant-modal-body {
     overflow: initial;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added a min-width to the Add Rule Modal, so the button alignment stays intact.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![Screen Shot 2023-07-28 at 11 16 41 AM](https://github.com/apache/superset/assets/11916151/6bb52115-c4c7-43b2-ab50-f8913fc64003)
After:
![Screenshot 2023-09-25 152515](https://github.com/apache/superset/assets/11916151/ce166fe8-01ac-4c12-ad32-b9ea11884aa4)
