### PR TITLE
fix: smarter date formatter

### DIFF
--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -17,6 +17,9 @@
  * under the License.
  */
 
+// timezone for unit tests
+process.env.TZ = 'America/New_York';
+
 module.exports = {
   testRegex:
     '\\/superset-frontend\\/(spec|src|plugins|packages|tools)\\/.*(_spec|\\.test)\\.[jt]sx?$',

--- a/superset-frontend/packages/superset-ui-core/src/time-format/formatters/finestTemporalGrain.test.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-format/formatters/finestTemporalGrain.test.ts
@@ -21,16 +21,43 @@ import finestTemporalGrain from './finestTemporalGrain';
 
 test('finestTemporalGrain', () => {
   const monthFormatter = finestTemporalGrain([
-    1041379200000, // 2003-01-01 00:00:00Z
-    1044057600000, // 2003-02-01 00:00:00Z
+    new Date('2003-01-01 00:00:00Z').getTime(),
+    new Date('2003-02-01 00:00:00Z').getTime(),
   ]);
-  expect(monthFormatter(1041379200000)).toBe('2003-01-01');
-  expect(monthFormatter(1044057600000)).toBe('2003-02-01');
+  expect(monthFormatter(new Date('2003-01-01 00:00:00Z').getTime())).toBe(
+    '2003-01-01',
+  );
+  expect(monthFormatter(new Date('2003-02-01 00:00:00Z').getTime())).toBe(
+    '2003-02-01',
+  );
 
   const yearFormatter = finestTemporalGrain([
-    1041379200000, // 2003-01-01 00:00:00Z
-    1072915200000, // 2004-01-01 00:00:00Z
+    new Date('2003-01-01 00:00:00Z').getTime(),
+    new Date('2004-01-01 00:00:00Z').getTime(),
   ]);
-  expect(yearFormatter(1041379200000)).toBe('2003');
-  expect(yearFormatter(1072915200000)).toBe('2004');
+  expect(yearFormatter(new Date('2003-01-01 00:00:00Z').getTime())).toBe(
+    '2003',
+  );
+  expect(yearFormatter(new Date('2004-01-01 00:00:00Z').getTime())).toBe(
+    '2004',
+  );
+
+  const milliSecondFormatter = finestTemporalGrain([
+    new Date('2003-01-01 00:00:00Z').getTime(),
+    new Date('2003-04-05 06:07:08.123Z').getTime(),
+  ]);
+  expect(milliSecondFormatter(new Date('2003-01-01 00:00:00Z').getTime())).toBe(
+    '2003-01-01 00:00:00.000',
+  );
+
+  const localTimeFormatter = finestTemporalGrain(
+    [
+      new Date('2003-01-01 00:00:00Z').getTime(),
+      new Date('2003-02-01 00:00:00Z').getTime(),
+    ],
+    true,
+  );
+  expect(localTimeFormatter(new Date('2003-01-01 00:00:00Z').getTime())).toBe(
+    '2002-12-31 19:00',
+  );
 });

--- a/superset-frontend/packages/superset-ui-core/src/time-format/formatters/finestTemporalGrain.test.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-format/formatters/finestTemporalGrain.test.ts
@@ -20,10 +20,17 @@
 import finestTemporalGrain from './finestTemporalGrain';
 
 test('finestTemporalGrain', () => {
-  const formatter = finestTemporalGrain([
-    1041379200000, // 2023-01-01 00:00:00
-    1044057600000, // 2023-02-01 00:00:00
+  const monthFormatter = finestTemporalGrain([
+    1041379200000, // 2003-01-01 00:00:00Z
+    1044057600000, // 2003-02-01 00:00:00Z
   ]);
-  expect(formatter(1041379200000)).toBe('2003-01-01');
-  expect(formatter(1044057600000)).toBe('2003-02-01');
+  expect(monthFormatter(1041379200000)).toBe('2003-01-01');
+  expect(monthFormatter(1044057600000)).toBe('2003-02-01');
+
+  const yearFormatter = finestTemporalGrain([
+    1041379200000, // 2003-01-01 00:00:00Z
+    1072915200000, // 2004-01-01 00:00:00Z
+  ]);
+  expect(yearFormatter(1041379200000)).toBe('2003');
+  expect(yearFormatter(1072915200000)).toBe('2004');
 });

--- a/superset-frontend/packages/superset-ui-core/src/time-format/formatters/finestTemporalGrain.test.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-format/formatters/finestTemporalGrain.test.ts
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0,
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import finestTemporalGrain from './finestTemporalGrain';
+
+test('finestTemporalGrain', () => {
+  const formatter = finestTemporalGrain([
+    1041379200000, // 2023-01-01 00:00:00
+    1044057600000, // 2023-02-01 00:00:00
+  ]);
+  expect(formatter(1041379200000)).toBe('2003-01-01');
+  expect(formatter(1044057600000)).toBe('2003-02-01');
+});

--- a/superset-frontend/packages/superset-ui-core/src/time-format/formatters/finestTemporalGrain.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-format/formatters/finestTemporalGrain.ts
@@ -21,6 +21,9 @@ import { utcFormat, timeFormat } from 'd3-time-format';
 import { utcUtils, localTimeUtils } from '../utils/d3Time';
 import TimeFormatter from '../TimeFormatter';
 
+/*
+ * A formatter that examines all the values, and uses the finest temporal grain.
+ */
 export default function finestTemporalGrain(
   values: any[],
   useLocalTime = false,

--- a/superset-frontend/packages/superset-ui-core/src/time-format/formatters/finestTemporalGrain.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-format/formatters/finestTemporalGrain.ts
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { utcFormat, timeFormat } from 'd3-time-format';
+import { utcUtils, localTimeUtils } from '../utils/d3Time';
+import TimeFormatter from '../TimeFormatter';
+
+export default function finestTemporalGrain(
+  values: any[],
+  useLocalTime = false,
+) {
+  const format = useLocalTime ? timeFormat : utcFormat;
+
+  const formatMillisecond = format('%Y-%m-%d %H:%M:%S.%L');
+  const formatSecond = format('%Y-%m-%d %H:%M:%S');
+  const formatMinute = format('%Y-%m-%d %H:%M');
+  const formatHour = format('%Y-%m-%d %H:%M');
+  const formatDay = format('%Y-%m-%d');
+  const formatMonth = format('%Y-%m-%d');
+  const formatYear = format('%Y');
+
+  const {
+    hasMillisecond,
+    hasSecond,
+    hasMinute,
+    hasHour,
+    isNotFirstDayOfMonth,
+    isNotFirstMonth,
+  } = useLocalTime ? localTimeUtils : utcUtils;
+
+  let formatFunc = formatYear;
+  values.forEach((value: any) => {
+    if (formatFunc === formatYear && isNotFirstMonth(value)) {
+      formatFunc = formatMonth;
+    }
+    if (formatFunc === formatMonth && isNotFirstDayOfMonth(value)) {
+      formatFunc = formatDay;
+    }
+    if (formatFunc === formatDay && hasHour(value)) {
+      formatFunc = formatHour;
+    }
+    if (formatFunc === formatHour && hasMinute(value)) {
+      formatFunc = formatMinute;
+    }
+    if (formatFunc === formatMinute && hasSecond(value)) {
+      formatFunc = formatSecond;
+    }
+    if (formatFunc === formatSecond && hasMillisecond(value)) {
+      formatFunc = formatMillisecond;
+    }
+  });
+
+  return new TimeFormatter({
+    description:
+      'Use the finest grain in an array of dates to format all dates in the array',
+    formatFunc,
+    id: 'finest_temporal_grain',
+    label: 'Format temporal columns with the finest grain',
+    useLocalTime,
+  });
+}

--- a/superset-frontend/packages/superset-ui-core/src/time-format/index.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-format/index.ts
@@ -35,6 +35,7 @@ export { default as createMultiFormatter } from './factories/createMultiFormatte
 export { default as smartDateFormatter } from './formatters/smartDate';
 export { default as smartDateDetailedFormatter } from './formatters/smartDateDetailed';
 export { default as smartDateVerboseFormatter } from './formatters/smartDateVerbose';
+export { default as finestTemporalGrainFormatter } from './formatters/finestTemporalGrain';
 
 export { default as normalizeTimestamp } from './utils/normalizeTimestamp';
 export { default as denormalizeTimestamp } from './utils/denormalizeTimestamp';

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -26,7 +26,6 @@ import {
   GenericDataType,
   getColumnLabel,
   JsonObject,
-  smartDateDetailedFormatter,
   finestTemporalGrainFormatter,
   t,
   tn,
@@ -118,10 +117,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
   const labelFormatter = useMemo(
     () =>
       getDataRecordFormatter({
-        timeFormatter:
-          datatype === GenericDataType.TEMPORAL
-            ? finestTemporalGrainFormatter(data.map(el => el.col))
-            : smartDateDetailedFormatter,
+        timeFormatter: finestTemporalGrainFormatter(data.map(el => el.col)),
       }),
     [data, datatype],
   );

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -119,7 +119,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
       getDataRecordFormatter({
         timeFormatter: finestTemporalGrainFormatter(data.map(el => el.col)),
       }),
-    [data, datatype],
+    [data],
   );
 
   const updateDataMask = useCallback(

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -27,6 +27,7 @@ import {
   getColumnLabel,
   JsonObject,
   smartDateDetailedFormatter,
+  finestTemporalGrainFormatter,
   t,
   tn,
 } from '@superset-ui/core';
@@ -117,9 +118,12 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
   const labelFormatter = useMemo(
     () =>
       getDataRecordFormatter({
-        timeFormatter: smartDateDetailedFormatter,
+        timeFormatter:
+          datatype === GenericDataType.TEMPORAL
+            ? finestTemporalGrainFormatter(data.map(el => el.col))
+            : smartDateDetailedFormatter,
       }),
-    [],
+    [data, datatype],
   );
 
   const updateDataMask = useCallback(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The `smartDateDetailedFormatter` used to format values in dashboard filters is not very smart, because it looks at values in isolation. This results in weird values in the dropdown:

<img width="246" alt="Screen Shot 2023-09-25 at 2 21 29 PM" src="https://github.com/apache/superset/assets/1534870/172b5334-86f3-41a6-9748-6b68017c6162">

This PR introduces a new formatter that examines all the values, finds the one with the finest grain, and uses that to format all the values:

<img width="249" alt="Screen Shot 2023-09-25 at 2 20 46 PM" src="https://github.com/apache/superset/assets/1534870/ba22283d-32d6-48cc-a238-6931b1bb119e">

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

See above.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
