### PR TITLE
fix: Ensures form data required properties exist at runtime (echarts-timeseries)

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/types/index.ts
+++ b/superset-frontend/packages/superset-ui-core/src/types/index.ts
@@ -28,3 +28,7 @@ export type Optional<T> = T | undefined;
 export type ValueOf<T> = T[keyof T];
 
 export type ValueFormatter = NumberFormatter | CurrencyFormatter;
+
+export type RequiredKeys<T> = {
+  [K in keyof T as undefined extends T[K] ? never : K]: T[K];
+};

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/constants.ts
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { RequiredKeys } from '@superset-ui/core';
+import {
+  DEFAULT_LEGEND_FORM_DATA,
+  DEFAULT_TITLE_FORM_DATA,
+  DEFAULT_FORM_DATA as TIMESERIES_DEFAULTS,
+} from '../constants';
+import { EchartsMixedTimeseriesFormData } from './types';
+
+export const DEFAULT_FORM_DATA: Omit<
+  EchartsMixedTimeseriesFormData,
+  'datasource'
+> = {
+  ...DEFAULT_LEGEND_FORM_DATA,
+  ...DEFAULT_TITLE_FORM_DATA,
+  annotationLayers: [],
+  minorSplitLine: TIMESERIES_DEFAULTS.minorSplitLine,
+  truncateYAxis: TIMESERIES_DEFAULTS.truncateYAxis,
+  truncateYAxisSecondary: TIMESERIES_DEFAULTS.truncateYAxis,
+  logAxis: TIMESERIES_DEFAULTS.logAxis,
+  logAxisSecondary: TIMESERIES_DEFAULTS.logAxis,
+  yAxisBounds: TIMESERIES_DEFAULTS.yAxisBounds,
+  yAxisBoundsSecondary: TIMESERIES_DEFAULTS.yAxisBounds,
+  yAxisFormat: TIMESERIES_DEFAULTS.yAxisFormat,
+  yAxisFormatSecondary: TIMESERIES_DEFAULTS.yAxisFormat,
+  yAxisTitleSecondary: DEFAULT_TITLE_FORM_DATA.yAxisTitle,
+  tooltipTimeFormat: TIMESERIES_DEFAULTS.tooltipTimeFormat,
+  xAxisTimeFormat: TIMESERIES_DEFAULTS.xAxisTimeFormat,
+  area: TIMESERIES_DEFAULTS.area,
+  areaB: TIMESERIES_DEFAULTS.area,
+  markerEnabled: TIMESERIES_DEFAULTS.markerEnabled,
+  markerEnabledB: TIMESERIES_DEFAULTS.markerEnabled,
+  markerSize: TIMESERIES_DEFAULTS.markerSize,
+  markerSizeB: TIMESERIES_DEFAULTS.markerSize,
+  opacity: TIMESERIES_DEFAULTS.opacity,
+  opacityB: TIMESERIES_DEFAULTS.opacity,
+  orderDesc: TIMESERIES_DEFAULTS.orderDesc,
+  orderDescB: TIMESERIES_DEFAULTS.orderDesc,
+  rowLimit: TIMESERIES_DEFAULTS.rowLimit,
+  rowLimitB: TIMESERIES_DEFAULTS.rowLimit,
+  seriesType: TIMESERIES_DEFAULTS.seriesType,
+  seriesTypeB: TIMESERIES_DEFAULTS.seriesType,
+  showValue: TIMESERIES_DEFAULTS.showValue,
+  showValueB: TIMESERIES_DEFAULTS.showValue,
+  stack: TIMESERIES_DEFAULTS.stack,
+  stackB: TIMESERIES_DEFAULTS.stack,
+  yAxisIndex: 0,
+  yAxisIndexB: 0,
+  groupby: [],
+  groupbyB: [],
+  zoomable: TIMESERIES_DEFAULTS.zoomable,
+  richTooltip: TIMESERIES_DEFAULTS.richTooltip,
+  viz_type: 'mixed_timeseries',
+  xAxisLabelRotation: TIMESERIES_DEFAULTS.xAxisLabelRotation,
+};
+
+export const FORM_DATA_REQUIRED_PROPERTIES: Record<
+  keyof RequiredKeys<EchartsMixedTimeseriesFormData>,
+  true
+> = {
+  annotationLayers: true,
+  area: true,
+  areaB: true,
+  datasource: true,
+  groupby: true,
+  groupbyB: true,
+  legendMargin: true,
+  legendOrientation: true,
+  legendType: true,
+  logAxis: true,
+  logAxisSecondary: true,
+  markerEnabled: true,
+  markerEnabledB: true,
+  markerSize: true,
+  markerSizeB: true,
+  minorSplitLine: true,
+  opacity: true,
+  opacityB: true,
+  orderDesc: true,
+  orderDescB: true,
+  richTooltip: true,
+  rowLimit: true,
+  rowLimitB: true,
+  seriesType: true,
+  seriesTypeB: true,
+  showLegend: true,
+  showValue: true,
+  showValueB: true,
+  stack: true,
+  stackB: true,
+  truncateYAxis: true,
+  truncateYAxisSecondary: true,
+  viz_type: true,
+  xAxisLabelRotation: true,
+  xAxisTitle: true,
+  xAxisTitleMargin: true,
+  yAxisBounds: true,
+  yAxisBoundsSecondary: true,
+  yAxisTitle: true,
+  yAxisTitleSecondary: true,
+  yAxisTitleMargin: true,
+  yAxisTitlePosition: true,
+  zoomable: true,
+};

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
@@ -30,7 +30,7 @@ import {
   sharedControls,
 } from '@superset-ui/chart-controls';
 
-import { DEFAULT_FORM_DATA } from './types';
+import { DEFAULT_FORM_DATA } from './constants';
 import { EchartsTimeseriesSeriesType } from '../Timeseries/types';
 import { legendSection, richTooltipSection } from '../controls';
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -43,7 +43,6 @@ import {
 import { getOriginalSeries } from '@superset-ui/chart-controls';
 import { EChartsCoreOption, SeriesOption } from 'echarts';
 import {
-  DEFAULT_FORM_DATA,
   EchartsMixedTimeseriesFormData,
   EchartsMixedTimeseriesChartTransformedProps,
   EchartsMixedTimeseriesProps,
@@ -193,7 +192,7 @@ export default function transformProps(
     percentageThreshold,
     metrics = [],
     metricsB = [],
-  }: EchartsMixedTimeseriesFormData = { ...DEFAULT_FORM_DATA, ...formData };
+  }: EchartsMixedTimeseriesFormData = formData;
 
   const refs: Refs = {};
   const colorScale = CategoricalColorNamespace.getScale(colorScheme as string);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
@@ -35,11 +35,6 @@ import {
   StackType,
   TitleFormData,
 } from '../types';
-import {
-  DEFAULT_LEGEND_FORM_DATA,
-  DEFAULT_TITLE_FORM_DATA,
-  DEFAULT_FORM_DATA as TIMESERIES_DEFAULTS,
-} from '../constants';
 
 export type EchartsMixedTimeseriesFormData = QueryFormData & {
   annotationLayers: AnnotationLayer[];
@@ -88,50 +83,6 @@ export type EchartsMixedTimeseriesFormData = QueryFormData & {
   groupbyB: QueryFormColumn[];
 } & LegendFormData &
   TitleFormData;
-
-// @ts-ignore
-export const DEFAULT_FORM_DATA: EchartsMixedTimeseriesFormData = {
-  ...DEFAULT_LEGEND_FORM_DATA,
-  annotationLayers: [],
-  minorSplitLine: TIMESERIES_DEFAULTS.minorSplitLine,
-  truncateYAxis: TIMESERIES_DEFAULTS.truncateYAxis,
-  truncateYAxisSecondary: TIMESERIES_DEFAULTS.truncateYAxis,
-  logAxis: TIMESERIES_DEFAULTS.logAxis,
-  logAxisSecondary: TIMESERIES_DEFAULTS.logAxis,
-  yAxisBounds: TIMESERIES_DEFAULTS.yAxisBounds,
-  yAxisBoundsSecondary: TIMESERIES_DEFAULTS.yAxisBounds,
-  yAxisFormat: TIMESERIES_DEFAULTS.yAxisFormat,
-  yAxisFormatSecondary: TIMESERIES_DEFAULTS.yAxisFormat,
-  yAxisTitleSecondary: DEFAULT_TITLE_FORM_DATA.yAxisTitle,
-  tooltipTimeFormat: TIMESERIES_DEFAULTS.tooltipTimeFormat,
-  xAxisTimeFormat: TIMESERIES_DEFAULTS.xAxisTimeFormat,
-  area: TIMESERIES_DEFAULTS.area,
-  areaB: TIMESERIES_DEFAULTS.area,
-  markerEnabled: TIMESERIES_DEFAULTS.markerEnabled,
-  markerEnabledB: TIMESERIES_DEFAULTS.markerEnabled,
-  markerSize: TIMESERIES_DEFAULTS.markerSize,
-  markerSizeB: TIMESERIES_DEFAULTS.markerSize,
-  opacity: TIMESERIES_DEFAULTS.opacity,
-  opacityB: TIMESERIES_DEFAULTS.opacity,
-  orderDesc: TIMESERIES_DEFAULTS.orderDesc,
-  orderDescB: TIMESERIES_DEFAULTS.orderDesc,
-  rowLimit: TIMESERIES_DEFAULTS.rowLimit,
-  rowLimitB: TIMESERIES_DEFAULTS.rowLimit,
-  seriesType: TIMESERIES_DEFAULTS.seriesType,
-  seriesTypeB: TIMESERIES_DEFAULTS.seriesType,
-  showValue: TIMESERIES_DEFAULTS.showValue,
-  showValueB: TIMESERIES_DEFAULTS.showValue,
-  stack: TIMESERIES_DEFAULTS.stack,
-  stackB: TIMESERIES_DEFAULTS.stack,
-  yAxisIndex: 0,
-  yAxisIndexB: 0,
-  groupby: [],
-  groupbyB: [],
-  zoomable: TIMESERIES_DEFAULTS.zoomable,
-  richTooltip: TIMESERIES_DEFAULTS.richTooltip,
-  xAxisLabelRotation: TIMESERIES_DEFAULTS.xAxisLabelRotation,
-  ...DEFAULT_TITLE_FORM_DATA,
-};
 
 export interface EchartsMixedTimeseriesProps
   extends BaseChartProps<EchartsMixedTimeseriesFormData> {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/constants.ts
@@ -52,6 +52,7 @@ export const DEFAULT_FORM_DATA: Omit<
   logAxis: false,
   markerEnabled: false,
   markerSize: 6,
+  metrics: [],
   minorSplitLine: false,
   opacity: 0.2,
   orderDesc: true,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/constants.ts
@@ -20,7 +20,7 @@ import {
   DEFAULT_SORT_SERIES_DATA,
   sections,
 } from '@superset-ui/chart-controls';
-import { t } from '@superset-ui/core';
+import { RequiredKeys, t } from '@superset-ui/core';
 import {
   OrientationType,
   EchartsTimeseriesSeriesType,
@@ -31,8 +31,10 @@ import {
   DEFAULT_TITLE_FORM_DATA,
 } from '../constants';
 
-// @ts-ignore
-export const DEFAULT_FORM_DATA: EchartsTimeseriesFormData = {
+export const DEFAULT_FORM_DATA: Omit<
+  EchartsTimeseriesFormData,
+  'datasource' | 'viz_type'
+> = {
   ...DEFAULT_LEGEND_FORM_DATA,
   ...DEFAULT_TITLE_FORM_DATA,
   ...DEFAULT_SORT_SERIES_DATA,
@@ -74,3 +76,48 @@ export const DEFAULT_FORM_DATA: EchartsTimeseriesFormData = {
 export const TIME_SERIES_DESCRIPTION_TEXT: string = t(
   'When using other than adaptive formatting, labels may overlap',
 );
+
+export const FORM_DATA_REQUIRED_PROPERTIES: Record<
+  keyof RequiredKeys<EchartsTimeseriesFormData>,
+  true
+> = {
+  annotationLayers: true,
+  area: true,
+  datasource: true,
+  forecastEnabled: true,
+  forecastPeriods: true,
+  forecastInterval: true,
+  forecastSeasonalityDaily: true,
+  forecastSeasonalityWeekly: true,
+  forecastSeasonalityYearly: true,
+  groupby: true,
+  legendMargin: true,
+  legendOrientation: true,
+  legendType: true,
+  logAxis: true,
+  markerEnabled: true,
+  markerSize: true,
+  metrics: true,
+  minorSplitLine: true,
+  onlyTotal: true,
+  opacity: true,
+  orderDesc: true,
+  percentageThreshold: true,
+  richTooltip: true,
+  rowLimit: true,
+  seriesType: true,
+  showExtraControls: true,
+  showLegend: true,
+  showValue: true,
+  stack: true,
+  truncateYAxis: true,
+  viz_type: true,
+  xAxisLabelRotation: true,
+  xAxisTitle: true,
+  xAxisTitleMargin: true,
+  yAxisBounds: true,
+  yAxisTitle: true,
+  yAxisTitleMargin: true,
+  yAxisTitlePosition: true,
+  zoomable: true,
+};

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -51,7 +51,6 @@ import {
   TimeseriesChartTransformedProps,
   OrientationType,
 } from './types';
-import { DEFAULT_FORM_DATA } from './constants';
 import { ForecastSeriesEnum, ForecastValue, Refs } from '../types';
 import { parseYAxisBound } from '../utils/controls';
 import {
@@ -103,8 +102,8 @@ export default function transformProps(
     width,
     height,
     filterState,
-    legendState,
     formData,
+    legendState,
     hooks,
     queriesData,
     datasource,
@@ -173,7 +172,7 @@ export default function transformProps(
     yAxisTitleMargin,
     yAxisTitlePosition,
     zoomable,
-  }: EchartsTimeseriesFormData = { ...DEFAULT_FORM_DATA, ...formData };
+  }: EchartsTimeseriesFormData = formData;
   const refs: Refs = {};
 
   const labelMap = Object.entries(label_map).reduce((acc, entry) => {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/index.ts
@@ -47,7 +47,15 @@ export { default as TreeTransformProps } from './Tree/transformProps';
 export { default as TreemapTransformProps } from './Treemap/transformProps';
 export { default as SunburstTransformProps } from './Sunburst/transformProps';
 
-export { DEFAULT_FORM_DATA as TimeseriesDefaultFormData } from './Timeseries/constants';
+export {
+  DEFAULT_FORM_DATA as TimeseriesDefaultFormData,
+  FORM_DATA_REQUIRED_PROPERTIES as TimeseriesRequiredProperties,
+} from './Timeseries/constants';
+
+export {
+  DEFAULT_FORM_DATA as MixedTimeseriesDefaultFormData,
+  FORM_DATA_REQUIRED_PROPERTIES as MixedTimeseriesRequiredProperties,
+} from './MixedTimeseries/constants';
 
 export * from './types';
 

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -33,12 +33,13 @@ import transformProps from '../../src/Timeseries/transformProps';
 
 describe('EchartsTimeseries transformProps', () => {
   const formData: SqlaFormData = {
+    annotation_layers: [],
     colorScheme: 'bnbColors',
     datasource: '3__table',
     granularity_sqla: 'ds',
     metric: 'sum__num',
     groupby: ['foo', 'bar'],
-    viz_type: 'my_viz',
+    viz_type: 'echarts_timeseries_line',
   };
   const queriesData = [
     {
@@ -417,7 +418,8 @@ describe('Does transformProps transform series correctly', () => {
   };
 
   const formData: SqlaFormData = {
-    viz_type: 'my_viz',
+    viz_type: 'echarts_timeseries_line',
+    annotation_layers: [],
     colorScheme: 'bnbColors',
     datasource: '3__table',
     granularity_sqla: 'ds',

--- a/superset-frontend/src/dashboard/containers/DashboardPage.tsx
+++ b/superset-frontend/src/dashboard/containers/DashboardPage.tsx
@@ -163,9 +163,6 @@ export const DashboardPage: FC<PageProps> = ({ idOrSlug }: PageProps) => {
     status,
   } = useDashboardDatasets(idOrSlug);
   const isDashboardHydrated = useRef(false);
-
-  // TODO: Parse charts form data
-
   const error = dashboardApiError || chartsApiError;
   const readyToRender = Boolean(dashboard && charts);
   const { dashboard_title, css, metadata, id = 0 } = dashboard || {};

--- a/superset-frontend/src/dashboard/containers/DashboardPage.tsx
+++ b/superset-frontend/src/dashboard/containers/DashboardPage.tsx
@@ -57,6 +57,7 @@ import {
 } from 'src/dashboard/components/nativeFilters/FilterBar/keyValue';
 import { DashboardContextForExplore } from 'src/types/DashboardContextForExplore';
 import shortid from 'shortid';
+import parseFormData from 'src/utils/parseFormData';
 import { RootState } from '../types';
 import { getActiveFilters } from '../util/activeDashboardFilters';
 import {
@@ -163,6 +164,8 @@ export const DashboardPage: FC<PageProps> = ({ idOrSlug }: PageProps) => {
   } = useDashboardDatasets(idOrSlug);
   const isDashboardHydrated = useRef(false);
 
+  // TODO: Parse charts form data
+
   const error = dashboardApiError || chartsApiError;
   const readyToRender = Boolean(dashboard && charts);
   const { dashboard_title, css, metadata, id = 0 } = dashboard || {};
@@ -230,7 +233,10 @@ export const DashboardPage: FC<PageProps> = ({ idOrSlug }: PageProps) => {
           hydrateDashboard({
             history,
             dashboard,
-            charts,
+            charts: charts?.map(chart => ({
+              ...chart,
+              form_data: parseFormData(chart.form_data),
+            })),
             activeTabs,
             dataMask,
           }),

--- a/superset-frontend/src/pages/Chart/index.tsx
+++ b/superset-frontend/src/pages/Chart/index.tsx
@@ -41,6 +41,7 @@ import { ExploreResponsePayload, SaveActionType } from 'src/explore/types';
 import { fallbackExploreInitialData } from 'src/explore/fixtures';
 import { getItem, LocalStorageKeys } from 'src/utils/localStorageHelpers';
 import { getFormDataWithDashboardContext } from 'src/explore/controlUtils/getFormDataWithDashboardContext';
+import parseFormData from 'src/utils/parseFormData';
 
 const isValidResult = (rv: JsonObject): boolean =>
   rv?.result?.form_data && isDefined(rv?.result?.dataset?.id);
@@ -125,6 +126,7 @@ export default function ExplorePage() {
     const saveAction = getUrlParam(
       URL_PARAMS.saveAction,
     ) as SaveActionType | null;
+    const vizType = getUrlParam(URL_PARAMS.vizType);
     const dashboardContextFormData = getDashboardContextFormData();
     if (!isExploreInitialized.current || !!saveAction) {
       fetchExploreData(exploreUrlParams)
@@ -136,10 +138,13 @@ export default function ExplorePage() {
                   dashboardContextFormData,
                 )
               : result.form_data;
+          if (vizType) {
+            formData.viz_type = vizType;
+          }
           dispatch(
             hydrateExplore({
               ...result,
-              form_data: formData,
+              form_data: parseFormData(formData),
               saveAction,
             }),
           );

--- a/superset-frontend/src/types/Chart.ts
+++ b/superset-frontend/src/types/Chart.ts
@@ -54,6 +54,7 @@ export interface Chart {
   };
   datasource_name_text?: string;
   form_data: {
+    datasource: string;
     viz_type: string;
   };
   is_managed_externally: boolean;

--- a/superset-frontend/src/utils/parseFormData.test.ts
+++ b/superset-frontend/src/utils/parseFormData.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { TimeseriesDefaultFormData } from '@superset-ui/plugin-chart-echarts';
+import parseFormData from './parseFormData';
+
+test('parses formData with all required properties', () => {
+  const formData = {
+    ...TimeseriesDefaultFormData,
+    viz_type: 'echarts_timeseries_line',
+  };
+  const parsedFormData = parseFormData(formData);
+  expect(parsedFormData).toEqual(formData);
+});
+
+test('parses formData with missing optional properties', () => {
+  const formData = {
+    datasource: '5__table',
+    viz_type: 'echarts_timeseries_line',
+    time_compare: undefined,
+  };
+  const expectedFormData = {
+    ...formData,
+    time_compare: undefined,
+  };
+  const parsedFormData = parseFormData(formData);
+  expect(parsedFormData).toEqual(expect.objectContaining(expectedFormData));
+});
+
+test('parses formData with missing required properties', () => {
+  const formData = {
+    datasource: '5__table',
+    viz_type: 'echarts_timeseries_line',
+    groupby: undefined,
+  };
+  const expectedFormData = {
+    ...formData,
+    groupby: TimeseriesDefaultFormData.groupby,
+  };
+  const parsedFormData = parseFormData(formData);
+  expect(parsedFormData).toEqual(expect.objectContaining(expectedFormData));
+});

--- a/superset-frontend/src/utils/parseFormData.test.ts
+++ b/superset-frontend/src/utils/parseFormData.test.ts
@@ -22,6 +22,7 @@ import parseFormData from './parseFormData';
 test('parses formData with all required properties', () => {
   const formData = {
     ...TimeseriesDefaultFormData,
+    datasource: '5__table',
     viz_type: 'echarts_timeseries_line',
   };
   const parsedFormData = parseFormData(formData);

--- a/superset-frontend/src/utils/parseFormData.ts
+++ b/superset-frontend/src/utils/parseFormData.ts
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { BaseFormData, RequiredKeys } from '@superset-ui/core/src/types';
+import {
+  TimeseriesDefaultFormData,
+  TimeseriesRequiredProperties,
+  MixedTimeseriesDefaultFormData,
+  MixedTimeseriesRequiredProperties,
+} from '@superset-ui/plugin-chart-echarts';
+import { logging } from '@superset-ui/core';
+
+const PLUGIN_METADATA: {
+  [key: string]: [BaseFormData, Record<keyof RequiredKeys<BaseFormData>, true>];
+} = {
+  echarts_timeseries_line: [
+    TimeseriesDefaultFormData,
+    TimeseriesRequiredProperties,
+  ],
+  mixed_timeseries: [
+    MixedTimeseriesDefaultFormData,
+    MixedTimeseriesRequiredProperties,
+  ],
+};
+
+/**
+ * Parses a formData object, and returns a new object with:
+ * - required properties without values set to their default values
+ * - optional properties not in formData set to their default values
+ * @param formData the formData object to parse
+ * @returns a new formData object
+ */
+export default function parseFormData(formData: BaseFormData) {
+  if (!(formData.viz_type in PLUGIN_METADATA)) {
+    logging.warn(
+      "Required form data properties won't be automatically filled because viz_type '%s' was not found in PLUGIN_METADATA",
+      formData.viz_type,
+    );
+    return formData;
+  }
+
+  const parsedFormData = { ...formData };
+  const [defaultFormData, requiredProperties] =
+    PLUGIN_METADATA[formData.viz_type];
+
+  Object.keys(defaultFormData).forEach((key: keyof BaseFormData) => {
+    const required = key in requiredProperties;
+    const inFormData = key in formData;
+    if (required) {
+      const value = formData[key];
+      if (!value) {
+        parsedFormData[key] = defaultFormData[key];
+      }
+    } else if (!inFormData) {
+      parsedFormData[key] = defaultFormData[key];
+    }
+  });
+  return parsedFormData;
+}

--- a/superset-frontend/src/utils/parseFormData.ts
+++ b/superset-frontend/src/utils/parseFormData.ts
@@ -26,7 +26,10 @@ import {
 import { logging } from '@superset-ui/core';
 
 const PLUGIN_METADATA: {
-  [key: string]: [BaseFormData, Record<keyof RequiredKeys<BaseFormData>, true>];
+  [key: string]: [
+    Partial<BaseFormData>,
+    Record<keyof RequiredKeys<BaseFormData>, true>,
+  ];
 } = {
   echarts_timeseries_line: [
     TimeseriesDefaultFormData,

--- a/superset/examples/supported_charts_dashboard.py
+++ b/superset/examples/supported_charts_dashboard.py
@@ -110,6 +110,8 @@ def create_slices(tbl: SqlaTable) -> list[Slice]:
                 viz_type="echarts_timeseries_line",
                 metrics=["sum__num"],
                 groupby=["gender"],
+                yAxisTitleMargin=15,
+                yAxisTitlePosition="Left",
             ),
         ),
         Slice(
@@ -336,6 +338,8 @@ def create_slices(tbl: SqlaTable) -> list[Slice]:
                 groupby=["gender"],
                 metrics_b=["sum__num"],
                 groupby_b=["state"],
+                yAxisTitleMargin=15,
+                yAxisTitlePosition="Left",
             ),
         ),
         Slice(


### PR DESCRIPTION
### SUMMARY
This PR fixes many potential problems related to missing required properties in form data objects. The form data object is a JSON representation of a chart's configuration and it evolves over time as new features are added. Unfortunately, these objects are not versioned and their Typescript definitions refer to their latest version. This causes some problems because we may have legacy versions of a form data type that don't obey to its Typescript definition. As an example, a required property might be `null` or don't exist in a legacy version. This leads to runtime exceptions and developers adding checks for `null` values when the type definition clearly states that it shouldn't be the case. To remedy this issue, this PR adds a generic solution to make sure Typescript required fields exist during runtime.

This PR adds the generic `parseFormData` function and focus on timeseries charts. The intention of this PR is to create the pattern to handle this problem and allow subsequent PRs for the other chart types.

Fixes https://github.com/apache/superset/issues/25354

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1779" alt="Screenshot 2023-09-26 at 12 00 36" src="https://github.com/apache/superset/assets/70410625/e6dba73a-0221-442e-8729-7cb0339ac981">
<br/><br/>
<img width="1780" alt="Screenshot 2023-09-26 at 11 58 11" src="https://github.com/apache/superset/assets/70410625/06726312-71f4-46cd-8516-9b299b117483">


### TESTING INSTRUCTIONS
TODO

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
