### PR TITLE
fix(sqllab): invalid start date

### DIFF
--- a/superset-frontend/src/SqlLab/reducers/getInitialState.test.ts
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.test.ts
@@ -18,6 +18,7 @@
  */
 
 import { DEFAULT_COMMON_BOOTSTRAP_DATA } from 'src/constants';
+import { runningQuery, successfulQuery } from 'src/SqlLab/fixtures';
 import getInitialState, { dedupeTabHistory } from './getInitialState';
 
 const apiData = {
@@ -191,6 +192,57 @@ describe('getInitialState', () => {
         },
       }).sqlLab.tables;
       expect(initializedTables.map(({ id }) => id)).toEqual([1, 2, 6]);
+    });
+
+    it('should parse the float dttm value', () => {
+      const startDttmInStr = '1693433503447.166992';
+      const endDttmInStr = '1693433503500.23132';
+
+      localStorage.setItem(
+        'redux',
+        JSON.stringify({
+          sqlLab: {
+            tables: [
+              { id: 1, name: 'test1' },
+              { id: 6, name: 'test6' },
+            ],
+            queryEditors: [{ id: 1, title: 'editor1' }],
+            queries: {
+              localStoragePersisted: {
+                ...successfulQuery,
+                id: 'localStoragePersisted',
+                startDttm: startDttmInStr,
+                endDttm: endDttmInStr,
+              },
+            },
+            tabHistory: [],
+          },
+        }),
+      );
+
+      const initializedQueries = getInitialState({
+        ...apiData,
+        queries: {
+          backendPersisted: {
+            ...runningQuery,
+            id: 'backendPersisted',
+            startDttm: startDttmInStr,
+            endDttm: endDttmInStr,
+          },
+        },
+      }).sqlLab.queries;
+      expect(initializedQueries.backendPersisted).toEqual(
+        expect.objectContaining({
+          startDttm: Number(startDttmInStr),
+          endDttm: Number(endDttmInStr),
+        }),
+      );
+      expect(initializedQueries.localStoragePersisted).toEqual(
+        expect.objectContaining({
+          startDttm: Number(startDttmInStr),
+          endDttm: Number(endDttmInStr),
+        }),
+      );
     });
   });
 });

--- a/superset-frontend/src/SqlLab/reducers/getInitialState.ts
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.ts
@@ -130,20 +130,7 @@ export default function getInitialState({
       });
   }
 
-  const queries = Object.fromEntries(
-    Object.entries(queries_ || {}).map(([queryId, query]) => [
-      queryId,
-      {
-        ...query,
-        ...(query.startDttm && {
-          startDttm: Number(query.startDttm),
-        }),
-        ...(query.endDttm && {
-          endDttm: Number(query.endDttm),
-        }),
-      },
-    ]),
-  );
+  const queries = { ...queries_ };
 
   /**
    * If the `SQLLAB_BACKEND_PERSISTENCE` feature flag is off, or if the user
@@ -205,7 +192,20 @@ export default function getInitialState({
       alerts: [],
       databases,
       offline: false,
-      queries,
+      queries: Object.fromEntries(
+        Object.entries(queries).map(([queryId, query]) => [
+          queryId,
+          {
+            ...query,
+            ...(query.startDttm && {
+              startDttm: Number(query.startDttm),
+            }),
+            ...(query.endDttm && {
+              endDttm: Number(query.endDttm),
+            }),
+          },
+        ]),
+      ),
       queryEditors: Object.values(queryEditors),
       tabHistory: dedupeTabHistory(tabHistory),
       tables: Object.values(tables),

--- a/superset-frontend/src/hooks/apiResources/sqlLab.ts
+++ b/superset-frontend/src/hooks/apiResources/sqlLab.ts
@@ -53,7 +53,14 @@ export type InitialState = {
     extra_json?: object;
   };
   databases: object[];
-  queries: Record<string, QueryResponse & { inLocalStorage?: boolean }>;
+  queries: Record<
+    string,
+    Omit<QueryResponse, 'startDttm' | 'endDttm'> & {
+      startDttm: number | string;
+      endDttm: number | string;
+      inLocalStorage?: boolean;
+    }
+  >;
   tab_state_ids: {
     id: number;
     label: string;


### PR DESCRIPTION
### SUMMARY
This commit fixes missing invalid date string in localStorage (in non persistence mode) from #25133
Move down the parse float value logic to cover both non-persistence and persistence mode cases.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

![Notification_Center](https://github.com/apache/superset/assets/1392866/b19ea43a-cd6a-4908-b700-808ab7c11f1f)

After:

![Screenshot 2023-09-01 at 10 04 27 AM](https://github.com/apache/superset/assets/1392866/1768b4fd-1b67-4da8-8143-1b45d67e1643)

### TESTING INSTRUCTIONS
Set SQLLAB_BACKEND_PERSISTENCE false
Run a bunch of queries and then reload the page
Check the start date string in query history

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
