### PR TITLE
docs: Add timeout parameter for Pinot connection

### DIFF
--- a/docs/docs/databases/pinot.mdx
+++ b/docs/docs/databases/pinot.mdx
@@ -14,3 +14,13 @@ The expected connection string is formatted as follows:
 ```
 pinot+http://<pinot-broker-host>:<pinot-broker-port>/query?controller=http://<pinot-controller-host>:<pinot-controller-port>/``
 ```
+
+### Customizing Pinot Connection
+
+The default request timeout is 5 seconds. To extend the timeout,
+add the following to the engine params:
+
+```
+engine_params:
+  {"connect_args": {"timeout": <seconds>}}
+```


### PR DESCRIPTION
### SUMMARY
Add the instruction on how to extend the timeout for Pinot connection

### ADDITIONAL INFORMATION

The default timeout is 5 seconds, and it is often too short. Please see the discussion in https://apache-superset.slack.com/archives/C0170U650CQ/p1695922183786009 
