### PR TITLE
fix(reporting): adhere to EMAIL_NOTIFICATIONS flag

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -880,7 +880,6 @@ def send_email_smtp(  # pylint: disable=invalid-name,too-many-arguments,too-many
     files: list[str] | None = None,
     data: dict[str, str] | None = None,
     images: dict[str, bytes] | None = None,
-    dryrun: bool = False,
     cc: str | None = None,
     bcc: str | None = None,
     mime_subtype: str = "mixed",
@@ -889,7 +888,7 @@ def send_email_smtp(  # pylint: disable=invalid-name,too-many-arguments,too-many
     """
     Send an email with html content, eg:
     send_email_smtp(
-        'test@example.com', 'foo', '<b>Foo</b> bar',['/dev/null'], dryrun=True)
+        'test@example.com', 'foo', '<b>Foo</b> bar',['/dev/null'])
     """
     smtp_mail_from = config["SMTP_MAIL_FROM"]
     smtp_mail_to = get_email_address_list(to)
@@ -948,7 +947,7 @@ def send_email_smtp(  # pylint: disable=invalid-name,too-many-arguments,too-many
     msg_mutator = config["EMAIL_HEADER_MUTATOR"]
     # the base notification returns the message without any editing.
     new_msg = msg_mutator(msg, **(header_data or {}))
-    send_mime_email(smtp_mail_from, recipients, new_msg, config, dryrun=dryrun)
+    send_mime_email(smtp_mail_from, recipients, new_msg, config)
 
 
 def send_mime_email(
@@ -956,7 +955,6 @@ def send_mime_email(
     e_to: list[str],
     mime_msg: MIMEMultipart,
     config: dict[str, Any],
-    dryrun: bool = False,
 ) -> None:
     smtp_host = config["SMTP_HOST"]
     smtp_port = config["SMTP_PORT"]
@@ -965,6 +963,7 @@ def send_mime_email(
     smtp_starttls = config["SMTP_STARTTLS"]
     smtp_ssl = config["SMTP_SSL"]
     smtp_ssl_server_auth = config["SMTP_SSL_SERVER_AUTH"]
+    dryrun = config["EMAIL_NOTIFICATIONS"]
 
     if dryrun:
         logger.info("Dryrun enabled, email notification content is below:")

--- a/tests/integration_tests/email_tests.py
+++ b/tests/integration_tests/email_tests.py
@@ -152,10 +152,11 @@ class TestEmailSmtp(SupersetTestCase):
     @mock.patch("smtplib.SMTP_SSL")
     @mock.patch("smtplib.SMTP")
     def test_send_mime(self, mock_smtp, mock_smtp_ssl):
+        app.config["EMAIL_NOTIFICATIONS"] = True
         mock_smtp.return_value = mock.Mock()
         mock_smtp_ssl.return_value = mock.Mock()
         msg = MIMEMultipart()
-        utils.send_mime_email("from", "to", msg, app.config, dryrun=False)
+        utils.send_mime_email("from", "to", msg, app.config)
         mock_smtp.assert_called_with(app.config["SMTP_HOST"], app.config["SMTP_PORT"])
         assert mock_smtp.return_value.starttls.called
         mock_smtp.return_value.login.assert_called_with(
@@ -170,9 +171,10 @@ class TestEmailSmtp(SupersetTestCase):
     @mock.patch("smtplib.SMTP")
     def test_send_mime_ssl(self, mock_smtp, mock_smtp_ssl):
         app.config["SMTP_SSL"] = True
+        app.config["EMAIL_NOTIFICATIONS"] = True
         mock_smtp.return_value = mock.Mock()
         mock_smtp_ssl.return_value = mock.Mock()
-        utils.send_mime_email("from", "to", MIMEMultipart(), app.config, dryrun=False)
+        utils.send_mime_email("from", "to", MIMEMultipart(), app.config)
         assert not mock_smtp.called
         mock_smtp_ssl.assert_called_with(
             app.config["SMTP_HOST"], app.config["SMTP_PORT"], context=None
@@ -183,9 +185,10 @@ class TestEmailSmtp(SupersetTestCase):
     def test_send_mime_ssl_server_auth(self, mock_smtp, mock_smtp_ssl):
         app.config["SMTP_SSL"] = True
         app.config["SMTP_SSL_SERVER_AUTH"] = True
+        app.config["EMAIL_NOTIFICATIONS"] = True
         mock_smtp.return_value = mock.Mock()
         mock_smtp_ssl.return_value = mock.Mock()
-        utils.send_mime_email("from", "to", MIMEMultipart(), app.config, dryrun=False)
+        utils.send_mime_email("from", "to", MIMEMultipart(), app.config)
         assert not mock_smtp.called
         mock_smtp_ssl.assert_called_with(
             app.config["SMTP_HOST"], app.config["SMTP_PORT"], context=mock.ANY
@@ -197,9 +200,10 @@ class TestEmailSmtp(SupersetTestCase):
     def test_send_mime_tls_server_auth(self, mock_smtp):
         app.config["SMTP_STARTTLS"] = True
         app.config["SMTP_SSL_SERVER_AUTH"] = True
+        app.config["EMAIL_NOTIFICATIONS"] = True
         mock_smtp.return_value = mock.Mock()
         mock_smtp.return_value.starttls.return_value = mock.Mock()
-        utils.send_mime_email("from", "to", MIMEMultipart(), app.config, dryrun=False)
+        utils.send_mime_email("from", "to", MIMEMultipart(), app.config)
         mock_smtp.return_value.starttls.assert_called_with(context=mock.ANY)
         called_context = mock_smtp.return_value.starttls.call_args.kwargs["context"]
         self.assertEqual(called_context.verify_mode, ssl.CERT_REQUIRED)
@@ -211,9 +215,10 @@ class TestEmailSmtp(SupersetTestCase):
         smtp_password = app.config["SMTP_PASSWORD"]
         app.config["SMTP_USER"] = None
         app.config["SMTP_PASSWORD"] = None
+        app.config["EMAIL_NOTIFICATIONS"] = True
         mock_smtp.return_value = mock.Mock()
         mock_smtp_ssl.return_value = mock.Mock()
-        utils.send_mime_email("from", "to", MIMEMultipart(), app.config, dryrun=False)
+        utils.send_mime_email("from", "to", MIMEMultipart(), app.config)
         assert not mock_smtp_ssl.called
         mock_smtp.assert_called_with(app.config["SMTP_HOST"], app.config["SMTP_PORT"])
         assert not mock_smtp.login.called
@@ -223,7 +228,8 @@ class TestEmailSmtp(SupersetTestCase):
     @mock.patch("smtplib.SMTP_SSL")
     @mock.patch("smtplib.SMTP")
     def test_send_mime_dryrun(self, mock_smtp, mock_smtp_ssl):
-        utils.send_mime_email("from", "to", MIMEMultipart(), app.config, dryrun=True)
+        app.config["EMAIL_NOTIFICATIONS"] = False
+        utils.send_mime_email("from", "to", MIMEMultipart(), app.config)
         assert not mock_smtp.called
         assert not mock_smtp_ssl.called
 


### PR DESCRIPTION
### SUMMARY
Backend now uses the config EMAIL_NOTIFICATIONS flag to determine the dryrun variable when sending emails via SMTP.

### TESTING INSTRUCTIONS
Set EMAIL_NOTIFICATIONS to False, and trigger an email report. You should receive an email.
Set EMAIL_NOTIFICATIONS to True, and trigger an email report. You shouldn't receive an email.

### ADDITIONAL INFORMATION
- [x] Has associated issue:
https://github.com/apache/superset/issues/25459 
- [x] Required feature flags:
ALERT_REPORTS
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in https://github.com/apache/superset/issues/13351)
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API