### PR TITLE
fix: Styles not loading because of faulty CSP setting

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -1426,7 +1426,11 @@ TALISMAN_CONFIG = {
             "https://events.mapbox.com",
         ],
         "object-src": "'none'",
-        "style-src": ["'self'", "'unsafe-inline'"],
+        "style-src": [
+            "'self'",
+            "'unsafe-inline'",
+            "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css",
+        ],
         "script-src": ["'self'", "'strict-dynamic'"],
     },
     "content_security_policy_nonce_in": ["script-src"],

--- a/superset/config.py
+++ b/superset/config.py
@@ -1429,7 +1429,7 @@ TALISMAN_CONFIG = {
         "style-src": ["'self'", "'unsafe-inline'"],
         "script-src": ["'self'", "'strict-dynamic'"],
     },
-    "content_security_policy_nonce_in": ["script-src", "style-src"],
+    "content_security_policy_nonce_in": ["script-src"],
     "force_https": False,
 }
 # React requires `eval` to work correctly in dev mode
@@ -1444,10 +1444,14 @@ TALISMAN_DEV_CONFIG = {
             "https://events.mapbox.com",
         ],
         "object-src": "'none'",
-        "style-src": ["'self'", "'unsafe-inline'"],
+        "style-src": [
+            "'self'",
+            "'unsafe-inline'",
+            "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css",
+        ],
         "script-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
     },
-    "content_security_policy_nonce_in": ["script-src", "style-src"],
+    "content_security_policy_nonce_in": ["script-src"],
     "force_https": False,
 }
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Add swagger css file url to allowed styles, remove creating a nonce for style-src - that causes the unsafe-inline directive to be ignored, which breaks every style in Superset


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

![image](https://github.com/apache/superset/assets/15073128/e8b3fd7f-1de2-469d-84de-56d1ac295bb7)

After:

normal Superset 😄 

### TESTING INSTRUCTIONS
1. Check if Superset loads normally
2. Check if Swagger (/swagger/v1) loads normally

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
