### PR TITLE
fix(sqllab): error with lazy_gettext for tab titles

### DIFF
--- a/superset/views/sql_lab/views.py
+++ b/superset/views/sql_lab/views.py
@@ -21,7 +21,7 @@ from flask import redirect, request, Response
 from flask_appbuilder import expose
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder.security.decorators import has_access, has_access_api
-from flask_babel import gettext as __, lazy_gettext as _
+from flask_babel import gettext as __
 from sqlalchemy import and_
 
 from superset import db

--- a/superset/views/sql_lab/views.py
+++ b/superset/views/sql_lab/views.py
@@ -90,7 +90,7 @@ class TabStateView(BaseSupersetView):
             user_id=get_user_id(),
             # This is for backward compatibility
             label=query_editor.get("name")
-            or query_editor.get("title", _("Untitled Query")),
+            or query_editor.get("title", str(_("Untitled Query"))),
             active=True,
             database_id=query_editor["dbId"],
             schema=query_editor.get("schema"),

--- a/superset/views/sql_lab/views.py
+++ b/superset/views/sql_lab/views.py
@@ -21,7 +21,7 @@ from flask import redirect, request, Response
 from flask_appbuilder import expose
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder.security.decorators import has_access, has_access_api
-from flask_babel import lazy_gettext as _
+from flask_babel import gettext as __, lazy_gettext as _
 from sqlalchemy import and_
 
 from superset import db
@@ -90,7 +90,7 @@ class TabStateView(BaseSupersetView):
             user_id=get_user_id(),
             # This is for backward compatibility
             label=query_editor.get("name")
-            or query_editor.get("title", str(_("Untitled Query"))),
+            or query_editor.get("title", __("Untitled Query")),
             active=True,
             database_id=query_editor["dbId"],
             schema=query_editor.get("schema"),


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Theres an issue with creating new tabs and using the default "Untitled Query" name, db engines cannot serialize LazyString types . 

Example error `sqlalchemy.exc.ProgrammingError: (psycopg2.ProgrammingError) can't adapt type 'LazyString'`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

open SQLLab using a query params, eg `/superset/sqllab/?dbid=1&schema=default&sql=SELECT%20*%20from%20foo`. Without this change it results in an error trying to create a new tab. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
