### PR TITLE
fix(sqllab): Broken query containing 'children'

### DIFF
--- a/superset-frontend/src/components/FilterableTable/FilterableTable.test.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.test.tsx
@@ -25,11 +25,11 @@ import userEvent from '@testing-library/user-event';
 
 describe('FilterableTable', () => {
   const mockedProps = {
-    orderedColumnKeys: ['a', 'b', 'c'],
+    orderedColumnKeys: ['a', 'b', 'c', 'children'],
     data: [
-      { a: 'a1', b: 'b1', c: 'c1', d: 0 },
-      { a: 'a2', b: 'b2', c: 'c2', d: 100 },
-      { a: null, b: 'b3', c: 'c3', d: 50 },
+      { a: 'a1', b: 'b1', c: 'c1', d: 0, children: 0 },
+      { a: 'a2', b: 'b2', c: 'c2', d: 100, children: 2 },
+      { a: null, b: 'b3', c: 'c3', d: 50, children: 1 },
     ],
     height: 500,
   };

--- a/superset-frontend/src/components/FilterableTable/index.tsx
+++ b/superset-frontend/src/components/FilterableTable/index.tsx
@@ -366,6 +366,7 @@ const FilterableTable = ({
           usePagination={false}
           columns={columns}
           data={filteredList}
+          childrenColumnName=""
           virtualize
           bordered
         />

--- a/superset-frontend/src/components/Table/index.tsx
+++ b/superset-frontend/src/components/Table/index.tsx
@@ -399,7 +399,9 @@ export function Table<RecordType extends object>(
     theme,
     height: bodyHeight,
     bordered,
-    childrenColumnName,
+    expandable: {
+      childrenColumnName,
+    },
   };
 
   return (

--- a/superset-frontend/src/components/Table/index.tsx
+++ b/superset-frontend/src/components/Table/index.tsx
@@ -152,7 +152,7 @@ export interface TableProps<RecordType> {
   allowHTML?: boolean;
 
   /**
-   * The column contains children to display.
+   * The column that contains children to display.
    * Check https://ant.design/components/table#table for more details.
    */
   childrenColumnName?: string;

--- a/superset-frontend/src/components/Table/index.tsx
+++ b/superset-frontend/src/components/Table/index.tsx
@@ -150,6 +150,12 @@ export interface TableProps<RecordType> {
    * only supported for virtualize == true
    */
   allowHTML?: boolean;
+
+  /**
+   * The column contains children to display.
+   * Check https://ant.design/components/table#table for more details.
+   */
+  childrenColumnName?: string;
 }
 
 const defaultRowSelection: React.Key[] = [];
@@ -259,6 +265,7 @@ export function Table<RecordType extends object>(
     recordCount,
     onRow,
     allowHTML = false,
+    childrenColumnName,
   } = props;
 
   const wrapperRef = useRef<HTMLDivElement | null>(null);
@@ -392,6 +399,7 @@ export function Table<RecordType extends object>(
     theme,
     height: bodyHeight,
     bordered,
+    childrenColumnName,
   };
 
   return (


### PR DESCRIPTION
### SUMMARY
The ant-design table has a special handling for the tree structure data and its default property name is `children`.
![Notification_Center](https://github.com/apache/superset/assets/1392866/aa4c97ad-2297-4dc8-908a-a7b6c4da0c6e)

This makes a bug when data contains a `children` column with a primary data format like a string or number.
This commit disable the tree structure data with 'children' prop for the sql editor table (FIlterableTable) to fix the issue.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://github.com/apache/superset/assets/1392866/cefb3d41-8449-4166-abf9-cd6f0cfbdb9f


After:

https://github.com/apache/superset/assets/1392866/657ada97-4b1d-4542-8040-1856f5881bd2


### TESTING INSTRUCTIONS

Go to SQL Lab and run the following query

```
SELECT 2 as children;
```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
