### PR TITLE
fix(header navlinks): link navlinks to path prefix

### DIFF
--- a/superset-frontend/src/features/home/Menu.test.tsx
+++ b/superset-frontend/src/features/home/Menu.test.tsx
@@ -295,7 +295,11 @@ test('should render the environment tag', async () => {
   const {
     data: { environment_tag },
   } = mockedProps;
-  render(<Menu {...mockedProps} />, { useRedux: true, useQueryParams: true });
+  render(<Menu {...mockedProps} />, {
+    useRedux: true,
+    useQueryParams: true,
+    useRouter: true,
+  });
   expect(await screen.findByText(environment_tag.text)).toBeInTheDocument();
 });
 

--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -209,7 +209,7 @@ export function Menu({
       default:
         setActiveTabs(['']);
     }
-  }, [location]);
+  }, [location.pathname]);
 
   const standalone = getUrlParam(URL_PARAMS.standalone);
   if (standalone || uiConfig.hideNav) return <></>;

--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -193,8 +193,8 @@ export function Menu({
     DATASETS = '/tablemodelview',
   }
 
-  const defaultSelection: string[] = [];
-  const [activeTabs, setActiveTabs] = useState(defaultSelection);
+  const defaultTabSelection: string[] = [];
+  const [activeTabs, setActiveTabs] = useState(defaultTabSelection);
   const location = useLocation();
   useEffect(() => {
     const path = location.pathname;
@@ -209,7 +209,7 @@ export function Menu({
         setActiveTabs(['Datasets']);
         break;
       default:
-        setActiveTabs([]);
+        setActiveTabs(defaultTabSelection);
     }
   }, [location.pathname]);
 

--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -192,7 +192,7 @@ export function Menu({
     CHART = '/chart',
     DATASETS = '/tablemodelview',
   }
-  const [activeTabs, setActiveTabs] = useState(['']);
+  const [activeTabs, setActiveTabs] = useState(Array<string>);
   const location = useLocation();
   useEffect(() => {
     const path = location.pathname;
@@ -207,7 +207,7 @@ export function Menu({
         setActiveTabs(['Datasets']);
         break;
       default:
-        setActiveTabs(['']);
+        setActiveTabs([]);
     }
   }, [location.pathname]);
 

--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -24,7 +24,7 @@ import { getUrlParam } from 'src/utils/urlUtils';
 import { Row, Col, Grid } from 'src/components';
 import { MainNav as DropdownMenu, MenuMode } from 'src/components/Menu';
 import { Tooltip } from 'src/components/Tooltip';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { GenericLink } from 'src/components/GenericLink/GenericLink';
 import Icons from 'src/components/Icons';
 import { useUiConfig } from 'src/components/UiConfigContext';
@@ -186,6 +186,31 @@ export function Menu({
     return () => window.removeEventListener('resize', windowResize);
   }, []);
 
+  enum paths {
+    EXPLORE = '/explore',
+    DASHBOARD = '/dashboard',
+    CHART = '/chart',
+    DATASETS = '/tablemodelview',
+  }
+  const [activeTabs, setActiveTabs] = useState(['']);
+  const location = useLocation();
+  useEffect(() => {
+    const path = location.pathname;
+    switch (true) {
+      case path.startsWith(paths.DASHBOARD):
+        setActiveTabs(['Dashboards']);
+        break;
+      case path.startsWith(paths.CHART) || path.startsWith(paths.EXPLORE):
+        setActiveTabs(['Charts']);
+        break;
+      case path.startsWith(paths.DATASETS):
+        setActiveTabs(['Datasets']);
+        break;
+      default:
+        setActiveTabs(['']);
+    }
+  }, [location]);
+
   const standalone = getUrlParam(URL_PARAMS.standalone);
   if (standalone || uiConfig.hideNav) return <></>;
 
@@ -268,6 +293,7 @@ export function Menu({
             mode={showMenu}
             data-test="navbar-top"
             className="main-nav"
+            selectedKeys={activeTabs}
           >
             {menu.map((item, index) => {
               const props = {

--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -192,7 +192,9 @@ export function Menu({
     CHART = '/chart',
     DATASETS = '/tablemodelview',
   }
-  const [activeTabs, setActiveTabs] = useState(Array<string>);
+
+  const defaultSelection: string[] = [];
+  const [activeTabs, setActiveTabs] = useState(defaultSelection);
   const location = useLocation();
   useEffect(() => {
     const path = location.pathname;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The navlinks were previously highlighted using click events, which meant that if a user was pushed to another portion of the site, the navlinks wouldn't highlight the correct tab that the user was located under. The proposed fix introduces logic to set the highlighted navlink based upon the url prefix rather than click events alone.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before: 
https://www.loom.com/share/67f59bc0320043dcbcdc6e2715b7da44?sid=c1821e43-cfc4-43f1-a8d6-cb87674da138

After:
https://www.loom.com/share/37b1679dce32469986ae743e318c132c?sid=c97fe956-581a-4adc-a551-204794c1f586

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
