### PR TITLE
chore(tags): don't allow users to create new tags from property dropdowns

### DIFF
--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -741,7 +741,6 @@ const PropertiesModal = ({
                 <AsyncSelect
                   ariaLabel="Tags"
                   mode="multiple"
-                  allowNewOptions
                   value={tagsAsSelectValues}
                   options={loadTags}
                   onChange={handleChangeTags}

--- a/superset-frontend/src/explore/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal/index.tsx
@@ -434,7 +434,6 @@ function PropertiesModal({
                 <AsyncSelect
                   ariaLabel="Tags"
                   mode="multiple"
-                  allowNewOptions
                   value={tagsAsSelectValues}
                   options={loadTags}
                   onChange={handleChangeTags}

--- a/superset-frontend/src/pages/AllEntities/index.tsx
+++ b/superset-frontend/src/pages/AllEntities/index.tsx
@@ -97,22 +97,28 @@ function AllEntities() {
     label: t('dataset name'),
   };
 
-  const description: Description = {
-    type: MetadataType.DESCRIPTION,
-    value: tag?.description || '',
-  };
+  const items = [];
+  if (tag?.description) {
+    const description: Description = {
+      type: MetadataType.DESCRIPTION,
+      value: tag?.description || '',
+    };
+    items.push(description);
+  }
 
   const owner: Owner = {
     type: MetadataType.OWNER,
     createdBy: `${tag?.created_by.first_name} ${tag?.created_by.last_name}`,
     createdOn: tag?.created_on_delta_humanized || '',
   };
+  items.push(owner);
+
   const lastModified: LastModified = {
     type: MetadataType.LAST_MODIFIED,
     value: tag?.changed_on_delta_humanized || '',
     modifiedBy: `${tag?.changed_by.first_name} ${tag?.changed_by.last_name}`,
   };
-  const items = [description, owner, lastModified];
+  items.push(lastModified);
 
   useEffect(() => {
     // fetch single tag met


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Since we've added #24839 users now have a centralized places to create tags, now we are going to stop user from a being able to create tags from the dropdown for permissioning reasons.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

https://github.com/apache/superset/assets/27827808/4fd5207e-1976-4a5c-8ab9-5e498141d7eb

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
