### PR TITLE
fix: Expand error detail on screencapture

### DIFF
--- a/superset-frontend/src/components/ErrorMessage/ErrorAlert.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorAlert.test.tsx
@@ -21,6 +21,7 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from 'spec/helpers/testing-library';
 import { supersetTheme } from '@superset-ui/core';
+import { isCurrentUserBot } from 'src/utils/isBot';
 import ErrorAlert from './ErrorAlert';
 import { ErrorLevel, ErrorSource } from './types';
 
@@ -31,6 +32,10 @@ jest.mock(
       <span role="img" aria-label={fileName.replace('_', '-')} />,
 );
 
+jest.mock('src/utils/isBot', () => ({
+  isCurrentUserBot: jest.fn(),
+}));
+
 const mockedProps = {
   body: 'Error body',
   level: 'warning' as ErrorLevel,
@@ -40,6 +45,14 @@ const mockedProps = {
   source: 'dashboard' as ErrorSource,
   description: 'we are unable to connect db.',
 };
+
+beforeEach(() => {
+  (isCurrentUserBot as jest.Mock).mockReturnValue(false);
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
 
 test('should render', () => {
   const { container } = render(<ErrorAlert {...mockedProps} />);
@@ -98,6 +111,17 @@ test('should render the See more button', () => {
   render(<ErrorAlert {...seemoreProps} />);
   expect(screen.getByRole('button')).toBeInTheDocument();
   expect(screen.getByText('See more')).toBeInTheDocument();
+});
+
+test('should render the error subtitle and body defaultly for the screen capture request', () => {
+  const seemoreProps = {
+    ...mockedProps,
+    source: 'explore' as ErrorSource,
+  };
+  (isCurrentUserBot as jest.Mock).mockReturnValue(true);
+  render(<ErrorAlert {...seemoreProps} />);
+  expect(screen.getByText('Error subtitle')).toBeInTheDocument();
+  expect(screen.getByText('Error body')).toBeInTheDocument();
 });
 
 test('should render the modal', () => {

--- a/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
@@ -21,6 +21,7 @@ import { styled, useTheme, t } from '@superset-ui/core';
 import { noOp } from 'src/utils/common';
 import Modal from 'src/components/Modal';
 import Button from 'src/components/Button';
+import { isCurrentUserBot } from 'src/utils/isBot';
 
 import Icons from 'src/components/Icons';
 import { ErrorLevel, ErrorSource } from './types';
@@ -102,9 +103,10 @@ export default function ErrorAlert({
   const theme = useTheme();
 
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [isBodyExpanded, setIsBodyExpanded] = useState(false);
+  const [isBodyExpanded, setIsBodyExpanded] = useState(isCurrentUserBot());
 
-  const isExpandable = ['explore', 'sqllab'].includes(source);
+  const isExpandable =
+    isCurrentUserBot() || ['explore', 'sqllab'].includes(source);
   const iconColor = theme.colors[level].base;
 
   return (


### PR DESCRIPTION
### SUMMARY
To help investigate the chart rendering error in the screen capture, this commit provides more detailed error information for the screen capture request.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1062" alt="Screenshot 2023-10-04 at 10 55 13 AM" src="https://github.com/apache/superset/assets/1392866/036549e7-f268-4762-b0e5-73af9101b13c">

After:
<img width="1067" alt="Screenshot 2023-10-04 at 10 54 27 AM" src="https://github.com/apache/superset/assets/1392866/e669ade9-b05d-4061-b7d2-eeca350c6709">

### TESTING INSTRUCTIONS
Set a chart with a error and then capture the screenshot for the specific chart/dashboard with the chart

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
