### PR TITLE
chore(websocket): [WIP] Making JWT algos configurable

### DIFF
--- a/superset-websocket/config.example.json
+++ b/superset-websocket/config.example.json
@@ -16,6 +16,7 @@
     "ssl": false
   },
   "redisStreamPrefix": "async-events-",
+  "jwtAlgorithms": ["HS256"],
   "jwtSecret": "CHANGE-ME",
   "jwtCookieName": "async-token"
 }

--- a/superset-websocket/src/config.ts
+++ b/superset-websocket/src/config.ts
@@ -36,6 +36,7 @@ type ConfigType = {
   redisStreamPrefix: string;
   redisStreamReadCount: number;
   redisStreamReadBlockMs: number;
+  jwtAlgorithms: string[];
   jwtSecret: string;
   jwtCookieName: string;
   jwtChannelIdKey: string;
@@ -53,6 +54,7 @@ function defaultConfig(): ConfigType {
     redisStreamPrefix: 'async-events-',
     redisStreamReadCount: 100,
     redisStreamReadBlockMs: 5000,
+    jwtAlgorithms: ['HS256'],
     jwtSecret: '',
     jwtCookieName: 'async-token',
     jwtChannelIdKey: 'channel',

--- a/superset-websocket/src/index.ts
+++ b/superset-websocket/src/index.ts
@@ -20,7 +20,7 @@ import * as http from 'http';
 import * as net from 'net';
 import WebSocket from 'ws';
 import { v4 as uuidv4 } from 'uuid';
-import jwt from 'jsonwebtoken';
+import jwt, { Algorithm } from 'jsonwebtoken';
 import cookie from 'cookie';
 import Redis from 'ioredis';
 import StatsD from 'hot-shots';
@@ -261,7 +261,10 @@ const readChannelId = (request: http.IncomingMessage): string => {
   const token = cookies[opts.jwtCookieName];
 
   if (!token) throw new Error('JWT not present');
-  const jwtPayload = jwt.verify(token, opts.jwtSecret) as JwtPayload;
+  const jwtPayload = jwt.verify(token, opts.jwtSecret, {
+    algorithms: opts.jwtAlgorithms as Algorithm[],
+    complete: false,
+  }) as JwtPayload;
   const channelId = jwtPayload[opts.jwtChannelIdKey];
 
   if (!channelId) throw new Error('Channel ID not present in JWT');


### PR DESCRIPTION
### SUMMARY
Adds new [optional] config key to websocket server, `jwtAlgorithms` that allows for multiple algos to be utilized, as defined here: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jsonwebtoken/index.d.ts#L146

* Retains the current default of `HS256`