### PR TITLE
fix(sqllab): Mistitled for new tab after rename

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -607,7 +607,12 @@ export function addNewQueryEditor() {
           '-- Note: Unless you save your query, these tabs will NOT persist if you clear your cookies or change browsers.\n\n',
         );
 
-    const name = newQueryTabName(queryEditors || []);
+    const name = newQueryTabName(
+      queryEditors?.map(qe => ({
+        ...qe,
+        ...(qe.id === unsavedQueryEditor.id && unsavedQueryEditor),
+      })) || [],
+    );
 
     return dispatch(
       addQueryEditor({

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -630,10 +630,12 @@ export function addNewQueryEditor() {
 export function cloneQueryToNewTab(query, autorun) {
   return function (dispatch, getState) {
     const state = getState();
-    const { queryEditors, tabHistory } = state.sqlLab;
-    const sourceQueryEditor = queryEditors.find(
-      qe => qe.id === tabHistory[tabHistory.length - 1],
-    );
+    const { queryEditors, unsavedQueryEditor, tabHistory } = state.sqlLab;
+    const sourceQueryEditor = {
+      ...queryEditors.find(qe => qe.id === tabHistory[tabHistory.length - 1]),
+      ...(tabHistory[tabHistory.length - 1] === unsavedQueryEditor.id &&
+        unsavedQueryEditor),
+    };
     const queryEditor = {
       name: t('Copy of %s', sourceQueryEditor.name),
       dbId: query.dbId ? query.dbId : null,

--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.js
@@ -389,8 +389,11 @@ describe('async actions', () => {
       const state = {
         sqlLab: {
           tabHistory: [id],
-          queryEditors: [{ id, name: 'Dummy query editor' }],
-          unsavedQueryEditor: {},
+          queryEditors: [{ id, name: 'out of updated title' }],
+          unsavedQueryEditor: {
+            id,
+            name: 'Dummy query editor',
+          },
         },
       };
       const store = mockStore(state);

--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.js
@@ -444,16 +444,23 @@ describe('async actions', () => {
 
     describe('addNewQueryEditor', () => {
       it('creates new query editor with new tab name', () => {
-        const store = mockStore(initialState);
+        const store = mockStore({
+          ...initialState,
+          sqlLab: {
+            ...initialState.sqlLab,
+            unsavedQueryEditor: {
+              id: defaultQueryEditor.id,
+              name: 'Untitled Query 6',
+            },
+          },
+        });
         const expectedActions = [
           {
             type: actions.ADD_QUERY_EDITOR,
             queryEditor: {
               id: 'abcd',
               sql: expect.stringContaining('SELECT ...'),
-              name: `Untitled Query ${
-                store.getState().sqlLab.queryEditors.length + 1
-              }`,
+              name: `Untitled Query 7`,
               dbId: defaultQueryEditor.dbId,
               schema: defaultQueryEditor.schema,
               autorun: false,


### PR DESCRIPTION
### SUMMARY
Following up the no.1 issue of https://github.com/apache/superset/pull/25151#issuecomment-1747279563

This commit fixes the bug of mistitled of new tab after renaming the existing tab.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://github.com/apache/superset/assets/1392866/a2b3e4d3-98bd-42a8-8ffc-6dd58d217964

After:

https://github.com/apache/superset/assets/1392866/391aa215-b0d7-4992-b1f8-8501ca412ab0


### TESTING INSTRUCTIONS
Go to SQL Lab and create a new tab
rename the current untitled tab and then create a new tab
Check the untitled tab as 'Untitled Query 1'

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
