### PR TITLE
fix: Breaking change in MachineAuthProvider constructor

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -1355,7 +1355,6 @@ WEBDRIVER_WINDOW = {
 # webdriver (when using Selenium) or browser context (when using Playwright - see
 # PLAYWRIGHT_REPORTS_AND_THUMBNAILS feature flag)
 WEBDRIVER_AUTH_FUNC = None
-BROWSER_CONTEXT_AUTH_FUNC = None
 
 # Any config options to be passed as-is to the webdriver
 WEBDRIVER_CONFIGURATION: dict[Any, Any] = {"service_log_path": "/dev/null"}

--- a/superset/utils/machine_auth.py
+++ b/superset/utils/machine_auth.py
@@ -45,7 +45,8 @@ class MachineAuthProvider:
         self,
         auth_webdriver_func_override: Callable[
             [WebDriver | BrowserContext, User], WebDriver | BrowserContext
-        ],
+        ]
+        | None = None,
     ):
         # This is here in order to allow for the authenticate_webdriver
         # or authenticate_browser_context (if PLAYWRIGHT_REPORTS_AND_THUMBNAILS is
@@ -63,7 +64,7 @@ class MachineAuthProvider:
         :return: The WebDriver passed in (fluent)
         """
         # Short-circuit this method if we have an override configured
-        if self._auth_webdriver_func_override:  # type: ignore
+        if self._auth_webdriver_func_override:
             return self._auth_webdriver_func_override(driver, user)
 
         # Setting cookies requires doing a request first
@@ -82,7 +83,7 @@ class MachineAuthProvider:
         user: User,
     ) -> BrowserContext:
         # Short-circuit this method if we have an override configured
-        if self._auth_webdriver_func_override:  # type: ignore
+        if self._auth_webdriver_func_override:
             return self._auth_webdriver_func_override(browser_context, user)
 
         url = urlparse(current_app.config["WEBDRIVER_BASEURL"])

--- a/superset/utils/machine_auth.py
+++ b/superset/utils/machine_auth.py
@@ -43,15 +43,15 @@ if TYPE_CHECKING:
 class MachineAuthProvider:
     def __init__(
         self,
-        auth_webdriver_func_override: Callable[[WebDriver, User], WebDriver],
-        auth_context_func_override: Callable[[BrowserContext, User], BrowserContext],
+        auth_webdriver_func_override: Callable[
+            [WebDriver | BrowserContext, User], WebDriver | BrowserContext
+        ],
     ):
         # This is here in order to allow for the authenticate_webdriver
         # or authenticate_browser_context (if PLAYWRIGHT_REPORTS_AND_THUMBNAILS is
         # enabled) func to be overridden via config, as opposed to the entire
         # provider implementation
         self._auth_webdriver_func_override = auth_webdriver_func_override
-        self._auth_context_func_override = auth_context_func_override
 
     def authenticate_webdriver(
         self,
@@ -82,8 +82,8 @@ class MachineAuthProvider:
         user: User,
     ) -> BrowserContext:
         # Short-circuit this method if we have an override configured
-        if self._auth_context_func_override:  # type: ignore
-            return self._auth_context_func_override(browser_context, user)
+        if self._auth_webdriver_func_override:  # type: ignore
+            return self._auth_webdriver_func_override(browser_context, user)
 
         url = urlparse(current_app.config["WEBDRIVER_BASEURL"])
 
@@ -145,12 +145,12 @@ class MachineAuthProvider:
 
 class MachineAuthProviderFactory:
     def __init__(self) -> None:
-        self._auth_provider = None
+        self._auth_provider: MachineAuthProvider | None = None
 
     def init_app(self, app: Flask) -> None:
         self._auth_provider = load_class_from_name(
             app.config["MACHINE_AUTH_PROVIDER_CLASS"]
-        )(app.config["WEBDRIVER_AUTH_FUNC"], app.config["BROWSER_CONTEXT_AUTH_FUNC"])
+        )(app.config["WEBDRIVER_AUTH_FUNC"])
 
     @property
     def instance(self) -> MachineAuthProvider:


### PR DESCRIPTION
### SUMMARY
A change introduced in https://github.com/apache/superset/pull/25247 in MachineAuthProvider caused some custom auth providers to be broken, because of unexpected second argument passed to the constructor. This PR reverts that behaviour and .allows only passing either Selenium or Playwright override auth function, not both at the same time.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Add a custom `MACHINE_AUTH_PROVIDER_CLASS` that inherits from `MachineAuthProvider` and uses an `__init__` method that accepts only 1 argument - custom auth function (existing implementations follow this pattern)
2. Verify that your custom auth provider works as expected.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
