### PR TITLE
chore: replace "dashboard" -> "report" in chart email report modal

### DIFF
--- a/superset-frontend/src/features/reports/ReportModal/index.tsx
+++ b/superset-frontend/src/features/reports/ReportModal/index.tsx
@@ -334,9 +334,7 @@ function ReportModal({
           <h4 css={(theme: SupersetTheme) => SectionHeaderStyle(theme)}>
             {t('Schedule')}
           </h4>
-          <p>
-            {t('The report will be sent to your email at')}
-          </p>
+          <p>{t('The report will be sent to your email at')}</p>
         </StyledScheduleTitle>
 
         <StyledCronPicker

--- a/superset-frontend/src/features/reports/ReportModal/index.tsx
+++ b/superset-frontend/src/features/reports/ReportModal/index.tsx
@@ -335,7 +335,7 @@ function ReportModal({
             {t('Schedule')}
           </h4>
           <p>
-            {t('A screenshot of the dashboard will be sent to your email at')}
+            {t('The report will be sent to your email at')}
           </p>
         </StyledScheduleTitle>
 


### PR DESCRIPTION
### SUMMARY
When setting up a new email report for a chart, the popup incorrectly says "dashboard" and "screenshot."

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
In Superset 3.0.0, click the `...` on a chart, then Manage email report, then Set up an email report.  You'll see:

![image](https://github.com/apache/superset/assets/7569808/1cd3f017-20a5-44d8-8a57-c57b907aad3d)

a) This shouldn't say screenshot because the user can pick a text or .CSV format choice
b) This should say chart instead of dashboard

### TESTING INSTRUCTIONS
N/A, just changing a line of text.