### PR TITLE
fix: Make `host.docker.internal` available on linux

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
     restart: unless-stopped
     ports:
       - "80:80"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - ./docker/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
   redis:


### PR DESCRIPTION
### SUMMARY
https://github.com/apache/superset/pull/25346 introduced an nginx container which uses `host.docker.internal`. Unfortunately, this is not available on Linux. This can be solved with the use of `extra-hosts` in docker-compose.yml.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Fixes the following error:

```bash
superset_nginx         | 2023/10/06 07:02:12 [emerg] 1#1: host not found in upstream "host.docker.internal:8088" in /etc/nginx/nginx.conf:94
superset_nginx         | nginx: [emerg] host not found in upstream "host.docker.internal:8088" in /etc/nginx/nginx.conf:94
```

### TESTING INSTRUCTIONS
- `docker-compose up` and check the nginx container logs
- ping `host.docker.internal` from nginx container

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
