### PR TITLE
fix(embedded): async query for embedded dashboard with RLS

### DIFF
--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -336,6 +336,10 @@ class ChartDataRestApi(ChartRestApi):
         except AsyncQueryTokenException:
             return self.response_401()
 
+        # If the user is guest we pass guest token to the celery task
+        if guest := security_manager.get_current_guest_user_if_guest():
+            form_data["guest_token"] = guest.guest_token
+
         result = async_command.run(form_data, get_user_id())
         return self.response(202, **result)
 

--- a/superset/tasks/async_queries.py
+++ b/superset/tasks/async_queries.py
@@ -70,6 +70,12 @@ def load_chart_data_into_cache(
         security_manager.get_user_by_id(job_metadata.get("user_id"))
         or security_manager.get_anonymous_user()
     )
+    if "guest_token" in form_data:
+        guest_token = form_data.pop("guest_token")
+        try:
+            user = security_manager.get_guest_user_from_token(guest_token)
+        except Exception:  # pylint: disable=broad-except
+            logger.warning("Invalid guest token", exc_info=True)
 
     with override_user(user, force=False):
         try:


### PR DESCRIPTION
### SUMMARY
Guest token with its RLS was not available in celery worker. That's why async queries for embedded dashboard have no RLS clauses.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
superset version: 2.1.0 or 3.0.0
superset_config:
```
GLOBAL_ASYNC_QUERIES_REDIS_CONFIG = {
    "port": REDIS_PORT,
    "host": REDIS_HOST,
    "password": "",
    "db": 0,
    "ssl": False,
}
FEATURE_FLAGS = {
    "EMBEDDED_SUPERSET": True,
    "GLOBAL_ASYNC_QUERIES": True,
}

```
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #24171
- [x] Required feature flags: EMBEDDED_SUPERSET, GLOBAL_ASYNC_QUERIES
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
