### PR TITLE
docs: handling "System limit for number of file watchers reached" error

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -625,9 +625,10 @@ The current value of max watches can be checked by below command.
 ```bash
 cat /proc/sys/fs/inotify/max_user_watches
 ```
-Edit the file /etc/sysctl.conf to change this value.
+Edit the file /etc/sysctl.conf to increase this value.
+The value needs to be decided based on the system memory.
 
-Open the file in editor and add a line at the bottom specifying the max watches values. 524288 is the limit.
+Open the file in editor and add a line at the bottom specifying the max watches values.
 ```bash
 fs.inotify.max_user_watches=524288
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -624,7 +624,7 @@ The current value of max watches can be checked with:
 cat /proc/sys/fs/inotify/max_user_watches
 ```
 Edit the file /etc/sysctl.conf to increase this value.
-The value needs to be decided based on the system memory.[(see this StackOverflow answer for more context)](https://stackoverflow.com/questions/535768/what-is-a-reasonable-amount-of-inotify-watches-with-linux)
+The value needs to be decided based on the system memory [(see this StackOverflow answer for more context)](https://stackoverflow.com/questions/535768/what-is-a-reasonable-amount-of-inotify-watches-with-linux).
 
 Open the file in editor and add a line at the bottom specifying the max watches values.
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -610,6 +610,25 @@ Then put this:
 export NODE_OPTIONS=--no-experimental-fetch
 ```
 
+If this type of error comes while building assets(i.e using above commands):
+
+```bash
+Error: ENOSPC: System limit for number of file watchers reached
+```
+The meaning of this error is that the number of files monitored by the system has reached the limit!
+
+Do the following to Modify the number of system monitoring files :
+```bash
+sudo gedit /etc/sysctl.conf
+```
+Add a line at the bottom
+```bash
+fs.inotify.max_user_watches=524288
+```
+save and exit
+```bash
+sudo sysctl -p
+```
 #### Webpack dev server
 
 The dev server by default starts at `http://localhost:9000` and proxies the backend requests to `http://localhost:8088`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -615,17 +615,23 @@ If Following type of error comes while running dev server(i.e using above comman
 ```bash
 Error: ENOSPC: System limit for number of file watchers reached
 ```
-The meaning of this error is that the number of files monitored by the system has reached the limit!
+The error is thrown because the number of files monitored by the system has reached the limit.
+The error can be fixed by increasing the amount of inotify watchers.
 
 Do the following to Modify the number of system monitoring files :
+
+
+The current value of max watches can be checked by below command.
 ```bash
-sudo gedit /etc/sysctl.conf
+cat /proc/sys/fs/inotify/max_user_watches
 ```
-Add a line at the bottom
+Edit the file /etc/sysctl.conf to change this value.
+
+Open the file in editor and add a line at the bottom specifying the max watches values. 524288 is the limit.
 ```bash
 fs.inotify.max_user_watches=524288
 ```
-save and exit
+save the file  and exit
 ```bash
 sudo sysctl -p
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -610,7 +610,7 @@ Then put this:
 export NODE_OPTIONS=--no-experimental-fetch
 ```
 
-If this type of error comes while building assets(i.e using above commands):
+If Following type of error comes while running dev server(i.e using above commands):
 
 ```bash
 Error: ENOSPC: System limit for number of file watchers reached

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -631,7 +631,7 @@ Open the file in editor and add a line at the bottom specifying the max watches 
 fs.inotify.max_user_watches=524288
 ```
 Save the file and exit editor.
-Run following command to load the updated value of max_user_watches from sysctl.conf
+To confirm that the change succeeded, run the following command to load the updated value of max_user_watches from sysctl.conf:
 ```bash
 sudo sysctl -p
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -610,29 +610,28 @@ Then put this:
 export NODE_OPTIONS=--no-experimental-fetch
 ```
 
-If Following type of error comes while running dev server(i.e using above commands):
+If while using the above commands you encounter an error related to the limit of file watchers:
 
 ```bash
 Error: ENOSPC: System limit for number of file watchers reached
 ```
 The error is thrown because the number of files monitored by the system has reached the limit.
-The error can be fixed by increasing the amount of inotify watchers.
-
-Do the following to Modify the number of system monitoring files :
+You can address this this error by increasing the number of inotify watchers.
 
 
-The current value of max watches can be checked by below command.
+The current value of max watches can be checked with:
 ```bash
 cat /proc/sys/fs/inotify/max_user_watches
 ```
 Edit the file /etc/sysctl.conf to increase this value.
-The value needs to be decided based on the system memory.
+The value needs to be decided based on the system memory.[(see this StackOverflow answer for more context)](https://stackoverflow.com/questions/535768/what-is-a-reasonable-amount-of-inotify-watches-with-linux)
 
 Open the file in editor and add a line at the bottom specifying the max watches values.
 ```bash
 fs.inotify.max_user_watches=524288
 ```
-save the file  and exit
+Save the file and exit editor.
+Run following command to load the updated value of max_user_watches from sysctl.conf
 ```bash
 sudo sysctl -p
 ```


### PR DESCRIPTION
Updated docs for handling "System limit for number of file watchers reached" error

