### PR TITLE
fix(Presto): catch DatabaseError when testing Presto views

### DIFF
--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -1268,11 +1268,12 @@ class PrestoEngineSpec(PrestoBaseEngineSpec):
             sql = f"SHOW CREATE VIEW {schema}.{table}"
             try:
                 cls.execute(cursor, sql)
+                rows = cls.fetch_data(cursor, 1)
+
+                return rows[0][0]
             except DatabaseError:  # not a VIEW
                 return None
-            rows = cls.fetch_data(cursor, 1)
 
-            return rows[0][0]
 
     @classmethod
     def get_tracking_url(cls, cursor: Cursor) -> str | None:

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -1274,7 +1274,6 @@ class PrestoEngineSpec(PrestoBaseEngineSpec):
             except DatabaseError:  # not a VIEW
                 return None
 
-
     @classmethod
     def get_tracking_url(cls, cursor: Cursor) -> str | None:
         with contextlib.suppress(AttributeError):

--- a/tests/integration_tests/db_engine_specs/presto_tests.py
+++ b/tests/integration_tests/db_engine_specs/presto_tests.py
@@ -927,7 +927,9 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
 
         mock_execute = mock.MagicMock(side_effect=DatabaseError())
         database = mock.MagicMock()
-        database.get_raw_connection().__enter__().cursor().execute.fetch_data = mock_execute
+        database.get_raw_connection().__enter__().cursor().execute.fetch_data = (
+            mock_execute
+        )
         schema = "schema"
         table = "table"
         result = PrestoEngineSpec.get_create_view(database, schema=schema, table=table)

--- a/tests/integration_tests/db_engine_specs/presto_tests.py
+++ b/tests/integration_tests/db_engine_specs/presto_tests.py
@@ -927,7 +927,7 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
 
         mock_execute = mock.MagicMock(side_effect=DatabaseError())
         database = mock.MagicMock()
-        database.get_raw_connection().__enter__().cursor().execute = mock_execute
+        database.get_raw_connection().__enter__().cursor().execute.fetch_data = mock_execute
         schema = "schema"
         table = "table"
         result = PrestoEngineSpec.get_create_view(database, schema=schema, table=table)

--- a/tests/integration_tests/db_engine_specs/presto_tests.py
+++ b/tests/integration_tests/db_engine_specs/presto_tests.py
@@ -925,11 +925,11 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
     def test_get_create_view_database_error(self):
         from pyhive.exc import DatabaseError
 
-        mock_execute = mock.MagicMock(side_effect=DatabaseError())
+        mock_execute = mock.MagicMock()
+        mock_fetch_data = mock.MagicMock(side_effect=DatabaseError())
         database = mock.MagicMock()
-        database.get_raw_connection().__enter__().cursor().execute.fetch_data = (
-            mock_execute
-        )
+        database.get_raw_connection().__enter__().cursor().execute = mock_execute
+        mock_execute.fetch_data = mock_fetch_data
         schema = "schema"
         table = "table"
         result = PrestoEngineSpec.get_create_view(database, schema=schema, table=table)

--- a/tests/integration_tests/db_engine_specs/presto_tests.py
+++ b/tests/integration_tests/db_engine_specs/presto_tests.py
@@ -929,7 +929,7 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
         mock_fetch_data = mock.MagicMock(side_effect=DatabaseError())
         database = mock.MagicMock()
         database.get_raw_connection().__enter__().cursor().execute = mock_execute
-        mock_execute.fetch_data = mock_fetch_data
+        database.get_raw_connection().__enter__().cursor().fetchall = mock_fetch_data
         schema = "schema"
         table = "table"
         result = PrestoEngineSpec.get_create_view(database, schema=schema, table=table)


### PR DESCRIPTION
### SUMMARY
In Presto DB engine spec, it is supposed to test if a table is a Presto table or Presto view by trying with `SHOW CREATE VIEW` statement. If it fails and throws a DatabaseError, then it is not a view as suggested in the comment. However, the exception is not caught at the right place, which resulted in error stacktrace showing up in the logs and also shows an error banner on the right bottom corner when fetching table schemas. Change it so that it catches the exception correctly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before, we see this exception in our service log. After we made the fix, the error is gone. From the stacktrace, you can see the error is raised on a different line instead of the previously expected one.

![Screenshot 2023-09-27 at 3 08 49 PM](https://github.com/apache/superset/assets/105950525/ed465415-1f46-47b1-a91f-490a24b252d8)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
This will require a Presto DB connection with any table in the database. The easiest way to reproduce the error is to use sqllab, and select the table from the dropdown list. An error should show up in the logs.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
