### PR TITLE
chore: Update pylint to 2.17.7

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -75,7 +75,6 @@ enable=
 # --disable=W"
 disable=
     cyclic-import,  # re-enable once this no longer raises false positives
-    no-member,  # re-enable once this no longer raises false positives. This will become redundant after the min required version is 3.11
     missing-docstring,
     duplicate-code,
     unspecified-encoding,

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -12,7 +12,7 @@
     #   -r requirements/development.in
 appnope==0.1.3
     # via ipython
-astroid==2.15.6
+astroid==2.15.8
     # via pylint
 asttokens==2.2.1
     # via stack-data
@@ -100,7 +100,7 @@ pyhive[hive_pure_sasl]==0.7.0
     # via apache-superset
 pyinstrument==4.4.0
     # via -r requirements/development.in
-pylint==2.17.4
+pylint==2.17.7
     # via -r requirements/development.in
 python-ldap==3.4.3
     # via -r requirements/development.in

--- a/superset/cli/test_db.py
+++ b/superset/cli/test_db.py
@@ -329,7 +329,6 @@ def test_sqlalchemy_dialect(
     return engine
 
 
-# pylint: disable=too-many-statements
 def test_database_connectivity(console: Console, engine: Engine) -> None:
     """
     Tests the DB API 2.0 driver.

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1339,7 +1339,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         from superset.connectors.sqla.models import SqlaTable
 
         # Check if watched fields have changed
-        table = SqlaTable.__table__ # pylint: disable=no-member
+        table = SqlaTable.__table__  # pylint: disable=no-member
         current_dataset = connection.execute(
             table.select().where(table.c.id == target.id)
         ).one()

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1339,7 +1339,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         from superset.connectors.sqla.models import SqlaTable
 
         # Check if watched fields have changed
-        table = SqlaTable.__table__
+        table = SqlaTable.__table__ # pylint: disable=no-member
         current_dataset = connection.execute(
             table.select().where(table.c.id == target.id)
         ).one()

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=too-many-lines, invalid-name
+# pylint: disable=invalid-name
 from __future__ import annotations
 
 import contextlib


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Bump pylint to 2.17.7 in order to fix the next false positive pylint issue for Enum
```
Instance of 'str' has no 'value' member (no-member)
```

https://github.com/pylint-dev/pylint/issues/8897 was resolved (created by @mdeshmu)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
