### PR TITLE
chore: Change the format for sha512 sum for releases

### DIFF
--- a/scripts/sign.sh
+++ b/scripts/sign.sh
@@ -32,10 +32,9 @@ fi
 NAME="${1}"
 if [ -z "${2}" ]; then
   gpg --armor --output "${NAME}".asc --detach-sig "${NAME}"
-  gpg --print-md SHA512 "${NAME}" > "${NAME}".sha512
 else
   # The GPG key name to use
   GPG_LOCAL_USER="${2}"
   gpg --local-user "${GPG_LOCAL_USER}" --armor --output "${NAME}".asc --detach-sig "${NAME}"
-  gpg --local-user "${GPG_LOCAL_USER}" --print-md SHA512 "${NAME}" > "${NAME}".sha512
 fi
+shasum -a 512 "${NAME}" > "${NAME}.sha512"


### PR DESCRIPTION
### SUMMARY
The current `release.tar.gz.sha512` file format does not allow an easy comparison of the SHA sum. See https://github.com/apache/superset/issues/25333

Resolves https://github.com/apache/superset/issues/25333

Mirrors https://github.com/apache/airflow/pull/12867

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
