### PR TITLE
fix(Charts): Set max row limit + removed the option to use an empty row limit value

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
@@ -255,7 +255,7 @@ const row_limit: SharedControlConfig<'SelectControl'> = {
   ],
   default: 10000,
   choices: formatSelectOptions(ROW_LIMIT_OPTIONS),
-  description: t('Limits the number of rows that get displayed!.'),
+  description: t('Limits the number of rows that get displayed.'),
 };
 
 const order_desc: SharedControlConfig<'CheckboxControl'> = {

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
@@ -47,6 +47,8 @@ import {
   isDefined,
   hasGenericChartAxes,
   NO_TIME_RANGE,
+  validateNonEmpty,
+  validateMaxValue,
 } from '@superset-ui/core';
 
 import {
@@ -245,10 +247,15 @@ const row_limit: SharedControlConfig<'SelectControl'> = {
   type: 'SelectControl',
   freeForm: true,
   label: t('Row limit'),
-  validators: [legacyValidateInteger],
+  clearable: false,
+  validators: [
+    validateNonEmpty,
+    legacyValidateInteger,
+    v => validateMaxValue(v, 100000),
+  ],
   default: 10000,
   choices: formatSelectOptions(ROW_LIMIT_OPTIONS),
-  description: t('Limits the number of rows that get displayed.'),
+  description: t('Limits the number of rows that get displayed!.'),
 };
 
 const order_desc: SharedControlConfig<'CheckboxControl'> = {

--- a/superset-frontend/packages/superset-ui-core/src/validator/validateMaxValue.ts
+++ b/superset-frontend/packages/superset-ui-core/src/validator/validateMaxValue.ts
@@ -1,0 +1,8 @@
+import { t } from '../translation';
+
+export default function validateMaxValue(v: unknown, max: unknown) {
+  if (typeof max === 'number' && typeof v === 'number' && v > max) {
+    return t('Value cannot exceed %s', max);
+  }
+  return false;
+}

--- a/superset-frontend/packages/superset-ui-core/src/validator/validateMaxValue.ts
+++ b/superset-frontend/packages/superset-ui-core/src/validator/validateMaxValue.ts
@@ -1,7 +1,7 @@
 import { t } from '../translation';
 
-export default function validateMaxValue(v: unknown, max: unknown) {
-  if (typeof +max === 'number' && typeof +v === 'number' && +v > +max) {
+export default function validateMaxValue(v: unknown, max: Number) {
+  if (typeof Number(v) === 'number' && Number(v) > +max) {
     return t('Value cannot exceed %s', max);
   }
   return false;

--- a/superset-frontend/packages/superset-ui-core/src/validator/validateMaxValue.ts
+++ b/superset-frontend/packages/superset-ui-core/src/validator/validateMaxValue.ts
@@ -1,7 +1,7 @@
 import { t } from '../translation';
 
 export default function validateMaxValue(v: unknown, max: unknown) {
-  if (typeof max === 'number' && typeof v === 'number' && v > max) {
+  if (typeof +max === 'number' && typeof +v === 'number' && +v > +max) {
     return t('Value cannot exceed %s', max);
   }
   return false;

--- a/superset-frontend/packages/superset-ui-core/src/validator/validateMaxValue.ts
+++ b/superset-frontend/packages/superset-ui-core/src/validator/validateMaxValue.ts
@@ -1,7 +1,7 @@
 import { t } from '../translation';
 
 export default function validateMaxValue(v: unknown, max: Number) {
-  if (typeof Number(v) === 'number' && Number(v) > +max) {
+  if (Number(v) > +max) {
     return t('Value cannot exceed %s', max);
   }
   return false;

--- a/superset-frontend/packages/superset-ui-core/test/validator/validateMaxValue.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/validator/validateMaxValue.test.ts
@@ -24,15 +24,15 @@ describe('validateInteger()', () => {
   it('returns the warning message if invalid', () => {
     expect(validateMaxValue(10.1, 10)).toBeTruthy();
     expect(validateMaxValue(1, 0)).toBeTruthy();
-    expect(validateMaxValue('2', '1')).toBeTruthy();
+    expect(validateMaxValue('2', 1)).toBeTruthy();
   });
   it('returns false if the input is valid', () => {
     expect(validateMaxValue(0, 1)).toBeFalsy();
     expect(validateMaxValue(10, 10)).toBeFalsy();
-    expect(validateMaxValue(undefined, undefined)).toBeFalsy();
+    expect(validateMaxValue(undefined, 1)).toBeFalsy();
     expect(validateMaxValue(NaN, NaN)).toBeFalsy();
-    expect(validateMaxValue(null, null)).toBeFalsy();
-    expect(validateMaxValue('1', '1')).toBeFalsy();
-    expect(validateMaxValue('a', 'b')).toBeFalsy();
+    expect(validateMaxValue(null, 1)).toBeFalsy();
+    expect(validateMaxValue('1', 1)).toBeFalsy();
+    expect(validateMaxValue('a', 1)).toBeFalsy();
   });
 });

--- a/superset-frontend/packages/superset-ui-core/test/validator/validateMaxValue.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/validator/validateMaxValue.test.ts
@@ -17,9 +17,19 @@
  * under the License.
  */
 
-export { default as legacyValidateInteger } from './legacyValidateInteger';
-export { default as legacyValidateNumber } from './legacyValidateNumber';
-export { default as validateInteger } from './validateInteger';
-export { default as validateNumber } from './validateNumber';
-export { default as validateNonEmpty } from './validateNonEmpty';
-export { default as validateMaxValue } from './validateMaxValue';
+import { validateMaxValue } from '@superset-ui/core';
+import './setup';
+
+describe('validateInteger()', () => {
+  it('returns the warning message if invalid', () => {
+    expect(validateMaxValue(10.1, 10)).toBeTruthy();
+    expect(validateMaxValue(1, 0)).toBeTruthy();
+  });
+  it('returns false if the input is valid', () => {
+    expect(validateMaxValue(0, 1)).toBeFalsy();
+    expect(validateMaxValue(10, 10)).toBeFalsy();
+    expect(validateMaxValue(undefined, undefined)).toBeFalsy();
+    expect(validateMaxValue(NaN, NaN)).toBeFalsy();
+    expect(validateMaxValue(null, null)).toBeFalsy();
+  });
+});

--- a/superset-frontend/packages/superset-ui-core/test/validator/validateMaxValue.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/validator/validateMaxValue.test.ts
@@ -24,6 +24,7 @@ describe('validateInteger()', () => {
   it('returns the warning message if invalid', () => {
     expect(validateMaxValue(10.1, 10)).toBeTruthy();
     expect(validateMaxValue(1, 0)).toBeTruthy();
+    expect(validateMaxValue('2', '1')).toBeTruthy();
   });
   it('returns false if the input is valid', () => {
     expect(validateMaxValue(0, 1)).toBeFalsy();
@@ -31,5 +32,7 @@ describe('validateInteger()', () => {
     expect(validateMaxValue(undefined, undefined)).toBeFalsy();
     expect(validateMaxValue(NaN, NaN)).toBeFalsy();
     expect(validateMaxValue(null, null)).toBeFalsy();
+    expect(validateMaxValue('1', '1')).toBeFalsy();
+    expect(validateMaxValue('a', 'b')).toBeFalsy();
   });
 });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Can no longer clear/remove the row limit
- New validator that checks if a value is larger than a given input

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![Row Limit 1](https://github.com/apache/superset/assets/11916151/fabe72b1-4b60-4c53-a3b6-52a252e1e3f9)
![Row Limit 2](https://github.com/apache/superset/assets/11916151/80217f0f-27c3-41a7-893a-ab79b47ac68d)
After:
![Screenshot 2023-10-09 120420](https://github.com/apache/superset/assets/11916151/3a5bac51-6064-40db-8884-9f70d4546b5c)
![Screenshot 2023-10-09 120447](https://github.com/apache/superset/assets/11916151/d614cb74-70d3-4466-8623-e93e5b7ea107)

