### PR TITLE
fix: REST API CSRF exempt list

### DIFF
--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -251,7 +251,7 @@ class BaseSupersetApi(BaseSupersetApiMixin, BaseApi):
     ...
 
 
-class BaseSupersetModelRestApi(ModelRestApi, BaseSupersetApiMixin):
+class BaseSupersetModelRestApi(BaseSupersetApiMixin, ModelRestApi):
     """
     Extends FAB's ModelResApi to implement specific superset generic functionality
     """

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -89,6 +89,15 @@ def app(request: SubRequest) -> Iterator[SupersetApp]:
     app.config["TESTING"] = True
 
     # loop over extra configs passed in by tests
+    # and update the app config
+    # to override the default configs use:
+    #
+    # @pytest.mark.parametrize(
+    #     "app",
+    #     [{"SOME_CONFIG": "SOME_VALUE"}],
+    #     indirect=True,
+    # )
+    # def test_some_test(app_context: None) -> None:
     if request and hasattr(request, "param"):
         for key, val in request.param.items():
             app.config[key] = val

--- a/tests/unit_tests/security/api_test.py
+++ b/tests/unit_tests/security/api_test.py
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import pytest
+
+from superset.extensions import csrf
+
+
+@pytest.mark.parametrize(
+    "app",
+    [{"WTF_CSRF_ENABLED": True}],
+    indirect=True,
+)
+def test_csrf_not_exempt(app_context: None) -> None:
+    """
+    Test that REST API is not exempt from CSRF.
+    """
+    assert csrf._exempt_blueprints == {"MenuApi", "SecurityApi", "OpenApi"}


### PR DESCRIPTION
### SUMMARY

Fixes `BaseSupersetModelRestApi` inheritance order. Before this PR `csrf_exempt` attribute was found first by python on class `ModelRestApi` and the evaluation would stop there. This is `True` by default on FAB.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
