### PR TITLE
chore(feature?): Bump `scarf-js` to 1.3.0 to get more telemetry data

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -86,7 +86,7 @@
     "@emotion/styled": "^11.3.0",
     "@fontsource/inter": "^4.0.0",
     "@reduxjs/toolkit": "^1.9.3",
-    "@scarf/scarf": "^1.1.1",
+    "@scarf/scarf": "^1.3.0",
     "@superset-ui/chart-controls": "file:./packages/superset-ui-chart-controls",
     "@superset-ui/core": "file:./packages/superset-ui-core",
     "@superset-ui/legacy-plugin-chart-calendar": "file:./plugins/legacy-plugin-chart-calendar",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Scarf 1.3.0 includes a fix to grab/aggregate the SHA of installations, so that we can know the relative age of installations that don't follow apache releases, know what security vulnerabilities they may be subject to, and know what proportion or our community uses Apache releases vs installs from GitHub.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
n/a

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
All should work as normal, but the Scarf dashboard should show a little more to Superset PMC members. Check the dashboard to make sure it works!

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
