### PR TITLE
fix: keep comments on single statement sql

### DIFF
--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -405,7 +405,9 @@ def execute_sql_statements(
 
     # Breaking down into multiple statements
     parsed_query = ParsedQuery(rendered_query, strip_comments=True)
-    if not db_engine_spec.run_multiple_statements_as_one:
+    raw_statement_count = len(ParsedQuery(rendered_query).get_statements())
+
+    if not db_engine_spec.run_multiple_statements_as_one and raw_statement_count > 1:
         statements = parsed_query.get_statements()
         logger.info(
             "Query %s: Executing %i statement(s)", str(query_id), len(statements)


### PR DESCRIPTION
### SUMMARY
Following by #12188 
The current behavior always strips comments from the original SQL, which I believe helps to distinguish the last SELECT statement including comments in the end.
At Airbnb, we wants to execute the original SQL without stripping comments in order to process an additional behavior using a custom comment block.
In order to satisfy both cases, this commit enables executing original sql only for the single statements.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
Run `SELECT 1 --comment` and check the executed sql

added unit tests.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
