### PR TITLE
fix(sqllab): template validation error within comments

### DIFF
--- a/superset/sqllab/query_render.py
+++ b/superset/sqllab/query_render.py
@@ -25,6 +25,7 @@ from jinja2.meta import find_undeclared_variables
 
 from superset import is_feature_enabled
 from superset.errors import SupersetErrorType
+from superset.sql_parse import ParsedQuery
 from superset.sqllab.commands.execute import SqlQueryRender
 from superset.sqllab.exceptions import SqlLabException
 from superset.utils import core as utils
@@ -57,8 +58,9 @@ class SqlQueryRenderImpl(SqlQueryRender):
                 database=query_model.database, query=query_model
             )
 
+            parsed_query = ParsedQuery(query_model.sql, strip_comments=True)
             rendered_query = sql_template_processor.process_template(
-                query_model.sql, **execution_context.template_params
+                parsed_query.stripped(), **execution_context.template_params
             )
             self._validate(execution_context, rendered_query, sql_template_processor)
             return rendered_query

--- a/tests/integration_tests/sqllab_tests.py
+++ b/tests/integration_tests/sqllab_tests.py
@@ -515,6 +515,13 @@ class TestSqlLab(SupersetTestCase):
         assert data["status"] == "success"
 
         data = self.run_sql(
+            "SELECT * FROM birth_names WHERE state = '{{ state }}' -- blabblah {{ extra1 }} {{fake.fn()}}\nLIMIT 10",
+            "3",
+            template_params=json.dumps({"state": "CA"}),
+        )
+        assert data["status"] == "success"
+
+        data = self.run_sql(
             "SELECT * FROM birth_names WHERE state = '{{ stat }}' LIMIT 10",
             "2",
             template_params=json.dumps({"state": "CA"}),


### PR DESCRIPTION
### SUMMARY
Fixes https://github.com/apache/superset/pull/24009

SQL Lab throws an error for undefined parameters even when those parameters are commented out of/not used by the query.
Template validation within comments is unnecessary because [comments are cleared](https://github.com/apache/superset/blob/17792a507c7245c9e09c6eb98a774f2ef4ec8568/superset/sql_lab.py#L407)  when SQL is executed.
This commit passes parsed_query to the template validation that can ignore the missing parameter validation error within comments.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

|Before|After|
|--|--|
|<img width="567" alt="Screenshot 2023-10-11 at 6 03 34 PM" src="https://github.com/apache/superset/assets/1392866/c8d701b9-31e7-4356-b094-4c3ba18902e6">|<img width="563" alt="Screenshot 2023-10-11 at 6 02 01 PM" src="https://github.com/apache/superset/assets/1392866/42e15289-899d-4d67-8a74-638815940ab9">|

### TESTING INSTRUCTIONS
Go to sqllab and then run a query including a template string within comment-out block like select 123 --,{{ds}} 

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
