### PR TITLE
chore: bump prophet and pip-tools

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -65,8 +65,6 @@ colorama==0.4.6
     # via
     #   apache-superset
     #   flask-appbuilder
-convertdate==2.4.0
-    # via holidays
 cron-descriptor==1.2.24
     # via apache-superset
 croniter==1.0.15
@@ -131,16 +129,12 @@ geographiclib==1.52
 geopy==2.2.0
     # via apache-superset
 greenlet==2.0.2
-    # via
-    #   shillelagh
-    #   sqlalchemy
+    # via shillelagh
 gunicorn==21.2.0
     # via apache-superset
 hashids==1.3.1
     # via apache-superset
-hijri-converter==2.3.1
-    # via holidays
-holidays==0.23
+holidays==0.25
     # via apache-superset
 humanize==3.11.0
     # via apache-superset
@@ -149,10 +143,7 @@ idna==3.2
     #   email-validator
     #   requests
 importlib-metadata==6.6.0
-    # via
-    #   apache-superset
-    #   flask
-    #   shillelagh
+    # via apache-superset
 importlib-resources==5.12.0
     # via limits
 isodate==0.6.0
@@ -220,6 +211,7 @@ packaging==23.1
     #   apache-superset
     #   apispec
     #   deprecation
+    #   gunicorn
     #   limits
     #   marshmallow
     #   shillelagh
@@ -248,8 +240,6 @@ pyjwt==2.4.0
     #   apache-superset
     #   flask-appbuilder
     #   flask-jwt-extended
-pymeeus==0.5.12
-    # via convertdate
 pynacl==1.5.0
     # via paramiko
 pyparsing==3.0.6
@@ -362,9 +352,7 @@ wtforms-json==0.3.5
 xlsxwriter==3.0.7
     # via apache-superset
 zipp==3.15.0
-    # via
-    #   importlib-metadata
-    #   importlib-resources
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -104,11 +104,6 @@ pylint==2.17.7
     # via -r requirements/development.in
 python-ldap==3.4.3
     # via -r requirements/development.in
-requests==2.31.0
-    # via
-    #   pydruid
-    #   tableschema
-    #   tabulator
 rfc3986==2.0.0
     # via tableschema
 s3transfer==0.6.1

--- a/requirements/integration.txt
+++ b/requirements/integration.txt
@@ -36,7 +36,7 @@ packaging==23.1
     #   tox
 pip-compile-multi==2.6.3
     # via -r requirements/integration.in
-pip-tools==6.13.0
+pip-tools==7.3.0
     # via pip-compile-multi
 platformdirs==3.8.1
     # via
@@ -55,6 +55,7 @@ pyyaml==6.0.1
 tomli==2.0.1
     # via
     #   build
+    #   pip-tools
     #   pyproject-api
     #   tox
 toposort==1.10

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -12,8 +12,6 @@
     #   -r requirements/base.in
     #   -r requirements/development.in
     #   -r requirements/testing.in
-apsw==3.42.0.1
-    # via shillelagh
 cmdstanpy==1.1.0
     # via prophet
 contourpy==1.0.7
@@ -106,7 +104,7 @@ pathable==0.4.3
     # via jsonschema-spec
 playwright==1.37.0
     # via apache-superset
-prophet==1.1.1
+prophet==1.1.5
     # via apache-superset
 proto-plus==1.22.2
     # via

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
         "geopy",
         "gunicorn>=21.2.0, <22.0; sys_platform != 'win32'",
         "hashids>=1.3.1, <2",
-        "holidays>=0.23, <0.24",
+        "holidays>=0.25, <0.26",
         "humanize",
         "importlib_metadata",
         "isodate",

--- a/setup.py
+++ b/setup.py
@@ -187,7 +187,7 @@ setup(
         "postgres": ["psycopg2-binary==2.9.6"],
         "presto": ["pyhive[presto]>=0.6.5"],
         "trino": ["trino>=0.324.0"],
-        "prophet": ["prophet==1.1.1"],
+        "prophet": ["prophet>=1.1.5, <1.2"],
         "redshift": ["sqlalchemy-redshift>=0.8.1, < 0.9"],
         "rockset": ["rockset-sqlalchemy>=0.0.1, <1.0.0"],
         "shillelagh": [


### PR DESCRIPTION
### SUMMARY
Prophet 1.1.5 adds support for M2 chipsets on which installation is currently failing. In addition, the current version of `pip-tools` is failing with `pip-compile-multi`, making it impossible to update the lock files. By upgrading to 7.3.0 the problem appears to go away. After updating the dependencies files, a few redundant libraries are also removed from the lock files.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
