### PR TITLE
chore: bump pip-tools

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -104,11 +104,6 @@ pylint==2.17.7
     # via -r requirements/development.in
 python-ldap==3.4.3
     # via -r requirements/development.in
-requests==2.31.0
-    # via
-    #   pydruid
-    #   tableschema
-    #   tabulator
 rfc3986==2.0.0
     # via tableschema
 s3transfer==0.6.1

--- a/requirements/integration.txt
+++ b/requirements/integration.txt
@@ -36,7 +36,7 @@ packaging==23.1
     #   tox
 pip-compile-multi==2.6.3
     # via -r requirements/integration.in
-pip-tools==6.13.0
+pip-tools==7.3.0
     # via pip-compile-multi
 platformdirs==3.8.1
     # via
@@ -55,6 +55,7 @@ pyyaml==6.0.1
 tomli==2.0.1
     # via
     #   build
+    #   pip-tools
     #   pyproject-api
     #   tox
 toposort==1.10

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -12,8 +12,6 @@
     #   -r requirements/base.in
     #   -r requirements/development.in
     #   -r requirements/testing.in
-apsw==3.42.0.1
-    # via shillelagh
 cmdstanpy==1.1.0
     # via prophet
 contourpy==1.0.7


### PR DESCRIPTION
### SUMMARY
Currently running `pip-compile-multi` fails on my devenv:

```bash
$ pip-compile-multi -P prophet
Locking requirements/base.in to requirements/base.txt. References: []
Locking requirements/integration.in to requirements/integration.txt. References: []
Locking requirements/development.in to requirements/development.txt. References: ['requirements/base.in']
Locking requirements/docker.in to requirements/docker.txt. References: ['requirements/base.in']
Locking requirements/local.in to requirements/local.txt. References: ['requirements/base.in', 'requirements/development.in']
Locking requirements/testing.in to requirements/testing.txt. References: ['requirements/base.in', 'requirements/development.in', 'requirements/integration.in']
ERROR executing /Users/ville/apple/apache-superset/venv/bin/python -m piptools compile --no-header --verbose --no-emit-index-url --resolver=legacy --emit-trusted-host --upgrade-package=prophet --rebuild --output-file requirements/testing.txt requirements/testing.in
Exit code: 1
/Users/ville/apple/apache-superset/venv/lib/python3.10/site-packages/_distutils_hack/__init__.py:33: UserWarning: Setuptools is replacing distutils.
  warnings.warn("Setuptools is replacing distutils.")
Traceback (most recent call last):
  File "/Users/ville/.pyenv/versions/3.10-dev/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Users/ville/.pyenv/versions/3.10-dev/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/Users/ville/apple/apache-superset/venv/lib/python3.10/site-packages/piptools/__main__.py", line 5, in <module>
    from piptools.scripts import compile, sync
  File "/Users/ville/apple/apache-superset/venv/lib/python3.10/site-packages/piptools/scripts/sync.py", line 16, in <module>
    from .. import sync
  File "/Users/ville/apple/apache-superset/venv/lib/python3.10/site-packages/piptools/sync.py", line 11, in <module>
    from pip._internal.commands.freeze import DEV_PKGS
ImportError: cannot import name 'DEV_PKGS' from 'pip._internal.commands.freeze' (/Users/ville/apple/apache-superset/venv/lib/python3.10/site-packages/pip/_internal/commands/freeze.py)

Traceback (most recent call last):
  File "/Users/ville/apple/apache-superset/venv/lib/python3.10/site-packages/pipcompilemulti/cli_v1.py", line 26, in cli
    recompile()
  File "/Users/ville/apple/apache-superset/venv/lib/python3.10/site-packages/pipcompilemulti/actions.py", line 31, in recompile
    compile_topologically(env_confs, deduplicator)
  File "/Users/ville/apple/apache-superset/venv/lib/python3.10/site-packages/pipcompilemulti/actions.py", line 38, in compile_topologically
    if env.maybe_create_lockfile():
  File "/Users/ville/apple/apache-superset/venv/lib/python3.10/site-packages/pipcompilemulti/environment.py", line 51, in maybe_create_lockfile
    self.create_lockfile()
  File "/Users/ville/apple/apache-superset/venv/lib/python3.10/site-packages/pipcompilemulti/environment.py", line 80, in create_lockfile
    raise RuntimeError("Failed to pip-compile {0}".format(self.infile))
RuntimeError: Failed to pip-compile requirements/testing.in
```

After upgrading to `7.3.0` the problem appears to go away:
```bash
$ pip-compile-multi -P prophet
Locking requirements/base.in to requirements/base.txt. References: []
Locking requirements/integration.in to requirements/integration.txt. References: []
Locking requirements/development.in to requirements/development.txt. References: ['requirements/base.in']
Locking requirements/docker.in to requirements/docker.txt. References: ['requirements/base.in']
Locking requirements/local.in to requirements/local.txt. References: ['requirements/base.in', 'requirements/development.in']
Locking requirements/testing.in to requirements/testing.txt. References: ['requirements/base.in', 'requirements/development.in', 'requirements/integration.in']
```

Judging by the changes to the lock files people have been manually updating the lock files for a while now, so this may help unblock others trying to automatically update them with `pip-compile-multi`..

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
