### PR TITLE
fix(email-notifications): Changes Suffix of Email Notification CSV Reports to ZIP

### DIFF
--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -167,7 +167,7 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
         )
 
         if self._content.csv:
-            csv_data = {__("%(name)s.csv", name=self._content.name): self._content.csv}
+            csv_data = {__("%(name)s.zip", name=self._content.name): self._content.csv}
         return EmailContent(
             body=body,
             images=images,


### PR DESCRIPTION
### SUMMARY
Fixes https://github.com/apache/superset/issues/25647

In short, attachments are being sent as "CSV" when they are in fact ZIP.

### TESTING INSTRUCTIONS
Notification can be set up for a chart with CSV output. The Attachment will now be a ZIP containing the Alert Query as well as the Chart Requested

I'm seeking assistance with testing this or writing automated tests to make sure that the attachments created are of the correct type matching the extension.
