### PR TITLE
docs: make project-specific security page more prominent

### DIFF
--- a/docs/docs/security/security.mdx
+++ b/docs/docs/security/security.mdx
@@ -264,4 +264,5 @@ analysing the findings.
 
 PLEASE PAY ATTENTION to report the security issue on the security email before disclosing it on
 public domain. The ASF Security Team maintains a page with the description of how vulnerabilities
-and potential threats are handled, check their web page for more details.
+and potential threats are handled, check [their web page](https://apache.org/security/committers.html)
+for more details.

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -246,7 +246,7 @@ const config = {
           <img class="footer__divider" src="/img/community/line.png" alt="Divider" />
           <p>
             <small>
-              <a href="https://www.apache.org/security/" target="_blank" rel="noreferrer">Security</a>&nbsp;|&nbsp;
+              <a href="https://superset.apache.org/docs/security/" target="_blank" rel="noreferrer">Security</a>&nbsp;|&nbsp;
               <a href="https://www.apache.org/foundation/sponsorship.html" target="_blank" rel="noreferrer">Donate</a>&nbsp;|&nbsp;
               <a href="https://www.apache.org/foundation/thanks.html" target="_blank" rel="noreferrer">Thanks</a>&nbsp;|&nbsp;
               <a href="https://apache.org/events/current-event" target="_blank" rel="noreferrer">Events</a>&nbsp;|&nbsp;


### PR DESCRIPTION
### SUMMARY

Link to https://superset.apache.org/docs/security/ so people are directed to the detailed SuperSet-specific security documentation. Link from there to the ASF-wide information.

### TESTING INSTRUCTIONS

Build the website, see the footer.