### PR TITLE
fix: Obscure error message on dataset creation

### DIFF
--- a/superset/datasets/commands/create.py
+++ b/superset/datasets/commands/create.py
@@ -31,6 +31,7 @@ from superset.datasets.commands.exceptions import (
     DatasetInvalidError,
     TableNotFoundValidationError,
 )
+from superset.exceptions import SupersetSecurityException
 from superset.extensions import db
 
 logger = logging.getLogger(__name__)
@@ -53,6 +54,9 @@ class CreateDatasetCommand(CreateMixin, BaseCommand):
             logger.warning(ex, exc_info=True)
             db.session.rollback()
             raise DatasetCreateFailedError() from ex
+        except SupersetSecurityException as ex:
+            db.session.rollback()
+            raise DatasetCreateFailedError(message=str(ex))
         return dataset
 
     def validate(self) -> None:

--- a/superset/datasets/commands/create.py
+++ b/superset/datasets/commands/create.py
@@ -53,7 +53,11 @@ class CreateDatasetCommand(CreateMixin, BaseCommand):
         except (SQLAlchemyError, DAOCreateFailedError, SupersetSecurityException) as ex:
             logger.warning(ex, exc_info=True)
             db.session.rollback()
-            raise DatasetCreateFailedError(message=str(ex)) from ex
+            raise DatasetCreateFailedError(
+                *{"message": str(ex)}
+                if isinstance(ex, SupersetSecurityException)
+                else {}
+            ) from ex
         return dataset
 
     def validate(self) -> None:

--- a/superset/datasets/commands/create.py
+++ b/superset/datasets/commands/create.py
@@ -54,7 +54,7 @@ class CreateDatasetCommand(CreateMixin, BaseCommand):
             logger.warning(ex, exc_info=True)
             db.session.rollback()
             raise DatasetCreateFailedError(
-                *{"message": str(ex)}
+                *{"message": str(ex), "exception": ex}
                 if isinstance(ex, SupersetSecurityException)
                 else {"exception": ex}
             ) from ex

--- a/superset/datasets/commands/create.py
+++ b/superset/datasets/commands/create.py
@@ -56,7 +56,7 @@ class CreateDatasetCommand(CreateMixin, BaseCommand):
             raise DatasetCreateFailedError() from ex
         except SupersetSecurityException as ex:
             db.session.rollback()
-            raise DatasetCreateFailedError(message=str(ex))
+            raise DatasetCreateFailedError(message=str(ex)) from ex
         return dataset
 
     def validate(self) -> None:

--- a/superset/datasets/commands/create.py
+++ b/superset/datasets/commands/create.py
@@ -50,11 +50,8 @@ class CreateDatasetCommand(CreateMixin, BaseCommand):
             # Updates columns and metrics from the dataset
             dataset.fetch_metadata(commit=False)
             db.session.commit()
-        except (SQLAlchemyError, DAOCreateFailedError) as ex:
+        except (SQLAlchemyError, DAOCreateFailedError, SupersetSecurityException) as ex:
             logger.warning(ex, exc_info=True)
-            db.session.rollback()
-            raise DatasetCreateFailedError() from ex
-        except SupersetSecurityException as ex:
             db.session.rollback()
             raise DatasetCreateFailedError(message=str(ex)) from ex
         return dataset

--- a/superset/datasets/commands/create.py
+++ b/superset/datasets/commands/create.py
@@ -56,7 +56,7 @@ class CreateDatasetCommand(CreateMixin, BaseCommand):
             raise DatasetCreateFailedError(
                 *{"message": str(ex)}
                 if isinstance(ex, SupersetSecurityException)
-                else {}
+                else {"exception": ex}
             ) from ex
         return dataset
 

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -725,7 +725,7 @@ class TestDatasetApi(SupersetTestCase):
         self.login(username="admin")
         table_data = {
             "database": energy_usage_ds.database_id,
-            "table_name": energy_usage_ds.table_name,
+            "table_name": "energy_usage_virtual",
             "sql": "insert into energy_usage select * from energy_usage",
         }
         if schema := get_example_default_schema():


### PR DESCRIPTION
### SUMMARY
When a SupersetSecurityException error is thrown while creating a dataset, it only shows "Fater Error" error message.
This commit adds the SupersetSecurityException case that displays the error message from the statement validation error.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:
<img width="806" alt="Screenshot 2023-10-16 at 4 32 05 PM" src="https://github.com/apache/superset/assets/1392866/09a8f225-02c8-450e-9b08-0425d86520e1">

After:
<img width="829" alt="Screenshot 2023-10-16 at 4 41 52 PM" src="https://github.com/apache/superset/assets/1392866/90386841-f966-4969-928d-1c575c16957b">

### TESTING INSTRUCTIONS
Go to SQL Lab and create an invalid select statement (`(SELECT 1)` with parentheses)
Create a dataset and see the error message

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
