### PR TITLE
feat: add France's regions to country map visualization

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-country-map/src/countries.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-country-map/src/countries.ts
@@ -40,6 +40,7 @@ import el_salvador from './countries/el salvador.geojson';
 import estonia from './countries/estonia.geojson';
 import ethiopia from './countries/ethiopia.geojson';
 import france from './countries/france.geojson';
+import france_regions from './countries/france_regions.geojson';
 import finland from './countries/finland.geojson';
 import germany from './countries/germany.geojson';
 import guatemala from './countries/guatemala.geojson';
@@ -133,6 +134,7 @@ export const countries = {
   estonia,
   ethiopia,
   france,
+  france_regions,
   finland,
   germany,
   guatemala,
@@ -209,6 +211,9 @@ export const countryOptions = Object.keys(countries).map(x => {
   }
   if (x === 'italy_regions') {
     return [x, 'Italy (regions)'];
+  }
+  if (x === 'france_regions') {
+    return [x, 'France (regions)'];
   }
   return [x, x[0].toUpperCase() + x.slice(1)];
 });


### PR DESCRIPTION
### SUMMARY
France's Regions have been added as a selection to the Country Map visualization. The geometries were taken from IGN's (France's National Geographic Institute) BD TOPO (R) administrative layer, and the ISO 3166-02 codes for the regions were added as an attribute.

### BEFORE/AFTER SCREENSHOTS
**France's Departments:**
![france_departments](https://github.com/apache/superset/assets/48763344/cd70e08e-54fd-4c39-ae6a-1caa3702243d)

**France's Regions:**
![france_regions](https://github.com/apache/superset/assets/48763344/ace4e891-9035-41e0-98dd-6d71faabf673)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
- [x] Has associated issue: #25673
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
