### PR TITLE
fix: remove unnecessary redirect

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet/ResultSet.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/ResultSet.test.tsx
@@ -95,7 +95,7 @@ const asyncRefetchResultsTableProps = {
     resultsKey: 'async results key',
   },
 };
-fetchMock.get('glob:*/api/v1/dataset?*', { result: [] });
+fetchMock.get('glob:*/api/v1/dataset/?*', { result: [] });
 
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
@@ -39,7 +39,7 @@ const mockedProps = {
   datasource: testQuery,
 };
 
-fetchMock.get('glob:*/api/v1/dataset?*', {
+fetchMock.get('glob:*/api/v1/dataset/?*', {
   result: mockdatasets,
   dataset_count: 3,
 });

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/index.tsx
@@ -253,7 +253,7 @@ export const SaveDatasetModal = ({
       });
 
       return SupersetClient.get({
-        endpoint: `/api/v1/dataset?q=${queryParams}`,
+        endpoint: `/api/v1/dataset/?q=${queryParams}`,
       }).then(response => ({
         data: response.json.result.map(
           (r: { table_name: string; id: number; owners: [DatasetOwner] }) => ({


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Flask follows strict URLs policy by default and current behaviour generates one unnecessary redirect.
`.../api/v1/dataset?q=...` redirects to `.../api/v1/dataset/?q=...` 

One possible workaround is to set `app.url_map.strict_slashes = False`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

0. Open dev tools to monitor network traffic.

1. Open SQLLab and try to save any query as Dataset.
<img width="144" alt="Screenshot 2023-10-17 at 18 43 16" src="https://github.com/apache/superset/assets/3982146/298cc091-eada-4421-8128-2aabdf60a8d4">

2. Click "Overwrite existing" and click on dropdown to see the list.
<img width="585" alt="Screenshot 2023-10-17 at 18 43 30" src="https://github.com/apache/superset/assets/3982146/a99672d7-5dbe-4567-add4-7b96ed175de4">

Expected result:
The single request to `.../api/v1/dataset/?q=...` without redirect.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
