### PR TITLE
feat: Add week time grain for Elasticsearch datasets

### DIFF
--- a/superset/db_engine_specs/elasticsearch.py
+++ b/superset/db_engine_specs/elasticsearch.py
@@ -46,6 +46,7 @@ class ElasticSearchEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-metho
         TimeGrain.MINUTE: "HISTOGRAM({col}, INTERVAL 1 MINUTE)",
         TimeGrain.HOUR: "HISTOGRAM({col}, INTERVAL 1 HOUR)",
         TimeGrain.DAY: "HISTOGRAM({col}, INTERVAL 1 DAY)",
+        TimeGrain.WEEK: "DATE_TRUNC('week', {col})",
         TimeGrain.MONTH: "HISTOGRAM({col}, INTERVAL 1 MONTH)",
         TimeGrain.YEAR: "HISTOGRAM({col}, INTERVAL 1 YEAR)",
     }

--- a/tests/integration_tests/db_engine_specs/elasticsearch_tests.py
+++ b/tests/integration_tests/db_engine_specs/elasticsearch_tests.py
@@ -21,34 +21,20 @@ from tests.integration_tests.db_engine_specs.base_tests import TestDbEngineSpec
 
 
 class TestElasticsearchDbEngineSpec(TestDbEngineSpec):
-    def test_timegrain_week_expression(self):
-        """
-        DB Eng Specs (elasticsearch): Test time grain expressions
-        """
+    def test_time_grain_week_expression(self):
         col = column("ts")
-        test_cases = {
-            "date": "DATE_TRUNC('week', ts)",
-            "date_nanos": "DATE_TRUNC('week', ts)",
-        }
-        for type_, expected in test_cases.items():
-            col.type = type_
-            actual = ElasticSearchEngineSpec.get_timestamp_expr(
-                col=col, pdf=None, time_grain="P1W"
-            )
-            self.assertEqual(str(actual), expected)
+        col.type = "datetime"
+        expected_time_grain_expression = "DATE_TRUNC('week', ts)"
+        actual = ElasticSearchEngineSpec.get_timestamp_expr(
+            col=col, pdf=None, time_grain="P1W"
+        )
+        self.assertEqual(str(actual), expected_time_grain_expression)
 
-    def test_timegrain_hour_expression(self):
-        """
-        DB Eng Specs (elasticsearch): Test time grain expressions
-        """
+    def test_time_grain_hour_expression(self):
         col = column("ts")
-        test_cases = {
-            "date": "HISTOGRAM(ts, INTERVAL 1 HOUR)",
-            "date_nanos": "HISTOGRAM(ts, INTERVAL 1 HOUR)",
-        }
-        for type_, expected in test_cases.items():
-            col.type = type_
-            actual = ElasticSearchEngineSpec.get_timestamp_expr(
-                col=col, pdf=None, time_grain="PT1H"
-            )
-            self.assertEqual(str(actual), expected)
+        col.type = "datetime"
+        expected_time_grain_expression = "HISTOGRAM(ts, INTERVAL 1 HOUR)"
+        actual = ElasticSearchEngineSpec.get_timestamp_expr(
+            col=col, pdf=None, time_grain="PT1H"
+        )
+        self.assertEqual(str(actual), expected_time_grain_expression)

--- a/tests/integration_tests/db_engine_specs/elasticsearch_tests.py
+++ b/tests/integration_tests/db_engine_specs/elasticsearch_tests.py
@@ -14,22 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import unittest.mock as mock
-
-import pytest
-from pandas import DataFrame
 from sqlalchemy import column
-
-from superset.connectors.sqla.models import TableColumn
-from superset.db_engine_specs.base import BaseEngineSpec
 from superset.db_engine_specs.elasticsearch import ElasticSearchEngineSpec
-from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
-from superset.sql_parse import Table
 from tests.integration_tests.db_engine_specs.base_tests import TestDbEngineSpec
-from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,
-    load_birth_names_data,
-)
 
 
 class TestElasticsearchDbEngineSpec(TestDbEngineSpec):

--- a/tests/integration_tests/db_engine_specs/elasticsearch_tests.py
+++ b/tests/integration_tests/db_engine_specs/elasticsearch_tests.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 from sqlalchemy import column
+
 from superset.db_engine_specs.elasticsearch import ElasticSearchEngineSpec
 from tests.integration_tests.db_engine_specs.base_tests import TestDbEngineSpec
 

--- a/tests/integration_tests/db_engine_specs/elasticsearch_tests.py
+++ b/tests/integration_tests/db_engine_specs/elasticsearch_tests.py
@@ -1,0 +1,66 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import unittest.mock as mock
+
+import pytest
+from pandas import DataFrame
+from sqlalchemy import column
+
+from superset.connectors.sqla.models import TableColumn
+from superset.db_engine_specs.base import BaseEngineSpec
+from superset.db_engine_specs.elasticsearch import ElasticSearchEngineSpec
+from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
+from superset.sql_parse import Table
+from tests.integration_tests.db_engine_specs.base_tests import TestDbEngineSpec
+from tests.integration_tests.fixtures.birth_names_dashboard import (
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
+)
+
+
+class TestElasticsearchDbEngineSpec(TestDbEngineSpec):
+    def test_timegrain_week_expression(self):
+        """
+        DB Eng Specs (elasticsearch): Test time grain expressions
+        """
+        col = column("ts")
+        test_cases = {
+            "date": "DATE_TRUNC('week', ts)",
+            "date_nanos": "DATE_TRUNC('week', ts)",
+        }
+        for type_, expected in test_cases.items():
+            col.type = type_
+            actual = ElasticSearchEngineSpec.get_timestamp_expr(
+                col=col, pdf=None, time_grain="P1W"
+            )
+            self.assertEqual(str(actual), expected)
+
+    def test_timegrain_hour_expression(self):
+        """
+        DB Eng Specs (elasticsearch): Test time grain expressions
+        """
+        col = column("ts")
+        test_cases = {
+            "date": "HISTOGRAM(ts, INTERVAL 1 HOUR)",
+            "date_nanos": "HISTOGRAM(ts, INTERVAL 1 HOUR)",
+        }
+        for type_, expected in test_cases.items():
+            col.type = type_
+            actual = ElasticSearchEngineSpec.get_timestamp_expr(
+                col=col, pdf=None, time_grain="PT1H"
+            )
+            self.assertEqual(str(actual), expected)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds the week time grain for the Elasticsearch database engine. This is needed if the user wants to see a week granularity in a time series chart.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
before:
![before](https://github.com/apache/superset/assets/3845586/52910bca-6c5f-4b55-8dd6-76f8acfe2caa)

after:
![after](https://github.com/apache/superset/assets/3845586/861cc44b-a3c5-4b35-84ea-554214062e41)
![chart](https://github.com/apache/superset/assets/3845586/672fc606-cb9b-4aa1-97b4-7ee87cfa9ff6)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
To verify the changes:
- Create a database connection to an Elasticsearch cluster
- Create an index in the Elasticsearch cluster. The index documents should have a date field and at least another field to be used in a metric
- Create a dataset using the Elasticsearch database, and the choose the index created previously as the table
- Create a time series chart and use the date field in the x axis
- Choose the Week Time Grain from the drop down menu


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #23271
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
