### PR TITLE
chore: Adds 3.0.1 data to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ under the License.
 
 ## Change Log
 
+- [3.0.1](#301-tue-oct-13-103221-2023--0700)
 - [3.0.0](#300-thu-aug-24-133627-2023--0600)
 - [2.1.1](#211-sun-apr-23-154421-2023-0100)
 - [2.1.0](#210-thu-mar-16-211305-2023--0700)
@@ -30,6 +31,51 @@ under the License.
 - [1.5.0](#150-fri-apr-22-172330-2022--0400)
 - [1.4.2](#142-sat-mar-19-000806-2022-0200)
 - [1.4.1](#141)
+
+### 3.0.1 (Tue Oct 13 10:32:21 2023 -0700)
+
+**Database Migrations**
+
+- [#25320](https://github.com/apache/superset/pull/25320) fix: Add explicit ON DELETE CASCADE for dashboard_roles (@john-bodley)
+
+**Fixes**
+
+- [#25541](https://github.com/apache/superset/pull/25541) fix: revert fix(sqllab): Force trino client async execution (#24859) (@villebro)
+- [#25618](https://github.com/apache/superset/pull/25618) fix: finestTemporalGrainFormatter (@betodealmeida)
+- [#25599](https://github.com/apache/superset/pull/25599) fix(window): unavailable localStorage and sessionStorage (@frassinier)
+- [#25579](https://github.com/apache/superset/pull/25579) fix(Charts): Set max row limit + removed the option to use an empty row limit value (@CorbinBullard)
+- [#25559](https://github.com/apache/superset/pull/25559) fix(Presto): catch DatabaseError when testing Presto views (@zhaorui2022)
+- [#25486](https://github.com/apache/superset/pull/25486) fix: thubmnails loading - Talisman default config (@Khrol)
+- [#25400](https://github.com/apache/superset/pull/25400) fix(RLS): Fix Info Tooltip + Button Alignment on RLS Modal (@CorbinBullard)
+- [#25590](https://github.com/apache/superset/pull/25590) fix: REST API CSRF exempt list (@dpgaspar)
+- [#25147](https://github.com/apache/superset/pull/25147) fix: Apply normalization to all dttm columns (@kgabryje)
+- [#25516](https://github.com/apache/superset/pull/25516) fix: tags permissions error message (@Khrol)
+- [#25519](https://github.com/apache/superset/pull/25519) fix: Expand error detail on screencapture (@justinpark)
+- [#25490](https://github.com/apache/superset/pull/25490) fix(sqllab): Broken query containing 'children' (@justinpark)
+- [#25390](https://github.com/apache/superset/pull/25390) fix: Unable to sync columns when database or dataset name contains `+` (@mapledan)
+- [#25494](https://github.com/apache/superset/pull/25494) fix: Address Mypy issue which is causing CI to fail (@john-bodley)
+- [#25469](https://github.com/apache/superset/pull/25469) fix(sqllab): error with lazy_gettext for tab titles (@nytai)
+- [#25468](https://github.com/apache/superset/pull/25468) fix: Styles not loading because of faulty CSP setting (@kgabryje)
+- [#24241](https://github.com/apache/superset/pull/24241) fix(mysql): handle string typed decimal results (@villebro)
+- [#25373](https://github.com/apache/superset/pull/25373) fix(helm chart): set chart appVersion to 3.0.0 (@celalettin1286)
+- [#25445](https://github.com/apache/superset/pull/25445) fix: update the SQLAlchemy model definition at json column for Log table (@cnabro)
+- [#25447](https://github.com/apache/superset/pull/25447) fix: Duplicate items when pasting into Select (@michael-s-molina)
+- [#25372](https://github.com/apache/superset/pull/25372) fix(SqlLab): make icon placement even (@CorbinBullard)
+- [#25282](https://github.com/apache/superset/pull/25282) fix(nativeFilters): Speed up native filters by removing unnecessary rerenders (@Always-prog)
+- [#25437](https://github.com/apache/superset/pull/25437) fix(sqllab): invalid start date (@justinpark)
+- [#25404](https://github.com/apache/superset/pull/25404) fix: smarter date formatter (@betodealmeida)
+- [#25368](https://github.com/apache/superset/pull/25368) fix: swagger UI CSP error (@dpgaspar)
+- [#25425](https://github.com/apache/superset/pull/25425) fix: chart import (@betodealmeida)
+- [#25106](https://github.com/apache/superset/pull/25106) fix: preventing save button from flickering in SQL Lab (@fisjac)
+- [#25424](https://github.com/apache/superset/pull/25424) fix: Rename on_delete parameter to ondelete (@john-bodley)
+- [#25398](https://github.com/apache/superset/pull/25398) fix(sqllab): invalid persisted tab state (#25308) (@justinpark)
+- [#25399](https://github.com/apache/superset/pull/25399) fix: Workaround for Cypress ECONNRESET error (@michael-s-molina)
+- [#25318](https://github.com/apache/superset/pull/25318) fix: datetime with timezone excel export (@betodealmeida)
+- [#25349](https://github.com/apache/superset/pull/25349) fix: DashboardRoles cascade operation (@michael-s-molina)
+- [#25239](https://github.com/apache/superset/pull/25239) fix: Improve the reliability of alerts & reports (@jfrag1)
+- [#25229](https://github.com/apache/superset/pull/25229) fix: Use RLS clause instead of ID for cache key (@jfrag1)
+- [#25126](https://github.com/apache/superset/pull/25126) fix(chart): Supporting custom SQL as temporal x-axis column with filter (@zephyring)
+- [#25290](https://github.com/apache/superset/pull/25290) fix: is_select with UNION (@betodealmeida)
 
 ### 3.0.0 (Thu Aug 24 13:36:27 2023 -0600)
 


### PR DESCRIPTION
### SUMMARY
Adds [3.0.1](https://github.com/apache/superset/blob/3.0.1/CHANGELOG.md) data to `CHANGELOG.md`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
