### PR TITLE
refactor: use DATE_TRUNC for Elasticsearch time grain

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1548,6 +1548,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         if cls.arraysize:
             cursor.arraysize = cls.arraysize
         try:
+            print(query)
             cursor.execute(query)
         except Exception as ex:
             raise cls.get_dbapi_mapped_exception(ex) from ex

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1548,7 +1548,6 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         if cls.arraysize:
             cursor.arraysize = cls.arraysize
         try:
-            print(query)
             cursor.execute(query)
         except Exception as ex:
             raise cls.get_dbapi_mapped_exception(ex) from ex

--- a/superset/db_engine_specs/elasticsearch.py
+++ b/superset/db_engine_specs/elasticsearch.py
@@ -40,15 +40,19 @@ class ElasticSearchEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-metho
     allows_subqueries = True
     allows_sql_comments = False
 
+    _date_trunc_functions = {
+        "DATETIME": "DATE_TRUNC",
+    }
+
     _time_grain_expressions = {
         None: "{col}",
-        TimeGrain.SECOND: "HISTOGRAM({col}, INTERVAL 1 SECOND)",
-        TimeGrain.MINUTE: "HISTOGRAM({col}, INTERVAL 1 MINUTE)",
-        TimeGrain.HOUR: "HISTOGRAM({col}, INTERVAL 1 HOUR)",
-        TimeGrain.DAY: "HISTOGRAM({col}, INTERVAL 1 DAY)",
-        TimeGrain.WEEK: "DATE_TRUNC('week', {col})",
-        TimeGrain.MONTH: "HISTOGRAM({col}, INTERVAL 1 MONTH)",
-        TimeGrain.YEAR: "HISTOGRAM({col}, INTERVAL 1 YEAR)",
+        TimeGrain.SECOND: "{func}('second', {col})",
+        TimeGrain.MINUTE: "{func}('minute', {col})",
+        TimeGrain.HOUR: "{func}('hour', {col})",
+        TimeGrain.DAY: "{func}('day', {col})",
+        TimeGrain.WEEK: "{func}('week', {col})",
+        TimeGrain.MONTH: "{func}('month', {col})",
+        TimeGrain.YEAR: "{func}('year', {col})",
     }
 
     type_code_map: dict[int, str] = {}  # loaded from get_datatype only if needed

--- a/tests/integration_tests/db_engine_specs/elasticsearch_tests.py
+++ b/tests/integration_tests/db_engine_specs/elasticsearch_tests.py
@@ -14,27 +14,30 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from parameterized import parameterized
 from sqlalchemy import column
 
+from superset.constants import TimeGrain
 from superset.db_engine_specs.elasticsearch import ElasticSearchEngineSpec
 from tests.integration_tests.db_engine_specs.base_tests import TestDbEngineSpec
 
 
 class TestElasticsearchDbEngineSpec(TestDbEngineSpec):
-    def test_time_grain_week_expression(self):
+    @parameterized.expand(
+        [
+            [TimeGrain.SECOND, "DATE_TRUNC('second', ts)"],
+            [TimeGrain.MINUTE, "DATE_TRUNC('minute', ts)"],
+            [TimeGrain.HOUR, "DATE_TRUNC('hour', ts)"],
+            [TimeGrain.DAY, "DATE_TRUNC('day', ts)"],
+            [TimeGrain.WEEK, "DATE_TRUNC('week', ts)"],
+            [TimeGrain.MONTH, "DATE_TRUNC('month', ts)"],
+            [TimeGrain.YEAR, "DATE_TRUNC('year', ts)"],
+        ]
+    )
+    def test_time_grain_expressions(self, time_grain, expected_time_grain_expression):
         col = column("ts")
-        col.type = "datetime"
-        expected_time_grain_expression = "DATE_TRUNC('week', ts)"
+        col.type = "DATETIME"
         actual = ElasticSearchEngineSpec.get_timestamp_expr(
-            col=col, pdf=None, time_grain="P1W"
-        )
-        self.assertEqual(str(actual), expected_time_grain_expression)
-
-    def test_time_grain_hour_expression(self):
-        col = column("ts")
-        col.type = "datetime"
-        expected_time_grain_expression = "HISTOGRAM(ts, INTERVAL 1 HOUR)"
-        actual = ElasticSearchEngineSpec.get_timestamp_expr(
-            col=col, pdf=None, time_grain="PT1H"
+            col=col, pdf=None, time_grain=time_grain
         )
         self.assertEqual(str(actual), expected_time_grain_expression)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As discussed in #25683 this is a follow-up PR to refactor the Elasticsearch time grain expressions to use `DATE_TRUNC` instead of `HISTOGRAM` in order to have consistency.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
To verify that the time grains still work:

- Create a database connection to an Elasticsearch cluster
- Create an index in the Elasticsearch cluster. The index documents should have a date field and at least another field to be used in a metric
- Create a dataset using the Elasticsearch database, and the choose the index created previously as the table
- Create a time series chart and use the date field in the x axis
- Select various time grains from the drop down menu and verify that the chart shows the time series data

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
