### PR TITLE
fix(horizontal filter label): show full tooltip with ellipsis

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
@@ -112,6 +112,7 @@ const HorizontalOverflowFilterControlContainer = styled(
 
 const VerticalFormItem = styled(StyledFormItem)`
   .ant-form-item-label {
+    overflow: visible;
     label.ant-form-item-required:not(.ant-form-item-required-mark-optional) {
       &::after {
         display: none;
@@ -127,6 +128,7 @@ const HorizontalFormItem = styled(StyledFormItem)`
   }
 
   .ant-form-item-label {
+    overflow: visible;
     padding-bottom: 0;
     margin-right: ${({ theme }) => theme.gridUnit * 2}px;
     label.ant-form-item-required:not(.ant-form-item-required-mark-optional) {
@@ -200,10 +202,11 @@ const DescriptionToolTip = ({ description }: { description: string }) => (
       placement="right"
       overlayInnerStyle={{
         display: '-webkit-box',
-        overflow: 'hidden',
-        WebkitLineClamp: 20,
+        WebkitLineClamp: 10,
         WebkitBoxOrient: 'vertical',
+        overflow: 'hidden',
         textOverflow: 'ellipsis',
+        whiteSpace: 'normal',
       }}
       getPopupContainer={trigger => trigger.parentElement as HTMLElement}
     >


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix the tooltip from being bound to the filter control label's box so that it will function as intended, hovering to the right of the icon showing 10 lines before hiding text with ellipsis.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
BEFORE:
![bug showing tooltip constrained](https://github.com/apache/superset/assets/92495987/1cfa5d41-7560-4388-ba17-cfcaed5999be)
AFTER:
![fix with tooltip positioned to right of icon](https://github.com/apache/superset/assets/92495987/74cf50e3-762f-4a40-bfd9-483f8fc8e782)



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

- Create a dashboard
- Set the filter bar to be horizontal
- On one of the filters, add a description in the filter configuration
- Hover over the filter description

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [X] Required feature flags: HORIZONTAL_FILTER_BAR
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
