### PR TITLE
fix(README): mismatched picture tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,7 @@ under the License.
 [![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](http://bit.ly/join-superset-slack)
 [![Documentation](https://img.shields.io/badge/docs-apache.org-blue.svg)](https://superset.apache.org)
 
-<picture
-  width="500"
->
+<picture width="500">
   <source
     media="(prefers-color-scheme: dark)"
     src="https://github.com/apache/superset/raw/master/superset-frontend/src/assets/branding/superset-logo-horiz-apache-dark.png"
@@ -188,7 +186,7 @@ Understanding the Superset Points of View
   - [Helm Chart](https://github.com/apache/superset/tree/master/helm/superset)
 
 - Recordings of Past [Superset Community Events](https://preset.io/events)
-  - [Mixed Time Series Charts](https://preset.io/events/mixed-time-series-visualization-in-superset-workshop/)  
+  - [Mixed Time Series Charts](https://preset.io/events/mixed-time-series-visualization-in-superset-workshop/)
   - [How the Bing Team Customized Superset for the Internal Self-Serve Data & Analytics Platform](https://preset.io/events/how-the-bing-team-heavily-customized-superset-for-their-internal-data/)
   - [Live Demo: Visualizing MongoDB and Pinot Data using Trino](https://preset.io/events/2021-04-13-visualizing-mongodb-and-pinot-data-using-trino/)
 	- [Introduction to the Superset API](https://preset.io/events/introduction-to-the-superset-api/)


### PR DESCRIPTION
### SUMMARY
Quick fix for mismatched HTML picture tags on main README.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![Screenshot_20231022-170349](https://github.com/apache/superset/assets/41118244/b4ed50c8-c9b8-4dc8-8c8d-8d8570649788)

### TESTING INSTRUCTIONS
Preview README.md for any unescaped HTML.
