### PR TITLE
fix(sqllab): slow pop datasource query

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -1397,6 +1397,7 @@ export function popDatasourceQuery(datasourceKey, sql) {
     const datasetId = datasourceKey.split('__')[0];
 
     const queryParams = rison.encode({
+      keys: ['none'],
       columns: ['name', 'schema', 'database.id', 'select_star'],
     });
 

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -1395,8 +1395,13 @@ export function popDatasourceQuery(datasourceKey, sql) {
   return function (dispatch) {
     const QUERY_TEXT = t('Query');
     const datasetId = datasourceKey.split('__')[0];
+
+    const queryParams = rison.encode({
+      columns: ['name', 'schema', 'database.id', 'select_star'],
+    });
+
     return SupersetClient.get({
-      endpoint: `/api/v1/dataset/${datasetId}?q=(keys:!(none))`,
+      endpoint: `/api/v1/dataset/${datasetId}?q=${queryParams}`,
     })
       .then(({ json }) =>
         dispatch(


### PR DESCRIPTION
### SUMMARY
Since #22102 migrated fetch_datasource_metadata to api v1, "View in SQL LAB" from explore became very slow when the selected dataset contains a lot of columns/metadata.
This commit changes the popDatasourceQuery to improve performance by only including the necessary columns.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:
<img width="657" alt="Screenshot 2023-10-23 at 1 11 54 PM" src="https://github.com/apache/superset/assets/1392866/52d994a3-0deb-4d45-8e02-edbe37fbae03">

After:
<img width="560" alt="Screenshot 2023-10-23 at 1 22 40 PM" src="https://github.com/apache/superset/assets/1392866/665d6de1-1dff-4a5f-8d12-33588cd0789a">

### TESTING INSTRUCTIONS
Go to a explore view of any charts
Click "View in SQL Lab" and check the network tab for `api/v1/datasets/[id]`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
