### PR TITLE
fix: dataset update uniqueness

### DIFF
--- a/superset/daos/dataset.py
+++ b/superset/daos/dataset.py
@@ -99,11 +99,15 @@ class DatasetDAO(BaseDAO[SqlaTable]):
 
     @staticmethod
     def validate_update_uniqueness(
-        database_id: int, dataset_id: int, name: str
+        database_id: int,
+        schema: str | None,
+        dataset_id: int,
+        name: str,
     ) -> bool:
         dataset_query = db.session.query(SqlaTable).filter(
             SqlaTable.table_name == name,
             SqlaTable.database_id == database_id,
+            SqlaTable.schema == schema,
             SqlaTable.id != dataset_id,
         )
         return not db.session.query(dataset_query.exists()).scalar()

--- a/superset/datasets/commands/update.py
+++ b/superset/datasets/commands/update.py
@@ -89,7 +89,10 @@ class UpdateDatasetCommand(UpdateMixin, BaseCommand):
         table_name = self._properties.get("table_name", None)
         # Validate uniqueness
         if not DatasetDAO.validate_update_uniqueness(
-            self._model.database_id, self._model_id, table_name
+            self._model.database_id,
+            self._model.schema,
+            self._model_id,
+            table_name,
         ):
             exceptions.append(DatasetExistsValidationError(table_name))
         # Validate/Populate database not allowed to change

--- a/tests/unit_tests/dao/dataset_test.py
+++ b/tests/unit_tests/dao/dataset_test.py
@@ -1,0 +1,83 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from sqlalchemy.orm.session import Session
+
+from superset.daos.dataset import DatasetDAO
+
+
+def test_validate_update_uniqueness(session: Session) -> None:
+    """
+    Test the `validate_update_uniqueness` static method.
+
+    In particular, allow datasets with the same name in the same database as long as they
+    are in different schemas
+    """
+    from superset.connectors.sqla.models import SqlaTable
+    from superset.models.core import Database
+
+    SqlaTable.metadata.create_all(session.get_bind())
+
+    database = Database(
+        database_name="my_db",
+        sqlalchemy_uri="sqlite://",
+    )
+    dataset1 = SqlaTable(
+        table_name="my_dataset",
+        schema="main",
+        database=database,
+    )
+    dataset2 = SqlaTable(
+        table_name="my_dataset",
+        schema="dev",
+        database=database,
+    )
+    session.add_all([database, dataset1, dataset2])
+    session.flush()
+
+    # same table name, different schema
+    assert (
+        DatasetDAO.validate_update_uniqueness(
+            database_id=database.id,
+            schema=dataset1.schema,
+            dataset_id=dataset1.id,
+            name=dataset1.table_name,
+        )
+        is True
+    )
+
+    # duplicate schema and table name
+    assert (
+        DatasetDAO.validate_update_uniqueness(
+            database_id=database.id,
+            schema=dataset2.schema,
+            dataset_id=dataset1.id,
+            name=dataset1.table_name,
+        )
+        is False
+    )
+
+    # no schema
+    assert (
+        DatasetDAO.validate_update_uniqueness(
+            database_id=database.id,
+            schema=None,
+            dataset_id=dataset1.id,
+            name=dataset1.table_name,
+        )
+        is True
+    )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When checking for uniqueness on a dataset update we are not taking into consideration the dataset schema. This means that updates will fail if we have two datasets in the same database, on different schemas, and with the same name:

- `database.main.some_dataset`
- `database.dev.some_dataset`

This PR fixes the `validate_update_uniqueness` static method to take the schema in consideration.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Added unit tests covering the bug.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
