### PR TITLE
chore: Add config options for Playwright wait_until and default timeout

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -682,10 +682,11 @@ SCREENSHOT_REPLACE_UNEXPECTED_ERRORS = False
 SCREENSHOT_WAIT_FOR_ERROR_MODAL_VISIBLE = 5
 # Max time to wait for error message modal to close, in seconds
 SCREENSHOT_WAIT_FOR_ERROR_MODAL_INVISIBLE = 5
-# event that Playwright waits for when loading a new page
-# possible values: "load", "commit", "domcontentloaded", "networkidle"
+# Event that Playwright waits for when loading a new page
+# Possible values: "load", "commit", "domcontentloaded", "networkidle"
+# Docs: https://playwright.dev/python/docs/api/class-page#page-goto-option-wait-until
 SCREENSHOT_PLAYWRIGHT_WAIT_UNTIL = "load"
-# default timeout for Playwright browser context for all operations
+# Default timeout for Playwright browser context for all operations
 SCREENSHOT_PLAYWRIGHT_DEFAULT_TIMEOUT = 10000
 
 # ---------------------------------------------------

--- a/superset/config.py
+++ b/superset/config.py
@@ -687,7 +687,7 @@ SCREENSHOT_WAIT_FOR_ERROR_MODAL_INVISIBLE = 5
 # Docs: https://playwright.dev/python/docs/api/class-page#page-goto-option-wait-until
 SCREENSHOT_PLAYWRIGHT_WAIT_UNTIL = "load"
 # Default timeout for Playwright browser context for all operations
-SCREENSHOT_PLAYWRIGHT_DEFAULT_TIMEOUT = 10000
+SCREENSHOT_PLAYWRIGHT_DEFAULT_TIMEOUT = 30000
 
 # ---------------------------------------------------
 # Image and file configuration

--- a/superset/config.py
+++ b/superset/config.py
@@ -685,9 +685,11 @@ SCREENSHOT_WAIT_FOR_ERROR_MODAL_INVISIBLE = 5
 # Event that Playwright waits for when loading a new page
 # Possible values: "load", "commit", "domcontentloaded", "networkidle"
 # Docs: https://playwright.dev/python/docs/api/class-page#page-goto-option-wait-until
-SCREENSHOT_PLAYWRIGHT_WAIT_UNTIL = "load"
+SCREENSHOT_PLAYWRIGHT_WAIT_EVENT = "load"
 # Default timeout for Playwright browser context for all operations
-SCREENSHOT_PLAYWRIGHT_DEFAULT_TIMEOUT = 30000
+SCREENSHOT_PLAYWRIGHT_DEFAULT_TIMEOUT = int(
+    timedelta(seconds=30).total_seconds() * 1000
+)
 
 # ---------------------------------------------------
 # Image and file configuration

--- a/superset/config.py
+++ b/superset/config.py
@@ -682,6 +682,11 @@ SCREENSHOT_REPLACE_UNEXPECTED_ERRORS = False
 SCREENSHOT_WAIT_FOR_ERROR_MODAL_VISIBLE = 5
 # Max time to wait for error message modal to close, in seconds
 SCREENSHOT_WAIT_FOR_ERROR_MODAL_INVISIBLE = 5
+# event that Playwright waits for when loading a new page
+# possible values: "load", "commit", "domcontentloaded", "networkidle"
+SCREENSHOT_PLAYWRIGHT_WAIT_UNTIL = "load"
+# default timeout for Playwright browser context for all operations
+SCREENSHOT_PLAYWRIGHT_DEFAULT_TIMEOUT = 10000
 
 # ---------------------------------------------------
 # Image and file configuration

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -167,7 +167,7 @@ class WebDriverPlaywright(WebDriverProxy):
             self.auth(user, context)
             page = context.new_page()
             page.goto(
-                url, wait_until=current_app.config["SCREENSHOT_PLAYWRIGHT_WAIT_UNTIL"]
+                url, wait_until=current_app.config["SCREENSHOT_PLAYWRIGHT_WAIT_EVENT"]
             )
             img: bytes | None = None
             selenium_headstart = current_app.config["SCREENSHOT_SELENIUM_HEADSTART"]
@@ -207,7 +207,7 @@ class WebDriverPlaywright(WebDriverProxy):
                     )
                     page.wait_for_selector(
                         ".loading",
-                        timeout=self._screenshot_locate_wait * 1000,
+                        timeout=self._screenshot_load_wait * 1000,
                         state="detached",
                     )
                 except PlaywrightTimeout as ex:


### PR DESCRIPTION
### SUMMARY
Added new config keys for Playwright:
- `SCREENSHOT_PLAYWRIGHT_WAIT_UNTIL` - defines an event that Playwright waits for after navigation (default - `load`)
- `SCREENSHOT_PLAYWRIGHT_DEFAULT_TIMEOUT` - default timeout for all Playwright operations (default - 30s)

Additionally I fixed catching Selenium specific exceptions in Playwright's class.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Enable `PLAYWRIGHT_REPORTS_AND_THUMBNAILS` feature flag
2. To test default timeout - try adding some explicit delays in dashboard's code to trigger timeout. Verify that Playwright times out after the time specified in `SCREENSHOT_PLAYWRIGHT_DEFAULT_TIMEOUT`
3. To test navigation wait - you could try to manually block loading of some external script, which prevents the browser from firing a "load" event. Playwright should time out on navigation then, with an error that "load" event was not detected. Then change `SCREENSHOT_PLAYWRIGHT_DEFAULT_TIMEOUT` to another value (for example `'domcontentloaded'`) - navigation should succeed then.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
