### PR TITLE
fix: Resolve issue #24195

### DIFF
--- a/superset-frontend/src/constants.ts
+++ b/superset-frontend/src/constants.ts
@@ -51,6 +51,10 @@ export const URL_PARAMS = {
     name: 'filter_set',
     type: 'string',
   },
+  showFilters: {
+    name: 'show_filters',
+    type: 'boolean',
+  },
   expandFilters: {
     name: 'expand_filters',
     type: 'boolean',


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR fixes https://github.com/apache/superset/issues/24195 as the `showFilters` URL parameter was wrongfully removed in https://github.com/apache/superset/pull/23228.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: https://github.com/apache/superset/issues/24195
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
