### PR TITLE
chore: Removes border of the color picker control

### DIFF
--- a/superset-frontend/src/explore/components/controls/ColorPickerControl.jsx
+++ b/superset-frontend/src/explore/components/controls/ColorPickerControl.jsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { SketchPicker } from 'react-color';
-import { getCategoricalSchemeRegistry, styled } from '@superset-ui/core';
+import { getCategoricalSchemeRegistry, styled, css } from '@superset-ui/core';
 import Popover from 'src/components/Popover';
 import ControlHeader from '../ControlHeader';
 
@@ -82,6 +82,11 @@ export default class ColorPickerControl extends React.Component {
     return (
       <div id="filter-popover" className="color-popover">
         <SketchPicker
+          css={css`
+            // We need to use important here as these are element level styles
+            padding: 0 !important;
+            box-shadow: none !important;
+          `}
           color={this.props.value}
           onChange={this.onChange}
           presetColors={presetColors}


### PR DESCRIPTION
### SUMMARY
Removes the weird border of the color picker control to match its style with other popovers in the application.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="360" alt="Screenshot 2023-10-31 at 14 15 33" src="https://github.com/apache/superset/assets/70410625/01a35a46-316d-4844-a9da-ec04a5943a1f">
<img width="340" alt="Screenshot 2023-10-31 at 16 05 25" src="https://github.com/apache/superset/assets/70410625/a04e4427-85f8-48bf-834a-0db3876280f6">

### TESTING INSTRUCTIONS
CI should be sufficient.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
