### PR TITLE
fix(sqllab): infinite fetching status after results are landed

### DIFF
--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -667,16 +667,27 @@ export default function sqlLabReducer(state = {}, action) {
     [actions.CLEAR_INACTIVE_QUERIES]() {
       const { queries } = state;
       const cleanedQueries = Object.fromEntries(
-        Object.entries(queries).filter(([, query]) => {
-          if (
-            ['running', 'pending'].includes(query.state) &&
-            Date.now() - query.startDttm > action.interval &&
-            query.progress === 0
-          ) {
-            return false;
-          }
-          return true;
-        }),
+        Object.entries(queries)
+          .filter(([, query]) => {
+            if (
+              ['running', 'pending'].includes(query.state) &&
+              Date.now() - query.startDttm > action.interval &&
+              query.progress === 0
+            ) {
+              return false;
+            }
+            return true;
+          })
+          .map(([id, query]) => [
+            id,
+            {
+              ...query,
+              state:
+                query.resultsKey && query.results?.status
+                  ? query.results.status
+                  : query.state,
+            },
+          ]),
       );
       return { ...state, queries: cleanedQueries };
     },

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { QueryState } from '@superset-ui/core';
 import sqlLabReducer from 'src/SqlLab/reducers/sqlLab';
 import * as actions from 'src/SqlLab/actions/sqlLab';
 import { table, initialState as mockState } from '../fixtures';
@@ -386,6 +387,40 @@ describe('sqlLabReducer', () => {
     });
     it('should refresh queries when polling returns empty', () => {
       newState = sqlLabReducer(newState, actions.refreshQueries({}));
+    });
+  });
+  describe('CLEAR_INACTIVE_QUERIES', () => {
+    let newState;
+    let query;
+    beforeEach(() => {
+      query = {
+        id: 'abcd',
+        changed_on: Date.now(),
+        startDttm: Date.now(),
+        state: QueryState.FETCHING,
+        progress: 100,
+        resultsKey: 'fa3dccc4-c549-4fbf-93c8-b4fb5a6fb8b7',
+        cached: false,
+      };
+    });
+    it('updates queries that have already been completed', () => {
+      newState = sqlLabReducer(
+        {
+          ...newState,
+          queries: {
+            abcd: {
+              ...query,
+              results: {
+                query_id: 1234,
+                status: QueryState.SUCCESS,
+                data: [],
+              },
+            },
+          },
+        },
+        actions.clearInactiveQueries(Date.now()),
+      );
+      expect(newState.queries.abcd.state).toBe(QueryState.SUCCESS);
     });
   });
 });


### PR DESCRIPTION
### SUMMARY
This commit fixes a bug that caused the fetching query state to be corrupted before the [hotfix](https://github.com/apache/superset/pull/25306#issuecomment-1723926567).
The bug was fixed by syncing result's query state.

### TESTING INSTRUCTIONS
unit test

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
