### PR TITLE
chore(docker-compose): more host network specifiers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,8 @@ services:
     restart: unless-stopped
     ports:
       - 8088:8088
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     user: *superset-user
     depends_on: *superset-depends-on
     volumes: *superset-volumes
@@ -79,6 +81,8 @@ services:
     image: superset-websocket
     ports:
       - 8080:8080
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       - redis
     # Mount everything in superset-websocket into container and
@@ -131,6 +135,8 @@ services:
     depends_on: *superset-depends-on
     user: *superset-user
     volumes: *superset-volumes
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     healthcheck:
       test: ["CMD-SHELL", "celery -A superset.tasks.celery_app:app inspect ping -d celery@$$HOSTNAME"]
     # Bump memory limit if processing selenium / thumbnails on superset-worker


### PR DESCRIPTION
Add host network to the app and worker containers as well, so that it's possible to connect a native database to superset running in docker-compose. Makes the dev environment a bit easier to work with and has no real drawbacks.

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Run superset with docker-compose

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
