### PR TITLE
chore: Singularize tag models

### DIFF
--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -27,7 +27,7 @@ from marshmallow.validate import Length, Range
 from superset import app
 from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
 from superset.db_engine_specs.base import builtin_time_grains
-from superset.tags.models import TagTypes
+from superset.tags.models import TagType
 from superset.utils import pandas_postprocessing, schema as utils
 from superset.utils.core import (
     AnnotationType,
@@ -146,7 +146,7 @@ openapi_spec_methods_override = {
 class TagSchema(Schema):
     id = fields.Int()
     name = fields.String()
-    type = fields.Enum(TagTypes, by_value=True)
+    type = fields.Enum(TagType, by_value=True)
 
 
 class ChartEntityResponseSchema(Schema):

--- a/superset/common/tags.py
+++ b/superset/common/tags.py
@@ -22,7 +22,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.sql import and_, func, join, literal, select
 
 from superset.extensions import db
-from superset.tags.models import ObjectTypes, TagTypes
+from superset.tags.models import ObjectType, TagType
 
 
 def add_types_to_charts(
@@ -35,7 +35,7 @@ def add_types_to_charts(
             [
                 tag.c.id.label("tag_id"),
                 slices.c.id.label("object_id"),
-                literal(ObjectTypes.chart.name).label("object_type"),
+                literal(ObjectType.chart.name).label("object_type"),
             ]
         )
         .select_from(
@@ -67,7 +67,7 @@ def add_types_to_dashboards(
             [
                 tag.c.id.label("tag_id"),
                 dashboard_table.c.id.label("object_id"),
-                literal(ObjectTypes.dashboard.name).label("object_type"),
+                literal(ObjectType.dashboard.name).label("object_type"),
             ]
         )
         .select_from(
@@ -99,7 +99,7 @@ def add_types_to_saved_queries(
             [
                 tag.c.id.label("tag_id"),
                 saved_query.c.id.label("object_id"),
-                literal(ObjectTypes.query.name).label("object_type"),
+                literal(ObjectType.query.name).label("object_type"),
             ]
         )
         .select_from(
@@ -131,7 +131,7 @@ def add_types_to_datasets(
             [
                 tag.c.id.label("tag_id"),
                 tables.c.id.label("object_id"),
-                literal(ObjectTypes.dataset.name).label("object_type"),
+                literal(ObjectType.dataset.name).label("object_type"),
             ]
         )
         .select_from(
@@ -221,9 +221,9 @@ def add_types(metadata: MetaData) -> None:
 
     # add a tag for each object type
     insert = tag.insert()
-    for type_ in ObjectTypes.__members__:
+    for type_ in ObjectType.__members__:
         with contextlib.suppress(IntegrityError):  # already exists
-            db.session.execute(insert, name=f"type:{type_}", type=TagTypes.type)
+            db.session.execute(insert, name=f"type:{type_}", type=TagType.type)
 
     add_types_to_charts(metadata, tag, tagged_object, columns)
     add_types_to_dashboards(metadata, tag, tagged_object, columns)
@@ -241,7 +241,7 @@ def add_owners_to_charts(
             [
                 tag.c.id.label("tag_id"),
                 slices.c.id.label("object_id"),
-                literal(ObjectTypes.chart.name).label("object_type"),
+                literal(ObjectType.chart.name).label("object_type"),
             ]
         )
         .select_from(
@@ -277,7 +277,7 @@ def add_owners_to_dashboards(
             [
                 tag.c.id.label("tag_id"),
                 dashboard_table.c.id.label("object_id"),
-                literal(ObjectTypes.dashboard.name).label("object_type"),
+                literal(ObjectType.dashboard.name).label("object_type"),
             ]
         )
         .select_from(
@@ -313,7 +313,7 @@ def add_owners_to_saved_queries(
             [
                 tag.c.id.label("tag_id"),
                 saved_query.c.id.label("object_id"),
-                literal(ObjectTypes.query.name).label("object_type"),
+                literal(ObjectType.query.name).label("object_type"),
             ]
         )
         .select_from(
@@ -349,7 +349,7 @@ def add_owners_to_datasets(
             [
                 tag.c.id.label("tag_id"),
                 tables.c.id.label("object_id"),
-                literal(ObjectTypes.dataset.name).label("object_type"),
+                literal(ObjectType.dataset.name).label("object_type"),
             ]
         )
         .select_from(
@@ -444,7 +444,7 @@ def add_owners(metadata: MetaData) -> None:
     insert = tag.insert()
     for (id_,) in db.session.execute(ids):
         with contextlib.suppress(IntegrityError):  # already exists
-            db.session.execute(insert, name=f"owner:{id_}", type=TagTypes.owner)
+            db.session.execute(insert, name=f"owner:{id_}", type=TagType.owner)
     add_owners_to_charts(metadata, tag, tagged_object, columns)
     add_owners_to_dashboards(metadata, tag, tagged_object, columns)
     add_owners_to_saved_queries(metadata, tag, tagged_object, columns)
@@ -482,7 +482,7 @@ def add_favorites(metadata: MetaData) -> None:
     insert = tag.insert()
     for (id_,) in db.session.execute(ids):
         with contextlib.suppress(IntegrityError):  # already exists
-            db.session.execute(insert, name=f"favorited_by:{id_}", type=TagTypes.type)
+            db.session.execute(insert, name=f"favorited_by:{id_}", type=TagType.type)
     favstars = (
         select(
             [

--- a/superset/daos/tag.py
+++ b/superset/daos/tag.py
@@ -32,10 +32,10 @@ from superset.tags.commands.exceptions import TagNotFoundError
 from superset.tags.commands.utils import to_object_type
 from superset.tags.models import (
     get_tag,
-    ObjectTypes,
+    ObjectType,
     Tag,
     TaggedObject,
-    TagTypes,
+    TagType,
     user_favorite_tag_table,
 )
 from superset.utils.core import get_user_id
@@ -56,7 +56,7 @@ class TagDAO(BaseDAO[Tag]):
 
     @staticmethod
     def create_custom_tagged_objects(
-        object_type: ObjectTypes, object_id: int, tag_names: list[str]
+        object_type: ObjectType, object_id: int, tag_names: list[str]
     ) -> None:
         tagged_objects = []
         for name in tag_names:
@@ -64,7 +64,7 @@ class TagDAO(BaseDAO[Tag]):
                 raise DAOCreateFailedError(
                     message="Invalid Tag Name (cannot contain ':' or ',')"
                 )
-            type_ = TagTypes.custom
+            type_ = TagType.custom
             tag_name = name.strip()
             tag = TagDAO.get_by_name(tag_name, type_)
             tagged_objects.append(
@@ -76,7 +76,7 @@ class TagDAO(BaseDAO[Tag]):
 
     @staticmethod
     def delete_tagged_object(
-        object_type: ObjectTypes, object_id: int, tag_name: str
+        object_type: ObjectType, object_id: int, tag_name: str
     ) -> None:
         """
         deletes a tagged object by the object_id, object_type, and tag_name
@@ -128,7 +128,7 @@ class TagDAO(BaseDAO[Tag]):
                 raise DAODeleteFailedError(exception=ex) from ex
 
     @staticmethod
-    def get_by_name(name: str, type_: TagTypes = TagTypes.custom) -> Tag:
+    def get_by_name(name: str, type_: TagType = TagType.custom) -> Tag:
         """
         returns a tag if one exists by that name, none otherwise.
         important!: Creates a tag by that name if the tag is not found.
@@ -152,7 +152,7 @@ class TagDAO(BaseDAO[Tag]):
 
     @staticmethod
     def find_tagged_object(
-        object_type: ObjectTypes, object_id: int, tag_id: int
+        object_type: ObjectType, object_id: int, tag_id: int
     ) -> TaggedObject:
         """
         returns a tagged object if one exists by that name, none otherwise.
@@ -185,7 +185,7 @@ class TagDAO(BaseDAO[Tag]):
                     TaggedObject,
                     and_(
                         TaggedObject.object_id == Dashboard.id,
-                        TaggedObject.object_type == ObjectTypes.dashboard,
+                        TaggedObject.object_type == ObjectType.dashboard,
                     ),
                 )
                 .join(Tag, TaggedObject.tag_id == Tag.id)
@@ -195,7 +195,7 @@ class TagDAO(BaseDAO[Tag]):
             results.extend(
                 {
                     "id": obj.id,
-                    "type": ObjectTypes.dashboard.name,
+                    "type": ObjectType.dashboard.name,
                     "name": obj.dashboard_title,
                     "url": obj.url,
                     "changed_on": obj.changed_on,
@@ -215,7 +215,7 @@ class TagDAO(BaseDAO[Tag]):
                     TaggedObject,
                     and_(
                         TaggedObject.object_id == Slice.id,
-                        TaggedObject.object_type == ObjectTypes.chart,
+                        TaggedObject.object_type == ObjectType.chart,
                     ),
                 )
                 .join(Tag, TaggedObject.tag_id == Tag.id)
@@ -224,7 +224,7 @@ class TagDAO(BaseDAO[Tag]):
             results.extend(
                 {
                     "id": obj.id,
-                    "type": ObjectTypes.chart.name,
+                    "type": ObjectType.chart.name,
                     "name": obj.slice_name,
                     "url": obj.url,
                     "changed_on": obj.changed_on,
@@ -244,7 +244,7 @@ class TagDAO(BaseDAO[Tag]):
                     TaggedObject,
                     and_(
                         TaggedObject.object_id == SavedQuery.id,
-                        TaggedObject.object_type == ObjectTypes.query,
+                        TaggedObject.object_type == ObjectType.query,
                     ),
                 )
                 .join(Tag, TaggedObject.tag_id == Tag.id)
@@ -253,7 +253,7 @@ class TagDAO(BaseDAO[Tag]):
             results.extend(
                 {
                     "id": obj.id,
-                    "type": ObjectTypes.query.name,
+                    "type": ObjectType.query.name,
                     "name": obj.label,
                     "url": obj.url(),
                     "changed_on": obj.changed_on,
@@ -363,7 +363,7 @@ class TagDAO(BaseDAO[Tag]):
 
     @staticmethod
     def create_tag_relationship(
-        objects_to_tag: list[tuple[ObjectTypes, int]],
+        objects_to_tag: list[tuple[ObjectType, int]],
         tag: Tag,
         bulk_create: bool = False,
     ) -> None:
@@ -373,7 +373,7 @@ class TagDAO(BaseDAO[Tag]):
         and an id, and creates a TaggedObject for each one, associating it with
         the provided tag. All created TaggedObjects are collected in a list.
         Args:
-            objects_to_tag (List[Tuple[ObjectTypes, int]]): A list of tuples, each
+            objects_to_tag (List[Tuple[ObjectType, int]]): A list of tuples, each
             containing an ObjectType and an id, representing the objects to be tagged.
 
             tag (Tag): The tag to be associated with the specified objects.

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -22,7 +22,7 @@ from marshmallow import fields, post_load, pre_load, Schema
 from marshmallow.validate import Length, ValidationError
 
 from superset.exceptions import SupersetException
-from superset.tags.models import TagTypes
+from superset.tags.models import TagType
 from superset.utils import core as utils
 
 get_delete_ids_schema = {"type": "array", "items": {"type": "integer"}}
@@ -169,7 +169,7 @@ class RolesSchema(Schema):
 class TagSchema(Schema):
     id = fields.Int()
     name = fields.String()
-    type = fields.Enum(TagTypes, by_value=True)
+    type = fields.Enum(TagType, by_value=True)
 
 
 class DashboardGetResponseSchema(Schema):

--- a/superset/migrations/versions/2018-07-26_11-10_c82ee8a39623_add_implicit_tags.py
+++ b/superset/migrations/versions/2018-07-26_11-10_c82ee8a39623_add_implicit_tags.py
@@ -33,7 +33,7 @@ from flask_appbuilder.models.mixins import AuditMixin
 from sqlalchemy import Column, DateTime, Enum, ForeignKey, Integer, String
 from sqlalchemy.ext.declarative import declarative_base, declared_attr
 
-from superset.tags.models import ObjectTypes, TagTypes
+from superset.tags.models import ObjectType, TagType
 from superset.utils.core import get_user_id
 
 Base = declarative_base()
@@ -77,7 +77,7 @@ class Tag(Base, AuditMixinNullable):
 
     id = Column(Integer, primary_key=True)
     name = Column(String(250), unique=True)
-    type = Column(Enum(TagTypes))
+    type = Column(Enum(TagType))
 
 
 class TaggedObject(Base, AuditMixinNullable):
@@ -86,7 +86,7 @@ class TaggedObject(Base, AuditMixinNullable):
     id = Column(Integer, primary_key=True)
     tag_id = Column(Integer, ForeignKey("tag.id"))
     object_id = Column(Integer)
-    object_type = Column(Enum(ObjectTypes))
+    object_type = Column(Enum(ObjectType))
 
 
 class User(Base):

--- a/superset/tags/api.py
+++ b/superset/tags/api.py
@@ -40,7 +40,7 @@ from superset.tags.commands.exceptions import (
     TagUpdateFailedError,
 )
 from superset.tags.commands.update import UpdateTagCommand
-from superset.tags.models import ObjectTypes, Tag
+from superset.tags.models import ObjectType, Tag
 from superset.tags.schemas import (
     delete_tags_schema,
     openapi_spec_methods_override,
@@ -364,7 +364,7 @@ class TagRestApi(BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.add_objects",
         log_to_statsd=False,
     )
-    def add_objects(self, object_type: ObjectTypes, object_id: int) -> Response:
+    def add_objects(self, object_type: ObjectType, object_id: int) -> Response:
         """Add tags to an object. Create new tags if they do not already exist.
         ---
         post:
@@ -429,7 +429,7 @@ class TagRestApi(BaseSupersetModelRestApi):
         log_to_statsd=True,
     )
     def delete_object(
-        self, object_type: ObjectTypes, object_id: int, tag: str
+        self, object_type: ObjectType, object_id: int, tag: str
     ) -> Response:
         """Delete a tagged object.
         ---

--- a/superset/tags/commands/create.py
+++ b/superset/tags/commands/create.py
@@ -24,13 +24,13 @@ from superset.daos.tag import TagDAO
 from superset.exceptions import SupersetSecurityException
 from superset.tags.commands.exceptions import TagCreateFailedError, TagInvalidError
 from superset.tags.commands.utils import to_object_model, to_object_type
-from superset.tags.models import ObjectTypes, TagTypes
+from superset.tags.models import ObjectType, TagType
 
 logger = logging.getLogger(__name__)
 
 
 class CreateCustomTagCommand(CreateMixin, BaseCommand):
-    def __init__(self, object_type: ObjectTypes, object_id: int, tags: list[str]):
+    def __init__(self, object_type: ObjectType, object_id: int, tags: list[str]):
         self._object_type = object_type
         self._object_id = object_id
         self._tags = tags
@@ -76,7 +76,7 @@ class CreateCustomTagWithRelationshipsCommand(CreateMixin, BaseCommand):
 
         try:
             tag_name = self._properties["name"]
-            tag = TagDAO.get_by_name(tag_name.strip(), TagTypes.custom)
+            tag = TagDAO.get_by_name(tag_name.strip(), TagType.custom)
             TagDAO.create_tag_relationship(
                 objects_to_tag=self._properties.get("objects_to_tag", []),
                 tag=tag,

--- a/superset/tags/commands/delete.py
+++ b/superset/tags/commands/delete.py
@@ -27,14 +27,14 @@ from superset.tags.commands.exceptions import (
     TagNotFoundError,
 )
 from superset.tags.commands.utils import to_object_type
-from superset.tags.models import ObjectTypes
+from superset.tags.models import ObjectType
 from superset.views.base import DeleteMixin
 
 logger = logging.getLogger(__name__)
 
 
 class DeleteTaggedObjectCommand(DeleteMixin, BaseCommand):
-    def __init__(self, object_type: ObjectTypes, object_id: int, tag: str):
+    def __init__(self, object_type: ObjectType, object_id: int, tag: str):
         self._object_type = object_type
         self._object_id = object_id
         self._tag = tag

--- a/superset/tags/commands/utils.py
+++ b/superset/tags/commands/utils.py
@@ -23,25 +23,25 @@ from superset.daos.query import SavedQueryDAO
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.models.sql_lab import SavedQuery
-from superset.tags.models import ObjectTypes
+from superset.tags.models import ObjectType
 
 
-def to_object_type(object_type: Union[ObjectTypes, int, str]) -> Optional[ObjectTypes]:
-    if isinstance(object_type, ObjectTypes):
+def to_object_type(object_type: Union[ObjectType, int, str]) -> Optional[ObjectType]:
+    if isinstance(object_type, ObjectType):
         return object_type
-    for type_ in ObjectTypes:
+    for type_ in ObjectType:
         if object_type in [type_.value, type_.name]:
             return type_
     return None
 
 
 def to_object_model(
-    object_type: ObjectTypes, object_id: int
+    object_type: ObjectType, object_id: int
 ) -> Optional[Union[Dashboard, SavedQuery, Slice]]:
-    if ObjectTypes.dashboard == object_type:
+    if ObjectType.dashboard == object_type:
         return DashboardDAO.find_by_id(object_id)
-    if ObjectTypes.query == object_type:
+    if ObjectType.query == object_type:
         return SavedQueryDAO.find_by_id(object_id)
-    if ObjectTypes.chart == object_type:
+    if ObjectType.chart == object_type:
         return ChartDAO.find_by_id(object_id)
     return None

--- a/superset/tags/models.py
+++ b/superset/tags/models.py
@@ -45,8 +45,7 @@ user_favorite_tag_table = Table(
 )
 
 
-class TagTypes(enum.Enum):
-
+class TagType(enum.Enum):
     """
     Types for tags.
 
@@ -65,8 +64,7 @@ class TagTypes(enum.Enum):
     favorited_by = 4
 
 
-class ObjectTypes(enum.Enum):
-
+class ObjectType(enum.Enum):
     """Object types."""
 
     # pylint: disable=invalid-name
@@ -83,7 +81,7 @@ class Tag(Model, AuditMixinNullable):
     __tablename__ = "tag"
     id = Column(Integer, primary_key=True)
     name = Column(String(250), unique=True)
-    type = Column(Enum(TagTypes))
+    type = Column(Enum(TagType))
     description = Column(Text)
 
     objects = relationship(
@@ -108,12 +106,12 @@ class TaggedObject(Model, AuditMixinNullable):
         ForeignKey("slices.id"),
         ForeignKey("saved_query.id"),
     )
-    object_type = Column(Enum(ObjectTypes))
+    object_type = Column(Enum(ObjectType))
 
     tag = relationship("Tag", back_populates="objects", overlaps="tags")
 
 
-def get_tag(name: str, session: Session, type_: TagTypes) -> Tag:
+def get_tag(name: str, session: Session, type_: TagType) -> Tag:
     tag_name = name.strip()
     tag = session.query(Tag).filter_by(name=tag_name, type=type_).one_or_none()
     if tag is None:
@@ -123,12 +121,12 @@ def get_tag(name: str, session: Session, type_: TagTypes) -> Tag:
     return tag
 
 
-def get_object_type(class_name: str) -> ObjectTypes:
+def get_object_type(class_name: str) -> ObjectType:
     mapping = {
-        "slice": ObjectTypes.chart,
-        "dashboard": ObjectTypes.dashboard,
-        "query": ObjectTypes.query,
-        "dataset": ObjectTypes.dataset,
+        "slice": ObjectType.chart,
+        "dashboard": ObjectType.dashboard,
+        "query": ObjectType.query,
+        "dataset": ObjectType.dataset,
     }
     try:
         return mapping[class_name.lower()]
@@ -155,7 +153,7 @@ class ObjectUpdater:
     ) -> None:
         for owner_id in cls.get_owners_ids(target):
             name = f"owner:{owner_id}"
-            tag = get_tag(name, session, TagTypes.owner)
+            tag = get_tag(name, session, TagType.owner)
             tagged_object = TaggedObject(
                 tag_id=tag.id, object_id=target.id, object_type=cls.object_type
             )
@@ -175,7 +173,7 @@ class ObjectUpdater:
             cls._add_owners(session, target)
 
             # add `type:` tags
-            tag = get_tag(f"type:{cls.object_type}", session, TagTypes.type)
+            tag = get_tag(f"type:{cls.object_type}", session, TagType.type)
             tagged_object = TaggedObject(
                 tag_id=tag.id, object_id=target.id, object_type=cls.object_type
             )
@@ -201,7 +199,7 @@ class ObjectUpdater:
                 .filter(
                     TaggedObject.object_type == cls.object_type,
                     TaggedObject.object_id == target.id,
-                    Tag.type == TagTypes.owner,
+                    Tag.type == TagType.owner,
                 )
             )
             ids = [row[0] for row in query]
@@ -276,7 +274,7 @@ class FavStarUpdater:
         session = Session(bind=connection)
         try:
             name = f"favorited_by:{target.user_id}"
-            tag = get_tag(name, session, TagTypes.favorited_by)
+            tag = get_tag(name, session, TagType.favorited_by)
             tagged_object = TaggedObject(
                 tag_id=tag.id,
                 object_id=target.obj_id,
@@ -299,7 +297,7 @@ class FavStarUpdater:
                 .join(Tag)
                 .filter(
                     TaggedObject.object_id == target.obj_id,
-                    Tag.type == TagTypes.favorited_by,
+                    Tag.type == TagType.favorited_by,
                     Tag.name == name,
                 )
             )

--- a/superset/utils/url_map_converters.py
+++ b/superset/utils/url_map_converters.py
@@ -18,7 +18,7 @@ from typing import Any
 
 from werkzeug.routing import BaseConverter, Map
 
-from superset.tags.models import ObjectTypes
+from superset.tags.models import ObjectType
 
 
 class RegexConverter(BaseConverter):
@@ -31,7 +31,7 @@ class ObjectTypeConverter(BaseConverter):
     """Validate that object_type is indeed an object type."""
 
     def to_python(self, value: str) -> Any:
-        return ObjectTypes[value]
+        return ObjectType[value]
 
     def to_url(self, value: Any) -> str:
         return value.name

--- a/tests/integration_tests/strategy_tests.py
+++ b/tests/integration_tests/strategy_tests.py
@@ -33,7 +33,7 @@ from superset.utils.database import get_example_database
 from superset import db
 
 from superset.models.core import Log
-from superset.tags.models import get_tag, ObjectTypes, TaggedObject, TagTypes
+from superset.tags.models import get_tag, ObjectType, TaggedObject, TagType
 from superset.tasks.cache import (
     DashboardTagsStrategy,
     TopNDashboardsStrategy,
@@ -93,7 +93,7 @@ class TestCacheWarmUp(SupersetTestCase):
         "load_unicode_dashboard_with_slice", "load_birth_names_dashboard_with_slices"
     )
     def test_dashboard_tags_strategy(self):
-        tag1 = get_tag("tag1", db.session, TagTypes.custom)
+        tag1 = get_tag("tag1", db.session, TagType.custom)
         # delete first to make test idempotent
         self.reset_tag(tag1)
 
@@ -103,11 +103,11 @@ class TestCacheWarmUp(SupersetTestCase):
         self.assertEqual(result, expected)
 
         # tag dashboard 'births' with `tag1`
-        tag1 = get_tag("tag1", db.session, TagTypes.custom)
+        tag1 = get_tag("tag1", db.session, TagType.custom)
         dash = self.get_dash_by_slug("births")
         tag1_urls = [{"chart_id": chart.id} for chart in dash.slices]
         tagged_object = TaggedObject(
-            tag_id=tag1.id, object_id=dash.id, object_type=ObjectTypes.dashboard
+            tag_id=tag1.id, object_id=dash.id, object_type=ObjectType.dashboard
         )
         db.session.add(tagged_object)
         db.session.commit()
@@ -115,7 +115,7 @@ class TestCacheWarmUp(SupersetTestCase):
         self.assertCountEqual(strategy.get_payloads(), tag1_urls)
 
         strategy = DashboardTagsStrategy(["tag2"])
-        tag2 = get_tag("tag2", db.session, TagTypes.custom)
+        tag2 = get_tag("tag2", db.session, TagType.custom)
         self.reset_tag(tag2)
 
         result = strategy.get_payloads()
@@ -128,7 +128,7 @@ class TestCacheWarmUp(SupersetTestCase):
         tag2_urls = [{"chart_id": chart.id}]
         object_id = chart.id
         tagged_object = TaggedObject(
-            tag_id=tag2.id, object_id=object_id, object_type=ObjectTypes.chart
+            tag_id=tag2.id, object_id=object_id, object_type=ObjectType.chart
         )
         db.session.add(tagged_object)
         db.session.commit()

--- a/tests/integration_tests/tagging_tests.py
+++ b/tests/integration_tests/tagging_tests.py
@@ -70,7 +70,7 @@ class TestTagging(SupersetTestCase):
         # Test to make sure that a dataset tag was added to the tagged_object table
         tags = self.query_tagged_object_table()
         self.assertEqual(1, len(tags))
-        self.assertEqual("ObjectTypes.dataset", str(tags[0].object_type))
+        self.assertEqual("ObjectType.dataset", str(tags[0].object_type))
         self.assertEqual(test_dataset.id, tags[0].object_id)
 
         # Cleanup the db
@@ -108,7 +108,7 @@ class TestTagging(SupersetTestCase):
         # Test to make sure that a chart tag was added to the tagged_object table
         tags = self.query_tagged_object_table()
         self.assertEqual(1, len(tags))
-        self.assertEqual("ObjectTypes.chart", str(tags[0].object_type))
+        self.assertEqual("ObjectType.chart", str(tags[0].object_type))
         self.assertEqual(test_chart.id, tags[0].object_id)
 
         # Cleanup the db
@@ -144,7 +144,7 @@ class TestTagging(SupersetTestCase):
         # Test to make sure that a dashboard tag was added to the tagged_object table
         tags = self.query_tagged_object_table()
         self.assertEqual(1, len(tags))
-        self.assertEqual("ObjectTypes.dashboard", str(tags[0].object_type))
+        self.assertEqual("ObjectType.dashboard", str(tags[0].object_type))
         self.assertEqual(test_dashboard.id, tags[0].object_id)
 
         # Cleanup the db
@@ -178,14 +178,14 @@ class TestTagging(SupersetTestCase):
 
         self.assertEqual(2, len(tags))
 
-        self.assertEqual("ObjectTypes.query", str(tags[0].object_type))
+        self.assertEqual("ObjectType.query", str(tags[0].object_type))
         self.assertEqual("owner:None", str(tags[0].tag.name))
-        self.assertEqual("TagTypes.owner", str(tags[0].tag.type))
+        self.assertEqual("TagType.owner", str(tags[0].tag.type))
         self.assertEqual(test_saved_query.id, tags[0].object_id)
 
-        self.assertEqual("ObjectTypes.query", str(tags[1].object_type))
+        self.assertEqual("ObjectType.query", str(tags[1].object_type))
         self.assertEqual("type:query", str(tags[1].tag.name))
-        self.assertEqual("TagTypes.type", str(tags[1].tag.type))
+        self.assertEqual("TagType.type", str(tags[1].tag.type))
         self.assertEqual(test_saved_query.id, tags[1].object_id)
 
         # Cleanup the db
@@ -217,7 +217,7 @@ class TestTagging(SupersetTestCase):
         # Test to make sure that a favorited object tag was added to the tagged_object table
         tags = self.query_tagged_object_table()
         self.assertEqual(1, len(tags))
-        self.assertEqual("ObjectTypes.chart", str(tags[0].object_type))
+        self.assertEqual("ObjectType.chart", str(tags[0].object_type))
         self.assertEqual(test_saved_query.obj_id, tags[0].object_id)
 
         # Cleanup the db

--- a/tests/integration_tests/tags/api_tests.py
+++ b/tests/integration_tests/tags/api_tests.py
@@ -35,7 +35,7 @@ from superset import db, security_manager
 from superset.common.db_query_status import QueryStatus
 from superset.models.core import Database
 from superset.utils.database import get_example_database, get_main_database
-from superset.tags.models import ObjectTypes, Tag, TagTypes, TaggedObject
+from superset.tags.models import ObjectType, Tag, TagType, TaggedObject
 from tests.integration_tests.fixtures.birth_names_dashboard import (
     load_birth_names_dashboard_with_slices,
     load_birth_names_data,
@@ -47,7 +47,7 @@ from tests.integration_tests.fixtures.world_bank_dashboard import (
 from tests.integration_tests.fixtures.tags import with_tagging_system_feature
 from tests.integration_tests.base_tests import SupersetTestCase
 from superset.daos.tag import TagDAO
-from superset.tags.models import ObjectTypes
+from superset.tags.models import ObjectType
 
 TAGS_FIXTURE_COUNT = 10
 
@@ -84,7 +84,7 @@ class TestTagApi(SupersetTestCase):
         self,
         tag_id: int,
         object_id: int,
-        object_type: ObjectTypes,
+        object_type: ObjectType,
     ) -> TaggedObject:
         tag = db.session.query(Tag).filter(Tag.id == tag_id).first()
         tagged_object = TaggedObject(
@@ -135,7 +135,7 @@ class TestTagApi(SupersetTestCase):
             "created_by": None,
             "id": tag.id,
             "name": "test get tag",
-            "type": TagTypes.custom.value,
+            "type": TagType.custom.value,
         }
         data = json.loads(rv.data.decode("utf-8"))
         for key, value in expected_result.items():
@@ -192,7 +192,7 @@ class TestTagApi(SupersetTestCase):
             .first()
         )
         dashboard_id = dashboard.id
-        dashboard_type = ObjectTypes.dashboard.value
+        dashboard_type = ObjectType.dashboard.value
         uri = f"api/v1/tag/{dashboard_type}/{dashboard_id}/"
         example_tag_names = ["example_tag_1", "example_tag_2"]
         data = {"properties": {"tags": example_tag_names}}
@@ -207,7 +207,7 @@ class TestTagApi(SupersetTestCase):
         tagged_objects = db.session.query(TaggedObject).filter(
             TaggedObject.tag_id.in_(tag_ids),
             TaggedObject.object_id == dashboard_id,
-            TaggedObject.object_type == ObjectTypes.dashboard,
+            TaggedObject.object_type == ObjectType.dashboard,
         )
         assert tagged_objects.count() == 2
         # clean up tags and tagged objects
@@ -225,7 +225,7 @@ class TestTagApi(SupersetTestCase):
     def test_delete_tagged_objects(self):
         self.login(username="admin")
         dashboard_id = 1
-        dashboard_type = ObjectTypes.dashboard
+        dashboard_type = ObjectType.dashboard
         tag_names = ["example_tag_1", "example_tag_2"]
         tags = db.session.query(Tag).filter(Tag.name.in_(tag_names))
         assert tags.count() == 2
@@ -295,7 +295,7 @@ class TestTagApi(SupersetTestCase):
             .first()
         )
         dashboard_id = dashboard.id
-        dashboard_type = ObjectTypes.dashboard
+        dashboard_type = ObjectType.dashboard
         tag_names = ["example_tag_1", "example_tag_2"]
         tags = db.session.query(Tag).filter(Tag.name.in_(tag_names))
         for tag in tags:
@@ -331,7 +331,7 @@ class TestTagApi(SupersetTestCase):
             .first()
         )
         dashboard_id = dashboard.id
-        dashboard_type = ObjectTypes.dashboard
+        dashboard_type = ObjectType.dashboard
         tag_names = ["example_tag_1", "example_tag_2"]
         tags = db.session.query(Tag).filter(Tag.name.in_(tag_names))
         for tag in tags:
@@ -480,7 +480,7 @@ class TestTagApi(SupersetTestCase):
         user_id = self.get_user(username="admin").get_id()
         tag = (
             db.session.query(Tag)
-            .filter(Tag.name == "my_tag", Tag.type == TagTypes.custom)
+            .filter(Tag.name == "my_tag", Tag.type == TagType.custom)
             .one_or_none()
         )
         assert tag is not None
@@ -560,13 +560,13 @@ class TestTagApi(SupersetTestCase):
 
         tagged_objects = db.session.query(TaggedObject).filter(
             TaggedObject.object_id == dashboard.id,
-            TaggedObject.object_type == ObjectTypes.dashboard,
+            TaggedObject.object_type == ObjectType.dashboard,
         )
         assert tagged_objects.count() == 2
 
         tagged_objects = db.session.query(TaggedObject).filter(
             TaggedObject.object_id == chart.id,
-            TaggedObject.object_type == ObjectTypes.chart,
+            TaggedObject.object_type == ObjectType.chart,
         )
         assert tagged_objects.count() == 2
 

--- a/tests/integration_tests/tags/commands_tests.py
+++ b/tests/integration_tests/tags/commands_tests.py
@@ -37,7 +37,7 @@ from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.tags.commands.create import CreateCustomTagCommand
 from superset.tags.commands.delete import DeleteTaggedObjectCommand, DeleteTagsCommand
-from superset.tags.models import ObjectTypes, Tag, TaggedObject, TagTypes
+from superset.tags.models import ObjectType, Tag, TaggedObject, TagType
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.importexport import (
     chart_config,
@@ -65,7 +65,7 @@ class TestCreateCustomTagCommand(SupersetTestCase):
         )
         example_tags = ["create custom tag example 1", "create custom tag example 2"]
         command = CreateCustomTagCommand(
-            ObjectTypes.dashboard.value, example_dashboard.id, example_tags
+            ObjectType.dashboard.value, example_dashboard.id, example_tags
         )
         command.run()
 
@@ -74,7 +74,7 @@ class TestCreateCustomTagCommand(SupersetTestCase):
             .join(TaggedObject)
             .filter(
                 TaggedObject.object_id == example_dashboard.id,
-                Tag.type == TagTypes.custom,
+                Tag.type == TagType.custom,
             )
             .all()
         )
@@ -101,7 +101,7 @@ class TestDeleteTagsCommand(SupersetTestCase):
         )
         example_tags = ["create custom tag example 1", "create custom tag example 2"]
         command = CreateCustomTagCommand(
-            ObjectTypes.dashboard.value, example_dashboard.id, example_tags
+            ObjectType.dashboard.value, example_dashboard.id, example_tags
         )
         command.run()
 
@@ -110,7 +110,7 @@ class TestDeleteTagsCommand(SupersetTestCase):
             .join(TaggedObject)
             .filter(
                 TaggedObject.object_id == example_dashboard.id,
-                Tag.type == TagTypes.custom,
+                Tag.type == TagType.custom,
             )
             .all()
         )
@@ -133,7 +133,7 @@ class TestDeleteTaggedObjectCommand(SupersetTestCase):
         )
         example_tags = ["create custom tag example 1", "create custom tag example 2"]
         command = CreateCustomTagCommand(
-            ObjectTypes.dashboard.value, example_dashboard.id, example_tags
+            ObjectType.dashboard.value, example_dashboard.id, example_tags
         )
         command.run()
 
@@ -142,14 +142,14 @@ class TestDeleteTaggedObjectCommand(SupersetTestCase):
             .join(Tag)
             .filter(
                 TaggedObject.object_id == example_dashboard.id,
-                TaggedObject.object_type == ObjectTypes.dashboard.name,
+                TaggedObject.object_type == ObjectType.dashboard.name,
                 Tag.name.in_(example_tags),
             )
         )
         assert tagged_objects.count() == 2
         # delete one of the tagged objects
         command = DeleteTaggedObjectCommand(
-            object_type=ObjectTypes.dashboard.value,
+            object_type=ObjectType.dashboard.value,
             object_id=example_dashboard.id,
             tag=example_tags[0],
         )
@@ -159,7 +159,7 @@ class TestDeleteTaggedObjectCommand(SupersetTestCase):
             .join(Tag)
             .filter(
                 TaggedObject.object_id == example_dashboard.id,
-                TaggedObject.object_type == ObjectTypes.dashboard.name,
+                TaggedObject.object_type == ObjectType.dashboard.name,
                 Tag.name.in_(example_tags),
             )
         )

--- a/tests/integration_tests/tags/dao_tests.py
+++ b/tests/integration_tests/tags/dao_tests.py
@@ -23,7 +23,7 @@ from superset.models.slice import Slice
 from superset.models.sql_lab import SavedQuery
 from superset.daos.tag import TagDAO
 from superset.tags.exceptions import InvalidTagNameError
-from superset.tags.models import ObjectTypes, Tag, TaggedObject
+from superset.tags.models import ObjectType, Tag, TaggedObject
 from tests.integration_tests.tags.api_tests import TAGS_FIXTURE_COUNT
 
 import tests.integration_tests.test_app  # pylint: disable=unused-import
@@ -57,7 +57,7 @@ class TestTagsDAO(SupersetTestCase):
         self,
         tag_id: int,
         object_id: int,
-        object_type: ObjectTypes,
+        object_type: ObjectType,
     ) -> TaggedObject:
         tag = db.session.query(Tag).filter(Tag.id == tag_id).first()
         tagged_object = TaggedObject(
@@ -113,7 +113,7 @@ class TestTagsDAO(SupersetTestCase):
                 tagged_objects.append(
                     self.insert_tagged_object(
                         object_id=dashboard_id,
-                        object_type=ObjectTypes.dashboard,
+                        object_type=ObjectType.dashboard,
                         tag_id=tag.id,
                     )
                 )
@@ -127,14 +127,14 @@ class TestTagsDAO(SupersetTestCase):
         # test that a tag cannot be added if it has ':' in it
         with pytest.raises(DAOCreateFailedError):
             TagDAO.create_custom_tagged_objects(
-                object_type=ObjectTypes.dashboard.name,
+                object_type=ObjectType.dashboard.name,
                 object_id=1,
                 tag_names=["invalid:example tag 1"],
             )
 
         # test that a tag can be added if it has a valid name
         TagDAO.create_custom_tagged_objects(
-            object_type=ObjectTypes.dashboard.name,
+            object_type=ObjectType.dashboard.name,
             object_id=1,
             tag_names=["example tag 1"],
         )
@@ -155,7 +155,7 @@ class TestTagsDAO(SupersetTestCase):
         dashboard_id = dashboard.id
         tag = db.session.query(Tag).filter_by(name="example_tag_1").one()
         self.insert_tagged_object(
-            object_id=dashboard_id, object_type=ObjectTypes.dashboard, tag_id=tag.id
+            object_id=dashboard_id, object_type=ObjectType.dashboard, tag_id=tag.id
         )
         # get objects
         tagged_objects = TagDAO.get_tagged_objects_for_tags(
@@ -179,7 +179,7 @@ class TestTagsDAO(SupersetTestCase):
                 TaggedObject,
                 and_(
                     TaggedObject.object_id == Slice.id,
-                    TaggedObject.object_type == ObjectTypes.chart,
+                    TaggedObject.object_type == ObjectType.chart,
                 ),
             )
             .distinct(Slice.id)
@@ -191,7 +191,7 @@ class TestTagsDAO(SupersetTestCase):
                 TaggedObject,
                 and_(
                     TaggedObject.object_id == Dashboard.id,
-                    TaggedObject.object_type == ObjectTypes.dashboard,
+                    TaggedObject.object_type == ObjectType.dashboard,
                 ),
             )
             .distinct(Dashboard.id)
@@ -213,7 +213,7 @@ class TestTagsDAO(SupersetTestCase):
     def test_find_tagged_object(self):
         tag = db.session.query(Tag).filter(Tag.name == "example_tag_1").first()
         tagged_object = TagDAO.find_tagged_object(
-            object_id=1, object_type=ObjectTypes.dashboard.name, tag_id=tag.id
+            object_id=1, object_type=ObjectType.dashboard.name, tag_id=tag.id
         )
         assert tagged_object is not None
 
@@ -269,20 +269,20 @@ class TestTagsDAO(SupersetTestCase):
             .filter(
                 TaggedObject.tag_id == tag.id,
                 TaggedObject.object_id == 1,
-                TaggedObject.object_type == ObjectTypes.dashboard.name,
+                TaggedObject.object_type == ObjectType.dashboard.name,
             )
             .first()
         )
         assert tagged_object is not None
         TagDAO.delete_tagged_object(
-            object_type=ObjectTypes.dashboard.name, object_id=1, tag_name=tag.name
+            object_type=ObjectType.dashboard.name, object_id=1, tag_name=tag.name
         )
         tagged_object = (
             db.session.query(TaggedObject)
             .filter(
                 TaggedObject.tag_id == tag.id,
                 TaggedObject.object_id == 1,
-                TaggedObject.object_type == ObjectTypes.dashboard.name,
+                TaggedObject.object_type == ObjectType.dashboard.name,
             )
             .first()
         )

--- a/tests/unit_tests/dao/tag_test.py
+++ b/tests/unit_tests/dao/tag_test.py
@@ -149,7 +149,7 @@ def test_user_favorite_tag_exc_raise(mocker):
 def test_create_tag_relationship(mocker):
     from superset.daos.tag import TagDAO
     from superset.tags.models import (  # Assuming these are defined in the same module
-        ObjectTypes,
+        ObjectType,
         TaggedObject,
     )
 
@@ -157,9 +157,9 @@ def test_create_tag_relationship(mocker):
 
     # Define a list of objects to tag
     objects_to_tag = [
-        (ObjectTypes.query, 1),
-        (ObjectTypes.chart, 2),
-        (ObjectTypes.dashboard, 3),
+        (ObjectType.query, 1),
+        (ObjectType.chart, 2),
+        (ObjectType.dashboard, 3),
     ]
 
     # Call the function

--- a/tests/unit_tests/tags/commands/create_test.py
+++ b/tests/unit_tests/tags/commands/create_test.py
@@ -55,7 +55,7 @@ def test_create_command_success(session_with_data: Session, mocker: MockFixture)
     from superset.models.slice import Slice
     from superset.models.sql_lab import Query, SavedQuery
     from superset.tags.commands.create import CreateCustomTagWithRelationshipsCommand
-    from superset.tags.models import ObjectTypes, TaggedObject
+    from superset.tags.models import ObjectType, TaggedObject
 
     # Define a list of objects to tag
     query = session_with_data.query(SavedQuery).first()
@@ -69,9 +69,9 @@ def test_create_command_success(session_with_data: Session, mocker: MockFixture)
     mocker.patch("superset.daos.query.SavedQueryDAO.find_by_id", return_value=query)
 
     objects_to_tag = [
-        (ObjectTypes.query, query.id),
-        (ObjectTypes.chart, chart.id),
-        (ObjectTypes.dashboard, dashboard.id),
+        (ObjectType.query, query.id),
+        (ObjectType.chart, chart.id),
+        (ObjectType.dashboard, dashboard.id),
     ]
 
     CreateCustomTagWithRelationshipsCommand(
@@ -98,7 +98,7 @@ def test_create_command_success_clear(session_with_data: Session, mocker: MockFi
     from superset.models.slice import Slice
     from superset.models.sql_lab import Query, SavedQuery
     from superset.tags.commands.create import CreateCustomTagWithRelationshipsCommand
-    from superset.tags.models import ObjectTypes, TaggedObject
+    from superset.tags.models import ObjectType, TaggedObject
 
     # Define a list of objects to tag
     query = session_with_data.query(SavedQuery).first()
@@ -112,9 +112,9 @@ def test_create_command_success_clear(session_with_data: Session, mocker: MockFi
     mocker.patch("superset.daos.query.SavedQueryDAO.find_by_id", return_value=query)
 
     objects_to_tag = [
-        (ObjectTypes.query, query.id),
-        (ObjectTypes.chart, chart.id),
-        (ObjectTypes.dashboard, dashboard.id),
+        (ObjectType.query, query.id),
+        (ObjectType.chart, chart.id),
+        (ObjectType.dashboard, dashboard.id),
     ]
 
     CreateCustomTagWithRelationshipsCommand(

--- a/tests/unit_tests/tags/commands/update_test.py
+++ b/tests/unit_tests/tags/commands/update_test.py
@@ -61,7 +61,7 @@ def test_update_command_success(session_with_data: Session, mocker: MockFixture)
     from superset.daos.tag import TagDAO
     from superset.models.dashboard import Dashboard
     from superset.tags.commands.update import UpdateTagCommand
-    from superset.tags.models import ObjectTypes, TaggedObject
+    from superset.tags.models import ObjectType, TaggedObject
 
     dashboard = session_with_data.query(Dashboard).first()
     mocker.patch(
@@ -72,7 +72,7 @@ def test_update_command_success(session_with_data: Session, mocker: MockFixture)
     )
 
     objects_to_tag = [
-        (ObjectTypes.dashboard, dashboard.id),
+        (ObjectType.dashboard, dashboard.id),
     ]
 
     tag_to_update = TagDAO.find_by_name("test_name")
@@ -99,7 +99,7 @@ def test_update_command_success_duplicates(
     from superset.models.slice import Slice
     from superset.tags.commands.create import CreateCustomTagWithRelationshipsCommand
     from superset.tags.commands.update import UpdateTagCommand
-    from superset.tags.models import ObjectTypes, TaggedObject
+    from superset.tags.models import ObjectType, TaggedObject
 
     dashboard = session_with_data.query(Dashboard).first()
     chart = session_with_data.query(Slice).first()
@@ -113,7 +113,7 @@ def test_update_command_success_duplicates(
     )
 
     objects_to_tag = [
-        (ObjectTypes.dashboard, dashboard.id),
+        (ObjectType.dashboard, dashboard.id),
     ]
 
     CreateCustomTagWithRelationshipsCommand(
@@ -123,7 +123,7 @@ def test_update_command_success_duplicates(
     tag_to_update = TagDAO.find_by_name("test_tag")
 
     objects_to_tag = [
-        (ObjectTypes.chart, chart.id),
+        (ObjectType.chart, chart.id),
     ]
     changed_model = UpdateTagCommand(
         tag_to_update.id,
@@ -150,12 +150,12 @@ def test_update_command_failed_validation(
     from superset.tags.commands.create import CreateCustomTagWithRelationshipsCommand
     from superset.tags.commands.exceptions import TagInvalidError
     from superset.tags.commands.update import UpdateTagCommand
-    from superset.tags.models import ObjectTypes
+    from superset.tags.models import ObjectType
 
     dashboard = session_with_data.query(Dashboard).first()
     chart = session_with_data.query(Slice).first()
     objects_to_tag = [
-        (ObjectTypes.chart, chart.id),
+        (ObjectType.chart, chart.id),
     ]
 
     mocker.patch(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

I noticed whilst spelunking through the code that various tag models/enums were plural as opposed to singular which is the standard convention. This PR—by way of `find` and `sed`—simply singularizes the tag models and enums.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
