### PR TITLE
fix: add validation on tag name to have name + onDelete refresh list view

### DIFF
--- a/superset-frontend/src/features/tags/TagModal.tsx
+++ b/superset-frontend/src/features/tags/TagModal.tsx
@@ -228,7 +228,7 @@ const TagModal: React.FC<TagModalProps> = ({
           addSuccessToast(t('Tag updated'));
         })
         .catch(err => {
-          addDangerToast(err.message ? err.message : 'Error Updating Tag');
+          addDangerToast(err.message || 'Error Updating Tag');
         });
     } else {
       SupersetClient.post({

--- a/superset-frontend/src/features/tags/TagModal.tsx
+++ b/superset-frontend/src/features/tags/TagModal.tsx
@@ -243,9 +243,7 @@ const TagModal: React.FC<TagModalProps> = ({
           refreshData();
           addSuccessToast(t('Tag created'));
         })
-        .catch(err =>
-          addDangerToast(err.message || 'Error Creating Tag'),
-        );
+        .catch(err => addDangerToast(err.message || 'Error Creating Tag'));
     }
     onHide();
   };

--- a/superset-frontend/src/features/tags/TagModal.tsx
+++ b/superset-frontend/src/features/tags/TagModal.tsx
@@ -222,10 +222,14 @@ const TagModal: React.FC<TagModalProps> = ({
           name: tagName,
           objects_to_tag: [...dashboards, ...charts, ...savedQueries],
         },
-      }).then(({ json = {} }) => {
-        refreshData();
-        addSuccessToast(t('Tag updated'));
-      });
+      })
+        .then(({ json = {} }) => {
+          refreshData();
+          addSuccessToast(t('Tag updated'));
+        })
+        .catch(err => {
+          addDangerToast(err.message ? err.message : 'Error Updating Tag');
+        });
     } else {
       SupersetClient.post({
         endpoint: `/api/v1/tag/`,
@@ -234,10 +238,14 @@ const TagModal: React.FC<TagModalProps> = ({
           name: tagName,
           objects_to_tag: [...dashboards, ...charts, ...savedQueries],
         },
-      }).then(({ json = {} }) => {
-        refreshData();
-        addSuccessToast(t('Tag created'));
-      });
+      })
+        .then(({ json = {} }) => {
+          refreshData();
+          addSuccessToast(t('Tag created'));
+        })
+        .catch(err =>
+          addDangerToast(err.message ? err.message : 'Error Creating Tag'),
+        );
     }
     onHide();
   };

--- a/superset-frontend/src/features/tags/TagModal.tsx
+++ b/superset-frontend/src/features/tags/TagModal.tsx
@@ -244,7 +244,7 @@ const TagModal: React.FC<TagModalProps> = ({
           addSuccessToast(t('Tag created'));
         })
         .catch(err =>
-          addDangerToast(err.message ? err.message : 'Error Creating Tag'),
+          addDangerToast(err.message || 'Error Creating Tag'),
         );
     }
     onHide();

--- a/superset-frontend/src/pages/Tags/index.tsx
+++ b/superset-frontend/src/pages/Tags/index.tsx
@@ -93,8 +93,6 @@ function TagList(props: TagListProps) {
   const initialSort = [{ id: 'changed_on_delta_humanized', desc: true }];
 
   function handleTagsDelete(tags: Tag[]) {
-    // TODO what permissions need to be checked here?
-    console.log(tags);
     deleteTags(
       tags,
       (msg: string) => {

--- a/superset-frontend/src/pages/Tags/index.tsx
+++ b/superset-frontend/src/pages/Tags/index.tsx
@@ -92,14 +92,20 @@ function TagList(props: TagListProps) {
 
   const initialSort = [{ id: 'changed_on_delta_humanized', desc: true }];
 
-  function handleTagsDelete(
-    tags: Tag[],
-    callback: (text: string) => void,
-    error: (text: string) => void,
-  ) {
+  function handleTagsDelete(tags: Tag[]) {
     // TODO what permissions need to be checked here?
-    deleteTags(tags, callback, error);
-    refreshData();
+    console.log(tags);
+    deleteTags(
+      tags,
+      (msg: string) => {
+        addSuccessToast(msg);
+        refreshData();
+      },
+      msg => {
+        addDangerToast(msg);
+        refreshData();
+      },
+    );
   }
 
   const handleTagEdit = (tag: Tag) => {
@@ -178,8 +184,6 @@ function TagList(props: TagListProps) {
       },
       {
         Cell: ({ row: { original } }: any) => {
-          const handleDelete = () =>
-            handleTagsDelete([original], addSuccessToast, addDangerToast);
           const handleEdit = () => handleTagEdit(original);
           return (
             <Actions className="actions">
@@ -192,7 +196,7 @@ function TagList(props: TagListProps) {
                       <b>{original.dashboard_title}</b>?
                     </>
                   }
-                  onConfirm={handleDelete}
+                  onConfirm={() => handleTagsDelete([original])}
                 >
                   {confirmDelete => (
                     <Tooltip
@@ -318,7 +322,7 @@ function TagList(props: TagListProps) {
   });
 
   const handleBulkDelete = (tagsToDelete: Tag[]) =>
-    handleTagsDelete(tagsToDelete, addSuccessToast, addDangerToast);
+    handleTagsDelete(tagsToDelete);
 
   return (
     <>

--- a/superset/tags/schemas.py
+++ b/superset/tags/schemas.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 from marshmallow import fields, Schema
-from marshmallow.validate import Range
+from marshmallow.validate import Length, Range
 
 from superset.dashboards.schemas import UserSchema
 
@@ -58,7 +58,7 @@ class TaggedObjectEntityResponseSchema(Schema):
 
 
 class TagObjectSchema(Schema):
-    name = fields.String()
+    name = fields.String(validate=Length(min=1))
     description = fields.String(required=False, allow_none=True)
     objects_to_tag = fields.List(
         fields.Tuple((fields.String(), fields.Int(validate=Range(min=1)))),

--- a/tests/integration_tests/tags/api_tests.py
+++ b/tests/integration_tests/tags/api_tests.py
@@ -486,6 +486,22 @@ class TestTagApi(SupersetTestCase):
         assert tag is not None
 
     @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
+    def test_post_tag_no_name_400(self):
+        self.login(username="admin")
+        uri = f"api/v1/tag/"
+        dashboard = (
+            db.session.query(Dashboard)
+            .filter(Dashboard.dashboard_title == "World Bank's Data")
+            .first()
+        )
+        rv = self.client.post(
+            uri,
+            json={"name": "", "objects_to_tag": [["dashboard", dashboard.id]]},
+        )
+
+        self.assertEqual(rv.status_code, 400)
+
+    @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
     @pytest.mark.usefixtures("create_tags")
     def test_put_tag(self):
         self.login(username="admin")


### PR DESCRIPTION
  <!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
#### add validation on tag name to have name
bug in production that allows users to create tags without names. So we added validation to the schema to make sure the length of the tag name field is atleast 1.

<img width="1329" alt="Screenshot 2023-11-02 at 4 49 21 PM" src="https://github.com/apache/superset/assets/27827808/64510dba-85a4-4ebf-89a7-fdccee0ce1e4">

#### fix reload callback after deleting tag
before hand the callback would execute before a tag would actually be deleted from the db. So fixed it the refresh to be called after success/failed request

https://github.com/apache/superset/assets/27827808/073d9acb-26a3-4fa5-a56a-36250b372a26

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
