### PR TITLE
fix(charts): Time grain is None when dataset uses Jinja

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/query/normalizeTimeColumn.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/normalizeTimeColumn.ts
@@ -70,10 +70,7 @@ export function normalizeTimeColumn(
       };
     }
 
-    const newQueryObject = omit(queryObject, [
-      'extras.time_grain_sqla',
-      'is_timeseries',
-    ]);
+    const newQueryObject = omit(queryObject, ['is_timeseries']);
     newQueryObject.columns = mutatedColumns;
 
     return newQueryObject;

--- a/superset-frontend/packages/superset-ui-core/test/query/normalizeTimeColumn.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/normalizeTimeColumn.test.ts
@@ -92,7 +92,9 @@ describe('GENERIC_CHART_AXES is disabled', () => {
       datasource: '5__table',
       viz_type: 'table',
       granularity: 'time_column',
-      extras: {},
+      extras: {
+        time_grain_sqla: 'P1Y',
+      },
       time_range: '1 year ago : 2013',
       orderby: [['count(*)', true]],
       columns: [
@@ -182,7 +184,7 @@ describe('GENERIC_CHART_AXES is enabled', () => {
       datasource: '5__table',
       viz_type: 'table',
       granularity: 'time_column',
-      extras: { where: '', having: '' },
+      extras: { where: '', having: '', time_grain_sqla: 'P1Y' },
       time_range: '1 year ago : 2013',
       orderby: [['count(*)', true]],
       columns: [
@@ -240,7 +242,7 @@ describe('GENERIC_CHART_AXES is enabled', () => {
       datasource: '5__table',
       viz_type: 'table',
       granularity: 'time_column',
-      extras: { where: '', having: '' },
+      extras: { where: '', having: '', time_grain_sqla: 'P1Y' },
       time_range: '1 year ago : 2013',
       orderby: [['count(*)', true]],
       columns: [

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/buildQuery.test.ts
@@ -307,6 +307,7 @@ test('should convert a queryObject with x-axis although FF is disabled', () => {
     extras: {
       having: '',
       where: "(foo in ('a', 'b'))",
+      time_grain_sqla: 'P1W',
     },
     applied_time_extras: {},
     columns: [

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/buildQuery.test.ts
@@ -120,7 +120,7 @@ describe('GENERIC_CHART_AXES is enabled', () => {
       expect.objectContaining({
         granularity: 'time_column',
         time_range: '1 year ago : 2013',
-        extras: { having: '', where: '' },
+        extras: { having: '', where: '', time_grain_sqla: 'P1Y' },
         columns: [
           {
             columnType: 'BASE_AXIS',
@@ -209,7 +209,7 @@ describe('GENERIC_CHART_AXES is disabled', () => {
       expect.objectContaining({
         granularity: 'time_column',
         time_range: '1 year ago : 2013',
-        extras: { having: '', where: '' },
+        extras: { having: '', where: '', time_grain_sqla: 'P1Y' },
         columns: [
           {
             columnType: 'BASE_AXIS',

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/buildQuery.ts
@@ -16,8 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import omit from 'lodash/omit';
-
 import {
   AdhocColumn,
   buildQueryContext,
@@ -72,9 +70,7 @@ export default function buildQuery(formData: PivotTableQueryFormData) {
     }
     return [
       {
-        ...(hasGenericChartAxes
-          ? omit(baseQueryObject, ['extras.time_grain_sqla'])
-          : baseQueryObject),
+        ...baseQueryObject,
         orderby: orderBy,
         columns,
       },

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/plugin/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/plugin/buildQuery.test.ts
@@ -121,3 +121,16 @@ test('should fallback to formData.time_grain_sqla if extra_form_data.time_grain_
     expressionType: 'SQL',
   });
 });
+
+test('should not omit extras.time_grain_sqla from queryContext so dashboards apply them', () => {
+  Object.defineProperty(supersetCoreModule, 'hasGenericChartAxes', {
+    value: true,
+  });
+  const modifiedFormData = {
+    ...formData,
+    extra_form_data: { time_grain_sqla: TimeGranularity.QUARTER },
+  };
+  const queryContext = buildQuery(modifiedFormData);
+  const [query] = queryContext.queries;
+  expect(query.extras?.time_grain_sqla).toEqual(TimeGranularity.QUARTER);
+});


### PR DESCRIPTION
### SUMMARY
When the underlaying dataset of a chart uses Jinja, some charts are not applying the time_grain properly to the inner query after you change it in the dashboard filters. Regular table charts work just fine.

Looking at what might be causing this, the call we're making to the API is omitting `extras.time_grain_sqla` when `GENERIC_CHART_AXES` is enabled which is our default now.

This PR is a first attempt to fix the issue by just putting that back in the API calls so Jinja time_grain is no longer None and gets properly applied.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: time_grain defaults to `YEAR` ignoring the filter.

![error](https://github.com/apache/superset/assets/38889534/84356f8d-abf7-4286-9a4e-ba584e0aa567)

After: charts applying the time_grain in the filter.

![test](https://github.com/apache/superset/assets/38889534/855cb18c-37ad-4143-8a8d-9c914adec1ab)


### TESTING INSTRUCTIONS
1. Create a dataset using below SQL query:
```
with jinja_grain as (
SELECT DATE_TRUNC(
{%- if time_grain == 'P1D' -%}
 'DAY'
{%- elif time_grain == 'P1W' -%}
 'WEEK'
{%- elif time_grain == 'P1M' -%}
 'MONTH'
{%- elif time_grain == 'P3M' -%}
 'QUARTER'
{%- elif time_grain == 'P1Y' -%}
 'YEAR'
{% else %}
 'YEAR'
{%- endif -%}
 ,order_date
) AS order_date_grained, *
FROM "Vehicle Sales" 
)
select * from jinja_grain
```

2. Use the dataset and create a pivot table. Use order_date_grained for rows and sum(sales) for metrics.
3. Save and add to a dashboard.
4. On the dashboard, add Time Grain filter.
5. Apply a different Time Grain from the filter.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: https://github.com/apache/superset/issues/22774
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
