### PR TITLE
fix: remove `update_charts_owners`

### DIFF
--- a/superset/daos/dashboard.py
+++ b/superset/daos/dashboard.py
@@ -179,15 +179,6 @@ class DashboardDAO(BaseDAO[Dashboard]):
         return True
 
     @staticmethod
-    def update_charts_owners(model: Dashboard, commit: bool = True) -> Dashboard:
-        owners = list(model.owners)
-        for slc in model.slices:
-            slc.owners = list(set(owners) | set(slc.owners))
-        if commit:
-            db.session.commit()
-        return model
-
-    @staticmethod
     def set_dash_metadata(  # pylint: disable=too-many-locals
         dashboard: Dashboard,
         data: dict[Any, Any],

--- a/superset/dashboards/commands/create.py
+++ b/superset/dashboards/commands/create.py
@@ -40,8 +40,7 @@ class CreateDashboardCommand(CreateMixin, BaseCommand):
     def run(self) -> Model:
         self.validate()
         try:
-            dashboard = DashboardDAO.create(attributes=self._properties, commit=False)
-            dashboard = DashboardDAO.update_charts_owners(dashboard, commit=True)
+            dashboard = DashboardDAO.create(attributes=self._properties, commit=True)
         except DAOCreateFailedError as ex:
             logger.exception(ex.exception)
             raise DashboardCreateFailedError() from ex

--- a/superset/dashboards/commands/update.py
+++ b/superset/dashboards/commands/update.py
@@ -58,7 +58,6 @@ class UpdateDashboardCommand(UpdateMixin, BaseCommand):
                     data=json.loads(self._properties.get("json_metadata", "{}")),
                     commit=False,
                 )
-            dashboard = DashboardDAO.update_charts_owners(dashboard, commit=False)
             db.session.commit()
         except DAOUpdateFailedError as ex:
             logger.exception(ex.exception)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Currently, when a user adds a chart they don't own to a dashboard they own, they are added as owners of the chart. This behavior doesn't make sense, and allows for malicious behavior — users can modify or delete any chart this way.

This PR removes that logic.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Create a chart as the admin user. Now login as the gamma user, and add that chart to a new dashboard. The gamma user should be able to add the chart, and they should not be added as an owner of the chart.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
