### PR TITLE
chore: Allow only iterables for BaseDAO.delete()

### DIFF
--- a/superset/daos/base.py
+++ b/superset/daos/base.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import Any, cast, Generic, get_args, TypeVar
+from typing import Any, Generic, get_args, TypeVar
 
 from flask_appbuilder.models.filters import BaseFilter
 from flask_appbuilder.models.sqla import Model
@@ -30,7 +30,6 @@ from superset.daos.exceptions import (
     DAOUpdateFailedError,
 )
 from superset.extensions import db
-from superset.utils.core import as_list
 
 T = TypeVar("T", bound=Model)
 
@@ -197,9 +196,9 @@ class BaseDAO(Generic[T]):
         return item  # type: ignore
 
     @classmethod
-    def delete(cls, item_or_items: T | list[T], commit: bool = True) -> None:
+    def delete(cls, items: list[T], commit: bool = True) -> None:
         """
-        Delete the specified item(s) including their associated relationships.
+        Delete the specified items including their associated relationships.
 
         Note that bulk deletion via `delete` is not invoked in the base class as this
         does not dispatch the ORM `after_delete` event which may be required to augment
@@ -209,12 +208,12 @@ class BaseDAO(Generic[T]):
         Subclasses may invoke bulk deletion but are responsible for instrumenting any
         post-deletion logic.
 
-        :param items: The item(s) to delete
+        :param items: The items to delete
         :param commit: Whether to commit the transaction
         :raises DAODeleteFailedError: If the deletion failed
         :see: https://docs.sqlalchemy.org/en/latest/orm/queryguide/dml.html
         """
-        items = cast(list[T], as_list(item_or_items))
+
         try:
             for item in items:
                 db.session.delete(item)

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -1349,8 +1349,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
-        for embedded in dashboard.embedded:
-            EmbeddedDashboardDAO.delete(embedded)
+        EmbeddedDashboardDAO.delete(dashboard.embedded)
         return self.response(200, message="OK")
 
     @expose("/<id_or_slug>/copy/", methods=("POST",))

--- a/superset/dashboards/filter_sets/commands/delete.py
+++ b/superset/dashboards/filter_sets/commands/delete.py
@@ -38,7 +38,7 @@ class DeleteFilterSetCommand(BaseFilterSetCommand):
         assert self._filter_set
 
         try:
-            FilterSetDAO.delete(self._filter_set)
+            FilterSetDAO.delete([self._filter_set])
         except DAODeleteFailedError as err:
             raise FilterSetDeleteFailedError(str(self._filter_set_id), "") from err
 

--- a/superset/databases/commands/delete.py
+++ b/superset/databases/commands/delete.py
@@ -44,7 +44,7 @@ class DeleteDatabaseCommand(BaseCommand):
         assert self._model
 
         try:
-            DatabaseDAO.delete(self._model)
+            DatabaseDAO.delete([self._model])
         except DAODeleteFailedError as ex:
             logger.exception(ex.exception)
             raise DatabaseDeleteFailedError() from ex

--- a/superset/databases/ssh_tunnel/commands/delete.py
+++ b/superset/databases/ssh_tunnel/commands/delete.py
@@ -43,7 +43,7 @@ class DeleteSSHTunnelCommand(BaseCommand):
         assert self._model
 
         try:
-            SSHTunnelDAO.delete(self._model)
+            SSHTunnelDAO.delete([self._model])
         except DAODeleteFailedError as ex:
             raise SSHTunnelDeleteFailedError() from ex
 

--- a/superset/datasets/columns/commands/delete.py
+++ b/superset/datasets/columns/commands/delete.py
@@ -43,7 +43,7 @@ class DeleteDatasetColumnCommand(BaseCommand):
         assert self._model
 
         try:
-            DatasetColumnDAO.delete(self._model)
+            DatasetColumnDAO.delete([self._model])
         except DAODeleteFailedError as ex:
             logger.exception(ex.exception)
             raise DatasetColumnDeleteFailedError() from ex

--- a/superset/datasets/metrics/commands/delete.py
+++ b/superset/datasets/metrics/commands/delete.py
@@ -43,7 +43,7 @@ class DeleteDatasetMetricCommand(BaseCommand):
         assert self._model
 
         try:
-            DatasetMetricDAO.delete(self._model)
+            DatasetMetricDAO.delete([self._model])
         except DAODeleteFailedError as ex:
             logger.exception(ex.exception)
             raise DatasetMetricDeleteFailedError() from ex

--- a/tests/integration_tests/dashboards/security/security_dataset_tests.py
+++ b/tests/integration_tests/dashboards/security/security_dataset_tests.py
@@ -192,4 +192,4 @@ class TestDashboardDatasetSecurity(DashboardTestCase):
         self.assert200(rv)
         data = json.loads(rv.data.decode("utf-8"))
         self.assertEqual(0, data["count"])
-        DashboardDAO.delete(dashboard)
+        DashboardDAO.delete([dashboard])


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Previous—due to legacy reasons when we had both single and bulk delete logic—the `BaseDAO.delete()` method accepted either a single item or a list of items. For simplicity and clarity this PR updates the function signature to support only the later. i.e., it is now apparent from the code that deletion is a bulk operation.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
