### PR TITLE
109 - refactor(logging): Clean up `statsd` logging

### DIFF
--- a/superset/advanced_data_type/api.py
+++ b/superset/advanced_data_type/api.py
@@ -57,7 +57,6 @@ class AdvancedDataTypeRestApi(BaseSupersetApi):
     @permission_name("read")
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.get",
-        log_to_statsd=False,  # pylint: disable-arguments-renamed
     )
     @rison(advanced_data_type_convert_schema)
     def get(self, **kwargs: Any) -> Response:
@@ -116,7 +115,6 @@ class AdvancedDataTypeRestApi(BaseSupersetApi):
     @permission_name("read")
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.get",
-        log_to_statsd=False,  # pylint: disable-arguments-renamed
     )
     def get_types(self) -> Response:
         """Return a list of available advanced data types.

--- a/superset/annotation_layers/annotations/api.py
+++ b/superset/annotation_layers/annotations/api.py
@@ -50,11 +50,8 @@ from superset.annotation_layers.annotations.schemas import (
 from superset.annotation_layers.commands.exceptions import AnnotationLayerNotFoundError
 from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP, RouteMethod
 from superset.models.annotations import Annotation
-from superset.views.base_api import (
-    BaseSupersetModelRestApi,
-    requires_json,
-    statsd_metrics,
-)
+from superset.views.base import statsd_metrics
+from superset.views.base_api import BaseSupersetModelRestApi, requires_json
 
 logger = logging.getLogger(__name__)
 

--- a/superset/annotation_layers/api.py
+++ b/superset/annotation_layers/api.py
@@ -44,11 +44,8 @@ from superset.annotation_layers.schemas import (
 from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP, RouteMethod
 from superset.extensions import event_logger
 from superset.models.annotations import AnnotationLayer
-from superset.views.base_api import (
-    BaseSupersetModelRestApi,
-    requires_json,
-    statsd_metrics,
-)
+from superset.views.base import statsd_metrics
+from superset.views.base_api import BaseSupersetModelRestApi, requires_json
 
 logger = logging.getLogger(__name__)
 
@@ -113,7 +110,6 @@ class AnnotationLayerRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.delete",
-        log_to_statsd=False,
     )
     @permission_name("delete")
     def delete(self, pk: int) -> Response:
@@ -167,7 +163,6 @@ class AnnotationLayerRestApi(BaseSupersetModelRestApi):
     @permission_name("post")
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.post",
-        log_to_statsd=False,
     )
     @requires_json
     def post(self) -> Response:
@@ -231,7 +226,6 @@ class AnnotationLayerRestApi(BaseSupersetModelRestApi):
     @permission_name("put")
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.put",
-        log_to_statsd=False,
     )
     @requires_json
     def put(self, pk: int) -> Response:
@@ -302,7 +296,6 @@ class AnnotationLayerRestApi(BaseSupersetModelRestApi):
     @rison(get_delete_ids_schema)
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.bulk_delete",
-        log_to_statsd=False,
     )
     def bulk_delete(self, **kwargs: Any) -> Response:
         """Bulk delete annotation layers.

--- a/superset/async_events/api.py
+++ b/superset/async_events/api.py
@@ -23,6 +23,7 @@ from flask_appbuilder.security.decorators import permission_name, protect
 
 from superset.async_events.async_query_manager import AsyncQueryTokenException
 from superset.extensions import async_query_manager, event_logger
+from superset.views.base import statsd_metrics
 from superset.views.base_api import BaseSupersetApi
 
 logger = logging.getLogger(__name__)
@@ -33,6 +34,7 @@ class AsyncEventsRestApi(BaseSupersetApi):
     allow_browser_login = True
 
     @expose("/", methods=("GET",))
+    @statsd_metrics
     @event_logger.log_this
     @protect()
     @safe

--- a/superset/available_domains/api.py
+++ b/superset/available_domains/api.py
@@ -23,7 +23,8 @@ from superset import conf
 from superset.available_domains.schemas import AvailableDomainsSchema
 from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP
 from superset.extensions import event_logger
-from superset.views.base_api import BaseSupersetApi, statsd_metrics
+from superset.views.base import statsd_metrics
+from superset.views.base_api import BaseSupersetApi
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +45,6 @@ class AvailableDomainsRestApi(BaseSupersetApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.get",
-        log_to_statsd=True,
     )
     def get(self) -> Response:
         """

--- a/superset/cachekeys/api.py
+++ b/superset/cachekeys/api.py
@@ -28,7 +28,8 @@ from superset.cachekeys.schemas import CacheInvalidationRequestSchema
 from superset.connectors.sqla.models import SqlaTable
 from superset.extensions import cache_manager, db, event_logger, stats_logger_manager
 from superset.models.cache import CacheKey
-from superset.views.base_api import BaseSupersetModelRestApi, statsd_metrics
+from superset.views.base import statsd_metrics
+from superset.views.base_api import BaseSupersetModelRestApi
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +49,7 @@ class CacheRestApi(BaseSupersetModelRestApi):
     @protect()
     @safe
     @statsd_metrics
-    @event_logger.log_this_with_context(log_to_statsd=False)
+    @event_logger.log_this
     def invalidate(self) -> Response:
         """
         Take a list of datasources, find and invalidate the associated cache records

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -83,12 +83,12 @@ from superset.tasks.thumbnails import cache_chart_thumbnail
 from superset.tasks.utils import get_current_user
 from superset.utils.screenshots import ChartScreenshot, DEFAULT_CHART_WINDOW_SIZE
 from superset.utils.urls import get_url_path
+from superset.views.base import statsd_metrics
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
     RelatedFieldFilter,
     requires_form_data,
     requires_json,
-    statsd_metrics,
 )
 from superset.views.filters import BaseFilterRelatedUsers, FilterRelatedOwners
 
@@ -281,7 +281,6 @@ class ChartRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.post",
-        log_to_statsd=False,
     )
     @requires_json
     def post(self) -> Response:
@@ -346,7 +345,6 @@ class ChartRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.put",
-        log_to_statsd=False,
     )
     @requires_json
     def put(self, pk: int) -> Response:
@@ -422,7 +420,6 @@ class ChartRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.delete",
-        log_to_statsd=False,
     )
     def delete(self, pk: int) -> Response:
         """Delete a chart.
@@ -478,7 +475,6 @@ class ChartRestApi(BaseSupersetModelRestApi):
     @rison(get_delete_ids_schema)
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.bulk_delete",
-        log_to_statsd=False,
     )
     def bulk_delete(self, **kwargs: Any) -> Response:
         """Bulk delete charts.
@@ -537,7 +533,6 @@ class ChartRestApi(BaseSupersetModelRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".cache_screenshot",
-        log_to_statsd=False,
     )
     def cache_screenshot(self, pk: int, **kwargs: Any) -> WerkzeugResponse:
         """Compute and cache a screenshot.
@@ -609,7 +604,6 @@ class ChartRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.screenshot",
-        log_to_statsd=False,
     )
     def screenshot(self, pk: int, digest: str) -> WerkzeugResponse:
         """Get a computed screenshot from cache.
@@ -663,7 +657,6 @@ class ChartRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.thumbnail",
-        log_to_statsd=False,
     )
     def thumbnail(self, pk: int, digest: str, **kwargs: Any) -> WerkzeugResponse:
         """Compute or get already computed chart thumbnail from cache.
@@ -751,7 +744,6 @@ class ChartRestApi(BaseSupersetModelRestApi):
     @rison(get_export_ids_schema)
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.export",
-        log_to_statsd=False,
     )
     def export(self, **kwargs: Any) -> Response:
         """Download multiple charts as YAML files.
@@ -815,7 +807,6 @@ class ChartRestApi(BaseSupersetModelRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".favorite_status",
-        log_to_statsd=False,
     )
     def favorite_status(self, **kwargs: Any) -> Response:
         """Check favorited charts for current user.
@@ -863,7 +854,6 @@ class ChartRestApi(BaseSupersetModelRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".add_favorite",
-        log_to_statsd=False,
     )
     def add_favorite(self, pk: int) -> Response:
         """Mark the chart as favorite for the current user.
@@ -906,7 +896,6 @@ class ChartRestApi(BaseSupersetModelRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".remove_favorite",
-        log_to_statsd=False,
     )
     def remove_favorite(self, pk: int) -> Response:
         """Remove the chart from the user favorite list.
@@ -949,7 +938,6 @@ class ChartRestApi(BaseSupersetModelRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".warm_up_cache",
-        log_to_statsd=False,
     )
     def warm_up_cache(self) -> Response:
         """Warm up the cache for the chart.
@@ -1003,7 +991,6 @@ class ChartRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.import_",
-        log_to_statsd=False,
     )
     @requires_form_data
     def import_(self) -> Response:

--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -48,8 +48,12 @@ from superset.exceptions import QueryObjectValidationError
 from superset.extensions import event_logger
 from superset.models.sql_lab import Query
 from superset.utils.core import create_zip, get_user_id, json_int_dttm_ser
-from superset.views.base import CsvResponse, generate_download_headers, XlsxResponse
-from superset.views.base_api import statsd_metrics
+from superset.views.base import (
+    CsvResponse,
+    generate_download_headers,
+    statsd_metrics,
+    XlsxResponse,
+)
 
 if TYPE_CHECKING:
     from superset.common.query_context import QueryContext
@@ -65,7 +69,6 @@ class ChartDataRestApi(ChartRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.data",
-        log_to_statsd=False,
     )
     def get_data(self, pk: int) -> Response:
         """
@@ -178,7 +181,6 @@ class ChartDataRestApi(ChartRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.data",
-        log_to_statsd=False,
     )
     def data(self) -> Response:
         """
@@ -263,7 +265,6 @@ class ChartDataRestApi(ChartRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".data_from_cache",
-        log_to_statsd=False,
     )
     def data_from_cache(self, cache_key: str) -> Response:
         """

--- a/superset/css_templates/api.py
+++ b/superset/css_templates/api.py
@@ -35,7 +35,8 @@ from superset.css_templates.schemas import (
 )
 from superset.extensions import event_logger
 from superset.models.core import CssTemplate
-from superset.views.base_api import BaseSupersetModelRestApi, statsd_metrics
+from superset.views.base import statsd_metrics
+from superset.views.base_api import BaseSupersetModelRestApi
 
 logger = logging.getLogger(__name__)
 
@@ -93,7 +94,6 @@ class CssTemplateRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.bulk_delete",
-        log_to_statsd=False,
     )
     @rison(get_delete_ids_schema)
     def bulk_delete(self, **kwargs: Any) -> Response:

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -86,13 +86,12 @@ from superset.tasks.utils import get_current_user
 from superset.utils.cache import etag_cache
 from superset.utils.screenshots import DashboardScreenshot
 from superset.utils.urls import get_url_path
-from superset.views.base import generate_download_headers
+from superset.views.base import generate_download_headers, statsd_metrics
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
     RelatedFieldFilter,
     requires_form_data,
     requires_json,
-    statsd_metrics,
 )
 from superset.views.filters import (
     BaseFilterRelatedRoles,
@@ -363,7 +362,6 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.get_datasets",
-        log_to_statsd=False,
     )
     def get_datasets(self, id_or_slug: str) -> Response:
         """Get dashboard's datasets.
@@ -433,7 +431,6 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.get_charts",
-        log_to_statsd=False,
     )
     def get_charts(self, id_or_slug: str) -> Response:
         """Get a dashboard's chart definitions.
@@ -489,7 +486,6 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.post",
-        log_to_statsd=False,
     )
     @requires_json
     def post(self) -> Response:
@@ -550,7 +546,6 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.put",
-        log_to_statsd=False,
     )
     @requires_json
     def put(self, pk: int) -> Response:
@@ -635,7 +630,6 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.delete",
-        log_to_statsd=False,
     )
     def delete(self, pk: int) -> Response:
         """Delete a dashboard.
@@ -691,7 +685,6 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     @rison(get_delete_ids_schema)
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.bulk_delete",
-        log_to_statsd=False,
     )
     def bulk_delete(self, **kwargs: Any) -> Response:
         """Bulk delete dashboards.
@@ -751,7 +744,6 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     @rison(get_export_ids_schema)
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.export",
-        log_to_statsd=False,
     )
     def export(self, **kwargs: Any) -> Response:  # pylint: disable=too-many-locals
         """Download multiple dashboards as YAML files.
@@ -835,7 +827,6 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     @rison(thumbnail_query_schema)
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.thumbnail",
-        log_to_statsd=False,
     )
     def thumbnail(self, pk: int, digest: str, **kwargs: Any) -> WerkzeugResponse:
         """Compute async or get already computed dashboard thumbnail from cache.
@@ -940,7 +931,6 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".favorite_status",
-        log_to_statsd=False,
     )
     def favorite_status(self, **kwargs: Any) -> Response:
         """Check favorited dashboards for current user.
@@ -989,7 +979,6 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".add_favorite",
-        log_to_statsd=False,
     )
     def add_favorite(self, pk: int) -> Response:
         """Mark the dashboard as favorite for the current user.
@@ -1032,7 +1021,6 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".remove_favorite",
-        log_to_statsd=False,
     )
     def remove_favorite(self, pk: int) -> Response:
         """Remove the dashboard from the user favorite list.
@@ -1073,7 +1061,6 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.import_",
-        log_to_statsd=False,
     )
     @requires_form_data
     def import_(self) -> Response:
@@ -1200,7 +1187,6 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.get_embedded",
-        log_to_statsd=False,
     )
     @with_dashboard
     def get_embedded(self, dashboard: Dashboard) -> Response:
@@ -1241,7 +1227,6 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.set_embedded",
-        log_to_statsd=False,
     )
     @with_dashboard
     def set_embedded(self, dashboard: Dashboard) -> Response:
@@ -1320,7 +1305,6 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.delete_embedded",
-        log_to_statsd=False,
     )
     @with_dashboard
     def delete_embedded(self, dashboard: Dashboard) -> Response:
@@ -1360,7 +1344,6 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.copy_dash",
-        log_to_statsd=False,
     )
     @with_dashboard
     def copy_dash(self, original_dash: Dashboard) -> Response:

--- a/superset/dashboards/filter_sets/api.py
+++ b/superset/dashboards/filter_sets/api.py
@@ -62,11 +62,8 @@ from superset.dashboards.filter_sets.schemas import (
 )
 from superset.extensions import event_logger
 from superset.models.filter_set import FilterSet
-from superset.views.base_api import (
-    BaseSupersetModelRestApi,
-    requires_json,
-    statsd_metrics,
-)
+from superset.views.base import statsd_metrics
+from superset.views.base_api import BaseSupersetModelRestApi, requires_json
 
 logger = logging.getLogger(__name__)
 
@@ -192,7 +189,6 @@ class FilterSetRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.post",
-        log_to_statsd=False,
     )
     @requires_json
     def post(self, dashboard_id: int) -> Response:
@@ -257,7 +253,6 @@ class FilterSetRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.put",
-        log_to_statsd=False,
     )
     @requires_json
     def put(self, dashboard_id: int, pk: int) -> Response:
@@ -328,7 +323,6 @@ class FilterSetRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.delete",
-        log_to_statsd=False,
     )
     def delete(self, dashboard_id: int, pk: int) -> Response:
         """Delete a dashboard's filter set.

--- a/superset/dashboards/filter_state/api.py
+++ b/superset/dashboards/filter_state/api.py
@@ -51,7 +51,6 @@ class DashboardFilterStateRestApi(TemporaryCacheRestApi):
     @safe
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.post",
-        log_to_statsd=False,
     )
     def post(self, pk: int) -> Response:
         """Create a dashboard's filter state.
@@ -100,7 +99,6 @@ class DashboardFilterStateRestApi(TemporaryCacheRestApi):
     @safe
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.put",
-        log_to_statsd=False,
     )
     def put(self, pk: int, key: str) -> Response:
         """Update a dashboard's filter state value.
@@ -155,7 +153,6 @@ class DashboardFilterStateRestApi(TemporaryCacheRestApi):
     @safe
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.get",
-        log_to_statsd=False,
     )
     def get(self, pk: int, key: str) -> Response:
         """Get a dashboard's filter state value.
@@ -200,7 +197,6 @@ class DashboardFilterStateRestApi(TemporaryCacheRestApi):
     @safe
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.delete",
-        log_to_statsd=False,
     )
     def delete(self, pk: int, key: str) -> Response:
         """Delete a dashboard's filter state value.

--- a/superset/dashboards/permalink/api.py
+++ b/superset/dashboards/permalink/api.py
@@ -52,7 +52,6 @@ class DashboardPermalinkRestApi(BaseSupersetApi):
     @safe
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.post",
-        log_to_statsd=False,
     )
     @requires_json
     def post(self, pk: str) -> Response:
@@ -118,7 +117,6 @@ class DashboardPermalinkRestApi(BaseSupersetApi):
     @safe
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.get",
-        log_to_statsd=False,
     )
     def get(self, key: str) -> Response:
         """Get dashboard's permanent link state.

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -94,12 +94,11 @@ from superset.models.core import Database
 from superset.superset_typing import FlaskResponse
 from superset.utils.core import error_msg_from_exception, parse_js_uri_path_item
 from superset.utils.ssh_tunnel import mask_password_info
-from superset.views.base import json_errors_response
+from superset.views.base import json_errors_response, statsd_metrics
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
     requires_form_data,
     requires_json,
-    statsd_metrics,
 )
 
 logger = logging.getLogger(__name__)
@@ -327,7 +326,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.post",
-        log_to_statsd=False,
     )
     @requires_json
     def post(self) -> FlaskResponse:
@@ -412,7 +410,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.put",
-        log_to_statsd=False,
     )
     @requires_json
     def put(self, pk: int) -> Response:
@@ -495,7 +492,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}" f".delete",
-        log_to_statsd=False,
     )
     def delete(self, pk: int) -> Response:
         """Delete a database.
@@ -551,7 +547,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}" f".schemas",
-        log_to_statsd=False,
     )
     def schemas(self, pk: int, **kwargs: Any) -> FlaskResponse:
         """Get all schemas from a database.
@@ -611,7 +606,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}" f".tables",
-        log_to_statsd=False,
     )
     def tables(self, pk: int, **kwargs: Any) -> FlaskResponse:
         """Get a list of tables for given database.
@@ -679,7 +673,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".table_metadata",
-        log_to_statsd=False,
     )
     def table_metadata(
         self, database: Database, table_name: str, schema_name: str
@@ -742,7 +735,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".table_extra_metadata",
-        log_to_statsd=False,
     )
     def table_extra_metadata(
         self, database: Database, table_name: str, schema_name: str
@@ -804,7 +796,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.select_star",
-        log_to_statsd=False,
     )
     def select_star(
         self, database: Database, table_name: str, schema_name: Optional[str] = None
@@ -864,7 +855,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".test_connection",
-        log_to_statsd=False,
     )
     @requires_json
     def test_connection(self) -> FlaskResponse:
@@ -914,7 +904,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".related_objects",
-        log_to_statsd=False,
     )
     def related_objects(self, pk: int) -> Response:
         """Get charts and dashboards count associated to a database.
@@ -980,7 +969,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.validate_sql",
-        log_to_statsd=False,
     )
     def validate_sql(self, pk: int) -> FlaskResponse:
         """Validate that arbitrary SQL is acceptable for the given database.
@@ -1041,7 +1029,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @rison(get_export_ids_schema)
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.export",
-        log_to_statsd=False,
     )
     def export(self, **kwargs: Any) -> Response:
         """Download database(s) and associated dataset(s) as a zip file.
@@ -1102,7 +1089,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.import_",
-        log_to_statsd=False,
     )
     @requires_form_data
     def import_(self) -> Response:
@@ -1226,7 +1212,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".function_names",
-        log_to_statsd=False,
     )
     def function_names(self, pk: int) -> Response:
         """Get function names supported by a database.
@@ -1265,7 +1250,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}" f".available",
-        log_to_statsd=False,
     )
     def available(self) -> Response:
         """Get names of databases currently available.
@@ -1380,7 +1364,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".validate_parameters",
-        log_to_statsd=False,
     )
     @requires_json
     def validate_parameters(self) -> FlaskResponse:
@@ -1436,7 +1419,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".delete_ssh_tunnel",
-        log_to_statsd=False,
     )
     def delete_ssh_tunnel(self, pk: int) -> Response:
         """Delete a SSH tunnel.
@@ -1498,7 +1480,6 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".schemas_access_for_file_upload",
-        log_to_statsd=False,
     )
     def schemas_access_for_file_upload(self, pk: int) -> Response:
         """The list of the database schemas where to upload information.

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -68,13 +68,16 @@ from superset.datasets.schemas import (
     openapi_spec_methods_override,
 )
 from superset.utils.core import parse_boolean_string
-from superset.views.base import DatasourceFilter, generate_download_headers
+from superset.views.base import (
+    DatasourceFilter,
+    generate_download_headers,
+    statsd_metrics,
+)
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
     RelatedFieldFilter,
     requires_form_data,
     requires_json,
-    statsd_metrics,
 )
 from superset.views.filters import BaseFilterRelatedUsers, FilterRelatedOwners
 
@@ -274,7 +277,6 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.post",
-        log_to_statsd=False,
     )
     @requires_json
     def post(self) -> Response:
@@ -335,7 +337,6 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.put",
-        log_to_statsd=False,
     )
     @requires_json
     def put(self, pk: int) -> Response:
@@ -421,7 +422,6 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.delete",
-        log_to_statsd=False,
     )
     def delete(self, pk: int) -> Response:
         """Delete a Dataset.
@@ -477,7 +477,6 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     @rison(get_export_ids_schema)
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.export",
-        log_to_statsd=False,
     )
     def export(self, **kwargs: Any) -> Response:  # pylint: disable=too-many-locals
         """Download multiple datasets as YAML files.
@@ -559,7 +558,6 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}" f".duplicate",
-        log_to_statsd=False,
     )
     @requires_json
     def duplicate(self) -> Response:
@@ -629,7 +627,6 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}" f".refresh",
-        log_to_statsd=False,
     )
     def refresh(self, pk: int) -> Response:
         """Refresh and update columns of a dataset.
@@ -685,7 +682,6 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".related_objects",
-        log_to_statsd=False,
     )
     def related_objects(self, pk: int) -> Response:
         """Get charts and dashboards count associated to a dataset.
@@ -746,7 +742,6 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     @rison(get_delete_ids_schema)
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.bulk_delete",
-        log_to_statsd=False,
     )
     def bulk_delete(self, **kwargs: Any) -> Response:
         """Bulk delete datasets.
@@ -806,7 +801,6 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.import_",
-        log_to_statsd=False,
     )
     @requires_form_data
     def import_(self) -> Response:
@@ -942,7 +936,6 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".get_or_create_dataset",
-        log_to_statsd=False,
     )
     def get_or_create_dataset(self) -> Response:
         """Retrieve a dataset by name, or create it if it does not exist.
@@ -1008,7 +1001,6 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".warm_up_cache",
-        log_to_statsd=False,
     )
     def warm_up_cache(self) -> Response:
         """Warm up the cache for each chart powered by the given table.

--- a/superset/datasets/columns/api.py
+++ b/superset/datasets/columns/api.py
@@ -28,7 +28,8 @@ from superset.datasets.columns.commands.exceptions import (
     DatasetColumnForbiddenError,
     DatasetColumnNotFoundError,
 )
-from superset.views.base_api import BaseSupersetModelRestApi, statsd_metrics
+from superset.views.base import statsd_metrics
+from superset.views.base_api import BaseSupersetModelRestApi
 
 logger = logging.getLogger(__name__)
 

--- a/superset/datasets/metrics/api.py
+++ b/superset/datasets/metrics/api.py
@@ -28,7 +28,8 @@ from superset.datasets.metrics.commands.exceptions import (
     DatasetMetricForbiddenError,
     DatasetMetricNotFoundError,
 )
-from superset.views.base_api import BaseSupersetModelRestApi, statsd_metrics
+from superset.views.base import statsd_metrics
+from superset.views.base_api import BaseSupersetModelRestApi
 
 logger = logging.getLogger(__name__)
 

--- a/superset/datasource/api.py
+++ b/superset/datasource/api.py
@@ -24,7 +24,8 @@ from superset.daos.exceptions import DatasourceNotFound, DatasourceTypeNotSuppor
 from superset.exceptions import SupersetSecurityException
 from superset.superset_typing import FlaskResponse
 from superset.utils.core import apply_max_row_limit, DatasourceType
-from superset.views.base_api import BaseSupersetApi, statsd_metrics
+from superset.views.base import statsd_metrics
+from superset.views.base_api import BaseSupersetApi
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +46,6 @@ class DatasourceRestApi(BaseSupersetApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".get_column_values",
-        log_to_statsd=False,
     )
     def get_column_values(
         self, datasource_type: str, datasource_id: int, column_name: str

--- a/superset/embedded/api.py
+++ b/superset/embedded/api.py
@@ -32,7 +32,8 @@ from superset.embedded_dashboard.commands.exceptions import (
 from superset.extensions import event_logger
 from superset.models.embedded_dashboard import EmbeddedDashboard
 from superset.reports.logs.schemas import openapi_spec_methods_override
-from superset.views.base_api import BaseSupersetModelRestApi, statsd_metrics
+from superset.views.base import statsd_metrics
+from superset.views.base_api import BaseSupersetModelRestApi
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +65,6 @@ class EmbeddedDashboardRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.get_embedded",
-        log_to_statsd=False,
     )
     # pylint: disable=arguments-differ, arguments-renamed)
     def get(self, uuid: str) -> Response:

--- a/superset/explore/api.py
+++ b/superset/explore/api.py
@@ -31,7 +31,8 @@ from superset.temporary_cache.commands.exceptions import (
     TemporaryCacheAccessDeniedError,
     TemporaryCacheResourceNotFoundError,
 )
-from superset.views.base_api import BaseSupersetApi, statsd_metrics
+from superset.views.base import statsd_metrics
+from superset.views.base_api import BaseSupersetApi
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +51,6 @@ class ExploreRestApi(BaseSupersetApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.get",
-        log_to_statsd=True,
     )
     def get(self) -> Response:
         """Assemble Explore related information (form_data, slice, dataset)

--- a/superset/explore/form_data/api.py
+++ b/superset/explore/form_data/api.py
@@ -32,7 +32,8 @@ from superset.temporary_cache.commands.exceptions import (
     TemporaryCacheAccessDeniedError,
     TemporaryCacheResourceNotFoundError,
 )
-from superset.views.base_api import BaseSupersetApi, requires_json, statsd_metrics
+from superset.views.base import statsd_metrics
+from superset.views.base_api import BaseSupersetApi, requires_json
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +54,6 @@ class ExploreFormDataRestApi(BaseSupersetApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.post",
-        log_to_statsd=False,
     )
     @requires_json
     def post(self) -> Response:
@@ -117,7 +117,6 @@ class ExploreFormDataRestApi(BaseSupersetApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.put",
-        log_to_statsd=True,
     )
     @requires_json
     def put(self, key: str) -> Response:
@@ -190,7 +189,6 @@ class ExploreFormDataRestApi(BaseSupersetApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.get",
-        log_to_statsd=True,
     )
     def get(self, key: str) -> Response:
         """Get a form_data.
@@ -241,7 +239,6 @@ class ExploreFormDataRestApi(BaseSupersetApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.delete",
-        log_to_statsd=True,
     )
     def delete(self, key: str) -> Response:
         """Delete a form_data.

--- a/superset/explore/permalink/api.py
+++ b/superset/explore/permalink/api.py
@@ -35,7 +35,8 @@ from superset.explore.permalink.exceptions import ExplorePermalinkInvalidStateEr
 from superset.explore.permalink.schemas import ExplorePermalinkStateSchema
 from superset.extensions import event_logger
 from superset.key_value.exceptions import KeyValueAccessDeniedError
-from superset.views.base_api import BaseSupersetApi, requires_json, statsd_metrics
+from superset.views.base import statsd_metrics
+from superset.views.base_api import BaseSupersetApi, requires_json
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +56,6 @@ class ExplorePermalinkRestApi(BaseSupersetApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.post",
-        log_to_statsd=False,
     )
     @requires_json
     def post(self) -> Response:
@@ -115,7 +115,6 @@ class ExplorePermalinkRestApi(BaseSupersetApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.get",
-        log_to_statsd=False,
     )
     def get(self, key: str) -> Response:
         """Get chart's permanent link state.

--- a/superset/importexport/api.py
+++ b/superset/importexport/api.py
@@ -30,7 +30,8 @@ from superset.commands.importers.exceptions import (
 from superset.commands.importers.v1.assets import ImportAssetsCommand
 from superset.commands.importers.v1.utils import get_contents_from_bundle
 from superset.extensions import event_logger
-from superset.views.base_api import BaseSupersetApi, requires_form_data, statsd_metrics
+from superset.views.base import statsd_metrics
+from superset.views.base_api import BaseSupersetApi, requires_form_data
 
 
 class ImportExportRestApi(BaseSupersetApi):
@@ -47,7 +48,6 @@ class ImportExportRestApi(BaseSupersetApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.export",
-        log_to_statsd=False,
     )
     def export(self) -> Response:
         """Export all assets.
@@ -96,7 +96,6 @@ class ImportExportRestApi(BaseSupersetApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.import_",
-        log_to_statsd=False,
     )
     @requires_form_data
     def import_(self) -> Response:

--- a/superset/queries/api.py
+++ b/superset/queries/api.py
@@ -35,11 +35,11 @@ from superset.queries.schemas import (
     StopQuerySchema,
 )
 from superset.superset_typing import FlaskResponse
+from superset.views.base import statsd_metrics
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
     RelatedFieldFilter,
     requires_json,
-    statsd_metrics,
 )
 from superset.views.filters import BaseFilterRelatedUsers, FilterRelatedOwners
 
@@ -156,7 +156,6 @@ class QueryRestApi(BaseSupersetModelRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".get_updated_since",
-        log_to_statsd=False,
     )
     def get_updated_since(self, **kwargs: Any) -> FlaskResponse:
         """Get a list of queries that changed after last_updated_ms.
@@ -208,7 +207,6 @@ class QueryRestApi(BaseSupersetModelRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".stop_query",
-        log_to_statsd=False,
     )
     @backoff.on_exception(
         backoff.constant,

--- a/superset/queries/saved_queries/api.py
+++ b/superset/queries/saved_queries/api.py
@@ -56,11 +56,8 @@ from superset.queries.saved_queries.schemas import (
     get_export_ids_schema,
     openapi_spec_methods_override,
 )
-from superset.views.base_api import (
-    BaseSupersetModelRestApi,
-    requires_form_data,
-    statsd_metrics,
-)
+from superset.views.base import statsd_metrics
+from superset.views.base_api import BaseSupersetModelRestApi, requires_form_data
 
 logger = logging.getLogger(__name__)
 
@@ -290,7 +287,6 @@ class SavedQueryRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.import_",
-        log_to_statsd=False,
     )
     @requires_form_data
     def import_(self) -> Response:

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -49,11 +49,11 @@ from superset.reports.schemas import (
     ReportSchedulePostSchema,
     ReportSchedulePutSchema,
 )
+from superset.views.base import statsd_metrics
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
     RelatedFieldFilter,
     requires_json,
-    statsd_metrics,
 )
 from superset.views.filters import BaseFilterRelatedUsers, FilterRelatedOwners
 
@@ -242,7 +242,6 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.delete",
-        log_to_statsd=False,
     )
     def delete(self, pk: int) -> Response:
         """Delete a report schedule.
@@ -452,7 +451,6 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
     @rison(get_delete_ids_schema)
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.bulk_delete",
-        log_to_statsd=False,
     )
     def bulk_delete(self, **kwargs: Any) -> Response:
         """Bulk delete report schedules.

--- a/superset/row_level_security/api.py
+++ b/superset/row_level_security/api.py
@@ -44,12 +44,8 @@ from superset.row_level_security.schemas import (
     RLSPutSchema,
     RLSShowSchema,
 )
-from superset.views.base import DatasourceFilter
-from superset.views.base_api import (
-    BaseSupersetModelRestApi,
-    requires_json,
-    statsd_metrics,
-)
+from superset.views.base import DatasourceFilter, statsd_metrics
+from superset.views.base_api import BaseSupersetModelRestApi, requires_json
 from superset.views.filters import BaseFilterRelatedRoles
 
 logger = logging.getLogger(__name__)
@@ -139,7 +135,6 @@ class RLSRestApi(BaseSupersetModelRestApi):
     @requires_json
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.post",
-        log_to_statsd=False,
     )
     def post(self) -> Response:
         """Create a new RLS rule.
@@ -216,7 +211,6 @@ class RLSRestApi(BaseSupersetModelRestApi):
     @requires_json
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.put",
-        log_to_statsd=False,
     )
     def put(self, pk: int) -> Response:
         """Update an RLS rule.
@@ -304,7 +298,6 @@ class RLSRestApi(BaseSupersetModelRestApi):
     @rison(get_delete_ids_schema)
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.bulk_delete",
-        log_to_statsd=False,
     )
     def bulk_delete(self, **kwargs: Any) -> Response:
         """Bulk delete RLS rules.

--- a/superset/security/api.py
+++ b/superset/security/api.py
@@ -29,7 +29,8 @@ from superset.embedded_dashboard.commands.exceptions import (
 )
 from superset.extensions import event_logger
 from superset.security.guest_token import GuestTokenResourceType
-from superset.views.base_api import BaseSupersetApi, statsd_metrics
+from superset.views.base import statsd_metrics
+from superset.views.base_api import BaseSupersetApi
 
 logger = logging.getLogger(__name__)
 

--- a/superset/sqllab/api.py
+++ b/superset/sqllab/api.py
@@ -60,8 +60,13 @@ from superset.sqllab.utils import bootstrap_sqllab_data
 from superset.sqllab.validators import CanAccessQueryValidatorImpl
 from superset.superset_typing import FlaskResponse
 from superset.utils import core as utils
-from superset.views.base import CsvResponse, generate_download_headers, json_success
-from superset.views.base_api import BaseSupersetApi, requires_json, statsd_metrics
+from superset.views.base import (
+    CsvResponse,
+    generate_download_headers,
+    json_success,
+    statsd_metrics,
+)
+from superset.views.base_api import BaseSupersetApi, requires_json
 
 config = app.config
 logger = logging.getLogger(__name__)
@@ -96,7 +101,6 @@ class SqlLabRestApi(BaseSupersetApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.get",
-        log_to_statsd=False,
     )
     def get(self) -> Response:
         """Get the bootstrap data for SqlLab
@@ -143,7 +147,6 @@ class SqlLabRestApi(BaseSupersetApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".estimate_query_cost",
-        log_to_statsd=False,
     )
     def estimate_query_cost(self) -> Response:
         """Estimate the SQL query execution cost.
@@ -191,7 +194,6 @@ class SqlLabRestApi(BaseSupersetApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".export_csv",
-        log_to_statsd=False,
     )
     def export_csv(self, client_id: str) -> CsvResponse:
         """Export the SQL query results to a CSV.
@@ -252,7 +254,6 @@ class SqlLabRestApi(BaseSupersetApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".get_results",
-        log_to_statsd=False,
     )
     def get_results(self, **kwargs: Any) -> FlaskResponse:
         """Get the result of a SQL query execution.
@@ -305,7 +306,6 @@ class SqlLabRestApi(BaseSupersetApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".get_results",
-        log_to_statsd=False,
     )
     def execute_sql_query(self) -> FlaskResponse:
         """Execute a SQL query.

--- a/superset/tags/api.py
+++ b/superset/tags/api.py
@@ -50,11 +50,8 @@ from superset.tags.schemas import (
     TagPostSchema,
     TagPutSchema,
 )
-from superset.views.base_api import (
-    BaseSupersetModelRestApi,
-    RelatedFieldFilter,
-    statsd_metrics,
-)
+from superset.views.base import statsd_metrics
+from superset.views.base_api import BaseSupersetModelRestApi, RelatedFieldFilter
 from superset.views.filters import BaseFilterRelatedUsers, FilterRelatedOwners
 
 logger = logging.getLogger(__name__)
@@ -150,7 +147,6 @@ class TagRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.post",
-        log_to_statsd=False,
     )
     def post(self) -> Response:
         """Creates a new Tags and tag items
@@ -202,7 +198,6 @@ class TagRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.bulk_create",
-        log_to_statsd=False,
     )
     def bulk_create(self) -> Response:
         """Bulk create tags and tagged objects
@@ -297,7 +292,6 @@ class TagRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.put",
-        log_to_statsd=False,
     )
     def put(self, pk: int) -> Response:
         """Changes a Tag
@@ -362,7 +356,6 @@ class TagRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.add_objects",
-        log_to_statsd=False,
     )
     def add_objects(self, object_type: ObjectTypes, object_id: int) -> Response:
         """Add tags to an object. Create new tags if they do not already exist.
@@ -426,7 +419,6 @@ class TagRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.delete_object",
-        log_to_statsd=True,
     )
     def delete_object(
         self, object_type: ObjectTypes, object_id: int, tag: str
@@ -494,7 +486,6 @@ class TagRestApi(BaseSupersetModelRestApi):
     @rison(delete_tags_schema)
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.bulk_delete",
-        log_to_statsd=False,
     )
     def bulk_delete(self, **kwargs: Any) -> Response:
         """Bulk delete tags. This will remove all tagged objects with this tag.
@@ -549,7 +540,6 @@ class TagRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.get_objects",
-        log_to_statsd=False,
     )
     def get_objects(self) -> Response:
         """Get all objects associated with a tag.
@@ -606,7 +596,6 @@ class TagRestApi(BaseSupersetModelRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".favorite_status",
-        log_to_statsd=False,
     )
     def favorite_status(self, **kwargs: Any) -> Response:
         """Favorite Stars for Dashboards
@@ -658,7 +647,6 @@ class TagRestApi(BaseSupersetModelRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".add_favorite",
-        log_to_statsd=False,
     )
     def add_favorite(self, pk: int) -> Response:
         """Marks the tag as favorite
@@ -705,7 +693,6 @@ class TagRestApi(BaseSupersetModelRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".remove_favorite",
-        log_to_statsd=False,
     )
     def remove_favorite(self, pk: int) -> Response:
         """Remove the tag from the user favorite list

--- a/superset/utils/log.py
+++ b/superset/utils/log.py
@@ -91,7 +91,7 @@ class AbstractEventLogger(ABC):
         self,
         action: str,
         object_ref: str | None = None,
-        log_to_statsd: bool = True,
+        log_to_statsd: bool = False,
         duration: timedelta | None = None,
         **payload_override: dict[str, Any],
     ) -> object:
@@ -135,7 +135,7 @@ class AbstractEventLogger(ABC):
         action: str,
         duration: timedelta | None = None,
         object_ref: str | None = None,
-        log_to_statsd: bool = True,
+        log_to_statsd: bool = False,
         **payload_override: dict[str, Any] | None,
     ) -> None:
         # pylint: disable=import-outside-toplevel
@@ -208,7 +208,7 @@ class AbstractEventLogger(ABC):
         self,
         action: str,
         object_ref: str | None = None,
-        log_to_statsd: bool = True,
+        log_to_statsd: bool = False,
     ) -> Iterator[Callable[..., None]]:
         """
         Log an event with additional information from the request context.

--- a/superset/views/api.py
+++ b/superset/views/api.py
@@ -35,7 +35,12 @@ from superset.models.slice import Slice
 from superset.superset_typing import FlaskResponse
 from superset.utils import core as utils
 from superset.utils.date_parser import get_since_until
-from superset.views.base import api, BaseSupersetView, handle_api_exception
+from superset.views.base import (
+    api,
+    BaseSupersetView,
+    handle_api_exception,
+    statsd_metrics,
+)
 
 if TYPE_CHECKING:
     from superset.common.query_context_factory import QueryContextFactory
@@ -46,6 +51,7 @@ get_time_range_schema = {"type": "string"}
 class Api(BaseSupersetView):
     query_context_factory = None
 
+    @statsd_metrics
     @event_logger.log_this
     @api
     @handle_api_exception
@@ -68,6 +74,7 @@ class Api(BaseSupersetView):
             payload_json, default=utils.json_int_dttm_ser, ignore_nan=True
         )
 
+    @statsd_metrics
     @event_logger.log_this
     @api
     @handle_api_exception

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -327,7 +327,7 @@ class BaseSupersetViewMixin:
         )
 
     def send_stats_metrics(
-        self, response: Response | str, key: str, time_delta: float | None = None
+        self, response: Response, key: str, time_delta: float | None = None
     ) -> None:
         """
         Helper function to handle sending statsd metrics
@@ -335,12 +335,6 @@ class BaseSupersetViewMixin:
         :param key: The function name
         :param time_delta: Optional time it took for the endpoint to execute
         """
-        # TODO: not all endpoints return Response
-        if isinstance(response, str):
-            print(f"debug {response}")
-            print(f"debug {key}")
-            return
-
         if 200 <= response.status_code < 400:
             self.incr_stats("success", key)
         elif 400 <= response.status_code < 500:

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -452,7 +452,6 @@ class BaseSupersetModelRestApi(BaseSupersetViewMixin, ModelRestApi):
     @expose("/related/<column_name>", methods=("GET",))
     @protect()
     @safe
-    # @statsd_metrics
     @rison(get_related_schema)
     @handle_api_exception
     def related(self, column_name: str, **kwargs: Any) -> FlaskResponse:
@@ -531,7 +530,6 @@ class BaseSupersetModelRestApi(BaseSupersetViewMixin, ModelRestApi):
     @expose("/distinct/<column_name>", methods=("GET",))
     @protect()
     @safe
-    # @statsd_metrics
     @rison(get_related_schema)
     @handle_api_exception
     def distinct(self, column_name: str, **kwargs: Any) -> FlaskResponse:

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -41,7 +41,11 @@ from superset.sql_lab import Query as SqllabQuery
 from superset.superset_typing import FlaskResponse
 from superset.tags.models import Tag
 from superset.utils.core import get_user_id, time_function
-from superset.views.base import BaseSupersetViewMixin, handle_api_exception
+from superset.views.base import (
+    BaseSupersetViewMixin,
+    handle_api_exception,
+    statsd_metrics,
+)
 
 logger = logging.getLogger(__name__)
 get_related_schema = {
@@ -448,6 +452,7 @@ class BaseSupersetModelRestApi(BaseSupersetViewMixin, ModelRestApi):
     @expose("/related/<column_name>", methods=("GET",))
     @protect()
     @safe
+    @statsd_metrics
     @rison(get_related_schema)
     @handle_api_exception
     def related(self, column_name: str, **kwargs: Any) -> FlaskResponse:
@@ -526,6 +531,7 @@ class BaseSupersetModelRestApi(BaseSupersetViewMixin, ModelRestApi):
     @expose("/distinct/<column_name>", methods=("GET",))
     @protect()
     @safe
+    @statsd_metrics
     @rison(get_related_schema)
     @handle_api_exception
     def distinct(self, column_name: str, **kwargs: Any) -> FlaskResponse:

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -41,11 +41,7 @@ from superset.sql_lab import Query as SqllabQuery
 from superset.superset_typing import FlaskResponse
 from superset.tags.models import Tag
 from superset.utils.core import get_user_id, time_function
-from superset.views.base import (
-    BaseSupersetViewMixin,
-    handle_api_exception,
-    statsd_metrics,
-)
+from superset.views.base import BaseSupersetViewMixin, handle_api_exception
 
 logger = logging.getLogger(__name__)
 get_related_schema = {

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -210,6 +210,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         payload = viz_obj.get_payload()
         return self.send_data_payload_response(viz_obj, payload)
 
+    @statsd_metrics
     @event_logger.log_this
     @api
     @has_access_api
@@ -257,6 +258,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @api
     @has_access_api
     @handle_api_exception
+    @statsd_metrics
     @event_logger.log_this
     @expose(
         "/explore_json/<datasource_type>/<int:datasource_id>/",
@@ -754,6 +756,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
         return json_success(json.dumps(response))
 
+    @statsd_metrics
     @event_logger.log_this
     @api
     @has_access_api
@@ -925,6 +928,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
     @api
     @handle_api_exception
     @has_access
+    @statsd_metrics
     @event_logger.log_this
     @expose("/fetch_datasource_metadata")
     @deprecated(
@@ -988,6 +992,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         )
 
     @has_access
+    @statsd_metrics
     @event_logger.log_this
     @expose("/profile/")
     @deprecated(new_target="/profile")
@@ -995,6 +1000,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         return redirect("/profile/")
 
     @has_access
+    @statsd_metrics
     @event_logger.log_this
     @expose(
         "/sqllab/",
@@ -1013,6 +1019,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
         return redirect(url)
 
     @has_access
+    @statsd_metrics
     @event_logger.log_this
     @expose("/sqllab/history/", methods=("GET",))
     @deprecated(new_target="/sqllab/history")

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name, too-many-lines
 from __future__ import annotations
 
 import contextlib

--- a/superset/views/dashboard/views.py
+++ b/superset/views/dashboard/views.py
@@ -37,6 +37,7 @@ from superset.views.base import (
     common_bootstrap_payload,
     DeleteMixin,
     generate_download_headers,
+    statsd_metrics,
     SupersetModelView,
 )
 from superset.views.dashboard.mixin import DashboardMixin
@@ -73,6 +74,7 @@ class DashboardModelView(
         ids = "".join(f"&id={d.id}" for d in items)
         return redirect(f"/dashboard/export_dashboards_form?{ids[1:]}")
 
+    @statsd_metrics
     @event_logger.log_this
     @has_access
     @expose("/export_dashboards_form")
@@ -125,6 +127,7 @@ class Dashboard(BaseSupersetView):
         return redirect(f"/superset/dashboard/{new_dashboard.id}/?edit=true")
 
     @expose("/<dashboard_id_or_slug>/embedded")
+    @statsd_metrics
     @event_logger.log_this_with_extra_payload
     def embedded(
         self,

--- a/superset/views/dashboard/views.py
+++ b/superset/views/dashboard/views.py
@@ -19,7 +19,7 @@ import json
 import re
 from typing import Callable, Union
 
-from flask import g, redirect, request, Response
+from flask import g, make_response, redirect, request, Response
 from flask_appbuilder import expose
 from flask_appbuilder.actions import action
 from flask_appbuilder.models.sqla.interface import SQLAInterface
@@ -34,6 +34,7 @@ from superset.superset_typing import FlaskResponse
 from superset.utils import core as utils
 from superset.views.base import (
     BaseSupersetView,
+    BaseSupersetViewMixin,
     common_bootstrap_payload,
     DeleteMixin,
     generate_download_headers,
@@ -44,7 +45,7 @@ from superset.views.dashboard.mixin import DashboardMixin
 
 
 class DashboardModelView(
-    DashboardMixin, SupersetModelView, DeleteMixin
+    DashboardMixin, SupersetModelView, DeleteMixin, BaseSupersetViewMixin
 ):  # pylint: disable=too-many-ancestors
     route_base = "/dashboard"
     datamodel = SQLAInterface(DashboardModel)
@@ -86,8 +87,10 @@ class DashboardModelView(
                 headers=generate_download_headers("json"),
                 mimetype="application/text",
             )
-        return self.render_template(
-            "superset/export_dashboards.html", dashboards_url="/dashboard/list"
+        return make_response(
+            self.render_template(
+                "superset/export_dashboards.html", dashboards_url="/dashboard/list"
+            )
         )
 
     def pre_add(self, item: "DashboardModelView") -> None:
@@ -158,12 +161,14 @@ class Dashboard(BaseSupersetView):
             "embedded": {"dashboard_id": dashboard_id_or_slug},
         }
 
-        return self.render_template(
-            "superset/spa.html",
-            entry="embedded",
-            bootstrap_data=json.dumps(
-                bootstrap_data, default=utils.pessimistic_json_iso_dttm_ser
-            ),
+        return make_response(
+            self.render_template(
+                "superset/spa.html",
+                entry="embedded",
+                bootstrap_data=json.dumps(
+                    bootstrap_data, default=utils.pessimistic_json_iso_dttm_ser
+                ),
+            )
         )
 
 

--- a/superset/views/datasource/views.py
+++ b/superset/views/datasource/views.py
@@ -64,7 +64,6 @@ class Datasource(BaseSupersetView):
     @expose("/save/", methods=("POST",))
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.save",
-        log_to_statsd=False,
     )
     @has_access_api
     @api

--- a/superset/views/explore.py
+++ b/superset/views/explore.py
@@ -21,7 +21,7 @@ from flask_appbuilder.security.decorators import has_access
 from superset import event_logger
 from superset.superset_typing import FlaskResponse
 
-from .base import BaseSupersetView
+from .base import BaseSupersetView, statsd_metrics
 
 
 class ExploreView(BaseSupersetView):
@@ -31,6 +31,7 @@ class ExploreView(BaseSupersetView):
     @expose("/")
     @has_access
     @permission_name("read")
+    @statsd_metrics
     @event_logger.log_this
     def root(self) -> FlaskResponse:
         return super().render_app_template()
@@ -43,6 +44,7 @@ class ExplorePermalinkView(BaseSupersetView):
     @expose("/explore/p/<key>/")
     @has_access
     @permission_name("read")
+    @statsd_metrics
     @event_logger.log_this
     # pylint: disable=unused-argument
     def permalink(self, key: str) -> FlaskResponse:

--- a/superset/views/key_value.py
+++ b/superset/views/key_value.py
@@ -25,7 +25,7 @@ from superset import db, event_logger, is_feature_enabled
 from superset.models import core as models
 from superset.superset_typing import FlaskResponse
 from superset.utils import core as utils
-from superset.views.base import BaseSupersetView, json_error_response
+from superset.views.base import BaseSupersetView, json_error_response, statsd_metrics
 
 
 class KV(BaseSupersetView):
@@ -41,6 +41,7 @@ class KV(BaseSupersetView):
         if not self.is_enabled():
             raise NotFound()
 
+    @statsd_metrics
     @event_logger.log_this
     @has_access_api
     @expose("/store/", methods=("POST",))
@@ -54,6 +55,7 @@ class KV(BaseSupersetView):
             return json_error_response(utils.error_msg_from_exception(ex))
         return Response(json.dumps({"id": obj.id}), status=200)
 
+    @statsd_metrics
     @event_logger.log_this
     @has_access_api
     @expose("/<int:key_id>/", methods=("GET",))

--- a/superset/views/log/api.py
+++ b/superset/views/log/api.py
@@ -27,7 +27,8 @@ from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP
 from superset.daos.log import LogDAO
 from superset.exceptions import SupersetSecurityException
 from superset.superset_typing import FlaskResponse
-from superset.views.base_api import BaseSupersetModelRestApi, statsd_metrics
+from superset.views.base import statsd_metrics
+from superset.views.base_api import BaseSupersetModelRestApi
 from superset.views.log import LogMixin
 from superset.views.log.schemas import (
     get_recent_activity_schema,
@@ -93,7 +94,6 @@ class LogRestApi(LogMixin, BaseSupersetModelRestApi):
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
         f".recent_activity",
-        log_to_statsd=False,
     )
     def recent_activity(self, **kwargs: Any) -> FlaskResponse:
         """Get recent activity data for a user.

--- a/superset/views/profile.py
+++ b/superset/views/profile.py
@@ -22,7 +22,7 @@ from flask_appbuilder.security.decorators import has_access
 from superset import event_logger, security_manager
 from superset.superset_typing import FlaskResponse
 
-from .base import BaseSupersetView
+from .base import BaseSupersetView, statsd_metrics
 
 
 class ProfileView(BaseSupersetView):
@@ -32,6 +32,7 @@ class ProfileView(BaseSupersetView):
     @expose("/")
     @has_access
     @permission_name("read")
+    @statsd_metrics
     @event_logger.log_this
     def root(self) -> FlaskResponse:
         user = g.user if hasattr(g, "user") and g.user else None

--- a/superset/views/redirects.py
+++ b/superset/views/redirects.py
@@ -24,7 +24,7 @@ from werkzeug.utils import redirect
 from superset import db, event_logger
 from superset.models import core as models
 from superset.superset_typing import FlaskResponse
-from superset.views.base import BaseSupersetView
+from superset.views.base import BaseSupersetView, statsd_metrics
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +53,7 @@ class R(BaseSupersetView):  # pylint: disable=invalid-name
 
         return None
 
+    @statsd_metrics
     @event_logger.log_this
     @expose("/<int:url_id>")
     def index(self, url_id: int) -> FlaskResponse:

--- a/superset/views/sqllab.py
+++ b/superset/views/sqllab.py
@@ -26,7 +26,7 @@ from superset import event_logger
 from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP
 from superset.superset_typing import FlaskResponse
 
-from .base import BaseSupersetView
+from .base import BaseSupersetView, statsd_metrics
 
 
 class SqllabView(BaseSupersetView):
@@ -38,6 +38,7 @@ class SqllabView(BaseSupersetView):
     @expose("/", methods=["GET", "POST"])
     @has_access
     @permission_name("read")
+    @statsd_metrics
     @event_logger.log_this
     def root(self) -> FlaskResponse:
         payload = {}
@@ -49,6 +50,7 @@ class SqllabView(BaseSupersetView):
     @expose("/history/", methods=("GET",))
     @has_access
     @permission_name("read")
+    @statsd_metrics
     @event_logger.log_this
     def history(self) -> FlaskResponse:
         return self.render_app_template()

--- a/tests/integration_tests/event_logger_tests.py
+++ b/tests/integration_tests/event_logger_tests.py
@@ -178,7 +178,6 @@ class TestEventLogger(unittest.TestCase):
                 action="foo",
                 duration=timedelta(days=64, seconds=29156, microseconds=10),
                 object_ref={"baz": "food"},
-                log_to_statsd=False,
                 payload_override={"engine": "sqlite"},
             )
 
@@ -225,7 +224,6 @@ class TestEventLogger(unittest.TestCase):
                 action="foo",
                 duration=timedelta(days=64, seconds=29156, microseconds=10),
                 object_ref={"baz": "food"},
-                log_to_statsd=False,
                 payload_override={"engine": "sqlite"},
             )
 


### PR DESCRIPTION
### SUMMARY

This PR removes the `log_to_statsd=` functionality from the `@event_logger` and replaces usage with already existing `@statsd_metrics` decorator. I basically moved `BaseSupersetApiMixin` from `base_api.py` --> `base.py` so that the flask views can use @statsd_metrics too.

Currently, there are two decorators for basically the same use case:
- `@event_logger.log_this_with_context(log_to_statsd=True)`
- `@statsd_metrics`

The `@event_logger` just increments a statsd counter, while `@statsd_metrics` additionally measures the execution time of a function.

### TESTING INSTRUCTIONS
- run unit + integration tests
- manually checked for new statsd metrics

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
