### PR TITLE
fix: Fires onChange when clearing all values of single select

### DIFF
--- a/superset-frontend/src/components/Select/AsyncSelect.test.tsx
+++ b/superset-frontend/src/components/Select/AsyncSelect.test.tsx
@@ -840,6 +840,34 @@ test('does not fire onChange when searching but no selection', async () => {
   expect(onChange).toHaveBeenCalledTimes(1);
 });
 
+test('fires onChange when clearing the selection in single mode', async () => {
+  const onChange = jest.fn();
+  render(
+    <AsyncSelect
+      {...defaultProps}
+      onChange={onChange}
+      mode="single"
+      value={OPTIONS[0]}
+    />,
+  );
+  clearAll();
+  expect(onChange).toHaveBeenCalledTimes(1);
+});
+
+test('fires onChange when clearing the selection in multiple mode', async () => {
+  const onChange = jest.fn();
+  render(
+    <AsyncSelect
+      {...defaultProps}
+      onChange={onChange}
+      mode="multiple"
+      value={OPTIONS[0]}
+    />,
+  );
+  clearAll();
+  expect(onChange).toHaveBeenCalledTimes(1);
+});
+
 test('does not duplicate options when using numeric values', async () => {
   render(
     <AsyncSelect

--- a/superset-frontend/src/components/Select/Select.test.tsx
+++ b/superset-frontend/src/components/Select/Select.test.tsx
@@ -957,6 +957,34 @@ test('does not fire onChange when searching but no selection', async () => {
   expect(onChange).toHaveBeenCalledTimes(1);
 });
 
+test('fires onChange when clearing the selection in single mode', async () => {
+  const onChange = jest.fn();
+  render(
+    <Select
+      {...defaultProps}
+      onChange={onChange}
+      mode="single"
+      value={OPTIONS[0]}
+    />,
+  );
+  clearAll();
+  expect(onChange).toHaveBeenCalledTimes(1);
+});
+
+test('fires onChange when clearing the selection in multiple mode', async () => {
+  const onChange = jest.fn();
+  render(
+    <Select
+      {...defaultProps}
+      onChange={onChange}
+      mode="multiple"
+      value={OPTIONS[0]}
+    />,
+  );
+  clearAll();
+  expect(onChange).toHaveBeenCalledTimes(1);
+});
+
 test('does not duplicate options when using numeric values', async () => {
   render(
     <Select

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -281,8 +281,8 @@ const Select = forwardRef(
                 : option.value,
             ),
         );
-        fireOnChange();
       }
+      fireOnChange();
     };
 
     const handleOnDeselect: SelectProps['onDeselect'] = (value, option) => {


### PR DESCRIPTION
### SUMMARY
Fires the `onChange` event when clearing all values of single select.

Fixes https://github.com/apache/superset/issues/25846

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://github.com/apache/superset/assets/70410625/cc0b2f45-9ddf-40b7-9d65-4df68a8d301d

https://github.com/apache/superset/assets/70410625/0172274e-2649-4a90-a237-1b4cb4bfbb7c

### TESTING INSTRUCTIONS
Check the videos and original issue for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
