### PR TITLE
feat(sqllab): Dynamic query limit dropdown

### DIFF
--- a/superset-frontend/src/SqlLab/components/QueryLimitSelect/QueryLimitSelect.test.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryLimitSelect/QueryLimitSelect.test.tsx
@@ -25,7 +25,6 @@ import { render, fireEvent, waitFor } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
 import { initialState, defaultQueryEditor } from 'src/SqlLab/fixtures';
 import QueryLimitSelect, {
-  LIMIT_DROPDOWN,
   QueryLimitSelectProps,
   convertToNumWithSpaces,
 } from 'src/SqlLab/components/QueryLimitSelect';
@@ -106,13 +105,67 @@ describe('QueryLimitSelect', () => {
   });
 
   it('renders dropdown select', async () => {
-    const { baseElement, getByRole } = setup({}, mockStore(initialState));
+    const { baseElement, getAllByRole, getByRole } = setup(
+      { maxRow: 50000 },
+      mockStore(initialState),
+    );
     const dropdown = baseElement.getElementsByClassName(
       'ant-dropdown-trigger',
     )[0];
 
     userEvent.click(dropdown);
     await waitFor(() => expect(getByRole('menu')).toBeInTheDocument());
+
+    const expectedLabels = [10, 100, 1000, 10000, 50000].map(i =>
+      convertToNumWithSpaces(i),
+    );
+    const actualLabels = getAllByRole('menuitem').map(elem =>
+      elem.textContent?.trim(),
+    );
+
+    expect(actualLabels).toEqual(expectedLabels);
+  });
+
+  it('renders dropdown select correctly when maxRow is less than 10', async () => {
+    const { baseElement, getAllByRole, getByRole } = setup(
+      { maxRow: 5 },
+      mockStore(initialState),
+    );
+    const dropdown = baseElement.getElementsByClassName(
+      'ant-dropdown-trigger',
+    )[0];
+
+    userEvent.click(dropdown);
+    await waitFor(() => expect(getByRole('menu')).toBeInTheDocument());
+
+    const expectedLabels = [5].map(i => convertToNumWithSpaces(i));
+    const actualLabels = getAllByRole('menuitem').map(elem =>
+      elem.textContent?.trim(),
+    );
+
+    expect(actualLabels).toEqual(expectedLabels);
+  });
+
+  it('renders dropdown select correctly when maxRow is a multiple of 10', async () => {
+    const { baseElement, getAllByRole, getByRole } = setup(
+      { maxRow: 10000 },
+      mockStore(initialState),
+    );
+    const dropdown = baseElement.getElementsByClassName(
+      'ant-dropdown-trigger',
+    )[0];
+
+    userEvent.click(dropdown);
+    await waitFor(() => expect(getByRole('menu')).toBeInTheDocument());
+
+    const expectedLabels = [10, 100, 1000, 10000].map(i =>
+      convertToNumWithSpaces(i),
+    );
+    const actualLabels = getAllByRole('menuitem').map(elem =>
+      elem.textContent?.trim(),
+    );
+
+    expect(actualLabels).toEqual(expectedLabels);
   });
 
   it('dispatches QUERY_EDITOR_SET_QUERY_LIMIT action on dropdown menu click', async () => {
@@ -133,7 +186,7 @@ describe('QueryLimitSelect', () => {
       expect(store.getActions()).toEqual([
         {
           type: 'QUERY_EDITOR_SET_QUERY_LIMIT',
-          queryLimit: LIMIT_DROPDOWN[expectedIndex],
+          queryLimit: 100,
           queryEditor: {
             id: defaultQueryEditor.id,
           },

--- a/superset-frontend/src/SqlLab/components/QueryLimitSelect/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryLimitSelect/index.tsx
@@ -31,8 +31,6 @@ export interface QueryLimitSelectProps {
   defaultQueryLimit: number;
 }
 
-export const LIMIT_DROPDOWN = [10, 100, 1000, 10000, 100000];
-
 export function convertToNumWithSpaces(num: number) {
   return num.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1 ');
 }
@@ -63,12 +61,17 @@ function renderQueryLimit(
   maxRow: number,
   setQueryLimit: (limit: number) => void,
 ) {
-  // Adding SQL_MAX_ROW value to dropdown
-  LIMIT_DROPDOWN.push(maxRow);
+  const limitDropdown = [];
+
+  // Construct limit dropdown as increasing powers of ten until we reach SQL_MAX_ROW
+  for (let i = 10; i < maxRow; i *= 10) {
+    limitDropdown.push(i);
+  }
+  limitDropdown.push(maxRow);
 
   return (
     <Menu>
-      {[...new Set(LIMIT_DROPDOWN)].map(limit => (
+      {[...new Set(limitDropdown)].map(limit => (
         <Menu.Item key={`${limit}`} onClick={() => setQueryLimit(limit)}>
           {/* // eslint-disable-line no-use-before-define */}
           <a role="button">{convertToNumWithSpaces(limit)}</a>{' '}


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Previously, this was a constant of powers of ten from 10 to 100000 and then we tacked on maxRow on the end, being the SQL_MAX_ROW config. This unfortunately results is very confusing behaviour if SQL_MAX_ROW is less than 100,000 as it still let you select 100,000, though wouldn't acctually use that LIMIT, and the messaging would not acknowledge the setting for SQL_MAX_ROW either.

Instead, construct the list by ascending through powers of ten until we reach the configured SQL_MAX_ROW.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### Before
![BEFORE-static](https://github.com/apache/superset/assets/2862039/64df2d87-0282-44c9-a9d3-7a94cb28e4be)

#### After
![AFTER-dynamic](https://github.com/apache/superset/assets/2862039/e28b06f7-2db9-4225-a215-088a31dc7fc5)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Set `SQL_MAX_ROW` to a value less than 100,000 or greater than 1,000,000
2. Use the LIMIT dropdown in SQL Lab
3. Observe that the drop down no longer displays values higher than `SQL_MAX_ROW`, and will display every power of 10 up to `SQL_MAX_ROW`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
