### PR TITLE
fix(tagging): change key from name to id for tagToSelectOption

### DIFF
--- a/superset-frontend/src/components/Tags/utils.test.tsx
+++ b/superset-frontend/src/components/Tags/utils.test.tsx
@@ -1,0 +1,35 @@
+import { tagToSelectOption } from 'src/components/Tags/utils';
+
+describe('tagToSelectOption', () => {
+  test('converts a Tag object with table_name to a SelectTagsValue', () => {
+    const tag = {
+      id: '1',
+      name: 'TagName',
+      table_name: 'Table1',
+    };
+
+    const expectedSelectTagsValue = {
+      value: 'TagName',
+      label: 'TagName',
+      key: '1',
+    };
+
+    expect(tagToSelectOption(tag)).toEqual(expectedSelectTagsValue);
+  });
+
+  test('handles tags with undefined properties', () => {
+    const tag = {
+      id: undefined,
+      name: undefined,
+      table_name: 'Table1',
+    };
+
+    const expectedSelectTagsValue = {
+      value: undefined,
+      label: undefined,
+      key: undefined,
+    };
+
+    expect(tagToSelectOption(tag)).toEqual(expectedSelectTagsValue);
+  });
+});

--- a/superset-frontend/src/components/Tags/utils.test.tsx
+++ b/superset-frontend/src/components/Tags/utils.test.tsx
@@ -16,20 +16,4 @@ describe('tagToSelectOption', () => {
 
     expect(tagToSelectOption(tag)).toEqual(expectedSelectTagsValue);
   });
-
-  test('handles tags with undefined properties', () => {
-    const tag = {
-      id: undefined,
-      name: undefined,
-      table_name: 'Table1',
-    };
-
-    const expectedSelectTagsValue = {
-      value: undefined,
-      label: undefined,
-      key: undefined,
-    };
-
-    expect(tagToSelectOption(tag)).toEqual(expectedSelectTagsValue);
-  });
 });

--- a/superset-frontend/src/components/Tags/utils.tsx
+++ b/superset-frontend/src/components/Tags/utils.tsx
@@ -46,7 +46,7 @@ export const tagToSelectOption = (
 ): SelectTagsValue => ({
   value: item.name,
   label: item.name,
-  key: item.name,
+  key: item.id,
 });
 
 export const loadTags = async (


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I've adjusted the tagToSelectOption function to key off the id instead of the name. This is to address a specific issue with our async select component.
The component wasn't effectively using the data when name, value, and label were identical. This redundancy wasn't practical and didn't utilize the potential of unique identifiers.
By keying on id, which is inherently unique, the async select component now operates as intended, with clear and distinct options.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
