### PR TITLE
fix(table): Double percenting ad-hoc percentage metrics

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -118,9 +118,10 @@ const processColumns = memoizeOne(function processColumns(
       // because users can also add things like `MAX(str_col)` as a metric.
       const isMetric = metricsSet.has(key) && isNumeric(key, records);
       const isPercentMetric = percentMetricsSet.has(key);
-      const label = isPercentMetric
-        ? `%${verboseMap?.[key.replace('%', '')] || key}`
-        : verboseMap?.[key] || key;
+      const label =
+        isPercentMetric && verboseMap?.hasOwnProperty(key.replace('%', ''))
+          ? `%${verboseMap[key.replace('%', '')]}`
+          : verboseMap?.[key] || key;
       const isTime = dataType === GenericDataType.TEMPORAL;
       const isNumber = dataType === GenericDataType.NUMERIC;
       const savedFormat = columnFormats?.[key];


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR fixes an issue which was a byproduct of another fix—https://github.com/apache/superset/pull/24158. 

Specifically the previous logic to use the verbose name (if the key sans `%` was present) would fallback to the key (containing the `%`) if not present (which is the case for ad-hoc metrics) and then (re)apply the `%`, i.e., rather than `%SUM(num)` the label would be `%%SUM(num)`. The fix is simply to only include the `%` prefix in the label if the key (sans `%`) is present in the map.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE 

<img width="1440" alt="Screenshot 2023-11-03 at 3 17 53 PM" src="https://github.com/apache/superset/assets/4567245/21c760f8-54f4-4ef2-a336-c3e5c9ee6589">

#### AFTER 

<img width="1440" alt="Screenshot 2023-11-03 at 3 14 02 PM" src="https://github.com/apache/superset/assets/4567245/e566a503-48c3-4f14-b5f2-c0a318ffba1a">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
