### PR TITLE
feat(sqllab): Show duration as separate column in Query History view

### DIFF
--- a/superset-frontend/src/pages/QueryHistoryList/index.tsx
+++ b/superset-frontend/src/pages/QueryHistoryList/index.tsx
@@ -34,6 +34,7 @@ import {
 } from 'src/views/CRUD/utils';
 import withToasts from 'src/components/MessageToasts/withToasts';
 import { useListViewResource } from 'src/views/CRUD/hooks';
+import Label, { Type } from 'src/components/Label';
 import SubMenu, { SubMenuProps } from 'src/features/home/SubMenu';
 import Popover from 'src/components/Popover';
 import { commonMenuData } from 'src/features/home/commonMenuData';
@@ -86,6 +87,11 @@ const StyledTableLabel = styled.div`
 
 const StyledPopoverItem = styled.div`
   color: ${({ theme }) => theme.colors.grayscale.dark2};
+`;
+
+const TimerLabel = styled(Label)`
+  text-align: left;
+  font-family: ${({ theme }) => theme.typography.families.monospace};
 `;
 
 function QueryList({ addDangerToast }: QueryListProps) {
@@ -204,7 +210,7 @@ function QueryList({ addDangerToast }: QueryListProps) {
         size: 'xl',
         Cell: ({
           row: {
-            original: { start_time, end_time },
+            original: { start_time },
           },
         }: any) => {
           const startMoment = moment.utc(start_time).local();
@@ -218,19 +224,25 @@ function QueryList({ addDangerToast }: QueryListProps) {
               {formattedStartTimeData[1]}
             </>
           );
-
-          return end_time ? (
-            <Tooltip
-              title={t(
-                'Duration: %s',
-                moment(moment.utc(end_time - start_time)).format(TIME_WITH_MS),
-              )}
-              placement="bottom"
-            >
-              <span>{formattedStartTime}</span>
-            </Tooltip>
-          ) : (
-            formattedStartTime
+          return formattedStartTime;
+        },
+      },
+      {
+        Header: t('Duration'),
+        size: 'xl',
+        Cell: ({
+          row: {
+            original: { status, start_time, end_time },
+          },
+        }: any) => {
+          const timer_type = status === QueryState.FAILED ? 'danger' : status;
+          const timer_time = end_time
+            ? moment(moment.utc(end_time - start_time)).format(TIME_WITH_MS)
+            : '00:00:00.000';
+          return (
+            <TimerLabel type={timer_type} role="timer">
+              {timer_time}
+            </TimerLabel>
           );
         },
       },

--- a/superset-frontend/src/pages/QueryHistoryList/index.tsx
+++ b/superset-frontend/src/pages/QueryHistoryList/index.tsx
@@ -34,7 +34,7 @@ import {
 } from 'src/views/CRUD/utils';
 import withToasts from 'src/components/MessageToasts/withToasts';
 import { useListViewResource } from 'src/views/CRUD/hooks';
-import Label, { Type } from 'src/components/Label';
+import Label from 'src/components/Label';
 import SubMenu, { SubMenuProps } from 'src/features/home/SubMenu';
 import Popover from 'src/components/Popover';
 import { commonMenuData } from 'src/features/home/commonMenuData';

--- a/superset-frontend/src/pages/QueryHistoryList/index.tsx
+++ b/superset-frontend/src/pages/QueryHistoryList/index.tsx
@@ -235,13 +235,13 @@ function QueryList({ addDangerToast }: QueryListProps) {
             original: { status, start_time, end_time },
           },
         }: any) => {
-          const timer_type = status === QueryState.FAILED ? 'danger' : status;
-          const timer_time = end_time
+          const timerType = status === QueryState.FAILED ? 'danger' : status;
+          const timerTime = end_time
             ? moment(moment.utc(end_time - start_time)).format(TIME_WITH_MS)
             : '00:00:00.000';
           return (
-            <TimerLabel type={timer_type} role="timer">
-              {timer_time}
+            <TimerLabel type={timerType} role="timer">
+              {timerTime}
             </TimerLabel>
           );
         },


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Show `Duration` as separate column in Query History view instead of as a tooltip on the `Time` column.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

before:
![image](https://github.com/apache/superset/assets/112352529/fc9a9ff1-20a2-4da7-ac21-b58efb912073)

after:
![image](https://github.com/apache/superset/assets/112352529/8863a3b7-5ea7-4bbb-a3ca-9e6ca77c3882)


### TESTING INSTRUCTIONS
- GitHub CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
