### PR TITLE
fix(trino): allow impersonate_user flag to be imported

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -185,6 +185,7 @@ class Database(
         "is_managed_externally",
         "external_url",
         "encrypted_extra",
+        "impersonate_user"
     ]
     export_children = ["tables"]
 

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -185,7 +185,7 @@ class Database(
         "is_managed_externally",
         "external_url",
         "encrypted_extra",
-        "impersonate_user"
+        "impersonate_user",
     ]
     export_children = ["tables"]
 


### PR DESCRIPTION
### SUMMARY
`impersonate_user` flag allows for user impersonation when connecting to trino using kerberos. Currently it cannot be imported. 


### TESTING INSTRUCTIONS
1. Create trino_from_ui connection using UI, check "impersonate user" box. 
2. Create trino_from_code connection file
```
    import_datasources.yaml: |
      databases:
      - database_name: trino_from_code
        sqlalchemy_uri: <url>
        cache_timeout: null
        expose_in_sqllab: true
        allow_run_async: true
        allow_ctas: true
        allow_cvas: true
        allow_dml: true
        allow_csv_upload: true
        impersonate_user: true
        extra: "<extra>"
        encrypted_extra: "<encrypted_extra>"
```
4. Import datasources using `superset import_datasources -p import_datasources.yaml`
5. Check in database if impersonate_user = "t" in "dbs" table for both connections.