### PR TITLE
fix: Saving Mixed Chart with dashboard filter applied breaks adhoc_filter_b

### DIFF
--- a/superset-frontend/src/explore/actions/saveModalActions.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.js
@@ -50,7 +50,7 @@ export function saveSliceSuccess(data) {
   return { type: SAVE_SLICE_SUCCESS, data };
 }
 
-const extractAddHocFiltersFromFormData = formDataToHandle =>
+const extractAdhocFiltersFromFormData = formDataToHandle =>
   Object.entries(formDataToHandle).reduce(
     (acc, [key, value]) =>
       ADHOC_FILTER_REGEX.test(key)
@@ -71,7 +71,7 @@ export const getSlicePayload = (
   owners,
   formDataFromSlice = {},
 ) => {
-  const adhocFilters = extractAddHocFiltersFromFormData(
+  const adhocFilters = extractAdhocFiltersFromFormData(
     formDataWithNativeFilters,
   );
 
@@ -80,10 +80,17 @@ export const getSlicePayload = (
   // to filter the chart. Before, any time range filter applied in the dashboard
   // would end up as an extra filter and when overwriting the chart the original
   // time range adhoc_filter was lost
-  if (isEmpty(adhocFilters?.adhoc_filters) && !isEmpty(formDataFromSlice)) {
-    formDataFromSlice?.adhoc_filters?.forEach(filter => {
-      if (filter.operator === Operators.TEMPORAL_RANGE && !filter.isExtra) {
-        adhocFilters.adhoc_filters.push({ ...filter, comparator: 'No filter' });
+  if (!isEmpty(formDataFromSlice)) {
+    Object.keys(adhocFilters || {}).forEach(adhocFilterKey => {
+      if (isEmpty(adhocFilters[adhocFilterKey])) {
+        formDataFromSlice?.[adhocFilterKey]?.forEach(filter => {
+          if (filter.operator === Operators.TEMPORAL_RANGE && !filter.isExtra) {
+            adhocFilters[adhocFilterKey].push({
+              ...filter,
+              comparator: 'No filter',
+            });
+          }
+        });
       }
     });
   }

--- a/superset-frontend/src/explore/actions/saveModalActions.test.js
+++ b/superset-frontend/src/explore/actions/saveModalActions.test.js
@@ -391,4 +391,57 @@ describe('getSlicePayload', () => {
       formDataFromSlice.adhoc_filters,
     );
   });
+
+  test('should return the correct payload when formDataWithNativeFilters has a filter with isExtra set to true in mixed chart', () => {
+    const formDataFromSliceWithAdhocFilterB = {
+      ...formDataFromSlice,
+      adhoc_filters_b: [
+        {
+          clause: 'WHERE',
+          subject: 'year',
+          operator: 'TEMPORAL_RANGE',
+          comparator: 'No filter',
+          expressionType: 'SIMPLE',
+        },
+      ],
+    };
+    const formDataWithAdhocFiltersWithExtra = {
+      ...formDataWithNativeFilters,
+      viz_type: 'mixed_timeseries',
+      adhoc_filters: [
+        {
+          clause: 'WHERE',
+          subject: 'year',
+          operator: 'TEMPORAL_RANGE',
+          comparator: 'No filter',
+          expressionType: 'SIMPLE',
+          isExtra: true,
+        },
+      ],
+      adhoc_filters_b: [
+        {
+          clause: 'WHERE',
+          subject: 'year',
+          operator: 'TEMPORAL_RANGE',
+          comparator: 'No filter',
+          expressionType: 'SIMPLE',
+          isExtra: true,
+        },
+      ],
+    };
+    const result = getSlicePayload(
+      sliceName,
+      formDataWithAdhocFiltersWithExtra,
+      dashboards,
+      owners,
+      formDataFromSliceWithAdhocFilterB,
+    );
+
+    expect(JSON.parse(result.params).adhoc_filters).toEqual(
+      formDataFromSliceWithAdhocFilterB.adhoc_filters,
+    );
+    expect(JSON.parse(result.params).adhoc_filters_b).toEqual(
+      formDataFromSliceWithAdhocFilterB.adhoc_filters_b,
+    );
+  });
 });


### PR DESCRIPTION
### SUMMARY
When user applies a temporal filter to a mixed chart on a dashboard, then opens that chart with dashboard filters and overwrites the chart (no changes required), the temporal filter from adhoc_filter_b is removed and it's not replaced by "no filter" (which is required for dashboard temporal filters to work).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://github.com/apache/superset/assets/15073128/a646a6ba-2a16-471c-9ce8-26528a99c5f0

After:

https://github.com/apache/superset/assets/15073128/5447471e-3a7a-4087-8719-7aa2991f8e19


### TESTING INSTRUCTIONS
1. Create a Mixed Chart using the `cleaned_sales_data` dataset. 
2. Use `order_date` as the X-Axis with any time grain.
3. Use any metric on queries A and B.
4. Save the chart to a dashboard, and access it
5. Add a temporal filter in the dashboard.
6. Apply a value to the temporal filter, and then access the chart (which will carry the temporal filters).
7. Overwrite the chart (no need to perform any actual changes).
8. Access the dashboard, and apply a new temporal filter.


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
