### PR TITLE
fix(embedded): Hide sensitive payload data from guest users

### DIFF
--- a/superset-frontend/src/hooks/apiResources/dashboards.ts
+++ b/superset-frontend/src/hooks/apiResources/dashboards.ts
@@ -31,6 +31,7 @@ export const useDashboard = (idOrSlug: string | number) =>
         (dashboard.json_metadata && JSON.parse(dashboard.json_metadata)) || {},
       position_data:
         dashboard.position_json && JSON.parse(dashboard.position_json),
+      owners: dashboard.owners || [],
     }),
   );
 

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -239,6 +239,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     edit_model_schema = DashboardPutSchema()
     chart_entity_response_schema = ChartEntityResponseSchema()
     dashboard_get_response_schema = DashboardGetResponseSchema()
+    # pylint: disable=invalid-name
     dashboard_get_response_schema_guest = DashboardGetResponseSchemaGuest()
     dashboard_dataset_schema = DashboardDatasetSchema()
     dashboard_dataset_schema_guest = DashboardDatasetSchemaGuest()
@@ -413,13 +414,11 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         try:
             datasets = DashboardDAO.get_datasets_for_dashboard(id_or_slug)
             schema = (
-              self.dashboard_dataset_schema_guest
-              if security_manager.is_guest_user()
-              else self.dashboard_dataset_schema
-          )
-            result = [
-                schema.dump(dataset) for dataset in datasets
-            ]
+                self.dashboard_dataset_schema_guest
+                if security_manager.is_guest_user()
+                else self.dashboard_dataset_schema
+            )
+            result = [schema.dump(dataset) for dataset in datasets]
             return self.response(200, result=result)
         except (TypeError, ValueError) as err:
             return self.response_400(

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -237,7 +237,6 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     edit_model_schema = DashboardPutSchema()
     chart_entity_response_schema = ChartEntityResponseSchema()
     dashboard_get_response_schema = DashboardGetResponseSchema()
-    # pylint: disable=invalid-name
     dashboard_dataset_schema = DashboardDatasetSchema()
     embedded_response_schema = EmbeddedDashboardResponseSchema()
     embedded_config_schema = EmbeddedDashboardConfigSchema()
@@ -343,7 +342,6 @@ class DashboardRestApi(BaseSupersetModelRestApi):
               $ref: '#/components/responses/404'
         """
         result = self.dashboard_get_response_schema.dump(dash)
-
         add_extra_log_payload(
             dashboard_id=dash.id, action=f"{self.__class__.__name__}.get"
         )

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -203,7 +203,7 @@ class DashboardGetResponseSchema(Schema):
     @post_dump()
     def post_dump(self, serialized: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
         if security_manager.is_guest_user():
-            serialized["owners"] = []
+            del serialized["owners"]
             del serialized["changed_by_name"]
             del serialized["changed_by"]
         return serialized
@@ -261,7 +261,7 @@ class DashboardDatasetSchema(Schema):
     @post_dump()
     def post_dump(self, serialized: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
         if security_manager.is_guest_user():
-            serialized["owners"] = []
+            del serialized["owners"]
             del serialized["database"]
         return serialized
 

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -196,6 +196,7 @@ class DashboardGetResponseSchemaGuest(Schema):
     changed_on_humanized = fields.String(data_key="changed_on_delta_humanized")
     is_managed_externally = fields.Boolean(allow_none=True, dump_default=False)
 
+    # pylint: disable=unused-argument
     @post_dump()
     def post_dump(self, serialized: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
         serialized["owners"] = []
@@ -258,6 +259,7 @@ class DashboardDatasetSchemaGuest(Schema):
     normalize_columns = fields.Bool()
     always_filter_main_dttm = fields.Bool()
 
+    # pylint: disable=unused-argument
     @post_dump()
     def post_dump(self, serialized: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
         serialized["owners"] = []


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, guest users can get access to more data than they need to when viewing an embedded dashboard.  The `api/v1/dashboard/{id}` and `api/v1/dashboard/{id}/datasets` endpoints would return owners' first and last names. The latter would return information about the underlying database(s) the datasets belong to, which could be useful for an attacker.  None of this data is necessary for the embedded dashboard to render.

I recognize this PR does break typical API patterns by stripping out certain data depending on the type of user requesting, which is pretty ugly.  However, this approach avoids making breaking changes for regular API use, while making the embedded experience more secure.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/22960
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
