### PR TITLE
feat: method for dynamic `allows_alias_in_select`

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -400,8 +400,8 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
 
     @classmethod
     def get_allows_alias_in_select(
-        cls, database: Database
-    ) -> bool:  # pylint: disable=unused-argument
+        cls, database: Database  # pylint: disable=unused-argument
+    ) -> bool:
         """
         Method for dynamic `allows_alias_in_select`.
 

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -399,6 +399,19 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     supports_dynamic_catalog = False
 
     @classmethod
+    def get_allows_alias_in_select(
+        cls, database: Database
+    ) -> bool:  # pylint: disable=unused-argument
+        """
+        Method for dynamic `allows_alias_in_select`.
+
+        In Dremio this atribute is version-dependent, so Superset needs to inspect the
+        database configuration in order to determine it. This method allows engine-specs
+        to define dynamic values for the attribute.
+        """
+        return cls.allows_alias_in_select
+
+    @classmethod
     def supports_url(cls, url: URL) -> bool:
         """
         Returns true if the DB engine spec supports a given SQLAlchemy URL.

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -965,7 +965,7 @@ class Database(
         """
         label_expected = label or sqla_col.name
         # add quotes to tables
-        if self.db_engine_spec.allows_alias_in_select:
+        if self.db_engine_spec.get_allows_alias_in_select(self):
             label = self.db_engine_spec.make_label_compatible(label_expected)
             sqla_col = sqla_col.label(label)
         sqla_col.key = label_expected

--- a/tests/unit_tests/db_engine_specs/test_dremio.py
+++ b/tests/unit_tests/db_engine_specs/test_dremio.py
@@ -18,6 +18,7 @@ from datetime import datetime
 from typing import Optional
 
 import pytest
+from pytest_mock import MockerFixture
 
 from tests.unit_tests.db_engine_specs.utils import assert_convert_dttm
 from tests.unit_tests.fixtures.common import dttm
@@ -40,3 +41,18 @@ def test_convert_dttm(
     from superset.db_engine_specs.dremio import DremioEngineSpec as spec
 
     assert_convert_dttm(spec, target_type, expected_result, dttm)
+
+
+def test_get_allows_alias_in_select(mocker: MockerFixture) -> None:
+    from superset.db_engine_specs.dremio import DremioEngineSpec
+
+    database = mocker.MagicMock()
+
+    database.get_extra.return_value = {}
+    assert DremioEngineSpec.get_allows_alias_in_select(database) is True
+
+    database.get_extra.return_value = {"version": "24.1.0"}
+    assert DremioEngineSpec.get_allows_alias_in_select(database) is True
+
+    database.get_extra.return_value = {"version": "24.0.0"}
+    assert DremioEngineSpec.get_allows_alias_in_select(database) is False


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

DB engine specs have an attribute called `allows_alias_in_select`, indicating if they support aliases in `SELECT` statements. For Dremio, this attribute is version dependent — see the fix in [their release notes](https://docs.dremio.com/current/release-notes/version-240-release/#2410-release-notes-june-2023).

Because of that, we've been ping-ponging on the attribute. First I disabled it in https://github.com/apache/superset/pull/23872, and later it was re-enabled in https://github.com/apache/superset/pull/25657 when the fix came out. Since we have Superset users running older versions, I added a new class method `get_allows_alias_in_select`, that uses the `version` field in the database extra configuration.

Note that this requires users running Dremio < 24.1.0 to explicitly add the `version` field when configuring their databases. I'm not sure if we could determine the version at runtime, but even if we could it would require us to run a pre-query every time, which is needlessly expensive.

Also note that the `version` field is already used in Presto for version-dependent features.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
