### PR TITLE
fix(Alerts/Reports): allow use of ";" separator in slack recipient entry

### DIFF
--- a/superset/reports/notifications/slack.py
+++ b/superset/reports/notifications/slack.py
@@ -60,8 +60,16 @@ class SlackNotification(BaseNotification):  # pylint: disable=too-few-public-met
 
     type = ReportRecipientType.SLACK
 
-    # Use utils function to parse & format recipients
     def _get_channel(self) -> str:
+        """
+        Get the recipient's channel(s).
+        
+        Note Slack SDK uses "channel" to refer to one or more
+        channels. Multiple channels are demarcated by a comma.
+    
+        :returns: The comma separated list of channel(s)
+        """
+        
         recipient_str = json.loads(self._recipient.recipient_config_json)["target"]
 
         return ",".join(get_email_address_list(recipient_str))

--- a/superset/reports/notifications/slack.py
+++ b/superset/reports/notifications/slack.py
@@ -44,6 +44,7 @@ from superset.reports.notifications.exceptions import (
     NotificationParamException,
     NotificationUnprocessableException,
 )
+from superset.utils.core import get_email_address_list
 from superset.utils.decorators import statsd_gauge
 
 logger = logging.getLogger(__name__)
@@ -59,8 +60,11 @@ class SlackNotification(BaseNotification):  # pylint: disable=too-few-public-met
 
     type = ReportRecipientType.SLACK
 
+    # Use utils function to parse & format recipients
     def _get_channel(self) -> str:
-        return json.loads(self._recipient.recipient_config_json)["target"]
+        recipient_str = json.loads(self._recipient.recipient_config_json)["target"]
+
+        return ", ".join(get_email_address_list(recipient_str))
 
     def _message_template(self, table: str = "") -> str:
         return __(

--- a/superset/reports/notifications/slack.py
+++ b/superset/reports/notifications/slack.py
@@ -63,7 +63,6 @@ class SlackNotification(BaseNotification):  # pylint: disable=too-few-public-met
     def _get_channel(self) -> str:
         """
         Get the recipient's channel(s).
-        
         Note Slack SDK uses "channel" to refer to one or more
         channels. Multiple channels are demarcated by a comma.
     

--- a/superset/reports/notifications/slack.py
+++ b/superset/reports/notifications/slack.py
@@ -65,7 +65,6 @@ class SlackNotification(BaseNotification):  # pylint: disable=too-few-public-met
         Get the recipient's channel(s).
         Note Slack SDK uses "channel" to refer to one or more
         channels. Multiple channels are demarcated by a comma.
-    
         :returns: The comma separated list of channel(s)
         """
         recipient_str = json.loads(self._recipient.recipient_config_json)["target"]

--- a/superset/reports/notifications/slack.py
+++ b/superset/reports/notifications/slack.py
@@ -64,7 +64,7 @@ class SlackNotification(BaseNotification):  # pylint: disable=too-few-public-met
     def _get_channel(self) -> str:
         recipient_str = json.loads(self._recipient.recipient_config_json)["target"]
 
-        return ", ".join(get_email_address_list(recipient_str))
+        return ",".join(get_email_address_list(recipient_str))
 
     def _message_template(self, table: str = "") -> str:
         return __(

--- a/superset/reports/notifications/slack.py
+++ b/superset/reports/notifications/slack.py
@@ -69,7 +69,6 @@ class SlackNotification(BaseNotification):  # pylint: disable=too-few-public-met
     
         :returns: The comma separated list of channel(s)
         """
-        
         recipient_str = json.loads(self._recipient.recipient_config_json)["target"]
 
         return ",".join(get_email_address_list(recipient_str))

--- a/tests/unit_tests/reports/notifications/slack_tests.py
+++ b/tests/unit_tests/reports/notifications/slack_tests.py
@@ -1,0 +1,80 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+from flask import g
+
+
+@patch("superset.reports.notifications.slack.logger")
+def test_get_channel_with_multi_recipients(
+    logger_mock: MagicMock,
+) -> None:
+    # `superset.models.helpers`, a dependency of following imports,
+    # requires app context
+    from superset.reports.models import ReportRecipients, ReportRecipientType
+    from superset.reports.notifications.base import NotificationContent
+    from superset.reports.notifications.slack import SlackNotification, WebClient
+
+    execution_id = uuid.uuid4()
+    g.context = {"execution_id": execution_id}
+    content = NotificationContent(
+        name="test alert",
+        header_data={
+            "notification_format": "PNG",
+            "notification_type": "Alert",
+            "owners": [1],
+            "notification_source": None,
+            "chart_id": None,
+            "dashboard_id": None,
+        },
+        embedded_data=pd.DataFrame(
+            {
+                "A": [1, 2, 3],
+                "B": [4, 5, 6],
+                "C": ["111", "222", '<a href="http://www.example.com">333</a>'],
+            }
+        ),
+        description='<p>This is <a href="#">a test</a> alert</p><br />',
+    )
+    # Set a return value for _get_channel
+    with patch.object(
+        SlackNotification,
+        "_get_channel",
+        return_value="some_channel,second_channel,third_channel",
+    ) as get_channel_mock:
+        slack_notification = SlackNotification(
+            recipient=ReportRecipients(
+                type=ReportRecipientType.SLACK,
+                recipient_config_json='{"target": "some_channel; second_channel, third_channel"}',
+            ),
+            content=content,
+        )
+
+        result = slack_notification._get_channel()
+
+        assert result == "some_channel,second_channel,third_channel"
+
+        # Ensure _get_channel was called
+        get_channel_mock.assert_called_once()
+
+        # Ensure other methods were not called
+        logger_mock.info.assert_not_called()
+
+    # reset g.context
+    g.context = None


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- This fix applies existing logic from utils/core.py (get_email_address_list) to the slack recipient parsing function of reports/notifications/slack.py (_get_channel) to properly format the recipient list into a string delimited by commas. This should allow users to enter slack recipients as per the current instructions of using either ',' or ';'

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Open the Alerts and Reports creation modal and choose a `Notification Method`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [X] Required feature flags: SLACK_API_TOKEN
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
