### PR TITLE
fix: trino cursor

### DIFF
--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import threading
+import time
 from typing import Any, TYPE_CHECKING
 
 import simplejson as json
@@ -151,13 +152,7 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
         return None
 
     @classmethod
-    def handle_cursor_with_query_id(
-        cls,
-        cursor: Cursor,
-        query: Query,
-        session: Session,
-        cancel_query_id: str,
-    ) -> None:
+    def handle_cursor(cls, cursor: Cursor, query: Query, session: Session) -> None:
         """
         Handle a trino client cursor.
 
@@ -167,6 +162,7 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
         """
 
         # Adds the executed query id to the extra payload so the query can be cancelled
+        cancel_query_id = cursor.query_id
         logger.debug("Query %d: queryId %s found in cursor", query.id, cancel_query_id)
         query.set_extra_json_key(key=QUERY_CANCEL_KEY, value=cancel_query_id)
 
@@ -184,15 +180,11 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
                 cancel_query_id=cancel_query_id,
             )
 
-        cls.handle_cursor(cursor=cursor, query=query, session=session)
+        super().handle_cursor(cursor=cursor, query=query, session=session)
 
     @classmethod
     def execute_with_cursor(
-        cls,
-        cursor: Cursor,
-        sql: str,
-        query: Query,
-        session: Session,
+        cls, cursor: Cursor, sql: str, query: Query, session: Session
     ) -> None:
         """
         Trigger execution of a query and handle the resulting cursor.
@@ -201,7 +193,7 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
         in another thread and invoke `handle_cursor` to poll for the query ID
         to appear on the cursor in parallel.
         """
-        # Fetch the query ID before hand, since it might fail inside the thread due to
+        # Fetch the query ID beforehand, since it might fail inside the thread due to
         # how the SQLAlchemy session is handled.
         query_id = query.id
 
@@ -223,10 +215,18 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
             args=(execute_result, execute_event),
         )
         execute_thread.start()
-        execute_event.wait()
+
+        # Wait for a query ID to be available before handling the cursor, as
+        # it's required by that method; it may never become available on error.
+        while not cursor.query_id and not execute_event.is_set():
+            time.sleep(0.1)
 
         logger.debug("Query %d: Handling cursor", query_id)
-        cls.handle_cursor_with_query_id(cursor, query, session, query_id)
+        cls.handle_cursor(cursor, query, session)
+
+        # Block until the query completes; same behaviour as the client itself
+        logger.debug("Query %d: Waiting for query to complete", query_id)
+        execute_event.wait()
 
         # Unfortunately we'll mangle the stack trace due to the thread, but
         # throwing the original exception allows mapping database errors as normal

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import contextlib
 import logging
 import threading
-import time
 from typing import Any, TYPE_CHECKING
 
 import simplejson as json
@@ -152,7 +151,13 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
         return None
 
     @classmethod
-    def handle_cursor(cls, cursor: Cursor, query: Query, session: Session) -> None:
+    def handle_cursor_with_query_id(
+        cls,
+        cursor: Cursor,
+        query: Query,
+        session: Session,
+        cancel_query_id: str,
+    ) -> None:
         """
         Handle a trino client cursor.
 
@@ -162,7 +167,6 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
         """
 
         # Adds the executed query id to the extra payload so the query can be cancelled
-        cancel_query_id = cursor.query_id
         logger.debug("Query %d: queryId %s found in cursor", query.id, cancel_query_id)
         query.set_extra_json_key(key=QUERY_CANCEL_KEY, value=cancel_query_id)
 
@@ -180,11 +184,15 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
                 cancel_query_id=cancel_query_id,
             )
 
-        super().handle_cursor(cursor=cursor, query=query, session=session)
+        cls.handle_cursor(cursor=cursor, query=query, session=session)
 
     @classmethod
     def execute_with_cursor(
-        cls, cursor: Any, sql: str, query: Query, session: Session
+        cls,
+        cursor: Cursor,
+        sql: str,
+        query: Query,
+        session: Session,
     ) -> None:
         """
         Trigger execution of a query and handle the resulting cursor.
@@ -193,34 +201,32 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
         in another thread and invoke `handle_cursor` to poll for the query ID
         to appear on the cursor in parallel.
         """
+        # Fetch the query ID before hand, since it might fail inside the thread due to
+        # how the SQLAlchemy session is handled.
+        query_id = query.id
+
         execute_result: dict[str, Any] = {}
+        execute_event = threading.Event()
 
-        def _execute(results: dict[str, Any]) -> None:
-            logger.debug("Query %d: Running query: %s", query.id, sql)
+        def _execute(results: dict[str, Any], event: threading.Event) -> None:
+            logger.debug("Query %d: Running query: %s", query_id, sql)
 
-            # Pass result / exception information back to the parent thread
             try:
                 cls.execute(cursor, sql)
-                results["complete"] = True
             except Exception as ex:  # pylint: disable=broad-except
-                results["complete"] = True
                 results["error"] = ex
+            finally:
+                event.set()
 
-        execute_thread = threading.Thread(target=_execute, args=(execute_result,))
+        execute_thread = threading.Thread(
+            target=_execute,
+            args=(execute_result, execute_event),
+        )
         execute_thread.start()
+        execute_event.wait()
 
-        # Wait for a query ID to be available before handling the cursor, as
-        # it's required by that method; it may never become available on error.
-        while not cursor.query_id and not execute_result.get("complete"):
-            time.sleep(0.1)
-
-        logger.debug("Query %d: Handling cursor", query.id)
-        cls.handle_cursor(cursor, query, session)
-
-        # Block until the query completes; same behaviour as the client itself
-        logger.debug("Query %d: Waiting for query to complete", query.id)
-        while not execute_result.get("complete"):
-            time.sleep(0.5)
+        logger.debug("Query %d: Handling cursor", query_id)
+        cls.handle_cursor_with_query_id(cursor, query, session, query_id)
 
         # Unfortunately we'll mangle the stack trace due to the thread, but
         # throwing the original exception allows mapping database errors as normal
@@ -234,7 +240,7 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
             session.commit()
 
     @classmethod
-    def cancel_query(cls, cursor: Any, query: Query, cancel_query_id: str) -> bool:
+    def cancel_query(cls, cursor: Cursor, query: Query, cancel_query_id: str) -> bool:
         """
         Cancel query in the underlying database.
 

--- a/tests/unit_tests/db_engine_specs/test_trino.py
+++ b/tests/unit_tests/db_engine_specs/test_trino.py
@@ -360,12 +360,7 @@ def test_handle_cursor_early_cancel(
     if cancel_early:
         TrinoEngineSpec.prepare_cancel_query(query=query, session=session_mock)
 
-    TrinoEngineSpec.handle_cursor_with_query_id(
-        cursor=cursor_mock,
-        query=query,
-        session=session_mock,
-        cancel_query_id=query_id,
-    )
+    TrinoEngineSpec.handle_cursor(cursor=cursor_mock, query=query, session=session_mock)
 
     if cancel_early:
         assert cancel_query_mock.call_args[1]["cancel_query_id"] == query_id
@@ -383,7 +378,6 @@ def test_execute_with_cursor_in_parallel(mocker: MockerFixture):
     mock_cursor.query_id = None
 
     mock_query = mocker.MagicMock()
-    mock_query.id = query_id
     mock_session = mocker.MagicMock()
 
     def _mock_execute(*args, **kwargs):
@@ -399,6 +393,5 @@ def test_execute_with_cursor_in_parallel(mocker: MockerFixture):
     )
 
     mock_query.set_extra_json_key.assert_called_once_with(
-        key=QUERY_CANCEL_KEY,
-        value=query_id,
+        key=QUERY_CANCEL_KEY, value=query_id
     )

--- a/tests/unit_tests/db_engine_specs/test_trino.py
+++ b/tests/unit_tests/db_engine_specs/test_trino.py
@@ -360,7 +360,12 @@ def test_handle_cursor_early_cancel(
     if cancel_early:
         TrinoEngineSpec.prepare_cancel_query(query=query, session=session_mock)
 
-    TrinoEngineSpec.handle_cursor(cursor=cursor_mock, query=query, session=session_mock)
+    TrinoEngineSpec.handle_cursor_with_query_id(
+        cursor=cursor_mock,
+        query=query,
+        session=session_mock,
+        cancel_query_id=query_id,
+    )
 
     if cancel_early:
         assert cancel_query_mock.call_args[1]["cancel_query_id"] == query_id
@@ -378,6 +383,7 @@ def test_execute_with_cursor_in_parallel(mocker: MockerFixture):
     mock_cursor.query_id = None
 
     mock_query = mocker.MagicMock()
+    mock_query.id = query_id
     mock_session = mocker.MagicMock()
 
     def _mock_execute(*args, **kwargs):
@@ -393,5 +399,6 @@ def test_execute_with_cursor_in_parallel(mocker: MockerFixture):
     )
 
     mock_query.set_extra_json_key.assert_called_once_with(
-        key=QUERY_CANCEL_KEY, value=query_id
+        key=QUERY_CANCEL_KEY,
+        value=query_id,
     )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR improves the Trino `execute_with_cursor` method:

1. It uses a `threading.Event` to indicate that the query running in a separate thread has finished, removing the overhead of context switching that happens with `sleep()` calls.
2. More importantly, it removes the call to `query.id` from inside the thread. The `Query` object is loaded lazily, so when `query.id` is accessed we need to use the session to retrieve the ID. In certain deployments the call to get the session inside the thread might fail (at Preset it fails because the thread is missing additional context that the application has).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
