### PR TITLE
fix: database version field

### DIFF
--- a/superset-frontend/src/features/databases/DatabaseModal/ExtraOptions.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/ExtraOptions.tsx
@@ -541,7 +541,7 @@ const ExtraOptions = ({
           </div>
           <div className="input-container" data-test="version-spinbutton-test">
             <input
-              type="number"
+              type="text"
               name="version"
               placeholder={t('Version number')}
               onChange={onExtraInputChange}
@@ -550,8 +550,8 @@ const ExtraOptions = ({
           </div>
           <div className="helper">
             {t(
-              'Specify the database version. This should be used with ' +
-                'Presto in order to enable query cost estimation.',
+              'Specify the database version. This is used with Presto for query cost ' +
+                'estimation, and Dremio for syntax changes, among others.',
             )}
           </div>
         </StyledInputContainer>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The `version` field in the database configuration modal should be a string, not a number.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before we can only put a number as the version:

<img width="501" alt="Screen Shot 2023-11-07 at 5 25 10 PM" src="https://github.com/apache/superset/assets/1534870/412fac9d-2d37-46e8-ae0a-f31aec3fe3ce">

After, note can we can put `1.2.3` as the version:

![superset local preset zone_databaseview_list__pageIndex=0 sortColumn=changed_on_delta_humanized sortOrder=desc](https://github.com/apache/superset/assets/1534870/94bcdc48-c145-49c8-aa7f-f09deef3ff7f)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
