### PR TITLE
fix(native filters): rendering performance improvement by reduce overrendering

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/chart/types/Base.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/types/Base.ts
@@ -58,7 +58,6 @@ export enum AppSection {
 export type FilterState = { value?: any; [key: string]: any };
 
 export type DataMask = {
-  __cache?: FilterState;
   extraFormData?: ExtraFormData;
   filterState?: FilterState;
   ownState?: JsonObject;

--- a/superset-frontend/src/dashboard/components/Dashboard.jsx
+++ b/superset-frontend/src/dashboard/components/Dashboard.jsx
@@ -25,9 +25,8 @@ import Loading from 'src/components/Loading';
 import getBootstrapData from 'src/utils/getBootstrapData';
 import getChartIdsFromLayout from '../util/getChartIdsFromLayout';
 import getLayoutComponentFromChartId from '../util/getLayoutComponentFromChartId';
-import DashboardBuilder from './DashboardBuilder/DashboardBuilder';
+
 import {
-  chartPropShape,
   slicePropShape,
   dashboardInfoPropShape,
   dashboardStatePropShape,
@@ -53,7 +52,6 @@ const propTypes = {
   }).isRequired,
   dashboardInfo: dashboardInfoPropShape.isRequired,
   dashboardState: dashboardStatePropShape.isRequired,
-  charts: PropTypes.objectOf(chartPropShape).isRequired,
   slices: PropTypes.objectOf(slicePropShape).isRequired,
   activeFilters: PropTypes.object.isRequired,
   chartConfiguration: PropTypes.object,
@@ -213,11 +211,6 @@ class Dashboard extends React.PureComponent {
     }
   }
 
-  // return charts in array
-  getAllCharts() {
-    return Object.values(this.props.charts);
-  }
-
   applyFilters() {
     const { appliedFilters } = this;
     const { activeFilters, ownDataCharts } = this.props;
@@ -288,11 +281,7 @@ class Dashboard extends React.PureComponent {
     if (this.context.loading) {
       return <Loading />;
     }
-    return (
-      <>
-        <DashboardBuilder />
-      </>
-    );
+    return this.props.children;
   }
 }
 

--- a/superset-frontend/src/dashboard/components/Dashboard.test.jsx
+++ b/superset-frontend/src/dashboard/components/Dashboard.test.jsx
@@ -21,7 +21,6 @@ import { shallow } from 'enzyme';
 import sinon from 'sinon';
 
 import Dashboard from 'src/dashboard/components/Dashboard';
-import DashboardBuilder from 'src/dashboard/components/DashboardBuilder/DashboardBuilder';
 import { CHART_TYPE } from 'src/dashboard/util/componentTypes';
 import newComponentFactory from 'src/dashboard/util/newComponentFactory';
 
@@ -63,8 +62,14 @@ describe('Dashboard', () => {
     loadStats: {},
   };
 
+  const ChildrenComponent = () => <div>Test</div>;
+
   function setup(overrideProps) {
-    const wrapper = shallow(<Dashboard {...props} {...overrideProps} />);
+    const wrapper = shallow(
+      <Dashboard {...props} {...overrideProps}>
+        <ChildrenComponent />
+      </Dashboard>,
+    );
     return wrapper;
   }
 
@@ -76,9 +81,9 @@ describe('Dashboard', () => {
     '3_country_name': { values: ['USA'], scope: [] },
   };
 
-  it('should render a DashboardBuilder', () => {
+  it('should render the children component', () => {
     const wrapper = setup();
-    expect(wrapper.find(DashboardBuilder)).toExist();
+    expect(wrapper.find(ChildrenComponent)).toExist();
   });
 
   describe('UNSAFE_componentWillReceiveProps', () => {

--- a/superset-frontend/src/dashboard/components/SyncDashboardState/SyncDashboardState.test.tsx
+++ b/superset-frontend/src/dashboard/components/SyncDashboardState/SyncDashboardState.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { render } from 'spec/helpers/testing-library';
+import { getItem, LocalStorageKeys } from 'src/utils/localStorageHelpers';
+import SyncDashboardState from '.';
+
+test('stores the dashboard info with local storages', () => {
+  const testDashboardPageId = 'dashboardPageId';
+  render(<SyncDashboardState dashboardPageId={testDashboardPageId} />, {
+    useRedux: true,
+  });
+  expect(getItem(LocalStorageKeys.dashboard__explore_context, {})).toEqual({
+    [testDashboardPageId]: expect.objectContaining({
+      dashboardPageId: testDashboardPageId,
+    }),
+  });
+});

--- a/superset-frontend/src/dashboard/components/SyncDashboardState/index.tsx
+++ b/superset-frontend/src/dashboard/components/SyncDashboardState/index.tsx
@@ -1,0 +1,103 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { useEffect } from 'react';
+import pick from 'lodash/pick';
+import { shallowEqual, useSelector } from 'react-redux';
+import { DashboardContextForExplore } from 'src/types/DashboardContextForExplore';
+import {
+  getItem,
+  LocalStorageKeys,
+  setItem,
+} from 'src/utils/localStorageHelpers';
+import { RootState } from 'src/dashboard/types';
+import { getActiveFilters } from 'src/dashboard/util/activeDashboardFilters';
+
+type Props = { dashboardPageId: string };
+
+const EMPTY_OBJECT = {};
+
+export const getDashboardContextLocalStorage = () => {
+  const dashboardsContexts = getItem(
+    LocalStorageKeys.dashboard__explore_context,
+    {},
+  );
+  // A new dashboard tab id is generated on each dashboard page opening.
+  // We mark ids as redundant when user leaves the dashboard, because they won't be reused.
+  // Then we remove redundant dashboard contexts from local storage in order not to clutter it
+  return Object.fromEntries(
+    Object.entries(dashboardsContexts).filter(
+      ([, value]) => !value.isRedundant,
+    ),
+  );
+};
+
+const updateDashboardTabLocalStorage = (
+  dashboardPageId: string,
+  dashboardContext: DashboardContextForExplore,
+) => {
+  const dashboardsContexts = getDashboardContextLocalStorage();
+  setItem(LocalStorageKeys.dashboard__explore_context, {
+    ...dashboardsContexts,
+    [dashboardPageId]: dashboardContext,
+  });
+};
+
+const SyncDashboardState: React.FC<Props> = ({ dashboardPageId }) => {
+  const dashboardContextForExplore = useSelector<
+    RootState,
+    DashboardContextForExplore
+  >(
+    ({ dashboardInfo, dashboardState, nativeFilters, dataMask }) => ({
+      labelColors: dashboardInfo.metadata?.label_colors || EMPTY_OBJECT,
+      sharedLabelColors:
+        dashboardInfo.metadata?.shared_label_colors || EMPTY_OBJECT,
+      colorScheme: dashboardState?.colorScheme,
+      chartConfiguration:
+        dashboardInfo.metadata?.chart_configuration || EMPTY_OBJECT,
+      nativeFilters: Object.entries(nativeFilters.filters).reduce(
+        (acc, [key, filterValue]) => ({
+          ...acc,
+          [key]: pick(filterValue, ['chartsInScope']),
+        }),
+        {},
+      ),
+      dataMask,
+      dashboardId: dashboardInfo.id,
+      filterBoxFilters: getActiveFilters(),
+      dashboardPageId,
+    }),
+    shallowEqual,
+  );
+
+  useEffect(() => {
+    updateDashboardTabLocalStorage(dashboardPageId, dashboardContextForExplore);
+    return () => {
+      // mark tab id as redundant when dashboard unmounts - case when user opens
+      // Explore in the same tab
+      updateDashboardTabLocalStorage(dashboardPageId, {
+        ...dashboardContextForExplore,
+        isRedundant: true,
+      });
+    };
+  }, [dashboardContextForExplore, dashboardPageId]);
+
+  return null;
+};
+
+export default SyncDashboardState;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
@@ -52,6 +52,7 @@ import {
   onFiltersRefreshSuccess,
   setDirectPathToChild,
 } from 'src/dashboard/actions/dashboardState';
+import { RESPONSIVE_WIDTH } from 'src/filters/components/common';
 import { FAST_DEBOUNCE } from 'src/constants';
 import { dispatchHoverAction, dispatchFocusAction } from './utils';
 import { FilterControlProps } from './types';
@@ -322,7 +323,7 @@ const FilterValue: React.FC<FilterControlProps> = ({
       ) : (
         <SuperChart
           height={HEIGHT}
-          width="100%"
+          width={RESPONSIVE_WIDTH}
           showOverflow={showOverflow}
           formData={formData}
           displaySettings={displaySettings}

--- a/superset-frontend/src/dashboard/containers/Dashboard.ts
+++ b/superset-frontend/src/dashboard/containers/Dashboard.ts
@@ -39,7 +39,6 @@ function mapStateToProps(state: RootState) {
   const {
     datasources,
     sliceEntities,
-    charts,
     dataMask,
     dashboardInfo,
     dashboardState,
@@ -54,7 +53,6 @@ function mapStateToProps(state: RootState) {
     userId: dashboardInfo.userId,
     dashboardInfo,
     dashboardState,
-    charts,
     datasources,
     // filters prop: a map structure for all the active filter_box's values and scope in this dashboard,
     // for each filter field. map key is [chartId_column]

--- a/superset-frontend/src/dataMask/reducer.ts
+++ b/superset-frontend/src/dataMask/reducer.ts
@@ -56,7 +56,6 @@ export function getInitialDataMask(
   }
   return {
     ...otherProps,
-    __cache: {},
     extraFormData: {},
     filterState: {},
     ownState: {},

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
@@ -91,15 +91,6 @@ describe('SelectFilterPlugin', () => {
   test('Add multiple values with first render', async () => {
     getWrapper();
     expect(setDataMask).toHaveBeenCalledWith({
-      extraFormData: {},
-      filterState: {
-        value: ['boy'],
-      },
-    });
-    expect(setDataMask).toHaveBeenCalledWith({
-      __cache: {
-        value: ['boy'],
-      },
       extraFormData: {
         filters: [
           {
@@ -118,9 +109,6 @@ describe('SelectFilterPlugin', () => {
     userEvent.click(screen.getByTitle('girl'));
     expect(await screen.findByTitle(/girl/i)).toBeInTheDocument();
     expect(setDataMask).toHaveBeenCalledWith({
-      __cache: {
-        value: ['boy'],
-      },
       extraFormData: {
         filters: [
           {
@@ -146,9 +134,6 @@ describe('SelectFilterPlugin', () => {
       }),
     );
     expect(setDataMask).toHaveBeenCalledWith({
-      __cache: {
-        value: ['boy'],
-      },
       extraFormData: {
         adhoc_filters: [
           {
@@ -174,9 +159,6 @@ describe('SelectFilterPlugin', () => {
       }),
     );
     expect(setDataMask).toHaveBeenCalledWith({
-      __cache: {
-        value: ['boy'],
-      },
       extraFormData: {},
       filterState: {
         label: undefined,
@@ -191,9 +173,6 @@ describe('SelectFilterPlugin', () => {
     expect(await screen.findByTitle('girl')).toBeInTheDocument();
     userEvent.click(screen.getByTitle('girl'));
     expect(setDataMask).toHaveBeenCalledWith({
-      __cache: {
-        value: ['boy'],
-      },
       extraFormData: {
         filters: [
           {
@@ -216,9 +195,6 @@ describe('SelectFilterPlugin', () => {
     expect(await screen.findByRole('combobox')).toBeInTheDocument();
     userEvent.click(screen.getByTitle(NULL_STRING));
     expect(setDataMask).toHaveBeenLastCalledWith({
-      __cache: {
-        value: ['boy'],
-      },
       extraFormData: {
         filters: [
           {

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -45,15 +45,11 @@ type DataMaskAction =
   | { type: 'ownState'; ownState: JsonObject }
   | {
       type: 'filterState';
-      __cache: JsonObject;
       extraFormData: ExtraFormData;
       filterState: { value: SelectValue; label?: string };
     };
 
-function reducer(
-  draft: DataMask & { __cache?: JsonObject },
-  action: DataMaskAction,
-) {
+function reducer(draft: DataMask, action: DataMaskAction) {
   switch (action.type) {
     case 'ownState':
       draft.ownState = {
@@ -62,10 +58,18 @@ function reducer(
       };
       return draft;
     case 'filterState':
-      draft.extraFormData = action.extraFormData;
-      // eslint-disable-next-line no-underscore-dangle
-      draft.__cache = action.__cache;
-      draft.filterState = { ...draft.filterState, ...action.filterState };
+      if (
+        JSON.stringify(draft.extraFormData) !==
+        JSON.stringify(action.extraFormData)
+      ) {
+        draft.extraFormData = action.extraFormData;
+      }
+      if (
+        JSON.stringify(draft.filterState) !== JSON.stringify(action.filterState)
+      ) {
+        draft.filterState = { ...draft.filterState, ...action.filterState };
+      }
+
       return draft;
     default:
       return draft;
@@ -129,7 +133,6 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
       const suffix = inverseSelection && values?.length ? t(' (excluded)') : '';
       dispatchDataMask({
         type: 'filterState',
-        __cache: filterState,
         extraFormData: getSelectExtraFormData(
           col,
           values,

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -37,7 +37,6 @@ import { Select } from 'src/components';
 import { SLOW_DEBOUNCE } from 'src/constants';
 import { hasOption, propertyComparator } from 'src/components/Select/utils';
 import { FilterBarOrientation } from 'src/dashboard/types';
-import { uniqWith, isEqual } from 'lodash';
 import { PluginFilterSelectProps, SelectValue } from './types';
 import { FilterPluginStyle, StatusMessage, StyledFormItem } from '../common';
 import { getDataRecordFormatter, getSelectExtraFormData } from '../../utils';
@@ -219,16 +218,13 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
   }, [filterState.validateMessage, filterState.validateStatus]);
 
   const uniqueOptions = useMemo(() => {
-    const allOptions = [...data];
-    return uniqWith(allOptions, isEqual).map(row => {
-      const [value] = groupby.map(col => row[col]);
-      return {
-        label: labelFormatter(value, datatype),
-        value,
-        isNewOption: false,
-      };
-    });
-  }, [data, datatype, groupby, labelFormatter]);
+    const allOptions = new Set([...data.map(el => el[col])]);
+    return [...allOptions].map((value: string) => ({
+      label: labelFormatter(value, datatype),
+      value,
+      isNewOption: false,
+    }));
+  }, [data, datatype, col, labelFormatter]);
 
   const options = useMemo(() => {
     if (search && !multiSelect && !hasOption(search, uniqueOptions, true)) {

--- a/superset-frontend/src/filters/components/common.ts
+++ b/superset-frontend/src/filters/components/common.ts
@@ -20,9 +20,11 @@ import { styled } from '@superset-ui/core';
 import { PluginFilterStylesProps } from './types';
 import FormItem from '../../components/Form/FormItem';
 
+export const RESPONSIVE_WIDTH = 0;
+
 export const FilterPluginStyle = styled.div<PluginFilterStylesProps>`
   min-height: ${({ height }) => height}px;
-  width: ${({ width }) => width}px;
+  width: ${({ width }) => (width === RESPONSIVE_WIDTH ? '100%' : `${width}px`)};
 `;
 
 export const StyledFormItem = styled(FormItem)`


### PR DESCRIPTION
### SUMMARY
Following up #25282, rendering performance can still be improved by reducing unnecessary rerenders (also known as over-rendering).
This commit improves performance in four areas.

#### 1. Inefficient uniqWith and object equality check in uniqueOptions

https://github.com/apache/superset/blob/d6fde3cdd5987e3bf9a37d1fcde2dc82ef695747/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx#L221-L224

![Screenshot 2023-11-01 at 1 48 34 PM](https://github.com/apache/superset/assets/1392866/5d619acc-9001-4338-87b8-caa94eda018d)

To get the list of unique values, it compares the entire data list (`arrayIncludesWith`) using object equality comparison (`isEqual`). This is slow because the data contains several attributes, and object equality comparison is slow.

As it shown in the above metric, `uniqueOptions` operation triggers four times every time a filter component re-renders, which takes more than 2 seconds per re-render for 10 filters (i.e. 50ms * 4 * 10 filters = 2s).

Using a hashmap approach (with unnecessary equality check)  reduced the delay from ~200m(=50ms * 4) to 10ms (95% reduction)
![Screenshot 2023-11-01 at 1 47 15 PM](https://github.com/apache/superset/assets/1392866/bd271944-c87d-4937-ade8-106fbc568489)

#### 2. Redundant filter re-renders due to the dynamic sizing

|Initially renders at a minimum width and then expands to its full width.|
|--|
|![native-filter-width-overrendering](https://github.com/apache/superset/assets/1392866/ea9f768b-dd3a-4f25-9e9e-fd68005f713f)|

Since the native filter's allocated to 100% of its width using [SuperChart](https://github.com/apache/superset/blob/e7a187680713867f22b082f3bb0a57296d2a331c/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChart.tsx#L245-L258), which is wrapped by `@vx/responsive`, it triggers re-renders every time the screen size is updated.
This commit removes the resize observer (by assigning the static width) and updates the filter component wrapper to the full width using CSS instead. As a result, the filters no longer re-render when the page size changes.
![native-filter-css-width](https://github.com/apache/superset/assets/1392866/19fc445b-4a2f-4808-a60d-b7c94a2d382b)

#### 3. descendants over-rendering

React's inherent behavior of rerendering all descendant components, coupled with the Redux container's rerendering upon state changes, leads to excessive rerendering of dashboard components, including filter components, whenever the chart fetch status updates the Redux store.
This commit replaces DashboardBuilder to the identical descendant (`props.children`) which prevents the rerenders when the container component rerenders.
To further optimize performance, the dashboard state synchronization logic was moved to a separate component, effectively decoupling it from the DashboardPage component and preventing unnecessary rerenders of the DashboardPage.

#### 4. Redundant `__cache` attribute

|Due to superfluous setDataMask calls triggered by __cache update, each setState update causes four unnecessary uniqWith executions|
|--|
|![fix_native_filters___rendering_performance_improvement_by_reduce_overrendering_by_justinpark_·_Pull_Request__25901_·_apache_superset](https://github.com/apache/superset/assets/1392866/f9df28ce-f6fb-4bd9-9aed-a817a0bbf064)|

An unnecessary __cache value was introduced in the SelectFilterPlugin in [PR#14869](https://github.com/apache/superset/pull/14869/commits/1749ed542a4f4cedc6847316bf65fc2b82eb1fbd#diff-b4d2de68c8a3b04879772237085ede1b49a6908b6f2890a9ab1aaeae9e18b854R65), but it was never utilized and resulted in superfluous rerenders of filter components.
This commit removes this redundant `__cache` value to resolve the problem.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Successfully optimized the application's performance, resulting in a 10% decrease in rendering count (255 to 228) and a remarkable 60% reduction in loading time (10.9 seconds to 4.5 seconds).

|Before|After|
|--|--|
|![Screenshot 2023-11-07 at 3 57 28 PM](https://github.com/apache/superset/assets/1392866/2e5dc6ad-a5e1-4e66-9e96-01f1fb3d7733)|![Screenshot 2023-11-07 at 3 58 18 PM](https://github.com/apache/superset/assets/1392866/4d82aa63-b884-467c-ace7-b2834c2d2841)|


### TESTING INSTRUCTIONS

1. Go to any dashboard
2. Add more than 10 select filters
3. Reload dashboard
4. See that filters take a lot of time for before render.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
