### PR TITLE
fix(sqllab): invalid sanitization on comparison symbol

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
@@ -44,6 +44,9 @@ describe('isProbablyHTML', () => {
     const plainText = 'Just a plain text';
     const isHTML = isProbablyHTML(plainText);
     expect(isHTML).toBe(false);
+
+    const trickyText = 'a <= 10 and b > 10';
+    expect(isProbablyHTML(trickyText)).toBe(false);
   });
 });
 

--- a/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
@@ -28,7 +28,7 @@ export function sanitizeHtml(htmlString: string) {
 }
 
 export function isProbablyHTML(text: string) {
-  return /<[^>]+>/.test(text);
+  return /<\/?[a-z][\s\S]*>/i.test(text);
 }
 
 export function sanitizeHtmlIfNeeded(htmlString: string) {

--- a/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
@@ -28,7 +28,9 @@ export function sanitizeHtml(htmlString: string) {
 }
 
 export function isProbablyHTML(text: string) {
-  return /<\/?[a-z][\s\S]*>/i.test(text);
+  return Array.from(
+    new DOMParser().parseFromString(text, 'text/html').body.childNodes,
+  ).some(({ nodeType }) => nodeType === 1);
 }
 
 export function sanitizeHtmlIfNeeded(htmlString: string) {


### PR DESCRIPTION
### SUMMARY
The current regular expression for HTML detection is inadequate, as it sanitizes the text containing comparison symbols. (i.e. `a <= 10 and b > 10`)
This commit updates the isProbablyHTML regex expression to fix the issue.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:
![Screenshot 2023-11-07 at 6 18 15 PM](https://github.com/apache/superset/assets/1392866/b3ec48c9-2846-426d-b7ca-436a404c09c6)

After:
![Screenshot 2023-11-07 at 6 17 58 PM](https://github.com/apache/superset/assets/1392866/6b454462-24be-4601-8b99-f9dc3bd27f0a)

### TESTING INSTRUCTIONS
Go to SQL Lab and run `select 'a <= 10 and b > 10'`
Check the result table

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
