### PR TITLE
chore(deps): bump dremio deps

### DIFF
--- a/docs/docs/configuration/databases.mdx
+++ b/docs/docs/configuration/databases.mdx
@@ -55,7 +55,7 @@ are compatible with Superset.
 | [ClickHouse](/docs/configuration/databases#clickhouse)                  | `pip install clickhouse-connect`                                                   | `clickhousedb://{username}:{password}@{hostname}:{port}/{database}`                                                                                    |
 | [CockroachDB](/docs/configuration/databases#cockroachdb)                | `pip install cockroachdb`                                                          | `cockroachdb://root@{hostname}:{port}/{database}?sslmode=disable`                                                                                      |
 | [Couchbase](/docs/configuration/databases#couchbase)                | `pip install couchbase-sqlalchemy`                                                          | `couchbase://{username}:{password}@{hostname}:{port}?truststorepath={ssl certificate path}`                                                                                      |
-| [Dremio](/docs/configuration/databases#dremio)                          | `pip install sqlalchemy_dremio`                                                    | `dremio://user:pwd@host:31010/`                                                                                                                        |
+| [Dremio](/docs/configuration/databases#dremio)                          | `pip install sqlalchemy_dremio`                                                    |`dremio+flight://{username}:{password}@{host}:31010, For ODBC dremio+pyodbc://{username}:{password}@{host}:32010`                                                                                                                           |
 | [Elasticsearch](/docs/configuration/databases#elasticsearch)            | `pip install elasticsearch-dbapi`                                                  | `elasticsearch+http://{user}:{password}@{host}:9200/`                                                                                                  |
 | [Exasol](/docs/configuration/databases#exasol)                          | `pip install sqlalchemy-exasol`                                                    | `exa+pyodbc://{username}:{password}@{hostname}:{port}/my_schema?CONNECTIONLCALL=en_US.UTF-8&driver=EXAODBC`                                            |
 | [Google BigQuery](/docs/configuration/databases#google-bigquery)                     | `pip install sqlalchemy-bigquery`                                                  | `bigquery://{project_id}`                                                                                                                              |
@@ -522,7 +522,7 @@ The recommended connector library for Dremio is
 The expected connection string for ODBC (Default port is 31010) is formatted as follows:
 
 ```
-dremio://{username}:{password}@{host}:{port}/{database_name}/dremio?SSL=1
+dremio+pyodbc://{username}:{password}@{host}:{port}/{database_name}/dremio?SSL=1
 ```
 
 The expected connection string for Arrow Flight (Dremio 4.9.1+. Default port is 32010) is formatted as follows:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ databricks = [
     "sqlalchemy-databricks>=0.2.0",
 ]
 db2 = ["ibm-db-sa>0.3.8, <=0.4.0"]
-dremio = ["sqlalchemy-dremio>=1.1.5, <1.3"]
+dremio = ["sqlalchemy-dremio>=1.2.1, <4"]
 drill = ["sqlalchemy-drill>=1.1.4, <2"]
 druid = ["pydruid>=0.6.5,<0.7"]
 duckdb = ["duckdb-engine>=0.9.5, <0.10"]

--- a/superset/db_engine_specs/dremio.py
+++ b/superset/db_engine_specs/dremio.py
@@ -38,6 +38,11 @@ class DremioEngineSpec(BaseEngineSpec):
     engine = "dremio"
     engine_name = "Dremio"
     engine_aliases = {"dremio+flight"}
+    drivers = {
+        "flight": "Arrow Flight driver for Dremio",
+        "pyodbc": "ODBC driver for Dremio",
+    }
+    default_driver = "flight"
     sqlalchemy_uri_placeholder = (
         "dremio+flight://data.dremio.cloud:443/?"
         "Token=<TOKEN>&"


### PR DESCRIPTION
### SUMMARY
Starting from version 1.2.1, [SQLAlchemy Dremio](https://github.com/narendrans/sqlalchemy_dremio) has fixed the missing has_table function that is required in Superset. With version 2.0, it drops support for pyodbc and sets pyarrow flight as the default. Additionally, starting from version 3.0, the driver supports Dremio Cloud.

This PR ensures backward compatibility by retaining pyodbc support.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
