### PR TITLE
fix: always denorm column value before querying values

### DIFF
--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -496,13 +496,6 @@ class BaseDatasource(
         """
         raise NotImplementedError()
 
-    def values_for_column(self, column_name: str, limit: int = 10000) -> list[Any]:
-        """Given a column, returns an iterable of distinct values
-
-        This is used to populate the dropdown showing a list of
-        values in filters in the explore view"""
-        raise NotImplementedError()
-
     @staticmethod
     def default_query(qry: Query) -> Query:
         return qry

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -793,34 +793,6 @@ class SqlaTable(
                 )
             ) from ex
 
-    def values_for_column(self, column_name: str, limit: int = 10000) -> list[Any]:
-        """Runs query against sqla to retrieve some
-        sample values for the given column.
-        """
-        cols = {col.column_name: col for col in self.columns}
-        target_col = cols[column_name]
-        tp = self.get_template_processor()
-        tbl, cte = self.get_from_clause(tp)
-
-        qry = (
-            select([target_col.get_sqla_col(template_processor=tp)])
-            .select_from(tbl)
-            .distinct()
-        )
-        if limit:
-            qry = qry.limit(limit)
-
-        if self.fetch_values_predicate:
-            qry = qry.where(self.get_fetch_values_predicate(template_processor=tp))
-
-        with self.database.get_sqla_engine_with_context() as engine:
-            sql = qry.compile(engine, compile_kwargs={"literal_binds": True})
-            sql = self._apply_cte(sql, cte)
-            sql = self.mutate_query_from_config(sql)
-
-            df = pd.read_sql_query(sql=sql, con=engine)
-            return df[column_name].to_list()
-
     def mutate_query_from_config(self, sql: str) -> str:
         """Apply config's SQL_QUERY_MUTATOR
 

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -46,7 +46,6 @@ from sqlalchemy import (
     inspect,
     Integer,
     or_,
-    select,
     String,
     Table,
     Text,

--- a/superset/datasource/api.py
+++ b/superset/datasource/api.py
@@ -116,14 +116,8 @@ class DatasourceRestApi(BaseSupersetApi):
 
         row_limit = apply_max_row_limit(app.config["FILTER_SELECT_ROW_LIMIT"])
         try:
-            # always denormalize column name before querying for values
-            db_engine_spec = datasource.database.db_engine_spec
-            db_dialect = datasource.database.get_dialect()
-            denomalized_col_name = db_engine_spec.denormalize_name(
-                db_dialect, column_name
-            )
             payload = datasource.values_for_column(
-                column_name=denomalized_col_name, limit=row_limit
+                column_name=column_name, limit=row_limit
             )
             return self.response(200, result=payload)
         except KeyError:

--- a/superset/datasource/api.py
+++ b/superset/datasource/api.py
@@ -116,8 +116,14 @@ class DatasourceRestApi(BaseSupersetApi):
 
         row_limit = apply_max_row_limit(app.config["FILTER_SELECT_ROW_LIMIT"])
         try:
+            # always denormalize column name before querying for values
+            db_engine_spec = datasource.database.db_engine_spec
+            db_dialect = datasource.database.get_dialect()
+            denomalized_col_name = db_engine_spec.denormalize_name(
+                db_dialect, column_name
+            )
             payload = datasource.values_for_column(
-                column_name=column_name, limit=row_limit
+                column_name=denomalized_col_name, limit=row_limit
             )
             return self.response(200, result=payload)
         except NotImplementedError:

--- a/superset/datasource/api.py
+++ b/superset/datasource/api.py
@@ -126,6 +126,10 @@ class DatasourceRestApi(BaseSupersetApi):
                 column_name=denomalized_col_name, limit=row_limit
             )
             return self.response(200, result=payload)
+        except KeyError:
+            return self.response(
+                400, message=f"Column name {column_name} does not exist"
+            )
         except NotImplementedError:
             return self.response(
                 400,

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -790,7 +790,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
 
     def get_fetch_values_predicate(
         self,
-        template_processor: Optional[
+        template_processor: Optional[  # pylint: disable=unused-argument
             BaseTemplateProcessor
         ] = None,  # pylint: disable=unused-argument
     ) -> TextClause:
@@ -1419,7 +1419,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
 
     def get_sqla_query(  # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements
         self,
-        apply_fetch_values_predicate: bool = False,  # pylint: disable=unused-argument
+        apply_fetch_values_predicate: bool = False,
         columns: Optional[list[Column]] = None,
         extras: Optional[dict[str, Any]] = None,
         filter: Optional[  # pylint: disable=redefined-builtin
@@ -1940,7 +1940,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                 )
                 having_clause_and += [self.text(having)]
 
-        if self.fetch_values_predicate:
+        if apply_fetch_values_predicate and self.fetch_values_predicate:
             qry = qry.where(
                 self.get_fetch_values_predicate(template_processor=template_processor)
             )

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -700,6 +700,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
         "MIN": sa.func.MIN,
         "MAX": sa.func.MAX,
     }
+    fetch_values_predicate = None
 
     @property
     def fetch_value_predicate(self) -> Optional[str]:
@@ -1339,8 +1340,8 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
 
     def values_for_column(self, column_name: str, limit: int = 10000) -> list[Any]:
         # always denormalize column name before querying for values
-        db_dialect = self.database.get_dialect()
-        denomalized_col_name = self.database.db_engine_spec.denormalize_name(
+        db_dialect = self.database.get_dialect()  # type: ignore
+        denomalized_col_name = self.database.db_engine_spec.denormalize_name(  # type: ignore
             db_dialect, column_name
         )
         cols = {col.column_name: col for col in self.columns}
@@ -1359,7 +1360,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
         if self.fetch_values_predicate:
             qry = qry.where(self.get_fetch_values_predicate(template_processor=tp))
 
-        with self.database.get_sqla_engine_with_context() as engine:
+        with self.database.get_sqla_engine_with_context() as engine:  # type: ignore
             sql = qry.compile(engine, compile_kwargs={"literal_binds": True})
             sql = self._apply_cte(sql, cte)
             sql = self.mutate_query_from_config(sql)
@@ -1937,7 +1938,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                 )
                 having_clause_and += [self.text(having)]
 
-        if apply_fetch_values_predicate and self.fetch_values_predicate:  # type: ignore
+        if self.fetch_values_predicate:
             qry = qry.where(
                 self.get_fetch_values_predicate(template_processor=template_processor)
             )

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1365,7 +1365,6 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
             sql = qry.compile(engine, compile_kwargs={"literal_binds": True})
             sql = self._apply_cte(sql, cte)
             sql = self.mutate_query_from_config(sql)
-
             df = pd.read_sql_query(sql=sql, con=engine)
             return df[column_name].to_list()
 

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -702,8 +702,8 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
     }
 
     @property
-    def fetch_value_predicate(self) -> str:
-        return "fix this!"
+    def fetch_value_predicate(self) -> Optional[str]:
+        return None
 
     @property
     def type(self) -> str:
@@ -1338,35 +1338,34 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
         return and_(*l)
 
     def values_for_column(self, column_name: str, limit: int = 10000) -> list[Any]:
-        """Runs query against sqla to retrieve some
-        sample values for the given column.
-        """
-        cols = {}
-        for col in self.columns:
-            if isinstance(col, dict):
-                cols[col.get("column_name")] = col
-            else:
-                cols[col.column_name] = col
-
-        target_col = cols[column_name]
-        tp = None  # todo(hughhhh): add back self.get_template_processor()
+        # always denormalize column name before querying for values
+        db_dialect = self.database.get_dialect()
+        denomalized_col_name = self.database.db_engine_spec.denormalize_name(
+            db_dialect, column_name
+        )
+        cols = {col.column_name: col for col in self.columns}
+        target_col = cols[denomalized_col_name]
+        tp = self.get_template_processor()
         tbl, cte = self.get_from_clause(tp)
 
-        if isinstance(target_col, dict):
-            sql_column = sa.column(target_col.get("name"))
-        else:
-            sql_column = target_col
-
-        qry = sa.select([sql_column]).select_from(tbl).distinct()
+        qry = (
+            sa.select([target_col.get_sqla_col(template_processor=tp)])
+            .select_from(tbl)
+            .distinct()
+        )
         if limit:
             qry = qry.limit(limit)
 
-        with self.database.get_sqla_engine_with_context() as engine:  # type: ignore
+        if self.fetch_values_predicate:
+            qry = qry.where(self.get_fetch_values_predicate(template_processor=tp))
+
+        with self.database.get_sqla_engine_with_context() as engine:
             sql = qry.compile(engine, compile_kwargs={"literal_binds": True})
             sql = self._apply_cte(sql, cte)
             sql = self.mutate_query_from_config(sql)
+
             df = pd.read_sql_query(sql=sql, con=engine)
-            return df[column_name].to_list()
+            return df[denomalized_col_name].to_list()
 
     def get_timestamp_expression(
         self,

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -789,7 +789,10 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
         raise NotImplementedError()
 
     def get_fetch_values_predicate(
-        self, template_processor: Optional[BaseTemplateProcessor] = None
+        self,
+        template_processor: Optional[
+            BaseTemplateProcessor
+        ] = None,  # pylint: disable=unused-argument
     ) -> TextClause:
         return self.fetch_values_predicate
 
@@ -1416,7 +1419,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
 
     def get_sqla_query(  # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements
         self,
-        apply_fetch_values_predicate: bool = False,
+        apply_fetch_values_predicate: bool = False,  # pylint: disable=unused-argument
         columns: Optional[list[Column]] = None,
         extras: Optional[dict[str, Any]] = None,
         filter: Optional[  # pylint: disable=redefined-builtin

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -708,10 +708,6 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
     fetch_values_predicate = None
 
     @property
-    def fetch_value_predicate(self) -> Optional[str]:
-        return None
-
-    @property
     def type(self) -> str:
         raise NotImplementedError()
 
@@ -786,16 +782,16 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
     def columns(self) -> list[Any]:
         raise NotImplementedError()
 
-    def get_fetch_values_predicate(
-        self, template_processor: Optional[BaseTemplateProcessor] = None
-    ) -> TextClause:
-        raise NotImplementedError()
-
     def get_extra_cache_keys(self, query_obj: dict[str, Any]) -> list[Hashable]:
         raise NotImplementedError()
 
     def get_template_processor(self, **kwargs: Any) -> BaseTemplateProcessor:
         raise NotImplementedError()
+
+    def get_fetch_values_predicate(
+        self, template_processor: Optional[BaseTemplateProcessor] = None
+    ) -> TextClause:
+        return self.fetch_values_predicate
 
     def get_sqla_row_level_filters(
         self,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
currently with some databases/engines the `/<datasource_type>/<int:datasource_id>/column/<column_name>/values/` endpoint values due to malformatted queries. One of the edge cases has to do with column names not being denormalized. To fix this we'll denormalize the column name before querying for values

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
