### PR TITLE
feat: global context for logging

### DIFF
--- a/superset/reports/notifications/base.py
+++ b/superset/reports/notifications/base.py
@@ -20,13 +20,11 @@ from typing import Any, Optional
 import pandas as pd
 
 from superset.reports.models import ReportRecipients, ReportRecipientType
-from superset.utils.core import HeaderDataType
 
 
 @dataclass
 class NotificationContent:
     name: str
-    header_data: HeaderDataType  # this is optional to account for error states
     csv: Optional[bytes] = None  # bytes for csv file
     screenshots: Optional[list[bytes]] = None  # bytes for a list of screenshots
     text: Optional[str] = None

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -30,7 +30,7 @@ from superset.exceptions import SupersetErrorsException
 from superset.reports.models import ReportRecipientType
 from superset.reports.notifications.base import BaseNotification
 from superset.reports.notifications.exceptions import NotificationError
-from superset.utils.core import HeaderDataType, send_email_smtp
+from superset.reports.notifications.utils import send_email_smtp
 from superset.utils.decorators import statsd_gauge
 
 logger = logging.getLogger(__name__)
@@ -68,7 +68,6 @@ ALLOWED_ATTRIBUTES = {
 @dataclass
 class EmailContent:
     body: str
-    header_data: Optional[HeaderDataType] = None
     data: Optional[dict[str, Any]] = None
     images: Optional[dict[str, bytes]] = None
 
@@ -173,7 +172,6 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
             body=body,
             images=images,
             data=csv_data,
-            header_data=self._content.header_data,
         )
 
     def _get_subject(self) -> str:
@@ -204,13 +202,13 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
                 bcc="",
                 mime_subtype="related",
                 dryrun=False,
-                header_data=content.header_data,
             )
             logger.info(
-                "Report sent to email, notification content is %s",
-                content.header_data,
+                "Report sent to email",
                 extra={
                     "execution_id": global_context.get("execution_id"),
+                    "dashboard_id": global_context.get("dashboard_id"),
+                    "chart_id": global_context.get("chart_id"),
                 },
             )
         except SupersetErrorsException as ex:

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -22,6 +22,7 @@ from email.utils import make_msgid, parseaddr
 from typing import Any, Optional
 
 import nh3
+from flask import g
 from flask_babel import gettext as __
 
 from superset import app
@@ -190,6 +191,7 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
         subject = self._get_subject()
         content = self._get_content()
         to = self._get_to()
+        global_context = getattr(g, "context", {}) or {}
         try:
             send_email_smtp(
                 to,
@@ -205,7 +207,11 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
                 header_data=content.header_data,
             )
             logger.info(
-                "Report sent to email, notification content is %s", content.header_data
+                "Report sent to email, notification content is %s",
+                content.header_data,
+                extra={
+                    "execution_id": global_context.get("execution_id"),
+                },
             )
         except SupersetErrorsException as ex:
             raise NotificationError(

--- a/superset/reports/notifications/slack.py
+++ b/superset/reports/notifications/slack.py
@@ -22,6 +22,7 @@ from typing import Union
 
 import backoff
 import pandas as pd
+from flask import g
 from flask_babel import gettext as __
 from slack_sdk import WebClient
 from slack_sdk.errors import (
@@ -166,6 +167,8 @@ Error: %(text)s
         channel = self._get_channel()
         body = self._get_body()
         file_type = "csv" if self._content.csv else "png"
+        global_context = getattr(g, "context", {}) or {}
+
         try:
             token = app.config["SLACK_API_TOKEN"]
             if callable(token):
@@ -183,7 +186,12 @@ Error: %(text)s
                     )
             else:
                 client.chat_postMessage(channel=channel, text=body)
-            logger.info("Report sent to slack")
+            logger.info(
+                "Report sent to slack",
+                extra={
+                    "execution_id": global_context.get("execution_id"),
+                },
+            )
         except (
             BotUserAccessError,
             SlackRequestError,

--- a/superset/reports/notifications/utils.py
+++ b/superset/reports/notifications/utils.py
@@ -1,0 +1,200 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+import logging
+import os
+import re
+import smtplib
+import ssl
+from email.mime.application import MIMEApplication
+from email.mime.image import MIMEImage
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from email.utils import formatdate
+from typing import Any, Optional
+
+from flask import g
+
+from superset import db
+from superset.reports.models import ReportSchedule, ReportSourceFormat
+from superset.reports.types import HeaderDataType
+
+logger = logging.getLogger(__name__)
+
+
+def get_email_address_list(address_string: str) -> list[str]:
+    address_string_list: list[str] = []
+    if isinstance(address_string, str):
+        address_string_list = re.split(r",|\s|;", address_string)
+    return [x.strip() for x in address_string_list if x.strip()]
+
+
+def _get_log_data() -> HeaderDataType:
+    global_context = getattr(g, "context", {}) or {}
+    chart_id = global_context.get("chart_id")
+    dashboard_id = global_context.get("dashboard_id")
+    report_schedule_id = global_context.get("report_schedule_id")
+    report_source: str = ""
+    report_format: str = ""
+    report_type: str = ""
+    owners: list[int] = []
+
+    # intentionally creating a new session to
+    # keep the logging session separate from the
+    # main session
+    session = db.create_scoped_session()
+    report_schedule = (
+        session.query(ReportSchedule).filter_by(id=report_schedule_id).one_or_none()
+    )
+    session.close()
+
+    if report_schedule is not None:
+        report_type = report_schedule.type
+        report_format = report_schedule.report_format
+        owners = report_schedule.owners
+        report_source = (
+            ReportSourceFormat.DASHBOARD
+            if report_schedule.dashboard_id
+            else ReportSourceFormat.CHART
+        )
+
+    log_data: HeaderDataType = {
+        "notification_type": report_type,
+        "notification_source": report_source,
+        "notification_format": report_format,
+        "chart_id": chart_id,
+        "dashboard_id": dashboard_id,
+        "owners": owners,
+    }
+    return log_data
+
+
+def send_email_smtp(
+    to: str,
+    subject: str,
+    html_content: str,
+    config: dict[str, Any],
+    files: Optional[list[str]] = None,
+    data: Optional[dict[str, str]] = None,
+    images: Optional[dict[str, bytes]] = None,
+    dryrun: bool = False,
+    cc: Optional[str] = None,
+    bcc: Optional[str] = None,
+    mime_subtype: str = "mixed",
+) -> None:
+    """
+    Send an email with html content, eg:
+    send_email_smtp(
+        'test@example.com', 'foo', '<b>Foo</b> bar',['/dev/null'], dryrun=True)
+    """
+    smtp_mail_from = config["SMTP_MAIL_FROM"]
+    smtp_mail_to = get_email_address_list(to)
+
+    msg = MIMEMultipart(mime_subtype)
+    msg["Subject"] = subject
+    msg["From"] = smtp_mail_from
+    msg["To"] = ", ".join(smtp_mail_to)
+
+    msg.preamble = "This is a multi-part message in MIME format."
+
+    recipients = smtp_mail_to
+    if cc:
+        smtp_mail_cc = get_email_address_list(cc)
+        msg["CC"] = ", ".join(smtp_mail_cc)
+        recipients = recipients + smtp_mail_cc
+
+    if bcc:
+        # don't add bcc in header
+        smtp_mail_bcc = get_email_address_list(bcc)
+        recipients = recipients + smtp_mail_bcc
+
+    msg["Date"] = formatdate(localtime=True)
+    mime_text = MIMEText(html_content, "html")
+    msg.attach(mime_text)
+
+    # Attach files by reading them from disk
+    for fname in files or []:
+        basename = os.path.basename(fname)
+        with open(fname, "rb") as f:
+            msg.attach(
+                MIMEApplication(
+                    f.read(),
+                    Content_Disposition=f"attachment; filename='{basename}'",
+                    Name=basename,
+                )
+            )
+
+    # Attach any files passed directly
+    for name, body in (data or {}).items():
+        msg.attach(
+            MIMEApplication(
+                body, Content_Disposition=f"attachment; filename='{name}'", Name=name
+            )
+        )
+
+    # Attach any inline images, which may be required for display in
+    # HTML content (inline)
+    for msgid, imgdata in (images or {}).items():
+        formatted_time = formatdate(localtime=True)
+        file_name = f"{subject} {formatted_time}"
+        image = MIMEImage(imgdata, name=file_name)
+        image.add_header("Content-ID", f"<{msgid}>")
+        image.add_header("Content-Disposition", "inline")
+        msg.attach(image)
+    msg_mutator = config["EMAIL_HEADER_MUTATOR"]
+    # the base notification returns the message without any editing.
+    header_data = _get_log_data()
+    new_msg = msg_mutator(msg, **(header_data or {}))
+    send_mime_email(smtp_mail_from, recipients, new_msg, config, dryrun=dryrun)
+
+
+def send_mime_email(
+    e_from: str,
+    e_to: list[str],
+    mime_msg: MIMEMultipart,
+    config: dict[str, Any],
+    dryrun: bool = False,
+) -> None:
+    smtp_host = config["SMTP_HOST"]
+    smtp_port = config["SMTP_PORT"]
+    smtp_user = config["SMTP_USER"]
+    smtp_password = config["SMTP_PASSWORD"]
+    smtp_starttls = config["SMTP_STARTTLS"]
+    smtp_ssl = config["SMTP_SSL"]
+    smtp_ssl_server_auth = config["SMTP_SSL_SERVER_AUTH"]
+
+    if dryrun:
+        logger.info("Dryrun enabled, email notification content is below:")
+        logger.info(mime_msg.as_string())
+        return
+
+    # Default ssl context is SERVER_AUTH using the default system
+    # root CA certificates
+    ssl_context = ssl.create_default_context() if smtp_ssl_server_auth else None
+    smtp = (
+        smtplib.SMTP_SSL(smtp_host, smtp_port, context=ssl_context)
+        if smtp_ssl
+        else smtplib.SMTP(smtp_host, smtp_port)
+    )
+    if smtp_starttls:
+        smtp.starttls(context=ssl_context)
+    if smtp_user and smtp_password:
+        smtp.login(smtp_user, smtp_password)
+    logger.debug("Sent an email to %s", str(e_to))
+    smtp.sendmail(e_from, e_to, mime_msg.as_string())
+    smtp.quit()

--- a/superset/utils/decorators.py
+++ b/superset/utils/decorators.py
@@ -114,11 +114,7 @@ def on_security_exception(self: Any, ex: Exception) -> Response:
     return self.response(403, **{"message": utils.error_msg_from_exception(ex)})
 
 
-def context(
-    slice_id: int | None = None,
-    dashboard_id: int | None = None,
-    execution_id: str | UUID | None = None,
-) -> Callable[..., Any]:
+def context(**ctx_kwargs: int | str | UUID | None) -> Callable[..., Any]:
     """
     Takes arguments and adds them to the global context.
     This is for logging purposes only and values should not be relied on or mutated
@@ -128,7 +124,12 @@ def context(
         def wrapped(*args: Any, **kwargs: Any) -> Any:
             if not hasattr(g, "context"):
                 g.context = {}
-            available_context_values = ["slice_id", "dashboard_id", "execution_id"]
+            available_context_values = [
+                "slice_id",
+                "dashboard_id",
+                "execution_id",
+                "report_schedule_id",
+            ]
             context_data = {
                 key: val
                 for key, val in kwargs.items()
@@ -138,7 +139,7 @@ def context(
             # if values are passed in to decorator directly, add them to context
             # by overriding values from kwargs
             for val in available_context_values:
-                if locals().get(val) is not None:
+                if ctx_kwargs.get(val) is not None:
                     context_data[val] = locals()[val]
 
             g.context.update(context_data)

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -23,7 +23,7 @@ from enum import Enum
 from time import sleep
 from typing import Any, TYPE_CHECKING
 
-from flask import current_app
+from flask import current_app, g
 from selenium.common.exceptions import (
     StaleElementReferenceException,
     TimeoutException,
@@ -227,6 +227,9 @@ class WebDriverPlaywright(WebDriverProxy):
                     "Taking a PNG screenshot of url %s as user %s",
                     url,
                     user.username,
+                    extra={
+                        "execution_id": getattr(g, "context", {}).get("execution_id"),
+                    },
                 )
                 if current_app.config["SCREENSHOT_REPLACE_UNEXPECTED_ERRORS"]:
                     unexpected_errors = WebDriverPlaywright.find_unexpected_errors(page)

--- a/tests/integration_tests/email_tests.py
+++ b/tests/integration_tests/email_tests.py
@@ -25,7 +25,7 @@ from email.mime.multipart import MIMEMultipart
 from unittest import mock
 
 from superset import app
-from superset.utils import core as utils
+from superset.reports.notifications import utils
 from tests.integration_tests.base_tests import SupersetTestCase
 
 from .utils import read_fixture

--- a/tests/integration_tests/utils_tests.py
+++ b/tests/integration_tests/utils_tests.py
@@ -45,17 +45,17 @@ from superset.models.core import Database, Log
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.utils.core import (
+    DTTM_ALIAS,
+    DateColumn,
+    GenericDataType,
+    as_list,
     base_json_conv,
     cast_to_num,
     convert_legacy_filters_into_adhoc,
     create_ssl_cert_file,
-    DTTM_ALIAS,
     extract_dataframe_dtypes,
     format_timedelta,
-    GenericDataType,
     get_form_data_token,
-    as_list,
-    get_email_address_list,
     get_stacktrace,
     json_int_dttm_ser,
     json_iso_dttm_ser,
@@ -63,14 +63,14 @@ from superset.utils.core import (
     merge_extra_form_data,
     merge_request_params,
     normalize_dttm_col,
-    parse_ssl_cert,
     parse_js_uri_path_item,
+    parse_ssl_cert,
     split,
     validate_json,
     zlib_compress,
     zlib_decompress,
-    DateColumn,
 )
+
 from superset.utils.database import get_or_create_db
 from superset.utils import schema
 from superset.utils.hashing import md5_sha_from_str
@@ -892,16 +892,6 @@ class TestUtils(SupersetTestCase):
         expected_filename = md5_sha_from_str(ssl_certificate)
         self.assertIn(expected_filename, path)
         self.assertTrue(os.path.exists(path))
-
-    def test_get_email_address_list(self):
-        self.assertEqual(get_email_address_list("a@a"), ["a@a"])
-        self.assertEqual(get_email_address_list(" a@a "), ["a@a"])
-        self.assertEqual(get_email_address_list("a@a\n"), ["a@a"])
-        self.assertEqual(get_email_address_list(",a@a;"), ["a@a"])
-        self.assertEqual(
-            get_email_address_list(",a@a; b@b c@c a-c@c; d@d, f@f"),
-            ["a@a", "b@b", "c@c", "a-c@c", "d@d", "f@f"],
-        )
 
     def test_get_form_data_default(self) -> None:
         with app.test_request_context():

--- a/tests/unit_tests/notifications/email_tests.py
+++ b/tests/unit_tests/notifications/email_tests.py
@@ -38,14 +38,6 @@ def test_render_description_with_html() -> None:
             }
         ),
         description='<p>This is <a href="#">a test</a> alert</p><br />',
-        header_data={
-            "notification_format": "PNG",
-            "notification_type": "Alert",
-            "owners": [1],
-            "notification_source": None,
-            "chart_id": None,
-            "dashboard_id": None,
-        },
     )
     email_body = (
         EmailNotification(
@@ -85,14 +77,6 @@ def test_send_email(
             }
         ),
         description='<p>This is <a href="#">a test</a> alert</p><br />',
-        header_data={
-            "notification_format": "PNG",
-            "notification_type": "Alert",
-            "owners": [1],
-            "notification_source": None,
-            "chart_id": None,
-            "dashboard_id": None,
-        },
     )
     EmailNotification(
         recipient=ReportRecipients(
@@ -103,16 +87,12 @@ def test_send_email(
     ).send()
 
     logger_mock.info.assert_called_with(
-        "Report sent to email, notification content is %s",
-        {
-            "notification_format": "PNG",
-            "notification_type": "Alert",
-            "owners": [1],
-            "notification_source": None,
+        "Report sent to email",
+        extra={
+            "execution_id": execution_id,
             "chart_id": None,
             "dashboard_id": None,
         },
-        extra={"execution_id": execution_id},
     )
     # clear logger_mock and g.context
     logger_mock.reset_mock()
@@ -127,14 +107,10 @@ def test_send_email(
         content=content,
     ).send()
     logger_mock.info.assert_called_with(
-        "Report sent to email, notification content is %s",
-        {
-            "notification_format": "PNG",
-            "notification_type": "Alert",
-            "owners": [1],
-            "notification_source": None,
+        "Report sent to email",
+        extra={
+            "execution_id": None,
             "chart_id": None,
             "dashboard_id": None,
         },
-        extra={"execution_id": None},
     )

--- a/tests/unit_tests/notifications/slack_tests.py
+++ b/tests/unit_tests/notifications/slack_tests.py
@@ -43,14 +43,6 @@ def test_send_slack(
             }
         ),
         description='<p>This is <a href="#">a test</a> alert</p><br />',
-        header_data={
-            "notification_format": "PNG",
-            "notification_type": "Alert",
-            "owners": [1],
-            "notification_source": None,
-            "chart_id": None,
-            "dashboard_id": None,
-        },
     )
     with patch.object(
         WebClient, "chat_postMessage", return_value=True

--- a/tests/unit_tests/notifications/slack_tests.py
+++ b/tests/unit_tests/notifications/slack_tests.py
@@ -1,0 +1,87 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+from flask import g
+
+
+@patch("superset.reports.notifications.slack.logger")
+def test_send_slack(
+    logger_mock: MagicMock,
+) -> None:
+    # `superset.models.helpers`, a dependency of following imports,
+    # requires app context
+    from superset.reports.models import ReportRecipients, ReportRecipientType
+    from superset.reports.notifications.base import NotificationContent
+    from superset.reports.notifications.slack import SlackNotification, WebClient
+
+    execution_id = uuid.uuid4()
+    g.context = {"execution_id": execution_id}
+    content = NotificationContent(
+        name="test alert",
+        embedded_data=pd.DataFrame(
+            {
+                "A": [1, 2, 3],
+                "B": [4, 5, 6],
+                "C": ["111", "222", '<a href="http://www.example.com">333</a>'],
+            }
+        ),
+        description='<p>This is <a href="#">a test</a> alert</p><br />',
+        header_data={
+            "notification_format": "PNG",
+            "notification_type": "Alert",
+            "owners": [1],
+            "notification_source": None,
+            "chart_id": None,
+            "dashboard_id": None,
+        },
+    )
+    with patch.object(
+        WebClient, "chat_postMessage", return_value=True
+    ) as chat_post_message_mock:
+        SlackNotification(
+            recipient=ReportRecipients(
+                type=ReportRecipientType.SLACK,
+                recipient_config_json='{"target": "some_channel"}',
+            ),
+            content=content,
+        ).send()
+        logger_mock.info.assert_called_with(
+            "Report sent to slack", extra={"execution_id": execution_id}
+        )
+        chat_post_message_mock.assert_called_with(
+            channel="some_channel",
+            text="""*test alert*
+
+<p>This is <a href="#">a test</a> alert</p><br />
+
+<None|Explore in Superset>
+
+```
+|    |   A |   B | C                                        |
+|---:|----:|----:|:-----------------------------------------|
+|  0 |   1 |   4 | 111                                      |
+|  1 |   2 |   5 | 222                                      |
+|  2 |   3 |   6 | <a href="http://www.example.com">333</a> |
+```
+""",
+        )
+
+    # reset g.context
+    g.context = None

--- a/tests/unit_tests/notifications/utils_tests.py
+++ b/tests/unit_tests/notifications/utils_tests.py
@@ -14,19 +14,20 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Optional, TypedDict
 
-from superset.dashboards.permalink.types import DashboardPermalinkState
-
-
-class ReportScheduleExtra(TypedDict):
-    dashboard: DashboardPermalinkState
+from superset.reports.notifications.utils import get_email_address_list
 
 
-class HeaderDataType(TypedDict):
-    notification_format: str
-    owners: list[int]
-    notification_type: str
-    notification_source: Optional[str]
-    chart_id: Optional[int]
-    dashboard_id: Optional[int]
+def test_get_email_address_list():
+    assert get_email_address_list("a@a") == ["a@a"]
+    assert get_email_address_list(" a@a ") == ["a@a"]
+    assert get_email_address_list("a@a\n") == ["a@a"]
+    assert get_email_address_list(",a@a;") == ["a@a"]
+    assert get_email_address_list(",a@a; b@b c@c a-c@c; d@d, f@f") == [
+        "a@a",
+        "b@b",
+        "c@c",
+        "a-c@c",
+        "d@d",
+        "f@f",
+    ]

--- a/tests/unit_tests/utils/test_decorators.py
+++ b/tests/unit_tests/utils/test_decorators.py
@@ -89,7 +89,6 @@ def test_statsd_gauge(
             mock.assert_called_once_with(expected_result, 1)
 
 
-# write a TDD test for a decorator that will log context to a global scope. It will write dashboard_id, slice_id, and execution_id to a global scope.
 def test_context_decorator() -> None:
     @decorators.context()
     def myfunc(*args, **kwargs) -> str:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
We have a few examples in the codebase where for logging purposes we need to pass data down to parts of the codebase that have no need to know about this data. It creates very coupled and bloated modules that often are just passing data down without even acting on it. This change proposes the use of a global context dictionary that is used for read-only purposes for logging. 

There are three places where we can use this functionality. One is an [open PR](https://github.com/apache/superset/pull/23114) that I wrote that helps us to log a report execution id to tie together multiple logs to the same report execution. 
Another example is [passing report header data](https://github.com/apache/superset/pull/20903) to an smtp event for logging in a mail server.
And the third use case is to pass [dashboard_id and chart_id](https://github.com/apache/superset/pull/25192) into the sql mutator for logging. 

I have rewritten the first two examples each in one commit in this PR for diffing the implementations for each with a global context. I'll add how the third example (sql mutator) either in this PR or in a subsequent one. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
