### PR TITLE
feat(metadb): handle decimals

### DIFF
--- a/superset/extensions/metadb.py
+++ b/superset/extensions/metadb.py
@@ -38,6 +38,7 @@ joins and unions are done in memory, using the SQLite engine.
 from __future__ import annotations
 
 import datetime
+import decimal
 import operator
 import urllib.parse
 from collections.abc import Iterator
@@ -86,7 +87,7 @@ class SupersetAPSWDialect(APSWDialect):
 
     Queries can also join data across different Superset databases.
 
-    The dialect is built in top of the shillelagh library, leveraging SQLite to
+    The dialect is built in top of the Shillelagh library, leveraging SQLite to
     create virtual tables on-the-fly proxying Superset tables. The
     `SupersetShillelaghAdapter` adapter is responsible for returning data when a
     Superset table is accessed.
@@ -164,11 +165,20 @@ class Duration(Field[datetime.timedelta, datetime.timedelta]):
     db_api_type = "DATETIME"
 
 
+class Decimal(Field[decimal.Decimal, decimal.Decimal]):
+    """
+    Shillelagh field used for representing decimals.
+    """
+
+    type = "DECIMAL"
+    db_api_type = "NUMBER"
+
+
 # pylint: disable=too-many-instance-attributes
 class SupersetShillelaghAdapter(Adapter):
 
     """
-    A shillelagh adapter for Superset tables.
+    A Shillelagh adapter for Superset tables.
 
     Shillelagh adapters are responsible for fetching data from a given resource,
     allowing it to be represented as a virtual table in SQLite. This one works
@@ -190,6 +200,7 @@ class SupersetShillelaghAdapter(Adapter):
         datetime.datetime: DateTime,
         datetime.time: Time,
         datetime.timedelta: Duration,
+        decimal.Decimal: Decimal,
     }
 
     @staticmethod


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add support for decimals to the meta database.

Note: this requires updating Shillelagh to 1.2.10, since it needs to convert between decimals and string for SQLite.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
