### PR TITLE
chore: Remove redundant validation functions

### DIFF
--- a/superset/annotation_layers/annotations/schemas.py
+++ b/superset/annotation_layers/annotations/schemas.py
@@ -14,13 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Union
 
-from marshmallow import fields, Schema, ValidationError
+from marshmallow import fields, Schema
 from marshmallow.validate import Length
 
-from superset.exceptions import SupersetException
-from superset.utils import core as utils
+from superset.utils.schema import validate_json
 
 openapi_spec_methods_override = {
     "get": {"get": {"summary": "Get an annotation layer"}},
@@ -47,13 +45,6 @@ annotation_layer = "The annotation layer id"
 annotation_short_descr = "A short description"
 annotation_long_descr = "A long description"
 annotation_json_metadata = "JSON metadata"
-
-
-def validate_json(value: Union[bytes, bytearray, str]) -> None:
-    try:
-        utils.validate_json(value)
-    except SupersetException as ex:
-        raise ValidationError("JSON not valid") from ex
 
 
 class AnnotationPostSchema(Schema):

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -21,9 +21,8 @@ from typing import Any, Union
 from marshmallow import fields, post_load, pre_load, Schema
 from marshmallow.validate import Length, ValidationError
 
-from superset.exceptions import SupersetException
 from superset.tags.models import TagTypes
-from superset.utils import core as utils
+from superset.utils.schema import validate_json
 
 get_delete_ids_schema = {"type": "array", "items": {"type": "integer"}}
 get_export_ids_schema = {"type": "array", "items": {"type": "integer"}}
@@ -83,13 +82,6 @@ openapi_spec_methods_override = {
         "get": {"description": "Get a list of all possible owners for a dashboard."}
     },
 }
-
-
-def validate_json(value: Union[bytes, bytearray, str]) -> None:
-    try:
-        utils.validate_json(value)
-    except SupersetException as ex:
-        raise ValidationError("JSON not valid") from ex
 
 
 def validate_json_metadata(value: Union[bytes, bytearray, str]) -> None:

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -42,14 +42,13 @@ from flask_appbuilder.forms import DynamicForm
 from flask_appbuilder.models.sqla.filters import BaseFilter
 from flask_appbuilder.security.sqla.models import User
 from flask_appbuilder.widgets import ListWidget
-from flask_babel import get_locale, gettext as __, lazy_gettext as _
+from flask_babel import get_locale, gettext as __
 from flask_jwt_extended.exceptions import NoAuthorizationError
 from flask_wtf.csrf import CSRFError
 from flask_wtf.form import FlaskForm
 from sqlalchemy import exc
 from sqlalchemy.orm import Query
 from werkzeug.exceptions import HTTPException
-from wtforms import Form
 from wtforms.fields.core import Field, UnboundField
 
 from superset import (
@@ -577,16 +576,6 @@ class ListWidgetWithCheckboxes(ListWidget):  # pylint: disable=too-few-public-me
     Works in conjunction with the `checkbox` view."""
 
     template = "superset/fab_overrides/list_with_checkboxes.html"
-
-
-def validate_json(form: Form, field: Field) -> None:  # pylint: disable=unused-argument
-    try:
-        json.loads(field.data)
-    except Exception as ex:
-        logger.exception(ex)
-        raise Exception(  # pylint: disable=broad-exception-raised
-            _("json isn't valid")
-        ) from ex
 
 
 class YamlExportMixin:  # pylint: disable=too-few-public-methods


### PR DESCRIPTION

### SUMMARY
This PR removes redundant `validate_json` functions and replaces usage with already existing `superset.utils.schema`.


### TESTING INSTRUCTIONS
- local unit / integration tests + GitHub CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
