### PR TITLE
chore: removing unused chartMetadata field

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/chart/models/ChartMetadata.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/models/ChartMetadata.ts
@@ -36,7 +36,6 @@ export interface ChartMetadataConfig {
   description?: string;
   datasourceCount?: number;
   enableNoResults?: boolean;
-  show?: boolean;
   supportedAnnotationTypes?: string[];
   thumbnail: string;
   useLegacyApi?: boolean;
@@ -63,8 +62,6 @@ export default class ChartMetadata {
   credits: string[];
 
   description: string;
-
-  show: boolean;
 
   supportedAnnotationTypes: string[];
 
@@ -100,7 +97,6 @@ export default class ChartMetadata {
       canBeAnnotationTypes = [],
       credits = [],
       description = '',
-      show = true,
       supportedAnnotationTypes = [],
       thumbnail,
       useLegacyApi = false,
@@ -120,7 +116,6 @@ export default class ChartMetadata {
     this.name = name;
     this.credits = credits;
     this.description = description;
-    this.show = show;
     this.canBeAnnotationTypes = canBeAnnotationTypes;
     this.canBeAnnotationTypesLookup = canBeAnnotationTypes.reduce(
       (prev: LookupTable, type: string) => {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In auditing plugin framework code, it seems the `chartMetadata` field `show` is not being used anywhere. Let's trim the fat!

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
