### PR TITLE
fix(sqllab): Allow router navigation to explore

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -67,6 +67,7 @@ import ExploreCtasResultsButton from '../ExploreCtasResultsButton';
 import ExploreResultsButton from '../ExploreResultsButton';
 import HighlightedSql from '../HighlightedSql';
 import QueryStateLabel from '../QueryStateLabel';
+import { useHistory } from 'react-router-dom';
 
 enum LIMITING_FACTOR {
   QUERY = 'QUERY',
@@ -161,6 +162,7 @@ const ResultSet = ({
   const [showSaveDatasetModal, setShowSaveDatasetModal] = useState(false);
   const [alertIsOpen, setAlertIsOpen] = useState(false);
 
+  const history = useHistory();
   const dispatch = useDispatch();
 
   const reRunQueryIfSessionTimeoutErrorOnMount = useCallback(() => {
@@ -215,8 +217,10 @@ const ResultSet = ({
     setSearchText(event.target.value);
   };
 
-  const createExploreResultsOnClick = async () => {
+  const createExploreResultsOnClick = async (clickEvent: React.MouseEvent) => {
     const { results } = query;
+
+    const openInNewWindow = clickEvent.metaKey;
 
     if (results?.query_id) {
       const key = await postFormData(results.query_id, 'query', {
@@ -229,7 +233,11 @@ const ResultSet = ({
       const url = mountExploreUrl(null, {
         [URL_PARAMS.formDataKey.name]: key,
       });
-      window.open(url, '_blank', 'noreferrer');
+      if (openInNewWindow) {
+        window.open(url, '_blank', 'noreferrer');
+      } else {
+        history.push(url);
+      }
     } else {
       addDangerToast(t('Unable to create chart without a query id.'));
     }

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -18,6 +18,7 @@
  */
 import React, { useCallback, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 import ButtonGroup from 'src/components/ButtonGroup';
 import Alert from 'src/components/Alert';
 import Button from 'src/components/Button';
@@ -67,7 +68,6 @@ import ExploreCtasResultsButton from '../ExploreCtasResultsButton';
 import ExploreResultsButton from '../ExploreResultsButton';
 import HighlightedSql from '../HighlightedSql';
 import QueryStateLabel from '../QueryStateLabel';
-import { useHistory } from 'react-router-dom';
 
 enum LIMITING_FACTOR {
   QUERY = 'QUERY',


### PR DESCRIPTION
### SUMMARY
Follow up https://github.com/apache/superset/pull/25151, this commit updates the "Create Chart" action in SQL Lab result panel by router navigation. It also keeps the option to open in new window forcefully (/w window/cmd key click).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://github.com/apache/superset/assets/1392866/0db08d1e-28f9-4185-8548-25474ded6a2d

After:

https://github.com/apache/superset/assets/1392866/3462bfc4-9a2a-489b-a450-bd29207cd333

### TESTING INSTRUCTIONS
Run a query in SQL Lab and then click "Create Chart"

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
