### PR TITLE
fix: update flask-caching to avoid breaking redis cache, solves #25339

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,7 +31,7 @@ bottleneck==1.3.7
     # via pandas
 brotli==1.0.9
     # via flask-compress
-cachelib==0.6.0
+cachelib==0.9.0
     # via
     #   flask-caching
     #   flask-session
@@ -103,7 +103,7 @@ flask-appbuilder==4.3.9
     # via apache-superset
 flask-babel==1.0.0
     # via flask-appbuilder
-flask-caching==1.11.1
+flask-caching==2.1.0
     # via apache-superset
 flask-compress==1.13
     # via apache-superset

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
         "deprecation>=2.1.0, <2.2.0",
         "flask>=2.2.5, <3.0.0",
         "flask-appbuilder>=4.3.9, <5.0.0",
-        "flask-caching>=1.11.1, <2.0",
+        "flask-caching>=2.0, <3",
         "flask-compress>=1.13, <2.0",
         "flask-talisman>=1.0.0, <2.0",
         "flask-login>=0.6.0, < 1.0",

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
         "deprecation>=2.1.0, <2.2.0",
         "flask>=2.2.5, <3.0.0",
         "flask-appbuilder>=4.3.9, <5.0.0",
-        "flask-caching>=2.0, <3",
+        "flask-caching>=2.1.0, <3",
         "flask-compress>=1.13, <2.0",
         "flask-talisman>=1.0.0, <2.0",
         "flask-login>=0.6.0, < 1.0",


### PR DESCRIPTION
### SUMMARY
If we have `flask-caching=~1.11.1` and `cachelib>=9` (`flask-caching` did not place the necessary constraints on the `cahcelib` dependency until 2.0, so it's very likely to happen...), we end up with this https://github.com/pallets-eco/flask-caching/issues/381
caused by this very line:
https://github.com/pallets-eco/flask-caching/blob/ac13e01baa11d65c68dcba64f99ccaafd9b5419c/src/flask_caching/backends/rediscache.py#L62

We can fix updating dependencies

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #25339

- [x] Has associated issue: closes #25339
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
