### PR TITLE
test: Reduce flaky integration tests triggered by `test_get_tag`

### DIFF
--- a/tests/integration_tests/tags/api_tests.py
+++ b/tests/integration_tests/tags/api_tests.py
@@ -131,7 +131,7 @@ class TestTagApi(SupersetTestCase):
         self.assertEqual(rv.status_code, 200)
         expected_result = {
             "changed_by": None,
-            "changed_on_delta_humanized": "now",
+            "changed_on_delta_humanized": ["now", "a second ago", "two seconds ago"],
             "created_by": None,
             "id": tag.id,
             "name": "test get tag",
@@ -139,6 +139,11 @@ class TestTagApi(SupersetTestCase):
         }
         data = json.loads(rv.data.decode("utf-8"))
         for key, value in expected_result.items():
+            if key == "changed_on_delta_humanized":
+                # 'changed_on_delta_humanized' sometimes fluctuates between 'now' and
+                # 'X second ago' which leads to flaky tests
+                self.assertIn(data["result"][key], value)
+                continue
             self.assertEqual(value, data["result"][key])
         # rollback changes
         db.session.delete(tag)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Local tests and GitHub CI runs sometimes fail because of
```bash
FAILED tests/integration_tests/tags/api_tests.py::TestTagApi::test_get_tag - AssertionError: 'now' != 'a second ago'
```

Examples from the last two weeks (note: the links will expire)
- https://github.com/apache/superset/actions/runs/6833128031/job/18584558641?pr=25948
- https://github.com/apache/superset/actions/runs/6818394597/job/18543861285
- https://github.com/apache/superset/actions/runs/6732039103/job/18297933474
- https://github.com/apache/superset/actions/runs/6722305797/job/18269963837
- https://github.com/apache/superset/actions/runs/6700573803/job/18206724898

The test now additionally checks for `a second ago` and `two seconds ago` as seen in the CI examples above.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
- `scripts/tests/run.sh --module tests/integration_tests/tags/api_tests.py::TestTagApi::test_get_tag`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
