### PR TITLE
fix(typings): model_id is a multiple option

### DIFF
--- a/superset/cli/thumbnails.py
+++ b/superset/cli/thumbnails.py
@@ -56,13 +56,13 @@ logger = logging.getLogger(__name__)
     default=False,
     help="Force refresh, even if previously cached",
 )
-@click.option("--model_id", "-i", "model_ids", multiple=True)
+@click.option("--model_id", "-i", multiple=True)
 def compute_thumbnails(
     asynchronous: bool,
     dashboards_only: bool,
     charts_only: bool,
     force: bool,
-    model_ids: list[int],
+    model_id: list[int],
 ) -> None:
     """Compute thumbnails"""
     # pylint: disable=import-outside-toplevel
@@ -97,7 +97,7 @@ def compute_thumbnails(
 
     if not charts_only:
         compute_generic_thumbnail(
-            "dashboard", Dashboard, model_ids, cache_dashboard_thumbnail
+            "dashboard", Dashboard, model_id, cache_dashboard_thumbnail
         )
     if not dashboards_only:
-        compute_generic_thumbnail("chart", Slice, model_ids, cache_chart_thumbnail)
+        compute_generic_thumbnail("chart", Slice, model_id, cache_chart_thumbnail)

--- a/superset/cli/thumbnails.py
+++ b/superset/cli/thumbnails.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
-from typing import Union
+from typing import List, Union
 
 import click
 from celery.utils.abstract import CallableTask
@@ -62,7 +62,7 @@ def compute_thumbnails(
     dashboards_only: bool,
     charts_only: bool,
     force: bool,
-    model_id: int,
+    model_id: List[int],
 ) -> None:
     """Compute thumbnails"""
     # pylint: disable=import-outside-toplevel
@@ -76,7 +76,7 @@ def compute_thumbnails(
     def compute_generic_thumbnail(
         friendly_type: str,
         model_cls: Union[type[Dashboard], type[Slice]],
-        model_id: int,
+        model_id: List[int],
         compute_func: CallableTask,
     ) -> None:
         query = db.session.query(model_cls)

--- a/superset/cli/thumbnails.py
+++ b/superset/cli/thumbnails.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
-from typing import List, Union
+from typing import Union
 
 import click
 from celery.utils.abstract import CallableTask
@@ -62,7 +62,7 @@ def compute_thumbnails(
     dashboards_only: bool,
     charts_only: bool,
     force: bool,
-    model_id: List[int],
+    model_id: list[int],
 ) -> None:
     """Compute thumbnails"""
     # pylint: disable=import-outside-toplevel
@@ -76,7 +76,7 @@ def compute_thumbnails(
     def compute_generic_thumbnail(
         friendly_type: str,
         model_cls: Union[type[Dashboard], type[Slice]],
-        model_id: List[int],
+        model_id: list[int],
         compute_func: CallableTask,
     ) -> None:
         query = db.session.query(model_cls)

--- a/superset/cli/thumbnails.py
+++ b/superset/cli/thumbnails.py
@@ -56,13 +56,13 @@ logger = logging.getLogger(__name__)
     default=False,
     help="Force refresh, even if previously cached",
 )
-@click.option("--model_id", "-i", multiple=True)
+@click.option("--model_id", "-i", "model_ids", multiple=True)
 def compute_thumbnails(
     asynchronous: bool,
     dashboards_only: bool,
     charts_only: bool,
     force: bool,
-    model_id: list[int],
+    model_ids: list[int],
 ) -> None:
     """Compute thumbnails"""
     # pylint: disable=import-outside-toplevel
@@ -76,12 +76,12 @@ def compute_thumbnails(
     def compute_generic_thumbnail(
         friendly_type: str,
         model_cls: Union[type[Dashboard], type[Slice]],
-        model_id: list[int],
+        model_ids: list[int],
         compute_func: CallableTask,
     ) -> None:
         query = db.session.query(model_cls)
-        if model_id:
-            query = query.filter(model_cls.id.in_(model_id))
+        if model_ids:
+            query = query.filter(model_cls.id.in_(model_ids))
         dashboards = query.all()
         count = len(dashboards)
         for i, model in enumerate(dashboards):
@@ -97,7 +97,7 @@ def compute_thumbnails(
 
     if not charts_only:
         compute_generic_thumbnail(
-            "dashboard", Dashboard, model_id, cache_dashboard_thumbnail
+            "dashboard", Dashboard, model_ids, cache_dashboard_thumbnail
         )
     if not dashboards_only:
-        compute_generic_thumbnail("chart", Slice, model_id, cache_chart_thumbnail)
+        compute_generic_thumbnail("chart", Slice, model_ids, cache_chart_thumbnail)


### PR DESCRIPTION
### SUMMARY
`superset compute-thumbnails` accepts multiple `--model_id` options. The `model_id` should be a `List[int]`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
