### PR TITLE
feat(alerts):  Adding custom Header and StyledPanel components for use in alerts&reports modal redesign

### DIFF
--- a/superset-frontend/src/features/alerts/components/StyledPanel.tsx
+++ b/superset-frontend/src/features/alerts/components/StyledPanel.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { css, SupersetTheme } from '@superset-ui/core';
+import { Collapse as AntdCollapse } from 'antd';
+import { CollapsePanelProps } from 'antd/lib/collapse';
+
+const anticonHeight = 12;
+const antdPanelStyles = (theme: SupersetTheme) => css`
+  .ant-collapse-header {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: flex-start;
+    padding: 0px ${theme.gridUnit * 4}px;
+
+    .anticon.anticon-right.ant-collapse-arrow {
+      padding: 0;
+      top: calc(50% - ${anticonHeight / 2}px);
+    }
+
+    .collapse-panel-title {
+      font-size: ${theme.gridUnit * 4}px;
+      font-weight: ${theme.typography.weights.bold};
+      line-height: 130%;
+    }
+
+    .collapse-panel-subtitle {
+      color: ${theme.colors.grayscale.base};
+      font-size: ${theme.typography.sizes.s}px;
+      font-weight: ${theme.typography.weights.normal};
+      line-height: 150%;
+      margin-bottom: 0;
+    }
+
+    .collapse-panel-asterisk {
+      color: var(--semantic-error-base, ${theme.colors.warning.dark1});
+    }
+    .validation-checkmark {
+      width: ${theme.gridUnit * 4}px;
+      height: ${theme.gridUnit * 4}px;
+      margin-left: ${theme.gridUnit}px;
+      color: ${theme.colors.success.base};
+    }
+  }
+`;
+
+export interface PanelProps extends CollapsePanelProps {
+  children?: React.ReactNode;
+}
+const StyledPanel = (props: PanelProps) => (
+  <AntdCollapse.Panel
+    css={(theme: SupersetTheme) => antdPanelStyles(theme)}
+    {...props}
+  />
+);
+
+export default StyledPanel;

--- a/superset-frontend/src/features/alerts/components/ValidatedPanelHeader.tsx
+++ b/superset-frontend/src/features/alerts/components/ValidatedPanelHeader.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { t } from '@superset-ui/core';
+import { CheckCircleOutlined } from '@ant-design/icons';
+
+const ValidatedPanelHeader = ({
+  title,
+  subtitle,
+  required,
+  validateCheckStatus,
+}: {
+  title: string;
+  subtitle: string;
+  required: boolean;
+  validateCheckStatus: boolean;
+}): JSX.Element => {
+  let asterisk;
+  if (required) {
+    asterisk = ' *';
+  }
+
+  let checkmark;
+  if (validateCheckStatus) {
+    checkmark = <CheckCircleOutlined />;
+  }
+
+  return (
+    <div className="collapse-panel-header">
+      <div className="collapse-panel-title">
+        <span>{t(title)}</span>
+        <span className="collapse-panel-asterisk">{asterisk}</span>
+        <span className="validation-checkmark">{checkmark}</span>
+      </div>
+      <p className="collapse-panel-subtitle">
+        {subtitle ? t(subtitle) : undefined}
+      </p>
+    </div>
+  );
+};
+
+export default ValidatedPanelHeader;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Context: This change is part of a broader design proposal https://github.com/apache/superset/discussions/25729 to change the Alerts & Reports modal requested by the Preset team. 

Added two components to the alerts frontend directory in preparation for future changes to the alerts&reports modal: 
(i) StyledPanel component which adds custom styling to the Antd Collapse.Panel component.
(ii) A ValidatedPanelHeader component which takes the following props {
  title: string;
  subtitle: string;
  required: boolean;
  validateCheckStatus: boolean;
};

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

#### BEFORE

![image](https://github.com/apache/superset/assets/41238731/ded096c9-8774-464d-830e-884429802b61)

#### AFTER

![image](https://github.com/apache/superset/assets/41238731/70a53379-f6c3-401c-b4fc-e2856a5ac464)
### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
