### PR TITLE
chore: exempt cache-warmup endpoint from CSRF protection

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -245,6 +245,7 @@ WTF_CSRF_ENABLED = True
 WTF_CSRF_EXEMPT_LIST = [
     "superset.views.core.log",
     "superset.views.core.explore_json",
+    "superset.charts.api.warm_up_cache",
     "superset.charts.data.api.data",
 ]
 


### PR DESCRIPTION
The default configuration for WTF_CSRF_ENABLED is 'True,' and this was causing the cache-warmup task to fail. 
The API request for the celery worker only includes session cookie.
Therefore, It should include superset.charts.api.warm_up_cache in the WTF_CSRF_EXEMPT_LIST.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TESTING INSTRUCTIONS
1. Configure the cache-warmup task.
2. The Celery task successfully executed the fetch_url action.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
