### PR TITLE
chore: Cleanup function for stripping comments from SQL statements

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -102,7 +102,7 @@ from superset.models.helpers import (
     QueryStringExtended,
     validate_adhoc_subquery,
 )
-from superset.sql_parse import ParsedQuery, sanitize_clause
+from superset.sql_parse import ParsedQuery, sanitize_clause, strip_comments_from_sql
 from superset.superset_typing import (
     AdhocColumn,
     AdhocMetric,
@@ -917,7 +917,7 @@ class SqlaTable(
                         msg=ex.message,
                     )
                 ) from ex
-        sql = sqlparse.format(sql.strip("\t\r\n; "), strip_comments=True)
+        sql = strip_comments_from_sql(sql)
         if not sql:
             raise QueryObjectValidationError(_("Virtual dataset query cannot be empty"))
         if len(sqlparse.split(sql)) > 1:

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -60,7 +60,7 @@ from superset import security_manager, sql_parse
 from superset.constants import TimeGrain as TimeGrainConstants
 from superset.databases.utils import make_url_safe
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
-from superset.sql_parse import ParsedQuery, Table
+from superset.sql_parse import ParsedQuery, strip_comments_from_sql, Table
 from superset.superset_typing import ResultSetColumnType, SQLAColumnType
 from superset.utils import core as utils
 from superset.utils.core import ColumnSpec, GenericDataType
@@ -917,7 +917,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         cte = None
         sql_remainder = None
         sql = sql.strip(" \t\n;")
-        sql_statement = sqlparse.format(sql, strip_comments=True)
+        sql_statement = strip_comments_from_sql(sql)
         query_limit: int | None = sql_parse.extract_top_from_query(
             sql_statement, cls.top_keywords
         )

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -24,7 +24,6 @@ from datetime import datetime
 from re import Pattern
 from typing import Any, TYPE_CHECKING
 
-import sqlparse
 from flask_babel import gettext as __
 from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION, ENUM, JSON
 from sqlalchemy.dialects.postgresql.base import PGInspector
@@ -37,6 +36,7 @@ from superset.db_engine_specs.base import BaseEngineSpec, BasicParametersMixin
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.exceptions import SupersetException, SupersetSecurityException
 from superset.models.sql_lab import Query
+from superset.sql_parse import strip_comments_from_sql
 from superset.utils import core as utils
 from superset.utils.core import GenericDataType
 
@@ -268,7 +268,7 @@ class PostgresEngineSpec(PostgresBaseEngineSpec, BasicParametersMixin):
         This method simply uses the parent method after checking that there are no
         malicious path setting in the query.
         """
-        sql = sqlparse.format(query.sql, strip_comments=True)
+        sql = strip_comments_from_sql(query.sql)
         if re.search(r"set\s+search_path\s*=", sql, re.IGNORECASE):
             raise SupersetSecurityException(
                 SupersetError(

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -73,6 +73,7 @@ from superset.sql_parse import (
     insert_rls_in_predicate,
     ParsedQuery,
     sanitize_clause,
+    strip_comments_from_sql,
 )
 from superset.superset_typing import (
     AdhocMetric,
@@ -1072,7 +1073,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                         msg=ex.message,
                     )
                 ) from ex
-        sql = sqlparse.format(sql.strip("\t\r\n; "), strip_comments=True)
+        sql = strip_comments_from_sql(sql)
         if not sql:
             raise QueryObjectValidationError(_("Virtual dataset query cannot be empty"))
         if len(sqlparse.split(sql)) > 1:

--- a/superset/sqllab/query_render.py
+++ b/superset/sqllab/query_render.py
@@ -25,7 +25,7 @@ from jinja2.meta import find_undeclared_variables
 
 from superset import is_feature_enabled
 from superset.errors import SupersetErrorType
-from superset.sql_parse import ParsedQuery
+from superset.sql_parse import strip_comments_from_sql
 from superset.sqllab.commands.execute import SqlQueryRender
 from superset.sqllab.exceptions import SqlLabException
 from superset.utils import core as utils
@@ -58,9 +58,9 @@ class SqlQueryRenderImpl(SqlQueryRender):
                 database=query_model.database, query=query_model
             )
 
-            parsed_query = ParsedQuery(query_model.sql, strip_comments=True)
             rendered_query = sql_template_processor.process_template(
-                parsed_query.stripped(), **execution_context.template_params
+                strip_comments_from_sql(query_model.sql),
+                **execution_context.template_params,
             )
             self._validate(execution_context, rendered_query, sql_template_processor)
             return rendered_query

--- a/tests/unit_tests/db_engine_specs/test_teradata.py
+++ b/tests/unit_tests/db_engine_specs/test_teradata.py
@@ -21,6 +21,7 @@ import pytest
 @pytest.mark.parametrize(
     "limit,original,expected",
     [
+        (100, "SELECT * FROM My_table", "SELECT TOP 100 * FROM My_table"),
         (100, "SEL TOP 1000 * FROM My_table", "SEL TOP 100 * FROM My_table"),
         (100, "SEL TOP 1000 * FROM My_table;", "SEL TOP 100 * FROM My_table"),
         (10000, "SEL TOP 1000 * FROM My_table;", "SEL TOP 1000 * FROM My_table"),

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -1192,14 +1192,35 @@ def test_messy_breakdown_statements() -> None:
         """
 SELECT 1;\t\n\n\n  \t
 \t\nSELECT 2;
-SELECT * FROM birth_names;;;
-SELECT * FROM birth_names LIMIT 1
+SELECT '--abc' FROM birth_names;;;
+SELECT * FROM birth_names LIMIT 1 --comment
 """
     )
     assert query.get_statements() == [
         "SELECT 1",
         "SELECT 2",
-        "SELECT * FROM birth_names",
+        "SELECT '--abc' FROM birth_names",
+        "SELECT * FROM birth_names LIMIT 1 --comment",
+    ]
+
+
+def test_messy_breakdown_statements_with_comments() -> None:
+    """
+    Test the messy multiple statements are parsed correctly with 'strip_comments=True'.
+    """
+    query = ParsedQuery(
+        """
+SELECT 1;\t\n\n\n  \t
+\t\nSELECT 2;
+SELECT '--abc' FROM birth_names;;;
+SELECT * FROM birth_names LIMIT 1 --comment
+""",
+        strip_comments=True,
+    )
+    assert query.get_statements() == [
+        "SELECT 1",
+        "SELECT 2",
+        "SELECT '--abc' FROM birth_names",
         "SELECT * FROM birth_names LIMIT 1",
     ]
 


### PR DESCRIPTION
### SUMMARY

- `sql_parse.strip_comments_from_sql()` needed to instantiate `ParsedQuery` just to strip comments from a raw SQL string. Now it is the other way around, `ParsedQuery.strip_comments()` uses `strip_comments_from_sql()`.
- DRY up duplicate strip-comments-logic in `ParsedQuery` constructor, in `ParsedQuery.strip_comments()` and `ParsedQuery.is_<EXPLAIN|SHOW|SET>`
- make use of `sql_parse.strip_comments_from_sql()` in the codebase
- add additional tests to cover comments in SQL statements

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
- local unit / integration tests + GitHub CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
