### PR TITLE
fix(explore): redandant force param

### DIFF
--- a/superset-frontend/src/components/Chart/Chart.jsx
+++ b/superset-frontend/src/components/Chart/Chart.jsx
@@ -169,7 +169,7 @@ class Chart extends React.PureComponent {
       // Create chart with POST request
       this.props.actions.postChartFormData(
         this.props.formData,
-        this.props.force || getUrlParam(URL_PARAMS.force), // allow override via url params force=true
+        Boolean(this.props.force || getUrlParam(URL_PARAMS.force)), // allow override via url params force=true
         this.props.timeout,
         this.props.chartId,
         this.props.dashboardId,

--- a/superset-frontend/src/components/Chart/chartAction.js
+++ b/superset-frontend/src/components/Chart/chartAction.js
@@ -183,7 +183,7 @@ const v1ChartDataRequest = async (
   const qs = {};
   if (sliceId !== undefined) qs.form_data = `{"slice_id":${sliceId}}`;
   if (dashboardId !== undefined) qs.dashboard_id = dashboardId;
-  if (force !== false) qs.force = force;
+  if (force) qs.force = force;
 
   const allowDomainSharding =
     // eslint-disable-next-line camelcase

--- a/superset-frontend/src/components/Chart/chartActions.test.js
+++ b/superset-frontend/src/components/Chart/chartActions.test.js
@@ -51,7 +51,7 @@ describe('chart actions', () => {
       .callsFake(() => MOCK_URL);
     getChartDataUriStub = sinon
       .stub(exploreUtils, 'getChartDataUri')
-      .callsFake(() => URI(MOCK_URL));
+      .callsFake(({ qs }) => URI(MOCK_URL).query(qs));
     fakeMetadata = { useLegacyApi: true };
     metadataRegistryStub = sinon
       .stub(chartlib, 'getChartMetadataRegistry')
@@ -81,7 +81,7 @@ describe('chart actions', () => {
     });
 
     it('should query with the built query', async () => {
-      const actionThunk = actions.postChartFormData({});
+      const actionThunk = actions.postChartFormData({}, null);
       await actionThunk(dispatch);
 
       expect(fetchMock.calls(MOCK_URL)).toHaveLength(1);


### PR DESCRIPTION
### SUMMARY
The chartDataUrl contains an empty `force` parameter due to `null` value from `getUrlParam(URL_PARAMS.force)`.
This commit cleans out the redundant force parameter for the falsy value case.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

![Screenshot 2023-11-14 at 11 51 39 AM](https://github.com/apache/superset/assets/1392866/37da1154-4354-459f-8885-c2bed98565ae)

After:

![Screenshot 2023-11-14 at 11 52 01 AM](https://github.com/apache/superset/assets/1392866/1f72c89b-ea8f-498c-996f-44e7fe504d42)

### TESTING INSTRUCTIONS
Go to any dashboard and check the url parameter for `/api/v1/chart/data` 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
