### PR TITLE
chore: Remove more redundant code in utils/core

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -122,18 +122,6 @@ InputType = TypeVar("InputType")  # pylint: disable=invalid-name
 ADHOC_FILTERS_REGEX = re.compile("^adhoc_filters")
 
 
-class LenientEnum(Enum):
-    """Enums with a `get` method that convert a enum value to `Enum` if it is a
-    valid value."""
-
-    @classmethod
-    def get(cls, value: Any) -> Any:
-        try:
-            return super().__new__(cls, value)
-        except ValueError:
-            return None
-
-
 class AdhocMetricExpressionType(StrEnum):
     SIMPLE = "SIMPLE"
     SQL = "SQL"
@@ -278,15 +266,6 @@ class PostProcessingContributionOrientation(StrEnum):
 
     ROW = "row"
     COLUMN = "column"
-
-
-class QueryMode(str, LenientEnum):
-    """
-    Whether the query runs on aggregate or returns raw records
-    """
-
-    RAW = "raw"
-    AGGREGATE = "aggregate"
 
 
 class QuerySource(Enum):
@@ -452,22 +431,6 @@ class DashboardEncoder(json.JSONEncoder):
             if isinstance(o, datetime):
                 return {"__datetime__": o.replace(microsecond=0).isoformat()}
             return json.JSONEncoder(sort_keys=True).default(o)
-
-
-class JSONEncodedDict(TypeDecorator):  # pylint: disable=abstract-method
-    """Represents an immutable structure as a json-encoded string."""
-
-    impl = TEXT
-
-    def process_bind_param(
-        self, value: dict[Any, Any] | None, dialect: str
-    ) -> str | None:
-        return json.dumps(value) if value is not None else None
-
-    def process_result_value(
-        self, value: str | None, dialect: str
-    ) -> dict[Any, Any] | None:
-        return json.loads(value) if value is not None else None
 
 
 def format_timedelta(time_delta: timedelta) -> str:

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -72,7 +72,7 @@ from sqlalchemy.dialects.mysql import MEDIUMTEXT
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.sql.type_api import Variant
-from sqlalchemy.types import TEXT, TypeDecorator, TypeEngine
+from sqlalchemy.types import TypeEngine
 from typing_extensions import TypeGuard
 
 from superset.constants import (

--- a/tests/integration_tests/utils_tests.py
+++ b/tests/integration_tests/utils_tests.py
@@ -59,7 +59,6 @@ from superset.utils.core import (
     get_stacktrace,
     json_int_dttm_ser,
     json_iso_dttm_ser,
-    JSONEncodedDict,
     merge_extra_filters,
     merge_extra_form_data,
     merge_request_params,
@@ -582,15 +581,6 @@ class TestUtils(SupersetTestCase):
             format_timedelta(timedelta(0) - timedelta(days=16, hours=4, minutes=3)),
             "-16 days, 4:03:00",
         )
-
-    def test_json_encoded_obj(self):
-        obj = {"a": 5, "b": ["a", "g", 5]}
-        val = '{"a": 5, "b": ["a", "g", 5]}'
-        jsonObj = JSONEncodedDict()
-        resp = jsonObj.process_bind_param(obj, "dialect")
-        self.assertIn('"a": 5', resp)
-        self.assertIn('"b": ["a", "g", 5]', resp)
-        self.assertEqual(jsonObj.process_result_value(val, "dialect"), obj)
 
     def test_validate_json(self):
         valid = '{"a": 5, "b": [1, 5, ["g", "h"]]}'


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This is basically a follow-up of https://github.com/apache/superset/pull/25912 to remove more redundant code. The unused classes were hard to spot so that's why this is a separate PR.

### TESTING INSTRUCTIONS
- local unit / integration tests + GitHub CI

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
