### PR TITLE
fix: Make Select component fire onChange listener when a selection is pasted in

### DIFF
--- a/superset-frontend/src/components/Select/AsyncSelect.test.tsx
+++ b/superset-frontend/src/components/Select/AsyncSelect.test.tsx
@@ -868,6 +868,20 @@ test('fires onChange when clearing the selection in multiple mode', async () => 
   expect(onChange).toHaveBeenCalledTimes(1);
 });
 
+test('fires onChange when pasting a selection', async () => {
+  const onChange = jest.fn();
+  render(<AsyncSelect {...defaultProps} onChange={onChange} />);
+  await open();
+  const input = getElementByClassName('.ant-select-selection-search-input');
+  const paste = createEvent.paste(input, {
+    clipboardData: {
+      getData: () => OPTIONS[0].label,
+    },
+  });
+  fireEvent(input, paste);
+  expect(onChange).toHaveBeenCalledTimes(1);
+});
+
 test('does not duplicate options when using numeric values', async () => {
   render(
     <AsyncSelect

--- a/superset-frontend/src/components/Select/AsyncSelect.tsx
+++ b/superset-frontend/src/components/Select/AsyncSelect.tsx
@@ -554,6 +554,7 @@ const AsyncSelect = forwardRef(
           ...values,
         ]);
       }
+      fireOnChange();
     };
 
     const shouldRenderChildrenOptions = useMemo(

--- a/superset-frontend/src/components/Select/Select.test.tsx
+++ b/superset-frontend/src/components/Select/Select.test.tsx
@@ -985,6 +985,20 @@ test('fires onChange when clearing the selection in multiple mode', async () => 
   expect(onChange).toHaveBeenCalledTimes(1);
 });
 
+test('fires onChange when pasting a selection', async () => {
+  const onChange = jest.fn();
+  render(<Select {...defaultProps} onChange={onChange} />);
+  await open();
+  const input = getElementByClassName('.ant-select-selection-search-input');
+  const paste = createEvent.paste(input, {
+    clipboardData: {
+      getData: () => OPTIONS[0].label,
+    },
+  });
+  fireEvent(input, paste);
+  expect(onChange).toHaveBeenCalledTimes(1);
+});
+
 test('does not duplicate options when using numeric values', async () => {
   render(
     <Select

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -571,6 +571,7 @@ const Select = forwardRef(
           ]);
         }
       }
+      fireOnChange();
     };
 
     return (


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, pasting a value into a `Select` does not trigger the `onChange` callback passed to the `Select`.  This resulted in a buggy experience when pasting values into the adhoc filter select component, as demonstrated below.  It's possible similar issues exist in other areas of the application which this change will also fix.

Fixes https://github.com/apache/superset/issues/25601

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
### Before:
![adhoc_paste_before](https://github.com/apache/superset/assets/47196419/88c1e868-4081-4bce-984d-a41ff286b374)


### After:
![adhoc_paste_after](https://github.com/apache/superset/assets/47196419/a41b64a9-7e7e-42fd-b369-c400ded986cf)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/25601
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
