### PR TITLE
chore: Optimize fetching samples logic

### DIFF
--- a/superset/views/datasource/utils.py
+++ b/superset/views/datasource/utils.py
@@ -104,21 +104,18 @@ def get_samples(  # pylint: disable=too-many-arguments,too-many-locals
         result_type=ChartDataResultType.FULL,
         force=force,
     )
-    samples_results = samples_instance.get_payload()
-    count_star_results = count_star_instance.get_payload()
 
     try:
-        sample_data = samples_results["queries"][0]
-        count_star_data = count_star_results["queries"][0]
-        failed_status = (
-            sample_data.get("status") == QueryStatus.FAILED
-            or count_star_data.get("status") == QueryStatus.FAILED
-        )
-        error_msg = sample_data.get("error") or count_star_data.get("error")
-        if failed_status and error_msg:
-            cache_key = sample_data.get("cache_key")
-            QueryCacheManager.delete(cache_key, region=CacheRegion.DATA)
-            raise DatasetSamplesFailedError(error_msg)
+        count_star_data = count_star_instance.get_payload()["queries"][0]
+
+        if count_star_data.get("status") == QueryStatus.FAILED:
+            raise DatasetSamplesFailedError(count_star_data.get("error"))
+
+        sample_data = samples_instance.get_payload()["queries"][0]
+
+        if sample_data.get("status") == QueryStatus.FAILED:
+            QueryCacheManager.delete(sample_data.get("cache_key"), CacheRegion.DATA)
+            raise DatasetSamplesFailedError(sample_data.get("error"))
 
         sample_data["page"] = page
         sample_data["per_page"] = per_page


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

At Airbnb (as mentioned previously) we have an uber wide dataset (circa thousands of columns) which is can be somewhat problematic for certain workflows. One such workflow is fetching sample data—which is used in explore and drill-to-detail. 

The existing logic constructs and executes a query for fetching both the sample data and `COUNT(*)` where the former is rather complex—relying on a very expensive SQLAlchemy query to fetch all the columns—before processing the results.

This PR introduces an optimization which first constructs and executes the `COUNT(*)` query (which is both cheap to construct and execute) and only proceeds to the sample data if the first query succeeds. Given that (in our formulation) the `COUNT(*)` aggregate is not supported the endpoint returns in a few seconds as opposed from a few minutes. The TL;DR is we should fail early if possible.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE

<img width="873" alt="Screenshot 2023-11-15 at 2 16 57 PM" src="https://github.com/apache/superset/assets/4567245/0ab6e286-c065-4d91-a0af-7d21240dafb7">

#### AFTER

<img width="873" alt="Screenshot 2023-11-15 at 2 17 15 PM" src="https://github.com/apache/superset/assets/4567245/4fe44f19-3e2c-433a-bc95-1abcd9dc36d1">

### TESTING INSTRUCTIONS

Existing unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
