### PR TITLE
chore(tags): Allow for lookup via ids vs. name in the API

### DIFF
--- a/superset-frontend/src/features/tags/TagModal.tsx
+++ b/superset-frontend/src/features/tags/TagModal.tsx
@@ -26,7 +26,7 @@ import { Input } from 'antd';
 import { Divider } from 'src/components';
 import Button from 'src/components/Button';
 import { Tag } from 'src/views/CRUD/types';
-import { fetchObjects } from 'src/features/tags/tags';
+import { fetchObjectsByTagIds } from 'src/features/tags/tags';
 
 const StyledModalBody = styled.div`
   .ant-select-dropdown {
@@ -107,8 +107,8 @@ const TagModal: React.FC<TagModalProps> = ({
     };
     clearResources();
     if (isEditMode) {
-      fetchObjects(
-        { tags: editTag.name, types: null },
+      fetchObjectsByTagIds(
+        { tagIds: [editTag.id], types: null },
         (data: Tag[]) => {
           data.forEach(updateResourceOptions);
           setDashboardsToTag(resourceMap[TaggableResources.Dashboard]);

--- a/superset-frontend/src/features/tags/tags.ts
+++ b/superset-frontend/src/features/tags/tags.ts
@@ -194,3 +194,20 @@ export function fetchObjects(
     .then(({ json }) => callback(json.result))
     .catch(response => error(response));
 }
+
+export function fetchObjectsByTagIds(
+  {
+    tagIds = [],
+    types,
+  }: { tagIds: number[] | undefined; types: string | null },
+  callback: (json: JsonObject) => void,
+  error: (response: Response) => void,
+) {
+  let url = `/api/v1/tag/get_objects/?tagIds=${tagIds}`;
+  if (types) {
+    url += `&types=${types}`;
+  }
+  SupersetClient.get({ endpoint: url })
+    .then(({ json }) => callback(json.result))
+    .catch(response => error(response));
+}

--- a/superset-frontend/src/pages/AllEntities/index.tsx
+++ b/superset-frontend/src/pages/AllEntities/index.tsx
@@ -33,7 +33,7 @@ import { PageHeaderWithActions } from 'src/components/PageHeaderWithActions';
 import { Tag } from 'src/views/CRUD/types';
 import TagModal from 'src/features/tags/TagModal';
 import withToasts, { useToasts } from 'src/components/MessageToasts/withToasts';
-import { fetchObjects, fetchSingleTag } from 'src/features/tags/tags';
+import { fetchObjectsByTagIds, fetchSingleTag } from 'src/features/tags/tags';
 import Loading from 'src/components/Loading';
 
 interface TaggedObject {
@@ -146,8 +146,8 @@ function AllEntities() {
 
   const fetchTaggedObjects = () => {
     setLoading(true);
-    fetchObjects(
-      { tags: tag?.name || '', types: null },
+    fetchObjectsByTagIds(
+      { tagIds: [tag?.id] || '', types: null },
       (data: TaggedObject[]) => {
         const objects = { dashboard: [], chart: [], query: [] };
         data.forEach(function (object) {

--- a/superset-frontend/src/pages/AllEntities/index.tsx
+++ b/superset-frontend/src/pages/AllEntities/index.tsx
@@ -146,6 +146,10 @@ function AllEntities() {
 
   const fetchTaggedObjects = () => {
     setLoading(true);
+    if (!tag) {
+      addDangerToast('Error tag object is not referenced!');
+      return;
+    }
     fetchObjectsByTagIds(
       { tagIds: [tag?.id] || '', types: null },
       (data: TaggedObject[]) => {

--- a/superset/daos/tag.py
+++ b/superset/daos/tag.py
@@ -169,9 +169,9 @@ class TagDAO(BaseDAO[Tag]):
 
     @staticmethod
     def get_tagged_objects_by_tag_id(
-        tagIds: Optional[list[int]], obj_types: Optional[list[str]] = None
+        tag_ids: Optional[list[int]], obj_types: Optional[list[str]] = None
     ) -> list[dict[str, Any]]:
-        tags = db.session.query(Tag).filter(Tag.id.in_(tagIds)).all()
+        tags = db.session.query(Tag).filter(Tag.id.in_(tag_ids)).all()
         tag_names = [tag.name for tag in tags]
         return TagDAO.get_tagged_objects_for_tags(tag_names, obj_types)
 

--- a/superset/daos/tag.py
+++ b/superset/daos/tag.py
@@ -168,6 +168,14 @@ class TagDAO(BaseDAO[Tag]):
         )
 
     @staticmethod
+    def get_tagged_objects_by_tag_id(
+        tagIds: Optional[list[int]], obj_types: Optional[list[str]] = None
+    ) -> list[dict[str, Any]]:
+        tags = db.session.query(Tag).filter(Tag.id.in_(tagIds)).all()
+        tag_names = [tag.name for tag in tags]
+        return TagDAO.get_tagged_objects_for_tags(tag_names, obj_types)
+
+    @staticmethod
     def get_tagged_objects_for_tags(
         tags: Optional[list[str]] = None, obj_types: Optional[list[str]] = None
     ) -> list[dict[str, Any]]:

--- a/superset/tags/api.py
+++ b/superset/tags/api.py
@@ -584,12 +584,21 @@ class TagRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
+        tagIds = [
+            tag_id for tag_id in request.args.get("tagIds", "").split(",") if tag_id
+        ]
         tags = [tag for tag in request.args.get("tags", "").split(",") if tag]
         # filter types
         types = [type_ for type_ in request.args.get("types", "").split(",") if type_]
 
         try:
-            tagged_objects = TagDAO.get_tagged_objects_for_tags(tags, types)
+            if tagIds:
+                # priotize using ids for lookups vs. names mainly using this
+                # for backward compatibility
+                tagged_objects = TagDAO.get_tagged_objects_by_tag_id(tagIds, types)
+            else:
+                tagged_objects = TagDAO.get_tagged_objects_for_tags(tags, types)
+
             result = [
                 self.object_entity_response_schema.dump(tagged_object)
                 for tagged_object in tagged_objects

--- a/superset/tags/api.py
+++ b/superset/tags/api.py
@@ -622,7 +622,7 @@ class TagRestApi(BaseSupersetModelRestApi):
         ---
         get:
           description: >-
-            Check favorited dashboards for current user
+            Check favorited tags for current user
           parameters:
           - in: query
             name: q

--- a/superset/tags/api.py
+++ b/superset/tags/api.py
@@ -584,7 +584,7 @@ class TagRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
-        tagIds = [
+        tag_ids = [
             tag_id for tag_id in request.args.get("tagIds", "").split(",") if tag_id
         ]
         tags = [tag for tag in request.args.get("tags", "").split(",") if tag]
@@ -592,10 +592,10 @@ class TagRestApi(BaseSupersetModelRestApi):
         types = [type_ for type_ in request.args.get("types", "").split(",") if type_]
 
         try:
-            if tagIds:
+            if tag_ids:
                 # priotize using ids for lookups vs. names mainly using this
                 # for backward compatibility
-                tagged_objects = TagDAO.get_tagged_objects_by_tag_id(tagIds, types)
+                tagged_objects = TagDAO.get_tagged_objects_by_tag_id(tag_ids, types)
             else:
                 tagged_objects = TagDAO.get_tagged_objects_for_tags(tags, types)
 

--- a/superset/tags/api.py
+++ b/superset/tags/api.py
@@ -618,11 +618,11 @@ class TagRestApi(BaseSupersetModelRestApi):
         log_to_statsd=False,
     )
     def favorite_status(self, **kwargs: Any) -> Response:
-        """Favorite Stars for Dashboards
+        """Favorite Stars for Tags
         ---
         get:
           description: >-
-            Check favorited tags for current user
+            Get favorited tags for current user
           parameters:
           - in: query
             name: q

--- a/tests/integration_tests/tags/dao_tests.py
+++ b/tests/integration_tests/tags/dao_tests.py
@@ -209,6 +209,39 @@ class TestTagsDAO(SupersetTestCase):
 
     @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
     @pytest.mark.usefixtures("with_tagging_system_feature")
+    @pytest.mark.usefixtures("create_tags")
+    # test get objects from tag
+    def test_get_objects_from_tag_with_id(self):
+        # create tagged objects
+        dashboard = (
+            db.session.query(Dashboard)
+            .filter(Dashboard.dashboard_title == "World Bank's Data")
+            .first()
+        )
+        dashboard_id = dashboard.id
+        tag_1 = db.session.query(Tag).filter_by(name="example_tag_1").one()
+        tag_2 = db.session.query(Tag).filter_by(name="example_tag_2").one()
+        tag_ids = [tag_1.id, tag_2.id]
+        self.insert_tagged_object(
+            object_id=dashboard_id, object_type=ObjectType.dashboard, tag_id=tag_1.id
+        )
+        # get objects
+        tagged_objects = TagDAO.get_tagged_objects_by_tag_id(tag_ids)
+        assert len(tagged_objects) == 1
+
+        # test get objects from tag with type
+        tagged_objects = TagDAO.get_tagged_objects_by_tag_id(
+            tag_ids, obj_types=["dashboard", "chart"]
+        )
+        assert len(tagged_objects) == 1
+
+        tagged_objects = TagDAO.get_tagged_objects_by_tag_id(
+            tag_ids, obj_types=["chart"]
+        )
+        assert len(tagged_objects) == 0
+
+    @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
+    @pytest.mark.usefixtures("with_tagging_system_feature")
     @pytest.mark.usefixtures("create_tagged_objects")
     def test_find_tagged_object(self):
         tag = db.session.query(Tag).filter(Tag.name == "example_tag_1").first()


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Previously we the API only supported queries using the names as way of querying tags, I've updated the API to now accept IDs (better pattern) to allow names to have commas. We discovered the issue in testing and took advantage the opportunity to refactor this piece of code, but also leaving `tags` param for backwards compatibility.

```
curl 'http://127.0.0.1:54647/api/v1/tag/get_objects/?tagIds=17,12,13' \
-X 'GET' \
-H 'Accept: application/json' \
# ...
```

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. goto all entities page (http://127.0.0.1:8080/superset/all_entities)
2. see page render with new network call

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
