### PR TITLE
chore: Allow external extensions to include their own package.json files

### DIFF
--- a/superset-frontend/lerna.json
+++ b/superset-frontend/lerna.json
@@ -1,7 +1,7 @@
 {
   "lerna": "3.2.1",
   "npmClient": "npm",
-  "packages": ["packages/*", "plugins/*"],
+  "packages": ["packages/*", "plugins/*", "src/setup/*"],
   "useWorkspaces": true,
   "version": "0.18.25",
   "ignoreChanges": [

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -33,7 +33,8 @@
   },
   "workspaces": [
     "packages/*",
-    "plugins/*"
+    "plugins/*",
+    "src/setup/*"
   ],
   "scripts": {
     "_lint": "eslint --ignore-path=.eslintignore --ext .js,.jsx,.ts,tsx .",


### PR DESCRIPTION
### SUMMARY
Superset supports external frontend extensions by registering them in `superset-frontend/src/setup/setupExtensions.ts`. However, the extensions could not easily add their own dependencies to superset's dependencies. This PR allows external extensions to install new dependencies by including `package.json` file within `superset-frontend/src/setup` tree (not necessarily root level, it will work with path such as `superset-frontend/src/setup/my-cool-extension-dir/package.json`).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Run `npm install` or `npm ci` when there is no `package.json` file under `src/setup` dir - there should be no changes to `node_modules` nor `package-lock.json`
2. Create a "fake" extension dir under `src/setup` and create a `package.json` file in it, e.g. `src/setup/my-extension/package.json`. Add some dependencies to it and run `npm install` or `npm ci`. Verify that the new dependencies were installed correctly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
