### PR TITLE
fix(security): restore default value of SESSION_COOKIE_SECURE to False

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -1442,7 +1442,7 @@ TALISMAN_CONFIG = {
     },
     "content_security_policy_nonce_in": ["script-src"],
     "force_https": False,
-    "session_cookie_secure": False
+    "session_cookie_secure": False,
 }
 # React requires `eval` to work correctly in dev mode
 TALISMAN_DEV_CONFIG = {
@@ -1464,7 +1464,7 @@ TALISMAN_DEV_CONFIG = {
     },
     "content_security_policy_nonce_in": ["script-src"],
     "force_https": False,
-    "session_cookie_secure": False
+    "session_cookie_secure": False,
 }
 
 #

--- a/superset/config.py
+++ b/superset/config.py
@@ -1442,6 +1442,7 @@ TALISMAN_CONFIG = {
     },
     "content_security_policy_nonce_in": ["script-src"],
     "force_https": False,
+    "session_cookie_secure": False
 }
 # React requires `eval` to work correctly in dev mode
 TALISMAN_DEV_CONFIG = {
@@ -1463,6 +1464,7 @@ TALISMAN_DEV_CONFIG = {
     },
     "content_security_policy_nonce_in": ["script-src"],
     "force_https": False,
+    "session_cookie_secure": False
 }
 
 #


### PR DESCRIPTION
### SUMMARY
The default value of SESSION_COOKIE_SECURE was historically False.  This was changed unintentionally when we enabled TALISMAN_CONFIG by default.  That comes with unstated, implicit settings including making SESSION_COOKIE_SECURE = True.   This contradicts our documentation (issue #25854).

More importantly, it contributed to a critical problem where new users who have not enabled HTTPS yet as part of their setup encounter a login loop and are unable to use Superset.  The canonical issue here is https://github.com/apache/superset/issues/24579#issuecomment-1814715020, please review that thread ending with the comment I linked.

When users discuss this problem in the issues, the two most upvoted "fixes" are to disable Talisman entirely or to revert to Superset 2.1.0 (which did not have Talisman enabled by default) 😬 

I'm not an expert in this area and there might be more we need to to do to get a combination of security values that works for out-of-the-box setups.  But this PR seemed like a good simple start in that it's reverting an unintended change that came when we implemented Talisman CSP.

### TESTING INSTRUCTIONS
Install a new instance of Superset with this config value in Talisman?  Two users in that thread report that this config change enabled them to install and use Superset.

### ADDITIONAL INFORMATION
- [x] Has associated issue:
  - Fixes #25854, fixes #24579 at least enough that it can be closed and, if a problem persists, a new issue created
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
