### PR TITLE
chore: cleanup unused code in pandas 2.0+

### DIFF
--- a/superset/translations/de/LC_MESSAGES/messages.json
+++ b/superset/translations/de/LC_MESSAGES/messages.json
@@ -2886,7 +2886,6 @@
       "Manage email report": ["E-Mail-Bericht verwalten"],
       "Manage your databases": ["Verwalten Sie Ihre Datenbanken"],
       "Mandatory": ["Notwendig"],
-      "Mangle Duplicate Columns": ["Doppelte Spalten zusammenführen"],
       "Manually set min/max values for the y-axis.": [
         "Min/Max-Werte für die y-Achse manuell festlegen."
       ],

--- a/superset/translations/de/LC_MESSAGES/messages.po
+++ b/superset/translations/de/LC_MESSAGES/messages.po
@@ -9407,10 +9407,6 @@ msgstr "Verwalten Sie Ihre Datenbanken"
 msgid "Mandatory"
 msgstr "Notwendig"
 
-#: superset/views/database/forms.py:360
-msgid "Mangle Duplicate Columns"
-msgstr "Doppelte Spalten zusammenführen"
-
 #: superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/index.jsx:297
 msgid "Manually set min/max values for the y-axis."
 msgstr "Min/Max-Werte für die y-Achse manuell festlegen."

--- a/superset/translations/en/LC_MESSAGES/messages.json
+++ b/superset/translations/en/LC_MESSAGES/messages.json
@@ -2093,7 +2093,6 @@
       "Manage email report": [""],
       "Manage your databases": [""],
       "Mandatory": [""],
-      "Mangle Duplicate Columns": [""],
       "Manually set min/max values for the y-axis.": [""],
       "Map": [""],
       "Map Style": [""],

--- a/superset/translations/en/LC_MESSAGES/messages.po
+++ b/superset/translations/en/LC_MESSAGES/messages.po
@@ -8797,10 +8797,6 @@ msgstr ""
 msgid "Mandatory"
 msgstr ""
 
-#: superset/views/database/forms.py:360
-msgid "Mangle Duplicate Columns"
-msgstr ""
-
 #: superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/index.jsx:297
 msgid "Manually set min/max values for the y-axis."
 msgstr ""

--- a/superset/translations/es/LC_MESSAGES/messages.json
+++ b/superset/translations/es/LC_MESSAGES/messages.json
@@ -1801,7 +1801,6 @@
       ],
       "Manage": ["Administrar"],
       "Mandatory": ["Oblugatorio"],
-      "Mangle Duplicate Columns": ["Manglar Columnas Duplicadas"],
       "MapBox": [""],
       "Mapbox": [""],
       "March": ["Marzo"],

--- a/superset/translations/es/LC_MESSAGES/messages.po
+++ b/superset/translations/es/LC_MESSAGES/messages.po
@@ -9400,10 +9400,6 @@ msgstr "Nombre de tu fuente de datos"
 msgid "Mandatory"
 msgstr "Oblugatorio"
 
-#: superset/views/database/forms.py:360
-msgid "Mangle Duplicate Columns"
-msgstr "Manglar Columnas Duplicadas"
-
 #: superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/index.jsx:297
 #, fuzzy
 msgid "Manually set min/max values for the y-axis."

--- a/superset/translations/fr/LC_MESSAGES/messages.json
+++ b/superset/translations/fr/LC_MESSAGES/messages.json
@@ -2065,7 +2065,6 @@
       ],
       "Manage": ["Gestion"],
       "Mandatory": ["Obligatoire"],
-      "Mangle Duplicate Columns": ["Supprimer les colonnes en double"],
       "Manually set min/max values for the y-axis.": [""],
       "Mapbox": ["Mapbox"],
       "March": ["Mars"],

--- a/superset/translations/fr/LC_MESSAGES/messages.po
+++ b/superset/translations/fr/LC_MESSAGES/messages.po
@@ -9574,10 +9574,6 @@ msgstr "Donner un nom à la base de données"
 msgid "Mandatory"
 msgstr "Obligatoire"
 
-#: superset/views/database/forms.py:360
-msgid "Mangle Duplicate Columns"
-msgstr "Supprimer les colonnes en double"
-
 #: superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/index.jsx:297
 msgid "Manually set min/max values for the y-axis."
 msgstr ""

--- a/superset/translations/it/LC_MESSAGES/messages.json
+++ b/superset/translations/it/LC_MESSAGES/messages.json
@@ -1755,7 +1755,6 @@
       ],
       "Manage": ["Gestisci"],
       "Mandatory": [""],
-      "Mangle Duplicate Columns": [""],
       "Manually set min/max values for the y-axis.": [""],
       "Map Style": [""],
       "Mapbox": ["Mapbox"],

--- a/superset/translations/it/LC_MESSAGES/messages.po
+++ b/superset/translations/it/LC_MESSAGES/messages.po
@@ -9152,10 +9152,6 @@ msgstr "Database"
 msgid "Mandatory"
 msgstr ""
 
-#: superset/views/database/forms.py:360
-msgid "Mangle Duplicate Columns"
-msgstr ""
-
 #: superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/index.jsx:297
 msgid "Manually set min/max values for the y-axis."
 msgstr ""

--- a/superset/translations/ja/LC_MESSAGES/messages.json
+++ b/superset/translations/ja/LC_MESSAGES/messages.json
@@ -1803,7 +1803,6 @@
       ],
       "Manage": ["管理"],
       "Mandatory": [""],
-      "Mangle Duplicate Columns": [""],
       "Manually set min/max values for the y-axis.": [""],
       "Map Style": [""],
       "MapBox": [""],

--- a/superset/translations/ja/LC_MESSAGES/messages.po
+++ b/superset/translations/ja/LC_MESSAGES/messages.po
@@ -9156,10 +9156,6 @@ msgstr "データベースのインポート"
 msgid "Mandatory"
 msgstr ""
 
-#: superset/views/database/forms.py:360
-msgid "Mangle Duplicate Columns"
-msgstr ""
-
 #: superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/index.jsx:297
 msgid "Manually set min/max values for the y-axis."
 msgstr ""

--- a/superset/translations/ko/LC_MESSAGES/messages.json
+++ b/superset/translations/ko/LC_MESSAGES/messages.json
@@ -1801,7 +1801,6 @@
       ],
       "Manage": ["관리"],
       "Mandatory": [""],
-      "Mangle Duplicate Columns": [""],
       "Manually set min/max values for the y-axis.": [""],
       "Map Style": [""],
       "MapBox": [""],

--- a/superset/translations/ko/LC_MESSAGES/messages.po
+++ b/superset/translations/ko/LC_MESSAGES/messages.po
@@ -9084,10 +9084,6 @@ msgstr "데이터베이스 선택"
 msgid "Mandatory"
 msgstr ""
 
-#: superset/views/database/forms.py:360
-msgid "Mangle Duplicate Columns"
-msgstr ""
-
 #: superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/index.jsx:297
 msgid "Manually set min/max values for the y-axis."
 msgstr ""

--- a/superset/translations/messages.pot
+++ b/superset/translations/messages.pot
@@ -8796,10 +8796,6 @@ msgstr ""
 msgid "Mandatory"
 msgstr ""
 
-#: superset/views/database/forms.py:360
-msgid "Mangle Duplicate Columns"
-msgstr ""
-
 #: superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/index.jsx:297
 msgid "Manually set min/max values for the y-axis."
 msgstr ""

--- a/superset/translations/nl/LC_MESSAGES/messages.json
+++ b/superset/translations/nl/LC_MESSAGES/messages.json
@@ -2214,7 +2214,6 @@
       ],
       "Manage": ["Beheer"],
       "Mandatory": ["Verplicht"],
-      "Mangle Duplicate Columns": ["Dubbele kolommen verwijderen"],
       "Manually set min/max values for the y-axis.": [""],
       "Map": [""],
       "Map Style": [""],

--- a/superset/translations/nl/LC_MESSAGES/messages.po
+++ b/superset/translations/nl/LC_MESSAGES/messages.po
@@ -9110,10 +9110,6 @@ msgstr "Importeer databases"
 msgid "Mandatory"
 msgstr "Verplicht"
 
-#: superset/views/database/forms.py:360
-msgid "Mangle Duplicate Columns"
-msgstr "Dubbele kolommen verwijderen"
-
 #: superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/index.jsx:297
 msgid "Manually set min/max values for the y-axis."
 msgstr ""

--- a/superset/translations/pt/LC_MESSAGES/message.json
+++ b/superset/translations/pt/LC_MESSAGES/message.json
@@ -876,7 +876,6 @@
       "Column to use as the row labels of the dataframe. Leave empty if no index column.": [
         ""
       ],
-      "Mangle Duplicate Columns": ["Coluna Datahora principal"],
       "Specify duplicate columns as \"X.0, X.1\".": [""],
       "Skip Initial Space": [""],
       "Skip spaces after delimiter.": [""],

--- a/superset/translations/pt/LC_MESSAGES/messages.json
+++ b/superset/translations/pt/LC_MESSAGES/messages.json
@@ -1730,7 +1730,6 @@
       "Manage email report": [""],
       "Manage your databases": [""],
       "Mandatory": [""],
-      "Mangle Duplicate Columns": ["Coluna Datahora principal"],
       "Manually set min/max values for the y-axis.": [""],
       "Map Style": [""],
       "Mapbox": ["Mapbox"],

--- a/superset/translations/pt/LC_MESSAGES/messages.po
+++ b/superset/translations/pt/LC_MESSAGES/messages.po
@@ -9263,10 +9263,6 @@ msgstr ""
 msgid "Mandatory"
 msgstr ""
 
-#: superset/views/database/forms.py:360
-msgid "Mangle Duplicate Columns"
-msgstr "Coluna Datahora principal"
-
 #: superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/index.jsx:297
 msgid "Manually set min/max values for the y-axis."
 msgstr ""

--- a/superset/translations/pt_BR/LC_MESSAGES/messages.json
+++ b/superset/translations/pt_BR/LC_MESSAGES/messages.json
@@ -2724,7 +2724,6 @@
       "Manage email report": ["Gerenciar relatório de e-mail"],
       "Manage your databases": ["Gerenciar seus bancos de dados"],
       "Mandatory": ["Obrigatório"],
-      "Mangle Duplicate Columns": ["Emaranhar colunas duplicadas"],
       "Manually set min/max values for the y-axis.": [
         "Definir manualmente os valores mínimo/máximo para o eixo y."
       ],

--- a/superset/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/superset/translations/pt_BR/LC_MESSAGES/messages.po
@@ -9396,10 +9396,6 @@ msgstr "Gerenciar seus bancos de dados"
 msgid "Mandatory"
 msgstr "Obrigatório"
 
-#: superset/views/database/forms.py:360
-msgid "Mangle Duplicate Columns"
-msgstr "Emaranhar colunas duplicadas"
-
 #: superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/index.jsx:297
 msgid "Manually set min/max values for the y-axis."
 msgstr "Definir manualmente os valores mínimo/máximo para o eixo y."

--- a/superset/translations/ru/LC_MESSAGES/messages.json
+++ b/superset/translations/ru/LC_MESSAGES/messages.json
@@ -2678,7 +2678,6 @@
       "Manage email report": ["Управление рассылкой по почте"],
       "Manage your databases": ["Управляйте своими базами данных"],
       "Mandatory": ["Обязательно"],
-      "Mangle Duplicate Columns": ["Управление повторяющимися столбцами"],
       "Manually set min/max values for the y-axis.": [
         "Вручную задать мин./макс. значения для оси Y"
       ],

--- a/superset/translations/ru/LC_MESSAGES/messages.po
+++ b/superset/translations/ru/LC_MESSAGES/messages.po
@@ -9259,10 +9259,6 @@ msgstr "Управляйте своими базами данных"
 msgid "Mandatory"
 msgstr "Обязательно"
 
-#: superset/views/database/forms.py:360
-msgid "Mangle Duplicate Columns"
-msgstr "Управление повторяющимися столбцами"
-
 #: superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/index.jsx:297
 msgid "Manually set min/max values for the y-axis."
 msgstr "Вручную задать мин./макс. значения для оси Y"

--- a/superset/translations/sk/LC_MESSAGES/messages.json
+++ b/superset/translations/sk/LC_MESSAGES/messages.json
@@ -2089,7 +2089,6 @@
       "Manage email report": [""],
       "Manage your databases": [""],
       "Mandatory": [""],
-      "Mangle Duplicate Columns": [""],
       "Manually set min/max values for the y-axis.": [""],
       "Map": [""],
       "Map Style": [""],

--- a/superset/translations/sk/LC_MESSAGES/messages.po
+++ b/superset/translations/sk/LC_MESSAGES/messages.po
@@ -8841,10 +8841,6 @@ msgstr ""
 msgid "Mandatory"
 msgstr ""
 
-#: superset/views/database/forms.py:360
-msgid "Mangle Duplicate Columns"
-msgstr ""
-
 #: superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/index.jsx:297
 msgid "Manually set min/max values for the y-axis."
 msgstr ""

--- a/superset/translations/sl/LC_MESSAGES/messages.json
+++ b/superset/translations/sl/LC_MESSAGES/messages.json
@@ -2484,7 +2484,6 @@
       "Manage email report": ["Upravljaj e-poštno poročilo"],
       "Manage your databases": ["Upravljajte podatkovne baze"],
       "Mandatory": ["Obvezno"],
-      "Mangle Duplicate Columns": ["Odstrani podvojene stolpce"],
       "Map": ["Zemljevid"],
       "Map Style": ["Slog zemljevida"],
       "MapBox": ["MapBox"],

--- a/superset/translations/sl/LC_MESSAGES/messages.po
+++ b/superset/translations/sl/LC_MESSAGES/messages.po
@@ -9418,10 +9418,6 @@ msgstr "Upravljajte podatkovne baze"
 msgid "Mandatory"
 msgstr "Obvezno"
 
-#: superset/views/database/forms.py:360
-msgid "Mangle Duplicate Columns"
-msgstr "Odstrani podvojene stolpce"
-
 #: superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/index.jsx:297
 #, fuzzy
 msgid "Manually set min/max values for the y-axis."

--- a/superset/translations/zh/LC_MESSAGES/messages.json
+++ b/superset/translations/zh/LC_MESSAGES/messages.json
@@ -1974,7 +1974,6 @@
       "Manage": ["管理"],
       "Manage your databases": ["管理你的数据库"],
       "Mandatory": ["必填参数"],
-      "Mangle Duplicate Columns": ["混合重复列"],
       "Map": ["地图"],
       "Map Style": ["地图样式"],
       "MapBox": ["MapBox地图"],

--- a/superset/translations/zh/LC_MESSAGES/messages.po
+++ b/superset/translations/zh/LC_MESSAGES/messages.po
@@ -9138,10 +9138,6 @@ msgstr "管理你的数据库"
 msgid "Mandatory"
 msgstr "必填参数"
 
-#: superset/views/database/forms.py:360
-msgid "Mangle Duplicate Columns"
-msgstr "混合重复列"
-
 #: superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/index.jsx:297
 #, fuzzy
 msgid "Manually set min/max values for the y-axis."

--- a/superset/views/database/forms.py
+++ b/superset/views/database/forms.py
@@ -357,10 +357,6 @@ class ExcelToDatabaseForm(UploadToDatabaseForm):
         validators=[Optional(), NumberRange(min=0)],
         widget=BS3TextFieldWidget(),
     )
-    mangle_dupe_cols = BooleanField(
-        _("Mangle Duplicate Columns"),
-        description=_('Specify duplicate columns as "X.0, X.1".'),
-    )
     skiprows = IntegerField(
         _("Skip Rows"),
         description=_("Number of rows to skip at start of file."),

--- a/superset/views/database/views.py
+++ b/superset/views/database/views.py
@@ -307,7 +307,6 @@ class ExcelToDatabaseView(SimpleFormView):
 
     def form_get(self, form: ExcelToDatabaseForm) -> None:
         form.header.data = 0
-        form.mangle_dupe_cols.data = True
         form.decimal.data = "."
         form.if_exists.data = "fail"
         form.sheet_name.data = ""
@@ -343,7 +342,7 @@ class ExcelToDatabaseView(SimpleFormView):
                 index_col=form.index_col.data,
                 io=form.excel_file.data,
                 keep_default_na=not form.null_values.data,
-                na_values=form.null_values.data if form.null_values.data else None,
+                na_values=form.null_values.data if form.null_values.data else [],
                 parse_dates=form.parse_dates.data,
                 skiprows=form.skiprows.data,
                 sheet_name=form.sheet_name.data if form.sheet_name.data else 0,

--- a/tests/integration_tests/csv_upload_tests.py
+++ b/tests/integration_tests/csv_upload_tests.py
@@ -165,7 +165,6 @@ def upload_excel(
         "sheet_name": "Sheet1",
         "if_exists": "fail",
         "index_label": "test_label",
-        "mangle_dupe_cols": False,
     }
     if schema := utils.get_example_default_schema():
         form_data["schema"] = schema


### PR DESCRIPTION
### SUMMARY

This is a follow-up of https://github.com/apache/superset/pull/24705 that bumped pandas. Per the Pandas 2.0 [changelog](https://pandas.pydata.org/docs/dev/whatsnew/v2.0.0.html) the `mangle_dupe_cols` was removed as the functionality was never implemented. This PR cleans up the residues.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
