### PR TITLE
fix: Prevent cached bootstrap data from leaking between users w/ same first/last name

### DIFF
--- a/superset/embedded/view.py
+++ b/superset/embedded/view.py
@@ -17,7 +17,7 @@
 import json
 from typing import Callable
 
-from flask import abort, g, request
+from flask import abort, request
 from flask_appbuilder import expose
 from flask_login import AnonymousUserMixin, login_user
 from flask_wtf.csrf import same_origin
@@ -78,7 +78,7 @@ class EmbeddedView(BaseSupersetView):
         )
 
         bootstrap_data = {
-            "common": common_bootstrap_payload(g.user),
+            "common": common_bootstrap_payload(),
             "embedded": {
                 "dashboard_id": embedded.dashboard_id,
             },

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -380,7 +380,9 @@ def menu_data(user: User) -> dict[str, Any]:
 
 
 @cache_manager.cache.memoize(timeout=60)
-def cached_common_bootstrap_data(user: User, locale: str) -> dict[str, Any]:
+def cached_common_bootstrap_data(
+    user: User, user_id: int | None, locale: str
+) -> dict[str, Any]:
     """Common data always sent to the client
 
     The function is memoized as the return value only changes when user permissions
@@ -424,8 +426,9 @@ def cached_common_bootstrap_data(user: User, locale: str) -> dict[str, Any]:
 
 
 def common_bootstrap_payload(user: User) -> dict[str, Any]:
+    user_id = user.id if hasattr(user, "id") else None
     return {
-        **cached_common_bootstrap_data(user, get_locale()),
+        **cached_common_bootstrap_data(user, user_id, get_locale()),
         "flash_messages": get_flashed_messages(with_categories=True),
     }
 

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -380,7 +380,7 @@ def menu_data(user: User) -> dict[str, Any]:
 
 
 @cache_manager.cache.memoize(timeout=60)
-def cached_common_bootstrap_data(
+def cached_common_bootstrap_data(  # pylint: disable=unused-argument
     user: User, user_id: int | None, locale: str
 ) -> dict[str, Any]:
     """Common data always sent to the client

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -296,7 +296,7 @@ class BaseSupersetView(BaseView):
     ) -> FlaskResponse:
         payload = {
             "user": bootstrap_user_data(g.user, include_perms=True),
-            "common": common_bootstrap_payload(g.user),
+            "common": common_bootstrap_payload(),
             **(extra_bootstrap_data or {}),
         }
         return self.render_template(
@@ -381,7 +381,7 @@ def menu_data(user: User) -> dict[str, Any]:
 
 @cache_manager.cache.memoize(timeout=60)
 def cached_common_bootstrap_data(  # pylint: disable=unused-argument
-    user: User, user_id: int | None, locale: str
+    user_id: int | None, locale: str
 ) -> dict[str, Any]:
     """Common data always sent to the client
 
@@ -419,16 +419,15 @@ def cached_common_bootstrap_data(  # pylint: disable=unused-argument
         "extra_sequential_color_schemes": conf["EXTRA_SEQUENTIAL_COLOR_SCHEMES"],
         "extra_categorical_color_schemes": conf["EXTRA_CATEGORICAL_COLOR_SCHEMES"],
         "theme_overrides": conf["THEME_OVERRIDES"],
-        "menu_data": menu_data(user),
+        "menu_data": menu_data(g.user),
     }
     bootstrap_data.update(conf["COMMON_BOOTSTRAP_OVERRIDES_FUNC"](bootstrap_data))
     return bootstrap_data
 
 
-def common_bootstrap_payload(user: User) -> dict[str, Any]:
-    user_id = user.id if hasattr(user, "id") else None
+def common_bootstrap_payload() -> dict[str, Any]:
     return {
-        **cached_common_bootstrap_data(user, user_id, get_locale()),
+        **cached_common_bootstrap_data(utils.get_user_id(), get_locale()),
         "flash_messages": get_flashed_messages(with_categories=True),
     }
 
@@ -538,7 +537,7 @@ def show_unexpected_exception(ex: Exception) -> FlaskResponse:
 def get_common_bootstrap_data() -> dict[str, Any]:
     def serialize_bootstrap_data() -> str:
         return json.dumps(
-            {"common": common_bootstrap_payload(g.user)},
+            {"common": common_bootstrap_payload()},
             default=utils.pessimistic_json_iso_dttm_ser,
         )
 
@@ -556,7 +555,7 @@ class SupersetModelView(ModelView):
     def render_app_template(self) -> FlaskResponse:
         payload = {
             "user": bootstrap_user_data(g.user, include_perms=True),
-            "common": common_bootstrap_payload(g.user),
+            "common": common_bootstrap_payload(),
         }
         return self.render_template(
             "superset/spa.html",

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -605,7 +605,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             "force": force,
             "user": bootstrap_user_data(g.user, include_perms=True),
             "forced_height": request.args.get("height"),
-            "common": common_bootstrap_payload(g.user),
+            "common": common_bootstrap_payload(),
         }
         if slc:
             title = slc.slice_name
@@ -863,7 +863,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
             bootstrap_data=json.dumps(
                 {
                     "user": bootstrap_user_data(g.user, include_perms=True),
-                    "common": common_bootstrap_payload(g.user),
+                    "common": common_bootstrap_payload(),
                 },
                 default=utils.pessimistic_json_iso_dttm_ser,
             ),
@@ -954,7 +954,7 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
         payload = {
             "user": bootstrap_user_data(g.user, include_perms=True),
-            "common": common_bootstrap_payload(g.user),
+            "common": common_bootstrap_payload(),
         }
 
         return self.render_template(

--- a/superset/views/dashboard/views.py
+++ b/superset/views/dashboard/views.py
@@ -151,7 +151,7 @@ class Dashboard(BaseSupersetView):
         )
 
         bootstrap_data = {
-            "common": common_bootstrap_payload(g.user),
+            "common": common_bootstrap_payload(),
             "embedded": {"dashboard_id": dashboard_id_or_slug},
         }
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The caching mechanism for bootstrap data was not working as intended in the case where two users share the same first/last name.  The cache key was dependent on the `User` object passed. When a non-primitive object is used to generate a cache key, `flask-caching` calls `repr()` on it to determine the key: https://flask-caching.readthedocs.io/en/latest/index.html#memoization.

The `User` class comes from flask appbuilder and has the following `__repr__`:
```python
def get_full_name(self):
    return "{0} {1}".format(self.first_name, self.last_name)

def __repr__(self):
    return self.get_full_name()
```
Therefore, when two users shared a first and last name, they would generate the same cache key and the cache could leak between the two users.  This was noticed because it would result in affected users seeing menu results they shouldn't see, though it potentially had other subtle effects as well, particularly for anyone adding a user-dependent `COMMON_BOOTSTRAP_OVERRIDES_FUNC`.

This PR fixes the issue by passing the actual user id to the memoized function so that it's included in the cache key.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
