### PR TITLE
feat(dashboard): Hide chart header controls in reports

### DIFF
--- a/superset-frontend/src/dashboard/components/SliceHeader/SliceHeader.test.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeader/SliceHeader.test.tsx
@@ -486,10 +486,10 @@ test('Add extension to SliceHeader', () => {
   expect(screen.getByText('This is an extension')).toBeInTheDocument();
 });
 
-test('Do not display slice header controls if user is a bot', () => {
-  Object.defineProperty(window.navigator, 'webdriver', {
+test('Do not display slice header controls in reports', () => {
+  Object.defineProperty(window, 'location', {
     get() {
-      return true;
+      return { search: 'standalone=3' };
     },
   });
   const props = createProps();

--- a/superset-frontend/src/dashboard/components/SliceHeader/SliceHeader.test.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeader/SliceHeader.test.tsx
@@ -485,3 +485,15 @@ test('Add extension to SliceHeader', () => {
 
   expect(screen.getByText('This is an extension')).toBeInTheDocument();
 });
+
+test('Do not display slice header controls if user is a bot', () => {
+  Object.defineProperty(window.navigator, 'webdriver', {
+    get() {
+      return true;
+    },
+  });
+  const props = createProps();
+  render(<SliceHeader {...props} />, { useRedux: true, useRouter: true });
+  expect(screen.queryByTestId('SliceHeaderControls')).not.toBeInTheDocument();
+  expect(screen.queryByTestId('FiltersBadge')).not.toBeInTheDocument();
+});

--- a/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
@@ -37,6 +37,7 @@ import Icons from 'src/components/Icons';
 import { RootState } from 'src/dashboard/types';
 import { getSliceHeaderTooltip } from 'src/dashboard/util/getSliceHeaderTooltip';
 import { DashboardPageIdContext } from 'src/dashboard/containers/DashboardPage';
+import { isCurrentUserBot } from 'src/utils/isBot';
 
 const extensionsRegistry = getExtensionsRegistry();
 
@@ -240,7 +241,7 @@ const SliceHeader: FC<SliceHeaderProps> = ({
         )}
       </div>
       <div className="header-controls">
-        {!editMode && (
+        {!editMode && !isCurrentUserBot() && (
           <>
             {SliceHeaderExtension && (
               <SliceHeaderExtension

--- a/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
@@ -34,10 +34,12 @@ import SliceHeaderControls, {
 } from 'src/dashboard/components/SliceHeaderControls';
 import FiltersBadge from 'src/dashboard/components/FiltersBadge';
 import Icons from 'src/components/Icons';
+import { getUrlParam } from 'src/utils/urlUtils';
+import { URL_PARAMS } from 'src/constants';
 import { RootState } from 'src/dashboard/types';
 import { getSliceHeaderTooltip } from 'src/dashboard/util/getSliceHeaderTooltip';
+import { DashboardStandaloneMode } from 'src/dashboard/util/constants';
 import { DashboardPageIdContext } from 'src/dashboard/containers/DashboardPage';
-import { isCurrentUserBot } from 'src/utils/isBot';
 
 const extensionsRegistry = getExtensionsRegistry();
 
@@ -177,6 +179,9 @@ const SliceHeader: FC<SliceHeaderProps> = ({
     ({ dashboardInfo }) => dashboardInfo.crossFiltersEnabled,
   );
 
+  const standaloneMode = getUrlParam(URL_PARAMS.standalone);
+  const isReport = standaloneMode === DashboardStandaloneMode.REPORT;
+
   const canExplore = !editMode && supersetCanExplore;
 
   useEffect(() => {
@@ -241,7 +246,7 @@ const SliceHeader: FC<SliceHeaderProps> = ({
         )}
       </div>
       <div className="header-controls">
-        {!editMode && !isCurrentUserBot() && (
+        {!editMode && !isReport && (
           <>
             {SliceHeaderExtension && (
               <SliceHeaderExtension


### PR DESCRIPTION
### SUMMARY
If report is running, hide the slice header controls (filters badge, 3 dots options menu etc.).
To determine if report is running, we check if `standalone` query param is equal to `DashboardStandaloneMode.REPORT`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1728" alt="image" src="https://github.com/apache/superset/assets/15073128/ca1c305a-fd14-4a74-b1bf-28baae7fa36a">

After:
<img width="1728" alt="image" src="https://github.com/apache/superset/assets/15073128/d4d362e7-02ad-4edd-adda-76d76b69cd04">

### TESTING INSTRUCTIONS
1. Open a dashboard - chart header controls (filters badge, 3 dots for menu etc.) should be visible
2. Run a report -chart header controls should not be visible

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
