### PR TITLE
docs(intro): fix a single broken link (BugHerd #97)

### DIFF
--- a/docs/docs/intro.mdx
+++ b/docs/docs/intro.mdx
@@ -15,7 +15,7 @@ Here are a **few different ways you can get started with Superset**:
 
 - Install Superset [from scratch](https://superset.apache.org/docs/installation/installing-superset-from-scratch/)
 - Deploy Superset locally with one command
-  [using Docker Compose](installation/installing-superset-using-docker-compose)
+  [using Docker Compose](https://superset.apache.org/docs/installation/installing-superset-using-docker-compose)
 - Deploy Superset [with Kubernetes](https://superset.apache.org/docs/installation/running-on-kubernetes)
 - Run a [Docker image](https://hub.docker.com/r/apache/superset) from Dockerhub
 - Download Superset [from Pypi here](https://pypi.org/project/apache-superset/)


### PR DESCRIPTION
### SUMMARY
Fixes a broken link to the how-to-install-with-Docker-Compose page.  Reported in BugHerd issue 97.