### PR TITLE
fix: radar chart sort by error

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Radar/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Radar/buildQuery.ts
@@ -23,8 +23,7 @@ import {
 } from '@superset-ui/core';
 
 export default function buildQuery(formData: QueryFormData) {
-  const { series_limit_metric } = formData;
-  const sortByMetric = ensureIsArray(series_limit_metric)[0];
+  const sortByMetric = ensureIsArray(formData.orderby)[0];
 
   return buildQueryContext(formData, baseQueryObject => {
     let { metrics, orderby = [] } = baseQueryObject;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx
@@ -67,7 +67,7 @@ const config: ControlPanelConfig = {
       controlSetRows: [
         ['groupby'],
         ['metrics'],
-        ['timeseries_limit_metric'],
+        ['orderby'],
         ['adhoc_filters'],
         [
           {


### PR DESCRIPTION
fix(radar chart): 'sort by' in controlPanel correctly

### SUMMARY
There is a typo in radar chart buildQuery.ts. fix it by changed  `timeseries_limit_metric` to `orderby` and by formData.orderby in buildQuery.ts.

### TESTING INSTRUCTIONS
sort by will be normal function in radar chart.
It can be checked by result table

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

