### PR TITLE
fix: Flaky test_explore_json_async test

### DIFF
--- a/tests/integration_tests/core_tests.py
+++ b/tests/integration_tests/core_tests.py
@@ -714,7 +714,7 @@ class TestCore(SupersetTestCase):
         keys = list(data.keys())
 
         # If chart is cached, it will return 200, otherwise 202
-        self.assertTrue(rv.status_code == 200 or rv.status_code == 202)
+        self.assertTrue(rv.status_code in {200, 202})
         self.assertCountEqual(
             keys, ["channel_id", "job_id", "user_id", "status", "errors", "result_url"]
         )

--- a/tests/integration_tests/core_tests.py
+++ b/tests/integration_tests/core_tests.py
@@ -713,7 +713,8 @@ class TestCore(SupersetTestCase):
         data = json.loads(rv.data.decode("utf-8"))
         keys = list(data.keys())
 
-        self.assertEqual(rv.status_code, 202)
+        # If chart is cached, it will return 200, otherwise 202
+        self.assertTrue(rv.status_code == 200 or rv.status_code == 202)
         self.assertCountEqual(
             keys, ["channel_id", "job_id", "user_id", "status", "errors", "result_url"]
         )


### PR DESCRIPTION
### SUMMARY
This PR fixes the following flaky CI error:

```
FAILED tests/integration_tests/core_tests.py::TestCore::test_explore_json_async
- AssertionError: 200 != 202
```
The problem is that the response status will vary [if the results are cached](https://github.com/apache/superset/blob/97121465ddf772013604ffdb5d7378885bc6ee26/superset/views/core.py#L313) which depends on the tests execution order. Given that both `200` and `202` are valid response status for this endpoint, I updated the test to reflect that.

### TESTING INSTRUCTIONS
CI should be sufficient.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
