### PR TITLE
fix: Optimize fetching samples logic

### DIFF
--- a/superset/views/datasource/utils.py
+++ b/superset/views/datasource/utils.py
@@ -114,7 +114,7 @@ def get_samples(  # pylint: disable=too-many-arguments,too-many-locals
         sample_data = samples_instance.get_payload()["queries"][0]
 
         if sample_data.get("status") == QueryStatus.FAILED:
-            QueryCacheManager.delete(sample_data.get("cache_key"), CacheRegion.DATA)
+            QueryCacheManager.delete(count_star_data.get("cache_key"), CacheRegion.DATA)
             raise DatasetSamplesFailedError(sample_data.get("error"))
 
         sample_data["page"] = page


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Not a fix per se to https://github.com/apache/superset/pull/25995, but an alteration based on https://github.com/apache/superset/pull/25995#discussion_r1398499898. Per [this](https://github.com/apache/superset/blob/e7797b65d1dadc1c466d1852747657b0aade9690/superset/common/query_context_processor.py#L138-L169) code block it seems like my hypothesis was correct, i.e., though a cache key is known a priori it's only materialized when the query is successful and thus in our case if the `COUNT(*)` succeeds but the sample data query fails we should be clearing the cache for the former rather than the later.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
