### PR TITLE
chore: Updates Announce template to include CHANGELOG.md and UPDATING.md files

### DIFF
--- a/RELEASING/email_templates/announce.j2
+++ b/RELEASING/email_templates/announce.j2
@@ -35,6 +35,12 @@ The PyPI package:
 
 https://pypi.org/project/apache-superset/
 
+The Change Log for the release:
+https://github.com/apache/{{ project_module }}/blob/{{ version }}/CHANGELOG.md
+
+The Updating instructions for the release:
+https://github.com/apache/{{ project_module }}/blob/{{ version }}/UPDATING.md
+
 If you have any usage questions or have problems when upgrading or
 find any issues with enhancements included in this release, please
 don't hesitate to let us know by sending feedback to this mailing


### PR DESCRIPTION
### SUMMARY
We currently display links for the `CHANGELOG.md` and `UPDATING.md` files in `[VOTE]` emails but not in `[ANNOUNCE]` emails. This PR changes the announce template to also include this information.

### TESTING INSTRUCTIONS
CI should be sufficient.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
