### PR TITLE
fix: Add all Trino dependencies for Kerberos enablement

### DIFF
--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -40,8 +40,10 @@ default-setup-command() {
 apt-get-install() {
   say "::group::apt-get install dependencies"
   sudo apt-get update && sudo apt-get install --yes \
-    libsasl2-dev \
-    libldap2-dev
+    krb5-config \
+    libkrb5-dev \
+    libldap2-dev \
+    libsasl2-dev
   say "::endgroup::"
 }
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -143,9 +143,7 @@ geographiclib==1.52
 geopy==2.2.0
     # via apache-superset
 greenlet==2.0.2
-    # via
-    #   shillelagh
-    #   sqlalchemy
+    # via shillelagh
 gunicorn==21.2.0
     # via apache-superset
 hashids==1.3.1
@@ -371,6 +369,7 @@ werkzeug==2.3.3
     # via
     #   apache-superset
     #   flask
+    #   flask-appbuilder
     #   flask-jwt-extended
     #   flask-login
 wrapt==1.15.0

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -77,12 +77,16 @@ grpcio==1.54.0
     #   grpcio-status
 grpcio-status==1.54.0
     # via google-api-core
+gssapi==1.8.3
+    # via pyspnego
 iniconfig==2.0.0
     # via pytest
 jsonschema-spec==0.1.4
     # via openapi-spec-validator
 kiwisolver==1.4.4
     # via matplotlib
+krb5==0.5.1
+    # via pyspnego
 lunarcalendar==0.0.9
     # via prophet
 matplotlib==3.7.1
@@ -121,6 +125,8 @@ pyee==9.0.4
     # via playwright
 pyfakefs==5.2.2
     # via -r requirements/testing.in
+pyspnego[kerberos]==0.10.2
+    # via requests-kerberos
 pytest==7.3.1
     # via
     #   -r requirements/testing.in
@@ -132,6 +138,8 @@ pytest-mock==3.10.0
     # via -r requirements/testing.in
 pytz-deprecation-shim==0.1.0.post0
     # via tzlocal
+requests-kerberos==0.14.0
+    # via trino
 requests-oauthlib==1.3.1
     # via google-auth-oauthlib
 rfc3339-validator==0.1.4
@@ -148,7 +156,7 @@ tqdm==4.65.0
     # via
     #   cmdstanpy
     #   prophet
-trino==0.324.0
+trino[all]==0.324.0
     # via apache-superset
 tzlocal==4.3
     # via trino

--- a/setup.py
+++ b/setup.py
@@ -186,7 +186,7 @@ setup(
         "playwright": ["playwright>=1.37.0, <2"],
         "postgres": ["psycopg2-binary==2.9.6"],
         "presto": ["pyhive[presto]>=0.6.5"],
-        "trino": ["trino>=0.324.0"],
+        "trino": ["trino[all]>=0.324.0"],
         "prophet": ["prophet==1.1.1"],
         "redshift": ["sqlalchemy-redshift>=0.8.1, < 0.9"],
         "rockset": ["rockset-sqlalchemy>=0.0.1, <1.0.0"],


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Per our [documentation](https://superset.apache.org/docs/databases/trino/#2-kerberos-authentication), Superset supports Kerberos authentication for Trino, however installing the `superset[trino]` dependencies are not suffice as the `trino` package additionally requires the [requests-kerberos](https://github.com/trinodb/trino-python-client/blob/f99ef245f28b4e1784a829b7935a31d0215ace4d/setup.py#L29-L34) package.

Rather than defining `trino[kerberos]` as a dependency I though it would be prudent to defining `trino[all]` as this contains additional requirements like SQLAlchemy.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Ran `pip-compile-multi --no-upgrade`.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
