### PR TITLE
fix(plugin-chart-echarts): support numerical x-axis

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -20,9 +20,13 @@
 import { invert } from 'lodash';
 import {
   AnnotationLayer,
+  AxisType,
+  buildCustomFormatters,
   CategoricalColorNamespace,
+  CurrencyFormatter,
   ensureIsArray,
   GenericDataType,
+  getCustomFormatter,
   getMetricLabel,
   getNumberFormatter,
   getXAxisLabel,
@@ -34,9 +38,6 @@ import {
   isTimeseriesAnnotationLayer,
   t,
   TimeseriesChartDataResponseResult,
-  buildCustomFormatters,
-  getCustomFormatter,
-  CurrencyFormatter,
 } from '@superset-ui/core';
 import {
   extractExtraMetrics,
@@ -48,8 +49,8 @@ import { ZRLineType } from 'echarts/types/src/util/types';
 import {
   EchartsTimeseriesChartProps,
   EchartsTimeseriesFormData,
-  TimeseriesChartTransformedProps,
   OrientationType,
+  TimeseriesChartTransformedProps,
 } from './types';
 import { DEFAULT_FORM_DATA } from './constants';
 import { ForecastSeriesEnum, ForecastValue, Refs } from '../types';
@@ -88,8 +89,8 @@ import {
 } from './transformers';
 import {
   StackControlsValue,
-  TIMESERIES_CONSTANTS,
   TIMEGRAIN_TO_TIMESTAMP,
+  TIMESERIES_CONSTANTS,
 } from '../constants';
 import { getDefaultTooltip } from '../utils/tooltip';
 import {
@@ -448,13 +449,13 @@ export default function transformProps(
       rotate: xAxisLabelRotation,
     },
     minInterval:
-      xAxisType === 'time' && timeGrainSqla
+      xAxisType === AxisType.time && timeGrainSqla
         ? TIMEGRAIN_TO_TIMESTAMP[timeGrainSqla]
         : 0,
   };
   let yAxis: any = {
     ...defaultYAxis,
-    type: logAxis ? 'log' : 'value',
+    type: logAxis ? AxisType.log : AxisType.value,
     min,
     max,
     minorTick: { show: true },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -25,12 +25,12 @@ import {
   DTTM_ALIAS,
   ensureIsArray,
   GenericDataType,
+  LegendState,
+  normalizeTimestamp,
   NumberFormats,
   NumberFormatter,
-  TimeFormatter,
   SupersetTheme,
-  normalizeTimestamp,
-  LegendState,
+  TimeFormatter,
   ValueFormatter,
 } from '@superset-ui/core';
 import { SortSeriesType } from '@superset-ui/chart-controls';
@@ -511,6 +511,9 @@ export function sanitizeHtml(text: string): string {
 export function getAxisType(dataType?: GenericDataType): AxisType {
   if (dataType === GenericDataType.TEMPORAL) {
     return AxisType.time;
+  }
+  if (dataType === GenericDataType.NUMERIC) {
+    return AxisType.value;
   }
   return AxisType.category;
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -18,6 +18,7 @@
  */
 import { SortSeriesType } from '@superset-ui/chart-controls';
 import {
+  AxisType,
   DataRecord,
   GenericDataType,
   getNumberFormatter,
@@ -31,6 +32,7 @@ import {
   extractSeries,
   extractShowValueIndexes,
   formatSeriesName,
+  getAxisType,
   getChartPadding,
   getLegendProps,
   getOverMaxHiddenFormatter,
@@ -869,4 +871,11 @@ test('calculateLowerLogTick', () => {
   expect(calculateLowerLogTick(99)).toEqual(10);
   expect(calculateLowerLogTick(2)).toEqual(1);
   expect(calculateLowerLogTick(0.005)).toEqual(0.001);
+});
+
+test('getAxisType', () => {
+  expect(getAxisType(GenericDataType.TEMPORAL)).toEqual(AxisType.time);
+  expect(getAxisType(GenericDataType.NUMERIC)).toEqual(AxisType.value);
+  expect(getAxisType(GenericDataType.BOOLEAN)).toEqual(AxisType.category);
+  expect(getAxisType(GenericDataType.STRING)).toEqual(AxisType.category);
 });


### PR DESCRIPTION
### SUMMARY
Currently using a numeric x-axis produces a chart with a categorical x-axis. This sets the x-axis to 

### AFTER
Now the x-axis is numerical:
<img width="725" alt="image" src="https://github.com/apache/superset/assets/33317356/dac8bdf1-7120-456b-863b-94dad702942f">

### BEFORE
Previously the x-axis was set as categorical:
<img width="708" alt="image" src="https://github.com/apache/superset/assets/33317356/75cf9ab9-5b57-44ad-a25f-9a7f822a8b46">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: fixes #26034
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
