### PR TITLE
fix: bump node-fetch to 2.6.7

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -325,7 +325,7 @@
     "less-loader": "^10.2.0",
     "mini-css-extract-plugin": "^2.7.6",
     "mock-socket": "^9.0.3",
-    "node-fetch": "^2.6.1",
+    "node-fetch": "^2.6.7",
     "prettier": "^2.4.1",
     "prettier-plugin-packagejson": "^2.2.15",
     "process": "^0.11.10",


### PR DESCRIPTION
### SUMMARY
Bump node-fectch to 2.6.7 address CVE-2022-0235

https://nvd.nist.gov/vuln/detail/cve-2022-0235


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
