### PR TITLE
fix: flaky test_explore_json_async test v2

### DIFF
--- a/tests/integration_tests/core_tests.py
+++ b/tests/integration_tests/core_tests.py
@@ -714,10 +714,16 @@ class TestCore(SupersetTestCase):
         keys = list(data.keys())
 
         # If chart is cached, it will return 200, otherwise 202
-        self.assertTrue(rv.status_code in {200, 202})
-        self.assertCountEqual(
-            keys, ["channel_id", "job_id", "user_id", "status", "errors", "result_url"]
-        )
+        assert rv.status_code in {200, 202}
+        if rv.status_code == 202:
+            assert keys == [
+                "channel_id",
+                "job_id",
+                "user_id",
+                "status",
+                "errors",
+                "result_url",
+            ]
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     @mock.patch.dict(


### PR DESCRIPTION
### SUMMARY
#26059 relaxed the assertion in `test_explore_json_async` to not fail if the result was already cached. However, since the response payload is different for the 202 response, the test still fails if a 200 is received. This PR changes the assertion from the legacy `self.assert` notation to the preferred `assert` one, and makes the `keys` assertion both conditional on a 202 response, and explicitly asserts the returned keys, instead of the key count.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
