### PR TITLE
fix(database-import): Support importing a DB connection with a version set

### DIFF
--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -750,6 +750,7 @@ class ImportV1DatabaseExtraSchema(Schema):
     allows_virtual_table_explore = fields.Boolean(required=False)
     cancel_query_on_windows_unload = fields.Boolean(required=False)
     disable_data_preview = fields.Boolean(required=False)
+    version = fields.String(required=False, allow_none=True)
 
 
 class ImportV1DatabaseSchema(Schema):

--- a/tests/unit_tests/databases/commands/importers/v1/import_test.py
+++ b/tests/unit_tests/databases/commands/importers/v1/import_test.py
@@ -17,6 +17,7 @@
 # pylint: disable=unused-argument, import-outside-toplevel, invalid-name
 
 import copy
+import json
 
 import pytest
 from pytest_mock import MockFixture
@@ -142,3 +143,23 @@ def test_import_database_without_permission(
         str(excinfo.value)
         == "Database doesn't exist and user doesn't have permission to create databases"
     )
+
+
+def test_import_database_with_version(mocker: MockFixture, session: Session) -> None:
+    """
+    Test importing a database with a version set.
+    """
+    from superset import security_manager
+    from superset.commands.database.importers.v1.utils import import_database
+    from superset.models.core import Database
+    from tests.integration_tests.fixtures.importexport import database_config
+
+    mocker.patch.object(security_manager, "can_access", return_value=True)
+
+    engine = session.get_bind()
+    Database.metadata.create_all(engine)  # pylint: disable=no-member
+
+    config = copy.deepcopy(database_config)
+    config["extra"]["version"] = "1.1.1"
+    database = import_database(session, config)
+    assert json.loads(database.extra)["version"] == "1.1.1"


### PR DESCRIPTION
### SUMMARY
Add support for importing a DB connection with a version set.

### TESTING INSTRUCTIONS
Unit test added for this case. To manually test it:
1. Create a DB connection.
2. Set a version for this connection in the **ADVANCED** tab, under the **Other** section.
3. Export the DB connection.
4. Import it.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes https://github.com/apache/superset/issues/26115
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
