### PR TITLE
docs: add quickstart

### DIFF
--- a/docs/docs/api.mdx
+++ b/docs/docs/api.mdx
@@ -1,7 +1,7 @@
 ---
 title: API
 hide_title: true
-sidebar_position: 9
+sidebar_position: 10
 ---
 
 import { Buffer } from 'buffer';

--- a/docs/docs/contributing/_category_.json
+++ b/docs/docs/contributing/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Contributing",
-  "position": 6
+  "position": 7
 }

--- a/docs/docs/databases/_category_.json
+++ b/docs/docs/databases/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Connecting to Databases",
-  "position": 3
+  "position": 5
 }

--- a/docs/docs/frequently-asked-questions.mdx
+++ b/docs/docs/frequently-asked-questions.mdx
@@ -1,7 +1,7 @@
 ---
 title: Frequently Asked Questions
 hide_title: true
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 ## Frequently Asked Questions

--- a/docs/docs/installation/_category_.json
+++ b/docs/docs/installation/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Installation and Configuration",
-  "position": 2
+  "position": 3
 }

--- a/docs/docs/miscellaneous/_category_.json
+++ b/docs/docs/miscellaneous/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Miscellaneous",
-  "position": 5
+  "position": 6
 }

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -4,19 +4,22 @@ hide_title: false
 sidebar_position: 2
 ---
 
-**Ready to give Apache Superset a try?** This quickstart will help you run Superset on your local machine in **5 simple steps**.
-It assumes that you have [Docker](https://www.docker.com) installed.
+**Ready to give Apache Superset a try?** This quickstart will help you run Superset on your local machine in
+**5 simple steps**. It assumes that you have [Docker](https://www.docker.com) installed.
 
 ### 1. Get Superset
-To get started, add the latest Superset version in the `SUPERSET_VERSION` environment variable, and pull the container from Docker Hub:
+To get started, set the `SUPERSET_VERSION` environment variable with the latest Superset version.
+[Click here](https://github.com/apache/superset/releases) to check the latest version.
+
 ```
-$ export SUPERSET_VERSION="";
-         docker pull apache/superset:$SUPERSET_VERSION
+$ export SUPERSET_VERSION=<latest_version>
 ```
-:::tip
-Not sure what the latest stable Superset version is? [Click here](https://github.com/apache/superset/releases) to check our release page 
-for up-to-date information.
-:::
+
+Pull the Superset image from Docker Hub:
+
+```
+$ docker pull apache/superset:$SUPERSET_VERSION
+```
 
 ### 2. Start Superset
 ```
@@ -49,7 +52,8 @@ $ docker exec -it superset superset db upgrade &&
 ```
 :::tip
 This step can take some time. While you wait, feel free to join the official Slack channel to check for new releases,
-ask questions, and engage with the community. [Click here to join.](https://apache-superset.slack.com/join/shared_invite/zt-26ol9ge4y-kzUnSo9inRepOay0ufBTsA#/shared-invite/email)
+ask questions, and engage with the community.
+[Click here to join.](https://apache-superset.slack.com/join/shared_invite/zt-26ol9ge4y-kzUnSo9inRepOay0ufBTsA#/shared-invite/email)
 :::
 
 ### 5. Start using Superset

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -8,20 +8,26 @@ sidebar_position: 2
 It assumes that you have [Docker](https://www.docker.com) installed.
 
 ### 1. Get Superset
+To get started, add the latest Superset version in the `SUPERSET_VERSION` environment variable, and pull the container from Docker Hub:
 ```
-$ docker pull apache/superset:3.0.2
+$ export SUPERSET_VERSION="";
+         docker pull apache/superset:$SUPERSET_VERSION
 ```
+:::tip
+Not sure what the latest stable Superset version is? [Click here](https://github.com/apache/superset/releases) to check our release page 
+for up-to-date information.
+:::
 
 ### 2. Start Superset
 ```
 $ docker run -d -p 8080:8088 \
              -e "SUPERSET_SECRET_KEY=$(openssl rand -base64 42)" \
              -e "TALISMAN_ENABLED=False" \
-             --name superset apache/superset:3.0.2
+             --name superset apache/superset:$SUPERSET_VERSION
 ```
 :::tip
-Note that some configuration is mandatory for Superset in order to start.
-In particular, Superset will not start without a user-specified value of `SECRET_KEY` in a Superset configuration file or `SUPERSET_SECRET_KEY` as an environment variable.
+Note that some configuration is mandatory for Superset in order to start. In particular, Superset will not start without
+a user-specified value of `SECRET_KEY` in a Superset configuration file or `SUPERSET_SECRET_KEY` as an environment variable.
 Please see [Configuring Superset](https://superset.apache.org/docs/installation/configuring-superset/) for more details.
 :::
 
@@ -62,8 +68,8 @@ Once you're done with Superset, you can stop and remove it just like any other c
 $ docker container rm -f superset
 ```
 :::tip
-You can use the same container more than once, as Superset will persist data locally. However, make sure to properly stop all processes by running Docker
-`stop` command. By doing so, you can avoid data corruption and/or loss of data.
+You can use the same container more than once, as Superset will persist data locally. However, make sure to properly stop all
+processes by running Docker `stop` command. By doing so, you can avoid data corruption and/or loss of data.
 :::
 
 ## What's next?

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -4,7 +4,7 @@ hide_title: false
 sidebar_position: 2
 ---
 
-**Ready to give Apache Superset a try?** This quickstart will help you run Superset on your local machine.
+**Ready to give Apache Superset a try?** This quickstart will help you run Superset on your local machine in **5 simple steps**.
 It assumes that you have [Docker](https://www.docker.com) installed.
 
 ### 1. Get Superset
@@ -14,49 +14,53 @@ $ docker pull apache/superset:3.0.2
 
 ### 2. Start Superset
 ```
-$ docker run -d -p 8080:8088 -e "SUPERSET_SECRET_KEY=$(openssl rand -base64 42)" --name superset apache/superset:3.0.2
+$ docker run -d -p 8080:8088 \
+             -e "SUPERSET_SECRET_KEY=$(openssl rand -base64 42)" \
+             -e "TALISMAN_ENABLED=False" \
+             --name superset apache/superset:3.0.2
 ```
+:::tip
+Note that some configuration is mandatory for Superset in order to start.
+In particular, Superset will not start without a user-specified value of `SECRET_KEY` in a Superset configuration file or `SUPERSET_SECRET_KEY` as an environment variable.
+Please see [Configuring Superset](https://superset.apache.org/docs/installation/configuring-superset/) for more details.
+:::
 
 ### 3. Create an account
 ```
 $ docker exec -it superset superset fab create-admin \
               --username admin \
-              --firstname Superset \
+              --firstname Admin \
               --lastname Admin \
-              --email admin@superset.apache.org \
+              --email admin@localhost \
               --password admin
 ```
 
-### 4. Update the database
+### 4. Configure Superset
 ```
-$ docker exec -it superset superset db upgrade
+$ docker exec -it superset superset db upgrade &&
+         docker exec -it superset superset load_examples &&
+         docker exec -it superset superset init
 ```
+:::tip
+This step can take some time. While you wait, feel free to join the official Slack channel to check for new releases,
+ask questions, and engage with the community. [Click here to join.](https://apache-superset.slack.com/join/shared_invite/zt-26ol9ge4y-kzUnSo9inRepOay0ufBTsA#/shared-invite/email)
+:::
 
-### 5. Load fresh examples
-```
-$ docker exec -it superset superset load_examples
-```
-
-### 6. Configure security roles
-```
-$ docker exec -it superset superset init
-```
-
-### 7. Start using Superset
-To access your fresh Superset instance, head over to [http://localhost:8088](http://localhost:8088) and
+### 5. Start using Superset
+After configuring your fresh instance, head over to [http://localhost:8080](http://localhost:8080) and
 log in with the default created account:
 ```
 username: admin
 password: admin
 ```
 
-#### 🎉 Congratulations! Superset is now up and running on your machine 🎉
-
+#### 🎉 Congratulations! Superset is now up and running on your machine! 🎉
 
 ## What's next?
 
-From this point, you can head on to:
+From this point on, you can head on to:
 - [Create your first Dashboard](https://superset.apache.org/docs/creating-charts-dashboards/creating-your-first-dashboard)
 - [Connect to a Database](https://superset.apache.org/docs/databases/installing-database-drivers)
+- [Configure Superset](https://superset.apache.org/docs/installation/configuring-superset/)
 
 Or just explore our Documentation!

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -1,0 +1,56 @@
+---
+title: Quickstart
+hide_title: true
+sidebar_position: 2
+---
+
+## Quickstart
+
+You’ll need to have Docker or similar software installed on your computer to follow this quickstart.
+
+### Get Apache Superset using Docker
+```
+$ docker pull apache/superset:latest
+```
+
+### Start a Superset instance
+```
+$ docker run -d -p 8080:8088 -e "SUPERSET_SECRET_KEY=$(openssl rand -base64 42)" --name superset apache/superset
+```
+
+### Create an account for the instance
+```
+$ docker exec -it superset superset fab create-admin \
+              --username admin \
+              --firstname Superset \
+              --lastname Admin \
+              --email admin@superset.apache.org \
+              --password admin
+```
+
+### Update the instance database
+```
+$ docker exec -it superset superset db upgrade
+```
+
+### Load fresh examples
+```
+$ docker exec -it superset superset load_examples
+```
+
+### Configure the default roles
+```
+$ docker exec -it superset superset init
+```
+
+### Log in and start using Superset
+To access your fresh Superset instance, head over to [http://localhost:8088](http://localhost:8088)
+log in with the default username and password:
+```
+username: admin
+password: admin
+```
+
+## What's next?
+
+From this point, you can head on to Create your first Dashboard, Connect to a Database, or explore our Documentation.

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -22,17 +22,17 @@ $ docker pull apache/superset:$SUPERSET_VERSION
 ```
 
 ### 2. Start Superset
+:::tip
+Note that some configuration is mandatory for Superset in order to start. In particular, Superset will not start without
+a user-specified value of `SECRET_KEY` in a Superset configuration file or `SUPERSET_SECRET_KEY` as an environment variable.
+Please see [Configuring Superset](https://superset.apache.org/docs/installation/configuring-superset/) for more details.
+:::
 ```
 $ docker run -d -p 8080:8088 \
              -e "SUPERSET_SECRET_KEY=$(openssl rand -base64 42)" \
              -e "TALISMAN_ENABLED=False" \
              --name superset apache/superset:$SUPERSET_VERSION
 ```
-:::tip
-Note that some configuration is mandatory for Superset in order to start. In particular, Superset will not start without
-a user-specified value of `SECRET_KEY` in a Superset configuration file or `SUPERSET_SECRET_KEY` as an environment variable.
-Please see [Configuring Superset](https://superset.apache.org/docs/installation/configuring-superset/) for more details.
-:::
 
 ### 3. Create an account
 ```

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -1,24 +1,23 @@
 ---
 title: Quickstart
-hide_title: true
+hide_title: false
 sidebar_position: 2
 ---
 
-## Quickstart
+**Ready to give Apache Superset a try?** This quickstart will help you run Superset on your local machine.
+It assumes that you have [Docker](https://www.docker.com) or similar software installed.
 
-You’ll need to have Docker or similar software installed on your computer to follow this quickstart.
-
-### Get Apache Superset using Docker
+### 1. Get Superset
 ```
-$ docker pull apache/superset:latest
-```
-
-### Start a Superset instance
-```
-$ docker run -d -p 8080:8088 -e "SUPERSET_SECRET_KEY=$(openssl rand -base64 42)" --name superset apache/superset
+$ docker pull apache/superset:3.0.1
 ```
 
-### Create an account for the instance
+### 2. Start Superset
+```
+$ docker run -d -p 8080:8088 -e "SUPERSET_SECRET_KEY=$(openssl rand -base64 42)" --name superset apache/superset:3.0.1
+```
+
+### 3. Create an account
 ```
 $ docker exec -it superset superset fab create-admin \
               --username admin \
@@ -28,29 +27,36 @@ $ docker exec -it superset superset fab create-admin \
               --password admin
 ```
 
-### Update the instance database
+### 4. Update the database
 ```
 $ docker exec -it superset superset db upgrade
 ```
 
-### Load fresh examples
+### 5. Load fresh examples
 ```
 $ docker exec -it superset superset load_examples
 ```
 
-### Configure the default roles
+### 6. Configure security roles
 ```
 $ docker exec -it superset superset init
 ```
 
-### Log in and start using Superset
-To access your fresh Superset instance, head over to [http://localhost:8088](http://localhost:8088)
+### 7. Start using Superset
+To access your fresh Superset instance, head over to [http://localhost:8088](http://localhost:8088) and
 log in with the default username and password:
 ```
 username: admin
 password: admin
 ```
 
+#### 🎉 Congratulations! Superset is now up and running on your machine 🎉
+
+
 ## What's next?
 
-From this point, you can head on to Create your first Dashboard, Connect to a Database, or explore our Documentation.
+From this point, you can head on to:
+- [Create your first Dashboard](https://superset.apache.org/docs/creating-charts-dashboards/creating-your-first-dashboard)
+- [Connect to a Database](https://superset.apache.org/docs/databases/installing-database-drivers)
+
+Or just explore our Documentation!

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -5,16 +5,16 @@ sidebar_position: 2
 ---
 
 **Ready to give Apache Superset a try?** This quickstart will help you run Superset on your local machine.
-It assumes that you have [Docker](https://www.docker.com) or similar software installed.
+It assumes that you have [Docker](https://www.docker.com) installed.
 
 ### 1. Get Superset
 ```
-$ docker pull apache/superset:3.0.1
+$ docker pull apache/superset:3.0.2
 ```
 
 ### 2. Start Superset
 ```
-$ docker run -d -p 8080:8088 -e "SUPERSET_SECRET_KEY=$(openssl rand -base64 42)" --name superset apache/superset:3.0.1
+$ docker run -d -p 8080:8088 -e "SUPERSET_SECRET_KEY=$(openssl rand -base64 42)" --name superset apache/superset:3.0.2
 ```
 
 ### 3. Create an account
@@ -44,7 +44,7 @@ $ docker exec -it superset superset init
 
 ### 7. Start using Superset
 To access your fresh Superset instance, head over to [http://localhost:8088](http://localhost:8088) and
-log in with the default username and password:
+log in with the default created account:
 ```
 username: admin
 password: admin

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -56,6 +56,16 @@ password: admin
 
 #### 🎉 Congratulations! Superset is now up and running on your machine! 🎉
 
+### Wrapping Up
+Once you're done with Superset, you can stop and remove it just like any other container:
+```
+$ docker container rm -f superset
+```
+:::tip
+You can use the same container more than once, as Superset will persist data locally. However, make sure to properly stop all processes by running Docker
+`stop` command. By doing so, you can avoid data corruption and/or loss of data.
+:::
+
 ## What's next?
 
 From this point on, you can head on to:

--- a/docs/docs/security/_category_.json
+++ b/docs/docs/security/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Security",
-  "position": 10
+  "position": 9
 }


### PR DESCRIPTION
### SUMMARY
As per Discussion #25976 and [DISCUSS] sent over the [Apache dev mailing list](https://lists.apache.org/thread/7w51kd3fktgmx2mnjgk33y554zcbypb1), this PR creates a quickstart page, simplifying the installation process, and providing:
- Simplifying the installation method.
- Allowing users to get up and running a Superset instance faster.

While allowing us to:
- Split installation and configuration topics.
- Provide a stable playground for users to explore (by making the user to install a stable release of Superset).
