### PR TITLE
feat: Adds legacy time support for Waterfall chart

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/buildQuery.ts
@@ -19,15 +19,14 @@
 import {
   buildQueryContext,
   ensureIsArray,
-  getXAxisColumn,
-  isXAxisSet,
   QueryFormData,
 } from '@superset-ui/core';
 
 export default function buildQuery(formData: QueryFormData) {
+  const { x_axis, granularity_sqla, groupby } = formData;
   const columns = [
-    ...(isXAxisSet(formData) ? ensureIsArray(getXAxisColumn(formData)) : []),
-    ...ensureIsArray(formData.groupby),
+    ...ensureIsArray(x_axis || granularity_sqla),
+    ...ensureIsArray(groupby),
   ];
   return buildQueryContext(formData, baseQueryObject => [
     {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/controlPanel.tsx
@@ -17,25 +17,27 @@
  * under the License.
  */
 import React from 'react';
-import { t } from '@superset-ui/core';
+import { hasGenericChartAxes, t } from '@superset-ui/core';
 import {
   ControlPanelConfig,
   ControlSubSectionHeader,
   D3_TIME_FORMAT_DOCS,
   DEFAULT_TIME_FORMAT,
   formatSelectOptions,
+  sections,
   sharedControls,
 } from '@superset-ui/chart-controls';
 import { showValueControl } from '../controls';
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
+    sections.genericTime,
     {
       label: t('Query'),
       expanded: true,
       controlSetRows: [
-        ['x_axis'],
-        ['time_grain_sqla'],
+        [hasGenericChartAxes ? 'x_axis' : null],
+        [hasGenericChartAxes ? 'time_grain_sqla' : null],
         ['groupby'],
         ['metric'],
         ['adhoc_filters'],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/index.ts
@@ -61,7 +61,7 @@ export default class EchartsWaterfallChartPlugin extends ChartPlugin<
           { url: example3 },
         ],
         name: t('Waterfall Chart'),
-        tags: [t('Categorical'), t('Comparison'), t('ECharts')],
+        tags: [t('Categorical'), t('Comparison'), t('ECharts'), t('Popular')],
         thumbnail,
       }),
       transformProps,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/transformProps.ts
@@ -185,6 +185,7 @@ export default function transformProps(
   const { setDataMask = () => {}, onContextMenu, onLegendStateChanged } = hooks;
   const {
     currencyFormat,
+    granularitySqla = '',
     groupby,
     increaseColor,
     decreaseColor,
@@ -213,7 +214,10 @@ export default function transformProps(
   const breakdownName = isAdhocColumn(breakdownColumn)
     ? breakdownColumn.label!
     : breakdownColumn;
-  const xAxisName = isAdhocColumn(xAxis) ? xAxis.label! : xAxis;
+  const xAxisColumn = xAxis || granularitySqla;
+  const xAxisName = isAdhocColumn(xAxisColumn)
+    ? xAxisColumn.label!
+    : xAxisColumn;
   const metricLabel = getMetricLabel(metric);
 
   const transformedData = transformer({


### PR DESCRIPTION
### SUMMARY
Follow-up of https://github.com/apache/superset/pull/25557 to add support for legacy time controls in Waterfall charts.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1754" alt="Screenshot 2023-11-29 at 15 47 46" src="https://github.com/apache/superset/assets/70410625/7c22ad84-7c98-48d9-a700-7217a1f13fb2">

### TESTING INSTRUCTIONS
1 - Set `GENERIC_CHART_AXES` feature flag to False
2 - Test if you are able to create a Waterfall chart using the legacy time controls

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
