### PR TITLE
fix(annotations): time grain column

### DIFF
--- a/superset-frontend/src/components/Chart/chartAction.js
+++ b/superset-frontend/src/components/Chart/chartAction.js
@@ -269,9 +269,13 @@ export function runAnnotationQuery({
       return Promise.resolve();
     }
 
-    const granularity = fd.time_grain_sqla || fd.granularity;
-    fd.time_grain_sqla = granularity;
-    fd.granularity = granularity;
+    // remap from controls to formData naming; in the original formData the
+    // `granularity` attribute represents the time grain, but in the request
+    // payload it corresponds to the name of the column where the time grain
+    // should be applied...
+    fd.time_grain_sqla = fd.time_grain_sqla || fd.granularity;
+    fd.granularity = fd.granularity_sqla;
+
     const overridesKeys = Object.keys(annotation.overrides);
     if (overridesKeys.includes('since') || overridesKeys.includes('until')) {
       annotation.overrides = {

--- a/superset-frontend/src/components/Chart/chartAction.js
+++ b/superset-frontend/src/components/Chart/chartAction.js
@@ -269,10 +269,9 @@ export function runAnnotationQuery({
       return Promise.resolve();
     }
 
-    // remap from controls to formData naming; in the original formData the
-    // `granularity` attribute represents the time grain, but in the request
-    // payload it corresponds to the name of the column where the time grain
-    // should be applied...
+    // In the original formData the `granularity` attribute represents the time grain (eg
+    // `P1D`), but in the request payload it corresponds to the name of the column where
+    // the time grain should be applied (eg, `Date`), so we need to move things around.
     fd.time_grain_sqla = fd.time_grain_sqla || fd.granularity;
     fd.granularity = fd.granularity_sqla;
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

A confusing bug in the annotation layers... it seems that in the form data the `granularity` attribute stores the time grain (eg, `P1D` for daily time grain):

https://github.com/apache/superset/blob/f1a6b2f852eb879e69c7a93803cf0dd2ed58ce76/superset-frontend/src/explore/controls.jsx#L248-L270

But in the request payload, `granularity` should point to the column name, not the grain:

https://github.com/apache/superset/blob/f1a6b2f852eb879e69c7a93803cf0dd2ed58ce76/superset/charts/schemas.py#L1146-L1149

When generating an annotation query we need to move things around to match the form data to the request schema.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
