### PR TITLE
chore: Rename SET_ACTIVE_TABS action, add a new action

### DIFF
--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -611,9 +611,14 @@ export function setDirectPathToChild(path) {
   return { type: SET_DIRECT_PATH, path };
 }
 
+export const SET_ACTIVE_TAB = 'SET_ACTIVE_TAB';
+export function setActiveTab(tabId, prevTabId) {
+  return { type: SET_ACTIVE_TAB, tabId, prevTabId };
+}
+
 export const SET_ACTIVE_TABS = 'SET_ACTIVE_TABS';
-export function setActiveTabs(tabId, prevTabId) {
-  return { type: SET_ACTIVE_TABS, tabId, prevTabId };
+export function setActiveTabs(activeTabs) {
+  return { type: SET_ACTIVE_TABS, activeTabs };
 }
 
 export const SET_FOCUSED_FILTER_FIELD = 'SET_FOCUSED_FILTER_FIELD';

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
@@ -25,7 +25,7 @@ import DashboardBuilder from 'src/dashboard/components/DashboardBuilder/Dashboar
 import useStoredSidebarWidth from 'src/components/ResizableSidebar/useStoredSidebarWidth';
 import {
   fetchFaveStar,
-  setActiveTabs,
+  setActiveTab,
   setDirectPathToChild,
 } from 'src/dashboard/actions/dashboardState';
 import {
@@ -41,7 +41,7 @@ fetchMock.get('glob:*/csstemplateasyncmodelview/api/read', {});
 jest.mock('src/dashboard/actions/dashboardState', () => ({
   ...jest.requireActual('src/dashboard/actions/dashboardState'),
   fetchFaveStar: jest.fn(),
-  setActiveTabs: jest.fn(),
+  setActiveTab: jest.fn(),
   setDirectPathToChild: jest.fn(),
 }));
 jest.mock('src/components/ResizableSidebar/useStoredSidebarWidth');
@@ -90,7 +90,7 @@ describe('DashboardBuilder', () => {
     favStarStub = (fetchFaveStar as jest.Mock).mockReturnValue({
       type: 'mock-action',
     });
-    activeTabsStub = (setActiveTabs as jest.Mock).mockReturnValue({
+    activeTabsStub = (setActiveTab as jest.Mock).mockReturnValue({
       type: 'mock-action',
     });
     (useStoredSidebarWidth as jest.Mock).mockImplementation(() => [

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -51,7 +51,7 @@ const propTypes = {
 
   // actions (from DashboardComponent.jsx)
   logEvent: PropTypes.func.isRequired,
-  setActiveTabs: PropTypes.func,
+  setActiveTab: PropTypes.func,
 
   // grid related
   availableColumnCount: PropTypes.number,
@@ -75,7 +75,7 @@ const defaultProps = {
   columnWidth: 0,
   activeTabs: [],
   directPathToChild: [],
-  setActiveTabs() {},
+  setActiveTab() {},
   onResizeStart() {},
   onResize() {},
   onResizeStop() {},
@@ -125,12 +125,12 @@ export class Tabs extends React.PureComponent {
   }
 
   componentDidMount() {
-    this.props.setActiveTabs(this.state.activeKey);
+    this.props.setActiveTab(this.state.activeKey);
   }
 
   componentDidUpdate(prevProps, prevState) {
     if (prevState.activeKey !== this.state.activeKey) {
-      this.props.setActiveTabs(this.state.activeKey, prevState.activeKey);
+      this.props.setActiveTab(this.state.activeKey, prevState.activeKey);
     }
   }
 

--- a/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
+++ b/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
@@ -35,7 +35,7 @@ import {
 } from 'src/dashboard/actions/dashboardLayout';
 import {
   setDirectPathToChild,
-  setActiveTabs,
+  setActiveTab,
   setFullSizeChartId,
 } from 'src/dashboard/actions/dashboardState';
 
@@ -109,7 +109,7 @@ function mapDispatchToProps(dispatch) {
       handleComponentDrop,
       setDirectPathToChild,
       setFullSizeChartId,
-      setActiveTabs,
+      setActiveTab,
       logEvent,
     },
     dispatch,

--- a/superset-frontend/src/dashboard/reducers/dashboardState.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.js
@@ -37,6 +37,7 @@ import {
   SET_DIRECT_PATH,
   SET_FOCUSED_FILTER_FIELD,
   UNSET_FOCUSED_FILTER_FIELD,
+  SET_ACTIVE_TAB,
   SET_ACTIVE_TABS,
   SET_FULL_SIZE_CHART_ID,
   ON_FILTERS_REFRESH,
@@ -179,13 +180,19 @@ export default function dashboardStateReducer(state = {}, action) {
         directPathLastUpdated: Date.now(),
       };
     },
-    [SET_ACTIVE_TABS]() {
+    [SET_ACTIVE_TAB]() {
       const newActiveTabs = new Set(state.activeTabs);
       newActiveTabs.delete(action.prevTabId);
       newActiveTabs.add(action.tabId);
       return {
         ...state,
         activeTabs: Array.from(newActiveTabs),
+      };
+    },
+    [SET_ACTIVE_TABS]() {
+      return {
+        ...state,
+        activeTabs: action.activeTabs,
       };
     },
     [SET_OVERRIDE_CONFIRM]() {

--- a/superset-frontend/src/dashboard/reducers/dashboardState.test.ts
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.test.ts
@@ -18,21 +18,33 @@
  */
 
 import dashboardStateReducer from './dashboardState';
-import { setActiveTabs } from '../actions/dashboardState';
+import { setActiveTab, setActiveTabs } from '../actions/dashboardState';
 
 describe('DashboardState reducer', () => {
-  it('SET_ACTIVE_TABS', () => {
+  it('SET_ACTIVE_TAB', () => {
     expect(
-      dashboardStateReducer({ activeTabs: [] }, setActiveTabs('tab1')),
+      dashboardStateReducer({ activeTabs: [] }, setActiveTab('tab1')),
     ).toEqual({ activeTabs: ['tab1'] });
     expect(
-      dashboardStateReducer({ activeTabs: ['tab1'] }, setActiveTabs('tab1')),
+      dashboardStateReducer({ activeTabs: ['tab1'] }, setActiveTab('tab1')),
     ).toEqual({ activeTabs: ['tab1'] });
     expect(
       dashboardStateReducer(
         { activeTabs: ['tab1'] },
-        setActiveTabs('tab2', 'tab1'),
+        setActiveTab('tab2', 'tab1'),
       ),
     ).toEqual({ activeTabs: ['tab2'] });
+  });
+
+  it('SET_ACTIVE_TABS', () => {
+    expect(
+      dashboardStateReducer({ activeTabs: [] }, setActiveTabs(['tab1'])),
+    ).toEqual({ activeTabs: ['tab1'] });
+    expect(
+      dashboardStateReducer(
+        { activeTabs: ['tab1', 'tab2'] },
+        setActiveTabs(['tab3', 'tab4']),
+      ),
+    ).toEqual({ activeTabs: ['tab3', 'tab4'] });
   });
 });


### PR DESCRIPTION
### SUMMARY
Previously `SET_ACTIVE_TABS` were in fact changing only 1 active tab in an array of tabs. I renamed it to `SET_ACTIVE_TAB` and created a new `SET_ACTIVE_TABS` action which allows us to programatically set active tabs state in the dashboard.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
No functional changes, added unit test for the new action.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
