### PR TITLE
fix: set label on adhoc column should persist

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { supersetTheme, ThemeProvider } from '@superset-ui/core';
+import ColumnSelectPopover from 'src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover';
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
+describe('ColumnSelectPopover - onTabChange function', () => {
+  it('updates adhocColumn when switching to sqlExpression tab with custom label', () => {
+    const mockColumns = [{ column_name: 'year' }];
+    const mockOnClose = jest.fn();
+    const mockOnChange = jest.fn();
+    const mockGetCurrentTab = jest.fn();
+    const mockSetDatasetModal = jest.fn();
+    const mockSetLabel = jest.fn();
+
+    const store = mockStore({ explore: { datasource: { type: 'table' } } });
+
+    const { container, getByText } = render(
+      <Provider store={store}>
+        <ThemeProvider theme={supersetTheme}>
+          <ColumnSelectPopover
+            columns={mockColumns}
+            editedColumn={mockColumns[0]}
+            getCurrentTab={mockGetCurrentTab}
+            hasCustomLabel
+            isTemporal
+            label="Custom Label"
+            onChange={mockOnChange}
+            onClose={mockOnClose}
+            setDatasetModal={mockSetDatasetModal}
+            setLabel={mockSetLabel}
+          />
+        </ThemeProvider>
+      </Provider>,
+    );
+
+    const sqlExpressionTab = container.querySelector(
+      '#adhoc-metric-edit-tabs-tab-sqlExpression',
+    );
+    expect(sqlExpressionTab).not.toBeNull();
+    fireEvent.click(sqlExpressionTab!);
+    expect(mockGetCurrentTab).toHaveBeenCalledWith('sqlExpression');
+
+    const saveButton = getByText('Save');
+    fireEvent.click(saveButton);
+    expect(mockOnChange).toHaveBeenCalledWith({
+      label: 'Custom Label',
+      sqlExpression: 'year',
+      expressionType: 'SQL',
+    });
+  });
+});

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
@@ -68,6 +68,7 @@ interface ColumnSelectPopoverProps {
   editedColumn?: ColumnMeta | AdhocColumn;
   onChange: (column: ColumnMeta | AdhocColumn) => void;
   onClose: () => void;
+  hasCustomLabel: boolean;
   setLabel: (title: string) => void;
   getCurrentTab: (tab: string) => void;
   label: string;
@@ -93,13 +94,14 @@ const getInitialColumnValues = (
 const ColumnSelectPopover = ({
   columns,
   editedColumn,
+  getCurrentTab,
+  hasCustomLabel,
+  isTemporal,
+  label,
   onChange,
   onClose,
   setDatasetModal,
   setLabel,
-  getCurrentTab,
-  label,
-  isTemporal,
 }: ColumnSelectPopoverProps) => {
   const datasourceType = useSelector<ExplorePageState, string | undefined>(
     state => state.explore.datasource.type,
@@ -224,11 +226,27 @@ const ColumnSelectPopover = ({
 
   const onTabChange = useCallback(
     tab => {
+      if (tab === 'sqlExpression' && hasCustomLabel) {
+        // if we switch to the Custom SQL tab and we have a custom label we need
+        // to update the adhoc column label
+        const sqlExpression =
+          adhocColumn?.sqlExpression ||
+          selectedSimpleColumn?.column_name ||
+          selectedCalculatedColumn?.expression ||
+          '';
+        setAdhocColumn({ label, sqlExpression, expressionType: 'SQL' });
+      }
       getCurrentTab(tab);
       // @ts-ignore
       sqlEditorRef.current?.editor.focus();
     },
-    [getCurrentTab],
+    [
+      getCurrentTab,
+      hasCustomLabel,
+      adhocColumn,
+      selectedSimpleColumn,
+      selectedCalculatedColumn,
+    ],
   );
 
   const onSqlEditorFocus = useCallback(() => {

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopoverTrigger.tsx
@@ -103,6 +103,7 @@ const ColumnSelectPopoverTrigger = ({
           setDatasetModal={setDatasetModal}
           onClose={handleClosePopover}
           onChange={onColumnEdit}
+          hasCustomLabel={hasCustomLabel}
           label={popoverLabel}
           setLabel={setPopoverLabel}
           getCurrentTab={getCurrentTab}
@@ -114,6 +115,7 @@ const ColumnSelectPopoverTrigger = ({
       columns,
       editedColumn,
       getCurrentTab,
+      hasCustomLabel,
       handleClosePopover,
       isTemporal,
       onColumnEdit,
@@ -121,10 +123,13 @@ const ColumnSelectPopoverTrigger = ({
     ],
   );
 
-  const onLabelChange = useCallback((e: any) => {
-    setPopoverLabel(e.target.value);
-    setHasCustomLabel(true);
-  }, []);
+  const onLabelChange = useCallback(
+    (e: any) => {
+      setPopoverLabel(e.target.value);
+      setHasCustomLabel(true);
+    },
+    [setPopoverLabel, setHasCustomLabel],
+  );
 
   const popoverTitle = useMemo(
     () => (


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<img src="https://github.com/apache/superset/assets/1534870/c502ebb6-1024-4971-9b1c-195dd368c2b5" width="50%" />

The component for defining columns has an unorthodox architecture:

```
 ____________________________________
|                                    |
| <DndColumnSelect />                |
|  ________________________________  |
| |                                | |
| | <ColumnSelectPopoverTrigger /> | |
| |                                | |
| | genre (pencil)                 | |
| |________________________________| |
|  ________________________________  |
| |                                | |
| | <ColumnSelectPopover />        | |
| |                                | |
| | Saved | Simple | Custom SQL    | |
| |                                | |
| | genre                          | |
| |                                | |
| | [    CLOSE    ] [    SAVE    ] | |
| |________________________________| |
|____________________________________|
```

When a user edits the label using the pencil in `<ColumnSelectPopoverTrigger />`, the `<ColumnSelectPopover />` component is not aware of that change. If the users then clicks "SAVE" to use the adhoc column ("CUSTOM SQL") with the new label, the `<ColumnSelectPopover />` won't do anything because it's not aware of any changes.

This PR modifies `<ColumnSelectPopover />` so that if the user selects "CUSTOM SQL" and the label has been modified (via a new prop `hasCustomLabel`), then an adhoc column is defined in the component's state. This way, when "SAVE" is clicked, the label gets persisted correctly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
