### PR TITLE
fix: Migration order due to cherry which went astray

### DIFF
--- a/superset/migrations/shared/utils.py
+++ b/superset/migrations/shared/utils.py
@@ -43,11 +43,9 @@ def table_has_column(table: str, column: str) -> bool:
     :param column: A column name
     :returns: True iff the column exists in the table
     """
-    config = op.get_context().config
-    engine = engine_from_config(
-        config.get_section(config.config_ini_section), prefix="sqlalchemy."
-    )
-    insp = reflection.Inspector.from_engine(engine)
+
+    insp = inspect(op.get_context().bind)
+
     try:
         return any(col["name"] == column for col in insp.get_columns(table))
     except NoSuchTableError:

--- a/superset/migrations/versions/2023-09-06_13-18_317970b4400c_added_time_secondary_column_to_.py
+++ b/superset/migrations/versions/2023-09-06_13-18_317970b4400c_added_time_secondary_column_to_.py
@@ -32,7 +32,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import Session
 
 from superset import db
-from superset.migrations.shared.utils import paginated_update
+from superset.migrations.shared.utils import paginated_update, table_has_column
 
 Base = declarative_base()
 
@@ -45,23 +45,25 @@ class SqlaTable(Base):
 
 
 def upgrade():
-    op.add_column(
-        "tables",
-        sa.Column(
-            "always_filter_main_dttm",
-            sa.Boolean(),
-            nullable=True,
-            default=False,
-            server_default=sa.false(),
-        ),
-    )
+    if not table_has_column("tables", "always_filter_main_dttm"):
+        op.add_column(
+            "tables",
+            sa.Column(
+                "always_filter_main_dttm",
+                sa.Boolean(),
+                nullable=True,
+                default=False,
+                server_default=sa.false(),
+            ),
+        )
 
-    bind = op.get_bind()
-    session = db.Session(bind=bind)
+        bind = op.get_bind()
+        session = db.Session(bind=bind)
 
-    for table in paginated_update(session.query(SqlaTable)):
-        table.always_filter_main_dttm = False
+        for table in paginated_update(session.query(SqlaTable)):
+            table.always_filter_main_dttm = False
 
 
 def downgrade():
-    op.drop_column("tables", "always_filter_main_dttm")
+    if table_has_column("tables", "always_filter_main_dttm"):
+        op.drop_column("tables", "always_filter_main_dttm")

--- a/superset/migrations/versions/2023-12-01_12-03_b7851ee5522f_replay_317970b4400c.py
+++ b/superset/migrations/versions/2023-12-01_12-03_b7851ee5522f_replay_317970b4400c.py
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""replay 317970b4400c
+
+Revision ID: b7851ee5522f
+Revises: 4b85906e5b91
+Create Date: 2023-12-01 12:03:27.538945
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "b7851ee5522f"
+down_revision = "4b85906e5b91"
+
+from importlib import import_module
+
+import sqlalchemy as sa
+from alembic import op
+
+module = import_module(
+    "superset.migrations.versions.2023-09-06_13-18_317970b4400c_added_time_secondary_column_to_"
+)
+
+
+def upgrade():
+    module.upgrade()
+
+
+def downgrade():
+    module.downgrade()


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR fixes a Alembic migration conundrum when upgrading from `3.0` to `3.1` due to a [picked cherry](https://github.com/apache/superset/commit/88e6f22180b61f1c3ba15134f2f64064a448ff92) which somehow went astray. 

The Alembic visions chain on the various branches is:

#### master

- `ec54aca4c8a2`
- `317970b4400c`
- `4b85906e5b91`

#### 3.0

- `ec54aca4c8a2`
- `4b85906e5b91`

#### 3.1 

- `ec54aca4c8a2`
- `317970b4400c`
- `4b85906e5b91`

i.e., per the previously mentioned cherry in 3.0 revision `4b85906e5b91` somehow became rewired from `317970b4400c` to `ec54aca4c8a2` meaning the `317970b4400c` was never present in 3.0. 

This PR:

1. Adds safeguards to `317970b4400c`.
2.  Adds revision `b7851ee5522f`—which should also be cherry-picked into `3.1`—which merely replays `317970b4400c` for both `master` and `3.1`.

These two steps ensure that if your upgrading/downgrading from either `master` or `3.0` that `317970b4400c` will run if and only if the migration has not been run previous—determined by the presence/absence of the column respectively.

<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes https://github.com/apache/superset/issues/26163
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
