### PR TITLE
feat: update time comparison choices (again)

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/sections/advancedAnalytics.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/sections/advancedAnalytics.tsx
@@ -121,6 +121,10 @@ export const advancedAnalyticsControls: ControlPanelSectionConfig = {
             ['2 years ago', t('2 years ago')],
             ['156 weeks ago', t('156 weeks ago')],
             ['3 years ago', t('3 years ago')],
+            ['208 weeks ago', t('208 weeks ago')],
+            ['4 years ago', t('4 years ago')],
+            ['261 weeks ago', t('261 weeks ago')],
+            ['5 years ago', t('5 years ago')],
           ],
           description: t(
             'Overlay one or more timeseries from a ' +

--- a/superset-frontend/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-partition/src/controlPanel.tsx
@@ -322,6 +322,10 @@ const config: ControlPanelConfig = {
                 ['2 years', t('2 years')],
                 ['156 weeks', t('156 weeks')],
                 ['3 years', t('3 years')],
+                ['208 weeks ago', t('208 weeks ago')],
+                ['4 years ago', t('4 years ago')],
+                ['261 weeks ago', t('261 weeks ago')],
+                ['5 years ago', t('5 years ago')],
               ],
               description: t(
                 'Overlay one or more timeseries from a ' +

--- a/superset-frontend/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-rose/src/controlPanel.tsx
@@ -204,6 +204,10 @@ const config: ControlPanelConfig = {
                 ['2 years', t('2 years')],
                 ['156 weeks', t('156 weeks')],
                 ['3 years', t('3 years')],
+                ['208 weeks ago', t('208 weeks ago')],
+                ['4 years ago', t('4 years ago')],
+                ['261 weeks ago', t('261 weeks ago')],
+                ['5 years ago', t('5 years ago')],
               ],
               description: t(
                 'Overlay one or more timeseries from a ' +

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/NVD3Controls.tsx
@@ -472,6 +472,10 @@ export const timeSeriesSection: ControlPanelSectionConfig[] = [
               ['2 years', t('2 years')],
               ['156 weeks', t('156 weeks')],
               ['3 years', t('3 years')],
+              ['208 weeks ago', t('208 weeks ago')],
+              ['4 years ago', t('4 years ago')],
+              ['261 weeks ago', t('261 weeks ago')],
+              ['5 years ago', t('5 years ago')],
             ],
             description: t(
               'Overlay one or more timeseries from a ' +

--- a/superset-frontend/src/explore/controlPanels/sections.tsx
+++ b/superset-frontend/src/explore/controlPanels/sections.tsx
@@ -202,6 +202,10 @@ export const NVD3TimeSeries: ControlPanelSectionConfig[] = [
               ['2 years', t('2 years')],
               ['156 weeks', t('156 weeks')],
               ['3 years', t('3 years')],
+              ['208 weeks ago', t('208 weeks ago')],
+              ['4 years ago', t('4 years ago')],
+              ['261 weeks ago', t('261 weeks ago')],
+              ['5 years ago', t('5 years ago')],
             ],
             description: t(
               'Overlay one or more timeseries from a ' +


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

<!--- Describe the change below, including rationale and design decisions -->
Similar to https://github.com/apache/superset/pull/22458, this PR adds Y5Y time comparison choices to make it faster to compare with pre-pandemic times.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
