### PR TITLE
fix: bump pyarrow constraints (CVE-2023-47248)

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -252,7 +252,7 @@ prison==0.2.1
     # via flask-appbuilder
 prompt-toolkit==3.0.38
     # via click-repl
-pyarrow==12.0.0
+pyarrow==14.0.1
     # via apache-superset
 pycparser==2.20
     # via cffi
@@ -371,6 +371,7 @@ werkzeug==2.3.3
     # via
     #   apache-superset
     #   flask
+    #   flask-appbuilder
     #   flask-jwt-extended
     #   flask-login
 wrapt==1.15.0

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ setup(
         "python-dateutil",
         "python-dotenv",
         "python-geohash",
-        "pyarrow>=12.0.0, <13",
+        "pyarrow>=14.0.1, <15",
         "pyyaml>=6.0.0, <7.0.0",
         "PyJWT>=2.4.0, <3.0",
         "redis>=4.5.4, <5.0",


### PR DESCRIPTION
PyArrow < 14.0.1 is vulnerable to RCE when using IPC, Flight or Parquet
from untrusted sources.

Superset SQLLab does so.

So we need to care about this vulnerability.
