### PR TITLE
chore: Lower giveup log level for retried functions to warning

### DIFF
--- a/superset/utils/retries.py
+++ b/superset/utils/retries.py
@@ -16,7 +16,6 @@
 # under the License.
 
 import logging
-
 from collections.abc import Generator
 from typing import Any, Callable, Optional
 

--- a/superset/utils/retries.py
+++ b/superset/utils/retries.py
@@ -15,8 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from collections.abc import Generator
 import logging
+
+from collections.abc import Generator
 from typing import Any, Callable, Optional
 
 import backoff

--- a/superset/utils/retries.py
+++ b/superset/utils/retries.py
@@ -16,6 +16,7 @@
 # under the License.
 
 from collections.abc import Generator
+import logging
 from typing import Any, Callable, Optional
 
 import backoff
@@ -26,6 +27,7 @@ def retry_call(
     *args: Any,
     strategy: Callable[..., Generator[int, None, None]] = backoff.constant,
     exception: type[Exception] = Exception,
+    giveup_log_level: int = logging.WARNING,
     fargs: Optional[list[Any]] = None,
     fkwargs: Optional[dict[str, Any]] = None,
     **kwargs: Any
@@ -33,6 +35,7 @@ def retry_call(
     """
     Retry a given call.
     """
+    kwargs["giveup_log_level"] = giveup_log_level
     decorated = backoff.on_exception(strategy, exception, *args, **kwargs)(func)
     fargs = fargs or []
     fkwargs = fkwargs or {}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The goal of this PR is to eliminate unnecessary error logs.  The `retry_call` function uses the `backoff` lib to decorate functions we want to retry.  After the retry limit is reached, the `backoff` decorator generates a log saying that it's giving up.  This log defaults to the error level, which isn't necessary here since the exception raised by the wrapped function gets bubbled up and logged at the appropriate level already.

This PR solves the issue by lowering the log from the `backoff` decorator to a warning

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
