### PR TITLE
chore: remove duplicate process_sql_expression

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -87,10 +87,8 @@ from superset.db_engine_specs.base import BaseEngineSpec, TimestampExpression
 from superset.exceptions import (
     ColumnNotFoundException,
     DatasetInvalidPermissionEvaluationException,
-    QueryClauseValidationException,
     QueryObjectValidationError,
     SupersetGenericDBErrorException,
-    SupersetSecurityException,
 )
 from superset.jinja_context import (
     BaseTemplateProcessor,
@@ -107,10 +105,9 @@ from superset.models.helpers import (
     process_sql_expression,
     QueryResult,
     QueryStringExtended,
-    validate_adhoc_subquery,
 )
 from superset.models.slice import Slice
-from superset.sql_parse import ParsedQuery, sanitize_clause
+from superset.sql_parse import ParsedQuery
 from superset.superset_typing import (
     AdhocColumn,
     AdhocMetric,

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -104,6 +104,7 @@ from superset.models.helpers import (
     CertificationMixin,
     ExploreMixin,
     ImportExportMixin,
+    process_sql_expression,
     QueryResult,
     QueryStringExtended,
     validate_adhoc_subquery,
@@ -1078,27 +1079,6 @@ sqlatable_user = Table(
 )
 
 
-def _process_sql_expression(
-    expression: str | None,
-    database_id: int,
-    schema: str,
-    template_processor: BaseTemplateProcessor | None = None,
-) -> str | None:
-    if template_processor and expression:
-        expression = template_processor.process_template(expression)
-    if expression:
-        try:
-            expression = validate_adhoc_subquery(
-                expression,
-                database_id,
-                schema,
-            )
-            expression = sanitize_clause(expression)
-        except (QueryClauseValidationException, SupersetSecurityException) as ex:
-            raise QueryObjectValidationError(ex.message) from ex
-    return expression
-
-
 class SqlaTable(
     Model, BaseDatasource, ExploreMixin
 ):  # pylint: disable=too-many-public-methods
@@ -1533,7 +1513,7 @@ class SqlaTable(
                 sqla_column = column(column_name)
             sqla_metric = self.sqla_aggregations[metric["aggregate"]](sqla_column)
         elif expression_type == utils.AdhocMetricExpressionType.SQL:
-            expression = _process_sql_expression(
+            expression = process_sql_expression(
                 expression=metric["sqlExpression"],
                 database_id=self.database_id,
                 schema=self.schema,
@@ -1563,7 +1543,7 @@ class SqlaTable(
         :rtype: sqlalchemy.sql.column
         """
         label = utils.get_column_name(col)
-        expression = _process_sql_expression(
+        expression = process_sql_expression(
             expression=col["sqlExpression"],
             database_id=self.database_id,
             schema=self.schema,

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -813,7 +813,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
         self,
         template_processor: Optional[  # pylint: disable=unused-argument
             BaseTemplateProcessor
-        ] = None,  # pylint: disable=unused-argument
+        ] = None,
     ) -> TextClause:
         return self.fetch_values_predicate
 

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -52,6 +52,7 @@ from superset.models.helpers import (
     ExploreMixin,
     ExtraJSONMixin,
     ImportExportMixin,
+    process_sql_expression,
 )
 from superset.sql_parse import CtasMethod, ParsedQuery, Table
 from superset.sqllab.limiting_factor import LimitingFactor
@@ -345,7 +346,7 @@ class Query(
         :rtype: sqlalchemy.sql.column
         """
         label = get_column_name(col)
-        expression = self._process_sql_expression(
+        expression = process_sql_expression(
             expression=col["sqlExpression"],
             database_id=self.database_id,
             schema=self.schema,

--- a/superset/views/datasource/utils.py
+++ b/superset/views/datasource/utils.py
@@ -43,7 +43,7 @@ def get_limit_clause(page: Optional[int], per_page: Optional[int]) -> dict[str, 
     return {"row_offset": offset, "row_limit": limit}
 
 
-def get_samples(  # pylint: disable=too-many-arguments,too-many-locals
+def get_samples(  # pylint: disable=too-many-arguments
     datasource_type: str,
     datasource_id: int,
     force: bool = False,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The `process_sql_expression` is duplicated. This PR cleans it up.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
