### PR TITLE
fix(chart-filter): Avoid column denormalization if not enabled

### DIFF
--- a/superset/datasource/api.py
+++ b/superset/datasource/api.py
@@ -115,9 +115,12 @@ class DatasourceRestApi(BaseSupersetApi):
             return self.response(403, message=ex.message)
 
         row_limit = apply_max_row_limit(app.config["FILTER_SELECT_ROW_LIMIT"])
+        denormalize_column = not datasource.normalize_columns
         try:
             payload = datasource.values_for_column(
-                column_name=column_name, limit=row_limit
+                column_name=column_name,
+                limit=row_limit,
+                denormalize_column=denormalize_column,
             )
             return self.response(200, result=payload)
         except KeyError:

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1340,14 +1340,18 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
             )
         return and_(*l)
 
-    def values_for_column(self, column_name: str, limit: int = 10000) -> list[Any]:
-        # always denormalize column name before querying for values
+    def values_for_column(
+        self, column_name: str, limit: int = 10000, denormalize_column: bool = False
+    ) -> list[Any]:
+        # denormalize column name before querying for values unless disabled in the dataset
         db_dialect = self.database.get_dialect()
-        denormalized_col_name = self.database.db_engine_spec.denormalize_name(
-            db_dialect, column_name
+        column_name_ = (
+            self.database.db_engine_spec.denormalize_name(db_dialect, column_name)
+            if denormalize_column
+            else column_name
         )
         cols = {col.column_name: col for col in self.columns}
-        target_col = cols[denormalized_col_name]
+        target_col = cols[column_name_]
         tp = self.get_template_processor()
         tbl, cte = self.get_from_clause(tp)
 

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -792,7 +792,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
         self,
         template_processor: Optional[  # pylint: disable=unused-argument
             BaseTemplateProcessor
-        ] = None,  # pylint: disable=unused-argument
+        ] = None,
     ) -> TextClause:
         return self.fetch_values_predicate
 
@@ -1343,7 +1343,8 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
     def values_for_column(
         self, column_name: str, limit: int = 10000, denormalize_column: bool = False
     ) -> list[Any]:
-        # denormalize column name before querying for values unless disabled in the dataset
+        # denormalize column name before querying for values
+        # unless disabled in the dataset configuration
         db_dialect = self.database.get_dialect()
         column_name_ = (
             self.database.db_engine_spec.denormalize_name(db_dialect, column_name)


### PR DESCRIPTION
### SUMMARY
Avoid de-normalizing column names in case the engine supports it **but column normalization is enabled in the dataset level**. This is enabled by default to datasets created prior to this feature, to make sure that syncing columns wouldn't break existing charts/etc.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before**

https://github.com/apache/superset/assets/96086495/f30e8688-81c8-4019-b10d-4e4aaef932f6

**After**

https://github.com/apache/superset/assets/96086495/31909ae1-91b7-4710-9c9e-3f531a344821

### TESTING INSTRUCTIONS
1. Create a dataset powered by an engine that supports column de-normalization (such as Snowflake). Note that:
 a. All columns are **uppercase**.
 b. Column normalization is disabled (under the **SETTINGS** tab).
2. Modify the dataset, and enable column normalization.
3. Save changes.
4. Modify the dataset again, and sync columns. Note that all columns are now **lowercase**.
5. Save changes.
6. Create a new chart using this dataset, and drop any column in the FILTERS section.
7. Validate the filter is showing available options in the dropdown.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes https://github.com/apache/superset/issues/26198
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
