### PR TITLE
fix: Includes 90° x-axis label rotation

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Bubble/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Bubble/controlPanel.tsx
@@ -138,6 +138,7 @@ const config: ControlPanelConfig = {
               choices: [
                 [0, '0°'],
                 [45, '45°'],
+                [90, '90°'],
               ],
               default: xAxisLabelRotation,
               renderTrigger: true,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
@@ -325,6 +325,7 @@ const config: ControlPanelConfig = {
               choices: [
                 [0, '0°'],
                 [45, '45°'],
+                [90, '90°'],
               ],
               default: xAxisLabelRotation,
               renderTrigger: true,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
@@ -202,6 +202,7 @@ const config: ControlPanelConfig = {
               choices: [
                 [0, '0°'],
                 [45, '45°'],
+                [90, '90°'],
               ],
               default: xAxisLabelRotation,
               renderTrigger: true,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -172,6 +172,7 @@ function createAxisControl(axis: 'x' | 'y'): ControlSetRow[] {
           choices: [
             [0, '0°'],
             [45, '45°'],
+            [90, '90°'],
           ],
           default: xAxisLabelRotation,
           renderTrigger: true,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/controlPanel.tsx
@@ -190,6 +190,7 @@ const config: ControlPanelConfig = {
               choices: [
                 [0, '0°'],
                 [45, '45°'],
+                [90, '90°'],
               ],
               default: xAxisLabelRotation,
               renderTrigger: true,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/controlPanel.tsx
@@ -133,6 +133,7 @@ const config: ControlPanelConfig = {
               choices: [
                 [0, '0°'],
                 [45, '45°'],
+                [90, '90°'],
               ],
               default: xAxisLabelRotation,
               renderTrigger: true,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/SmoothLine/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/SmoothLine/controlPanel.tsx
@@ -132,6 +132,7 @@ const config: ControlPanelConfig = {
               choices: [
                 [0, '0°'],
                 [45, '45°'],
+                [90, '90°'],
               ],
               default: xAxisLabelRotation,
               renderTrigger: true,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/controlPanel.tsx
@@ -184,6 +184,7 @@ const config: ControlPanelConfig = {
               choices: [
                 [0, '0°'],
                 [45, '45°'],
+                [90, '90°'],
               ],
               default: xAxisLabelRotation,
               renderTrigger: true,


### PR DESCRIPTION
### SUMMARY
Includes 90° x-axis label rotation by default, as opposed to requiring users to input the value, as it's frequently used for charts with many data points.

Check https://github.com/apache/superset/issues/26159 for more context.

### TESTING INSTRUCTIONS
CI should be sufficient.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
