### PR TITLE
fix(Calendar Heatmap): Add Back chart options for Calendar Heatmap

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/src/Calendar.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/src/Calendar.ts
@@ -56,6 +56,9 @@ interface CalendarProps {
   valueFormatter: (value: number) => string;
   verboseMap: Record<string, string>;
   theme: SupersetTheme;
+  colorRangeEnd?: number;
+  colorRangeStart?: number;
+  useCustomColorRange?: boolean;
 }
 
 function Calendar(element: HTMLElement, props: CalendarProps) {

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/src/Calendar.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/src/Calendar.ts
@@ -76,6 +76,9 @@ function Calendar(element: HTMLElement, props: CalendarProps) {
     valueFormatter,
     verboseMap,
     theme,
+    colorRangeEnd,
+    colorRangeStart,
+    useCustomColorRange,
   } = props;
 
   const container = d3Select(element)
@@ -98,10 +101,9 @@ function Calendar(element: HTMLElement, props: CalendarProps) {
       calContainer.text(`${METRIC_TEXT}: ${verboseMap[metric] || metric}`);
     }
     const timestamps = metricsData[metric];
-    const rawExtents = d3Extent(
-      Object.keys(timestamps),
-      key => timestamps[key],
-    );
+    const rawExtents = useCustomColorRange
+      ? ([colorRangeStart, colorRangeEnd - 1] as [number, number])
+      : d3Extent(Object.keys(timestamps), key => timestamps[key]);
     // Guard against undefined extents (empty data)
     const extents: [number, number] =
       rawExtents[0] != null && rawExtents[1] != null

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/src/Calendar.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/src/Calendar.ts
@@ -105,7 +105,10 @@ function Calendar(element: HTMLElement, props: CalendarProps) {
     }
     const timestamps = metricsData[metric];
     const rawExtents = useCustomColorRange
-      ? ([colorRangeStart, colorRangeEnd - 1] as [number, number])
+      ? ([
+          Math.min(colorRangeStart as number, colorRangeEnd as number),
+          Math.max(colorRangeStart as number, colorRangeEnd as number),
+        ] as [number, number])
       : d3Extent(Object.keys(timestamps), key => timestamps[key]);
     // Guard against undefined extents (empty data)
     const extents: [number, number] =

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/src/Calendar.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/src/Calendar.ts
@@ -58,7 +58,6 @@ interface CalendarProps {
   theme: SupersetTheme;
   colorRangeEnd?: number;
   colorRangeStart?: number;
-  useCustomColorRange?: boolean;
 }
 
 function Calendar(element: HTMLElement, props: CalendarProps) {
@@ -81,7 +80,6 @@ function Calendar(element: HTMLElement, props: CalendarProps) {
     theme,
     colorRangeEnd,
     colorRangeStart,
-    useCustomColorRange,
   } = props;
 
   const container = d3Select(element)
@@ -104,6 +102,8 @@ function Calendar(element: HTMLElement, props: CalendarProps) {
       calContainer.text(`${METRIC_TEXT}: ${verboseMap[metric] || metric}`);
     }
     const timestamps = metricsData[metric];
+    const useCustomColorRange =
+      Number.isFinite(colorRangeStart) && Number.isFinite(colorRangeEnd);
     const rawExtents = useCustomColorRange
       ? ([
           Math.min(colorRangeStart as number, colorRangeEnd as number),

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts
@@ -147,7 +147,11 @@ const config: ControlPanelConfig = {
               renderTrigger: true,
               default: undefined,
               label: t('Color Range Start'),
-              description: t('test'),
+              description: t(
+                'Lower bound of the color scale. When both start and end are ' +
+                  'set, the legend uses this fixed range instead of the ' +
+                  'automatic data range.',
+              ),
             },
           },
           {
@@ -159,7 +163,11 @@ const config: ControlPanelConfig = {
               renderTrigger: true,
               default: undefined,
               label: t('Color Range End'),
-              description: t('test'),
+              description: t(
+                'Upper bound of the color scale. When both start and end are ' +
+                  'set, the legend uses this fixed range instead of the ' +
+                  'automatic data range.',
+              ),
             },
           },
         ],

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/src/controlPanel.ts
@@ -82,7 +82,7 @@ const config: ControlPanelConfig = {
     {
       label: t('Chart Options'),
       expanded: true,
-      tabOverride: 'customize',
+      description: t('Options'),
       controlSetRows: [
         ['linear_color_scheme'],
         [
@@ -138,6 +138,32 @@ const config: ControlPanelConfig = {
           },
         ],
         [
+          {
+            name: 'color_range_start',
+            config: {
+              type: 'TextControl',
+              isInt: true,
+              validators: [legacyValidateInteger],
+              renderTrigger: true,
+              default: undefined,
+              label: t('Color Range Start'),
+              description: t('test'),
+            },
+          },
+          {
+            name: 'color_range_end',
+            config: {
+              type: 'TextControl',
+              isInt: true,
+              validators: [legacyValidateInteger],
+              renderTrigger: true,
+              default: undefined,
+              label: t('Color Range End'),
+              description: t('test'),
+            },
+          },
+        ],
+        [
           'y_axis_format',
           {
             name: 'x_axis_time_format',
@@ -182,7 +208,6 @@ const config: ControlPanelConfig = {
             config: {
               type: 'CheckboxControl',
               label: t('Show Metric Names'),
-              renderTrigger: true,
               default: true,
               description: t('Whether to display the metric name as a title'),
             },

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/src/transformProps.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/src/transformProps.ts
@@ -35,12 +35,21 @@ export default function transformProps(chartProps: ChartProps) {
     subdomainGranularity,
     xAxisTimeFormat,
     yAxisFormat,
+    colorRangeEnd,
+    colorRangeStart,
   } = formData;
 
   const { verboseMap } = datasource;
   const timeFormatter = (ts: number | string) =>
     getFormattedUTCTime(ts, xAxisTimeFormat);
   const valueFormatter = getNumberFormatter(yAxisFormat);
+
+  // Get the color range if both are specified
+  const useCustomColorRange =
+    colorRangeEnd !== undefined &&
+    colorRangeEnd !== '' &&
+    colorRangeStart !== undefined &&
+    colorRangeStart !== '';
 
   return {
     height,
@@ -58,5 +67,8 @@ export default function transformProps(chartProps: ChartProps) {
     timeFormatter,
     valueFormatter,
     verboseMap,
+    colorRangeEnd,
+    colorRangeStart,
+    useCustomColorRange,
   };
 }

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/src/transformProps.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/src/transformProps.ts
@@ -44,10 +44,6 @@ export default function transformProps(chartProps: ChartProps) {
     getFormattedUTCTime(ts, xAxisTimeFormat);
   const valueFormatter = getNumberFormatter(yAxisFormat);
 
-  // Use a fixed color range only when both bounds are valid numbers
-  const useCustomColorRange =
-    Number.isFinite(colorRangeStart) && Number.isFinite(colorRangeEnd);
-
   return {
     height,
     data: queriesData[0].data,
@@ -66,6 +62,5 @@ export default function transformProps(chartProps: ChartProps) {
     verboseMap,
     colorRangeEnd,
     colorRangeStart,
-    useCustomColorRange,
   };
 }

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/src/transformProps.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/src/transformProps.ts
@@ -44,12 +44,9 @@ export default function transformProps(chartProps: ChartProps) {
     getFormattedUTCTime(ts, xAxisTimeFormat);
   const valueFormatter = getNumberFormatter(yAxisFormat);
 
-  // Get the color range if both are specified
+  // Use a fixed color range only when both bounds are valid numbers
   const useCustomColorRange =
-    colorRangeEnd !== undefined &&
-    colorRangeEnd !== '' &&
-    colorRangeStart !== undefined &&
-    colorRangeStart !== '';
+    Number.isFinite(colorRangeStart) && Number.isFinite(colorRangeEnd);
 
   return {
     height,


### PR DESCRIPTION
## **User description**
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

SIP: #26229

Adds chart options back to the Calendar Heatmap. The new list of Chart options is:
- Color Scheme
- Cell size
- Cell padding
- Cell Radius
- Color Steps
- Color Range
- Number/Time Formatting
- Legend Toggle
- Show Values Toggle

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

![Screenshot 2023-12-10 at 1 46 10 PM](https://github.com/apache/superset/assets/36670322/1f1eb8b1-3b0a-4327-bc59-ed552039c40e)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Choose a dataset with time data
2. Select a calendar heatmap to chart
3. Change the different Chart options and check that they work properly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #26229
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Restore chart options for Calendar Heatmap and add custom color range controls

### What Changed
- Adds two new chart options: "Color Range Start" and "Color Range End" so users can specify an explicit numeric color range for the heatmap.
- When both color range fields are provided, the heatmap uses the specified start/end values to compute color buckets instead of deriving them from the data; otherwise it falls back to automatic scaling.
- Control panel text and layout updated so the Chart Options section shows the new controls and a simplified description; the "Show Metric Names" option remains available by default.

### Impact
`✅ Clearer color scaling when users set explicit ranges`
`✅ Fewer unexpected color buckets for sparse or skewed data`
`✅ Easier to configure heatmap color bounds via Chart Options`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
