### PR TITLE
chore: improve CSP add base uri restriction

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -1425,6 +1425,7 @@ TALISMAN_ENABLED = utils.cast_to_boolean(os.environ.get("TALISMAN_ENABLED", True
 # If you want Talisman, how do you want it configured??
 TALISMAN_CONFIG = {
     "content_security_policy": {
+        "base-uri": ["'self'"],
         "default-src": ["'self'"],
         "img-src": ["'self'", "blob:", "data:"],
         "worker-src": ["'self'", "blob:"],
@@ -1447,6 +1448,7 @@ TALISMAN_CONFIG = {
 # React requires `eval` to work correctly in dev mode
 TALISMAN_DEV_CONFIG = {
     "content_security_policy": {
+        "base-uri": ["'self'"],
         "default-src": ["'self'"],
         "img-src": ["'self'", "blob:", "data:"],
         "worker-src": ["'self'", "blob:"],


### PR DESCRIPTION
### SUMMARY

Improves our current default CSP policy by adding `base-uri` to `self`. base-uri directive restricts the URLs which can be used in a document's [<base>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base) element.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
