### PR TITLE
chore(async queries): sending statsd event for async events API call

### DIFF
--- a/superset/async_events/api.py
+++ b/superset/async_events/api.py
@@ -23,7 +23,7 @@ from flask_appbuilder.security.decorators import permission_name, protect
 
 from superset.async_events.async_query_manager import AsyncQueryTokenException
 from superset.extensions import async_query_manager, event_logger
-from superset.views.base_api import BaseSupersetApi
+from superset.views.base_api import BaseSupersetApi, statsd_metrics
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +36,7 @@ class AsyncEventsRestApi(BaseSupersetApi):
     @event_logger.log_this
     @protect()
     @safe
+    @statsd_metrics
     @permission_name("list")
     def events(self) -> Response:
         """


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Logging statsd event for async_events endpoint so that we can track http call count, duration to this API.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Go to your statsd provider, for example datadog. You should be able to see metrics like `AsyncEventsRestApi.events.duration`, `AsyncEventsRestApi.events.success` etc.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
