### PR TITLE
fix: Stacked charts with numerical columns

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -223,7 +223,7 @@ export default function transformProps(
 
   const dataTypes = getColtypesMapping(queriesData[0]);
   const xAxisDataType = dataTypes?.[xAxisLabel] ?? dataTypes?.[xAxisOrig];
-  const xAxisType = getAxisType(xAxisDataType);
+  const xAxisType = getAxisType(stack, xAxisDataType);
   const series: SeriesOption[] = [];
   const formatter = contributionMode
     ? getNumberFormatter(',.0%')

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -247,7 +247,7 @@ export default function transformProps(
   const isAreaExpand = stack === StackControlsValue.Expand;
   const xAxisDataType = dataTypes?.[xAxisLabel] ?? dataTypes?.[xAxisOrig];
 
-  const xAxisType = getAxisType(xAxisDataType);
+  const xAxisType = getAxisType(stack, xAxisDataType);
   const series: SeriesOption[] = [];
 
   const forcePercentFormatter = Boolean(contributionMode || isAreaExpand);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -508,11 +508,14 @@ export function sanitizeHtml(text: string): string {
   return format.encodeHTML(text);
 }
 
-export function getAxisType(dataType?: GenericDataType): AxisType {
+export function getAxisType(
+  stack: StackType,
+  dataType?: GenericDataType,
+): AxisType {
   if (dataType === GenericDataType.TEMPORAL) {
     return AxisType.time;
   }
-  if (dataType === GenericDataType.NUMERIC) {
+  if (dataType === GenericDataType.NUMERIC && !stack) {
     return AxisType.value;
   }
   return AxisType.category;

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -875,10 +875,13 @@ test('calculateLowerLogTick', () => {
 });
 
 test('getAxisType', () => {
-  expect(getAxisType(GenericDataType.TEMPORAL)).toEqual(AxisType.time);
-  expect(getAxisType(GenericDataType.NUMERIC)).toEqual(AxisType.value);
-  expect(getAxisType(GenericDataType.BOOLEAN)).toEqual(AxisType.category);
-  expect(getAxisType(GenericDataType.STRING)).toEqual(AxisType.category);
+  expect(getAxisType(false, GenericDataType.TEMPORAL)).toEqual(AxisType.time);
+  expect(getAxisType(false, GenericDataType.NUMERIC)).toEqual(AxisType.value);
+  expect(getAxisType(true, GenericDataType.NUMERIC)).toEqual(AxisType.category);
+  expect(getAxisType(false, GenericDataType.BOOLEAN)).toEqual(
+    AxisType.category,
+  );
+  expect(getAxisType(false, GenericDataType.STRING)).toEqual(AxisType.category);
 });
 
 test('getMinAndMaxFromBounds returns empty object when not truncating', () => {


### PR DESCRIPTION
### SUMMARY
https://github.com/apache/superset/pull/26087 added support for numerical x-axis but ended up introducing https://github.com/apache/superset/issues/26255 and https://github.com/apache/superset/issues/26256 because ECharts does not support stacked charts with numerical x-axis. This PR converts the x-axis to type `category` when a chart is stacked.

Fixes: https://github.com/apache/superset/issues/26255
Fixes: https://github.com/apache/superset/issues/26256

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1777" alt="Screenshot 2023-12-13 at 11 14 13" src="https://github.com/apache/superset/assets/70410625/90696850-7fd7-4861-945e-fad605383f41">
<img width="1779" alt="Screenshot 2023-12-13 at 11 13 16" src="https://github.com/apache/superset/assets/70410625/1b045025-44f6-4da1-ba94-079bee57f628">

### TESTING INSTRUCTIONS
1 - Create a stacked chart with a numerical x-axis
2 - Make sure the axis and tooltip are calculated correctly

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
