### PR TITLE
fix(dashboard): load redshift date filter correctly

### DIFF
--- a/superset/db_engine_specs/redshift.py
+++ b/superset/db_engine_specs/redshift.py
@@ -16,6 +16,7 @@
 # under the License.
 import logging
 import re
+from datetime import datetime
 from re import Pattern
 from typing import Any, Optional
 
@@ -29,6 +30,7 @@ from superset.errors import SupersetErrorType
 from superset.models.core import Database
 from superset.models.sql_lab import Query
 from superset.sql_parse import Table
+from sqlalchemy.types import Date, DateTime
 
 logger = logging.getLogger()
 
@@ -146,6 +148,19 @@ class RedshiftEngineSpec(PostgresBaseEngineSpec, BasicParametersMixin):
         :return: Conditionally mutated label
         """
         return label.lower()
+
+    @classmethod
+    def convert_dttm(
+        cls, target_type: str, dttm: datetime, db_extra: dict[str, Any] | None = None
+    ) -> str | None:
+        sqla_type = cls.get_sqla_column_type(target_type)
+
+        if isinstance(sqla_type, Date):
+            return f"TO_DATE('{dttm.date().isoformat()}', 'YYYY-MM-DD')"
+        if isinstance(sqla_type, DateTime):
+            dttm_formatted = dttm.isoformat(sep=" ", timespec="microseconds")
+            return f"""TO_TIMESTAMP('{dttm_formatted}', 'YYYY-MM-DD HH24:MI:SS.US')"""
+        return None
 
     @classmethod
     def get_cancel_query_id(cls, cursor: Any, query: Query) -> Optional[str]:


### PR DESCRIPTION
add convert_dttm method for redshift

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
1. There was convert_dttm implementation missing for redshift
2.  due to this date filter on redshit dataset not working
3. giving sqlalchemy error ```raise exc.CompileError(
sqlalchemy.exc.CompileError: Cannot compile Column object until its 'name' is assigned.```

query that was getting submitted: ```10:20:33,526:INFO:superset.connectors.sqla.models:SELECT day AS day
FROM (SELECT date_trunc('day', created_on)  as day
FROM public.redshift_order) AS virtual_table
WHERE day IN (<name unknown>)```

### BEFORE SCREENSHOTS OR ANIMATED GIF


<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
