### PR TITLE
fix(sql lab): Use quote_schema instead of quote method to format schema name

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1433,8 +1433,9 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         if show_cols:
             fields = cls._get_fields(cols)
         quote = engine.dialect.identifier_preparer.quote
+        quote_schema = engine.dialect.identifier_preparer.quote_schema
         if schema:
-            full_table_name = quote(schema) + "." + quote(table_name)
+            full_table_name = quote_schema(schema) + "." + quote(table_name)
         else:
             full_table_name = quote(table_name)
 


### PR DESCRIPTION
### SUMMARY
DuckDB supports multiple databases. This means schemas can be specified as `<db name>.<schema name>`, e.g., `"my db".main`. However, when such a schema name is specified, it gets quoted as `"my db.main"` instead of `"my db"."main"`. This PR fixes that by using the `quote_schema` method of the `identifier_preparer` instead of `quote`. This method defaults to `identifier_preparer.quote` is overridden in the DuckDB sqlalchemy driver to parse the string and add quotes in the right places.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated PR: https://github.com/Mause/duckdb_engine/pull/848
