### PR TITLE
feat(async_queries): allow dynamic feature flag to take effect after initial app bootstrapping

### DIFF
--- a/superset/async_events/async_query_manager_factory.py
+++ b/superset/async_events/async_query_manager_factory.py
@@ -32,4 +32,11 @@ class AsyncQueryManagerFactory:
         self._async_query_manager.init_app(app)
 
     def instance(self) -> AsyncQueryManager:
+        # check instance init again to allow dynamic feature flag change to apply
+        # after initial app bootstrapping
+        if not self._async_query_manager:
+            from superset import is_feature_enabled
+            if is_feature_enabled("GLOBAL_ASYNC_QUERIES"):
+                from flask import current_app
+                self.init_app(current_app)
         return self._async_query_manager

--- a/superset/async_events/async_query_manager_factory.py
+++ b/superset/async_events/async_query_manager_factory.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from flask import Flask
+from flask import current_app, Flask
 
 from superset.async_events.async_query_manager import AsyncQueryManager
 from superset.utils.class_utils import load_class_from_name
@@ -32,8 +32,7 @@ class AsyncQueryManagerFactory:
         self._async_query_manager.init_app(app)
 
     def instance(self) -> AsyncQueryManager:
-        from flask import current_app
-
+        # pylint: disable=import-outside-toplevel
         from superset import is_feature_enabled
 
         # check instance init again to allow dynamic feature flag change to apply

--- a/superset/async_events/async_query_manager_factory.py
+++ b/superset/async_events/async_query_manager_factory.py
@@ -32,11 +32,12 @@ class AsyncQueryManagerFactory:
         self._async_query_manager.init_app(app)
 
     def instance(self) -> AsyncQueryManager:
+        from flask import current_app
+
+        from superset import is_feature_enabled
+
         # check instance init again to allow dynamic feature flag change to apply
         # after initial app bootstrapping
-        if not self._async_query_manager:
-            from superset import is_feature_enabled
-            if is_feature_enabled("GLOBAL_ASYNC_QUERIES"):
-                from flask import current_app
-                self.init_app(current_app)
+        if not self._async_query_manager and is_feature_enabled("GLOBAL_ASYNC_QUERIES"):
+            self.init_app(current_app)
         return self._async_query_manager

--- a/tests/unit_tests/async_events/async_query_manager_factory_tests.py
+++ b/tests/unit_tests/async_events/async_query_manager_factory_tests.py
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from unittest import mock
+
+from flask import current_app
+from pytest import fixture
+
+from superset.async_events.async_query_manager import AsyncQueryManager
+from superset.async_events.async_query_manager_factory import AsyncQueryManagerFactory
+
+JWT_TOKEN_SECRET = "some_secret"
+JWT_TOKEN_COOKIE_NAME = "superset_async_jwt"
+
+
+@fixture
+def async_query_manager():
+    query_manager = AsyncQueryManager()
+    query_manager._jwt_secret = JWT_TOKEN_SECRET
+    query_manager._jwt_cookie_name = JWT_TOKEN_COOKIE_NAME
+
+    return query_manager
+
+
+def test_init_app():
+    # mock a secret lenght larger than 32
+    current_app.config["GLOBAL_ASYNC_QUERIES_JWT_SECRET"] = "test_secret" * 10
+    query_manager_factory = AsyncQueryManagerFactory()
+    query_manager_factory.init_app(current_app)
+    assert query_manager_factory._async_query_manager is not None
+
+
+@mock.patch("superset.is_feature_enabled", return_value=False)
+def test_get_instance_with_feature_flag_off(mock_is_feature_enabled):
+    query_manager_factory = AsyncQueryManagerFactory()
+    manager_instance = query_manager_factory.instance()
+    assert manager_instance is None
+
+
+@mock.patch("superset.is_feature_enabled", return_value=True)
+def test_get_instance_with_feature_flag_on(mock_is_feature_enabled):
+    current_app.config["GLOBAL_ASYNC_QUERIES_JWT_SECRET"] = "test_secret" * 10
+    query_manager_factory = AsyncQueryManagerFactory()
+    manager_instance = query_manager_factory.instance()
+    assert manager_instance is not None

--- a/tests/unit_tests/async_events/async_query_manager_factory_tests.py
+++ b/tests/unit_tests/async_events/async_query_manager_factory_tests.py
@@ -17,22 +17,8 @@
 from unittest import mock
 
 from flask import current_app
-from pytest import fixture
 
-from superset.async_events.async_query_manager import AsyncQueryManager
 from superset.async_events.async_query_manager_factory import AsyncQueryManagerFactory
-
-JWT_TOKEN_SECRET = "some_secret"
-JWT_TOKEN_COOKIE_NAME = "superset_async_jwt"
-
-
-@fixture
-def async_query_manager():
-    query_manager = AsyncQueryManager()
-    query_manager._jwt_secret = JWT_TOKEN_SECRET
-    query_manager._jwt_cookie_name = JWT_TOKEN_COOKIE_NAME
-
-    return query_manager
 
 
 def test_init_app():


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Before this change, we only initialize _async_query_manager instance on app init.
If `GLOBAL_ASYNC_QUERIES` feature flag changes afterwards, we will not able to an instance of get async_query_manager and thus all requests fail without restarting the app.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
