### PR TITLE
fix(redshift): convert_dttm method for redshift dataset and tests

### DIFF
--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -182,6 +182,19 @@ class PostgresBaseEngineSpec(BaseEngineSpec):
     def epoch_to_dttm(cls) -> str:
         return "(timestamp 'epoch' + {col} * interval '1 second')"
 
+    @classmethod
+    def convert_dttm(
+        cls, target_type: str, dttm: datetime, db_extra: dict[str, Any] | None = None
+    ) -> str | None:
+        sqla_type = cls.get_sqla_column_type(target_type)
+
+        if isinstance(sqla_type, Date):
+            return f"TO_DATE('{dttm.date().isoformat()}', 'YYYY-MM-DD')"
+        if isinstance(sqla_type, DateTime):
+            dttm_formatted = dttm.isoformat(sep=" ", timespec="microseconds")
+            return f"""TO_TIMESTAMP('{dttm_formatted}', 'YYYY-MM-DD HH24:MI:SS.US')"""
+        return None
+
 
 class PostgresEngineSpec(PostgresBaseEngineSpec, BasicParametersMixin):
     engine = "postgresql"
@@ -356,19 +369,6 @@ WHERE datistemplate = false;
         return set(inspector.get_table_names(schema)) | set(
             inspector.get_foreign_table_names(schema)
         )
-
-    @classmethod
-    def convert_dttm(
-        cls, target_type: str, dttm: datetime, db_extra: dict[str, Any] | None = None
-    ) -> str | None:
-        sqla_type = cls.get_sqla_column_type(target_type)
-
-        if isinstance(sqla_type, Date):
-            return f"TO_DATE('{dttm.date().isoformat()}', 'YYYY-MM-DD')"
-        if isinstance(sqla_type, DateTime):
-            dttm_formatted = dttm.isoformat(sep=" ", timespec="microseconds")
-            return f"""TO_TIMESTAMP('{dttm_formatted}', 'YYYY-MM-DD HH24:MI:SS.US')"""
-        return None
 
     @staticmethod
     def get_extra_params(database: Database) -> dict[str, Any]:

--- a/superset/db_engine_specs/redshift.py
+++ b/superset/db_engine_specs/redshift.py
@@ -23,7 +23,7 @@ from typing import Any
 
 import pandas as pd
 from flask_babel import gettext as __
-from sqlalchemy.types import Date, DateTime, NVARCHAR
+from sqlalchemy.types import NVARCHAR
 
 from superset.db_engine_specs.base import BasicParametersMixin
 from superset.db_engine_specs.postgres import PostgresBaseEngineSpec

--- a/superset/db_engine_specs/redshift.py
+++ b/superset/db_engine_specs/redshift.py
@@ -20,12 +20,11 @@ import logging
 import re
 from datetime import datetime
 from re import Pattern
-from typing import Any, Optional
+from typing import Any
 
 import pandas as pd
 from flask_babel import gettext as __
-from sqlalchemy.types import NVARCHAR
-from sqlalchemy.types import Date, DateTime
+from sqlalchemy.types import Date, DateTime, NVARCHAR
 
 from superset.db_engine_specs.base import BasicParametersMixin
 from superset.db_engine_specs.postgres import PostgresBaseEngineSpec
@@ -165,7 +164,7 @@ class RedshiftEngineSpec(PostgresBaseEngineSpec, BasicParametersMixin):
         return None
 
     @classmethod
-    def get_cancel_query_id(cls, cursor: Any, query: Query) -> Optional[str]:
+    def get_cancel_query_id(cls, cursor: Any, query: Query) -> str | None:
         """
         Get Redshift PID that will be used to cancel all other running
         queries in the same session.

--- a/superset/db_engine_specs/redshift.py
+++ b/superset/db_engine_specs/redshift.py
@@ -25,6 +25,7 @@ from typing import Any, Optional
 import pandas as pd
 from flask_babel import gettext as __
 from sqlalchemy.types import NVARCHAR
+from sqlalchemy.types import Date, DateTime
 
 from superset.db_engine_specs.base import BasicParametersMixin
 from superset.db_engine_specs.postgres import PostgresBaseEngineSpec
@@ -32,7 +33,6 @@ from superset.errors import SupersetErrorType
 from superset.models.core import Database
 from superset.models.sql_lab import Query
 from superset.sql_parse import Table
-from sqlalchemy.types import Date, DateTime
 
 logger = logging.getLogger()
 

--- a/superset/db_engine_specs/redshift.py
+++ b/superset/db_engine_specs/redshift.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import logging
 import re
-from datetime import datetime
 from re import Pattern
 from typing import Any
 
@@ -149,19 +148,6 @@ class RedshiftEngineSpec(PostgresBaseEngineSpec, BasicParametersMixin):
         :return: Conditionally mutated label
         """
         return label.lower()
-
-    @classmethod
-    def convert_dttm(
-        cls, target_type: str, dttm: datetime, db_extra: dict[str, Any] | None = None
-    ) -> str | None:
-        sqla_type = cls.get_sqla_column_type(target_type)
-
-        if isinstance(sqla_type, Date):
-            return f"TO_DATE('{dttm.date().isoformat()}', 'YYYY-MM-DD')"
-        if isinstance(sqla_type, DateTime):
-            dttm_formatted = dttm.isoformat(sep=" ", timespec="microseconds")
-            return f"""TO_TIMESTAMP('{dttm_formatted}', 'YYYY-MM-DD HH24:MI:SS.US')"""
-        return None
 
     @classmethod
     def get_cancel_query_id(cls, cursor: Any, query: Query) -> str | None:

--- a/tests/unit_tests/db_engine_specs/test_redshift.py
+++ b/tests/unit_tests/db_engine_specs/test_redshift.py
@@ -16,7 +16,7 @@
 # under the License.
 
 from datetime import datetime
-from typing import Any, Optional
+from typing import Optional
 
 import pytest
 

--- a/tests/unit_tests/db_engine_specs/test_redshift.py
+++ b/tests/unit_tests/db_engine_specs/test_redshift.py
@@ -45,5 +45,3 @@ def test_convert_dttm(
     from superset.db_engine_specs.redshift import RedshiftEngineSpec as spec
 
     assert_convert_dttm(spec, target_type, expected_result, dttm)
-
-

--- a/tests/unit_tests/db_engine_specs/test_redshift.py
+++ b/tests/unit_tests/db_engine_specs/test_redshift.py
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from datetime import datetime
+from typing import Any, Optional
+
+import pytest
+
+from tests.unit_tests.db_engine_specs.utils import assert_convert_dttm
+from tests.unit_tests.fixtures.common import dttm
+
+
+@pytest.mark.parametrize(
+    "target_type,expected_result",
+    [
+        ("Date", "TO_DATE('2019-01-02', 'YYYY-MM-DD')"),
+        (
+            "DateTime",
+            "TO_TIMESTAMP('2019-01-02 03:04:05.678900', 'YYYY-MM-DD HH24:MI:SS.US')",
+        ),
+        (
+            "TimeStamp",
+            "TO_TIMESTAMP('2019-01-02 03:04:05.678900', 'YYYY-MM-DD HH24:MI:SS.US')",
+        ),
+        ("UnknownType", None),
+    ],
+)
+def test_convert_dttm(
+    target_type: str, expected_result: Optional[str], dttm: datetime
+) -> None:
+    from superset.db_engine_specs.redshift import RedshiftEngineSpec as spec
+
+    assert_convert_dttm(spec, target_type, expected_result, dttm)
+
+


### PR DESCRIPTION
add convert_dttm method for redshift

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
1. There was convert_dttm implementation missing for redshift
2.  due to this date filter on redshit dataset not working
3. giving sqlalchemy error ```raise exc.CompileError(
sqlalchemy.exc.CompileError: Cannot compile Column object until its 'name' is assigned.```

query that was getting submitted: ```10:20:33,526:INFO:superset.connectors.sqla.models:SELECT day AS day
FROM (SELECT date_trunc('day', created_on)  as day
FROM public.redshift_order) AS virtual_table
WHERE day IN (<name unknown>)```

### BEFORE SCREENSHOTS OR ANIMATED GIF


<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
