### PR TITLE
feat(echarts-funnel): Implement % calculation type

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/controlPanel.tsx
@@ -20,16 +20,20 @@ import React from 'react';
 import { t } from '@superset-ui/core';
 import {
   ControlPanelConfig,
+  ControlStateMapping,
   ControlSubSectionHeader,
+  D3_FORMAT_DOCS,
   D3_FORMAT_OPTIONS,
   D3_NUMBER_FORMAT_DESCRIPTION_VALUES_TEXT,
+  getStandardizedControls,
   sections,
   sharedControls,
-  ControlStateMapping,
-  getStandardizedControls,
-  D3_FORMAT_DOCS,
 } from '@superset-ui/chart-controls';
-import { DEFAULT_FORM_DATA, EchartsFunnelLabelTypeType } from './types';
+import {
+  DEFAULT_FORM_DATA,
+  EchartsFunnelLabelTypeType,
+  PercentCalcType,
+} from './types';
 import { legendSection } from '../controls';
 
 const { labelType, numberFormat, showLabels, defaultTooltipLabel } =
@@ -67,6 +71,25 @@ const config: ControlPanelConfig = {
               description: t(
                 'Whether to sort results by the selected metric in descending order.',
               ),
+            },
+          },
+        ],
+        [
+          {
+            name: 'percent_calculation_type',
+            config: {
+              type: 'SelectControl',
+              label: t('% calculation'),
+              description: t(
+                'Display percents in the label and tooltip as the percent of the total value, from the first step of the funnel, or from the previous step in the funnel.',
+              ),
+              choices: [
+                [PercentCalcType.FIRST_STEP, t('Calculate from first step')],
+                [PercentCalcType.PREV_STEP, t('Calculate from previous step')],
+                [PercentCalcType.TOTAL, t('Percent of total')],
+              ],
+              default: PercentCalcType.FIRST_STEP,
+              renderTrigger: true,
             },
           },
         ],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/types.ts
@@ -42,6 +42,7 @@ export type EchartsFunnelFormData = QueryFormData &
     gap: number;
     sort: 'descending' | 'ascending' | 'none' | undefined;
     orient: 'vertical' | 'horizontal' | undefined;
+    percentCalculationType: PercentCalcType;
   };
 
 export enum EchartsFunnelLabelTypeType {
@@ -78,3 +79,9 @@ export type FunnelChartTransformedProps =
   BaseTransformedProps<EchartsFunnelFormData> &
     CrossFilterTransformedProps &
     ContextMenuTransformedProps;
+
+export enum PercentCalcType {
+  TOTAL = 'total',
+  PREV_STEP = 'prev_step',
+  FIRST_STEP = 'first_step',
+}

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Funnel/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Funnel/transformProps.test.ts
@@ -27,6 +27,7 @@ import transformProps, {
 import {
   EchartsFunnelChartProps,
   EchartsFunnelLabelTypeType,
+  PercentCalcType,
 } from '../../src/Funnel/types';
 
 describe('Funnel transformProps', () => {
@@ -81,12 +82,18 @@ describe('Funnel transformProps', () => {
 describe('formatFunnelLabel', () => {
   it('should generate a valid funnel chart label', () => {
     const numberFormatter = getNumberFormatter();
-    const params = { name: 'My Label', value: 1234, percent: 12.34 };
+    const params = {
+      name: 'My Label',
+      value: 1234,
+      percent: 12.34,
+      data: { firstStepPercent: 0.5, prevStepPercent: 0.85 },
+    };
     expect(
       formatFunnelLabel({
         params,
         numberFormatter,
         labelType: EchartsFunnelLabelTypeType.Key,
+        percentCalculationType: PercentCalcType.TOTAL,
       }),
     ).toEqual('My Label');
     expect(
@@ -94,6 +101,7 @@ describe('formatFunnelLabel', () => {
         params,
         numberFormatter,
         labelType: EchartsFunnelLabelTypeType.Value,
+        percentCalculationType: PercentCalcType.TOTAL,
       }),
     ).toEqual('1.23k');
     expect(
@@ -101,13 +109,31 @@ describe('formatFunnelLabel', () => {
         params,
         numberFormatter,
         labelType: EchartsFunnelLabelTypeType.Percent,
+        percentCalculationType: PercentCalcType.TOTAL,
       }),
     ).toEqual('12.34%');
     expect(
       formatFunnelLabel({
         params,
         numberFormatter,
+        labelType: EchartsFunnelLabelTypeType.Percent,
+        percentCalculationType: PercentCalcType.FIRST_STEP,
+      }),
+    ).toEqual('50.00%');
+    expect(
+      formatFunnelLabel({
+        params,
+        numberFormatter,
+        labelType: EchartsFunnelLabelTypeType.Percent,
+        percentCalculationType: PercentCalcType.PREV_STEP,
+      }),
+    ).toEqual('85.00%');
+    expect(
+      formatFunnelLabel({
+        params,
+        numberFormatter,
         labelType: EchartsFunnelLabelTypeType.KeyValue,
+        percentCalculationType: PercentCalcType.TOTAL,
       }),
     ).toEqual('My Label: 1.23k');
     expect(
@@ -115,6 +141,7 @@ describe('formatFunnelLabel', () => {
         params,
         numberFormatter,
         labelType: EchartsFunnelLabelTypeType.KeyPercent,
+        percentCalculationType: PercentCalcType.TOTAL,
       }),
     ).toEqual('My Label: 12.34%');
     expect(
@@ -122,6 +149,7 @@ describe('formatFunnelLabel', () => {
         params,
         numberFormatter,
         labelType: EchartsFunnelLabelTypeType.KeyValuePercent,
+        percentCalculationType: PercentCalcType.TOTAL,
       }),
     ).toEqual('My Label: 1.23k (12.34%)');
     expect(
@@ -129,6 +157,7 @@ describe('formatFunnelLabel', () => {
         params: { ...params, name: '<NULL>' },
         numberFormatter,
         labelType: EchartsFunnelLabelTypeType.Key,
+        percentCalculationType: PercentCalcType.TOTAL,
       }),
     ).toEqual('<NULL>');
     expect(
@@ -136,6 +165,7 @@ describe('formatFunnelLabel', () => {
         params: { ...params, name: '<NULL>' },
         numberFormatter,
         labelType: EchartsFunnelLabelTypeType.Key,
+        percentCalculationType: PercentCalcType.TOTAL,
         sanitizeName: true,
       }),
     ).toEqual('&lt;NULL&gt;');

--- a/superset/migrations/versions/2023-12-15_17-58_06dd9ff00fe8_add_percent_calculation_type_funnel_.py
+++ b/superset/migrations/versions/2023-12-15_17-58_06dd9ff00fe8_add_percent_calculation_type_funnel_.py
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""add_percent_calculation_type_funnel_chart
+
+Revision ID: 06dd9ff00fe8
+Revises: b7851ee5522f
+Create Date: 2023-12-15 17:58:18.277951
+
+"""
+import json
+
+from alembic import op
+from sqlalchemy import Column, Integer, String, Text
+from sqlalchemy.ext.declarative import declarative_base
+
+from superset import db
+
+# revision identifiers, used by Alembic.
+revision = "06dd9ff00fe8"
+down_revision = "b7851ee5522f"
+
+Base = declarative_base()
+
+
+class Slice(Base):
+    __tablename__ = "slices"
+    id = Column(Integer, primary_key=True)
+    viz_type = Column(String(250))
+    params = Column(Text)
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    for slc in session.query(Slice).filter(Slice.viz_type == "funnel"):
+        params = json.loads(slc.params)
+        percent_calculation = params.get("percent_calculation_type")
+        if not percent_calculation:
+            params["percent_calculation_type"] = "total"
+            slc.params = json.dumps(params)
+            session.commit()
+    session.close()
+
+
+def downgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    for slc in session.query(Slice).filter(Slice.viz_type == "funnel"):
+        params = json.loads(slc.params)
+        percent_calculation = params.get("percent_calculation_type")
+        if percent_calculation:
+            del params["percent_calculation_type"]
+            slc.params = json.dumps(params)
+            session.commit()
+    session.close()

--- a/superset/migrations/versions/2023-12-15_17-58_06dd9ff00fe8_add_percent_calculation_type_funnel_.py
+++ b/superset/migrations/versions/2023-12-15_17-58_06dd9ff00fe8_add_percent_calculation_type_funnel_.py
@@ -28,6 +28,7 @@ from sqlalchemy import Column, Integer, String, Text
 from sqlalchemy.ext.declarative import declarative_base
 
 from superset import db
+from superset.migrations.shared.utils import paginated_update
 
 # revision identifiers, used by Alembic.
 revision = "06dd9ff00fe8"
@@ -47,7 +48,9 @@ def upgrade():
     bind = op.get_bind()
     session = db.Session(bind=bind)
 
-    for slc in session.query(Slice).filter(Slice.viz_type == "funnel"):
+    for slc in paginated_update(
+        session.query(Slice).filter(Slice.viz_type == "funnel")
+    ):
         params = json.loads(slc.params)
         percent_calculation = params.get("percent_calculation_type")
         if not percent_calculation:
@@ -61,7 +64,9 @@ def downgrade():
     bind = op.get_bind()
     session = db.Session(bind=bind)
 
-    for slc in session.query(Slice).filter(Slice.viz_type == "funnel"):
+    for slc in paginated_update(
+        session.query(Slice).filter(Slice.viz_type == "funnel")
+    ):
         params = json.loads(slc.params)
         percent_calculation = params.get("percent_calculation_type")
         if percent_calculation:

--- a/superset/migrations/versions/2023-12-15_17-58_06dd9ff00fe8_add_percent_calculation_type_funnel_.py
+++ b/superset/migrations/versions/2023-12-15_17-58_06dd9ff00fe8_add_percent_calculation_type_funnel_.py
@@ -56,7 +56,6 @@ def upgrade():
         if not percent_calculation:
             params["percent_calculation_type"] = "total"
             slc.params = json.dumps(params)
-            session.commit()
     session.close()
 
 
@@ -72,5 +71,4 @@ def downgrade():
         if percent_calculation:
             del params["percent_calculation_type"]
             slc.params = json.dumps(params)
-            session.commit()
     session.close()


### PR DESCRIPTION
### SUMMARY
Add "% Calculation" field to Funnel chart's control panel. Currently, the % of each level of funnel chart is calculated as % of total. This PR allows user to also display % of each level as % of the first step or % of previous step.

Example of calculations:

| Value | Percent of total | Calculate from first step | Calculate from previous step |
| --- | --- | --- | --- | 
| 100 | 57% | 100% | 100% | 
| 50 | 28% | 50% | 50% | 
| 25 | 14% | 25% | 50% |

The default value for new charts is "Calculate from first step". For existing charts, a migration was added to keep "Percent of total" as selected option.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<img width="1721" alt="image" src="https://github.com/apache/superset/assets/15073128/f695bfd1-aa80-486a-9159-323b62bc6582">

<img width="1720" alt="image" src="https://github.com/apache/superset/assets/15073128/cc5a8279-d417-4d40-b3d7-ae047c13c067">

<img width="1724" alt="image" src="https://github.com/apache/superset/assets/15073128/7b581695-7685-4bf3-b6f1-142492ee590b">


### TESTING INSTRUCTIONS
1. Create a funnel chart
2. Verify that the calculated percents of each step match expected values for each option

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided
Current: 0.21 s
10+: 0.21 s
100+: 0.12 s
1000+: 0.13 s
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
