### PR TITLE
chore: Add downloadAsImage types, change filter selector

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -251,6 +251,7 @@
     "@testing-library/react-hooks": "^5.0.3",
     "@testing-library/user-event": "^12.7.0",
     "@types/classnames": "^2.2.10",
+    "@types/dom-to-image": "^2.6.7",
     "@types/enzyme": "^3.10.5",
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/fetch-mock": "^7.3.2",

--- a/superset-frontend/src/types/dom-to-image-more.d.ts
+++ b/superset-frontend/src/types/dom-to-image-more.d.ts
@@ -18,20 +18,6 @@
  */
 
 declare module 'dom-to-image-more' {
-  export interface Options {
-    filter?: ((node: Node) => boolean) | undefined;
-    bgcolor?: string | undefined;
-    width?: number | undefined;
-    height?: number | undefined;
-    style?: {} | undefined;
-    quality?: number | undefined;
-    imagePlaceholder?: string | undefined;
-    cacheBust?: boolean | undefined;
-  }
-
-  class DomToImageMore {
-    static toJpeg(node: Node, options?: Options): Promise<string>;
-  }
-
-  export default DomToImageMore;
+  import domToImage = require('dom-to-image-more');
+  export = domToImage;
 }

--- a/superset-frontend/src/utils/downloadAsImage.ts
+++ b/superset-frontend/src/utils/downloadAsImage.ts
@@ -62,7 +62,7 @@ export default function downloadAsImage(
       if (typeof node.className === 'string') {
         return (
           node.className !== 'mapboxgl-control-container' &&
-          !node.className.includes('ant-dropdown')
+          !node.className.includes('header-controls')
         );
       }
       return true;
@@ -70,17 +70,16 @@ export default function downloadAsImage(
 
     return domToImage
       .toJpeg(elementToPrint, {
-        quality: 1,
         bgcolor: supersetTheme.colors.grayscale.light4,
         filter,
       })
-      .then(dataUrl => {
+      .then((dataUrl: string) => {
         const link = document.createElement('a');
         link.download = `${generateFileStem(description)}.jpg`;
         link.href = dataUrl;
         link.click();
       })
-      .catch(e => {
+      .catch((e: Error) => {
         console.error('Creating image failed', e);
       });
   };


### PR DESCRIPTION
### SUMMARY
This PR adds a dev dependency with types for `dom-to-image` package. Also filters out `header-controls` instead of only `ant-dropdown` trigger before taking a screenshot.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
Use "Download as image" option on a chart in Explore, a chart in a dashboard and on the whole dashboard, verify that it works.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
