### PR TITLE
fix: Invalid references in the basic template

### DIFF
--- a/superset/templates/superset/basic.html
+++ b/superset/templates/superset/basic.html
@@ -51,6 +51,21 @@ governing permissions and limitations under the License. #}
       type="text/css"
       href="{{ assets_prefix }}/static/appbuilder/css/fontawesome/brands.min.css"
     />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="{{ assets_prefix }}/static/appbuilder/css/bootstrap-datepicker/bootstrap-datepicker3.min.css"
+    />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="{{ assets_prefix }}/static/appbuilder/css/select2/select2.min.css"
+    />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="{{ assets_prefix }}/static/appbuilder/css/select2/select2-bootstrap.min.css"
+    />
 
     {{ css_bundle("theme") }} {% if entry %} {{ css_bundle(entry) }} {% endif %}
     {% endblock %} {{ js_bundle("theme") }}

--- a/superset/templates/superset/basic.html
+++ b/superset/templates/superset/basic.html
@@ -1,116 +1,118 @@
-{#
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-#}
+{# Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements. See the NOTICE file distributed with this work
+for additional information regarding copyright ownership. The ASF licenses this
+file to you under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by
+applicable law or agreed to in writing, software distributed under the License
+is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. #}
 
 <!DOCTYPE html>
-{% import 'appbuilder/general/lib.html' as lib %}
-{% from 'superset/partials/asset_bundle.html' import css_bundle, js_bundle with context %}
-
-{% set favicons = appbuilder.app.config['FAVICONS'] %}
+{% import 'appbuilder/general/lib.html' as lib %} {% from
+'superset/partials/asset_bundle.html' import css_bundle, js_bundle with context
+%} {% set favicons = appbuilder.app.config['FAVICONS'] %}
 <html>
   <head>
     <title>
-      {% block title %}
-        {% if title %}
-          {{ title }}
-        {% elif appbuilder and appbuilder.app_name %}
-          {{ appbuilder.app_name }}
-        {% endif %}
-      {% endblock %}
+      {% block title %} {% if title %} {{ title }} {% elif appbuilder and
+      appbuilder.app_name %} {{ appbuilder.app_name }} {% endif %} {% endblock
+      %}
     </title>
-    {% block head_meta %}{% endblock %}
-    {% block head_css %}
-      {% for favicon in favicons %}
-        <link
-          rel="{{favicon.rel if favicon.rel else "icon"}}"
-          type="{{favicon.type if favicon.type else "image/png"}}"
-          {% if favicon.sizes %}sizes={{favicon.sizes}}{% endif %}
-          href="{{ "" if favicon.href.startswith("http") else assets_prefix }}{{favicon.href}}"
-        >
-      {% endfor %}
-      <link rel="stylesheet" type="text/css" href="{{ assets_prefix }}/static/appbuilder/css/flags/flags16.css" />
-      <link rel="stylesheet" type="text/css" href="{{ assets_prefix }}/static/appbuilder/css/fontawesome/fontawesome.min.css">
-      <link rel="stylesheet" type="text/css" href="{{ assets_prefix }}/static/appbuilder/css/fontawesome/regular.min.css">
-      <link rel="stylesheet" type="text/css" href="{{ assets_prefix }}/static/appbuilder/css/fontawesome/solid.min.css">
-      <link rel="stylesheet" type="text/css" href="{{ assets_prefix }}/static/appbuilder/css/fontawesome/brands.min.css">
-      <link rel="stylesheet" type="text/css" href="{{ assets_prefix }}/static/appbuilder/datepicker/bootstrap-datepicker.css">
-      <link rel="stylesheet" type="text/css" href="{{ assets_prefix }}/static/appbuilder/datepicker/bootstrap-datepicker.css">
-      <link rel="stylesheet" type="text/css" href="{{ assets_prefix }}/static/appbuilder/select2/select2.css">
-      <link rel="stylesheet" type="text/css" href="{{ assets_prefix }}/static/appbuilder/select2/select2-bootstrap-theme.css">
+    {% block head_meta %}{% endblock %} {% block head_css %} {% for favicon in
+    favicons %} <link rel="{{favicon.rel if favicon.rel else "icon"}}"
+    type="{{favicon.type if favicon.type else "image/png"}}" {% if favicon.sizes
+    %}sizes={{favicon.sizes}}{% endif %} href="{{ "" if
+    favicon.href.startswith("http") else assets_prefix }}{{favicon.href}}" > {%
+    endfor %}
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="{{ assets_prefix }}/static/appbuilder/css/flags/flags16.css"
+    />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="{{ assets_prefix }}/static/appbuilder/css/fontawesome/fontawesome.min.css"
+    />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="{{ assets_prefix }}/static/appbuilder/css/fontawesome/regular.min.css"
+    />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="{{ assets_prefix }}/static/appbuilder/css/fontawesome/solid.min.css"
+    />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="{{ assets_prefix }}/static/appbuilder/css/fontawesome/brands.min.css"
+    />
 
-      {{ css_bundle("theme") }}
-
-      {% if entry %}
-        {{ css_bundle(entry) }}
-      {% endif %}
-
-    {% endblock %}
-
-    {{ js_bundle("theme") }}
+    {{ css_bundle("theme") }} {% if entry %} {{ css_bundle(entry) }} {% endif %}
+    {% endblock %} {{ js_bundle("theme") }}
 
     <input
       type="hidden"
       name="csrf_token"
       id="csrf_token"
       value="{{ csrf_token() if csrf_token else '' }}"
-    >
+    />
   </head>
 
-  <body {% if standalone_mode %}class="standalone"{% endif %}>
-    {% block navbar %}
-      {% if not standalone_mode %}
-        {% include 'appbuilder/navbar.html' %}
-      {% endif %}
-    {% endblock %}
-
-    {% block body %}
-      <div id="app" data-bootstrap="{{ bootstrap_data }}">
-        <img src="{{ assets_prefix }}/static/assets/images/loading.gif" style="width: 50px; position: absolute; top: 50%; left: 50%; transform: translate(-50%,-50%)">
-      </div>
+  <body {% if standalone_mode %}class="standalone" {% endif %}>
+    {% block navbar %} {% if not standalone_mode %} {% include
+    'appbuilder/navbar.html' %} {% endif %} {% endblock %} {% block body %}
+    <div id="app" data-bootstrap="{{ bootstrap_data }}">
+      <img
+        src="{{ assets_prefix }}/static/assets/images/loading.gif"
+        style="
+          width: 50px;
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          transform: translate(-50%, -50%);
+        "
+      />
+    </div>
     {% endblock %}
 
     <!-- Modal for misc messages / alerts  -->
-    <div class="misc-modal modal fade" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+    <div
+      class="misc-modal modal fade"
+      tabindex="-1"
+      role="dialog"
+      aria-labelledby="myModalLabel"
+    >
       <div class="modal-dialog" role="document">
         <div class="modal-content" data-test="modal-content">
           <div class="modal-header" data-test="modal-header">
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close" data-test="modal-header-close-button">
+            <button
+              type="button"
+              class="close"
+              data-dismiss="modal"
+              aria-label="Close"
+              data-test="modal-header-close-button"
+            >
               <span aria-hidden="true">&times;</span>
             </button>
             <h4 data-test="modal-title" class="modal-title"></h4>
           </div>
-          <div data-test="modal-body" class="modal-body">
-          </div>
+          <div data-test="modal-body" class="modal-body"></div>
           <div data-test="modal-footer" class="modal-footer">
-            <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+            <button type="button" class="btn btn-default" data-dismiss="modal">
+              Close
+            </button>
           </div>
         </div>
       </div>
     </div>
 
-    {% block tail_js %}
-      {% if not standalone_mode %}
-        {{ js_bundle('menu') }}
-      {% endif %}
-      {% if entry %}
-        {{ js_bundle(entry) }}
-      {% endif %}
-      {% include "tail_js_custom_extra.html" %}
-    {% endblock %}
+    {% block tail_js %} {% if not standalone_mode %} {{ js_bundle('menu') }} {%
+    endif %} {% if entry %} {{ js_bundle(entry) }} {% endif %} {% include
+    "tail_js_custom_extra.html" %} {% endblock %}
   </body>
 </html>


### PR DESCRIPTION
### SUMMARY
Fixes invalid references in `superset/templates/superset/basic.html` which were generating the following 404 errors:

```
GET http://localhost:9000/static/appbuilder/datepicker/ net::ERR_ABORTED 404

GET http://localhost:9000/static/appbuilder/datepicker/bootstrap-datepicker.css net::ERR_ABORTED 404
        
GET http://localhost:9000/static/appbuilder/select2/select2.css net::ERR_ABORTED 404
        
GET http://localhost:9000/static/appbuilder/select2/select2-bootstrap-theme.css net::ERR_ABORTED 404
```

These references were introduced by https://github.com/apache/superset/pull/24390.

The new references are:

```
GET http://localhost:9000/static/appbuilder/css/bootstrap-datepicker/bootstrap-datepicker3.min.css

GET http://localhost:9000/static/appbuilder/css/select2/select2.min.css

GET http://localhost:9000/static/appbuilder/css/select2/select2-bootstrap.min.css
```

Fixes https://github.com/apache/superset/issues/26267

Fixes https://github.com/apache/superset/issues/26072

### TESTING INSTRUCTIONS
Follow the instructions in the original issue.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
