### PR TITLE
fix(logging): Filter out undefined columns

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -274,7 +274,9 @@ class Chart extends React.Component {
   changeFilter(newSelectedValues = {}) {
     this.props.logEvent(LOG_ACTIONS_CHANGE_DASHBOARD_FILTER, {
       id: this.props.chart.id,
-      columns: Object.keys(newSelectedValues),
+      columns: Object.keys(newSelectedValues).filter(
+        key => newSelectedValues[key] !== null,
+      ),
     });
     this.props.changeFilter(this.props.chart.id, newSelectedValues);
   }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

The `LOG_ACTIONS_CHANGE_DASHBOARD_FILTER` action logs the chart ID and columns which a filter impacts. The issue is if one were to clear a filter the key still persists in the `newSelectedValues` object, i.e., `{'country_name': null}`, resulting in a misleading log entry.

This PR simply filters out any key in which the associated value is `null`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Verified that when clearing the `COUNTRY_NAME` filter on the "World Bank's Data" dashboard the `country_name` column was not logged, i.e., the following SQL statement,

```sql
SELECT
    json_extract(json, '$.columns')
FROM 
    logs
WHERE 
    json_extract(json, '$.event_name') = 'change_dashboard_filter' 
ORDER BY
    dttm DESC
```

returned:

```
[]
["country_name"]
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
