### PR TITLE
chore: Use WEBDRIVER_OPTION_ARGS with Playwright

### DIFF
--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -137,7 +137,8 @@ class WebDriverPlaywright(WebDriverProxy):
         self, url: str, element_name: str, user: User
     ) -> bytes | None:
         with sync_playwright() as playwright:
-            browser = playwright.chromium.launch()
+            browser_args = current_app.config["WEBDRIVER_OPTION_ARGS"]
+            browser = playwright.chromium.launch(args=browser_args)
             pixel_density = current_app.config["WEBDRIVER_WINDOW"].get(
                 "pixel_density", 1
             )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Use WEBDRIVER_OPTION_ARGS with Playwright to enable overriding default Chromium flags from config file.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
Add a flag in `WEBDRIVER_OPTION_ARGS` in `superset/config`, verify that the change was picked up by Playwright

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
