### PR TITLE
chore: Adds a tooltip for the alert's SQL input

### DIFF
--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -401,11 +401,12 @@ export const TRANSLATIONS = {
   ALERT_CONDITION_TEXT: t('Alert condition'),
   DATABASE_TEXT: t('Database'),
   SQL_QUERY_TEXT: t('SQL Query'),
-  SQL_QUERY_TOOLTIP: t('The result of this query should be a numeric value'),
+  SQL_QUERY_TOOLTIP: t(
+    'The result of this query should be a numeric-esque value',
+  ),
   TRIGGER_ALERT_IF_TEXT: t('Trigger Alert If...'),
   CONDITION_TEXT: t('Condition'),
   VALUE_TEXT: t('Value'),
-  VALUE_TOOLTIP: t('Threshold value should be double precision number'),
   REPORT_SCHEDULE_TEXT: t('Report schedule'),
   ALERT_CONDITION_SCHEDULE_TEXT: t('Alert condition schedule'),
   TIMEZONE_TEXT: t('Timezone'),
@@ -1326,7 +1327,6 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                 <StyledInputContainer>
                   <div className="control-label">
                     {TRANSLATIONS.VALUE_TEXT}
-                    <StyledTooltip tooltip={TRANSLATIONS.VALUE_TOOLTIP} />
                     <span className="required">*</span>
                   </div>
                   <div className="input-container">

--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -152,6 +152,10 @@ const StyledModal = styled(Modal)`
   }
 `;
 
+const StyledTooltip = styled(InfoTooltipWithTrigger)`
+  margin-left: ${({ theme }) => theme.gridUnit}px;
+`;
+
 const StyledIcon = (theme: SupersetTheme) => css`
   margin: auto ${theme.gridUnit * 2}px auto 0;
   color: ${theme.colors.grayscale.base};
@@ -397,6 +401,7 @@ export const TRANSLATIONS = {
   ALERT_CONDITION_TEXT: t('Alert condition'),
   DATABASE_TEXT: t('Database'),
   SQL_QUERY_TEXT: t('SQL Query'),
+  SQL_QUERY_TOOLTIP: t('The result of this query should be a numeric value'),
   TRIGGER_ALERT_IF_TEXT: t('Trigger Alert If...'),
   CONDITION_TEXT: t('Condition'),
   VALUE_TEXT: t('Value'),
@@ -1284,6 +1289,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
               <StyledInputContainer>
                 <div className="control-label">
                   {TRANSLATIONS.SQL_QUERY_TEXT}
+                  <StyledTooltip tooltip={TRANSLATIONS.SQL_QUERY_TOOLTIP} />
                   <span className="required">*</span>
                 </div>
                 <TextAreaControl
@@ -1319,10 +1325,8 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                 </StyledInputContainer>
                 <StyledInputContainer>
                   <div className="control-label">
-                    {TRANSLATIONS.VALUE_TEXT}{' '}
-                    <InfoTooltipWithTrigger
-                      tooltip={TRANSLATIONS.VALUE_TOOLTIP}
-                    />
+                    {TRANSLATIONS.VALUE_TEXT}
+                    <StyledTooltip tooltip={TRANSLATIONS.VALUE_TOOLTIP} />
                     <span className="required">*</span>
                   </div>
                   <div className="input-container">


### PR DESCRIPTION
### SUMMARY
It's not very clear that the SQL used to create an alert should return a numeric value. When non-numeric values are returned, the error `Alert query returned a non-number value` is thrown when firing the alert. This PR adds a tooltip for the alert's SQL input to instruct users in advance. 

Closes https://github.com/apache/superset/issues/26298

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="401" alt="Screenshot 2023-12-20 at 09 03 28" src="https://github.com/apache/superset/assets/70410625/a41aff89-b1fa-44c6-96ae-d900c78d2880">

<img width="398" alt="Screenshot 2023-12-20 at 09 04 04" src="https://github.com/apache/superset/assets/70410625/378446d0-9d85-49b1-87c5-fd1529b62002">

### TESTING INSTRUCTIONS
1 - Open the alert creation modal
2 - Check the displayed tooltip

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
