### PR TITLE
fix(logging): Add logging of change_dashboard_filter event for native dashboard filters

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -44,6 +44,8 @@ import { getInitialDataMask } from 'src/dataMask/reducer';
 import { URL_PARAMS } from 'src/constants';
 import { getUrlParam } from 'src/utils/urlUtils';
 import { useTabId } from 'src/hooks/useTabId';
+import { logEvent } from 'src/logger/actions';
+import { LOG_ACTIONS_CHANGE_DASHBOARD_FILTER } from 'src/logger/LogUtils';
 import { FilterBarOrientation, RootState } from 'src/dashboard/types';
 import { checkIsApplyDisabled } from './utils';
 import { FiltersBarProps } from './types';
@@ -223,6 +225,7 @@ const FilterBar: React.FC<FiltersBarProps> = ({
   }, [dashboardId, dataMaskAppliedText, history, updateKey, tabId]);
 
   const handleApply = useCallback(() => {
+    dispatch(logEvent(LOG_ACTIONS_CHANGE_DASHBOARD_FILTER, {}));
     const filterIds = Object.keys(dataMaskSelected);
     setUpdateKey(1);
     filterIds.forEach(filterId => {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

For filter-box charts whenever the chart filters are changed we [log an event](https://github.com/apache/superset/blob/5e85f5c81f66b2da6fa11d9112216004f35170c8/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx#L275-L278) per the `LOG_ACTIONS_CHANGE_DASHBOARD_FILTER` action—containing the filter-box chart ID and the associated filtered dataset columns—which is useful for performance logging.

The native dashboard filters log no such event and thus this PR simply logs the same action whenever anyone clicks the `APPLY FILTERS` button. I omitted both the chart ID and columns from the payload. The former is obsolete and the later is somewhat irrelevant as (unlike a filter-box chart) there are multiple datasets/columns impacted. Simply logging the event is suffice for tracking when the filters were updated resulting in a re-render of the dashboard.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Verified the action was logged to the `logs` table when the `APPLY FILTERS` button was clicked:

```
sqlite> SELECT json FROM logs WHERE json_extract(json, '$.event_name') = 'change_dashboard_filter' ORDER BY dttm;
{"source": "dashboard", "source_id": 2, "impression_id": "z8yL1F6XI", "version": "v2", "ts": 1703189280582, "event_name": "change_dashboard_filter", "event_type": "user", "event_id": "UXk2HJFqs", "visibility": "visible"}
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
