### PR TITLE
fix(dashboard): Don't switch to first tab when directPathToChild changes

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardContainer.tsx
@@ -18,7 +18,7 @@
  */
 // ParentSize uses resize observer so the dashboard will update size
 // when its container size changes, due to e.g., builder side panel opening
-import React, { FC, useCallback, useEffect, useMemo } from 'react';
+import React, { FC, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   FeatureFlag,
@@ -51,7 +51,7 @@ import { setColorScheme } from 'src/dashboard/actions/dashboardState';
 import jsonStringify from 'json-stringify-pretty-compact';
 import { NATIVE_FILTER_DIVIDER_PREFIX } from '../nativeFilters/FiltersConfigModal/utils';
 import { findTabsWithChartsInScope } from '../nativeFilters/utils';
-import { getRootLevelTabIndex, getRootLevelTabsComponent } from './utils';
+import { getRootLevelTabsComponent } from './utils';
 
 type DashboardContainerProps = {
   topLevelTabs?: LayoutItem;
@@ -89,15 +89,18 @@ const DashboardContainer: FC<DashboardContainerProps> = ({ topLevelTabs }) => {
     Object.values(state.charts).map(chart => chart.id),
   );
 
+  const prevTabIndexRef = useRef();
   const tabIndex = useMemo(() => {
     const nextTabIndex = findTabIndexByComponentId({
       currentComponent: getRootLevelTabsComponent(dashboardLayout),
       directPathToChild,
     });
 
-    return nextTabIndex > -1
-      ? nextTabIndex
-      : getRootLevelTabIndex(dashboardLayout, directPathToChild);
+    if (nextTabIndex === -1) {
+      return prevTabIndexRef.current ?? 0;
+    }
+    prevTabIndexRef.current = nextTabIndex;
+    return nextTabIndex;
   }, [dashboardLayout, directPathToChild]);
 
   useEffect(() => {

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/utils.ts
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/utils.ts
@@ -21,7 +21,6 @@ import {
   DASHBOARD_ROOT_ID,
 } from 'src/dashboard/util/constants';
 import { DashboardLayout } from 'src/dashboard/types';
-import findTabIndexByComponentId from 'src/dashboard/util/findTabIndexByComponentId';
 
 export const getRootLevelTabsComponent = (dashboardLayout: DashboardLayout) => {
   const dashboardRoot = dashboardLayout[DASHBOARD_ROOT_ID];
@@ -38,15 +37,3 @@ export const shouldFocusTabs = (
   // don't focus the tabs when we click on a tab
   event.target.className === 'ant-tabs-nav-wrap' ||
   container.contains(event.target);
-
-export const getRootLevelTabIndex = (
-  dashboardLayout: DashboardLayout,
-  directPathToChild: string[],
-): number =>
-  Math.max(
-    0,
-    findTabIndexByComponentId({
-      currentComponent: getRootLevelTabsComponent(dashboardLayout),
-      directPathToChild,
-    }),
-  );


### PR DESCRIPTION


### SUMMARY
When user performed an action that caused `directPathToChild` to point to an element outside of `DashboardContainer` (such as clicking on applied native filter's name in chart's header to highlight the native filter), it caused the tabs to switch to the first tab.
This PR fixes that behaviour to instead remain on current tab.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://github.com/apache/superset/assets/15073128/0ff04c0c-c3ed-43d9-a061-438c72a7dd61


After:

https://github.com/apache/superset/assets/15073128/90e25fa9-0203-4c7a-867b-1578a3310753



### TESTING INSTRUCTIONS
1. Create a dashboard with tabs
2. Apply some native filters, go to a chart in 2nd tab and click on filter's name in filters badge
3. Verify that the native filter got highlighted, but the tab didn't switch
4. Sometimes we _do_ expect the tabs to switch. For example, apply a cross filter to a chart in 2nd tab from a chart in 1st tab.
5. Click on cross filter's name in filters badge in 2nd tab.
6. Verify that the tab switched and the source chart is highlighted

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/26262
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
