### PR TITLE
fix(SelectControl): select zero value

### DIFF
--- a/superset-frontend/src/explore/components/controls/SelectControl.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectControl.jsx
@@ -215,7 +215,7 @@ export default class SelectControl extends React.PureComponent {
 
     const getValue = () => {
       const currentValue =
-        value ||
+        value ??
         (this.props.default !== undefined ? this.props.default : undefined);
 
       // safety check - the value is intended to be undefined but null was used


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
If SelectControl has options with numeric values, then the value 0 can be selected.
In this case, if defaultValue is not set or it is set to undefined, then currentValue will be set to undefined instead of 0.
This fix allows correctly save SelectControl with selected option, which value equals to 0, when the default value is undefined.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Create SelectControl instance in the controlPanel and set choices with numeric value:
[[0, "label_1"],  [1, "label_2"]]
Don't specify default value or set default value to undefined.
2. Select option with value 0 and save chart.
3. Reload page and check, whether the SelectControl has selected value. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
