### PR TITLE
fix(cross-filters): tag for cross filters over multiple columns

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/query/types/Operator.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Operator.ts
@@ -18,7 +18,7 @@
  */
 
 /** List of operators that do not require another operand */
-const UNARY_OPERATORS = ['IS NOT NULL', 'IS NULL'] as const;
+export const UNARY_OPERATORS = ['IS NOT NULL', 'IS NULL'] as const;
 
 /** List of operators that require another operand that is a single value */
 const BINARY_OPERATORS = [

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilter.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilter.test.tsx
@@ -30,6 +30,9 @@ const mockedProps = {
     value: 'Italy',
     status: IndicatorStatus.CrossFilterApplied,
     path: ['test-path'],
+    selectedFilters: {
+      country_name: 'Italy',
+    },
   },
   orientation: FilterBarOrientation.HORIZONTAL,
   last: false,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilter.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilter.tsx
@@ -78,7 +78,7 @@ const CrossFilter = (props: {
         orientation={orientation || FilterBarOrientation.HORIZONTAL}
         onHighlightFilterSource={() => handleHighlightFilterSource(filter.path)}
       />
-      {(filter.column || filter.value) && (
+      {Object.keys(filter.selectedFilters).length && (
         <CrossFilterTag
           filter={filter}
           orientation={orientation}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilterTag.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilterTag.test.tsx
@@ -35,6 +35,9 @@ const mockedProps: {
     value: 'Italy',
     status: IndicatorStatus.CrossFilterApplied,
     path: ['test-path'],
+    selectedFilters: {
+      country_name: 'Italy',
+    },
   },
   orientation: FilterBarOrientation.HORIZONTAL,
   removeCrossFilter: jest.fn(),
@@ -59,6 +62,9 @@ test('CrossFilterTag with adhoc column should render', () => {
         label: 'My column',
         sqlExpression: 'country_name',
         expressionType: 'SQL' as const,
+      },
+      selectedFilters: {
+        'My column': 'Italy',
       },
     },
   };

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilterTag.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilterTag.tsx
@@ -18,13 +18,7 @@
  */
 
 import React from 'react';
-import {
-  styled,
-  css,
-  useTheme,
-  getColumnLabel,
-  useCSSTextTruncation,
-} from '@superset-ui/core';
+import { styled, css, useTheme, useCSSTextTruncation } from '@superset-ui/core';
 import { CrossFilterIndicator } from 'src/dashboard/components/nativeFilters/selectors';
 import { Tag } from 'src/components';
 import { Tooltip } from 'src/components/Tooltip';
@@ -50,8 +44,22 @@ const StyledTag = styled(Tag)`
   ${({ theme }) => `
     border: 1px solid ${theme.colors.grayscale.light3};
     border-radius: 2px;
+    max-width: 100%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+
     .anticon-close {
       vertical-align: middle;
+    }
+    .tooltip-wrapper {
+      padding-right: ${theme.gridUnit}px;
+    }
+    .tag-wrapper {
+      max-width: calc(100% - 17px);
+      overflow: hidden;
+      text-wrap: balance;
+      display: inline-block;
     }
   `}
 `;
@@ -62,12 +70,12 @@ const CrossFilterTag = (props: {
   removeCrossFilter: (filterId: number) => void;
 }) => {
   const { filter, orientation, removeCrossFilter } = props;
+  const { selectedFilters } = filter;
   const theme = useTheme();
   const [columnRef, columnIsTruncated] =
     useCSSTextTruncation<HTMLSpanElement>();
   const [valueRef, valueIsTruncated] = useCSSTextTruncation<HTMLSpanElement>();
 
-  const columnLabel = getColumnLabel(filter.column ?? '');
   return (
     <StyledTag
       css={css`
@@ -82,16 +90,25 @@ const CrossFilterTag = (props: {
       closable
       onClose={() => removeCrossFilter(filter.emitterId)}
     >
-      <Tooltip title={columnIsTruncated ? columnLabel : null}>
-        <StyledCrossFilterColumn ref={columnRef}>
-          {columnLabel}
-        </StyledCrossFilterColumn>
-      </Tooltip>
-      <Tooltip title={valueIsTruncated ? filter.value : null}>
-        <StyledCrossFilterValue ref={valueRef}>
-          {filter.value}
-        </StyledCrossFilterValue>
-      </Tooltip>
+      <span className="tag-wrapper">
+        {Object.keys(selectedFilters).map(columnLabel => {
+          const value = selectedFilters[columnLabel];
+          return (
+            <span className="tooltip-wrapper">
+              <Tooltip title={columnIsTruncated ? columnLabel : null}>
+                <StyledCrossFilterColumn ref={columnRef}>
+                  {columnLabel}
+                </StyledCrossFilterColumn>
+              </Tooltip>
+              <Tooltip title={valueIsTruncated ? value : null}>
+                <StyledCrossFilterValue ref={valueRef}>
+                  {value}
+                </StyledCrossFilterValue>
+              </Tooltip>
+            </span>
+          );
+        })}
+      </span>
     </StyledTag>
   );
 };

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/VerticalCollapse.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/VerticalCollapse.test.tsx
@@ -18,10 +18,14 @@
  */
 import React from 'react';
 import { render, screen } from 'spec/helpers/testing-library';
-import { IndicatorStatus } from '../../selectors';
+import { CrossFilterIndicator, IndicatorStatus } from '../../selectors';
 import VerticalCollapse from './VerticalCollapse';
 
-const mockedProps = {
+type MockedProps = {
+  crossFilters: CrossFilterIndicator[];
+};
+
+const mockedProps: MockedProps = {
   crossFilters: [
     {
       name: 'test',
@@ -30,6 +34,9 @@ const mockedProps = {
       value: 'Italy',
       status: IndicatorStatus.CrossFilterApplied,
       path: ['test-path'],
+      selectedFilters: {
+        country_name: 'Italy',
+      },
     },
     {
       name: 'test-b',
@@ -38,6 +45,9 @@ const mockedProps = {
       value: 'IT',
       status: IndicatorStatus.CrossFilterApplied,
       path: ['test-path-2'],
+      selectedFilters: {
+        country_code: 'IT',
+      },
     },
   ],
 };

--- a/superset-frontend/src/dashboard/components/nativeFilters/selectors.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/selectors.ts
@@ -71,7 +71,7 @@ export const extractLabel = (filter?: FilterState): string | null => {
     return filter.label;
   }
   if (filter?.value) {
-    return ensureIsArray(filter?.value).join(', ');
+    return ensureIsArray(filter?.value).flat().join(', ');
   }
   return null;
 };
@@ -165,7 +165,12 @@ export type Indicator = {
   path?: string[];
 };
 
-export type CrossFilterIndicator = Indicator & { emitterId: number };
+export type CrossFilterIndicator = Indicator & {
+  emitterId: number;
+  selectedFilters: {
+    [key: string]: string;
+  };
+};
 
 export const getCrossFilterIndicator = (
   chartId: number,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
There are some custom visualizations which allow to perform cross-filtration over multiple columns. In this case, current implementation of cross-filters tag does not display data correctly, since it shows only the first column name. For example, it can be seen in Pivot Table with multi-select. This fix allows to display all column names and corresponding values in the cross-filter tag.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![изображение](https://github.com/apache/superset/assets/76280175/5d40f8a3-1f44-41d7-a2cb-28e7465b08e3)
After:
![изображение](https://github.com/apache/superset/assets/76280175/fe977f84-7422-46f6-93b8-62b0f7207265)

### TESTING INSTRUCTIONS
1. In Pivot Table plugin (PivotTableChart.tsx) in the toggleFilter function, un-comment code concerning multi select and comment code of single select. 
https://github.com/apache/superset/blob/b6d433de32cad21c0866ee98fd5ae85b4459c23b/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx#L407-L420
2. Open any dashboard with Pivot Table and select values from different columns.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
