### PR TITLE
fix: Reactivates native filters E2E tests

### DIFF
--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/nativeFilters.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/nativeFilters.test.ts
@@ -414,7 +414,7 @@ describe('Native filters', () => {
       cy.createSampleDashboards([0]);
     });
 
-    it.only('Verify that default value is respected after revisit', () => {
+    it('Verify that default value is respected after revisit', () => {
       prepareDashboardFilters([
         { name: 'country_name', column: 'country_name', datasetId: 2 },
       ]);


### PR DESCRIPTION
### SUMMARY
This PR reactivates the native filters E2E tests that were accidentally disabled by https://github.com/apache/superset/pull/26158.

### TESTING INSTRUCTIONS
CI should be sufficient.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
