### PR TITLE
docs: fix config webdriver snippet in install on K8s

### DIFF
--- a/docs/docs/installation/running-on-kubernetes.mdx
+++ b/docs/docs/installation/running-on-kubernetes.mdx
@@ -310,15 +310,17 @@ supersetWorker:
     - |
       # Install chrome webdriver
       # See https://github.com/apache/superset/blob/4fa3b6c7185629b87c27fc2c0e5435d458f7b73d/docs/src/pages/docs/installation/email_reports.mdx
-      apt update
+      apt-get update
+      apt-get install -y wget
       wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-      apt install -y --no-install-recommends ./google-chrome-stable_current_amd64.deb
+      apt-get install -y --no-install-recommends ./google-chrome-stable_current_amd64.deb
       wget https://chromedriver.storage.googleapis.com/88.0.4324.96/chromedriver_linux64.zip
+      apt-get install -y zip
       unzip chromedriver_linux64.zip
       chmod +x chromedriver
       mv chromedriver /usr/bin
-      apt autoremove -yqq --purge
-      apt clean
+      apt-get autoremove -yqq --purge
+      apt-get clean
       rm -f google-chrome-stable_current_amd64.deb chromedriver_linux64.zip
 
       # Run


### PR DESCRIPTION
### SUMMARY
The current example of installing `webdriver` on worker nodes when installing Superset on Kubernetes causes the configuration to fail. This PR is fix the issue.

### TESTING INSTRUCTIONS
1. Configure the Helm `values.yaml` file as per the new snippet included in this PR
2. Deploy Superset on K8s
3. Check celery worker logs: `kubectl logs -f superset-worker-<xxx>`

### ADDITIONAL INFORMATION
Fixes #26370 

- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
