### PR TITLE
fix: Duplicated plugin registration

### DIFF
--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailMenuItems.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailMenuItems.test.tsx
@@ -19,6 +19,7 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, screen, within } from 'spec/helpers/testing-library';
+import setupPlugins from 'src/setup/setupPlugins';
 import { getMockStoreWithNativeFilters } from 'spec/fixtures/mockStore';
 import chartQueries, { sliceId } from 'spec/fixtures/mockChartQueries';
 import { BinaryQueryObjectFilterClause } from '@superset-ui/core';
@@ -240,6 +241,10 @@ const expectDrillToDetailByAll = async (
   await expectMenuItemEnabled(drillToDetailBySubmenuItem);
   await expectDrillToDetailModal(menuItemName, filters);
 };
+
+beforeAll(() => {
+  setupPlugins();
+});
 
 test('dropdown menu for unsupported chart', async () => {
   renderMenu({ formData: unsupportedChartFormData });

--- a/superset-frontend/src/dashboard/containers/DashboardPage.tsx
+++ b/superset-frontend/src/dashboard/containers/DashboardPage.tsx
@@ -39,7 +39,6 @@ import {
 import { hydrateDashboard } from 'src/dashboard/actions/hydrate';
 import { setDatasources } from 'src/dashboard/actions/datasources';
 import injectCustomCss from 'src/dashboard/util/injectCustomCss';
-import setupPlugins from 'src/setup/setupPlugins';
 
 import { LocalStorageKeys, setItem } from 'src/utils/localStorageHelpers';
 import { URL_PARAMS } from 'src/constants';
@@ -65,7 +64,6 @@ import SyncDashboardState, {
 
 export const DashboardPageIdContext = React.createContext('');
 
-setupPlugins();
 const DashboardBuilder = React.lazy(
   () =>
     import(

--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -64,7 +64,6 @@ import Tag from 'src/types/TagType';
 import { Tooltip } from 'src/components/Tooltip';
 import Icons from 'src/components/Icons';
 import { nativeFilterGate } from 'src/dashboard/components/nativeFilters/utils';
-import setupPlugins from 'src/setup/setupPlugins';
 import InfoTooltip from 'src/components/InfoTooltip';
 import CertifiedBadge from 'src/components/CertifiedBadge';
 import { GenericLink } from 'src/components/GenericLink/GenericLink';
@@ -106,7 +105,6 @@ const CONFIRM_OVERWRITE_MESSAGE = t(
     'sure you want to overwrite?',
 );
 
-setupPlugins();
 const registry = getChartMetadataRegistry();
 
 const createFetchDatasets = async (


### PR DESCRIPTION
### SUMMARY
This PR removes the duplicated plugin registration that generates the following type of warning:

```
Item with key "deck_arc" already exists. You are assigning a new value.
Item with key "deck_arc" already exists. You are assigning a new value.
Item with key "big_number" already exists. You are assigning a new value.
Item with key "box_plot" already exists. You are assigning a new value.
```

The duplicate registration was necessary when those pages belonged to different React apps. Now, they belong to the same app which makes the registration unnecessary.

The registration should happen only once when the [application initializes](https://github.com/apache/superset/blob/3a0391bbb9138f1a3dab4d3c10d08e5520a4274d/superset-frontend/src/views/App.tsx#L45).

### TESTING INSTRUCTIONS
1 - Open any dashboard
2 - Check that the warnings are not there anymore

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
