### PR TITLE
fix(chart): Resolve incorrect column customization when switching metrics in table chart

### DIFF
--- a/superset-frontend/src/explore/actions/exploreActions.test.js
+++ b/superset-frontend/src/explore/actions/exploreActions.test.js
@@ -21,6 +21,63 @@ import { defaultState } from 'src/explore/store';
 import exploreReducer from 'src/explore/reducers/exploreReducer';
 import * as actions from 'src/explore/actions/exploreActions';
 
+const METRICS = [
+  {
+    expressionType: 'SIMPLE',
+    column: {
+      advanced_data_type: null,
+      certification_details: null,
+      certified_by: null,
+      column_name: 'a',
+      description: null,
+      expression: null,
+      filterable: true,
+      groupby: true,
+      id: 1,
+      is_certified: false,
+      is_dttm: false,
+      python_date_format: null,
+      type: 'DOUBLE PRECISION',
+      type_generic: 0,
+      verbose_name: null,
+      warning_markdown: null,
+    },
+    aggregate: 'SUM',
+    sqlExpression: null,
+    datasourceWarning: false,
+    hasCustomLabel: false,
+    label: 'SUM(a)',
+    optionName: 'metric_1a2b3c4d5f_1a2b3c4d5f',
+  },
+  {
+    expressionType: 'SIMPLE',
+    column: {
+      advanced_data_type: null,
+      certification_details: null,
+      certified_by: null,
+      column_name: 'b',
+      description: null,
+      expression: null,
+      filterable: true,
+      groupby: true,
+      id: 2,
+      is_certified: false,
+      is_dttm: false,
+      python_date_format: null,
+      type: 'BIGINT',
+      type_generic: 0,
+      verbose_name: null,
+      warning_markdown: null,
+    },
+    aggregate: 'AVG',
+    sqlExpression: null,
+    datasourceWarning: false,
+    hasCustomLabel: false,
+    label: 'AVG(b)',
+    optionName: 'metric_6g7h8i9j0k_6g7h8i9j0k',
+  },
+];
+
 describe('reducers', () => {
   it('Does not set a control value if control does not exist', () => {
     const newState = exploreReducer(
@@ -36,5 +93,128 @@ describe('reducers', () => {
     );
     expect(newState.controls.y_axis_format.value).toBe('$,.2f');
     expect(newState.form_data.y_axis_format).toBe('$,.2f');
+  });
+  it('Keeps the column config when metric column positions are swapped', () => {
+    const mockedState = {
+      ...defaultState,
+      controls: {
+        ...defaultState.controls,
+        metrics: {
+          ...defaultState.controls.metrics,
+          value: METRICS,
+        },
+        column_config: {
+          ...defaultState.controls.column_config,
+          value: {
+            'AVG(b)': {
+              currencyFormat: {
+                symbolPosition: 'prefix',
+                symbol: 'USD',
+              },
+            },
+          },
+        },
+      },
+      form_data: {
+        ...defaultState.form_data,
+        metrics: METRICS,
+        column_config: {
+          'AVG(b)': {
+            currencyFormat: {
+              symbolPosition: 'prefix',
+              symbol: 'USD',
+            },
+          },
+        },
+      },
+    };
+
+    const swappedMetrics = [METRICS[1], METRICS[0]];
+    const newState = exploreReducer(
+      mockedState,
+      actions.setControlValue('metrics', swappedMetrics, []),
+    );
+
+    const expectedColumnConfig = {
+      'AVG(b)': {
+        currencyFormat: {
+          symbolPosition: 'prefix',
+          symbol: 'USD',
+        },
+      },
+    };
+
+    expect(newState.controls.metrics.value).toStrictEqual(swappedMetrics);
+    expect(newState.form_data.metrics).toStrictEqual(swappedMetrics);
+    expect(newState.controls.column_config.value).toStrictEqual(
+      expectedColumnConfig,
+    );
+    expect(newState.form_data.column_config).toStrictEqual(
+      expectedColumnConfig,
+    );
+  });
+
+  it('Keeps the column config when metric column name is updated', () => {
+    const mockedState = {
+      ...defaultState,
+      controls: {
+        ...defaultState.controls,
+        metrics: {
+          ...defaultState.controls.metrics,
+          value: METRICS,
+        },
+        column_config: {
+          ...defaultState.controls.column_config,
+          value: {
+            'AVG(b)': {
+              currencyFormat: {
+                symbolPosition: 'prefix',
+                symbol: 'USD',
+              },
+            },
+          },
+        },
+      },
+      form_data: {
+        ...defaultState.form_data,
+        metrics: METRICS,
+        column_config: {
+          'AVG(b)': {
+            currencyFormat: {
+              symbolPosition: 'prefix',
+              symbol: 'USD',
+            },
+          },
+        },
+      },
+    };
+
+    const updatedMetrics = [
+      METRICS[0],
+      {
+        ...METRICS[1],
+        hasCustomLabel: true,
+        label: 'AVG of b',
+      },
+    ];
+
+    const newState = exploreReducer(
+      mockedState,
+      actions.setControlValue('metrics', updatedMetrics, []),
+    );
+
+    const expectedColumnConfig = {
+      'AVG of b': {
+        currencyFormat: {
+          symbolPosition: 'prefix',
+          symbol: 'USD',
+        },
+      },
+    };
+    expect(newState.controls.metrics.value).toStrictEqual(updatedMetrics);
+    expect(newState.form_data.metrics).toStrictEqual(updatedMetrics);
+    expect(newState.form_data.column_config).toStrictEqual(
+      expectedColumnConfig,
+    );
   });
 });

--- a/superset-frontend/src/explore/reducers/exploreReducer.js
+++ b/superset-frontend/src/explore/reducers/exploreReducer.js
@@ -115,7 +115,12 @@ export default function exploreReducer(state = {}, action) {
       // need to update column config as well to keep the previous config.
       if (controlName === 'metrics' && old_metrics_data && new_column_config) {
         value.forEach((item, index) => {
+          const itemExist = old_metrics_data.some(
+            oldItem => oldItem?.label === item?.label,
+          );
+
           if (
+            !itemExist &&
             item?.label !== old_metrics_data[index]?.label &&
             !!new_column_config[old_metrics_data[index]?.label]
           ) {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I have found that when attempting to swap the positions of metrics in the table chart with applied column configuration, the column configuration is switched to another column, which is related to the addition of #19841 for maintaining configurations when metrics are renamed. To address this issue, I have added a condition to first check if the column name is found in the old metrics. If it is found, it will avoid updating the column configuration. Reassignment will only occur if the new column name is not found among the existing ones to maintain configurations when metrics are renamed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
**Before:** Currency prefix is switched to SUM(quantity_ordered)

https://github.com/apache/superset/assets/96282005/8f83aa5f-2794-4f9a-adfb-2085293dc0f2


**After:** Currency prefix is applied to SUM(sales) as expected

https://github.com/apache/superset/assets/96282005/e17f0ed8-5dff-482e-9797-4edb0bcdf8d7


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Create a table chart with dimensions and two or more metrics. 
2. Apply number formatting to any of the metrics. 
3. Attempt to swap the positions of the metrics.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
