### PR TITLE
feat: add custom sort by x-axis for mixed charts

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/sortOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/sortOperator.ts
@@ -18,10 +18,11 @@
  */
 import { isEmpty } from 'lodash';
 import {
+  isFeatureEnabled,
+  FeatureFlag,
   ensureIsArray,
   getMetricLabel,
   getXAxisLabel,
-  hasGenericChartAxes,
   isDefined,
   PostProcessingSort,
 } from '@superset-ui/core';
@@ -40,7 +41,7 @@ export const sortOperator: PostProcessingFactory<PostProcessingSort> = (
   ].filter(Boolean);
 
   if (
-    hasGenericChartAxes &&
+    isFeatureEnabled(FeatureFlag.GENERIC_CHART_AXES) &&
     isDefined(formData?.x_axis_sort) &&
     isDefined(formData?.x_axis_sort_asc) &&
     sortableLabels.includes(formData.x_axis_sort) &&

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/buildQuery.ts
@@ -47,7 +47,7 @@ export default function buildQuery(formData: QueryFormData) {
     ...formData,
   };
 
-  if (!!baseFormData.orderby) {
+  if (baseFormData.orderby) {
     baseFormData.x_axis_sort = formData.orderby.label;
     baseFormData.x_axis_sort_asc = !formData.order_desc_x_axis;
   }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/buildQuery.ts
@@ -35,6 +35,7 @@ import {
   rollingWindowOperator,
   timeCompareOperator,
   resampleOperator,
+  sortOperator,
 } from '@superset-ui/chart-controls';
 import {
   retainFormDataSuffix,
@@ -45,6 +46,11 @@ export default function buildQuery(formData: QueryFormData) {
   const baseFormData = {
     ...formData,
   };
+
+  if (!!baseFormData.orderby) {
+    baseFormData.x_axis_sort = formData.orderby.label;
+    baseFormData.x_axis_sort_asc = !formData.order_desc_x_axis;
+  }
 
   const formData1 = removeFormDataSuffix(baseFormData, '_b');
   const formData2 = retainFormDataSuffix(baseFormData, '_b');
@@ -75,6 +81,7 @@ export default function buildQuery(formData: QueryFormData) {
         time_offsets: isTimeComparison(fd, queryObject) ? fd.time_compare : [],
         post_processing: [
           pivotOperatorInRuntime,
+          sortOperator(fd, queryObject),
           rollingWindowOperator(fd, queryObject),
           timeCompareOperator(fd, queryObject),
           resampleOperator(fd, queryObject),

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/buildQuery.ts
@@ -19,6 +19,7 @@
 import {
   buildQueryContext,
   ensureIsArray,
+  getMetricLabel,
   normalizeOrderBy,
   PostProcessingPivot,
   QueryFormData,
@@ -48,7 +49,7 @@ export default function buildQuery(formData: QueryFormData) {
   };
 
   if (baseFormData.orderby) {
-    baseFormData.x_axis_sort = formData.orderby.label;
+    baseFormData.x_axis_sort = getMetricLabel(formData.orderby);
     baseFormData.x_axis_sort_asc = !formData.order_desc_x_axis;
   }
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/buildQuery.ts
@@ -82,11 +82,11 @@ export default function buildQuery(formData: QueryFormData) {
         time_offsets: isTimeComparison(fd, queryObject) ? fd.time_compare : [],
         post_processing: [
           pivotOperatorInRuntime,
-          sortOperator(fd, queryObject),
-          rollingWindowOperator(fd, queryObject),
           timeCompareOperator(fd, queryObject),
           resampleOperator(fd, queryObject),
           renameOperator(fd, queryObject),
+          sortOperator(fd, queryObject),
+          rollingWindowOperator(fd, queryObject),
           flattenOperator(fd, queryObject),
         ],
       } as QueryObject;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
@@ -289,7 +289,22 @@ const config: ControlPanelConfig = {
       ? {
           label: t('Shared query fields'),
           expanded: true,
-          controlSetRows: [['x_axis'], ['time_grain_sqla']],
+          controlSetRows: [
+            ['x_axis'],
+            ['time_grain_sqla'],
+            ['orderby'],
+            [
+              {
+                name: `order_desc_x_axis`,
+                config: {
+                  type: 'CheckboxControl',
+                  label: t('Sort Descending'),
+                  default: orderDesc,
+                  description: t('Whether to sort descending or ascending'),
+                },
+              },
+            ],
+          ],
         }
       : null,
     createQuerySection(t('Query A'), ''),

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/buildQuery.test.ts
@@ -515,3 +515,37 @@ test('ensure correct pivot columns with GENERIC_CHART_AXES enabled', () => {
 
   windowSpy.mockRestore();
 });
+
+test('ensure sort on x-axis with GENERIC_CHART_AXES enabled', () => {
+  const windowSpy = jest
+    .spyOn(window, 'window', 'get')
+    // @ts-ignore
+    .mockImplementation(() => ({
+      featureFlags: {
+        GENERIC_CHART_AXES: true,
+      },
+    }));
+
+  const query = buildQuery({
+    ...formDataMixedChart,
+    datasource: 'dummy',
+    viz_type: 'mixed_timeseries',
+    groupby: [],
+    metrics: ['sum(sales)'],
+    x_axis: 'customer_name',
+    x_axis_sort: 'sum(sales)',
+    x_axis_sort_asc: true,
+  }).queries[0];
+
+  expect(
+    query.post_processing?.find(operator => operator?.operation === 'sort'),
+  ).toEqual({
+    operation: 'sort',
+    options: {
+      by: 'sum(sales)',
+      ascending: true,
+    },
+  });
+
+  windowSpy.mockRestore();
+});


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Enables sorting mixed data chart by x-axis using different columns

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![image](https://github.com/apache/superset/assets/201315/bdce520a-9344-46be-9b6f-6d4fe67cfa15)

After: 
![image](https://github.com/apache/superset/assets/201315/c0e00608-c6c0-4d9f-bb8b-2c2c29fd5150)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
