### PR TITLE
fix(sqllab): Bump duckdb-engine version to 0.9.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -155,7 +155,7 @@ setup(
         "dremio": ["sqlalchemy-dremio>=1.1.5, <1.3"],
         "drill": ["sqlalchemy-drill==0.1.dev"],
         "druid": ["pydruid>=0.6.5,<0.7"],
-        "duckdb": ["duckdb-engine==0.9.2"],
+        "duckdb": ["duckdb-engine==0.9.5"],
         "dynamodb": ["pydynamodb>=0.4.2"],
         "solr": ["sqlalchemy-solr >= 0.2.0"],
         "elasticsearch": ["elasticsearch-dbapi>=0.2.9, <0.3.0"],

--- a/setup.py
+++ b/setup.py
@@ -155,7 +155,7 @@ setup(
         "dremio": ["sqlalchemy-dremio>=1.1.5, <1.3"],
         "drill": ["sqlalchemy-drill==0.1.dev"],
         "druid": ["pydruid>=0.6.5,<0.7"],
-        "duckdb": ["duckdb-engine>=0.9.5, <1.0"],
+        "duckdb": ["duckdb-engine>=0.9.5, <0.10"],
         "dynamodb": ["pydynamodb>=0.4.2"],
         "solr": ["sqlalchemy-solr >= 0.2.0"],
         "elasticsearch": ["elasticsearch-dbapi>=0.2.9, <0.3.0"],

--- a/setup.py
+++ b/setup.py
@@ -155,7 +155,7 @@ setup(
         "dremio": ["sqlalchemy-dremio>=1.1.5, <1.3"],
         "drill": ["sqlalchemy-drill==0.1.dev"],
         "druid": ["pydruid>=0.6.5,<0.7"],
-        "duckdb": ["duckdb-engine==0.9.5"],
+        "duckdb": ["duckdb-engine>=0.9.5, <1.0"],
         "dynamodb": ["pydynamodb>=0.4.2"],
         "solr": ["sqlalchemy-solr >= 0.2.0"],
         "elasticsearch": ["elasticsearch-dbapi>=0.2.9, <0.3.0"],


### PR DESCRIPTION
### SUMMARY
Currently, when a user selects a DuckDB database, the schema dropdown shows multiple instances of `main`. This was an issue in the SQLAlchemy driver and has been fixed on the latest version of `duckdb_engine`.

### BEFORE/AFTER SCREENSHOTS

Before:
<img width="390" alt="Screenshot 2024-01-03 at 4 32 23 PM" src="https://github.com/apache/superset/assets/4041805/bf336a62-0e21-4a28-a1fd-c3a5cc3d40d7">

After:
<img width="389" alt="Screenshot 2024-01-03 at 4 34 02 PM" src="https://github.com/apache/superset/assets/4041805/3bf9ecb1-7d49-43c6-ad8e-b91adf2762b1">


### TESTING INSTRUCTIONS
- Add a DuckDB database to Superset
- Open SQLLab
- Select the duckdb database
- Click on the "schema" dropdown
- Schema dropdown should contain unique `db_name.schema_name` items instead of many `main` schema duplicates

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/26286
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
