### PR TITLE
feat: Add ValuePercent option to LABEL TYPE for Pie and Funnel charts

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/controlPanel.tsx
@@ -124,6 +124,10 @@ const config: ControlPanelConfig = {
                   EchartsFunnelLabelTypeType.KeyValuePercent,
                   t('Category, Value and Percentage'),
                 ],
+                [
+                  EchartsFunnelLabelTypeType.ValuePercent,
+                  t('Value and Percentage'),
+                ],
               ],
               description: t('What should be shown as the label'),
             },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/transformProps.ts
@@ -94,6 +94,8 @@ export function formatFunnelLabel({
       return `${name}: ${formattedValue} (${formattedPercent})`;
     case EchartsFunnelLabelTypeType.KeyPercent:
       return `${name}: ${formattedPercent}`;
+    case EchartsFunnelLabelTypeType.ValuePercent:
+      return `${formattedValue} (${formattedPercent})`;
     default:
       return name;
   }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/types.ts
@@ -52,6 +52,7 @@ export enum EchartsFunnelLabelTypeType {
   KeyValue,
   KeyPercent,
   KeyValuePercent,
+  ValuePercent,
 }
 
 export interface EchartsFunnelChartProps

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx
@@ -107,6 +107,7 @@ const config: ControlPanelConfig = {
                 ['key_value', t('Category and Value')],
                 ['key_percent', t('Category and Percentage')],
                 ['key_value_percent', t('Category, Value and Percentage')],
+                ['value_percent', t('Value and Percentage')],
               ],
               description: t('What should be shown on the label?'),
             },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
@@ -80,6 +80,8 @@ export function formatPieLabel({
       return `${name}: ${formattedValue} (${formattedPercent})`;
     case EchartsPieLabelType.KeyPercent:
       return `${name}: ${formattedPercent}`;
+    case EchartsPieLabelType.ValuePercent:
+      return `${formattedValue} (${formattedPercent})`;
     default:
       return name;
   }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Pie/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Pie/types.ts
@@ -54,6 +54,7 @@ export enum EchartsPieLabelType {
   KeyValue = 'key_value',
   KeyPercent = 'key_percent',
   KeyValuePercent = 'key_value_percent',
+  ValuePercent = 'value_percent',
 }
 
 export interface EchartsPieChartProps


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add ValuePercent option to LABEL TYPE for pie and funnel charts

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![image](https://github.com/apache/superset/assets/28430952/0fb9d89d-662e-4c43-9588-6aaed4ea1fd9)
![image](https://github.com/apache/superset/assets/28430952/a07a51d4-d6cc-4d11-8863-a71c886ff0a6)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
When the modification is complete, you can create a new Pie or Funnel chart in Superset, and select 'Value and Percentage' for the LABEL TYPE in CUSTOMIZE to validate.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
