### PR TITLE
fix(dashboard): Chart menu disable is fixed on chart-fullscreen in issue #25992

### DIFF
--- a/superset-frontend/src/components/Dropdown/index.tsx
+++ b/superset-frontend/src/components/Dropdown/index.tsx
@@ -104,12 +104,6 @@ interface ExtendedDropDownProps extends DropDownProps {
   ref?: RefObject<HTMLDivElement>;
 }
 
-// @z-index-below-dashboard-header (100) - 1 = 99
 export const NoAnimationDropdown = (
   props: ExtendedDropDownProps & { children?: React.ReactNode },
-) => (
-  <AntdDropdown
-    overlayStyle={{ zIndex: 99, animationDuration: '0s' }}
-    {...props}
-  />
-);
+) => <AntdDropdown overlayStyle={props.overlayStyle} {...props} />;

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -373,6 +373,12 @@ const SliceHeaderControls = (props: SliceHeaderControlsPropsWithRouter) => {
     ? t('Exit fullscreen')
     : t('Enter fullscreen');
 
+  // @z-index-below-dashboard-header (100) - 1 = 99 for !isFullSize and 101 for isFullSize
+  const dropdownOverlayStyle = {
+    zIndex: isFullSize ? 101 : 99,
+    animationDuration: '0s',
+  };
+
   const menu = (
     <Menu
       onClick={handleMenuClick}
@@ -541,6 +547,7 @@ const SliceHeaderControls = (props: SliceHeaderControlsPropsWithRouter) => {
       )}
       <NoAnimationDropdown
         overlay={menu}
+        overlayStyle={dropdownOverlayStyle}
         trigger={['click']}
         placement="bottomRight"
       >

--- a/superset-frontend/src/features/reports/ReportModal/HeaderReportDropdown/index.tsx
+++ b/superset-frontend/src/features/reports/ReportModal/HeaderReportDropdown/index.tsx
@@ -191,6 +191,12 @@ export default function HeaderReportDropDown({
 
   const showReportSubMenu = report && setShowReportSubMenu && canAddReports();
 
+  // @z-index-below-dashboard-header (100) - 1 = 99
+  const dropdownOverlayStyle = {
+    zIndex: 99,
+    animationDuration: '0s',
+  };
+
   useEffect(() => {
     if (showReportSubMenu) {
       setShowReportSubMenu(true);
@@ -288,6 +294,7 @@ export default function HeaderReportDropDown({
       <>
         <NoAnimationDropdown
           overlay={menu()}
+          overlayStyle={dropdownOverlayStyle}
           trigger={['click']}
           getPopupContainer={(triggerNode: any) =>
             triggerNode.closest('.action-button')


### PR DESCRIPTION
### SUMMARY
This PR solves the issue mentioned in #25992. I have passed zindex of 101 if in fullsize else 99 to NoAnimationDropdown component as dropdownOverlayStyle props from SliceHeaderControls and similarly changed all files which uses NoAnimationDropdown component 

### BEFORE 
[![Before Changes]](https://github.com/apache/superset/assets/95441117/788cd2b7-2e98-486d-8a45-f16d6a7cd63b)

### AFTER
[![After Changes]](https://github.com/apache/superset/assets/95441117/fcde5f1b-9273-494d-9686-064f0789c88a)

### TESTING INSTRUCTIONS
Kindle select any dashboard and use the dropdown menu in top right corner of any graph and select Enter fullscreen. Now u can access the dropdown in fullscreen

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #25992 
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
