### PR TITLE
fix(embedded): Hide dashboard fullscreen option for embedded context

### DIFF
--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
@@ -92,6 +92,14 @@ const editModeOnWithFilterScopesProps = {
   },
 };
 
+const guestUserProps = {
+  ...createProps(),
+  dashboardInfo: {
+    ...createProps().dashboardInfo,
+    userId: undefined,
+  },
+};
+
 function setup(props: HeaderDropdownProps) {
   return render(
     <div className="dashboard-header">
@@ -132,6 +140,14 @@ test('should render the menu items in edit mode', async () => {
   expect(screen.getByText('Edit properties')).toBeInTheDocument();
   expect(screen.getByText('Edit CSS')).toBeInTheDocument();
   expect(screen.getByText('Download')).toBeInTheDocument();
+});
+
+test('should render the menu items in Embedded mode', async () => {
+  setup(guestUserProps);
+  expect(screen.getAllByRole('menuitem')).toHaveLength(3);
+  expect(screen.getByText('Refresh dashboard')).toBeInTheDocument();
+  expect(screen.getByText('Download')).toBeInTheDocument();
+  expect(screen.getByText('Set auto-refresh interval')).toBeInTheDocument();
 });
 
 describe('with native filters feature flag disabled', () => {

--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx
@@ -19,7 +19,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { isEmpty } from 'lodash';
-import { connect } from 'react-redux';
 import {
   isFeatureEnabled,
   FeatureFlag,
@@ -217,8 +216,7 @@ class HeaderActionsDropdown extends React.PureComponent {
     const emailSubject = `${emailTitle} ${dashboardTitle}`;
     const emailBody = t('Check out this dashboard: ');
 
-    const { user } = this.props;
-    const isEmbedded = !user?.userId;
+    const isEmbedded = !dashboardInfo?.userId;
 
     const url = getDashboardUrl({
       pathname: window.location.pathname,
@@ -396,9 +394,4 @@ class HeaderActionsDropdown extends React.PureComponent {
 HeaderActionsDropdown.propTypes = propTypes;
 HeaderActionsDropdown.defaultProps = defaultProps;
 
-function mapStateToProps(state) {
-  return {
-    user: state.user,
-  };
-}
-export default connect(mapStateToProps)(HeaderActionsDropdown);
+export default HeaderActionsDropdown;

--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx
@@ -19,6 +19,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { isEmpty } from 'lodash';
+import { connect } from 'react-redux';
 import {
   isFeatureEnabled,
   FeatureFlag,
@@ -216,6 +217,9 @@ class HeaderActionsDropdown extends React.PureComponent {
     const emailSubject = `${emailTitle} ${dashboardTitle}`;
     const emailBody = t('Check out this dashboard: ');
 
+    const { user } = this.props;
+    const isEmbedded = !user?.userId;
+
     const url = getDashboardUrl({
       pathname: window.location.pathname,
       filters: getActiveFilters(),
@@ -237,7 +241,7 @@ class HeaderActionsDropdown extends React.PureComponent {
             {t('Refresh dashboard')}
           </Menu.Item>
         )}
-        {!editMode && (
+        {!editMode && !isEmbedded && (
           <Menu.Item
             key={MENU_KEYS.TOGGLE_FULLSCREEN}
             onClick={this.handleMenuClick}
@@ -392,4 +396,9 @@ class HeaderActionsDropdown extends React.PureComponent {
 HeaderActionsDropdown.propTypes = propTypes;
 HeaderActionsDropdown.defaultProps = defaultProps;
 
-export default HeaderActionsDropdown;
+function mapStateToProps(state) {
+  return {
+    user: state.user,
+  };
+}
+export default connect(mapStateToProps)(HeaderActionsDropdown);


### PR DESCRIPTION
### SUMMARY
When a dashboard is loaded in embedded mode, the layout is already matching "fullscreen mode" (the top navigation bar is not visible), so there's no reason to show this option in embedded mode. Also, the dashboard is stuck loading when clicking on this option in embedded mode. 

Fixes https://github.com/apache/superset/issues/22537

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:**
<img width="359" alt="image" src="https://github.com/apache/superset/assets/96086495/f199e411-705d-46a0-8f74-51cc1b3a46d8">

**After:**
<img width="312" alt="image" src="https://github.com/apache/superset/assets/96086495/b265a909-04b3-4f47-8f02-9903612e8b7e">

### TESTING INSTRUCTIONS
1. Make sure you have Embedded enabled and properly configured in your environment. 
2. Access a dashboard in embedded mode.
3. Access the dashboard menu, and confirm that **Enter fullscreen** option is not visible.

### ADDITIONAL INFORMATION
- [x] Has associated issue: https://github.com/apache/superset/issues/22537
- [x] Required feature flags: `EMBEDDED_SUPERSET`
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
