### PR TITLE
fix: In chart gallery thumbnail is rendered in case of no example in #16707

### DIFF
--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -852,23 +852,22 @@ export default function VizTypeGallery(props: VizTypeGalleryProps) {
               {t('Examples')}
             </SectionTitle>
             <Examples>
-              {selectedVizMetadata?.exampleGallery.length ? (
-                (selectedVizMetadata?.exampleGallery || []).map(example => (
-                  <img
-                    key={example.url}
-                    src={example.url}
-                    alt={example.caption}
-                    title={example.caption}
-                  />
-                ))
-              ) : (
+              {(selectedVizMetadata?.exampleGallery?.length
+                ? selectedVizMetadata.exampleGallery
+                : [
+                    {
+                      url: selectedVizMetadata?.thumbnail,
+                      caption: selectedVizMetadata?.name,
+                    },
+                  ]
+              ).map(example => (
                 <img
-                  key={selectedVizMetadata?.thumbnail}
-                  src={selectedVizMetadata?.thumbnail}
-                  alt={selectedVizMetadata?.name}
-                  title={selectedVizMetadata?.name}
+                  key={example.url}
+                  src={example.url}
+                  alt={example.caption}
+                  title={example.caption}
                 />
-              )}
+              ))}
             </Examples>
           </>
         </div>

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -849,17 +849,26 @@ export default function VizTypeGallery(props: VizTypeGalleryProps) {
                 grid-area: examples-header;
               `}
             >
-              {!!selectedVizMetadata?.exampleGallery?.length && t('Examples')}
+              {t('Examples')}
             </SectionTitle>
             <Examples>
-              {(selectedVizMetadata?.exampleGallery || []).map(example => (
+              {selectedVizMetadata?.exampleGallery.length ? (
+                (selectedVizMetadata?.exampleGallery || []).map(example => (
+                  <img
+                    key={example.url}
+                    src={example.url}
+                    alt={example.caption}
+                    title={example.caption}
+                  />
+                ))
+              ) : (
                 <img
-                  key={example.url}
-                  src={example.url}
-                  alt={example.caption}
-                  title={example.caption}
+                  key={selectedVizMetadata?.thumbnail}
+                  src={selectedVizMetadata?.thumbnail}
+                  alt={selectedVizMetadata?.name}
+                  title={selectedVizMetadata?.name}
                 />
-              ))}
+              )}
             </Examples>
           </>
         </div>


### PR DESCRIPTION
### SUMMARY
This PR solves the issue mentioned in #16707 . I have made VizTypeGallery component to render the thumbnail image for selected chart for which example images are not available.

### BEFORE
[![Before Changes]](https://github.com/apache/superset/assets/95441117/8e39d778-c7bc-49aa-a279-8b6ab99a51ba)

### AFTER
[![After Changes]](https://github.com/apache/superset/assets/95441117/9d5325fd-26e3-42cd-aacd-578b2b379254)



### TESTING INSTRUCTIONS
Kindly go to http://localhost:9000/chart/add and please select any chart so that you can be able to see example images of selected chart


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #16707 
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
