### PR TITLE
fix: improve performance on reports log queries

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -31,6 +31,8 @@ assists people when migrating to a new version.
 
 ### Potential Downtime
 
+- [26416](https://github.com/apache/superset/pull/26416): adds 2 database indexes to report_execution_log and 1 to report_recipient to improve performance, this may cause downtime on large deployments.
+
 ### Other
 
 - [24982](https://github.com/apache/superset/pull/24982): By default, physical datasets on Oracle-like dialects like Snowflake will now use denormalized column names. However, existing datasets won't be affected. To change this behavior, the "Advanced" section on the dataset modal has a "Normalize column names" flag which can be changed to change this behavior.

--- a/superset/migrations/versions/2024-01-05_16-20_65a167d4c62e_add_indexes_to_report_models.py
+++ b/superset/migrations/versions/2024-01-05_16-20_65a167d4c62e_add_indexes_to_report_models.py
@@ -45,9 +45,6 @@ def upgrade():
         unique=False,
     )
     op.create_index(
-        "ix_report_execution_log_state", "report_execution_log", ["state"], unique=False
-    )
-    op.create_index(
         "ix_report_recipient_report_schedule_id",
         "report_recipient",
         ["report_schedule_id"],
@@ -59,7 +56,6 @@ def downgrade():
     op.drop_index(
         "ix_report_recipient_report_schedule_id", table_name="report_recipient"
     )
-    op.drop_index("ix_report_execution_log_state", table_name="report_execution_log")
     op.drop_index(
         "ix_report_execution_log_start_dttm", table_name="report_execution_log"
     )

--- a/superset/migrations/versions/2024-01-05_16-20_65a167d4c62e_add_indexes_to_report_models.py
+++ b/superset/migrations/versions/2024-01-05_16-20_65a167d4c62e_add_indexes_to_report_models.py
@@ -1,0 +1,68 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""add indexes to report models
+
+Revision ID: 65a167d4c62e
+Revises: 06dd9ff00fe8
+Create Date: 2024-01-05 16:20:31.598995
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "65a167d4c62e"
+down_revision = "06dd9ff00fe8"
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+def upgrade():
+    op.create_index(
+        "ix_report_execution_log_report_schedule_id",
+        "report_execution_log",
+        ["report_schedule_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_report_execution_log_start_dttm",
+        "report_execution_log",
+        ["start_dttm"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_report_execution_log_state", "report_execution_log", ["state"], unique=False
+    )
+    op.create_index(
+        "ix_report_recipient_report_schedule_id",
+        "report_recipient",
+        ["report_schedule_id"],
+        unique=False,
+    )
+
+
+def downgrade():
+    op.drop_index(
+        "ix_report_recipient_report_schedule_id", table_name="report_recipient"
+    )
+    op.drop_index("ix_report_execution_log_state", table_name="report_execution_log")
+    op.drop_index(
+        "ix_report_execution_log_start_dttm", table_name="report_execution_log"
+    )
+    op.drop_index(
+        "ix_report_execution_log_report_schedule_id", table_name="report_execution_log"
+    )

--- a/superset/reports/models.py
+++ b/superset/reports/models.py
@@ -24,6 +24,7 @@ from sqlalchemy import (
     DateTime,
     Float,
     ForeignKey,
+    Index,
     Integer,
     String,
     Table,
@@ -184,6 +185,7 @@ class ReportRecipients(Model, AuditMixinNullable):
     """
 
     __tablename__ = "report_recipient"
+
     id = Column(Integer, primary_key=True)
     type = Column(String(50), nullable=False)
     recipient_config_json = Column(Text, default="{}")
@@ -194,6 +196,10 @@ class ReportRecipients(Model, AuditMixinNullable):
         ReportSchedule,
         backref=backref("recipients", cascade="all,delete,delete-orphan"),
         foreign_keys=[report_schedule_id],
+    )
+
+    __table_args__ = (
+        Index("ix_report_recipient_report_schedule_id", report_schedule_id),
     )
 
 
@@ -227,4 +233,10 @@ class ReportExecutionLog(Model):  # pylint: disable=too-few-public-methods
         ReportSchedule,
         backref=backref("logs", cascade="all,delete,delete-orphan"),
         foreign_keys=[report_schedule_id],
+    )
+
+    __table_args__ = (
+        Index("ix_report_execution_log_report_schedule_id", report_schedule_id),
+        Index("ix_report_execution_log_start_dttm", start_dttm),
+        Index("ix_report_execution_log_state", state),
     )

--- a/superset/reports/models.py
+++ b/superset/reports/models.py
@@ -237,5 +237,4 @@ class ReportExecutionLog(Model):  # pylint: disable=too-few-public-methods
     __table_args__ = (
         Index("ix_report_execution_log_report_schedule_id", report_schedule_id),
         Index("ix_report_execution_log_start_dttm", start_dttm),
-        Index("ix_report_execution_log_state", state),
     )

--- a/superset/reports/models.py
+++ b/superset/reports/models.py
@@ -185,7 +185,6 @@ class ReportRecipients(Model, AuditMixinNullable):
     """
 
     __tablename__ = "report_recipient"
-
     id = Column(Integer, primary_key=True)
     type = Column(String(50), nullable=False)
     recipient_config_json = Column(Text, default="{}")


### PR DESCRIPTION
### SUMMARY
Add indexes to alerts and reports logs to improve REST API performance

Using test data with 100 reports with 10K report logs each spread out by 100 days. total 1M logs. Globally on 100 reports we have 10K logs per day.

Current PG explain for:
``` sql
explain analyse SELECT report_execution_log.id AS report_execution_log_id, report_execution_log.uuid AS report_execution_log_uuid, report_execution_log.scheduled_dttm AS report_execution_log_scheduled_dttm, report_execution_log.start_dttm AS report_execution_log_start_dttm, report_execution_log.end_dttm AS report_execution_log_end_dttm, report_execution_log.value AS report_execution_log_value, report_execution_log.value_row_json AS report_execution_log_value_row_json, report_execution_log.state AS report_execution_log_state, report_execution_log.error_message AS report_execution_log_error_message
FROM report_execution_log
WHERE report_execution_log.start_dttm > '2023-04-01T00:00:00.000000'::timestamp AND report_execution_log.state != 'Working' AND 13 = report_execution_log.report_schedule_id ORDER BY report_execution_log.start_dttm DESC
 LIMIT 100 OFFSET 100
```
```
Limit  (cost=17645.78..17657.45 rows=100 width=124) (actual time=286.918..303.029 rows=100 loops=1)
  ->  Gather Merge  (cost=17634.11..17736.55 rows=878 width=124) (actual time=286.798..302.946 rows=200 loops=1)
        Workers Planned: 2
        Workers Launched: 2
        ->  Sort  (cost=16634.09..16635.18 rows=439 width=124) (actual time=250.493..250.548 rows=67 loops=3)
              Sort Key: start_dttm DESC
              Sort Method: top-N heapsort  Memory: 50kB
              Worker 0:  Sort Method: quicksort  Memory: 25kB
              Worker 1:  Sort Method: quicksort  Memory: 25kB
              ->  Parallel Seq Scan on report_execution_log  (cost=0.00..16615.11 rows=439 width=124) (actual time=154.762..248.396 rows=333 loops=3)
                    Filter: ((start_dttm > '2023-04-01 00:00:00'::timestamp without time zone) AND ((state)::text <> 'Working'::text) AND (13 = report_schedule_id))
                    Rows Removed by Filter: 333000
Planning Time: 0.654 ms
Execution Time: 303.230 ms
```

Other simpler example:
``` sql
explain analyse SELECT report_execution_log.id AS report_execution_log_id, report_execution_log.uuid AS report_execution_log_uuid, report_execution_log.scheduled_dttm AS report_execution_log_scheduled_dttm, report_execution_log.start_dttm AS report_execution_log_start_dttm, report_execution_log.end_dttm AS report_execution_log_end_dttm, report_execution_log.value AS report_execution_log_value, report_execution_log.value_row_json AS report_execution_log_value_row_json, report_execution_log.state AS report_execution_log_state, report_execution_log.error_message AS report_execution_log_error_message
FROM report_execution_log 
WHERE report_execution_log.report_schedule_id = 13
 LIMIT 100 OFFSET 100
```
```
Limit  (cost=202.54..405.08 rows=100 width=124) (actual time=1.658..1.836 rows=100 loops=1)
  ->  Seq Scan on report_execution_log  (cost=0.00..21807.34 rows=10767 width=124) (actual time=1.488..1.727 rows=200 loops=1)
        Filter: (report_schedule_id = 13)
        Rows Removed by Filter: 1440
Planning Time: 1.900 ms
Execution Time: 2.560 ms
```


### After creating the indexes
``` sql
explain analyse SELECT report_execution_log.id AS report_execution_log_id, report_execution_log.uuid AS report_execution_log_uuid, report_execution_log.scheduled_dttm AS report_execution_log_scheduled_dttm, report_execution_log.start_dttm AS report_execution_log_start_dttm, report_execution_log.end_dttm AS report_execution_log_end_dttm, report_execution_log.value AS report_execution_log_value, report_execution_log.value_row_json AS report_execution_log_value_row_json, report_execution_log.state AS report_execution_log_state, report_execution_log.error_message AS report_execution_log_error_message
FROM report_execution_log
WHERE report_execution_log.start_dttm > '2023-04-01T00:00:00.000000'::timestamp AND report_execution_log.state != 'Working' AND 13 = report_execution_log.report_schedule_id ORDER BY report_execution_log.start_dttm DESC
 LIMIT 100 OFFSET 100
```

```
Limit  (cost=433.36..433.61 rows=100 width=124) (actual time=17.852..17.937 rows=100 loops=1)
  ->  Sort  (cost=433.11..435.75 rows=1057 width=124) (actual time=17.790..17.857 rows=200 loops=1)
        Sort Key: start_dttm DESC
        Sort Method: top-N heapsort  Memory: 50kB
        ->  Index Scan using ix_report_execution_log_report_schedule_id on report_execution_log  (cost=0.42..387.43 rows=1057 width=124) (actual time=0.238..15.534 rows=1000 loops=1)
              Index Cond: (report_schedule_id = 13)
              Filter: ((start_dttm > '2023-04-01 00:00:00'::timestamp without time zone) AND ((state)::text <> 'Working'::text))
              Rows Removed by Filter: 9000
Planning Time: 1.083 ms
Execution Time: 18.130 ms
```

On the simpler example:
``` sql
explain analyse SELECT report_execution_log.id AS report_execution_log_id, report_execution_log.uuid AS report_execution_log_uuid, report_execution_log.scheduled_dttm AS report_execution_log_scheduled_dttm, report_execution_log.start_dttm AS report_execution_log_start_dttm, report_execution_log.end_dttm AS report_execution_log_end_dttm, report_execution_log.value AS report_execution_log_value, report_execution_log.value_row_json AS report_execution_log_value_row_json, report_execution_log.state AS report_execution_log_state, report_execution_log.error_message AS report_execution_log_error_message
FROM report_execution_log 
WHERE report_execution_log.report_schedule_id = 13
 LIMIT 100 OFFSET 100
```

```
Limit  (cost=3.51..6.59 rows=100 width=124) (actual time=0.352..0.606 rows=100 loops=1)
  ->  Index Scan using ix_report_execution_log_report_schedule_id on report_execution_log  (cost=0.42..333.43 rows=10800 width=124) (actual time=0.123..0.505 rows=200 loops=1)
        Index Cond: (report_schedule_id = 13)
Planning Time: 0.480 ms
Execution Time: 0.761 ms
```

Observed improvement:
- Using start_dttm and report_schedule_id filters: ~**16x**
- Using just a report_schedule_id filter: ~**3x**

### Locally upgrading took:
```
flask db upgrade  2.46s user 2.26s system 29% cpu 16.261 total
```


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
