### PR TITLE
feat: global logs context

### DIFF
--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -71,6 +71,7 @@ from superset.tasks.utils import get_executor
 from superset.utils.celery import session_scope
 from superset.utils.core import HeaderDataType, override_user
 from superset.utils.csv import get_chart_csv_data, get_chart_dataframe
+from superset.utils.decorators import logs_context
 from superset.utils.screenshots import ChartScreenshot, DashboardScreenshot
 from superset.utils.urls import get_url_path
 
@@ -81,6 +82,7 @@ class BaseReportState:
     current_states: list[ReportState] = []
     initial: bool = False
 
+    @logs_context()
     def __init__(
         self,
         session: Session,

--- a/superset/utils/decorators.py
+++ b/superset/utils/decorators.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import logging
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -26,6 +27,8 @@ from flask import current_app, g, Response
 
 from superset.utils import core as utils
 from superset.utils.dates import now_as_float
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from superset.stats_logger import BaseStatsLogger
@@ -125,10 +128,10 @@ def logs_context(
                         }
                     )
 
-            except (TypeError, KeyError):
+            except (TypeError, KeyError, AttributeError):
                 # do nothing if the key doesn't exist
                 # or context is not callable
-                pass
+                logger.warning("Invalid data was passed to the logs context decorator")
 
             g.logs_context.update(logs_context_data)
             return f(*args, **kwargs)

--- a/superset/utils/decorators.py
+++ b/superset/utils/decorators.py
@@ -91,7 +91,8 @@ def logs_context(**ctx_kwargs: int | str | UUID | None) -> Callable[..., Any]:
                 if ctx_kwargs.get(key) is not None:
                     logs_context_data[key] = ctx_kwargs[key]
                     try:
-                        # override value from local kwargs from function execution if it exists
+                        # override value from local kwargs from
+                        # function execution if it exists
                         # e.g. @logs_context(slice_id=1, dashboard_id=1)
                         #      def my_func(slice_id=None, **kwargs)
                         #

--- a/tests/unit_tests/notifications/slack_tests.py
+++ b/tests/unit_tests/notifications/slack_tests.py
@@ -21,9 +21,11 @@ import pandas as pd
 from flask import g
 
 
+@patch("superset.reports.notifications.slack.g")
 @patch("superset.reports.notifications.slack.logger")
 def test_send_slack(
     logger_mock: MagicMock,
+    flask_global_mock: MagicMock,
 ) -> None:
     # `superset.models.helpers`, a dependency of following imports,
     # requires app context
@@ -32,7 +34,7 @@ def test_send_slack(
     from superset.reports.notifications.slack import SlackNotification, WebClient
 
     execution_id = uuid.uuid4()
-    g.logs_context = {"execution_id": execution_id}
+    flask_global_mock.logs_context = {"execution_id": execution_id}
     content = NotificationContent(
         name="test alert",
         header_data={
@@ -82,6 +84,3 @@ def test_send_slack(
 ```
 """,
         )
-
-    # reset g.logs_context
-    g.logs_context = None

--- a/tests/unit_tests/notifications/slack_tests.py
+++ b/tests/unit_tests/notifications/slack_tests.py
@@ -1,0 +1,87 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+from flask import g
+
+
+@patch("superset.reports.notifications.slack.logger")
+def test_send_slack(
+    logger_mock: MagicMock,
+) -> None:
+    # `superset.models.helpers`, a dependency of following imports,
+    # requires app context
+    from superset.reports.models import ReportRecipients, ReportRecipientType
+    from superset.reports.notifications.base import NotificationContent
+    from superset.reports.notifications.slack import SlackNotification, WebClient
+
+    execution_id = uuid.uuid4()
+    g.logs_context = {"execution_id": execution_id}
+    content = NotificationContent(
+        name="test alert",
+        header_data={
+            "notification_format": "PNG",
+            "notification_type": "Alert",
+            "owners": [1],
+            "notification_source": None,
+            "chart_id": None,
+            "dashboard_id": None,
+        },
+        embedded_data=pd.DataFrame(
+            {
+                "A": [1, 2, 3],
+                "B": [4, 5, 6],
+                "C": ["111", "222", '<a href="http://www.example.com">333</a>'],
+            }
+        ),
+        description='<p>This is <a href="#">a test</a> alert</p><br />',
+    )
+    with patch.object(
+        WebClient, "chat_postMessage", return_value=True
+    ) as chat_post_message_mock:
+        SlackNotification(
+            recipient=ReportRecipients(
+                type=ReportRecipientType.SLACK,
+                recipient_config_json='{"target": "some_channel"}',
+            ),
+            content=content,
+        ).send()
+        logger_mock.info.assert_called_with(
+            "Report sent to slack", extra={"execution_id": execution_id}
+        )
+        chat_post_message_mock.assert_called_with(
+            channel="some_channel",
+            text="""*test alert*
+
+<p>This is <a href="#">a test</a> alert</p><br />
+
+<None|Explore in Superset>
+
+```
+|    |   A |   B | C                                        |
+|---:|----:|----:|:-----------------------------------------|
+|  0 |   1 |   4 | 111                                      |
+|  1 |   2 |   5 | 222                                      |
+|  2 |   3 |   6 | <a href="http://www.example.com">333</a> |
+```
+""",
+        )
+
+    # reset g.logs_context
+    g.logs_context = None

--- a/tests/unit_tests/utils/test_decorators.py
+++ b/tests/unit_tests/utils/test_decorators.py
@@ -90,13 +90,10 @@ def test_statsd_gauge(
 
 @patch("superset.utils.decorators.g")
 def test_context_decorator(flask_g_mock) -> None:
-    flask_g_mock.logs_context = {}
-
     @decorators.logs_context()
     def myfunc(*args, **kwargs) -> str:
         return "test"
 
-    # should be able to add values to the decorator function directly
     @decorators.logs_context(slice_id=1, dashboard_id=1, execution_id=uuid.uuid4())
     def myfunc_with_kwargs(*args, **kwargs) -> str:
         return "test"
@@ -111,39 +108,36 @@ def test_context_decorator(flask_g_mock) -> None:
     def myfunc_with_context(*args, **kwargs) -> str:
         return "test"
 
-    # should not add any data to the global.logs_context scope
+    ### should not add any data to the global.logs_context scope
+    flask_g_mock.logs_context = {}
     myfunc(1, 1)
     assert flask_g_mock.logs_context == {}
 
-    # should add dashboard_id to the global.logs_context scope
+    ### should add dashboard_id to the global.logs_context scope
+    flask_g_mock.logs_context = {}
     myfunc(1, 1, dashboard_id=1)
     assert flask_g_mock.logs_context == {"dashboard_id": 1}
-    # reset logs_context
-    flask_g_mock.logs_context = {}
 
-    # should add slice_id to the global.logs_context scope
+    ### should add slice_id to the global.logs_context scope
+    flask_g_mock.logs_context = {}
     myfunc(1, 1, slice_id=1)
     assert flask_g_mock.logs_context == {"slice_id": 1}
-    # reset logs_context
-    flask_g_mock.logs_context = {}
 
-    # should add execution_id to the global.logs_context scope
+    ### should add execution_id to the global.logs_context scope
+    flask_g_mock.logs_context = {}
     myfunc(1, 1, execution_id=1)
     assert flask_g_mock.logs_context == {"execution_id": 1}
-    # reset logs_context
-    flask_g_mock.logs_context = {}
 
-    # should add all three to the global.logs_context scope
+    ### should add all three to the global.logs_context scope
+    flask_g_mock.logs_context = {}
     myfunc(1, 1, dashboard_id=1, slice_id=1, execution_id=1)
     assert flask_g_mock.logs_context == {
         "dashboard_id": 1,
         "slice_id": 1,
         "execution_id": 1,
     }
-    # reset logs_context
-    flask_g_mock.logs_context = {}
 
-    # should overwrite existing values in the global.logs_context scope
+    ### should overwrite existing values in the global.logs_context scope
     flask_g_mock.logs_context = {"dashboard_id": 2, "slice_id": 2, "execution_id": 2}
     myfunc(1, 1, dashboard_id=3, slice_id=3, execution_id=3)
     assert flask_g_mock.logs_context == {
@@ -151,35 +145,107 @@ def test_context_decorator(flask_g_mock) -> None:
         "slice_id": 3,
         "execution_id": 3,
     }
-    # reset logs_context
-    flask_g_mock.logs_context = {}
 
-    # should not add a value that does not exist in the global.logs_context scope
+    ### Test when g.logs_context already exists
+    flask_g_mock.logs_context = {"slice_id": 2, "dashboard_id": 2}
+    args = (3, 4)
+    kwargs = {"slice_id": 3, "dashboard_id": 3}
+    myfunc(*args, **kwargs)
+    assert flask_g_mock.logs_context == {"slice_id": 3, "dashboard_id": 3}
+
+    ### Test when kwargs contain additional keys
+    flask_g_mock.logs_context = {}
+    args = (1, 2)
+    kwargs = {
+        "slice_id": 1,
+        "dashboard_id": 1,
+        "dataset_id": 1,
+        "execution_id": 1,
+        "report_schedule_id": 1,
+        "extra_key": 1,
+    }
+    myfunc(*args, **kwargs)
+    assert flask_g_mock.logs_context == {
+        "slice_id": 1,
+        "dashboard_id": 1,
+        "dataset_id": 1,
+        "execution_id": 1,
+        "report_schedule_id": 1,
+    }
+
+    ### should not add a value that does not exist in the global.logs_context scope
+    flask_g_mock.logs_context = {}
     myfunc_with_dissallowed_kwargs()
     assert flask_g_mock.logs_context == {}
-    # reset logs_context
-    flask_g_mock.logs_context = {}
 
-    # should be able to add values to the decorator function directly
+    ### should be able to add values to the decorator function directly
+    flask_g_mock.logs_context = {}
     myfunc_with_kwargs()
     assert flask_g_mock.logs_context["dashboard_id"] == 1
     assert flask_g_mock.logs_context["slice_id"] == 1
     assert isinstance(flask_g_mock.logs_context["execution_id"], uuid.UUID)
-    # reset logs_context
-    flask_g_mock.logs_context = {}
 
-    # should be able to add values to the decorator function directly
+    ### should be able to add values to the decorator function directly
     # and it will overwrite any kwargs passed into the decorated function
+    flask_g_mock.logs_context = {}
     myfunc_with_kwargs(execution_id=4)
 
     assert flask_g_mock.logs_context["dashboard_id"] == 1
     assert flask_g_mock.logs_context["slice_id"] == 1
     assert isinstance(flask_g_mock.logs_context["execution_id"], uuid.UUID)
-    # reset logs_context
-    flask_g_mock.logs_context = {}
 
-    # should be able to pass a callable context to the decorator
+    ### should be able to pass a callable context to the decorator
+    flask_g_mock.logs_context = {}
     myfunc_with_context(chart_id=1)
     assert flask_g_mock.logs_context == {"slice_id": 1}
-    # reset logs_context
+
+    ### Test when context_func returns additional keys
+    # it should use the context_func values
     flask_g_mock.logs_context = {}
+    args = (1, 2)
+    kwargs = {"slice_id": 1, "dashboard_id": 1}
+
+    @decorators.logs_context(
+        context_func=lambda *args, **kwargs: {
+            "slice_id": 2,
+            "dashboard_id": 2,
+            "dataset_id": 2,
+            "execution_id": 2,
+            "report_schedule_id": 2,
+            "extra_key": 2,
+        }
+    )
+    def myfunc_with_extra_keys_context(*args, **kwargs) -> str:
+        return "test"
+
+    myfunc_with_extra_keys_context(
+        *args,
+        **kwargs,
+    )
+    assert flask_g_mock.logs_context == {
+        "slice_id": 2,
+        "dashboard_id": 2,
+        "dataset_id": 2,
+        "execution_id": 2,
+        "report_schedule_id": 2,
+    }
+
+    ### Test when context_func does not return a dictionary
+    flask_g_mock.logs_context = {}
+
+    @decorators.logs_context(context_func=lambda: "foo")  # type: ignore
+    def myfunc_with_bad_return_value() -> str:
+        return "test"
+
+    myfunc_with_bad_return_value()
+    assert flask_g_mock.logs_context == {}
+
+    ### Test when context_func is not callable
+    flask_g_mock.logs_context = {}
+
+    @decorators.logs_context(context_func="foo")  # type: ignore
+    def context_func_not_callable() -> str:
+        return "test"
+
+    context_func_not_callable()
+    assert flask_g_mock.logs_context == {}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is the first PR for https://github.com/apache/superset/issues/26019 [SIP-109] Global logs context. 
It introduces a decorator `logs_context` that will add permitted values to a global variable `logs_context` that can later be retrieved for logging information when a larger context is needed than what is available to the method that is calling the logging function. I included an example for slack notifications, but there are more examples in my POC/draft pr https://github.com/apache/superset/pull/25920 that has more examples of how we can use this decorator.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
