### PR TITLE
chore(docs): remove incorrect answer from FAQ

### DIFF
--- a/docs/docs/frequently-asked-questions.mdx
+++ b/docs/docs/frequently-asked-questions.mdx
@@ -175,10 +175,6 @@ non-OLTP databases are not designed for this type of workload.
 You can take a look at this Flask-AppBuilder
 [configuration example](https://github.com/dpgaspar/Flask-AppBuilder/blob/master/examples/oauth/config.py).
 
-### How can I set a default filter on my dashboard?
-
-Simply apply the filter and save the dashboard while the filter is active.
-
 ### Is there a way to force the dashboard to use specific colors?
 
 It is possible on a per-dashboard basis by providing a mapping of labels to colors in the JSON


### PR DESCRIPTION
### SUMMARY
This answer might have applied to filter boxes.  It does not apply to dashboard native filters and is actively incorrect.  I did not replace it with new content b/c I think the user experience is good enough that setting a default value is self-explanatory.  That is, this is no longer a frequently-asked question.

### TESTING INSTRUCTIONS
Docs only, no code changed.