### PR TITLE
fix(post-processing): handle missing values in cumulative operator

### DIFF
--- a/superset/utils/pandas_postprocessing/cum.py
+++ b/superset/utils/pandas_postprocessing/cum.py
@@ -46,6 +46,7 @@ def cum(
     """
     columns = columns or {}
     df_cum = df.loc[:, columns.keys()]
+    df_cum = df_cum.fillna(0)
     operation = "cum" + operator
     if operation not in ALLOWLIST_CUMULATIVE_FUNCTIONS or not hasattr(
         df_cum, operation

--- a/tests/unit_tests/fixtures/dataframes.py
+++ b/tests/unit_tests/fixtures/dataframes.py
@@ -130,6 +130,11 @@ timeseries_df = DataFrame(
     data={"label": ["x", "y", "z", "q"], "y": [1.0, 2.0, 3.0, 4.0]},
 )
 
+timeseries_with_gap_df = DataFrame(
+    index=to_datetime(["2019-01-01", "2019-01-02", "2019-01-05", "2019-01-07"]),
+    data={"label": ["x", "y", "z", "q"], "y": [1.0, 2.0, None, 4.0]},
+)
+
 timeseries_df2 = DataFrame(
     index=to_datetime(["2019-01-01", "2019-01-02", "2019-01-05", "2019-01-07"]),
     data={

--- a/tests/unit_tests/pandas_postprocessing/test_cum.py
+++ b/tests/unit_tests/pandas_postprocessing/test_cum.py
@@ -90,32 +90,6 @@ def test_cum_with_gap():
     assert series_to_list(post_df["y"]) == [1.0, 2.0, None, 4.0]
     assert series_to_list(post_df["y2"]) == [1.0, 3.0, 3.0, 7.0]
 
-    # overwrite column (cumprod)
-    post_df = pp.cum(
-        df=timeseries_with_gap_df,
-        columns={"y": "y"},
-        operator="prod",
-    )
-    assert post_df.columns.tolist() == ["label", "y"]
-    assert series_to_list(post_df["y"]) == [1.0, 2.0, 0, 0]
-
-    # overwrite column (cummin)
-    post_df = pp.cum(
-        df=timeseries_with_gap_df,
-        columns={"y": "y"},
-        operator="min",
-    )
-    assert post_df.columns.tolist() == ["label", "y"]
-    assert series_to_list(post_df["y"]) == [1.0, 1.0, 0, 0]
-
-    # invalid operator
-    with pytest.raises(InvalidPostProcessingError):
-        pp.cum(
-            df=timeseries_df,
-            columns={"y": "y"},
-            operator="abc",
-        )
-
 
 def test_cum_after_pivot_with_single_metric():
     pivot_df = pp.pivot(

--- a/tests/unit_tests/pandas_postprocessing/test_cum.py
+++ b/tests/unit_tests/pandas_postprocessing/test_cum.py
@@ -24,6 +24,7 @@ from tests.unit_tests.fixtures.dataframes import (
     multiple_metrics_df,
     single_metric_df,
     timeseries_df,
+    timeseries_with_gap_df,
 )
 from tests.unit_tests.pandas_postprocessing.utils import series_to_list
 
@@ -67,6 +68,45 @@ def test_cum():
     )
     assert post_df.columns.tolist() == ["label", "y"]
     assert series_to_list(post_df["y"]) == [1.0, 1.0, 1.0, 1.0]
+
+    # invalid operator
+    with pytest.raises(InvalidPostProcessingError):
+        pp.cum(
+            df=timeseries_df,
+            columns={"y": "y"},
+            operator="abc",
+        )
+
+
+def test_cum_with_gap():
+    # create new column (cumsum)
+    post_df = pp.cum(
+        df=timeseries_with_gap_df,
+        columns={"y": "y2"},
+        operator="sum",
+    )
+    assert post_df.columns.tolist() == ["label", "y", "y2"]
+    assert series_to_list(post_df["label"]) == ["x", "y", "z", "q"]
+    assert series_to_list(post_df["y"]) == [1.0, 2.0, None, 4.0]
+    assert series_to_list(post_df["y2"]) == [1.0, 3.0, 3.0, 7.0]
+
+    # overwrite column (cumprod)
+    post_df = pp.cum(
+        df=timeseries_with_gap_df,
+        columns={"y": "y"},
+        operator="prod",
+    )
+    assert post_df.columns.tolist() == ["label", "y"]
+    assert series_to_list(post_df["y"]) == [1.0, 2.0, 0, 0]
+
+    # overwrite column (cummin)
+    post_df = pp.cum(
+        df=timeseries_with_gap_df,
+        columns={"y": "y"},
+        operator="min",
+    )
+    assert post_df.columns.tolist() == ["label", "y"]
+    assert series_to_list(post_df["y"]) == [1.0, 1.0, 0, 0]
 
     # invalid operator
     with pytest.raises(InvalidPostProcessingError):


### PR DESCRIPTION
### SUMMARY
If your data contains nulls, using the cumsum operator will cause gaps in the chart. This is because null values appear as nulls in the series instead of the cumulative value. To avoid this, we replace nulls with zeros before applying the operator, ensuring that all values are present in the series.

### AFTER
Now gaps in the data won't cause the bar to be truncated:
<img width="1093" alt="image" src="https://github.com/apache/superset/assets/33317356/38053c39-9fd7-4ce7-8cdf-0eab155116e9">

### BEFORE
Previously, missing values would cause the cumulative series to be missing in the chart, causing gaps in the graph:
<img width="1092" alt="image" src="https://github.com/apache/superset/assets/33317356/1685ba06-2463-470b-972b-4ea748989387">


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #21093
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
