### PR TITLE
chore(deps): adding dependabot for plugins/packages and upping PR limits.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,19 +52,7 @@ updates:
     open-pull-requests-limit: 10
     versioning-strategy: increase
 
-  # Now for all of our plugins!!!
-  - package-ecosystem: "npm"
-    directory: "/superset-frontend/plugins/plugin-chart-echarts/"
-    schedule:
-      interval: "daily"
-    labels:
-      - npm
-      - dependabot
-      - plugins
-    open-pull-requests-limit: 5
-    versioning-strategy: increase
-
-  # Now for all of our plugins!!! Here's the list, to compare against more easily later:
+  # Now for all of our plugins and packages!
 
   - package-ecosystem: "npm"
     directory: "/superset-frontend/plugins/legacy-plugin-chart-calendar/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
     labels:
       - npm
       - dependabot
+    open-pull-requests-limit: 30
     versioning-strategy: increase
 
   - package-ecosystem: "pip"
@@ -16,19 +17,20 @@ updates:
     labels:
       - pip
       - dependabot
+    open-pull-requests-limit: 30
 
   - package-ecosystem: "npm"
     directory: ".github/actions"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 10
     versioning-strategy: increase
 
   - package-ecosystem: "npm"
     directory: "/docs/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 10
     versioning-strategy: increase
 
   - package-ecosystem: "npm"
@@ -47,4 +49,338 @@ updates:
     labels:
       - npm
       - dependabot
+    open-pull-requests-limit: 10
+    versioning-strategy: increase
+
+  # Now for all of our plugins!!!
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/plugins/plugin-chart-echarts/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  # Now for all of our plugins!!! Here's the list, to compare against more easily later:
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/plugins/legacy-plugin-chart-calendar/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/plugins/legacy-plugin-chart-histogram/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/plugins/legacy-plugin-chart-partition/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/plugins/legacy-plugin-chart-world-map/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/plugins/plugin-chart-pivot-table/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/plugins/legacy-plugin-chart-chord/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/plugins/legacy-plugin-chart-horizon/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/plugins/legacy-plugin-chart-rose/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/plugins/legacy-preset-chart-deckgl/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/plugins/plugin-chart-table/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/plugins/legacy-plugin-chart-country-map/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/plugins/legacy-plugin-chart-map-box/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/plugins/legacy-plugin-chart-sankey/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/plugins/legacy-preset-chart-nvd3/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/plugins/plugin-chart-word-cloud/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/plugins/legacy-plugin-chart-event-flow/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/plugins/legacy-plugin-chart-paired-t-test/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/plugins/legacy-plugin-chart-sankey-loop/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/plugins/plugin-chart-echarts/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/plugins/preset-chart-xy/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/plugins/legacy-plugin-chart-heatmap/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/plugins/legacy-plugin-chart-sunburst/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/plugins/plugin-chart-handlebars/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/packages/generator-superset/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/packages/superset-ui-chart-controls/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/packages/superset-ui-core/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/packages/superset-ui-demo/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: "npm"
+    directory: "/superset-frontend/packages/superset-ui-switchboard/"
+    schedule:
+      interval: "daily"
+    labels:
+      - npm
+      - dependabot
+      - plugins
+    open-pull-requests-limit: 5
     versioning-strategy: increase

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -13,7 +13,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/requirements/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - pip
       - dependabot
@@ -22,21 +22,21 @@ updates:
   - package-ecosystem: "npm"
     directory: ".github/actions"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 10
     versioning-strategy: increase
 
   - package-ecosystem: "npm"
     directory: "/docs/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 10
     versioning-strategy: increase
 
   - package-ecosystem: "npm"
     directory: "/superset-websocket/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -45,7 +45,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-websocket/utils/client-ws-app/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -57,7 +57,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/plugins/legacy-plugin-chart-calendar/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -68,7 +68,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/plugins/legacy-plugin-chart-histogram/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -79,7 +79,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/plugins/legacy-plugin-chart-partition/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -90,7 +90,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/plugins/legacy-plugin-chart-world-map/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -101,7 +101,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/plugins/plugin-chart-pivot-table/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -112,7 +112,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/plugins/legacy-plugin-chart-chord/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -123,7 +123,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/plugins/legacy-plugin-chart-horizon/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -134,7 +134,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/plugins/legacy-plugin-chart-rose/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -145,7 +145,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/plugins/legacy-preset-chart-deckgl/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -156,7 +156,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/plugins/plugin-chart-table/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -167,7 +167,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/plugins/legacy-plugin-chart-country-map/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -178,7 +178,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/plugins/legacy-plugin-chart-map-box/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -189,7 +189,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/plugins/legacy-plugin-chart-sankey/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -200,7 +200,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/plugins/legacy-preset-chart-nvd3/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -211,7 +211,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/plugins/plugin-chart-word-cloud/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -222,7 +222,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/plugins/legacy-plugin-chart-event-flow/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -233,7 +233,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/plugins/legacy-plugin-chart-paired-t-test/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -244,7 +244,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/plugins/legacy-plugin-chart-sankey-loop/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -255,7 +255,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/plugins/plugin-chart-echarts/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -266,7 +266,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/plugins/preset-chart-xy/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -277,7 +277,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/plugins/legacy-plugin-chart-heatmap/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -288,7 +288,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -299,7 +299,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/plugins/legacy-plugin-chart-sunburst/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -310,7 +310,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/plugins/plugin-chart-handlebars/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -321,7 +321,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/packages/generator-superset/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -332,7 +332,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/packages/superset-ui-chart-controls/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -343,7 +343,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/packages/superset-ui-core/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -354,7 +354,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/packages/superset-ui-demo/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot
@@ -365,7 +365,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/packages/superset-ui-switchboard/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - npm
       - dependabot


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Dependabot was not configured to watch package.json files of packages and plugins. Now it is! Also upping the PR limit for the other watch jobs (default is 5 PRs, the docs say)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
