### PR TITLE
chore: Deprecates the KV_STORE feature flag

### DIFF
--- a/RESOURCES/FEATURE_FLAGS.md
+++ b/RESOURCES/FEATURE_FLAGS.md
@@ -28,7 +28,6 @@ These features are considered **unfinished** and should only be used on developm
 [//]: # "PLEASE KEEP THE LIST SORTED ALPHABETICALLY"
 
 - ENABLE_ADVANCED_DATA_TYPES
-- KV_STORE
 - PRESTO_EXPAND_DATA
 - SHARE_QUERIES_VIA_KV_STORE
 - TAGGING_SYSTEM
@@ -96,5 +95,6 @@ These features flags currently default to True and **will be removed in a future
 - ENABLE_EXPLORE_JSON_CSRF_PROTECTION
 - ENABLE_TEMPLATE_REMOVE_FILTERS
 - GENERIC_CHART_AXES
+- KV_STORE
 - REMOVE_SLICE_LEVEL_LABEL_COLORS
 - VERSIONED_EXPORT

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -27,6 +27,8 @@ assists people when migrating to a new version.
 - [26034](https://github.com/apache/superset/issues/26034): Fixes a problem where numeric x-axes were being treated as categorical values. As a consequence of that, the way labels are displayed might change given that ECharts has a different treatment for numerical and categorical values. To revert to the old behavior, users need to manually convert numerical columns to text so that they are treated as categories. Check https://github.com/apache/superset/issues/26159 for more details.
 - [24657](https://github.com/apache/superset/pull/24657): Bumps the cryptography package to augment the OpenSSL security vulnerability.
 
+- [26450](https://github.com/apache/superset/pull/26450): Deprecates the `KV_STORE` feature flag and its related assets such as the API endpoint and `keyvalue` table. The main dependency of this feature is the `SHARE_QUERIES_VIA_KV_STORE` feature flag which allows sharing SQL Lab queries without the necessity of saving the query. Our intention is to use the permalink feature to implement this use case before 5.0 and that's why we are deprecating the feature flag now.
+
 ### Breaking Changes
 
 ### Potential Downtime

--- a/superset/config.py
+++ b/superset/config.py
@@ -427,7 +427,7 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # geospatial ones) by inputting javascript in controls. This exposes
     # an XSS security vulnerability
     "ENABLE_JAVASCRIPT_CONTROLS": False,
-    "KV_STORE": False,
+    "KV_STORE": False,  # deprecated
     # When this feature is enabled, nested types in Presto will be
     # expanded into extra columns and/or arrays. This is experimental,
     # and doesn't work with all nested types.

--- a/superset/views/key_value.py
+++ b/superset/views/key_value.py
@@ -25,7 +25,7 @@ from superset import db, event_logger, is_feature_enabled
 from superset.models import core as models
 from superset.superset_typing import FlaskResponse
 from superset.utils import core as utils
-from superset.views.base import BaseSupersetView, json_error_response
+from superset.views.base import BaseSupersetView, deprecated, json_error_response
 
 
 class KV(BaseSupersetView):
@@ -44,6 +44,7 @@ class KV(BaseSupersetView):
     @event_logger.log_this
     @has_access_api
     @expose("/store/", methods=("POST",))
+    @deprecated(eol_version="4.0.0")
     def store(self) -> FlaskResponse:
         try:
             value = request.form.get("data")
@@ -57,6 +58,7 @@ class KV(BaseSupersetView):
     @event_logger.log_this
     @has_access_api
     @expose("/<int:key_id>/", methods=("GET",))
+    @deprecated(eol_version="4.0.0")
     def get_value(self, key_id: int) -> FlaskResponse:
         try:
             kv = db.session.query(models.KeyValue).filter_by(id=key_id).scalar()


### PR DESCRIPTION
### SUMMARY
As part of the [4.0 approved initiatives](https://github.com/orgs/apache/projects/292/views/1), this PR deprecates the `KV_STORE` feature flag and its related assets such as the API endpoint and `keyvalue` table. The main dependency of this feature is the `SHARE_QUERIES_VIA_KV_STORE` feature flag which allows sharing SQL Lab queries without the necessity of saving the query. Our intention is to use the permalink feature to implement this use case before 5.0 and that's why we are deprecating the feature flag now.

### TESTING INSTRUCTIONS
CI.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
