### PR TITLE
fix(BigQuery): Support special characters in column/metric names used in ORDER BY

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1974,9 +1974,9 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                 and db_engine_spec.allows_hidden_cc_in_orderby
                 and col.name in [select_col.name for select_col in select_exprs]
             ):
-                engine = self.database._get_sqla_engine()
-                quote = engine.dialect.identifier_preparer.quote
-                col = literal_column(quote(col.name))
+                with self.database.get_sqla_engine_with_context() as engine:
+                    quote = engine.dialect.identifier_preparer.quote
+                    col = literal_column(quote(col.name))
             direction = sa.asc if ascending else sa.desc
             qry = qry.order_by(direction(col))
 

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1974,7 +1974,9 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                 and db_engine_spec.allows_hidden_cc_in_orderby
                 and col.name in [select_col.name for select_col in select_exprs]
             ):
-                col = literal_column(col.name)
+                engine = self.database._get_sqla_engine()
+                quote = engine.dialect.identifier_preparer.quote
+                col = literal_column(quote(col.name))
             direction = sa.asc if ascending else sa.desc
             qry = qry.order_by(direction(col))
 

--- a/tests/integration_tests/db_engine_specs/bigquery_tests.py
+++ b/tests/integration_tests/db_engine_specs/bigquery_tests.py
@@ -381,4 +381,4 @@ class TestBigQueryDbEngineSpec(TestDbEngineSpec):
             "orderby": [["gender_cc", True]],
         }
         sql = table.get_query_str(query_obj)
-        assert "ORDER BY gender_cc ASC" in sql
+        assert "ORDER BY `gender_cc` ASC" in sql


### PR DESCRIPTION
### SUMMARY
The `BigQueryEngineSpec` has `allows_hidden_cc_in_orderby` set to `True`, so the `ORDER BY` statement uses the actual metric/dimension alias, rather than its SQL expression (implementation PR: https://github.com/apache/superset/pull/17196).

In case the metric alias has a special characters (like accents or Chinese characters for example), the query will throw an error.

Fixes https://github.com/apache/superset/issues/26459

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before:**

https://github.com/apache/superset/assets/96086495/3db44c50-1fbb-4809-a123-cd4ea23f65ca

**After:**

https://github.com/apache/superset/assets/96086495/36a0745a-0f67-4130-934a-2abc77b0ff70




### TESTING INSTRUCTIONS
1. Create a dataset from a BQ connection.
2. Use it to create a **Table** chart.
3. Add any column as its dimension, and create a metric named `métric` using `COUNT(*)` as its SQL expression.

### ADDITIONAL INFORMATION
- [X] Has associated issue: https://github.com/apache/superset/issues/26459
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
