### PR TITLE
fix(database): allow filtering by UUID

### DIFF
--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -205,6 +205,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         "changed_by",
         "database_name",
         "expose_in_sqllab",
+        "uuid",
     ]
     search_filters = {"allow_file_upload": [DatabaseUploadEnabledFilter]}
     allowed_rel_fields = {"changed_by", "created_by"}

--- a/tests/unit_tests/databases/api_test.py
+++ b/tests/unit_tests/databases/api_test.py
@@ -29,6 +29,46 @@ from pytest_mock import MockFixture
 from sqlalchemy.orm.session import Session
 
 
+def test_filter_by_uuid(
+    session: Session,
+    client: Any,
+    full_api_access: None,
+) -> None:
+    """
+    Test that we can filter databases by UUID.
+
+    Note: this functionality is not used by the Superset UI, but is needed by 3rd
+    party tools that use the Superset API. If this tests breaks, please make sure
+    that the functionality is properly deprecated between major versions with
+    enough warning so that tools can be adapted.
+    """
+    from superset.databases.api import DatabaseRestApi
+    from superset.models.core import Database
+
+    DatabaseRestApi.datamodel.session = session
+
+    # create table for databases
+    Database.metadata.create_all(session.get_bind())  # pylint: disable=no-member
+    session.add(
+        Database(
+            database_name="my_db",
+            sqlalchemy_uri="sqlite://",
+            uuid=UUID("7c1b7880-a59d-47cd-8bf1-f1eb8d2863cb"),
+        )
+    )
+    session.commit()
+
+    response = client.get(
+        "/api/v1/database/?q=(filters:!((col:uuid,opr:eq,value:"
+        "%277c1b7880-a59d-47cd-8bf1-f1eb8d2863cb%27)))"
+    )
+    assert response.status_code == 200
+
+    payload = response.json
+    assert len(payload["result"]) == 1
+    assert payload["result"][0]["uuid"] == "7c1b7880-a59d-47cd-8bf1-f1eb8d2863cb"
+
+
 def test_post_with_uuid(
     session: Session,
     client: Any,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

I found a regression where we can longer filter databases by the UUID. While this functionality is not used by Superset, the [Preset CLI](https://github.com/preset-io/backend-sdk) relies on it (and is used not just with Preset workspaces, but with standalone Superset deployments for multiple reasons).

This PR brings back the functionality, and adds a unit test to prevent future breakage.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Run something like:

http://localhost:8089/api/v1/database/?q=(filters:!((col:uuid,opr:eq,value:%276ae566ae36f64a19a210621253414d03%27),(col:changed_by,opr:rel_o_m,value:1)),order_column:changed_on_delta_humanized,order_direction:desc,page:0,page_size:25)

And verify that it works.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
