### PR TITLE
chore(API): Include changed_by.id in Get Charts and Get Datasets API responses

### DIFF
--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -159,6 +159,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
         "cache_timeout",
         "changed_by.first_name",
         "changed_by.last_name",
+        "changed_by.id",
         "changed_by_name",
         "changed_on_delta_humanized",
         "changed_on_dttm",

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -108,6 +108,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         "changed_by_name",
         "changed_by.first_name",
         "changed_by.last_name",
+        "changed_by.id",
         "changed_on_utc",
         "changed_on_delta_humanized",
         "default_endpoint",


### PR DESCRIPTION
### SUMMARY
The API responses for fetching all charts (`/api/v1/chart/`) and all datasets (`/api/v1/dataset/`) don't include the `changed_by.id` attribute. This is useful when implementing automations to maintain content (that involve reaching out to the user that last modified it). 

This PR includes this field in the two API responses. It is already available when fetching all dashboards (`/api/v1/dashboard/`).

### TESTING INSTRUCTIONS
1. Make sure you have at least 1 chart and 1 dashboard created.
2. Overwrite/modify both of them.
3. Send a `GET` request to `/api/v1/chart/` and confirm the `changed_by.id` is visible there. 
4. Send a `GET` request to `/api/v1/dataset/` and confirm the `changed_by.id` is visible there. 

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
