### PR TITLE
docs: fix links

### DIFF
--- a/docs/docs/contributing/local-backend.mdx
+++ b/docs/docs/contributing/local-backend.mdx
@@ -9,7 +9,7 @@ version: 1
 
 #### OS Dependencies
 
-Make sure your machine meets the [OS dependencies](https://superset.apache.org/docs/installation/installing-superset-from-scratch#os-dependencies) before following these steps.
+Make sure your machine meets the [OS dependencies](/docs/installation/installing-superset-from-scratch#os-dependencies) before following these steps.
 You also need to install MySQL or [MariaDB](https://mariadb.com/downloads).
 
 Ensure that you are using Python version 3.9 or 3.10, then proceed with:

--- a/docs/docs/creating-charts-dashboards/creating-your-first-dashboard.mdx
+++ b/docs/docs/creating-charts-dashboards/creating-your-first-dashboard.mdx
@@ -185,7 +185,7 @@ Access to dashboards is managed via owners (users that have edit permissions to 
 Non-owner users access can be managed two different ways:
 
 1. Dataset permissions - if you add to the relevant role permissions to datasets it automatically grants implicit access to all dashboards that uses those permitted datasets
-2. Dashboard roles - if you enable **DASHBOARD_RBAC** [feature flag](https://superset.apache.org/docs/installation/configuring-superset#feature-flags) then you be able to manage which roles can access the dashboard
+2. Dashboard roles - if you enable **DASHBOARD_RBAC** [feature flag](/docs/installation/configuring-superset#feature-flags) then you be able to manage which roles can access the dashboard
    - Granting a role access to a dashboard will bypass dataset level checks. Having dashboard access implicitly grants read access to all the featured charts in the dashboard, and thereby also all the associated datasets.
    - If no roles are specified for a dashboard, regular **Dataset permissions** will apply.
 

--- a/docs/docs/databases/docker-add-drivers.mdx
+++ b/docs/docs/databases/docker-add-drivers.mdx
@@ -50,9 +50,9 @@ After the rebuild of the Docker images is complete, relaunch Superset by running
 
 Now that you've got a MySQL driver installed in your container, you should be able to connect to your database via the Superset web UI.
 
-As an admin user, go to Settings -> Data: Database Connections and click the +DATABASE button. From there, follow the steps on the [Using Database Connection UI page](https://superset.apache.org/docs/databases/db-connection-ui).
+As an admin user, go to Settings -> Data: Database Connections and click the +DATABASE button. From there, follow the steps on the [Using Database Connection UI page](/docs/databases/db-connection-ui).
 
-Consult the page for your specific database type in the Superset documentation to determine the connection string and any other parameters you need to input.  For instance, on the [MySQL page](https://superset.apache.org/docs/databases/mysql), we see that the connection string to a local MySQL database differs depending on whether the setup is running on Linux or Mac.
+Consult the page for your specific database type in the Superset documentation to determine the connection string and any other parameters you need to input.  For instance, on the [MySQL page](/docs/databases/mysql), we see that the connection string to a local MySQL database differs depending on whether the setup is running on Linux or Mac.
 
 Click the “Test Connection” button, which should result in a popup message saying, "Connection looks good!".
 

--- a/docs/docs/frequently-asked-questions.mdx
+++ b/docs/docs/frequently-asked-questions.mdx
@@ -161,7 +161,7 @@ table afterwards to configure the Columns tab, check the appropriate boxes and s
 
 To clarify, the database backend is an OLTP database used by Superset to store its internal
 information like your list of users and dashboard definitions. While Superset supports a
-[variety of databases as data *sources*](https://superset.apache.org/docs/databases/installing-database-drivers/),
+[variety of databases as data *sources*](/docs/databases/installing-database-drivers/),
 only a few database engines are supported for use as the OLTP backend / metadata store.
 
 Superset is tested using MySQL, PostgreSQL, and SQLite backends. It’s recommended you install
@@ -267,7 +267,7 @@ Superset uses [Scarf](https://about.scarf.sh/) by default to collect basic telem
 We use the [Scarf Gateway](https://docs.scarf.sh/gateway/) to sit in front of container registries, the [scarf-js](https://about.scarf.sh/package-sdks) package to track `npm` installations, and a Scarf pixel to gather anonymous analytics on Superset page views.
 Scarf purges PII and provides aggregated statistics. Superset users can easily opt out of analytics in various ways documented [here](https://docs.scarf.sh/gateway/#do-not-track) and [here](https://docs.scarf.sh/package-analytics/#as-a-user-of-a-package-using-scarf-js-how-can-i-opt-out-of-analytics).
 Superset maintainers can also opt out of telemetry data collection by setting the `SCARF_ANALYTICS` environment variable to `false` in the Superset container (or anywhere Superset/webpack are run).
-Additional opt-out instructions for Docker users are available on the [Docker Installation](https://superset.apache.org/docs/installation/installing-superset-using-docker-compose) page.
+Additional opt-out instructions for Docker users are available on the [Docker Installation](/docs/installation/installing-superset-using-docker-compose) page.
 
 ### Does Superset have an archive panel or trash bin from which a user can recover deleted assets?
 

--- a/docs/docs/installation/alerts-reports.mdx
+++ b/docs/docs/installation/alerts-reports.mdx
@@ -20,7 +20,7 @@ Alerts and reports are disabled by default. To turn them on, you need to do some
 
 ##### In your `superset_config.py` or `superset_config_docker.py`
 
-- `"ALERT_REPORTS"` [feature flag](https://superset.apache.org/docs/installation/configuring-superset#feature-flags) must be turned to True.
+- `"ALERT_REPORTS"` [feature flag](/docs/installation/configuring-superset#feature-flags) must be turned to True.
 - `beat_schedule` in CeleryConfig must contain schedule for `reports.scheduler`.
 - At least one of those must be configured, depending on what you want to use:
   - emails: `SMTP_*` settings
@@ -35,7 +35,7 @@ Screenshots will be taken but no messages actually sent as long as `ALERT_REPORT
 - You must install a headless browser, for taking screenshots of the charts and dashboards. Only Firefox and Chrome are currently supported.
   > If you choose Chrome, you must also change the value of `WEBDRIVER_TYPE` to `"chrome"` in your `superset_config.py`.
 
-Note: All the components required (Firefox headless browser, Redis, Postgres db, celery worker and celery beat) are present in the *dev* docker image if you are following [Installing Superset Locally](https://superset.apache.org/docs/installation/installing-superset-using-docker-compose/).
+Note: All the components required (Firefox headless browser, Redis, Postgres db, celery worker and celery beat) are present in the *dev* docker image if you are following [Installing Superset Locally](/docs/installation/installing-superset-using-docker-compose/).
 All you need to do is add the required config variables described in this guide (See `Detailed Config`).
 
 If you are running a non-dev docker image, e.g., a stable release like `apache/superset:2.0.1`, that image does not include a headless browser.  Only the `superset_worker` container needs this headless browser to browse to the target chart or dashboard.

--- a/docs/docs/installation/cache.mdx
+++ b/docs/docs/installation/cache.mdx
@@ -81,7 +81,7 @@ See [Async Queries via Celery](/docs/installation/async-queries-celery) for deta
 
 ### Caching Thumbnails
 
-This is an optional feature that can be turned on by activating it’s [feature flag](https://superset.apache.org/docs/installation/configuring-superset#feature-flags) on config:
+This is an optional feature that can be turned on by activating it’s [feature flag](/docs/installation/configuring-superset#feature-flags) on config:
 
 ```
 FEATURE_FLAGS = {

--- a/docs/docs/installation/installing-superset-from-scratch.mdx
+++ b/docs/docs/installation/installing-superset-from-scratch.mdx
@@ -130,7 +130,7 @@ superset db upgrade
 ```
 
 :::tip
-Note that some configuration is mandatory for production instances of Superset. In particular, Superset will not start without a user-specified value of SECRET_KEY. Please see [Configuring Superset](https://superset.apache.org/docs/installation/configuring-superset).
+Note that some configuration is mandatory for production instances of Superset. In particular, Superset will not start without a user-specified value of SECRET_KEY. Please see [Configuring Superset](/docs/installation/configuring-superset).
 :::
 
 Finish installing by running through the following commands:

--- a/docs/docs/installation/installing-superset-from-scratch.mdx
+++ b/docs/docs/installation/installing-superset-from-scratch.mdx
@@ -64,7 +64,7 @@ We don't recommend using the system installed Python. Instead, first install the
 brew install readline pkg-config libffi openssl mysql postgresql@14
 ```
 
-You should install a recent version of Python. Refer to the (setup.py file)[https://github.com/apache/superset/blob/master/setup.py] for a list of Python versions officially supported by Superset. We'd recommend using a Python version manager like [pyenv](https://github.com/pyenv/pyenv) (and also [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv)).
+You should install a recent version of Python. Refer to the [setup.py](https://github.com/apache/superset/blob/master/setup.py) file for a list of Python versions officially supported by Superset. We'd recommend using a Python version manager like [pyenv](https://github.com/pyenv/pyenv) (and also [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv)).
 
 :::tip
 To identify the Python version used by the official docker image, see the [Dockerfile](https://github.com/apache/superset/blob/master/Dockerfile). Additional docker images published for newer versions of Python can be found in [this file](https://github.com/apache/superset/blob/master/scripts/docker_build_push.sh).

--- a/docs/docs/installation/installing-superset-from-scratch.mdx
+++ b/docs/docs/installation/installing-superset-from-scratch.mdx
@@ -67,7 +67,7 @@ brew install readline pkg-config libffi openssl mysql postgresql@14
 You should install a recent version of Python. Refer to the (setup.py file)[https://github.com/apache/superset/blob/master/setup.py] for a list of Python versions officially supported by Superset. We'd recommend using a Python version manager like [pyenv](https://github.com/pyenv/pyenv) (and also [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv)).
 
 :::tip
-To identify the Python version used by the official docker image, see the [Dockerfile](https://github.com/apache/superset/blob/master/Dockerfile). Additional docker images published for newer versions of Python can be found in [this file](https://github.com/apache/superset/blob/master/.github/workflows/docker_build_push.sh).
+To identify the Python version used by the official docker image, see the [Dockerfile](https://github.com/apache/superset/blob/master/Dockerfile). Additional docker images published for newer versions of Python can be found in [this file](https://github.com/apache/superset/blob/master/scripts/docker_build_push.sh).
 :::
 
 Let's also make sure we have the latest version of `pip` and `setuptools`:

--- a/docs/docs/installation/installing-superset-using-docker-compose.mdx
+++ b/docs/docs/installation/installing-superset-using-docker-compose.mdx
@@ -93,7 +93,7 @@ docker compose -f docker-compose-non-dev.yml up
 ```
 
 :::tip
-Note that some configuration is mandatory for production instances of Superset. In particular, Superset will not start without a user-specified value of `SECRET_KEY` in a Superset config file or `SUPERSET_SECRET_KEY` as an [environment variable](https://github.com/apache/superset/blob/master/docker/.env-non-dev). Please see [Configuring Superset](https://superset.apache.org/docs/installation/configuring-superset/) for more details.
+Note that some configuration is mandatory for production instances of Superset. In particular, Superset will not start without a user-specified value of `SECRET_KEY` in a Superset config file or `SUPERSET_SECRET_KEY` as an [environment variable](https://github.com/apache/superset/blob/master/docker/.env-non-dev). Please see [Configuring Superset](/docs/installation/configuring-superset/) for more details.
 :::
 :::caution
 All of the content belonging to a Superset instance - charts, dashboards, users, etc. - is stored in its metadata database. In production, this database should be backed up.

--- a/docs/docs/installation/sql-templating.mdx
+++ b/docs/docs/installation/sql-templating.mdx
@@ -10,7 +10,7 @@ version: 1
 ### Jinja Templates
 
 SQL Lab and Explore supports [Jinja templating](https://jinja.palletsprojects.com/en/2.11.x/) in queries.
-To enable templating, the `ENABLE_TEMPLATE_PROCESSING` [feature flag](https://superset.apache.org/docs/installation/configuring-superset#feature-flags) needs to be enabled in
+To enable templating, the `ENABLE_TEMPLATE_PROCESSING` [feature flag](/docs/installation/configuring-superset#feature-flags) needs to be enabled in
 `superset_config.py`. When templating is enabled, python code can be embedded in virtual datasets and
 in Custom SQL in the filter and metric controls in Explore. By default, the following variables are
 made available in the Jinja context:

--- a/docs/docs/intro.mdx
+++ b/docs/docs/intro.mdx
@@ -13,10 +13,10 @@ geospatial charts.
 
 Here are a **few different ways you can get started with Superset**:
 
-- Install Superset [from scratch](https://superset.apache.org/docs/installation/installing-superset-from-scratch/)
+- Install Superset [from scratch](/docs/installation/installing-superset-from-scratch/)
 - Deploy Superset locally with one command
-  [using Docker Compose](https://superset.apache.org/docs/installation/installing-superset-using-docker-compose)
-- Deploy Superset [with Kubernetes](https://superset.apache.org/docs/installation/running-on-kubernetes)
+  [using Docker Compose](/docs/installation/installing-superset-using-docker-compose)
+- Deploy Superset [with Kubernetes](/docs/installation/running-on-kubernetes)
 - Run a [Docker image](https://hub.docker.com/r/apache/superset) from Dockerhub
 - Download Superset [from Pypi here](https://pypi.org/project/apache-superset/)
 - Install the latest version of Superset
@@ -36,7 +36,7 @@ Superset provides:
 - Code-free visualization builder to extract and present datasets
 - A world-class SQL IDE for preparing data for visualization, including a rich metadata browser
 - A lightweight semantic layer which empowers data analysts to quickly define custom dimensions and metrics
-- Out-of-the-box support for [most SQL-speaking databases](https://superset.apache.org/docs/databases/installing-database-drivers/)
+- Out-of-the-box support for [most SQL-speaking databases](/docs/databases/installing-database-drivers/)
 - Seamless, in-memory asynchronous caching and queries
 - An extensible security model that allows configuration of very intricate rules on who can access which product features and datasets.
 - Integration with major authentication backends (database, OpenID, LDAP, OAuth, REMOTE_USER, etc)
@@ -59,7 +59,7 @@ Superset is also cloud-native in the sense that it is flexible and lets you choo
 - Results backend (Redis, S3, Memcached, etc.),
 - Caching layer (Redis, Memcached, etc.)
 
-Superset also works well with [event-logging](https://superset.apache.org/docs/installation/event-logging/)
+Superset also works well with [event-logging](/docs/installation/event-logging/)
 services like StatsD, NewRelic, and DataDog.
 
 Superset is currently run at scale at many companies. For example, Superset is run in Airbnb’s

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -25,7 +25,7 @@ $ docker pull apache/superset:$SUPERSET_VERSION
 :::tip
 Note that some configuration is mandatory for Superset in order to start. In particular, Superset will not start without
 a user-specified value of `SECRET_KEY` in a Superset configuration file or `SUPERSET_SECRET_KEY` as an environment variable.
-Please see [Configuring Superset](https://superset.apache.org/docs/installation/configuring-superset/) for more details.
+Please see [Configuring Superset](/docs/installation/configuring-superset/) for more details.
 :::
 ```
 $ docker run -d -p 8080:8088 \
@@ -79,8 +79,8 @@ processes by running Docker `stop` command. By doing so, you can avoid data corr
 ## What's next?
 
 From this point on, you can head on to:
-- [Create your first Dashboard](https://superset.apache.org/docs/creating-charts-dashboards/creating-your-first-dashboard)
-- [Connect to a Database](https://superset.apache.org/docs/databases/installing-database-drivers)
-- [Configure Superset](https://superset.apache.org/docs/installation/configuring-superset/)
+- [Create your first Dashboard](/docs/creating-charts-dashboards/creating-your-first-dashboard)
+- [Connect to a Database](/docs/databases/installing-database-drivers)
+- [Configure Superset](/docs/installation/configuring-superset/)
 
 Or just explore our Documentation!

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -246,7 +246,7 @@ const config = {
           <img class="footer__divider" src="/img/community/line.png" alt="Divider" />
           <p>
             <small>
-              <a href="https://superset.apache.org/docs/security/" target="_blank" rel="noreferrer">Security</a>&nbsp;|&nbsp;
+              <a href="/docs/security/" target="_blank" rel="noreferrer">Security</a>&nbsp;|&nbsp;
               <a href="https://www.apache.org/foundation/sponsorship.html" target="_blank" rel="noreferrer">Donate</a>&nbsp;|&nbsp;
               <a href="https://www.apache.org/foundation/thanks.html" target="_blank" rel="noreferrer">Thanks</a>&nbsp;|&nbsp;
               <a href="https://apache.org/events/current-event" target="_blank" rel="noreferrer">Events</a>&nbsp;|&nbsp;


### PR DESCRIPTION
### SUMMARY

Fix link to `docker_build_push.sh` in `docs/docs/installation/installing-superset-from-scratch.mdx`
Fix syntax of link to `setup.py` file in `docs/docs/installation/installing-superset-from-scratch.mdx`

Fix links in multiple doc pages so that they take us to the locally hosted URL when we run the docs using the below commands

```bash
cd docs
npm run start
```

### TESTING INSTRUCTIONS

Start local version of docs using the below commands

```bash
cd docs
npm run start
```

Visit http://localhost:3000/docs/installation/installing-superset-from-scratch

Before the fix - `setup.py` was shown as plain text
![image](https://github.com/apache/superset/assets/42742240/587bd065-23a7-4254-aede-ea40c50bbdd2)

After the fix - `setup.py` is highlighted as a link
![Screenshot from 2024-01-14 17-12-38](https://github.com/apache/superset/assets/42742240/9bcc0ac2-58e6-4c99-ab33-764e0b64af58)

Clicking on `this file` link on the same page should take us to a valid file on the GitHub.
![image](https://github.com/apache/superset/assets/42742240/31480cb7-4be7-44a8-9da2-baac9fd499db)

Clicking on `Configuring Superset` should take us to http://localhost:3001/docs/installation/configuring-superset instead of https://superset.apache.org/docs/installation/configuring-superset/ . We can test other pages in the same way.
![image](https://github.com/apache/superset/assets/42742240/ca7b8a71-74fa-40e6-8f1d-0ef5c99b8ea3)
