### PR TITLE
fix: RLS modal styling

### DIFF
--- a/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
+++ b/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
@@ -116,9 +116,7 @@ const LabeledErrorBoundInput = ({
       <StyledFormLabel htmlFor={id} required={required}>
         {label}
       </StyledFormLabel>
-      {hasTooltip && (
-        <InfoTooltip tooltip={`${tooltipText}`} viewBox="0 -1 24 24" />
-      )}
+      {hasTooltip && <InfoTooltip tooltip={`${tooltipText}`} />}
     </StyledAlignment>
     <FormItem
       css={(theme: SupersetTheme) => alertIconStyles(theme, !!errorMessage)}

--- a/superset-frontend/src/components/InfoTooltip/index.tsx
+++ b/superset-frontend/src/components/InfoTooltip/index.tsx
@@ -73,7 +73,7 @@ export default function InfoTooltip({
   trigger = 'hover',
   overlayStyle = defaultOverlayStyle,
   bgColor = defaultColor,
-  viewBox = '0 -2 24 24',
+  viewBox = '0 -1 24 24',
 }: InfoTooltipProps) {
   return (
     <StyledTooltip

--- a/superset-frontend/src/features/rls/RowLevelSecurityModal.tsx
+++ b/superset-frontend/src/features/rls/RowLevelSecurityModal.tsx
@@ -31,11 +31,18 @@ import Select from 'src/components/Select/Select';
 import AsyncSelect from 'src/components/Select/AsyncSelect';
 import rison from 'rison';
 import { LabeledErrorBoundInput } from 'src/components/Form';
-import { noBottomMargin } from 'src/features/reports/ReportModal/styles';
 import InfoTooltip from 'src/components/InfoTooltip';
 import { useSingleViewResource } from 'src/views/CRUD/hooks';
 import { FilterOptions } from './constants';
 import { FilterType, RLSObject, RoleObject, TableObject } from './types';
+
+const noMargins = css`
+  margin: 0;
+
+  .ant-input {
+    margin: 0;
+  }
+`;
 
 const StyledModal = styled(Modal)`
   max-width: 1200px;
@@ -59,9 +66,17 @@ const StyledSectionContainer = styled.div`
   padding: ${({ theme }) =>
     `${theme.gridUnit * 3}px ${theme.gridUnit * 4}px ${theme.gridUnit * 2}px`};
 
-  label {
+  label,
+  .control-label {
+    display: inline-block;
     font-size: ${({ theme }) => theme.typography.sizes.s}px;
-    color: ${({ theme }) => theme.colors.grayscale.light1};
+    color: ${({ theme }) => theme.colors.grayscale.base};
+    vertical-align: middle;
+  }
+
+  .info-solid-small {
+    vertical-align: middle;
+    padding-bottom: ${({ theme }) => theme.gridUnit / 2}px;
   }
 `;
 
@@ -69,7 +84,6 @@ const StyledInputContainer = styled.div`
   display: flex;
   flex-direction: column;
   margin: ${({ theme }) => theme.gridUnit}px;
-
   margin-bottom: ${({ theme }) => theme.gridUnit * 4}px;
 
   .input-container {
@@ -79,11 +93,6 @@ const StyledInputContainer = styled.div`
     > div {
       width: 100%;
     }
-
-    label {
-      display: flex;
-      margin-right: ${({ theme }) => theme.gridUnit * 2}px;
-    }
   }
 
   input,
@@ -91,15 +100,17 @@ const StyledInputContainer = styled.div`
     flex: 1 1 auto;
   }
 
-  textarea {
-    height: 100px;
-    resize: none;
-  }
-
   .required {
     margin-left: ${({ theme }) => theme.gridUnit / 2}px;
     color: ${({ theme }) => theme.colors.error.base};
   }
+`;
+
+const StyledTextArea = styled.textarea`
+  height: 100px;
+  resize: none;
+  margin-top: ${({ theme }) => theme.gridUnit}px;
+  border: 1px solid ${({ theme }) => theme.colors.secondary.light3};
 `;
 
 export interface RowLevelSecurityModalProps {
@@ -355,9 +366,11 @@ function RowLevelSecurityModal(props: RowLevelSecurityModalProps) {
                 onChange: ({ target }: { target: HTMLInputElement }) =>
                   onTextChange(target),
               }}
-              css={noBottomMargin}
+              css={noMargins}
               label={t('Rule Name')}
               data-test="rule-name-test"
+              tooltipText={t('The name of the rule must be unique')}
+              hasTooltip
             />
           </StyledInputContainer>
 
@@ -433,7 +446,7 @@ function RowLevelSecurityModal(props: RowLevelSecurityModalProps) {
                 onChange: ({ target }: { target: HTMLInputElement }) =>
                   onTextChange(target),
               }}
-              css={noBottomMargin}
+              css={noMargins}
               label={t('Group Key')}
               hasTooltip
               tooltipText={t(
@@ -454,7 +467,7 @@ function RowLevelSecurityModal(props: RowLevelSecurityModalProps) {
                   onChange: ({ target }: { target: HTMLInputElement }) =>
                     onTextChange(target),
                 }}
-                css={noBottomMargin}
+                css={noMargins}
                 label={t('Clause')}
                 hasTooltip
                 tooltipText={t(
@@ -468,7 +481,7 @@ function RowLevelSecurityModal(props: RowLevelSecurityModalProps) {
           <StyledInputContainer>
             <div className="control-label">{t('Description')}</div>
             <div className="input-container">
-              <textarea
+              <StyledTextArea
                 name="description"
                 value={currentRule ? currentRule.description : ''}
                 onChange={event => onTextChange(event.target)}

--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -356,9 +356,7 @@ function ChartList(props: ChartListProps) {
               )}
               {sliceName}
             </Link>
-            {description && (
-              <InfoTooltip tooltip={description} viewBox="0 -1 24 24" />
-            )}
+            {description && <InfoTooltip tooltip={description} />}
           </FlexRowContainer>
         ),
         Header: t('Name'),

--- a/superset-frontend/src/pages/DatasetList/index.tsx
+++ b/superset-frontend/src/pages/DatasetList/index.tsx
@@ -349,9 +349,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
                   />
                 )}
                 {titleLink}
-                {description && (
-                  <InfoTooltip tooltip={description} viewBox="0 -1 24 24" />
-                )}
+                {description && <InfoTooltip tooltip={description} />}
               </FlexRowContainer>
             );
           } catch {


### PR DESCRIPTION
### SUMMARY
The style of the RLS modal presented a few issues:

- Info icons should be centered with the text horizontally
- There should be the same spacing between the labels and inputs vertically
- The colors of the labels should all be the same
- The border color of the description field should be same as others

### BEFORE

<img width="930" alt="Screenshot 2024-01-16 at 17 20 21" src="https://github.com/apache/superset/assets/60598000/29597b15-2185-43a2-87b8-b9235e93cf0a">


### AFTER

<img width="1180" alt="Screenshot 2024-01-16 at 17 16 15" src="https://github.com/apache/superset/assets/60598000/cb7d95c8-36b3-4640-8082-18d6d3914248">


### TESTING INSTRUCTIONS
1. Add a new rule in the Row Level Security settings
2. Make sure the style of the modal is consistent with other modals in Superset

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
