### PR TITLE
fix: Avoid 500 if end users write bad SQL

### DIFF
--- a/superset/db_engine_specs/exceptions.py
+++ b/superset/db_engine_specs/exceptions.py
@@ -38,4 +38,4 @@ class SupersetDBAPIOperationalError(SupersetDBAPIError):
 
 
 class SupersetDBAPIProgrammingError(SupersetDBAPIError):
-    pass
+    status = 400

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -341,8 +341,10 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
             requests_exceptions.ConnectionError: SupersetDBAPIConnectionError,
         }
 
-        class _CustomMapping(dict):
-            def get(self, item: type[Exception]) -> type[Exception] | None:
+        class _CustomMapping(dict[type[Exception], type[Exception]]):
+            def get(  # type: ignore[override]
+                self, item: type[Exception], default: type[Exception] | None = None
+            ) -> type[Exception] | None:
                 if static := static_mapping.get(item):
                     return static
                 if issubclass(item, trino_exceptions.InternalError):
@@ -351,6 +353,7 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
                     return SupersetDBAPIOperationalError
                 if issubclass(item, trino_exceptions.ProgrammingError):
                     return SupersetDBAPIProgrammingError
+                return default
 
         return _CustomMapping()
 

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -32,7 +32,12 @@ from sqlalchemy.orm import Session
 from superset.constants import QUERY_CANCEL_KEY, QUERY_EARLY_CANCEL_KEY, USER_AGENT
 from superset.databases.utils import make_url_safe
 from superset.db_engine_specs.base import BaseEngineSpec
-from superset.db_engine_specs.exceptions import SupersetDBAPIConnectionError
+from superset.db_engine_specs.exceptions import (
+    SupersetDBAPIConnectionError,
+    SupersetDBAPIDatabaseError,
+    SupersetDBAPIOperationalError,
+    SupersetDBAPIProgrammingError,
+)
 from superset.db_engine_specs.presto import PrestoBaseEngineSpec
 from superset.models.sql_lab import Query
 from superset.superset_typing import ResultSetColumnType
@@ -330,9 +335,13 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
     def get_dbapi_exception_mapping(cls) -> dict[type[Exception], type[Exception]]:
         # pylint: disable=import-outside-toplevel
         from requests import exceptions as requests_exceptions
+        from trino import exceptions as trino_exceptions
 
         return {
             requests_exceptions.ConnectionError: SupersetDBAPIConnectionError,
+            trino_exceptions.DatabaseError: SupersetDBAPIDatabaseError,
+            trino_exceptions.OperationalError: SupersetDBAPIOperationalError,
+            trino_exceptions.ProgrammingError: SupersetDBAPIProgrammingError,
         }
 
     @classmethod

--- a/tests/unit_tests/db_engine_specs/test_trino.py
+++ b/tests/unit_tests/db_engine_specs/test_trino.py
@@ -551,3 +551,4 @@ def test_get_dbapi_exception_mapping():
     assert mapping.get(TrinoInternalError) == SupersetDBAPIDatabaseError
     assert mapping.get(TrinoExternalError) == SupersetDBAPIOperationalError
     assert mapping.get(RequestsConnectionError) == SupersetDBAPIConnectionError
+    assert mapping.get(Exception) is None

--- a/tests/unit_tests/db_engine_specs/test_trino.py
+++ b/tests/unit_tests/db_engine_specs/test_trino.py
@@ -24,11 +24,19 @@ from unittest.mock import Mock, patch
 import pandas as pd
 import pytest
 from pytest_mock import MockerFixture
+from requests.exceptions import ConnectionError as RequestsConnectionError
 from sqlalchemy import types
+from trino.exceptions import TrinoExternalError, TrinoInternalError, TrinoUserError
 from trino.sqlalchemy import datatype
 
 import superset.config
 from superset.constants import QUERY_CANCEL_KEY, QUERY_EARLY_CANCEL_KEY, USER_AGENT
+from superset.db_engine_specs.exceptions import (
+    SupersetDBAPIConnectionError,
+    SupersetDBAPIDatabaseError,
+    SupersetDBAPIOperationalError,
+    SupersetDBAPIProgrammingError,
+)
 from superset.superset_typing import ResultSetColumnType, SQLAColumnType
 from superset.utils.core import GenericDataType
 from tests.unit_tests.db_engine_specs.utils import (
@@ -533,3 +541,13 @@ def test_get_indexes_no_table():
         db_mock, inspector_mock, "test_table", "test_schema"
     )
     assert result == []
+
+
+def test_get_dbapi_exception_mapping():
+    from superset.db_engine_specs.trino import TrinoEngineSpec
+
+    mapping = TrinoEngineSpec.get_dbapi_exception_mapping()
+    assert mapping.get(TrinoUserError) == SupersetDBAPIProgrammingError
+    assert mapping.get(TrinoInternalError) == SupersetDBAPIDatabaseError
+    assert mapping.get(TrinoExternalError) == SupersetDBAPIOperationalError
+    assert mapping.get(RequestsConnectionError) == SupersetDBAPIConnectionError


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

While end users deal with Superset+Trino we are observing quite some 500 errors on backend.

For example, a user can create/edit a virtual dataset and make mistakes in SQL. Trino client raises the exception and it goes uncaught to 500.

If SupersetDBAPIProgrammingError is raised it's better to return 400 to the end user because nothing bad happens with Superset instance.

I don't know what to do with `SupersetDBAPIError` in general. If underlying Database has problems, should it lead to Superset's 500 or it's ok to stay with 400 because Superset itself works fine.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
