### PR TITLE
fix: Removes unused cache cleanup

### DIFF
--- a/superset/commands/chart/delete.py
+++ b/superset/commands/chart/delete.py
@@ -31,7 +31,6 @@ from superset.daos.chart import ChartDAO
 from superset.daos.exceptions import DAODeleteFailedError
 from superset.daos.report import ReportScheduleDAO
 from superset.exceptions import SupersetSecurityException
-from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 
 logger = logging.getLogger(__name__)
@@ -45,9 +44,6 @@ class DeleteChartCommand(BaseCommand):
     def run(self) -> None:
         self.validate()
         assert self._models
-
-        for model_id in self._model_ids:
-            Dashboard.clear_cache_for_slice(slice_id=model_id)
 
         try:
             ChartDAO.delete(self._models)

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -41,13 +41,11 @@ from sqlalchemy import (
 from sqlalchemy.engine.base import Connection
 from sqlalchemy.orm import relationship, sessionmaker, subqueryload
 from sqlalchemy.orm.mapper import Mapper
-from sqlalchemy.sql import join, select
 from sqlalchemy.sql.elements import BinaryExpression
 
 from superset import app, db, is_feature_enabled, security_manager
 from superset.connectors.sqla.models import BaseDatasource, SqlaTable
 from superset.daos.datasource import DatasourceDAO
-from superset.extensions import cache_manager
 from superset.models.helpers import AuditMixinNullable, ImportExportMixin
 from superset.models.slice import Slice
 from superset.models.user_attributes import UserAttribute
@@ -55,7 +53,6 @@ from superset.tasks.thumbnails import cache_dashboard_thumbnail
 from superset.tasks.utils import get_current_user
 from superset.thumbnails.digest import get_dashboard_digest
 from superset.utils import core as utils
-from superset.utils.decorators import debounce
 
 metadata = Model.metadata  # pylint: disable=no-member
 config = app.config
@@ -137,7 +134,6 @@ DashboardRoles = Table(
 )
 
 
-# pylint: disable=too-many-public-methods
 class Dashboard(AuditMixinNullable, ImportExportMixin, Model):
     """The dashboard object!"""
 
@@ -321,36 +317,6 @@ class Dashboard(AuditMixinNullable, ImportExportMixin, Model):
             dashboard_id=self.id,
             force=True,
         )
-
-    @debounce(0.1)
-    def clear_cache(self) -> None:
-        cache_manager.cache.delete_memoized(Dashboard.datasets_trimmed_for_slices, self)
-
-    @classmethod
-    @debounce(0.1)
-    def clear_cache_for_slice(cls, slice_id: int) -> None:
-        filter_query = select([dashboard_slices.c.dashboard_id], distinct=True).where(
-            dashboard_slices.c.slice_id == slice_id
-        )
-        for (dashboard_id,) in db.engine.execute(filter_query):
-            cls(id=dashboard_id).clear_cache()
-
-    @classmethod
-    @debounce(0.1)
-    def clear_cache_for_datasource(cls, datasource_id: int) -> None:
-        filter_query = select(
-            [dashboard_slices.c.dashboard_id],
-            distinct=True,
-        ).select_from(
-            join(
-                dashboard_slices,
-                Slice,
-                (Slice.id == dashboard_slices.c.slice_id)
-                & (Slice.datasource_id == datasource_id),
-            )
-        )
-        for (dashboard_id,) in db.engine.execute(filter_query):
-            cls(id=dashboard_id).clear_cache()
 
     @classmethod
     def export_dashboards(  # pylint: disable=too-many-locals


### PR DESCRIPTION
### SUMMARY
Follow-up of https://github.com/apache/superset/pull/26349 to remove unused cache cleanup functions. Fixes https://github.com/apache/superset/pull/26349#issuecomment-1894769156.

### TESTING INSTRUCTIONS
CI should be sufficient.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
