### PR TITLE
fix(import): only import FORMULA annotations

### DIFF
--- a/superset/cli/importexport.py
+++ b/superset/cli/importexport.py
@@ -130,12 +130,13 @@ def export_datasources(datasource_file: Optional[str] = None) -> None:
 @click.option(
     "--path",
     "-p",
+    required=True,
     help="Path to a single ZIP file",
 )
 @click.option(
     "--username",
     "-u",
-    default=None,
+    required=True,
     help="Specify the user name to assign dashboards to",
 )
 def import_dashboards(path: str, username: Optional[str]) -> None:

--- a/tests/integration_tests/charts/commands_tests.py
+++ b/tests/integration_tests/charts/commands_tests.py
@@ -190,6 +190,7 @@ class TestImportChartsCommand(SupersetTestCase):
         )
         dataset = chart.datasource
         assert json.loads(chart.params) == {
+            "annotation_layers": [],
             "color_picker": {"a": 1, "b": 135, "g": 122, "r": 0},
             "datasource": dataset.uid,
             "js_columns": ["color"],

--- a/tests/integration_tests/cli_tests.py
+++ b/tests/integration_tests/cli_tests.py
@@ -160,7 +160,8 @@ def test_import_dashboards_versioned_export(import_dashboards_command, app_conte
 
     runner = app.test_cli_runner()
     response = runner.invoke(
-        superset.cli.importexport.import_dashboards, ("-p", "dashboards.json")
+        superset.cli.importexport.import_dashboards,
+        ("-p", "dashboards.json", "-u", "admin"),
     )
 
     assert response.exit_code == 0
@@ -174,7 +175,8 @@ def test_import_dashboards_versioned_export(import_dashboards_command, app_conte
 
     runner = app.test_cli_runner()
     response = runner.invoke(
-        superset.cli.importexport.import_dashboards, ("-p", "dashboards.zip")
+        superset.cli.importexport.import_dashboards,
+        ("-p", "dashboards.json", "-u", "admin"),
     )
 
     assert response.exit_code == 0
@@ -205,7 +207,8 @@ def test_failing_import_dashboards_versioned_export(
 
     runner = app.test_cli_runner()
     response = runner.invoke(
-        superset.cli.importexport.import_dashboards, ("-p", "dashboards.json")
+        superset.cli.importexport.import_dashboards,
+        ("-p", "dashboards.json", "-u", "admin"),
     )
 
     assert_cli_fails_properly(response, caplog)
@@ -217,7 +220,8 @@ def test_failing_import_dashboards_versioned_export(
 
     runner = app.test_cli_runner()
     response = runner.invoke(
-        superset.cli.importexport.import_dashboards, ("-p", "dashboards.zip")
+        superset.cli.importexport.import_dashboards,
+        ("-p", "dashboards.json", "-u", "admin"),
     )
 
     assert_cli_fails_properly(response, caplog)

--- a/tests/integration_tests/cli_tests.py
+++ b/tests/integration_tests/cli_tests.py
@@ -176,7 +176,7 @@ def test_import_dashboards_versioned_export(import_dashboards_command, app_conte
     runner = app.test_cli_runner()
     response = runner.invoke(
         superset.cli.importexport.import_dashboards,
-        ("-p", "dashboards.json", "-u", "admin"),
+        ("-p", "dashboards.zip", "-u", "admin"),
     )
 
     assert response.exit_code == 0
@@ -221,7 +221,7 @@ def test_failing_import_dashboards_versioned_export(
     runner = app.test_cli_runner()
     response = runner.invoke(
         superset.cli.importexport.import_dashboards,
-        ("-p", "dashboards.json", "-u", "admin"),
+        ("-p", "dashboards.zip", "-u", "admin"),
     )
 
     assert_cli_fails_properly(response, caplog)

--- a/tests/integration_tests/fixtures/importexport.py
+++ b/tests/integration_tests/fixtures/importexport.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from copy import deepcopy
 from typing import Any
 
 # example V0 import/export format
@@ -575,6 +576,40 @@ chart_config: dict[str, Any] = {
     "version": "1.0.0",
     "dataset_uuid": "10808100-158b-42c4-842e-f32b99d88dfb",
 }
+chart_config_with_mixed_annotations: dict[str, Any] = deepcopy(chart_config)
+chart_config_with_mixed_annotations["params"]["annotation_layers"] = [
+    {
+        "name": "Formula test layer",
+        "annotationType": "FORMULA",
+        "color": None,
+        "descriptionColumns": [],
+        "hideLine": False,
+        "opacity": "",
+        "overrides": {"time_range": None},
+        "show": True,
+        "showLabel": False,
+        "showMarkers": False,
+        "style": "solid",
+        "value": "100000",
+        "width": 1,
+    },
+    {
+        "name": "Native layer to be removed on import",
+        "annotationType": "EVENT",
+        "sourceType": "NATIVE",
+        "color": None,
+        "opacity": "",
+        "style": "solid",
+        "width": 1,
+        "showMarkers": False,
+        "hideLine": False,
+        "value": 2,
+        "overrides": {"time_range": None},
+        "show": True,
+        "showLabel": False,
+        "descriptionColumns": [],
+    },
+]
 
 dashboard_config: dict[str, Any] = {
     "dashboard_title": "Test dash",

--- a/tests/unit_tests/charts/commands/importers/v1/import_test.py
+++ b/tests/unit_tests/charts/commands/importers/v1/import_test.py
@@ -108,3 +108,22 @@ def test_import_chart_without_permission(
         str(excinfo.value)
         == "Chart doesn't exist and user doesn't have permission to create charts"
     )
+
+
+def test_filter_chart_annotations(mocker: MockFixture, session: Session) -> None:
+    """
+    Test importing a chart.
+    """
+    from superset import security_manager
+    from superset.commands.chart.importers.v1.utils import filter_chart_annotations
+    from tests.integration_tests.fixtures.importexport import (
+        chart_config_with_mixed_annotations,
+    )
+
+    config = copy.deepcopy(chart_config_with_mixed_annotations)
+    filter_chart_annotations(config)
+    params = config["params"]
+    annotation_layers = params["annotation_layers"]
+
+    assert len(annotation_layers) == 1
+    assert all([al["annotationType"] == "FORMULA" for al in annotation_layers])


### PR DESCRIPTION
### SUMMARY
export/import currently attempts to bring in annotations that are attached to charts, but does not handle the dependencies properly, resulting in some referential integrity-type issues. This happens when the annotation depends on either an "annotation layer", or on another chart that doesn't exist in the current environment.

The solution here is lazy, and refrains from importing any annotation that may depend on other objects that are not handled by the current import/export logic.

Longer term solution would including handling of dependencies, and allowing the users to package dependencies on export and/or ask/warn about what to do here. 

### TESTING
On top of a simple unit test on the new function I introduce, I conducted the following manual test
* exported a dashboard that contains a chart with multiple annotations of different types
* deleting the chart objects in the environment
* importing using the CLI
* verifying that only FORMULA annotation survived the export/import
