### PR TITLE
feat: prevent adhoc metrics from guest user

### DIFF
--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -199,7 +199,7 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
             raise SupersetSecurityException(
                 SupersetError(
                     error_type=SupersetErrorType.DASHBOARD_SECURITY_ACCESS_ERROR,
-                    message="Guest users can only use predefined metrics",
+                    message=_("Guest users can only use predefined metrics"),
                     level=ErrorLevel.ERROR,
                 ),
             )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Ensure that guest users (from embedded dashboards) can only use predefined metrics in chart queries.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Added unit tests covering both `EMBEDDED_SUPERSET` enabled and disabled.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
