### PR TITLE
chore(actions): chill out on docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,9 +3,7 @@ name: Docker
 on:
   push:
     branches:
-      - 'master'
-  pull_request:
-    types: [synchronize, opened, reopened, ready_for_review]
+      - "master"
 
 jobs:
   config:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This needs discussion! 

Does anyone see a need for docker builds on every PR? The only purpose seems to be as a canary for docker builds on master. Now that this takes about 75 minutes of build time for every PR, I think we should just stop it, and bring back a more optimized/parallelized version if someone wants to invest in that. People keep an eye on builds on master pretty regularly, so let's just revert anything that breaks this if/when we need to.

Hopefully, this will save a lot of coal out there somewhere in the world.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
