### PR TITLE
build: Parallelize the CI image builds (continued)

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -29,17 +29,17 @@ jobs:
       fail-fast: false
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           submodules: recursive
           ref: ${{ github.ref }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Build Docker Image
         env:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -22,6 +22,11 @@ jobs:
     if: needs.config.outputs.has-secrets
     name: docker-release
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: ["dev", "lean", "lean310", "lean39", "websocket", "dockerize"]
+        platform: ["linux/amd64", "linux/arm64"]
+      fail-fast: false
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v3
@@ -29,14 +34,17 @@ jobs:
           persist-credentials: false
           submodules: recursive
           ref: ${{ github.ref }}
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - shell: bash
+
+      - name: Build Docker Image
         env:
           DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           GITHUB_RELEASE_TAG_NAME="${{ github.event.release.tag_name }}"
-          ./scripts/docker_build_push.sh "$GITHUB_RELEASE_TAG_NAME"
+          ./scripts/docker_build_push.sh "$GITHUB_RELEASE_TAG_NAME" ${{ matrix.target }} ${{ matrix.platform }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: ["dev", "lean", "lean310", "lean39", "websocket", "dockerize"]
+        target: ["dev", "lean", "lean310", "websocket", "dockerize"]
         platform: ["linux/amd64", "linux/arm64"]
       fail-fast: false
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,6 +54,12 @@ jobs:
         run: |
           ./scripts/docker_build_push.sh "" ${{ matrix.target }} ${{ matrix.platform }}
 
+  ephemeral-docker-build:
+    needs: config
+    if: needs.config.outputs.has-secrets
+    name: docker-build
+    runs-on: ubuntu-latest
+    steps:
       - name: Build ephemeral env image
         if: github.event_name == 'pull_request'
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,15 +36,15 @@ jobs:
       fail-fast: false
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Build Docker Image
         shell: bash

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,6 +60,17 @@ jobs:
     name: docker-build
     runs-on: ubuntu-latest
     steps:
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build ephemeral env image
         if: github.event_name == 'pull_request'
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Upload build artifacts
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: build/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,27 +24,35 @@ jobs:
             echo "has-secrets=0" >> "$GITHUB_OUTPUT"
             echo "no secrets!"
           fi
-
   docker-build:
     needs: config
     if: needs.config.outputs.has-secrets
     name: docker-build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: ["dev", "lean", "lean310", "lean39", "websocket", "dockerize"]
+        platform: ["linux/amd64", "linux/arm64"]
+      fail-fast: false
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v3
         with:
           persist-credentials: false
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - shell: bash
+
+      - name: Build Docker Image
+        shell: bash
         env:
           DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
-          ./scripts/docker_build_push.sh
+          ./scripts/docker_build_push.sh "" ${{ matrix.target }} ${{ matrix.platform }}
 
       - name: Build ephemeral env image
         if: github.event_name == 'pull_request'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,7 +62,7 @@ jobs:
           echo ${{ github.event.pull_request.number }} > ./build/PR-NUM
           docker buildx build --target ci \
             --load \
-            --cache-from=type=local,src=/tmp/superset \
+            --cache-from=type=registry,ref=apache/superset:lean \
             -t ${{ github.sha }} \
             -t "pr-${{ github.event.pull_request.number }}" \
             --platform linux/amd64 \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: ["dev", "lean", "lean310", "lean39", "websocket", "dockerize"]
+        target: ["dev", "lean", "lean310", "websocket", "dockerize"]
         platform: ["linux/amd64", "linux/arm64"]
       fail-fast: false
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,13 +85,14 @@ RUN --mount=type=bind,target=./requirements/local.txt,src=./requirements/local.t
     --mount=type=cache,target=/root/.cache/pip \
     pip install -r requirements/local.txt
 
-COPY --chown=superset:superset --from=superset-node /app/superset/static/assets superset/static/assets
-## Lastly, let's install superset itself
-COPY --chown=superset:superset superset superset
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install -e . \
     && flask fab babel-compile --target superset/translations \
     && chown -R superset:superset superset/translations
+
+COPY --chown=superset:superset --from=superset-node /app/superset/static/assets superset/static/assets
+## Lastly, let's install superset itself
+COPY --chown=superset:superset superset superset
 
 COPY --chmod=755 ./docker/run-server.sh /usr/bin/
 USER superset

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,14 +85,13 @@ RUN --mount=type=bind,target=./requirements/local.txt,src=./requirements/local.t
     --mount=type=cache,target=/root/.cache/pip \
     pip install -r requirements/local.txt
 
+COPY --chown=superset:superset --from=superset-node /app/superset/static/assets superset/static/assets
+## Lastly, let's install superset itself
+COPY --chown=superset:superset superset superset
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install -e . \
     && flask fab babel-compile --target superset/translations \
     && chown -R superset:superset superset/translations
-
-COPY --chown=superset:superset --from=superset-node /app/superset/static/assets superset/static/assets
-## Lastly, let's install superset itself
-COPY --chown=superset:superset superset superset
 
 COPY --chmod=755 ./docker/run-server.sh /usr/bin/
 USER superset

--- a/scripts/docker_build_push.sh
+++ b/scripts/docker_build_push.sh
@@ -18,9 +18,51 @@
 set -eo pipefail
 
 GITHUB_RELEASE_TAG_NAME="$1"
+TARGET="$2"
+BUILD_PLATFORM="$3" # should be either 'linux/amd64' or 'linux/arm64'
 
+# Common variables
 SHA=$(git rev-parse HEAD)
 REPO_NAME="apache/superset"
+DOCKER_ARGS="--load" # default args, change as needed
+DOCKER_CONTEXT="."
+
+
+case "${TARGET}" in
+  "dev")
+    DOCKER_TAGS="-t ${REPO_NAME}:${SHA}-dev -t ${REPO_NAME}:${REFSPEC}-dev -t ${DEV_TAG}"
+    BUILD_TARGET="dev"
+    ;;
+  "lean")
+    DOCKER_TAGS="-t ${REPO_NAME}:${SHA} -t ${REPO_NAME}:${REFSPEC} -t ${REPO_NAME}:${LATEST_TAG}"
+    BUILD_TARGET="lean"
+    ;;
+  "lean310")
+    DOCKER_TAGS="-t ${REPO_NAME}:${SHA}-py310 -t ${REPO_NAME}:${REFSPEC}-py310 -t ${REPO_NAME}:${LATEST_TAG}-py310"
+    BUILD_TARGET="lean"
+    BUILD_ARG="3.10-slim-bookworm"
+    ;;
+  "lean39")
+    DOCKER_TAGS="-t ${REPO_NAME}:${SHA}-py39 -t ${REPO_NAME}:${REFSPEC}-py39 -t ${REPO_NAME}:${LATEST_TAG}-py39"
+    BUILD_TARGET="lean"
+    BUILD_ARG="3.9-slim-bullseye"
+    ;;
+  "websocket")
+    DOCKER_TAGS="-t ${REPO_NAME}:${SHA}-websocket -t ${REPO_NAME}:${REFSPEC}-websocket -t ${REPO_NAME}:${LATEST_TAG}-websocket"
+    BUILD_TARGET="websocket"
+	DOCKER_CONTEXT="superset-websocket"
+    ;;
+  "dockerize")
+    DOCKER_TAGS="-t ${REPO_NAME}:dockerize"
+    BUILD_TARGET="dockerize"
+	DOCKER_CONTEXT="-f dockerize.Dockerfile ."
+    ;;
+  *)
+    echo "Invalid TARGET: ${TARGET}"
+    exit 1
+    ;;
+esac
+
 
 if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
   REFSPEC=$(echo "${GITHUB_HEAD_REF}" | sed 's/[^a-zA-Z0-9]/-/g' | head -c 40)
@@ -67,13 +109,11 @@ if [ -z "${DOCKERHUB_TOKEN}" ]; then
   echo "Skipping Docker push"
   # By default load it back
   DOCKER_ARGS="--load"
-  ARCHITECTURE_FOR_BUILD="linux/amd64 linux/arm64"
 else
   # Login and push
   docker logout
   docker login --username "${DOCKERHUB_USER}" --password "${DOCKERHUB_TOKEN}"
   DOCKER_ARGS="--push"
-  ARCHITECTURE_FOR_BUILD="linux/amd64,linux/arm64"
 fi
 set -x
 
@@ -85,105 +125,15 @@ else
   DEV_TAG="${REPO_NAME}:${LATEST_TAG}-dev"
 fi
 
-for BUILD_PLATFORM in $ARCHITECTURE_FOR_BUILD; do
-#
-# Build the dev image
-#
-docker buildx build --target dev \
-  $DOCKER_ARGS \
-  --cache-from=type=registry,ref=apache/superset:master-dev \
-  --cache-from=type=local,src=/tmp/superset \
-  --cache-to=type=local,ignore-error=true,dest=/tmp/superset \
-  -t "${REPO_NAME}:${SHA}-dev" \
-  -t "${REPO_NAME}:${REFSPEC}-dev" \
-  -t "${DEV_TAG}" \
+docker buildx build --target ${BUILD_TARGET} \
+  ${DOCKER_ARGS} \
+  --cache-from=type=registry,ref=apache/superset:${BUILD_TARGET} \
+  --cache-to=type=registry,mode=max,ref=apache/superset:${BUILD_TARGET} \
+  ${DOCKER_TAGS} \
   --platform ${BUILD_PLATFORM} \
   --label "sha=${SHA}" \
   --label "built_at=$(date)" \
-  --label "target=dev" \
+  --label "target=${BUILD_TARGET}" \
   --label "build_actor=${GITHUB_ACTOR}" \
-  .
-
-#
-# Build the "lean" image
-#
-docker buildx build --target lean \
-  $DOCKER_ARGS \
-  --cache-from=type=local,src=/tmp/superset \
-  --cache-to=type=local,ignore-error=true,dest=/tmp/superset \
-  -t "${REPO_NAME}:${SHA}" \
-  -t "${REPO_NAME}:${REFSPEC}" \
-  -t "${REPO_NAME}:${LATEST_TAG}" \
-  --platform ${BUILD_PLATFORM} \
-  --label "sha=${SHA}" \
-  --label "built_at=$(date)" \
-  --label "target=lean" \
-  --label "build_actor=${GITHUB_ACTOR}" \
-  .
-
-#
-# Build the "lean310" image
-#
-docker buildx build --target lean \
-  $DOCKER_ARGS \
-  --cache-from=type=local,src=/tmp/superset \
-  --cache-to=type=local,ignore-error=true,dest=/tmp/superset \
-  -t "${REPO_NAME}:${SHA}-py310" \
-  -t "${REPO_NAME}:${REFSPEC}-py310" \
-  -t "${REPO_NAME}:${LATEST_TAG}-py310" \
-  --platform ${BUILD_PLATFORM} \
-  --build-arg PY_VER="3.10-slim-bookworm"\
-  --label "sha=${SHA}" \
-  --label "built_at=$(date)" \
-  --label "target=lean310" \
-  --label "build_actor=${GITHUB_ACTOR}" \
-  .
-
-#
-# Build the "lean39" image
-#
-docker buildx build --target lean \
-  $DOCKER_ARGS \
-  --cache-from=type=local,src=/tmp/superset \
-  --cache-to=type=local,ignore-error=true,dest=/tmp/superset \
-  -t "${REPO_NAME}:${SHA}-py39" \
-  -t "${REPO_NAME}:${REFSPEC}-py39" \
-  -t "${REPO_NAME}:${LATEST_TAG}-py39" \
-  --platform ${BUILD_PLATFORM} \
-  --build-arg PY_VER="3.9-slim-bullseye"\
-  --label "sha=${SHA}" \
-  --label "built_at=$(date)" \
-  --label "target=lean39" \
-  --label "build_actor=${GITHUB_ACTOR}" \
-  .
-
-#
-# Build the "websocket" image
-#
-docker buildx build \
-  $DOCKER_ARGS \
-  --cache-from=type=registry,ref=apache/superset:master-websocket \
-  -t "${REPO_NAME}:${SHA}-websocket" \
-  -t "${REPO_NAME}:${REFSPEC}-websocket" \
-  -t "${REPO_NAME}:${LATEST_TAG}-websocket" \
-  --platform ${BUILD_PLATFORM} \
-  --label "sha=${SHA}" \
-  --label "built_at=$(date)" \
-  --label "target=websocket" \
-  --label "build_actor=${GITHUB_ACTOR}" \
-  superset-websocket
-
-#
-# Build the dockerize image
-#
-docker buildx build \
-  $DOCKER_ARGS \
-  --cache-from=type=registry,ref=apache/superset:dockerize \
-  -t "${REPO_NAME}:dockerize" \
-  --platform ${BUILD_PLATFORM} \
-  --label "sha=${SHA}" \
-  --label "built_at=$(date)" \
-  --label "build_actor=${GITHUB_ACTOR}" \
-  -f dockerize.Dockerfile \
-  .
-done
+  ${BUILD_ARG:+--build-arg PY_VER="${BUILD_ARG}"} \
+  $DOCKER_CONTEXT

--- a/scripts/docker_build_push.sh
+++ b/scripts/docker_build_push.sh
@@ -81,12 +81,12 @@ case "${TARGET}" in
     ;;
   "websocket")
     DOCKER_TAGS="-t ${REPO_NAME}:${SHA}-websocket -t ${REPO_NAME}:${REFSPEC}-websocket -t ${REPO_NAME}:${LATEST_TAG}-websocket"
-    BUILD_TARGET="websocket"
+    BUILD_TARGET=""
 	DOCKER_CONTEXT="superset-websocket"
     ;;
   "dockerize")
     DOCKER_TAGS="-t ${REPO_NAME}:dockerize"
-    BUILD_TARGET="dockerize"
+    BUILD_TARGET=""
 	DOCKER_CONTEXT="-f dockerize.Dockerfile ."
     ;;
   *)
@@ -123,7 +123,13 @@ else
   DEV_TAG="${REPO_NAME}:${LATEST_TAG}-dev"
 fi
 
-docker buildx build --target ${BUILD_TARGET} \
+TARGET_ARGUMENT=""
+if [[ -n "${BUILD_TARGET}" ]]; then
+  TARGET_ARGUMENT="--target ${TARGET}"
+fi
+
+docker buildx build \
+  ${TARGET_ARGUMENT}
   ${DOCKER_ARGS} \
   --cache-from=type=registry,ref=apache/superset:${BUILD_TARGET} \
   --cache-to=type=registry,mode=max,ref=apache/superset:${BUILD_TARGET} \

--- a/scripts/docker_build_push.sh
+++ b/scripts/docker_build_push.sh
@@ -131,7 +131,7 @@ fi
 docker buildx build \
   ${TARGET_ARGUMENT} \
   ${DOCKER_ARGS} \
-  --cache-from=type=registry,ref=apache/superset:${BUILD_TARGET} \
+  --cache-from=type=registry,ref=apache/superset:${TARGET} \
   --cache-to=type=registry,mode=max,ref=apache/superset:${BUILD_TARGET} \
   ${DOCKER_TAGS} \
   --platform ${BUILD_PLATFORM} \

--- a/scripts/docker_build_push.sh
+++ b/scripts/docker_build_push.sh
@@ -129,7 +129,7 @@ if [[ -n "${BUILD_TARGET}" ]]; then
 fi
 
 docker buildx build \
-  ${TARGET_ARGUMENT}
+  ${TARGET_ARGUMENT} \
   ${DOCKER_ARGS} \
   --cache-from=type=registry,ref=apache/superset:${BUILD_TARGET} \
   --cache-to=type=registry,mode=max,ref=apache/superset:${BUILD_TARGET} \

--- a/scripts/docker_build_push.sh
+++ b/scripts/docker_build_push.sh
@@ -68,6 +68,8 @@ else
   DEV_TAG="${REPO_NAME}:${LATEST_TAG}-dev"
 fi
 
+BUILD_ARG="3.9-slim-bookworm"
+
 case "${TARGET}" in
   "dev")
     DOCKER_TAGS="-t ${REPO_NAME}:${SHA}-dev -t ${REPO_NAME}:${REFSPEC}-dev -t ${DEV_TAG}"
@@ -81,11 +83,6 @@ case "${TARGET}" in
     DOCKER_TAGS="-t ${REPO_NAME}:${SHA}-py310 -t ${REPO_NAME}:${REFSPEC}-py310 -t ${REPO_NAME}:${LATEST_TAG}-py310"
     BUILD_TARGET="lean"
     BUILD_ARG="3.10-slim-bookworm"
-    ;;
-  "lean39")
-    DOCKER_TAGS="-t ${REPO_NAME}:${SHA}-py39 -t ${REPO_NAME}:${REFSPEC}-py39 -t ${REPO_NAME}:${LATEST_TAG}-py39"
-    BUILD_TARGET="lean"
-    BUILD_ARG="3.9-slim-bullseye"
     ;;
   "websocket")
     DOCKER_TAGS="-t ${REPO_NAME}:${SHA}-websocket -t ${REPO_NAME}:${REFSPEC}-websocket -t ${REPO_NAME}:${LATEST_TAG}-websocket"
@@ -138,6 +135,7 @@ docker buildx build \
   --label "sha=${SHA}" \
   --label "built_at=$(date)" \
   --label "target=${TARGET}" \
+  --label "base=${PY_VER}" \
   --label "build_actor=${GITHUB_ACTOR}" \
   ${BUILD_ARG:+--build-arg PY_VER="${BUILD_ARG}"} \
   ${DOCKER_CONTEXT}

--- a/scripts/docker_build_push.sh
+++ b/scripts/docker_build_push.sh
@@ -136,4 +136,4 @@ docker buildx build --target ${BUILD_TARGET} \
   --label "target=${BUILD_TARGET}" \
   --label "build_actor=${GITHUB_ACTOR}" \
   ${BUILD_ARG:+--build-arg PY_VER="${BUILD_ARG}"} \
-  $DOCKER_CONTEXT
+  ${DOCKER_CONTEXT}

--- a/scripts/docker_build_push.sh
+++ b/scripts/docker_build_push.sh
@@ -132,12 +132,12 @@ docker buildx build \
   ${TARGET_ARGUMENT} \
   ${DOCKER_ARGS} \
   --cache-from=type=registry,ref=apache/superset:${TARGET} \
-  --cache-to=type=registry,mode=max,ref=apache/superset:${BUILD_TARGET} \
+  --cache-to=type=registry,mode=max,ref=apache/superset:${TARGET} \
   ${DOCKER_TAGS} \
   --platform ${BUILD_PLATFORM} \
   --label "sha=${SHA}" \
   --label "built_at=$(date)" \
-  --label "target=${BUILD_TARGET}" \
+  --label "target=${TARGET}" \
   --label "build_actor=${GITHUB_ACTOR}" \
   ${BUILD_ARG:+--build-arg PY_VER="${BUILD_ARG}"} \
   ${DOCKER_CONTEXT}

--- a/scripts/docker_build_push.sh
+++ b/scripts/docker_build_push.sh
@@ -60,6 +60,14 @@ if [[ "${TEST_ENV}" == "true" ]]; then
   exit 0
 fi
 
+# for the dev image, it's ok to tag master as latest-dev
+# for production, we only want to tag the latest official release as latest
+if [ "${LATEST_TAG}" = "master" ]; then
+  DEV_TAG="${REPO_NAME}:latest-dev"
+else
+  DEV_TAG="${REPO_NAME}:${LATEST_TAG}-dev"
+fi
+
 case "${TARGET}" in
   "dev")
     DOCKER_TAGS="-t ${REPO_NAME}:${SHA}-dev -t ${REPO_NAME}:${REFSPEC}-dev -t ${DEV_TAG}"
@@ -114,14 +122,6 @@ else
   DOCKER_ARGS="--push"
 fi
 set -x
-
-# for the dev image, it's ok to tag master as latest-dev
-# for production, we only want to tag the latest official release as latest
-if [ "${LATEST_TAG}" = "master" ]; then
-  DEV_TAG="${REPO_NAME}:latest-dev"
-else
-  DEV_TAG="${REPO_NAME}:${LATEST_TAG}-dev"
-fi
 
 TARGET_ARGUMENT=""
 if [[ -n "${BUILD_TARGET}" ]]; then

--- a/scripts/docker_build_push.sh
+++ b/scripts/docker_build_push.sh
@@ -125,7 +125,7 @@ fi
 
 TARGET_ARGUMENT=""
 if [[ -n "${BUILD_TARGET}" ]]; then
-  TARGET_ARGUMENT="--target ${TARGET}"
+  TARGET_ARGUMENT="--target ${BUILD_TARGET}"
 fi
 
 docker buildx build \

--- a/tests/unit_tests/fixtures/bash_mock.py
+++ b/tests/unit_tests/fixtures/bash_mock.py
@@ -32,10 +32,10 @@ class BashMock:
         return result
 
     @staticmethod
-    def docker_build_push(tag, branch):
-        bash_command = f"./scripts/docker_build_push.sh {tag}"
+    def docker_build_push(tag, target, platform, branch):
+        cmd = f'./scripts/docker_build_push.sh "{tag}" "{target}" "{platform}"'
         result = subprocess.run(
-            bash_command,
+            cmd,
             shell=True,
             capture_output=True,
             text=True,

--- a/tests/unit_tests/scripts/docker_build_push_test.py
+++ b/tests/unit_tests/scripts/docker_build_push_test.py
@@ -19,8 +19,8 @@ def wrapped(*args, **kwargs):
     [
         ("1.0.0", "lean", "linux/amd64", "LATEST_TAG is master", "master"),
         ("2.1.0", "lean", "linux/amd64", "LATEST_TAG is master", "master"),
-        # ("2.1.1", "lean", "linux/amd64", "LATEST_TAG is master", "master"),
-        # ("3.0.0", "lean", "linux/amd64", "LATEST_TAG is master", "master"),
+        ("2.1.1", "lean", "linux/amd64", "LATEST_TAG is latest", "master"),
+        ("3.0.0", "lean", "linux/amd64", "LATEST_TAG is latest", "master"),
         ("2.1.0rc1", "lean", "linux/amd64", "LATEST_TAG is 2.1.0", "2.1.0"),
         ("", "lean", "linux/amd64", "LATEST_TAG is foo", "foo"),
         ("2.1", "lean", "linux/amd64", "LATEST_TAG is 2.1", "2.1"),

--- a/tests/unit_tests/scripts/docker_build_push_test.py
+++ b/tests/unit_tests/scripts/docker_build_push_test.py
@@ -15,27 +15,31 @@ def wrapped(*args, **kwargs):
 
 
 @pytest.mark.parametrize(
-    "tag, expected_output, branch",
+    "tag, target, platform, expected_output, branch",
     [
-        ("1.0.0", "LATEST_TAG is master", "master"),
-        ("2.1.0", "LATEST_TAG is master", "master"),
-        ("2.1.1", "LATEST_TAG is latest", "master"),
-        ("3.0.0", "LATEST_TAG is latest", "master"),
-        ("2.1.0rc1", "LATEST_TAG is 2.1.0", "2.1.0"),
-        ("", "LATEST_TAG is foo", "foo"),
-        ("2.1", "LATEST_TAG is 2.1", "2.1"),
-        ("does_not_exist", "LATEST_TAG is does-not-exist", "does_not_exist"),
+        ("1.0.0", "lean", "linux/amd64", "LATEST_TAG is master", "master"),
+        ("2.1.0", "lean", "linux/amd64", "LATEST_TAG is master", "master"),
+        # ("2.1.1", "lean", "linux/amd64", "LATEST_TAG is master", "master"),
+        # ("3.0.0", "lean", "linux/amd64", "LATEST_TAG is master", "master"),
+        ("2.1.0rc1", "lean", "linux/amd64", "LATEST_TAG is 2.1.0", "2.1.0"),
+        ("", "lean", "linux/amd64", "LATEST_TAG is foo", "foo"),
+        ("2.1", "lean", "linux/amd64", "LATEST_TAG is 2.1", "2.1"),
+        (
+            "does_not_exist",
+            "lean",
+            "linux/amd64",
+            "LATEST_TAG is does-not-exist",
+            "does_not_exist",
+        ),
     ],
 )
-def test_tag_latest_release(tag, expected_output, branch):
+def test_tag_latest_release(tag, target, platform, expected_output, branch):
     with mock.patch(
         "tests.unit_tests.fixtures.bash_mock.subprocess.run", wraps=wrapped
     ) as subprocess_mock:
-        result = BashMock.docker_build_push(tag, branch)
+        result = BashMock.docker_build_push(tag, target, platform, branch)
 
-        params = f"{tag} lean linux/amd64"
-        cmd = f"./scripts/docker_build_push.sh {params}"
-        print(cmd)
+        cmd = f'./scripts/docker_build_push.sh "{tag}" "{target}" "{platform}"'
         subprocess_mock.assert_called_once_with(
             cmd,
             shell=True,
@@ -43,5 +47,4 @@ def test_tag_latest_release(tag, expected_output, branch):
             text=True,
             env={"TEST_ENV": "true", "GITHUB_REF": f"refs/heads/{branch}"},
         )
-
-        assert re.search(expected_output, result.stdout, re.MULTILINE)
+        assert re.search(expected_output, result.stdout.strip(), re.MULTILINE)

--- a/tests/unit_tests/scripts/docker_build_push_test.py
+++ b/tests/unit_tests/scripts/docker_build_push_test.py
@@ -33,8 +33,11 @@ def test_tag_latest_release(tag, expected_output, branch):
     ) as subprocess_mock:
         result = BashMock.docker_build_push(tag, branch)
 
+        params = f"{tag} lean linux/amd64"
+        cmd = f"./scripts/docker_build_push.sh {params}"
+        print(cmd)
         subprocess_mock.assert_called_once_with(
-            f"./scripts/docker_build_push.sh {tag}",
+            cmd,
             shell=True,
             capture_output=True,
             text=True,


### PR DESCRIPTION
# new approach
originally started from https://github.com/apache/superset/pull/25564, but got tangled in intricate changes around release tag management that conflicted with the approach used originally, so I started over by

1. refactoring `scripts/docker_build_push.sh`, that originally generated a bunch of docker build commands to be executed sequentially, here I move to this bash script running a single command given the parameters, so it can be reused to run multiple build commands in parallel while orchestrating in GitHub actions. I tried to DRY what was in there cautiously
1. changed GitHub actions to generate a matrix of commands for each "target" (dev, lean, lean39, lean310, ...) and "platform" (linux/amd64, linux/arm64), similar to https://github.com/apache/superset/pull/25564