### PR TITLE
fix(tags): Filter system tags from the tags list

### DIFF
--- a/superset-frontend/src/pages/Tags/index.tsx
+++ b/superset-frontend/src/pages/Tags/index.tsx
@@ -59,6 +59,17 @@ function TagList(props: TagListProps) {
   const { addDangerToast, addSuccessToast, user } = props;
   const { userId } = user;
 
+  const initialFilters = useMemo(
+    () => [
+      {
+        id: 'type',
+        operator: 'custom_tag',
+        value: true,
+      },
+    ],
+    [],
+  );
+
   const {
     state: {
       loading,
@@ -70,7 +81,14 @@ function TagList(props: TagListProps) {
     fetchData,
     toggleBulkSelect,
     refreshData,
-  } = useListViewResource<Tag>('tag', t('tag'), addDangerToast);
+  } = useListViewResource<Tag>(
+    'tag',
+    t('tag'),
+    addDangerToast,
+    undefined,
+    undefined,
+    initialFilters,
+  );
 
   const [showTagModal, setShowTagModal] = useState<boolean>(false);
   const [tagToEdit, setTagToEdit] = useState<Tag | null>(null);

--- a/superset/commands/dashboard/importers/v0.py
+++ b/superset/commands/dashboard/importers/v0.py
@@ -80,7 +80,7 @@ def import_chart(
 
 
 def import_dashboard(
-    # pylint: disable=too-many-branches,too-many-locals,too-many-statements
+    # pylint: disable=too-many-locals,too-many-statements
     dashboard_to_import: Dashboard,
     dataset_id_mapping: Optional[dict[int, int]] = None,
     import_time: Optional[int] = None,

--- a/superset/tags/api.py
+++ b/superset/tags/api.py
@@ -20,9 +20,7 @@ from typing import Any
 from flask import request, Response
 from flask_appbuilder.api import expose, protect, rison, safe
 from flask_appbuilder.models.sqla.interface import SQLAInterface
-from flask_babel import lazy_gettext as _
 from marshmallow import ValidationError
-from sqlalchemy.orm import Query
 
 from superset.commands.tag.create import (
     CreateCustomTagCommand,
@@ -43,7 +41,7 @@ from superset.daos.tag import TagDAO
 from superset.exceptions import MissingUserContextException
 from superset.extensions import event_logger
 from superset.tags.filters import UserCreatedTagTypeFilter
-from superset.tags.models import ObjectType, Tag, TagType
+from superset.tags.models import ObjectType, Tag
 from superset.tags.schemas import (
     delete_tags_schema,
     openapi_spec_methods_override,
@@ -53,7 +51,6 @@ from superset.tags.schemas import (
     TagPostSchema,
     TagPutSchema,
 )
-from superset.views.base import BaseFilter
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
     RelatedFieldFilter,

--- a/superset/tags/api.py
+++ b/superset/tags/api.py
@@ -42,6 +42,7 @@ from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP, RouteMethod
 from superset.daos.tag import TagDAO
 from superset.exceptions import MissingUserContextException
 from superset.extensions import event_logger
+from superset.tags.filters import UserCreatedTagTypeFilter
 from superset.tags.models import ObjectType, Tag, TagType
 from superset.tags.schemas import (
     delete_tags_schema,
@@ -61,24 +62,6 @@ from superset.views.base_api import (
 from superset.views.filters import BaseFilterRelatedUsers, FilterRelatedOwners
 
 logger = logging.getLogger(__name__)
-
-
-class UserCreatedTagTypeFilter(BaseFilter):  # pylint: disable=too-few-public-methods
-    """
-    Filter for tag type.
-    When set to True, only user-created tags are returned.
-    When set to False, only system tags are returned.
-    """
-
-    name = _("Is custom tag")
-    arg_name = "custom_tag"
-
-    def apply(self, query: Query, value: bool) -> Query:
-        if value:
-            return query.filter(Tag.type == TagType.custom)
-        elif value is False:
-            return query.filter(Tag.type != TagType.custom)
-        return query
 
 
 class TagRestApi(BaseSupersetModelRestApi):

--- a/superset/tags/filters.py
+++ b/superset/tags/filters.py
@@ -34,6 +34,6 @@ class UserCreatedTagTypeFilter(BaseFilter):  # pylint: disable=too-few-public-me
     def apply(self, query: Query, value: bool) -> Query:
         if value:
             return query.filter(Tag.type == TagType.custom)
-        elif value is False:
+        if value is False:
             return query.filter(Tag.type != TagType.custom)
         return query

--- a/superset/tags/filters.py
+++ b/superset/tags/filters.py
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from flask_babel import lazy_gettext as _
+from sqlalchemy.orm import Query
+
+from superset.tags.models import Tag, TagType
+from superset.views.base import BaseFilter
+
+
+class UserCreatedTagTypeFilter(BaseFilter):  # pylint: disable=too-few-public-methods
+    """
+    Filter for tag type.
+    When set to True, only user-created tags are returned.
+    When set to False, only system tags are returned.
+    """
+
+    name = _("Is custom tag")
+    arg_name = "custom_tag"
+
+    def apply(self, query: Query, value: bool) -> Query:
+        if value:
+            return query.filter(Tag.type == TagType.custom)
+        elif value is False:
+            return query.filter(Tag.type != TagType.custom)
+        return query

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=invalid-name
-# pylint: disable=too-many-lines
 from __future__ import annotations
 
 import contextlib


### PR DESCRIPTION
### SUMMARY
System tags used to be filtered from the Tags list (by filtering tags with `:` on their name). As a consequence, any user-created tag that included `:` were not listed as well. https://github.com/apache/superset/pull/26324 fixed the issue by showing PRs with `:`, which re-introduced system tags to the table. 

This PR adds a `custom_tag` boolean filter operator to the Tags API so that system tags are properly filtered out from the API response. Filtering these tags in the Client/Frontend side is not effective since your first page might be only system tags, so you would end up with 0 results in the table (and no option to paginate) + you would also end up with inconsistent counts per page.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before**

![image](https://github.com/apache/superset/assets/96086495/da60182f-127c-4bef-87ad-9fc193730ae0)

**After**

![image](https://github.com/apache/superset/assets/96086495/df345af4-072f-45f8-b0c1-f047e4fa2bfb)

### TESTING INSTRUCTIONS
1. Make sure that `TAGGING_SYSTEM` is enabled. 
2. Add any account as an owner to any asset. 
3. Navigate to **Settings > Tags**.
4. Validate that the system tag (`owner:{{user_id}}`) is not listed.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Required feature flags: `TAGGING_SYSTEM`
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
