### PR TITLE
chore: fix GitHub 'Unchanged files with check annotations' reports in PR

### DIFF
--- a/.github/workflows/superset-websocket.yml
+++ b/.github/workflows/superset-websocket.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm ci
       - name: eslint
         working-directory: ./superset-websocket
-        run: npm run eslint -- .
+        run: npm run eslint -- . --quiet
       - name: typescript checks
         working-directory: ./superset-websocket
         run: npm run type

--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/drillby.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/drillby.test.ts
@@ -77,6 +77,7 @@ const drillBy = (targetDrillByColumn: string, isLegacy = false) => {
 
 const verifyExpectedFormData = (
   interceptedRequest: Interception,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   expectedFormData: Record<string, any>,
 ) => {
   const actualFormData = interceptedRequest.request.body?.form_data;

--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/editmode.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/editmode.test.ts
@@ -88,6 +88,7 @@ function visitEdit(sampleDashboard = SAMPLE_DASHBOARD_1) {
 }
 
 function resetTabbedDashboard(go = false) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   cy.getDashboard('tabbed_dash').then((r: Record<string, any>) => {
     const jsonMetadata = r?.json_metadata || '{}';
     const metadata = JSON.parse(jsonMetadata);

--- a/superset-frontend/cypress-base/cypress/support/e2e.ts
+++ b/superset-frontend/cypress-base/cypress/support/e2e.ts
@@ -20,6 +20,8 @@ import '@cypress/code-coverage/support';
 import '@applitools/eyes-cypress/commands';
 import failOnConsoleError from 'cypress-fail-on-console-error';
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 require('cy-verify-downloads').addCustomCommand();
 
 // fail on console error, allow config to override individual tests

--- a/superset-frontend/cypress-base/cypress/utils/index.ts
+++ b/superset-frontend/cypress-base/cypress/utils/index.ts
@@ -41,12 +41,23 @@ export function clearAllInputs() {
   });
 }
 
-const toSlicelike = ($chart: JQuery<HTMLElement>): Slice => ({
-  slice_id: parseInt($chart.attr('data-test-chart-id')!, 10),
-  form_data: {
-    viz_type: $chart.attr('data-test-viz-type')!,
-  },
-});
+const toSlicelike = ($chart: JQuery<HTMLElement>): Slice => {
+  const chartId = $chart.attr('data-test-chart-id');
+  const vizType = $chart.attr('data-test-viz-type');
+
+  return {
+    slice_id: chartId ? parseInt(chartId, 10) : null,
+    form_data: {
+      viz_type: vizType || null,
+    },
+  };
+};
+
+export function getChartGridComponent({ name, viz }: ChartSpec) {
+  return cy
+    .get(`[data-test-chart-name="${name}"]`)
+    .should('have.attr', 'data-test-viz-type', viz);
+}
 
 export function getChartAliasBySpec(chart: ChartSpec) {
   return getChartGridComponent(chart).then($chart =>
@@ -65,12 +76,6 @@ export function getChartAliasesBySpec(charts: readonly ChartSpec[]) {
   // That way callers can chain off this function
   // and actually get the list of aliases.
   return cy.wrap(aliases);
-}
-
-export function getChartGridComponent({ name, viz }: ChartSpec) {
-  return cy
-    .get(`[data-test-chart-name="${name}"]`)
-    .should('have.attr', 'data-test-viz-type', viz);
 }
 
 export function waitForChartLoad(chart: ChartSpec) {

--- a/superset-frontend/cypress-base/cypress/utils/vizPlugins.ts
+++ b/superset-frontend/cypress-base/cypress/utils/vizPlugins.ts
@@ -49,6 +49,7 @@ export function isLegacyChart(vizType: string): boolean {
   return !V1_PLUGINS.includes(vizType);
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isLegacyResponse(response: any): boolean {
   return !response.result;
 }


### PR DESCRIPTION
### SUMMARY
Addressing the GitHub-reported lint warnings that show up in every PR. It's unclear to me why those warnings are surfaced by not others, but let's silence those clean up future PR from this. Note that there are 255 other warnings that are not surfaced in PRs, wondering if they do some sort of top N (?). We'll know soon enough.

<img width="982" alt="Screenshot 2024-01-20 at 1 40 52 PM" src="https://github.com/apache/superset/assets/487433/f5769f17-64be-439f-bd1d-8df33b15569f">

Related issue filed with GitHub about this annoying beta feature -> https://github.com/actions/toolkit/issues/457
