### PR TITLE
chore: silence SECRET_KEY warning when running tests

### DIFF
--- a/tests/integration_tests/superset_test_config.py
+++ b/tests/integration_tests/superset_test_config.py
@@ -31,6 +31,7 @@ logging.getLogger("flask_appbuilder.api").setLevel(logging.WARNING)
 logging.getLogger("flask_appbuilder.security.sqla.manager").setLevel(logging.WARNING)
 logging.getLogger("sqlalchemy.engine.Engine").setLevel(logging.WARNING)
 
+SECRET_KEY = "dummy_secret_key_for_test_to_silence_warnings"
 AUTH_USER_REGISTRATION_ROLE = "alpha"
 SQLALCHEMY_DATABASE_URI = "sqlite:///" + os.path.join(
     DATA_DIR, "unittests.integration_tests.db"

--- a/tests/integration_tests/superset_test_config_thumbnails.py
+++ b/tests/integration_tests/superset_test_config_thumbnails.py
@@ -19,6 +19,7 @@ from copy import copy
 
 from superset.config import *
 
+SECRET_KEY = "dummy_secret_key_for_test_to_silence_warnings"
 AUTH_USER_REGISTRATION_ROLE = "alpha"
 SQLALCHEMY_DATABASE_URI = "sqlite:///" + os.path.join(
     DATA_DIR, "unittests.integration_tests.db"


### PR DESCRIPTION
### SUMMARY
I saw this crazy amount of warning logs about SECRET_KEY in CI logs, and thought this might silence it. Observed in another PR here -> https://github.com/apache/superset/actions/runs/7590421536/job/20676883024?pr=26698

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1053" alt="Screenshot 2024-01-20 at 1 57 29 PM" src="https://github.com/apache/superset/assets/487433/c85195fe-9eb5-439a-b117-3bbcc35b07a9">
<img width="738" alt="Screenshot 2024-01-20 at 1 57 20 PM" src="https://github.com/apache/superset/assets/487433/e269068a-68d4-4b66-bba7-ec94a600f0ce">
