### PR TITLE
fix(legacy-charts): Show Time Grain control for legacy charts

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
@@ -205,7 +205,7 @@ const time_grain_sqla: SharedControlConfig<'SelectControl'> = {
     choices: (datasource as Dataset)?.time_grain_sqla || [],
   }),
   visibility: ({ controls }) => {
-    if (!hasGenericChartAxes) {
+    if (!hasGenericChartAxes || !controls?.x_axis) {
       return true;
     }
 


### PR DESCRIPTION
### SUMMARY
The Time Grain control is no longer visible for legacy charts in case `GENERIC_CHART_AXES` is enabled. This issue was briefly discussed in this PR: https://github.com/apache/superset/pull/26372#issuecomment-1889676989

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before**

![image](https://github.com/apache/superset/assets/96086495/2c3ec066-9ce1-44af-a7d8-0a6035813d4b)


**After**

![image](https://github.com/apache/superset/assets/96086495/573d1264-e45d-4304-b4aa-826195a90d6a)


### TESTING INSTRUCTIONS
1. Make sure that `GENERIC_CHART_AXES` is disabled. 
2. Create a legacy line chart with a temporal column and a time grain applied.
3. Enable `GENERIC_CHART_AXES` and access the chart.
4. Make sure that the Time Grain field is still visible. 

I also created charts using all nvd3 charts + all viz types using `legacyTimeseriesTime` and confirmed that changing the FF value did not introduced any issues, and the time grain field was visible and working.

Fixes https://github.com/apache/superset/issues/26474

### ADDITIONAL INFORMATION
- [x] Has associated issue: https://github.com/apache/superset/issues/26474
- [x] Required feature flags: `GENERIC_CHART_AXES`
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
