### PR TITLE
fix(time grain): time grain clickhouse db error

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -397,6 +397,9 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     # Can the catalog be changed on a per-query basis?
     supports_dynamic_catalog = False
 
+     # Use column alias instead of aggregate function in GROUP BY
+    use_column_alias_in_groupby = False
+
     @classmethod
     def get_allows_alias_in_select(
         cls, database: Database  # pylint: disable=unused-argument

--- a/superset/db_engine_specs/clickhouse.py
+++ b/superset/db_engine_specs/clickhouse.py
@@ -53,6 +53,7 @@ class ClickHouseBaseEngineSpec(BaseEngineSpec):
     """Shared engine spec for ClickHouse."""
 
     time_groupby_inline = True
+    use_column_alias_in_groupby = True
 
     _time_grain_expressions = {
         None: "{col}",

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1733,7 +1733,10 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
         tbl, cte = self.get_from_clause(template_processor)
 
         if groupby_all_columns:
-            qry = qry.group_by(*groupby_all_columns.values())
+            if db_engine_spec.use_column_alias_in_groupby:
+                qry = qry.group_by(*groupby_all_columns.keys())
+            else:
+                qry = qry.group_by(*groupby_all_columns.values())
 
         where_clause_and = []
         having_clause_and = []


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
DB error on chart load when time granularity is set when the source is Clickhouse. Error example: ```Error: Orig exception: Code: 215.
DB::Exception: Column `Column2` is not under aggregate function and not in GROUP BY: While processing toStartOfDay(toDateTime(Column2)) AS Column2, count() AS count.```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
before:
![image](https://github.com/apache/superset/assets/66740070/f5efd034-78c5-42a9-9c1f-f5c01d377057)
after:
![image](https://github.com/apache/superset/assets/66740070/80e1832d-8783-4da6-9915-665578ac7f83)


### TESTING INSTRUCTIONS

1. Create ClickHouse database
2. Make table with temporal column
3. Install the Clickhouse driver via adding ```clickhouse-sqlalchemy==0.2.5``` line in  `docker/requirements-local.txt`
4. Connect ClickHouse DB to superset
5. Create line chart from table datasource and select temporal column in X-Axis option

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes [#23384](https://github.com/apache/superset/issues/23384)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
