### PR TITLE
fix(db2): Improving support for ibm db2 connections

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,7 @@ setup(
             "databricks-sql-connector>=2.0.2, <3",
             "sqlalchemy-databricks>=0.2.0",
         ],
-        "db2": ["ibm-db-sa>=0.3.5, <0.4"],
+        "db2": ["ibm-db-sa>0.3.8, <=0.4.0"],
         "dremio": ["sqlalchemy-dremio>=1.1.5, <1.3"],
         "drill": ["sqlalchemy-drill==0.1.dev"],
         "druid": ["pydruid>=0.6.5,<0.7"],

--- a/superset/db_engine_specs/db2.py
+++ b/superset/db_engine_specs/db2.py
@@ -14,8 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import logging
+from typing import Optional, Union
+
+from sqlalchemy.engine.reflection import Inspector
+
 from superset.constants import TimeGrain
 from superset.db_engine_specs.base import BaseEngineSpec, LimitMethod
+
+logger = logging.getLogger(__name__)
 
 
 class Db2EngineSpec(BaseEngineSpec):
@@ -25,6 +32,8 @@ class Db2EngineSpec(BaseEngineSpec):
     limit_method = LimitMethod.WRAP_SQL
     force_column_alias_quotes = True
     max_column_name_length = 30
+
+    supports_dynamic_schema = True
 
     _time_grain_expressions = {
         None: "{col}",
@@ -52,3 +61,49 @@ class Db2EngineSpec(BaseEngineSpec):
     @classmethod
     def epoch_to_dttm(cls) -> str:
         return "(TIMESTAMP('1970-01-01', '00:00:00') + {col} SECONDS)"
+
+    @classmethod
+    def get_table_comment(
+        cls, inspector: Inspector, table_name: str, schema: Union[str, None]
+    ) -> Optional[str]:
+        """
+        Get comment of table from a given schema
+
+        Ibm Db2 return comments as tuples, so we need to get the first element
+
+        :param inspector: SqlAlchemy Inspector instance
+        :param table_name: Table name
+        :param schema: Schema name. If omitted, uses default schema for database
+        :return: comment of table
+        """
+        comment = None
+        try:
+            table_comment = inspector.get_table_comment(table_name, schema)
+            comment = table_comment.get("text")
+            return comment[0]
+        except IndexError:
+            return comment
+        except Exception as ex:  # pylint: disable=broad-except
+            logger.error("Unexpected error while fetching table comment", exc_info=True)
+            logger.exception(ex)
+            return comment
+
+    @classmethod
+    def get_prequeries(
+        cls,
+        catalog: Union[str, None] = None,
+        schema: Union[str, None] = None,
+    ) -> list[str]:
+        """
+        Set the search path to the specified schema.
+
+        This is important for two reasons: in SQL Lab it will allow queries to run in
+        the schema selected in the dropdown, resolving unqualified table names to the
+        expected schema.
+
+        But more importantly, in SQL Lab this is used to check if the user has access to
+        any tables with unqualified names. If the schema is not set by SQL Lab it could
+        be anything, and we would have to block users from running any queries
+        referencing tables without an explicit schema.
+        """
+        return [f'set current_schema "{schema}"'] if schema else []

--- a/tests/unit_tests/db_engine_specs/test_db2.py
+++ b/tests/unit_tests/db_engine_specs/test_db2.py
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+from pytest_mock import MockerFixture
+
+
+def test_epoch_to_dttm() -> None:
+    """
+    Test the `epoch_to_dttm` method.
+    """
+    from superset.db_engine_specs.db2 import Db2EngineSpec
+
+    assert (
+        Db2EngineSpec.epoch_to_dttm().format(col="epoch_dttm")
+        == "(TIMESTAMP('1970-01-01', '00:00:00') + epoch_dttm SECONDS)"
+    )
+
+
+def test_get_table_comment(mocker: MockerFixture):
+    """
+    Test the `get_table_comment` method.
+    """
+    from superset.db_engine_specs.db2 import Db2EngineSpec
+
+    mock_inspector = mocker.MagicMock()
+    mock_inspector.get_table_comment.return_value = {
+        "text": ("This is a table comment",)
+    }
+
+    assert (
+        Db2EngineSpec.get_table_comment(mock_inspector, "my_table", "my_schema")
+        == "This is a table comment"
+    )
+
+
+def test_get_table_comment_empty(mocker: MockerFixture):
+    """
+    Test the `get_table_comment` method
+    when no comment is returned.
+    """
+    from superset.db_engine_specs.db2 import Db2EngineSpec
+
+    mock_inspector = mocker.MagicMock()
+    mock_inspector.get_table_comment.return_value = {}
+
+    assert (
+        Db2EngineSpec.get_table_comment(mock_inspector, "my_table", "my_schema") == None
+    )
+
+
+def test_get_prequeries() -> None:
+    """
+    Test the ``get_prequeries`` method.
+    """
+    from superset.db_engine_specs.db2 import Db2EngineSpec
+
+    assert Db2EngineSpec.get_prequeries() == []
+    assert Db2EngineSpec.get_prequeries(schema="my_schema") == [
+        'set current_schema "my_schema"'
+    ]


### PR DESCRIPTION
### SUMMARY
This PR fixes some issues with the IBM Db2 engine spec:

#### Connection issues
When trying to establish a connection to an IBM Db2 Cloud Instance, below error is displayed in case `ibm_db_sa==0.3.8` is installed:

<img width="1117" alt="image" src="https://github.com/apache/superset/assets/96086495/cbd6beac-6f27-4058-8098-8cb4cd7016ab">

To fix this, I updated the version limits in `setup.py`.

#### Unable to create a physical dataset
Trying to create a virtual dataset would return an error, because `get_table_comment()` returns a `Tuple()` for this engine:

![image](https://github.com/apache/superset/assets/96086495/00d47fc6-2f01-4c04-bbd6-3e003423d6db)

stack trace:
```
2024-01-22 14:04:37,371:ERROR:flask_appbuilder.api:Object of type LegacyRow is not JSON serializable
Traceback (most recent call last):
  File "/Users/vitoravila/.pyenv/versions/3.10.12/envs/superset-mods/lib/python3.10/site-packages/flask_appbuilder/api/__init__.py", line 110, in wraps
    return f(self, *args, **kwargs)
  File "/Users/vitoravila/code/superset-mods/superset/superset/views/base_api.py", line 127, in wraps
    raise ex
  File "/Users/vitoravila/code/superset-mods/superset/superset/views/base_api.py", line 121, in wraps
    duration, response = time_function(f, self, *args, **kwargs)
  File "/Users/vitoravila/code/superset-mods/superset/superset/utils/core.py", line 1454, in time_function
    response = func(*args, **kwargs)
  File "/Users/vitoravila/code/superset-mods/superset/superset/utils/log.py", line 255, in wrapper
    value = f(*args, **kwargs)
  File "/Users/vitoravila/code/superset-mods/superset/superset/databases/api.py", line 749, in table_metadata
    return self.response(200, **table_info)
  File "/Users/vitoravila/.pyenv/versions/3.10.12/envs/superset-mods/lib/python3.10/site-packages/flask_appbuilder/api/__init__.py", line 772, in response
    _ret_json = jsonify(kwargs)
  File "/Users/vitoravila/.pyenv/versions/3.10.12/envs/superset-mods/lib/python3.10/site-packages/flask/json/__init__.py", line 342, in jsonify
    return current_app.json.response(*args, **kwargs)
  File "/Users/vitoravila/.pyenv/versions/3.10.12/envs/superset-mods/lib/python3.10/site-packages/flask/json/provider.py", line 309, in response
    f"{self.dumps(obj, **dump_args)}\n", mimetype=mimetype
  File "/Users/vitoravila/.pyenv/versions/3.10.12/envs/superset-mods/lib/python3.10/site-packages/flask/json/provider.py", line 230, in dumps
    return json.dumps(obj, **kwargs)
  File "/Users/vitoravila/.pyenv/versions/3.10.12/lib/python3.10/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "/Users/vitoravila/.pyenv/versions/3.10.12/lib/python3.10/json/encoder.py", line 201, in encode
    chunks = list(chunks)
  File "/Users/vitoravila/.pyenv/versions/3.10.12/lib/python3.10/json/encoder.py", line 431, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "/Users/vitoravila/.pyenv/versions/3.10.12/lib/python3.10/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "/Users/vitoravila/.pyenv/versions/3.10.12/lib/python3.10/json/encoder.py", line 438, in _iterencode
    o = _default(o)
  File "/Users/vitoravila/.pyenv/versions/3.10.12/envs/superset-mods/lib/python3.10/site-packages/flask/json/provider.py", line 122, in _default
    raise TypeError(f"Object of type {type(o).__name__} is not JSON serializable")
```

To fix this, I created a db2-specific `get_table_comment()` method in the `Db2EngineSpec`.

#### Unable to execute un-classified queries in SQL Lab
It was not possible to run a query without specifying the schema in SQL Lab (even if the schema was selected in the dropdown):

![image](https://github.com/apache/superset/assets/96086495/41beed9c-9530-41a7-9d7f-43823b11efc1)

To fix this, I created a db2-specific `get_prequeries()` method in the `Db2EngineSpec`, and also set `supports_dynamic_schema` to `True`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Screenshots for **Before** added in Summary. After this PR:

![image](https://github.com/apache/superset/assets/96086495/0a88b1aa-b4d4-475c-bb13-8f4789297b7e)

![image](https://github.com/apache/superset/assets/96086495/c63de3cc-e9f7-46f4-9688-bb9a7cd3b6d0)

![image](https://github.com/apache/superset/assets/96086495/ad3a1d99-5614-4ecf-a311-c8b3df4bb9a3)

### TESTING INSTRUCTIONS
Unit tests added. To manually test:
1. Make sure you're able to connect to an IBM Db2 instance.
2. Validate you're able to create physical datasets.
3. Check you're able to run a SQL query without specifying the schema in the SQL statement as long as it's selected in the dropdown. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
