### PR TITLE
fix: add user to latest-release-tag workflow

### DIFF
--- a/.github/workflows/latest-release-tag.yml
+++ b/.github/workflows/latest-release-tag.yml
@@ -22,6 +22,11 @@ jobs:
       run: |
         source ./scripts/tag_latest_release.sh $(echo ${{ github.event.release.tag_name }}) --dry-run
 
+    - name: Configure Git
+      run: |
+        git config user.name "$GITHUB_ACTOR"
+        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
     - name: Run latest-tag
       uses: ./.github/actions/latest-tag
       if: (! ${{ steps.latest-tag.outputs.SKIP_TAG }} )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The github workflow that adds a 'latest' tag to the latest official release version was not working because it was missing some github config info. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
