### PR TITLE
chore: prevent CI double runs on push + pull_request

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -66,8 +66,8 @@ github:
           - cypress-matrix (3, chrome)
           - docker-build
           - frontend-build
-          - pre-commit (3.9)
-          - python-lint (3.9)
+          - pre-commit
+          - python-lint
           - test-mysql (3.9)
           - test-postgres (3.9)
           - test-postgres (3.10)

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -66,8 +66,8 @@ github:
           - cypress-matrix (3, chrome)
           - docker-build
           - frontend-build
-          - pre-commit
-          - python-lint
+          - pre-commit (3.9)
+          - python-lint (3.9)
           - test-mysql (3.9)
           - test-postgres (3.9)
           - test-postgres (3.10)

--- a/.github/workflows/check_db_migration_confict.yml
+++ b/.github/workflows/check_db_migration_confict.yml
@@ -3,6 +3,12 @@ on:
   push:
     paths:
       - "superset/migrations/**"
+    branches:
+      - 'master'
+  pull_request:
+    paths:
+      - "superset/migrations/**"
+    types: [synchronize, opened, reopened, ready_for_review]
 
 jobs:
   check_db_migration_conflict:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,6 +33,13 @@ jobs:
       matrix:
         target: ["dev", "lean", "lean310", "websocket", "dockerize"]
         platform: ["linux/amd64", "linux/arm64"]
+        exclude:
+          # disabling because slow! no python wheels for arm/py39 and
+          # QEMU is slow!
+          - target: "dev"
+            platform: "linux/arm64"
+          - target: "lean"
+            platform: "linux/arm64"
       fail-fast: false
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -2,9 +2,10 @@ name: License Check
 
 on:
   push:
-    branches-ignore:
-      - "dependabot/**"
+    branches:
+      - 'master'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
 
 jobs:
   config:

--- a/.github/workflows/no-op.yml
+++ b/.github/workflows/no-op.yml
@@ -31,7 +31,7 @@ jobs:
           echo "This is a no-op step for frontend-build to ensure a successful status."
           exit 0
 
-  pre-commit (3.9):
+  "pre-commit (3.9)":
     runs-on: ubuntu-latest
     steps:
       - name: No-op for pre-commit
@@ -39,7 +39,7 @@ jobs:
           echo "This is a no-op step for pre-commit to ensure a successful status."
           exit 0
 
-  python-lint (3.9):
+  "python-lint (3.9)":
     runs-on: ubuntu-latest
     steps:
       - name: No-op for python-lint

--- a/.github/workflows/no-op.yml
+++ b/.github/workflows/no-op.yml
@@ -31,7 +31,7 @@ jobs:
           echo "This is a no-op step for frontend-build to ensure a successful status."
           exit 0
 
-  pre-commit:
+  pre-commit (3.9):
     runs-on: ubuntu-latest
     steps:
       - name: No-op for pre-commit
@@ -39,7 +39,7 @@ jobs:
           echo "This is a no-op step for pre-commit to ensure a successful status."
           exit 0
 
-  python-lint:
+  python-lint (3.9):
     runs-on: ubuntu-latest
     steps:
       - name: No-op for python-lint

--- a/.github/workflows/no-op.yml
+++ b/.github/workflows/no-op.yml
@@ -32,6 +32,9 @@ jobs:
           exit 0
 
   pre-commit:
+    strategy:
+      matrix:
+        python-version: ["3.9"]
     runs-on: ubuntu-latest
     steps:
       - name: No-op for pre-commit
@@ -40,6 +43,9 @@ jobs:
           exit 0
 
   python-lint:
+    strategy:
+      matrix:
+        python-version: ["3.9"]
     runs-on: ubuntu-latest
     steps:
       - name: No-op for python-lint

--- a/.github/workflows/no-op.yml
+++ b/.github/workflows/no-op.yml
@@ -31,7 +31,7 @@ jobs:
           echo "This is a no-op step for frontend-build to ensure a successful status."
           exit 0
 
-  "pre-commit (3.9)":
+  pre-commit:
     runs-on: ubuntu-latest
     steps:
       - name: No-op for pre-commit
@@ -39,7 +39,7 @@ jobs:
           echo "This is a no-op step for pre-commit to ensure a successful status."
           exit 0
 
-  "python-lint (3.9)":
+  python-lint:
     runs-on: ubuntu-latest
     steps:
       - name: No-op for python-lint

--- a/.github/workflows/no-op.yml
+++ b/.github/workflows/no-op.yml
@@ -1,0 +1,48 @@
+# no-op.yml
+#
+# Purpose:
+# This workflow provides a workaround for the "required status checks" feature in GitHub Actions
+# when using path-specific conditions in other workflows. Required checks might remain in a "Pending"
+# state if the conditions are not met, thus blocking pull requests from being merged.
+# This no-op (no operation) workflow provides dummy success statuses for these required jobs when
+# the real jobs do not run due to path-specific conditions.
+#
+# How it works:
+# - It defines jobs with the same names as the required jobs in the main workflows.
+# - These jobs simply execute a command (`exit 0`) to succeed immediately.
+# - When a pull request is created or updated, both this no-op workflow and the main workflows are triggered.
+# - If the main workflows' jobs don't run (due to path conditions), these no-op jobs provide successful statuses.
+# - If the main workflows' jobs do run and fail, their failure statuses take precedence,
+#   ensuring that pull requests are not merged with failing checks.
+#
+# Usage:
+# - Ensure that the job names in this workflow match exactly the names of the corresponding jobs in the main workflows.
+# - This workflow should be kept as-is, without path-specific conditions.
+
+name: No Operation Checks
+on: pull_request
+
+jobs:
+  frontend-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op for frontend-build
+        run: |
+          echo "This is a no-op step for frontend-build to ensure a successful status."
+          exit 0
+
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op for pre-commit
+        run: |
+          echo "This is a no-op step for pre-commit to ensure a successful status."
+          exit 0
+
+  python-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op for python-lint
+        run: |
+          echo "This is a no-op step for python-lint to ensure a successful status."
+          exit 0

--- a/.github/workflows/prefer-typescript.yml
+++ b/.github/workflows/prefer-typescript.yml
@@ -2,9 +2,10 @@ name: Prefer TypeScript
 
 on:
   push:
-    branches-ignore:
-      - "dependabot/**"
+    branches:
+      - 'master'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
 
 jobs:
   prefer_typescript:

--- a/.github/workflows/prefer-typescript.yml
+++ b/.github/workflows/prefer-typescript.yml
@@ -10,7 +10,6 @@ on:
     types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "superset-frontend/src/**"
-
 jobs:
   prefer_typescript:
     if: github.ref == 'ref/heads/master' && github.event_name == 'pull_request'

--- a/.github/workflows/prefer-typescript.yml
+++ b/.github/workflows/prefer-typescript.yml
@@ -4,8 +4,12 @@ on:
   push:
     branches:
       - 'master'
+    paths:
+      - "superset-frontend/src/**"
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
+    paths:
+      - "superset-frontend/src/**"
 
 jobs:
   prefer_typescript:

--- a/.github/workflows/superset-cli.yml
+++ b/.github/workflows/superset-cli.yml
@@ -2,8 +2,8 @@ name: Superset CLI tests
 
 on:
   push:
-    branches-ignore:
-      - "dependabot/npm_and_yarn/**"
+    branches:
+      - 'master'
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
 

--- a/.github/workflows/superset-docs.yml
+++ b/.github/workflows/superset-docs.yml
@@ -4,9 +4,12 @@ on:
   push:
     paths:
       - "docs/**"
+    branches:
+      - 'master'
   pull_request:
     paths:
       - "docs/**"
+    types: [synchronize, opened, reopened, ready_for_review]
 
 jobs:
   config:

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -2,10 +2,8 @@ name: E2E
 
 on:
   push:
-    branches-ignore:
-      - "dependabot/**/docs/**"
-    paths-ignore:
-      - "docs/**"
+    branches:
+      - 'master'
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
 

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -6,7 +6,6 @@ on:
       - 'master'
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
-
 jobs:
   cypress-matrix:
     runs-on: ubuntu-20.04

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -6,6 +6,7 @@ on:
       - 'master'
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
+
 jobs:
   cypress-matrix:
     runs-on: ubuntu-20.04

--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -2,11 +2,14 @@ name: Frontend
 
 on:
   push:
-    branches-ignore:
-      - "dependabot/**/docs/**"
-      - "dependabot/**/cypress-base/**"
+    branches:
+      - "master"
+    paths:
+      - "superset-frontend/**"
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
+    paths:
+      - "superset-frontend/**"
 
 jobs:
   frontend-build:

--- a/.github/workflows/superset-helm-lint.yml
+++ b/.github/workflows/superset-helm-lint.yml
@@ -3,6 +3,8 @@ name: Lint and Test Charts
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
+    paths:
+      - "helm/**"
 
 jobs:
   lint-test:

--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -3,8 +3,8 @@ name: Python-Integration
 
 on:
   push:
-    branches-ignore:
-      - "dependabot/npm_and_yarn/**"
+    branches:
+      - 'master'
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
 

--- a/.github/workflows/superset-python-misc.yml
+++ b/.github/workflows/superset-python-misc.yml
@@ -3,10 +3,14 @@ name: Python Misc
 
 on:
   push:
-    branches-ignore:
-      - "dependabot/npm_and_yarn/**"
+    branches:
+      - 'master'
+    paths:
+      - "superset/**"
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
+    paths:
+      - "superset/**"
 
 jobs:
   python-lint:

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -3,10 +3,14 @@ name: Python Presto/Hive
 
 on:
   push:
-    branches-ignore:
-      - "dependabot/npm_and_yarn/**"
+    branches:
+      - 'master'
+    paths:
+      - "superset/**"
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
+    paths:
+      - "superset/**"
 
 jobs:
   test-postgres-presto:

--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -3,10 +3,14 @@ name: Python-Unit
 
 on:
   push:
-    branches-ignore:
-      - "dependabot/npm_and_yarn/**"
+    branches:
+      - 'master'
+    paths:
+      - "superset/**"
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
+    paths:
+      - "superset/**"
 
 jobs:
   unit-tests:

--- a/.github/workflows/superset-translations.yml
+++ b/.github/workflows/superset-translations.yml
@@ -2,8 +2,8 @@ name: Translations
 
 on:
   push:
-    branches-ignore:
-      - "dependabot/npm_and_yarn/**"
+    branches:
+      - 'master'
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
 

--- a/.github/workflows/superset-websocket.yml
+++ b/.github/workflows/superset-websocket.yml
@@ -1,11 +1,14 @@
 name: WebSocket server
 on:
   push:
+    branches:
+      - 'master'
     paths:
       - "superset-websocket/**"
   pull_request:
     paths:
       - "superset-websocket/**"
+    types: [synchronize, opened, reopened, ready_for_review]
 
 jobs:
   app-checks:

--- a/scripts/docker_build_push.sh
+++ b/scripts/docker_build_push.sh
@@ -133,8 +133,8 @@ fi
 docker buildx build \
   ${TARGET_ARGUMENT} \
   ${DOCKER_ARGS} \
-  --cache-from=type=registry,ref=${REPO_NAME} \
-  --cache-to=type=registry,mode=max,ref=${REPO_NAME} \
+  --cache-from=type=registry,ref=${REPO_NAME}-cache \
+  --cache-to=type=registry,mode=max,ref=${REPO_NAME}-cache \
   ${DOCKER_TAGS} \
   --platform ${BUILD_PLATFORM} \
   --label "sha=${SHA}" \

--- a/scripts/docker_build_push.sh
+++ b/scripts/docker_build_push.sh
@@ -74,7 +74,6 @@ BUILD_ARG="3.9-slim-bookworm"
 SAFE_BUILD_PLATFORM=$(echo "${BUILD_PLATFORM}" | sed 's/\//-/g')
 MAIN_UNIQUE_TAG="${REPO_NAME}:${SHA}-${TARGET}-${SAFE_BUILD_PLATFORM}-${BUILD_ARG}"
 
-
 case "${TARGET}" in
   "dev")
     DOCKER_TAGS="-t ${MAIN_UNIQUE_TAG} -t ${REPO_NAME}:${SHA}-dev -t ${REPO_NAME}:${REFSPEC}-dev -t ${DEV_TAG}"
@@ -107,6 +106,7 @@ esac
 
 cat<<EOF
   Rolling with tags:
+  - $MAIN_UNIQUE_TAG
   - ${REPO_NAME}:${SHA}
   - ${REPO_NAME}:${REFSPEC}
   - ${REPO_NAME}:${LATEST_TAG}
@@ -133,8 +133,8 @@ fi
 docker buildx build \
   ${TARGET_ARGUMENT} \
   ${DOCKER_ARGS} \
-  --cache-from=type=registry,ref=${MAIN_UNIQUE_TAG} \
-  --cache-to=type=registry,mode=max,ref=${MAIN_UNIQUE_TAG} \
+  --cache-from=type=registry,ref=${REPO_NAME} \
+  --cache-to=type=registry,mode=max,ref=${REPO_NAME} \
   ${DOCKER_TAGS} \
   --platform ${BUILD_PLATFORM} \
   --label "sha=${SHA}" \

--- a/scripts/docker_build_push.sh
+++ b/scripts/docker_build_push.sh
@@ -69,28 +69,29 @@ else
 fi
 
 BUILD_ARG="3.9-slim-bookworm"
+MAIN_UNIQUE_TAG="${REPO_NAME}:${SHA}:${TARGET}:${BUILD_PLATFORM}:${BUILD_ARG}"
 
 case "${TARGET}" in
   "dev")
-    DOCKER_TAGS="-t ${REPO_NAME}:${SHA}-dev -t ${REPO_NAME}:${REFSPEC}-dev -t ${DEV_TAG}"
+    DOCKER_TAGS="-t ${MAIN_UNIQUE_TAG} -t ${REPO_NAME}:${SHA}-dev -t ${REPO_NAME}:${REFSPEC}-dev -t ${DEV_TAG}"
     BUILD_TARGET="dev"
     ;;
   "lean")
-    DOCKER_TAGS="-t ${REPO_NAME}:${SHA} -t ${REPO_NAME}:${REFSPEC} -t ${REPO_NAME}:${LATEST_TAG}"
+    DOCKER_TAGS="-t ${MAIN_UNIQUE_TAG} -t ${REPO_NAME}:${SHA} -t ${REPO_NAME}:${REFSPEC} -t ${REPO_NAME}:${LATEST_TAG}"
     BUILD_TARGET="lean"
     ;;
   "lean310")
-    DOCKER_TAGS="-t ${REPO_NAME}:${SHA}-py310 -t ${REPO_NAME}:${REFSPEC}-py310 -t ${REPO_NAME}:${LATEST_TAG}-py310"
+    DOCKER_TAGS="-t ${MAIN_UNIQUE_TAG} -t ${REPO_NAME}:${SHA}-py310 -t ${REPO_NAME}:${REFSPEC}-py310 -t ${REPO_NAME}:${LATEST_TAG}-py310"
     BUILD_TARGET="lean"
     BUILD_ARG="3.10-slim-bookworm"
     ;;
   "websocket")
-    DOCKER_TAGS="-t ${REPO_NAME}:${SHA}-websocket -t ${REPO_NAME}:${REFSPEC}-websocket -t ${REPO_NAME}:${LATEST_TAG}-websocket"
+    DOCKER_TAGS="-t ${MAIN_UNIQUE_TAG} -t ${REPO_NAME}:${SHA}-websocket -t ${REPO_NAME}:${REFSPEC}-websocket -t ${REPO_NAME}:${LATEST_TAG}-websocket"
     BUILD_TARGET=""
 	DOCKER_CONTEXT="superset-websocket"
     ;;
   "dockerize")
-    DOCKER_TAGS="-t ${REPO_NAME}:dockerize"
+    DOCKER_TAGS="-t ${MAIN_UNIQUE_TAG} -t ${REPO_NAME}:dockerize"
     BUILD_TARGET=""
 	DOCKER_CONTEXT="-f dockerize.Dockerfile ."
     ;;
@@ -128,8 +129,8 @@ fi
 docker buildx build \
   ${TARGET_ARGUMENT} \
   ${DOCKER_ARGS} \
-  --cache-from=type=registry,ref=apache/superset:${TARGET} \
-  --cache-to=type=registry,mode=max,ref=apache/superset:${TARGET} \
+  --cache-from=type=registry,ref=${MAIN_UNIQUE_TAG} \
+  --cache-to=type=registry,mode=max,ref=${MAIN_UNIQUE_TAG} \
   ${DOCKER_TAGS} \
   --platform ${BUILD_PLATFORM} \
   --label "sha=${SHA}" \

--- a/scripts/docker_build_push.sh
+++ b/scripts/docker_build_push.sh
@@ -130,11 +130,13 @@ if [[ -n "${BUILD_TARGET}" ]]; then
   TARGET_ARGUMENT="--target ${BUILD_TARGET}"
 fi
 
+CACHE_REF="${REPO_NAME}-cache:${BUILD_TARGET}-${BUILD_ARG}"
+
 docker buildx build \
   ${TARGET_ARGUMENT} \
   ${DOCKER_ARGS} \
-  --cache-from=type=registry,ref=${REPO_NAME}-cache \
-  --cache-to=type=registry,mode=max,ref=${REPO_NAME}-cache \
+  --cache-from=type=registry,ref=${CACHE_REF} \
+  --cache-to=type=registry,mode=max,ref=${CACHE_REF} \
   ${DOCKER_TAGS} \
   --platform ${BUILD_PLATFORM} \
   --label "sha=${SHA}" \

--- a/scripts/docker_build_push.sh
+++ b/scripts/docker_build_push.sh
@@ -130,7 +130,8 @@ if [[ -n "${BUILD_TARGET}" ]]; then
   TARGET_ARGUMENT="--target ${BUILD_TARGET}"
 fi
 
-CACHE_REF="${REPO_NAME}-cache:${BUILD_TARGET}-${BUILD_ARG}"
+CACHE_REF="${REPO_NAME}-cache:${TARGET}-${BUILD_ARG}"
+CACHE_REF=$(echo "${CACHE_REF}" | tr -d '.')
 
 docker buildx build \
   ${TARGET_ARGUMENT} \

--- a/scripts/docker_build_push.sh
+++ b/scripts/docker_build_push.sh
@@ -69,7 +69,8 @@ else
 fi
 
 BUILD_ARG="3.9-slim-bookworm"
-MAIN_UNIQUE_TAG="${REPO_NAME}:${SHA}:${TARGET}:${BUILD_PLATFORM}:${BUILD_ARG}"
+MAIN_UNIQUE_TAG="${REPO_NAME}:${SHA}-${TARGET}-${BUILD_PLATFORM}-${BUILD_ARG}"
+
 
 case "${TARGET}" in
   "dev")

--- a/scripts/docker_build_push.sh
+++ b/scripts/docker_build_push.sh
@@ -69,7 +69,10 @@ else
 fi
 
 BUILD_ARG="3.9-slim-bookworm"
-MAIN_UNIQUE_TAG="${REPO_NAME}:${SHA}-${TARGET}-${BUILD_PLATFORM}-${BUILD_ARG}"
+
+# Replace '/' with '-' in BUILD_PLATFORM
+SAFE_BUILD_PLATFORM=$(echo "${BUILD_PLATFORM}" | sed 's/\//-/g')
+MAIN_UNIQUE_TAG="${REPO_NAME}:${SHA}-${TARGET}-${SAFE_BUILD_PLATFORM}-${BUILD_ARG}"
 
 
 case "${TARGET}" in


### PR DESCRIPTION
### SUMMARY
I noticed recently that we get many "double-triggers" of CI actions on some PRs, most notable on PRs opened from the main apache repo, triggering against the master branch (see screenshot bellow). This is typically one for the `push` action and one for the `pull_request` action, running effectively the exact same CI script twice. Note that I think the double triggers also on forks (I'd have to double check), but just doesn't show under the PR list of required CI steps, and is probably just associated with the fork of the user.

Anyhow, so I went through all the githbub workflows and applied more restrictions. In most cases we apply the main pattern:
```yaml
on:
  push:
    branches:
      - 'master'
  pull_request:
    types: [synchronize, opened, reopened, ready_for_review]
```
This will trigger for each change on the pull request, and for every commit as it merges on the `master` branch.

In some other cases, I added a `paths` statement where I knew we should only run a workflow given a certain obvious folder, like frontend tests should only run if we touch `superset-frontend/**` and such.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="595" alt="Screenshot 2024-01-23 at 10 32 13 AM" src="https://github.com/apache/superset/assets/487433/1cbf7f3e-4569-4162-8ce1-514674e7a5f0">

