### PR TITLE
fix(docker): credentials issues around superset-cache in forks

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,18 +15,20 @@ jobs:
     steps:
       - name: "Check for secrets"
         id: check
-        shell: bash
+        env:
+          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
-          if [ -n "${{ (secrets.DOCKERHUB_USER != '' && secrets.DOCKERHUB_TOKEN != '') || '' }}" ]; then
-            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+          if [[ -n "$DOCKERHUB_USER" && -n "$DOCKERHUB_TOKEN" ]]; then
+            echo "has-secrets=true" >> "$GITHUB_ENV"
             echo "has secrets!"
           else
-            echo "has-secrets=0" >> "$GITHUB_OUTPUT"
+            echo "has-secrets=false" >> "$GITHUB_ENV"
             echo "no secrets!"
           fi
   docker-build:
     needs: config
-    if: needs.config.outputs.has-secrets
+    if: needs.config.outputs.has-secrets == 'true'
     name: docker-build
     runs-on: ubuntu-latest
     strategy:

--- a/scripts/docker_build_push.sh
+++ b/scripts/docker_build_push.sh
@@ -131,6 +131,7 @@ if [[ -n "${BUILD_TARGET}" ]]; then
 fi
 
 CACHE_REF="${REPO_NAME}:cache-${TARGET}-${BUILD_ARG}"
+CACHE_REF="${REPO_NAME}"
 CACHE_REF=$(echo "${CACHE_REF}" | tr -d '.')
 
 docker buildx build \

--- a/scripts/docker_build_push.sh
+++ b/scripts/docker_build_push.sh
@@ -130,6 +130,7 @@ if [[ -n "${BUILD_TARGET}" ]]; then
   TARGET_ARGUMENT="--target ${BUILD_TARGET}"
 fi
 
+
 CACHE_REF="${REPO_NAME}-cache:${TARGET}-${BUILD_ARG}"
 CACHE_REF=$(echo "${CACHE_REF}" | tr -d '.')
 

--- a/scripts/docker_build_push.sh
+++ b/scripts/docker_build_push.sh
@@ -131,14 +131,15 @@ if [[ -n "${BUILD_TARGET}" ]]; then
 fi
 
 CACHE_REF="${REPO_NAME}:cache-${TARGET}-${BUILD_ARG}"
-CACHE_REF="${REPO_NAME}"
 CACHE_REF=$(echo "${CACHE_REF}" | tr -d '.')
+
+# TODO: Commenting out two flags until we figure out how to make this work in forks
+#--cache-from=type=registry,ref=${CACHE_REF} \
+#--cache-to=type=registry,mode=max,ref=${CACHE_REF} \
 
 docker buildx build \
   ${TARGET_ARGUMENT} \
   ${DOCKER_ARGS} \
-  --cache-from=type=registry,ref=${CACHE_REF} \
-  --cache-to=type=registry,mode=max,ref=${CACHE_REF} \
   ${DOCKER_TAGS} \
   --platform ${BUILD_PLATFORM} \
   --label "sha=${SHA}" \

--- a/scripts/docker_build_push.sh
+++ b/scripts/docker_build_push.sh
@@ -130,8 +130,7 @@ if [[ -n "${BUILD_TARGET}" ]]; then
   TARGET_ARGUMENT="--target ${BUILD_TARGET}"
 fi
 
-
-CACHE_REF="${REPO_NAME}-cache:${TARGET}-${BUILD_ARG}"
+CACHE_REF="${REPO_NAME}:cache-${TARGET}-${BUILD_ARG}"
 CACHE_REF=$(echo "${CACHE_REF}" | tr -d '.')
 
 docker buildx build \

--- a/scripts/docker_build_push.sh
+++ b/scripts/docker_build_push.sh
@@ -130,16 +130,14 @@ if [[ -n "${BUILD_TARGET}" ]]; then
   TARGET_ARGUMENT="--target ${BUILD_TARGET}"
 fi
 
-CACHE_REF="${REPO_NAME}:cache-${TARGET}-${BUILD_ARG}"
+CACHE_REF="${REPO_NAME}-cache:${TARGET}-${BUILD_ARG}"
 CACHE_REF=$(echo "${CACHE_REF}" | tr -d '.')
-
-# TODO: Commenting out two flags until we figure out how to make this work in forks
-#--cache-from=type=registry,ref=${CACHE_REF} \
-#--cache-to=type=registry,mode=max,ref=${CACHE_REF} \
 
 docker buildx build \
   ${TARGET_ARGUMENT} \
   ${DOCKER_ARGS} \
+  --cache-from=type=registry,ref=${CACHE_REF} \
+  --cache-to=type=registry,mode=max,ref=${CACHE_REF} \
   ${DOCKER_TAGS} \
   --platform ${BUILD_PLATFORM} \
   --label "sha=${SHA}" \


### PR DESCRIPTION
Fixing the docker builds after merging a PR where I was getting a false positive since it was directly location on the main fork. Now when rebasing and executing docker from forks we get errors messages.

The root cause was this: https://github.com/apache/superset/pull/26766/files#diff-bcd99032795eb96dd42d38ceeeec262f6d4ab3952e3dbfb75905763c116cd0d7R133-R134

Where I used the `apache/superset-cache` DockerHub instead of the main one, as it was recommended for optimization purposes. In this PR, I'll point it back to `apache/superset` after confirming the issue, so I can confirm the fix.

Error looked like this on cache-push:
```
#17 exporting cache to registry
#17 preparing build cache for export
#17 writing layer sha256:6574fa54520867ff3b1634aa74c4749441c37892c2ee032cf292b798e4ee6770
#17 preparing build cache for export 0.1s done
#17 writing layer sha256:6574fa54520867ff3b1634aa74c4749441c37892c2ee032cf292b798e4ee6770 0.1s done
#17 ERROR: error writing layer blob: failed to authorize: failed to fetch oauth token: unexpected status from GET request to https://auth.docker.io/token?scope=repository%3Aapache%2Fsuperset-cache%3Apull%2Cpush&service=registry.docker.io: 401 Unauthorized

#18 [auth] apache/superset-cache:pull,push token for registry-1.docker.io
#18 DONE 0.0s
------
 > exporting cache to registry:
------
ERROR: failed to solve: error writing layer blob: failed to authorize: failed to fetch oauth token: unexpected status from GET request to https://auth.docker.io/token?scope=repository%3Aapache%2Fsuperset-cache%3Apull%2Cpush&service=registry.docker.io: 401 Unauthorized
Error: Process completed with exit code 1.
```

This is confusing as we're able to push images and layers, but not use the hub as cache. Probably some permission setting of some kind. Though I think the security is a bit reversed, meaning people shouldn't be able to publish an actual image, say to `apache/superset:latest` from a fork, but the "using the repo as a cache" is less of an issue as no one would pull from random cache. Probably one for the ASF infra folks