### PR TITLE
chore: refactor the github actions has-secrets logic

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -64,6 +64,7 @@ github:
           - cypress-matrix (1, chrome)
           - cypress-matrix (2, chrome)
           - cypress-matrix (3, chrome)
+          - docker-build
           - frontend-build
           - pre-commit (3.9)
           - python-lint (3.9)

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -64,7 +64,6 @@ github:
           - cypress-matrix (1, chrome)
           - cypress-matrix (2, chrome)
           - cypress-matrix (3, chrome)
-          - docker-build
           - frontend-build
           - pre-commit (3.9)
           - python-lint (3.9)

--- a/.github/workflows/check-secrets.yml
+++ b/.github/workflows/check-secrets.yml
@@ -1,0 +1,22 @@
+name: Check Secrets
+
+on:
+  workflow_call:
+    inputs:
+      secret_name:
+        required: true
+        type: string
+
+jobs:
+  check-secrets:
+    runs-on: ubuntu-latest
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
+    steps:
+      - id: check
+        run: |
+          if [[ -n "${{ secrets[inputs.secret_name] }}" ]]; then
+            echo "has-secrets=true" >> "$GITHUB_ENV"
+          else
+            echo "has-secrets=false" >> "$GITHUB_ENV"
+          fi

--- a/.github/workflows/chromatic-master.yml
+++ b/.github/workflows/chromatic-master.yml
@@ -32,22 +32,13 @@ on:
 
 # List of jobs
 jobs:
-  config:
-    runs-on: "ubuntu-latest"
-    outputs:
-      has-secrets: ${{ steps.check.outputs.has-secrets }}
-    steps:
-      - name: "Check for secrets"
-        id: check
-        shell: bash
-        run: |
-          if [ -n "${{ (secrets.CHROMATIC_PROJECT_TOKEN != '') || '' }}" ]; then
-            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
-          fi
-
+  check-secrets:
+    uses: ./.github/workflows/check-secrets.yml
+    with:
+      secret_name: 'CHROMATIC_PROJECT_TOKEN'
   chromatic-deployment:
-    needs: config
-    if: needs.config.outputs.has-secrets
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     # Operating System
     runs-on: ubuntu-latest
     # Job steps

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -4,22 +4,13 @@ on:
   release:
     types: [published]
 jobs:
-  config:
-    runs-on: "ubuntu-latest"
-    outputs:
-      has-secrets: ${{ steps.check.outputs.has-secrets }}
-    steps:
-      - name: "Check for secrets"
-        id: check
-        shell: bash
-        run: |
-          if [ -n "${{ (secrets.DOCKERHUB_USER != '' && secrets.DOCKERHUB_TOKEN != '') || '' }}" ]; then
-            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
-          fi
-
+  check-secrets:
+    uses: ./.github/workflows/check-secrets.yml
+    with:
+      secret_name: 'DOCKERHUB_USER'
   docker-release:
-    needs: config
-    if: needs.config.outputs.has-secrets
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     name: docker-release
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,27 +8,14 @@ on:
     types: [synchronize, opened, reopened, ready_for_review]
 
 jobs:
-  config:
-    runs-on: "ubuntu-latest"
-    outputs:
-      has-secrets: ${{ steps.check.outputs.has-secrets }}
-    steps:
-      - name: "Check for secrets"
-        id: check
-        env:
-          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: |
-          if [[ -n "$DOCKERHUB_USER" && -n "$DOCKERHUB_TOKEN" ]]; then
-            echo "has-secrets=true" >> "$GITHUB_ENV"
-            echo "has secrets!"
-          else
-            echo "has-secrets=false" >> "$GITHUB_ENV"
-            echo "no secrets!"
-          fi
+  jobs:
+  check-secrets:
+    uses: ./.github/workflows/check-secrets.yml
+    with:
+      secret_name: 'DOCKERHUB_USER'
   docker-build:
-    needs: config
-    if: needs.config.outputs.has-secrets == 'true'
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     name: docker-build
     runs-on: ubuntu-latest
     strategy:
@@ -64,8 +51,8 @@ jobs:
           ./scripts/docker_build_push.sh "" ${{ matrix.target }} ${{ matrix.platform }}
 
   ephemeral-docker-build:
-    needs: config
-    if: needs.config.outputs.has-secrets
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     name: docker-build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ephemeral-env-pr-close.yml
+++ b/.github/workflows/ephemeral-env-pr-close.yml
@@ -5,22 +5,13 @@ on:
     types: [closed]
 
 jobs:
-  config:
-    runs-on: "ubuntu-latest"
-    outputs:
-      has-secrets: ${{ steps.check.outputs.has-secrets }}
-    steps:
-      - name: "Check for secrets"
-        id: check
-        shell: bash
-        run: |
-          if [ -n "${{ (secrets.AWS_ACCESS_KEY_ID != '' && secrets.AWS_SECRET_ACCESS_KEY != '') || '' }}" ]; then
-            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
-          fi
-
+  check-secrets:
+    uses: ./.github/workflows/check-secrets.yml
+    with:
+      secret_name: 'AWS_SECRET_ACCESS_KEY'
   ephemeral-env-cleanup:
-    needs: config
-    if: needs.config.outputs.has-secrets
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     name: Cleanup ephemeral envs
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ephemeral-env.yml
+++ b/.github/workflows/ephemeral-env.yml
@@ -5,23 +5,13 @@ on:
     types: [created]
 
 jobs:
-  config:
-    runs-on: "ubuntu-latest"
-    if: github.event.issue.pull_request
-    outputs:
-      has-secrets: ${{ steps.check.outputs.has-secrets }}
-    steps:
-      - name: "Check for secrets"
-        id: check
-        shell: bash
-        run: |
-          if [ -n "${{ (secrets.AWS_ACCESS_KEY_ID != '' && secrets.AWS_SECRET_ACCESS_KEY != '') || '' }}" ]; then
-            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
-          fi
-
+  check-secrets:
+    uses: ./.github/workflows/check-secrets.yml
+    with:
+      secret_name: 'AWS_SECRET_ACCESS_KEY'
   ephemeral_env_comment:
-    needs: config
-    if: needs.config.outputs.has-secrets
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     name: Evaluate ephemeral env comment trigger (/testenv)
     runs-on: ubuntu-latest
     permissions:
@@ -80,8 +70,8 @@ jobs:
           core.setFailed(errMsg)
 
   docker_ephemeral_env:
-    needs: config
-    if: needs.config.outputs.has-secrets
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     name: Push ephemeral env Docker image to ECR
     runs-on: ubuntu-latest
 

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -8,22 +8,13 @@ on:
     types: [synchronize, opened, reopened, ready_for_review]
 
 jobs:
-  config:
-    runs-on: "ubuntu-latest"
-    outputs:
-      has-secrets: ${{ steps.check.outputs.has-secrets }}
-    steps:
-      - name: "Check for secrets"
-        id: check
-        shell: bash
-        run: |
-          if [ -n "${{ (secrets.FOSSA_API_KEY != '' ) || '' }}" ]; then
-            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
-          fi
-
+  check-secrets:
+    uses: ./.github/workflows/check-secrets.yml
+    with:
+      secret_name: 'FOSSA_API_KEY'
   license_check:
-    needs: config
-    if: needs.config.outputs.has-secrets
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     name: License Check
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/no-op.yml
+++ b/.github/workflows/no-op.yml
@@ -31,6 +31,14 @@ jobs:
           echo "This is a no-op step for frontend-build to ensure a successful status."
           exit 0
 
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op for docker build
+        run: |
+          echo "This is a no-op step for frontend-build to ensure a successful status."
+          exit 0
+
   pre-commit:
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,22 +6,13 @@ on:
       - 'master'
 
 jobs:
-  config:
-    runs-on: "ubuntu-latest"
-    outputs:
-      has-secrets: ${{ steps.check.outputs.has-secrets }}
-    steps:
-      - name: "Check for secrets"
-        id: check
-        shell: bash
-        run: |
-          if [ -n "${{ (secrets.NPM_TOKEN != '' && secrets.GH_PERSONAL_ACCESS_TOKEN != '') || '' }}" ]; then
-            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
-          fi
-
+  check-secrets:
+    uses: ./.github/workflows/check-secrets.yml
+    with:
+      secret_name: 'NPM_TOKEN' # also note that GH_PERSONAL_ACCESS_TOKEN is used
   build:
-    needs: config
-    if: needs.config.outputs.has-secrets
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     name: Bump version and publish package(s)
 
     runs-on: ubuntu-20.04

--- a/.github/workflows/superset-applitool-cypress.yml
+++ b/.github/workflows/superset-applitool-cypress.yml
@@ -5,22 +5,13 @@ on:
     - cron: "0 1 * * *"
 
 jobs:
-  config:
-    runs-on: "ubuntu-latest"
-    outputs:
-      has-secrets: ${{ steps.check.outputs.has-secrets }}
-    steps:
-      - name: "Check for secrets"
-        id: check
-        shell: bash
-        run: |
-          if [ -n "${{ (secrets.APPLITOOLS_API_KEY != '' && secrets.APPLITOOLS_API_KEY != '') || '' }}" ]; then
-            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
-          fi
-
+  check-secrets:
+    uses: ./.github/workflows/check-secrets.yml
+    with:
+      secret_name: 'APPLITOOLS_API_KEY'
   cypress-applitools:
-    needs: config
-    if: needs.config.outputs.has-secrets
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false

--- a/.github/workflows/superset-applitools-storybook.yml
+++ b/.github/workflows/superset-applitools-storybook.yml
@@ -11,22 +11,13 @@ env:
   APPLITOOLS_BATCH_NAME: Superset Storybook
 
 jobs:
-  config:
-    runs-on: "ubuntu-latest"
-    outputs:
-      has-secrets: ${{ steps.check.outputs.has-secrets }}
-    steps:
-      - name: "Check for secrets"
-        id: check
-        shell: bash
-        run: |
-          if [ -n "${{ (secrets.APPLITOOLS_API_KEY != '' && secrets.APPLITOOLS_API_KEY != '') || '' }}" ]; then
-            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
-          fi
-
+  check-secrets:
+    uses: ./.github/workflows/check-secrets.yml
+    with:
+      secret_name: 'APPLITOOLS_API_KEY'
   cron:
-    needs: config
-    if: needs.config.outputs.has-secrets
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/superset-docs.yml
+++ b/.github/workflows/superset-docs.yml
@@ -12,22 +12,13 @@ on:
     types: [synchronize, opened, reopened, ready_for_review]
 
 jobs:
-  config:
-    runs-on: "ubuntu-latest"
-    outputs:
-      has-secrets: ${{ steps.check.outputs.has-secrets }}
-    steps:
-      - name: "Check for secrets"
-        id: check
-        shell: bash
-        run: |
-          if [ -n "${{ (secrets.SUPERSET_SITE_BUILD != '' && secrets.SUPERSET_SITE_BUILD != '') || '' }}" ]; then
-            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
-          fi
-
+  check-secrets:
+    uses: ./.github/workflows/check-secrets.yml
+    with:
+      secret_name: 'SUPERSET_SITE_BUILD'
   build-deploy:
-    needs: config
-    if: needs.config.outputs.has-secrets
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     name: Build & Deploy
     runs-on: ubuntu-20.04
     defaults:

--- a/.github/workflows/superset-translations.yml
+++ b/.github/workflows/superset-translations.yml
@@ -4,8 +4,12 @@ on:
   push:
     branches:
       - 'master'
+    paths:
+      - "superset-frontend/**"
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
+    paths:
+      - "superset-frontend/**"
 
 jobs:
   frontend-check:


### PR DESCRIPTION
While working on https://github.com/apache/superset/pull/26772, I realized that the has-secret logic was broken for unclear reasons. Now after doing this fix, I looked and realized that there's similar logic across about a dozen other gh actions, and thought it'd be a good thing to refactor/fix this with a reusable action.

Now many of these workflows are set to trigger on push-on-master only meaning it's less of an issue since a false positive on has-secret dpesn't matter in that context since there's always a secret.

I still thought I should refactor this to something we can trust and build upon.

The solution introduces this new simple reusable action.

One minor note is in cases where we need multiple secrets, as in say DOCKERHUB_TOKEN and DOCKERHUB_USER, we simply look at one and assume that's clear-enough of an indicator.
