### PR TITLE
chore: refactor the github actions has-secrets logic

### DIFF
--- a/.github/workflows/check-secrets.yml
+++ b/.github/workflows/check-secrets.yml
@@ -9,6 +9,7 @@ on:
     outputs:
       has-secrets:
         type: string
+        value: ''
 
 jobs:
   check-secrets:

--- a/.github/workflows/check-secrets.yml
+++ b/.github/workflows/check-secrets.yml
@@ -8,7 +8,6 @@ on:
         type: string
     outputs:
       has-secrets:
-        type: string
         value: ''
 
 jobs:

--- a/.github/workflows/check-secrets.yml
+++ b/.github/workflows/check-secrets.yml
@@ -17,6 +17,8 @@ jobs:
         run: |
           if [[ -n "${{ secrets[inputs.secret_name] }}" ]]; then
             echo "has-secrets=true" >> "$GITHUB_ENV"
+            echo "DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}"
           else
             echo "has-secrets=false" >> "$GITHUB_ENV"
+            echo "DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}"
           fi

--- a/.github/workflows/check-secrets.yml
+++ b/.github/workflows/check-secrets.yml
@@ -6,6 +6,9 @@ on:
       secret_name:
         required: true
         type: string
+    outputs:
+      has-secrets:
+        type: string
 
 jobs:
   check-secrets:

--- a/.github/workflows/check-secrets.yml
+++ b/.github/workflows/check-secrets.yml
@@ -8,19 +8,19 @@ on:
         type: string
     outputs:
       has-secrets:
-        value: ${{ jobs.example_job.outputs.output }}
+        value: ${{ jobs.example_job.outputs.has-secrets }}
 
 jobs:
   check:
     runs-on: ubuntu-latest
     outputs:
-      output: ${{ steps.check.outputs.output }}
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
     steps:
       - id: check
         run: |
           if [[ -n "${{ secrets[inputs.secret_name] }}" ]]; then
             echo "Secret for ${{ inputs.secret_name }} is available"
-            echo "output=true" >> $GITHUB_OUTPUT
+            echo "has-secrets=true" >> $GITHUB_OUTPUT
           else
             echo "Secret for ${{ inputs.secret_name }} is NOT available"
           fi

--- a/.github/workflows/check-secrets.yml
+++ b/.github/workflows/check-secrets.yml
@@ -16,8 +16,7 @@ jobs:
       - id: check
         run: |
           if [[ -n "${{ secrets[inputs.secret_name] }}" ]]; then
-            echo "has-secrets=true" >> "$GITHUB_ENV"
-          else
+            echo "has-secrets=1" >> "$GITHUB_ENV"
           fi
           echo "DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}"
           echo "FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}"

--- a/.github/workflows/check-secrets.yml
+++ b/.github/workflows/check-secrets.yml
@@ -8,10 +8,10 @@ on:
         type: string
     outputs:
       has-secrets:
-        value: ''
+        value: 'false'
 
 jobs:
-  check-secrets:
+  check:
     runs-on: ubuntu-latest
     outputs:
       has-secrets: ${{ steps.check.outputs.has-secrets }}
@@ -19,7 +19,7 @@ jobs:
       - id: check
         run: |
           if [[ -n "${{ secrets[inputs.secret_name] }}" ]]; then
-            echo "has-secrets=true" >> "$GITHUB_OUTPUT"
+            echo "has-secrets=true" >> $GITHUB_OUTPUT
             echo "Secret for ${{ inputs.secret_name }} is available"
           else
             echo "Secret for ${{ inputs.secret_name }} is NOT available"

--- a/.github/workflows/check-secrets.yml
+++ b/.github/workflows/check-secrets.yml
@@ -16,7 +16,7 @@ jobs:
       - id: check
         run: |
           if [[ -n "${{ secrets[inputs.secret_name] }}" ]]; then
-            echo "has-secrets=true" >> "$GITHUB_ENV"
+            echo "has-secrets=true" >> "$GITHUB_OUTPUT"
             echo "Secret for ${{ inputs.secret_name }} is available"
           else
             echo "Secret for ${{ inputs.secret_name }} is NOT available"

--- a/.github/workflows/check-secrets.yml
+++ b/.github/workflows/check-secrets.yml
@@ -1,0 +1,22 @@
+name: Check Secrets
+
+on:
+  workflow_call:
+    inputs:
+      secret_name:
+        required: true
+        type: string
+
+jobs:
+  check-secrets:
+    runs-on: ubuntu-latest
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
+    steps:
+      - id: check
+        run: |
+          if [[ -n "${{ secrets[inputs.secret_name] }}" ]]; then
+            echo "has-secrets=true" >> "$GITHUB_ENV"
+          else
+            echo "has-secrets=false" >> "$GITHUB_ENV"
+          fi

--- a/.github/workflows/check-secrets.yml
+++ b/.github/workflows/check-secrets.yml
@@ -16,5 +16,8 @@ jobs:
       - id: check
         run: |
           if [[ -n "${{ secrets[inputs.secret_name] }}" ]]; then
-            echo "has-secrets=1" >> "$GITHUB_ENV"
+            echo "has-secrets=true" >> "$GITHUB_ENV"
+            echo "Secret for ${{ inputs.secret_name }} is available"
+          else
+            echo "Secret for ${{ inputs.secret_name }} is NOT available"
           fi

--- a/.github/workflows/check-secrets.yml
+++ b/.github/workflows/check-secrets.yml
@@ -16,7 +16,7 @@ jobs:
       - id: check
         run: |
           if [[ -n "${{ secrets[inputs.secret_name] }}" ]]; then
-            echo "has-secrets=1" >> "$GITHUB_ENV"
+            echo "has-secrets=true" >> "$GITHUB_ENV"
             echo "Secret for ${{ inputs.secret_name }} is available"
           else
             echo "Secret for ${{ inputs.secret_name }} is NOT available"

--- a/.github/workflows/check-secrets.yml
+++ b/.github/workflows/check-secrets.yml
@@ -17,8 +17,7 @@ jobs:
         run: |
           if [[ -n "${{ secrets[inputs.secret_name] }}" ]]; then
             echo "has-secrets=true" >> "$GITHUB_ENV"
-            echo "DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}"
           else
-            echo "has-secrets=false" >> "$GITHUB_ENV"
-            echo "DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}"
           fi
+          echo "DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}"
+          echo "FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}"

--- a/.github/workflows/check-secrets.yml
+++ b/.github/workflows/check-secrets.yml
@@ -8,19 +8,19 @@ on:
         type: string
     outputs:
       has-secrets:
-        value: 'false'
+        value: ${{ jobs.example_job.outputs.output }}
 
 jobs:
   check:
     runs-on: ubuntu-latest
     outputs:
-      has-secrets: ${{ steps.check.outputs.has-secrets }}
+      output: ${{ steps.check.outputs.output }}
     steps:
       - id: check
         run: |
           if [[ -n "${{ secrets[inputs.secret_name] }}" ]]; then
-            echo "has-secrets=true" >> $GITHUB_OUTPUT
             echo "Secret for ${{ inputs.secret_name }} is available"
+            echo "output=true" >> $GITHUB_OUTPUT
           else
             echo "Secret for ${{ inputs.secret_name }} is NOT available"
           fi

--- a/.github/workflows/check-secrets.yml
+++ b/.github/workflows/check-secrets.yml
@@ -8,13 +8,13 @@ on:
         type: string
     outputs:
       hassecret:
-        value: ${{ jobs.example_job.outputs.hassecret }}
+        value: ${{ jobs.example_job.outputs.output1 }}
 
 jobs:
   check:
     runs-on: ubuntu-latest
     outputs:
-      hassecret: ${{ steps.check.outputs.hassecret }}
+      output1: ${{ steps.check.outputs.hassecret }}
     steps:
       - id: check
         run: |

--- a/.github/workflows/check-secrets.yml
+++ b/.github/workflows/check-secrets.yml
@@ -1,4 +1,4 @@
-name: Check Secrets
+name: Check hassecret
 
 on:
   workflow_call:
@@ -7,20 +7,20 @@ on:
         required: true
         type: string
     outputs:
-      has-secrets:
-        value: ${{ jobs.example_job.outputs.has-secrets }}
+      hassecret:
+        value: ${{ jobs.example_job.outputs.hassecret }}
 
 jobs:
   check:
     runs-on: ubuntu-latest
     outputs:
-      has-secrets: ${{ steps.check.outputs.has-secrets }}
+      hassecret: ${{ steps.check.outputs.hassecret }}
     steps:
       - id: check
         run: |
-          if [[ -n "${{ secrets[inputs.secret_name] }}" ]]; then
+          if [[ -n "${{ hassecret[inputs.secret_name] }}" ]]; then
             echo "Secret for ${{ inputs.secret_name }} is available"
-            echo "has-secrets=true" >> $GITHUB_OUTPUT
+            echo "hassecret=true" >> $GITHUB_OUTPUT
           else
             echo "Secret for ${{ inputs.secret_name }} is NOT available"
           fi

--- a/.github/workflows/check-secrets.yml
+++ b/.github/workflows/check-secrets.yml
@@ -18,5 +18,3 @@ jobs:
           if [[ -n "${{ secrets[inputs.secret_name] }}" ]]; then
             echo "has-secrets=1" >> "$GITHUB_ENV"
           fi
-          echo "DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}"
-          echo "FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}"

--- a/.github/workflows/check-secrets.yml
+++ b/.github/workflows/check-secrets.yml
@@ -16,7 +16,7 @@ jobs:
       - id: check
         run: |
           if [[ -n "${{ secrets[inputs.secret_name] }}" ]]; then
-            echo "has-secrets=true" >> "$GITHUB_ENV"
+            echo "has-secrets=1" >> "$GITHUB_ENV"
             echo "Secret for ${{ inputs.secret_name }} is available"
           else
             echo "Secret for ${{ inputs.secret_name }} is NOT available"

--- a/.github/workflows/check-secrets.yml
+++ b/.github/workflows/check-secrets.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - id: check
         run: |
-          if [[ -n "${{ hassecret[inputs.secret_name] }}" ]]; then
+          if [[ -n "${{ secrets[inputs.secret_name] }}" ]]; then
             echo "Secret for ${{ inputs.secret_name }} is available"
             echo "hassecret=true" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/chromatic-master.yml
+++ b/.github/workflows/chromatic-master.yml
@@ -36,9 +36,10 @@ jobs:
     uses: ./.github/workflows/check-secrets.yml
     with:
       secret_name: 'CHROMATIC_PROJECT_TOKEN'
+    secrets: inherit
   chromatic-deployment:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == 'true'
+    if: needs.check-secrets.outputs.has-secrets
     # Operating System
     runs-on: ubuntu-latest
     # Job steps

--- a/.github/workflows/chromatic-master.yml
+++ b/.github/workflows/chromatic-master.yml
@@ -39,7 +39,7 @@ jobs:
     secrets: inherit
   chromatic-deployment:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets
+    if: needs.check-secrets.outputs.has-secrets == "1"
     # Operating System
     runs-on: ubuntu-latest
     # Job steps

--- a/.github/workflows/chromatic-master.yml
+++ b/.github/workflows/chromatic-master.yml
@@ -39,7 +39,7 @@ jobs:
     secrets: inherit
   chromatic-deployment:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == '1'
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     # Operating System
     runs-on: ubuntu-latest
     # Job steps

--- a/.github/workflows/chromatic-master.yml
+++ b/.github/workflows/chromatic-master.yml
@@ -39,7 +39,7 @@ jobs:
     secrets: inherit
   chromatic-deployment:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == "1"
+    if: needs.check-secrets.outputs.has-secrets == '1'
     # Operating System
     runs-on: ubuntu-latest
     # Job steps

--- a/.github/workflows/chromatic-master.yml
+++ b/.github/workflows/chromatic-master.yml
@@ -32,22 +32,13 @@ on:
 
 # List of jobs
 jobs:
-  config:
-    runs-on: "ubuntu-latest"
-    outputs:
-      has-secrets: ${{ steps.check.outputs.has-secrets }}
-    steps:
-      - name: "Check for secrets"
-        id: check
-        shell: bash
-        run: |
-          if [ -n "${{ (secrets.CHROMATIC_PROJECT_TOKEN != '') || '' }}" ]; then
-            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
-          fi
-
+  check-secrets:
+    uses: ./.github/workflows/check-secrets.yml
+    with:
+      secret_name: 'CHROMATIC_PROJECT_TOKEN'
   chromatic-deployment:
-    needs: config
-    if: needs.config.outputs.has-secrets
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     # Operating System
     runs-on: ubuntu-latest
     # Job steps

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -8,9 +8,10 @@ jobs:
     uses: ./.github/workflows/check-secrets.yml
     with:
       secret_name: 'DOCKERHUB_USER'
+    secrets: inherit
   docker-release:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == 'true'
+    if: needs.check-secrets.outputs.has-secrets
     name: docker-release
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -4,22 +4,13 @@ on:
   release:
     types: [published]
 jobs:
-  config:
-    runs-on: "ubuntu-latest"
-    outputs:
-      has-secrets: ${{ steps.check.outputs.has-secrets }}
-    steps:
-      - name: "Check for secrets"
-        id: check
-        shell: bash
-        run: |
-          if [ -n "${{ (secrets.DOCKERHUB_USER != '' && secrets.DOCKERHUB_TOKEN != '') || '' }}" ]; then
-            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
-          fi
-
+  check-secrets:
+    uses: ./.github/workflows/check-secrets.yml
+    with:
+      secret_name: 'DOCKERHUB_USER'
   docker-release:
-    needs: config
-    if: needs.config.outputs.has-secrets
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     name: docker-release
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -11,7 +11,7 @@ jobs:
     secrets: inherit
   docker-release:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == '1'
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     name: docker-release
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -11,7 +11,7 @@ jobs:
     secrets: inherit
   docker-release:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets
+    if: needs.check-secrets.outputs.has-secrets == "1"
     name: docker-release
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -11,7 +11,7 @@ jobs:
     secrets: inherit
   docker-release:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == "1"
+    if: needs.check-secrets.outputs.has-secrets == '1'
     name: docker-release
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ephemeral-env-pr-close.yml
+++ b/.github/workflows/ephemeral-env-pr-close.yml
@@ -9,9 +9,10 @@ jobs:
     uses: ./.github/workflows/check-secrets.yml
     with:
       secret_name: 'AWS_SECRET_ACCESS_KEY'
+    secrets: inherit
   ephemeral-env-cleanup:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == 'true'
+    if: needs.check-secrets.outputs.has-secrets
     name: Cleanup ephemeral envs
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ephemeral-env-pr-close.yml
+++ b/.github/workflows/ephemeral-env-pr-close.yml
@@ -12,7 +12,7 @@ jobs:
     secrets: inherit
   ephemeral-env-cleanup:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == "1"
+    if: needs.check-secrets.outputs.has-secrets == '1'
     name: Cleanup ephemeral envs
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ephemeral-env-pr-close.yml
+++ b/.github/workflows/ephemeral-env-pr-close.yml
@@ -12,7 +12,7 @@ jobs:
     secrets: inherit
   ephemeral-env-cleanup:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == '1'
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     name: Cleanup ephemeral envs
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ephemeral-env-pr-close.yml
+++ b/.github/workflows/ephemeral-env-pr-close.yml
@@ -12,7 +12,7 @@ jobs:
     secrets: inherit
   ephemeral-env-cleanup:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets
+    if: needs.check-secrets.outputs.has-secrets == "1"
     name: Cleanup ephemeral envs
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ephemeral-env-pr-close.yml
+++ b/.github/workflows/ephemeral-env-pr-close.yml
@@ -5,22 +5,13 @@ on:
     types: [closed]
 
 jobs:
-  config:
-    runs-on: "ubuntu-latest"
-    outputs:
-      has-secrets: ${{ steps.check.outputs.has-secrets }}
-    steps:
-      - name: "Check for secrets"
-        id: check
-        shell: bash
-        run: |
-          if [ -n "${{ (secrets.AWS_ACCESS_KEY_ID != '' && secrets.AWS_SECRET_ACCESS_KEY != '') || '' }}" ]; then
-            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
-          fi
-
+  check-secrets:
+    uses: ./.github/workflows/check-secrets.yml
+    with:
+      secret_name: 'AWS_SECRET_ACCESS_KEY'
   ephemeral-env-cleanup:
-    needs: config
-    if: needs.config.outputs.has-secrets
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     name: Cleanup ephemeral envs
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ephemeral-env.yml
+++ b/.github/workflows/ephemeral-env.yml
@@ -12,7 +12,7 @@ jobs:
     secrets: inherit
   ephemeral_env_comment:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == "1"
+    if: needs.check-secrets.outputs.has-secrets == '1'
     name: Evaluate ephemeral env comment trigger (/testenv)
     runs-on: ubuntu-latest
     permissions:
@@ -72,7 +72,7 @@ jobs:
 
   docker_ephemeral_env:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == "1"
+    if: needs.check-secrets.outputs.has-secrets == '1'
     name: Push ephemeral env Docker image to ECR
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ephemeral-env.yml
+++ b/.github/workflows/ephemeral-env.yml
@@ -12,7 +12,7 @@ jobs:
     secrets: inherit
   ephemeral_env_comment:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets
+    if: needs.check-secrets.outputs.has-secrets == "1"
     name: Evaluate ephemeral env comment trigger (/testenv)
     runs-on: ubuntu-latest
     permissions:
@@ -72,7 +72,7 @@ jobs:
 
   docker_ephemeral_env:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets
+    if: needs.check-secrets.outputs.has-secrets == "1"
     name: Push ephemeral env Docker image to ECR
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ephemeral-env.yml
+++ b/.github/workflows/ephemeral-env.yml
@@ -9,9 +9,10 @@ jobs:
     uses: ./.github/workflows/check-secrets.yml
     with:
       secret_name: 'AWS_SECRET_ACCESS_KEY'
+    secrets: inherit
   ephemeral_env_comment:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == 'true'
+    if: needs.check-secrets.outputs.has-secrets
     name: Evaluate ephemeral env comment trigger (/testenv)
     runs-on: ubuntu-latest
     permissions:
@@ -71,7 +72,7 @@ jobs:
 
   docker_ephemeral_env:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == 'true'
+    if: needs.check-secrets.outputs.has-secrets
     name: Push ephemeral env Docker image to ECR
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ephemeral-env.yml
+++ b/.github/workflows/ephemeral-env.yml
@@ -12,7 +12,7 @@ jobs:
     secrets: inherit
   ephemeral_env_comment:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == '1'
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     name: Evaluate ephemeral env comment trigger (/testenv)
     runs-on: ubuntu-latest
     permissions:
@@ -72,7 +72,7 @@ jobs:
 
   docker_ephemeral_env:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == '1'
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     name: Push ephemeral env Docker image to ECR
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ephemeral-env.yml
+++ b/.github/workflows/ephemeral-env.yml
@@ -5,23 +5,13 @@ on:
     types: [created]
 
 jobs:
-  config:
-    runs-on: "ubuntu-latest"
-    if: github.event.issue.pull_request
-    outputs:
-      has-secrets: ${{ steps.check.outputs.has-secrets }}
-    steps:
-      - name: "Check for secrets"
-        id: check
-        shell: bash
-        run: |
-          if [ -n "${{ (secrets.AWS_ACCESS_KEY_ID != '' && secrets.AWS_SECRET_ACCESS_KEY != '') || '' }}" ]; then
-            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
-          fi
-
+  check-secrets:
+    uses: ./.github/workflows/check-secrets.yml
+    with:
+      secret_name: 'AWS_SECRET_ACCESS_KEY'
   ephemeral_env_comment:
-    needs: config
-    if: needs.config.outputs.has-secrets
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     name: Evaluate ephemeral env comment trigger (/testenv)
     runs-on: ubuntu-latest
     permissions:
@@ -80,8 +70,8 @@ jobs:
           core.setFailed(errMsg)
 
   docker_ephemeral_env:
-    needs: config
-    if: needs.config.outputs.has-secrets
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     name: Push ephemeral env Docker image to ECR
     runs-on: ubuntu-latest
 

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -15,7 +15,7 @@ jobs:
     secrets: inherit
   license_check:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == "1"
+    if: needs.check-secrets.outputs.has-secrets == '1'
     name: License Check
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -15,7 +15,7 @@ jobs:
     secrets: inherit
   license_check:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets
+    if: needs.check-secrets.outputs.has-secrets == "1"
     name: License Check
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -15,7 +15,7 @@ jobs:
     secrets: inherit
   license_check:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == 'true'
+    if: needs.check-secrets.outputs.has-secrets
     name: License Check
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -15,7 +15,7 @@ jobs:
     secrets: inherit
   license_check:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == '1'
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     name: License Check
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -8,22 +8,13 @@ on:
     types: [synchronize, opened, reopened, ready_for_review]
 
 jobs:
-  config:
-    runs-on: "ubuntu-latest"
-    outputs:
-      has-secrets: ${{ steps.check.outputs.has-secrets }}
-    steps:
-      - name: "Check for secrets"
-        id: check
-        shell: bash
-        run: |
-          if [ -n "${{ (secrets.FOSSA_API_KEY != '' ) || '' }}" ]; then
-            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
-          fi
-
+  check-secrets:
+    uses: ./.github/workflows/check-secrets.yml
+    with:
+      secret_name: 'FOSSA_API_KEY'
   license_check:
-    needs: config
-    if: needs.config.outputs.has-secrets
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     name: License Check
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -12,6 +12,7 @@ jobs:
     uses: ./.github/workflows/check-secrets.yml
     with:
       secret_name: 'FOSSA_API_KEY'
+    secrets: inherit
   license_check:
     needs: check-secrets
     if: needs.check-secrets.outputs.has-secrets == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,10 @@ jobs:
     uses: ./.github/workflows/check-secrets.yml
     with:
       secret_name: 'NPM_TOKEN' # also note that GH_PERSONAL_ACCESS_TOKEN is used
+    secrets: inherit
   build:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == 'true'
+    if: needs.check-secrets.outputs.has-secrets
     name: Bump version and publish package(s)
 
     runs-on: ubuntu-20.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     secrets: inherit
   build:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == '1'
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     name: Bump version and publish package(s)
 
     runs-on: ubuntu-20.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     secrets: inherit
   build:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets
+    if: needs.check-secrets.outputs.has-secrets == "1"
     name: Bump version and publish package(s)
 
     runs-on: ubuntu-20.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,22 +6,13 @@ on:
       - 'master'
 
 jobs:
-  config:
-    runs-on: "ubuntu-latest"
-    outputs:
-      has-secrets: ${{ steps.check.outputs.has-secrets }}
-    steps:
-      - name: "Check for secrets"
-        id: check
-        shell: bash
-        run: |
-          if [ -n "${{ (secrets.NPM_TOKEN != '' && secrets.GH_PERSONAL_ACCESS_TOKEN != '') || '' }}" ]; then
-            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
-          fi
-
+  check-secrets:
+    uses: ./.github/workflows/check-secrets.yml
+    with:
+      secret_name: 'NPM_TOKEN' # also note that GH_PERSONAL_ACCESS_TOKEN is used
   build:
-    needs: config
-    if: needs.config.outputs.has-secrets
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     name: Bump version and publish package(s)
 
     runs-on: ubuntu-20.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     secrets: inherit
   build:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == "1"
+    if: needs.check-secrets.outputs.has-secrets == '1'
     name: Bump version and publish package(s)
 
     runs-on: ubuntu-20.04

--- a/.github/workflows/superset-applitool-cypress.yml
+++ b/.github/workflows/superset-applitool-cypress.yml
@@ -9,9 +9,10 @@ jobs:
     uses: ./.github/workflows/check-secrets.yml
     with:
       secret_name: 'APPLITOOLS_API_KEY'
+    secrets: inherit
   cypress-applitools:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == 'true'
+    if: needs.check-secrets.outputs.has-secrets
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false

--- a/.github/workflows/superset-applitool-cypress.yml
+++ b/.github/workflows/superset-applitool-cypress.yml
@@ -12,7 +12,7 @@ jobs:
     secrets: inherit
   cypress-applitools:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == "1"
+    if: needs.check-secrets.outputs.has-secrets == '1'
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false

--- a/.github/workflows/superset-applitool-cypress.yml
+++ b/.github/workflows/superset-applitool-cypress.yml
@@ -12,7 +12,7 @@ jobs:
     secrets: inherit
   cypress-applitools:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == '1'
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false

--- a/.github/workflows/superset-applitool-cypress.yml
+++ b/.github/workflows/superset-applitool-cypress.yml
@@ -12,7 +12,7 @@ jobs:
     secrets: inherit
   cypress-applitools:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets
+    if: needs.check-secrets.outputs.has-secrets == "1"
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false

--- a/.github/workflows/superset-applitool-cypress.yml
+++ b/.github/workflows/superset-applitool-cypress.yml
@@ -5,22 +5,13 @@ on:
     - cron: "0 1 * * *"
 
 jobs:
-  config:
-    runs-on: "ubuntu-latest"
-    outputs:
-      has-secrets: ${{ steps.check.outputs.has-secrets }}
-    steps:
-      - name: "Check for secrets"
-        id: check
-        shell: bash
-        run: |
-          if [ -n "${{ (secrets.APPLITOOLS_API_KEY != '' && secrets.APPLITOOLS_API_KEY != '') || '' }}" ]; then
-            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
-          fi
-
+  check-secrets:
+    uses: ./.github/workflows/check-secrets.yml
+    with:
+      secret_name: 'APPLITOOLS_API_KEY'
   cypress-applitools:
-    needs: config
-    if: needs.config.outputs.has-secrets
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false

--- a/.github/workflows/superset-applitools-storybook.yml
+++ b/.github/workflows/superset-applitools-storybook.yml
@@ -18,7 +18,7 @@ jobs:
     secrets: inherit
   cron:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == '1'
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/superset-applitools-storybook.yml
+++ b/.github/workflows/superset-applitools-storybook.yml
@@ -15,9 +15,10 @@ jobs:
     uses: ./.github/workflows/check-secrets.yml
     with:
       secret_name: 'APPLITOOLS_API_KEY'
+    secrets: inherit
   cron:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == 'true'
+    if: needs.check-secrets.outputs.has-secrets
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/superset-applitools-storybook.yml
+++ b/.github/workflows/superset-applitools-storybook.yml
@@ -18,7 +18,7 @@ jobs:
     secrets: inherit
   cron:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == "1"
+    if: needs.check-secrets.outputs.has-secrets == '1'
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/superset-applitools-storybook.yml
+++ b/.github/workflows/superset-applitools-storybook.yml
@@ -11,22 +11,13 @@ env:
   APPLITOOLS_BATCH_NAME: Superset Storybook
 
 jobs:
-  config:
-    runs-on: "ubuntu-latest"
-    outputs:
-      has-secrets: ${{ steps.check.outputs.has-secrets }}
-    steps:
-      - name: "Check for secrets"
-        id: check
-        shell: bash
-        run: |
-          if [ -n "${{ (secrets.APPLITOOLS_API_KEY != '' && secrets.APPLITOOLS_API_KEY != '') || '' }}" ]; then
-            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
-          fi
-
+  check-secrets:
+    uses: ./.github/workflows/check-secrets.yml
+    with:
+      secret_name: 'APPLITOOLS_API_KEY'
   cron:
-    needs: config
-    if: needs.config.outputs.has-secrets
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/superset-applitools-storybook.yml
+++ b/.github/workflows/superset-applitools-storybook.yml
@@ -18,7 +18,7 @@ jobs:
     secrets: inherit
   cron:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets
+    if: needs.check-secrets.outputs.has-secrets == "1"
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/superset-docs.yml
+++ b/.github/workflows/superset-docs.yml
@@ -19,7 +19,7 @@ jobs:
     secrets: inherit
   build-deploy:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == "true"
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     name: Build & Deploy
     runs-on: ubuntu-20.04
     defaults:

--- a/.github/workflows/superset-docs.yml
+++ b/.github/workflows/superset-docs.yml
@@ -19,7 +19,7 @@ jobs:
     secrets: inherit
   build-deploy:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == 'true'
+    if: needs.check-secrets.outputs.has-secrets
     name: Build & Deploy
     runs-on: ubuntu-20.04
     defaults:

--- a/.github/workflows/superset-docs.yml
+++ b/.github/workflows/superset-docs.yml
@@ -16,9 +16,10 @@ jobs:
     uses: ./.github/workflows/check-secrets.yml
     with:
       secret_name: 'SUPERSET_SITE_BUILD'
+    secrets: inherit
   build-deploy:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == 'true'
+    if: needs.check-secrets.outputs.has-secrets
     name: Build & Deploy
     runs-on: ubuntu-20.04
     defaults:

--- a/.github/workflows/superset-docs.yml
+++ b/.github/workflows/superset-docs.yml
@@ -19,7 +19,7 @@ jobs:
     secrets: inherit
   build-deploy:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == 'true'
+    if: needs.check-secrets.outputs.hassecret == 'true'
     name: Build & Deploy
     runs-on: ubuntu-20.04
     defaults:

--- a/.github/workflows/superset-docs.yml
+++ b/.github/workflows/superset-docs.yml
@@ -19,7 +19,7 @@ jobs:
     secrets: inherit
   build-deploy:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets
+    #if: needs.check-secrets.outputs.has-secrets
     name: Build & Deploy
     runs-on: ubuntu-20.04
     defaults:

--- a/.github/workflows/superset-docs.yml
+++ b/.github/workflows/superset-docs.yml
@@ -19,33 +19,13 @@ jobs:
     secrets: inherit
   build-deploy:
     needs: check-secrets
-    if: needs.check-secrets.outputs.hassecret == 'true'
+      #if: needs.check-secrets.outputs.hassecret == 'true'
     name: Build & Deploy
     runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: docs
     steps:
-      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-          submodules: recursive
       - name: yarn install
         run: |
-          yarn install --check-cache
-      - name: yarn build
-        run: |
-          yarn build
-      - name: deploy docs
-        if: github.ref == 'refs/heads/master'
-        uses: ./.github/actions/github-action-push-to-another-repository
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.SUPERSET_SITE_BUILD }}
-        with:
-          source-directory: './docs/build'
-          destination-github-username: 'apache'
-          destination-repository-name: 'superset-site'
-          target-branch: 'asf-site'
-          commit-message: "deploying docs: ${{ github.event.head_commit.message }} (apache/superset@${{ github.sha }})"
-          user-email: dev@superset.apache.org
+          echo ${{needs.check-secrets.outputs.hassecret }}

--- a/.github/workflows/superset-docs.yml
+++ b/.github/workflows/superset-docs.yml
@@ -19,7 +19,7 @@ jobs:
     secrets: inherit
   build-deploy:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == '1'
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     name: Build & Deploy
     runs-on: ubuntu-20.04
     defaults:

--- a/.github/workflows/superset-docs.yml
+++ b/.github/workflows/superset-docs.yml
@@ -19,7 +19,7 @@ jobs:
     secrets: inherit
   build-deploy:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets
+    if: needs.check-secrets.outputs.has-secrets == "true"
     name: Build & Deploy
     runs-on: ubuntu-20.04
     defaults:

--- a/.github/workflows/superset-docs.yml
+++ b/.github/workflows/superset-docs.yml
@@ -19,7 +19,7 @@ jobs:
     secrets: inherit
   build-deploy:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets == "1"
+    if: needs.check-secrets.outputs.has-secrets == '1'
     name: Build & Deploy
     runs-on: ubuntu-20.04
     defaults:

--- a/.github/workflows/superset-docs.yml
+++ b/.github/workflows/superset-docs.yml
@@ -19,7 +19,7 @@ jobs:
     secrets: inherit
   build-deploy:
     needs: check-secrets
-    if: needs.check-secrets.outputs.has-secrets
+    if: needs.check-secrets.outputs.has-secrets == "1"
     name: Build & Deploy
     runs-on: ubuntu-20.04
     defaults:

--- a/.github/workflows/superset-docs.yml
+++ b/.github/workflows/superset-docs.yml
@@ -19,7 +19,7 @@ jobs:
     secrets: inherit
   build-deploy:
     needs: check-secrets
-    #if: needs.check-secrets.outputs.has-secrets
+    if: needs.check-secrets.outputs.has-secrets
     name: Build & Deploy
     runs-on: ubuntu-20.04
     defaults:

--- a/.github/workflows/superset-docs.yml
+++ b/.github/workflows/superset-docs.yml
@@ -12,22 +12,13 @@ on:
     types: [synchronize, opened, reopened, ready_for_review]
 
 jobs:
-  config:
-    runs-on: "ubuntu-latest"
-    outputs:
-      has-secrets: ${{ steps.check.outputs.has-secrets }}
-    steps:
-      - name: "Check for secrets"
-        id: check
-        shell: bash
-        run: |
-          if [ -n "${{ (secrets.SUPERSET_SITE_BUILD != '' && secrets.SUPERSET_SITE_BUILD != '') || '' }}" ]; then
-            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
-          fi
-
+  check-secrets:
+    uses: ./.github/workflows/check-secrets.yml
+    with:
+      secret_name: 'SUPERSET_SITE_BUILD'
   build-deploy:
-    needs: config
-    if: needs.config.outputs.has-secrets
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     name: Build & Deploy
     runs-on: ubuntu-20.04
     defaults:

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,5 +16,4 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-
 This is the public documentation site for Superset, built using [Docusaurus 2](https://docusaurus.io/). See [CONTRIBUTING.md](../CONTRIBUTING.md#documentation) for documentation on contributing to documentation.


### PR DESCRIPTION
[reopening] While working on https://github.com/apache/superset/pull/26772, I realized that the has-secret logic was broken for unclear reasons. Now after doing this fix, I looked and realized that there's similar logic across about a dozen other gh actions, and thought it'd be a good thing to refactor/fix this with a reusable action.

Now many of these workflows are set to trigger on push-on-master only meaning it's less of an issue since a false positive on has-secret dpesn't matter in that context since there's always a secret.

I still thought I should refactor this to something we can trust and build upon.

The solution introduces this new simple reusable action.

One minor note is in cases where we need multiple secrets, as in say DOCKERHUB_TOKEN and DOCKERHUB_USER, we simply look at one and assume that's clear-enough of an indicator.