### PR TITLE
fix: docker should always run, even in forks

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,27 +8,7 @@ on:
     types: [synchronize, opened, reopened, ready_for_review]
 
 jobs:
-  config:
-    runs-on: "ubuntu-latest"
-    outputs:
-      has-secrets: ${{ steps.check.outputs.has-secrets }}
-    steps:
-      - name: "Check for secrets"
-        id: check
-        env:
-          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: |
-          if [[ -n "$DOCKERHUB_USER" && -n "$DOCKERHUB_TOKEN" ]]; then
-            echo "has-secrets=true" >> "$GITHUB_ENV"
-            echo "has secrets!"
-          else
-            echo "has-secrets=false" >> "$GITHUB_ENV"
-            echo "no secrets!"
-          fi
   docker-build:
-    needs: config
-    if: needs.config.outputs.has-secrets == 'true'
     name: docker-build
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,8 +44,6 @@ jobs:
           ./scripts/docker_build_push.sh "" ${{ matrix.target }} ${{ matrix.platform }}
 
   ephemeral-docker-build:
-    needs: config
-    if: needs.config.outputs.has-secrets
     name: docker-build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,6 +43,7 @@ jobs:
         run: |
           ./scripts/docker_build_push.sh "" ${{ matrix.target }} ${{ matrix.platform }}
 
+
   ephemeral-docker-build:
     name: docker-build
     runs-on: ubuntu-latest

--- a/scripts/docker_build_push.sh
+++ b/scripts/docker_build_push.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-    needs: config
-    if: needs.config.outputs.has-secrets == 'true'
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/scripts/docker_build_push.sh
+++ b/scripts/docker_build_push.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+    needs: config
+    if: needs.config.outputs.has-secrets == 'true'
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/scripts/docker_build_push.sh
+++ b/scripts/docker_build_push.sh
@@ -132,15 +132,22 @@ if [[ -n "${BUILD_TARGET}" ]]; then
   TARGET_ARGUMENT="--target ${BUILD_TARGET}"
 fi
 
+# Building the cache settings
 CACHE_REF="${REPO_NAME}-cache:${TARGET}-${BUILD_ARG}"
 CACHE_REF=$(echo "${CACHE_REF}" | tr -d '.')
+CACHE_FROM_ARG="--cache-from=type=registry,ref=${CACHE_REF}"
+CACHE_TO_ARG=""
+if [ -z "${DOCKERHUB_TOKEN}" ]; then
+  # need to be logged in to push to the cache
+  CACHE_TO_ARG="--cache-to=type=registry,mode=max,ref=${CACHE_REF}"
+fi
 
 docker buildx build \
   ${TARGET_ARGUMENT} \
   ${DOCKER_ARGS} \
-  --cache-from=type=registry,ref=${CACHE_REF} \
-  --cache-to=type=registry,mode=max,ref=${CACHE_REF} \
   ${DOCKER_TAGS} \
+  ${CACHE_FROM_ARG} \
+  ${CACHE_TO_ARG} \
   --platform ${BUILD_PLATFORM} \
   --label "sha=${SHA}" \
   --label "built_at=$(date)" \

--- a/scripts/docker_build_push.sh
+++ b/scripts/docker_build_push.sh
@@ -137,7 +137,7 @@ CACHE_REF="${REPO_NAME}-cache:${TARGET}-${BUILD_ARG}"
 CACHE_REF=$(echo "${CACHE_REF}" | tr -d '.')
 CACHE_FROM_ARG="--cache-from=type=registry,ref=${CACHE_REF}"
 CACHE_TO_ARG=""
-if [ -z "${DOCKERHUB_TOKEN}" ]; then
+if [ -n "${DOCKERHUB_TOKEN}" ]; then
   # need to be logged in to push to the cache
   CACHE_TO_ARG="--cache-to=type=registry,mode=max,ref=${CACHE_REF}"
 fi


### PR DESCRIPTION
Realized that docker build should always runs, and simply not `--push` if we're not in `master` / don't have the creds. The logic in the bash script already exists for that.

After this PR, docker will always run, though outside of the main fork, it won't push to docker hub.

### Testing
Using this PR, that is against the main fork, I validated that:
- the docker build matrix is triggered properly
- the docker command `--push` to the repo
- check cache settings

Using the sibling PR https://github.com/apache/superset/pull/26802 that is identical but against a fork, I validated that:
- same as above, except that the docker command does `--load`
- check that `--cache-to` is NOT set