### PR TITLE
fix(time-series table): Can't compare from the beginning of the time range

### DIFF
--- a/superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/TimeSeriesColumnControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/TimeSeriesColumnControl.test.tsx
@@ -104,6 +104,19 @@ test('triggers onChange when time lag changes', () => {
   expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ timeLag }));
 });
 
+test('time lag allows negative values', () => {
+  const timeLag = '-1';
+  const onChange = jest.fn();
+  render(<TimeSeriesColumnControl colType="time" onChange={onChange} />);
+  userEvent.click(screen.getByRole('button'));
+  const timeLagInput = screen.getByPlaceholderText('Time Lag');
+  userEvent.clear(timeLagInput);
+  userEvent.type(timeLagInput, timeLag);
+  expect(onChange).not.toHaveBeenCalled();
+  userEvent.click(screen.getByRole('button', { name: 'Save' }));
+  expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ timeLag }));
+});
+
 test('triggers onChange when color bounds changes', () => {
   const min = 1;
   const max = 5;

--- a/superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/index.jsx
@@ -248,7 +248,9 @@ export default class TimeSeriesColumnControl extends React.Component {
         {['time', 'avg'].indexOf(this.state.colType) >= 0 &&
           this.formRow(
             t('Time lag'),
-            t('Number of periods to compare against'),
+            t(
+              'Number of periods to compare against. You can use negative numbers to compare from the beginning of the time range.',
+            ),
             'time-lag',
             <Input
               value={this.state.timeLag}

--- a/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
+++ b/superset-frontend/src/visualizations/TimeTable/TimeTable.jsx
@@ -181,11 +181,13 @@ const TimeTable = ({
       let v;
       let errorMsg;
       if (column.colType === 'time') {
-        // Time lag ratio
+        // If time lag is negative, we compare from the beginning of the data
         const timeLag = column.timeLag || 0;
         const totalLag = Object.keys(reversedEntries).length;
-        if (timeLag >= totalLag) {
+        if (Math.abs(timeLag) >= totalLag) {
           errorMsg = `The time lag set at ${timeLag} is too large for the length of data at ${reversedEntries.length}. No data available.`;
+        } else if (timeLag < 0) {
+          v = reversedEntries[totalLag + timeLag][valueField];
         } else {
           v = reversedEntries[timeLag][valueField];
         }


### PR DESCRIPTION
### SUMMARY
When using the Time-series table chart, many times users want to compare the current value of a metric with the beginning of the time range. The problem is that the time lag is a fixed number of periods calculated from the last data point, and as time advances, users lose the initial reference, making it impossible to compare a value agains the beginning of the time range. This PR fixes this problem by allowing negative time lag values which will calculate the time period starting from the beginning of the time range, increasing the chart's flexibility. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://github.com/apache/superset/assets/70410625/dd5daaab-7573-4c5e-a94c-f8a330837d25

### TESTING INSTRUCTIONS
Check the video for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
