### PR TITLE
chore: add google-auth for new example dashboard

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -38,6 +38,8 @@ cachelib==0.9.0
     # via
     #   flask-caching
     #   flask-session
+cachetools==5.3.2
+    # via google-auth
 cattrs==23.2.1
     # via requests-cache
 celery==5.3.6
@@ -88,6 +90,8 @@ dnspython==2.1.0
     # via email-validator
 email-validator==1.1.3
     # via flask-appbuilder
+exceptiongroup==1.2.0
+    # via cattrs
 flask==2.2.5
     # via
     #   apache-superset
@@ -138,6 +142,8 @@ geographiclib==1.52
     # via geopy
 geopy==2.2.0
     # via apache-superset
+google-auth==2.27.0
+    # via shillelagh
 greenlet==2.0.2
     # via
     #   shillelagh
@@ -155,7 +161,10 @@ idna==3.2
     #   email-validator
     #   requests
 importlib-metadata==6.6.0
-    # via apache-superset
+    # via
+    #   apache-superset
+    #   flask
+    #   shillelagh
 importlib-resources==5.12.0
     # via limits
 isodate==0.6.0
@@ -245,6 +254,12 @@ prompt-toolkit==3.0.38
     # via click-repl
 pyarrow==14.0.1
     # via apache-superset
+pyasn1==0.5.1
+    # via
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.3.0
+    # via google-auth
 pycparser==2.20
     # via cffi
 pygments==2.15.0
@@ -295,9 +310,11 @@ requests-cache==1.1.1
     # via shillelagh
 rich==13.3.4
     # via flask-limiter
+rsa==4.9
+    # via google-auth
 selenium==3.141.0
     # via apache-superset
-shillelagh==1.2.10
+shillelagh[gsheetsapi]==1.2.10
     # via apache-superset
 shortid==0.1.2
     # via apache-superset
@@ -338,7 +355,9 @@ tabulate==0.8.9
 typing-extensions==4.4.0
     # via
     #   apache-superset
+    #   cattrs
     #   flask-limiter
+    #   kombu
     #   limits
     #   shillelagh
 tzdata==2023.3
@@ -379,7 +398,9 @@ wtforms-json==0.3.5
 xlsxwriter==3.0.7
     # via apache-superset
 zipp==3.15.0
-    # via importlib-metadata
+    # via
+    #   importlib-metadata
+    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -82,12 +82,10 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyasn1==0.5.0
+pure-sasl==0.6.2
     # via
-    #   pyasn1-modules
-    #   python-ldap
-pyasn1-modules==0.3.0
-    # via python-ldap
+    #   pyhive
+    #   thrift-sasl
 pydruid==0.6.5
     # via apache-superset
 pyhive[hive_pure_sasl]==0.7.0
@@ -111,7 +109,14 @@ tableschema==1.20.2
 tabulator==1.53.5
     # via tableschema
 thrift==0.16.0
-    # via apache-superset
+    # via
+    #   apache-superset
+    #   pyhive
+    #   thrift-sasl
+thrift-sasl==0.4.3
+    # via pyhive
+tomli==2.0.1
+    # via pylint
 tomlkit==0.11.8
     # via pylint
 traitlets==5.9.0

--- a/requirements/integration.txt
+++ b/requirements/integration.txt
@@ -7,7 +7,7 @@
 #
 build==0.10.0
     # via pip-tools
-cachetools==5.3.1
+cachetools==5.3.2
     # via tox
 cfgv==3.3.1
     # via pre-commit
@@ -52,6 +52,12 @@ pyproject-hooks==1.0.0
     # via build
 pyyaml==6.0.1
     # via pre-commit
+tomli==2.0.1
+    # via
+    #   build
+    #   pip-tools
+    #   pyproject-api
+    #   tox
 toposort==1.10
     # via pip-compile-multi
 tox==4.6.4

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -37,14 +37,6 @@ google-api-core[grpc]==2.11.0
     #   google-cloud-core
     #   pandas-gbq
     #   sqlalchemy-bigquery
-google-auth==2.17.3
-    # via
-    #   google-api-core
-    #   google-auth-oauthlib
-    #   google-cloud-core
-    #   pandas-gbq
-    #   pydata-google-auth
-    #   sqlalchemy-bigquery
 google-auth-oauthlib==1.0.0
     # via
     #   pandas-gbq
@@ -132,8 +124,6 @@ requests-oauthlib==1.3.1
     # via google-auth-oauthlib
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
-rsa==4.9
-    # via google-auth
 sqlalchemy-bigquery==1.6.1
     # via apache-superset
 statsd==4.0.1

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ setup(
         "PyJWT>=2.4.0, <3.0",
         "redis>=4.5.4, <5.0",
         "selenium>=3.141.0, <4.10.0",
-        "shillelagh>=1.2.10, <2.0",
+        "shillelagh[gsheetsapi]>=1.2.10, <2.0",
         "shortid",
         "sshtunnel>=0.4.0, <0.5",
         "simplejson>=3.15.0",
@@ -192,9 +192,7 @@ setup(
         "prophet": ["prophet>=1.1.5, <2"],
         "redshift": ["sqlalchemy-redshift>=0.8.1, <0.9"],
         "rockset": ["rockset-sqlalchemy>=0.0.1, <1"],
-        "shillelagh": [
-            "shillelagh[datasetteapi,gsheetsapi,socrata,weatherapi]>=1.2.10, <2"
-        ],
+        "shillelagh": ["shillelagh[all]>=1.2.10, <2"],
         "snowflake": ["snowflake-sqlalchemy>=1.2.4, <2"],
         "spark": [
             "pyhive[hive]>=0.6.5;python_version<'3.11'",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add the `google-auth` (via `shillelagh[gsheetsapi]`) so that we can have Evan's fancy dashboard (https://github.com/apache/superset/pull/26442) as an example in new Superset installs.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
