### PR TITLE
chore(CI): get docs building on ALL branches.

### DIFF
--- a/.github/workflows/superset-docs-deploy.yml
+++ b/.github/workflows/superset-docs-deploy.yml
@@ -1,12 +1,29 @@
-name: Docs Testing
+name: Docs Deployment
 
 on:
-  pull_request:
+  push:
     paths:
       - "docs/**"
-    types: [synchronize, opened, reopened, ready_for_review]
+    branches:
+      - "master"
+
 jobs:
+  config:
+    runs-on: "ubuntu-latest"
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
+    steps:
+      - name: "Check for secrets"
+        id: check
+        shell: bash
+        run: |
+          if [ -n "${{ (secrets.SUPERSET_SITE_BUILD != '' && secrets.SUPERSET_SITE_BUILD != '') || '' }}" ]; then
+            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+          fi
+
   build-deploy:
+    needs: config
+    if: needs.config.outputs.has-secrets
     name: Build & Deploy
     runs-on: ubuntu-20.04
     defaults:
@@ -21,9 +38,18 @@ jobs:
       - name: yarn install
         run: |
           yarn install --check-cache
-      - name: yarn typecheck
-        run: |
-          yarn typecheck
       - name: yarn build
         run: |
           yarn build
+      - name: deploy docs
+        if: github.ref == 'refs/heads/master'
+        uses: ./.github/actions/github-action-push-to-another-repository
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.SUPERSET_SITE_BUILD }}
+        with:
+          source-directory: "./docs/build"
+          destination-github-username: "apache"
+          destination-repository-name: "superset-site"
+          target-branch: "asf-site"
+          commit-message: "deploying docs: ${{ github.event.head_commit.message }} (apache/superset@${{ github.sha }})"
+          user-email: dev@superset.apache.org

--- a/.github/workflows/superset-docs-deploy.yml
+++ b/.github/workflows/superset-docs-deploy.yml
@@ -23,7 +23,7 @@ jobs:
           yarn install --check-cache
       - name: yarn typecheck
         run: |
-          yarn buitypecheck
+          yarn typecheck
       - name: yarn build
         run: |
           yarn build

--- a/.github/workflows/superset-docs-deploy.yml
+++ b/.github/workflows/superset-docs-deploy.yml
@@ -1,0 +1,29 @@
+name: Docs Testing
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+    types: [synchronize, opened, reopened, ready_for_review]
+jobs:
+  build-deploy:
+    name: Build & Deploy
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: docs
+    steps:
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - name: yarn install
+        run: |
+          yarn install --check-cache
+      - name: yarn typecheck
+        run: |
+          yarn buitypecheck
+      - name: yarn build
+        run: |
+          yarn build

--- a/.github/workflows/superset-docs-verify.yml
+++ b/.github/workflows/superset-docs-verify.yml
@@ -1,15 +1,11 @@
-name: Docs
+name: Docs Deployment
 
 on:
   push:
     paths:
       - "docs/**"
     branches:
-      - 'master'
-  pull_request:
-    paths:
-      - "docs/**"
-    types: [synchronize, opened, reopened, ready_for_review]
+      - "master"
 
 jobs:
   config:
@@ -51,9 +47,9 @@ jobs:
         env:
           API_TOKEN_GITHUB: ${{ secrets.SUPERSET_SITE_BUILD }}
         with:
-          source-directory: './docs/build'
-          destination-github-username: 'apache'
-          destination-repository-name: 'superset-site'
-          target-branch: 'asf-site'
+          source-directory: "./docs/build"
+          destination-github-username: "apache"
+          destination-repository-name: "superset-site"
+          target-branch: "asf-site"
           commit-message: "deploying docs: ${{ github.event.head_commit.message }} (apache/superset@${{ github.sha }})"
           user-email: dev@superset.apache.org

--- a/.github/workflows/superset-docs-verify.yml
+++ b/.github/workflows/superset-docs-verify.yml
@@ -1,29 +1,12 @@
-name: Docs Deployment
+name: Docs Testing
 
 on:
-  push:
+  pull_request:
     paths:
       - "docs/**"
-    branches:
-      - "master"
-
+    types: [synchronize, opened, reopened, ready_for_review]
 jobs:
-  config:
-    runs-on: "ubuntu-latest"
-    outputs:
-      has-secrets: ${{ steps.check.outputs.has-secrets }}
-    steps:
-      - name: "Check for secrets"
-        id: check
-        shell: bash
-        run: |
-          if [ -n "${{ (secrets.SUPERSET_SITE_BUILD != '' && secrets.SUPERSET_SITE_BUILD != '') || '' }}" ]; then
-            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
-          fi
-
   build-deploy:
-    needs: config
-    if: needs.config.outputs.has-secrets
     name: Build & Deploy
     runs-on: ubuntu-20.04
     defaults:
@@ -38,18 +21,9 @@ jobs:
       - name: yarn install
         run: |
           yarn install --check-cache
+      - name: yarn typecheck
+        run: |
+          yarn typecheck
       - name: yarn build
         run: |
           yarn build
-      - name: deploy docs
-        if: github.ref == 'refs/heads/master'
-        uses: ./.github/actions/github-action-push-to-another-repository
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.SUPERSET_SITE_BUILD }}
-        with:
-          source-directory: "./docs/build"
-          destination-github-username: "apache"
-          destination-repository-name: "superset-site"
-          target-branch: "asf-site"
-          commit-message: "deploying docs: ${{ github.event.head_commit.message }} (apache/superset@${{ github.sha }})"
-          user-email: dev@superset.apache.org

--- a/docs/src/components/SectionHeader.tsx
+++ b/docs/src/components/SectionHeader.tsx
@@ -96,7 +96,7 @@ const StyledSectionHeaderH2 = styled(StyledSectionHeader)`
 interface SectionHeaderProps {
   level: any;
   title: string;
-  subtitle?: string;
+  subtitle?: string | Element | React.ReactNode;
   dark?: boolean;
 }
 

--- a/docs/src/pages/community.tsx
+++ b/docs/src/pages/community.tsx
@@ -217,7 +217,6 @@ const Community = () => {
                     </a>
                   }
                   description={<p className="description">{description}</p>}
-                  role="group"
                   aria-label="Community link"
                 />
               </List.Item>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR does a few things:

* Splits the github action for docs in half
  * One now only runs on pushes to master... it builds and deploys docs after checking for secrets
  * One now only runs on PRs, and doesn't need secrets. It does typechecking (new step) and builds docs, and should run even on forks (e.g. dependabot bumps)
 * Fixes a couple of typescript checks that were noticed by the typechecking script.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
