### PR TITLE
chore(actions): run docs actions on Node 16 to conform with the project

### DIFF
--- a/.github/workflows/superset-docs-deploy.yml
+++ b/.github/workflows/superset-docs-deploy.yml
@@ -25,7 +25,7 @@ jobs:
     needs: config
     if: needs.config.outputs.has-secrets
     name: Build & Deploy
-    runs-on: ubuntu-20.04
+    runs-on: "ubuntu-latest"
     defaults:
       run:
         working-directory: docs
@@ -35,6 +35,10 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+      - name: Set up Node.js 16
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
       - name: yarn install
         run: |
           yarn install --check-cache

--- a/.github/workflows/superset-docs-verify.yml
+++ b/.github/workflows/superset-docs-verify.yml
@@ -18,6 +18,10 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+      - name: Set up Node.js 16
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
       - name: yarn install
         run: |
           yarn install --check-cache

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,5 +16,4 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-
 This is the public documentation site for Superset, built using [Docusaurus 2](https://docusaurus.io/). See [CONTRIBUTING.md](../CONTRIBUTING.md#documentation) for documentation on contributing to documentation.


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Some dependabot PRs were passing CI because they were running on node 18 instead of 16. These installs ought to fail on node 16, but weren't. This should make things fail when they ought to. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
