### PR TITLE
chore(dependabot): auto-update lockfiles for monorepo package bumps

### DIFF
--- a/.github/workflows/update-monorepo-lockfiles.yml
+++ b/.github/workflows/update-monorepo-lockfiles.yml
@@ -1,0 +1,41 @@
+name: Update Lockfiles for Dependabot Monorepo PRs
+
+on:
+  pull_request:
+    branches: 
+      - main
+    paths:
+      - 'superset-frontend/packages/**/package.json'
+      - 'superset-frontend/plugins/**/package.json'
+    # Trigger this workflow when Dependabot creates a pull request
+    types: [opened, synchronize, reopened]
+
+jobs:
+  update-lock-file:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' # Ensure it only runs for Dependabot PRs
+    defaults:
+      run:
+        working-directory: superset-frontend
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }} # Checkout the branch that made the PR
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: Install Dependencies and Update Lock File
+        run: |
+          npm install
+
+      - name: Commit and Push Changes
+        run: |
+          git config user.name "GitHub-Actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package-lock.json
+          git commit -m "Update lock file for Dependabot PR" -a # Commit the changes
+          git push # Push the changes back to the branch

--- a/.github/workflows/update-monorepo-lockfiles.yml
+++ b/.github/workflows/update-monorepo-lockfiles.yml
@@ -2,8 +2,6 @@ name: Update Lockfiles for Dependabot Monorepo PRs
 
 on:
   pull_request:
-    branches: 
-      - main
     paths:
       - 'superset-frontend/packages/**/package.json'
       - 'superset-frontend/plugins/**/package.json'
@@ -13,7 +11,7 @@ on:
 jobs:
   update-lock-file:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]' # Ensure it only runs for Dependabot PRs
+    if: github.event.pull_request.user.login == 'dependabot[bot]' # Ensure it only runs for Dependabot PRs
     defaults:
       run:
         working-directory: superset-frontend

--- a/.github/workflows/update-monorepo-lockfiles.yml
+++ b/.github/workflows/update-monorepo-lockfiles.yml
@@ -6,7 +6,7 @@ on:
       - 'superset-frontend/packages/**/package.json'
       - 'superset-frontend/plugins/**/package.json'
     # Trigger this workflow when Dependabot creates a pull request
-    types: [opened, synchronize, reopened]
+    types: [opened]
 
 jobs:
   update-lock-file:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When dependabot bumps packages for monorepo packages/plugins, it doesn't work out. It bumps package.json, but it's not smart enough to know that it needs to run `npm install` from the root of the `superset-frontend` folder. This action will keep an eye out for these PRs from dependabot on those paths, and run the installation command, and push the package lock file.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
