### PR TITLE
feat(ci): add a check to make sure there's no hold label on the PR

### DIFF
--- a/.github/workflows/no-hold-label.yml
+++ b/.github/workflows/no-hold-label.yml
@@ -1,0 +1,20 @@
+name: Hold Label Check
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, reopened, synchronize]
+
+jobs:
+  check-hold-label:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check for 'hold' label
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          const payload = context.payload.pull_request
+          const label = !!payload.labels.find(label => label.name.includes('hold'))
+          if (label) {
+            core.setFailed('Hold label is present, merge is blocked.')
+          }

--- a/.github/workflows/no-hold-label.yml
+++ b/.github/workflows/no-hold-label.yml
@@ -14,7 +14,7 @@ jobs:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           const payload = context.payload.pull_request
-          const label = !!payload.labels.find(label => label.name.includes('hold'))
-          if (label) {
+          const holdLabelPresent = !!payload.labels.find(label => label.name.includes('hold'))
+          if (holdLabelPresent) {
             core.setFailed('Hold label is present, merge is blocked.')
           }


### PR DESCRIPTION
noticed on another PR (https://github.com/apache/superset/pull/26836) that we use `hold.*` labels, but they don't really hold the merge. After almost merging and realizing the hold after, I got GPT to generate the action here and tested it on that PR.

Note that this will hold all PRs with any label containing the string `hold`, which is what we need since we have multiple hold-related labels.

<img width="977" alt="Screenshot 2024-01-29 at 5 18 56 PM" src="https://github.com/apache/superset/assets/487433/373acea4-33e9-41fb-b03e-c761e60e8702">
