### PR TITLE
fix: Allow exporting saved queries without schema information

### DIFF
--- a/superset/commands/query/export.py
+++ b/superset/commands/query/export.py
@@ -40,11 +40,16 @@ class ExportSavedQueriesCommand(ExportModelsCommand):
     def _export(
         model: SavedQuery, export_related: bool = True
     ) -> Iterator[tuple[str, str]]:
-        # build filename based on database, optional schema, and label
+        # build filename based on database, optional schema, and label.
+        # we call secure_filename() multiple times and join the directories afterwards,
+        # as secure_filename() replaces "/" with "_".
         database_slug = secure_filename(model.database.database_name)
-        schema_slug = secure_filename(model.schema)
         query_slug = secure_filename(model.label) or str(model.uuid)
-        file_name = f"queries/{database_slug}/{schema_slug}/{query_slug}.yaml"
+        if model.schema is None:
+            file_name = f"queries/{database_slug}/{query_slug}.yaml"
+        else:
+            schema_slug = secure_filename(model.schema)
+            file_name = f"queries/{database_slug}/{schema_slug}/{query_slug}.yaml"
 
         payload = model.export_to_dict(
             recursive=False,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Fixes https://github.com/apache/superset/issues/26885
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: See linked issue
After:
![image](https://github.com/apache/superset/assets/29303194/9a131faa-0374-45cc-a0f5-bc5e3aad2e30)

The query without schema information is placed top-level within the database folder:

![image](https://github.com/apache/superset/assets/29303194/3625a7b4-1cd3-40be-9a6a-b744f42de413)

### TESTING INSTRUCTIONS
See linked issue, stored saved query `select 42` (so that no schema information is added) and try to export it using the UI.
As an alternative you can use the `/api/v1/assets/export` API.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/26885
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
