### PR TITLE
chore(ci): make action/labeler work on fork PRs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-- pull_request
+- pull_request_target
 
 jobs:
   labeler:


### PR DESCRIPTION
more about why this change is required for this feature to work on forks https://github.com/actions/labeler?tab=readme-ov-file#notes-regarding-pull_request_target-event
