### PR TITLE
fix(svg): reformatting svgs to allow license without breaking images

### DIFF
--- a/docs/static/img/databases/apache-hive.svg
+++ b/docs/static/img/databases/apache-hive.svg
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file
@@ -16,7 +17,6 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" height="900" width="1e3" version="1.1" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" viewBox="0 0 1000 900">
  <g stroke="#fdee21" stroke-width="5.1286" transform="translate(-.53268 66.8)" fill-rule="evenodd">
   <path d="m597.33 637.79v192.85h47.346v-88.632l9.7674 0.18273v88.45h47.881v-192.85h-47.881v71.552h-9.7674v-71.552z"/>

--- a/docs/static/img/databases/apache-pinot.svg
+++ b/docs/static/img/databases/apache-pinot.svg
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file
@@ -16,7 +17,6 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<?xml version="1.0" encoding="UTF-8"?>
 <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="512" height="270" viewBox="0 0 512 270">
   <g id="Page-1">
     <path id="Path" d="M108.65,67.02c-1.34,1.34-1.42,2.85-.18,4.41,1.83,2.36,4.85,1.02,4.85-2.09s-2.63-4.41-4.68-2.32Z"/>

--- a/docs/static/img/databases/csv.svg
+++ b/docs/static/img/databases/csv.svg
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file
@@ -16,7 +17,6 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<?xml version="1.0" encoding="UTF-8"?>
 <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="512" height="270" viewBox="0 0 512 270">
   <path d="M324.72,93.76h-38.76V55c0-1.65-1.34-2.98-2.98-2.98h-83.49c-1.65,0-2.98,1.34-2.98,2.98v83.49c0,1.65,1.34,2.98,2.98,2.98h80.51v47.71h-80.51c-1.65,0-2.98,1.34-2.98,2.98v23.85c0,1.65,1.34,2.98,2.98,2.98h125.24c1.65,0,2.98-1.34,2.98-2.98V96.74c0-1.65-1.34-2.98-2.98-2.98Z" style="fill: #eee;"/>
   <rect x="184.58" y="135.51" width="101.38" height="59.64" rx="2.98" ry="2.98" style="fill: #66bb6a;"/>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Editing a couple problematic SVG images so that they display correctly AND include the required apache license boilerplace.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: Fixes #26882
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
