### PR TITLE
chore(docs): remove misplaced k8s installation instructions

### DIFF
--- a/docs/docs/installation/installing-superset-from-scratch.mdx
+++ b/docs/docs/installation/installing-superset-from-scratch.mdx
@@ -152,18 +152,3 @@ superset run -p 8088 --with-threads --reload --debugger
 
 If everything worked, you should be able to navigate to `hostname:port` in your browser (e.g.
 locally by default at `localhost:8088`) and login using the username and password you created.
-
-### Installing Superset with Helm in Kubernetes
-
-You can install Superset into Kubernetes with [Helm](https://helm.sh/). The chart is located in
-the `helm/` directory.
-
-To install Superset in your Kubernetes cluster with Helm 3, run:
-
-```
-helm dep up ./helm/superset
-helm upgrade --install superset ./helm/superset
-```
-
-Note that the above command will install Superset into `default` namespace of your Kubernetes
-cluster.


### PR DESCRIPTION
### SUMMARY
A user pointed out that there is already a [dedicated page for Kubernetes installation](https://superset.apache.org/docs/installation/running-on-kubernetes).  We should eliminate the few sentences here that are mistakenly on this "installing from scratch" page.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Addresses BugHerd 102: https://www.bugherd.com/projects/334204/tasks/102