### PR TITLE
fix(dependabot): lockfile updater won't fail when there's nothing to push

### DIFF
--- a/.github/workflows/update-monorepo-lockfiles.yml
+++ b/.github/workflows/update-monorepo-lockfiles.yml
@@ -35,5 +35,5 @@ jobs:
           git config user.name "GitHub-Actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add package-lock.json
-          git commit -m "Update lock file for Dependabot PR" -a # Commit the changes
-          git push https://${{ github.token }}@github.com/${{ github.repository }}.git
+          git diff --staged --quiet || (git commit -m "Update lock file for Dependabot PR" -a && git push https://${{ github.token }}@github.com/${{ github.repository }}.git)
+  


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The script seems to be pushing lockfiles OK, but when there's nothing to push, the action was failing and blocking PRs. This should allow it to skip the push rather than fail.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
