### PR TITLE
fix(pinot): typo in the name for epoch_ms_to_dttm

### DIFF
--- a/superset/db_engine_specs/pinot.py
+++ b/superset/db_engine_specs/pinot.py
@@ -62,7 +62,7 @@ class PinotEngineSpec(BaseEngineSpec):
         )
 
     @classmethod
-    def epoch_ms_to_dttm_(cls) -> str:
+    def epoch_ms_to_dttm(cls) -> str:
         return (
             "DATETIMECONVERT({col}, '1:MILLISECONDS:EPOCH', "
             + "'1:MILLISECONDS:EPOCH', '1:MILLISECONDS')"

--- a/tests/integration_tests/db_engine_specs/pinot_tests.py
+++ b/tests/integration_tests/db_engine_specs/pinot_tests.py
@@ -84,6 +84,20 @@ class TestPinotDbEngineSpec(TestDbEngineSpec):
             expected,
         )
 
+    def test_pinot_time_expression_millisec_one_1m_grain(self):
+        col = column("tstamp")
+        expr = PinotEngineSpec.get_timestamp_expr(col, "epoch_ms", "P1M")
+        result = str(expr.compile())
+        expected = (
+            "CAST(DATE_TRUNC('month', CAST("
+            + "DATETIMECONVERT(tstamp, '1:MILLISECONDS:EPOCH', "
+            + "'1:MILLISECONDS:EPOCH', '1:MILLISECONDS') AS TIMESTAMP)) AS TIMESTAMP)"
+        )
+        self.assertEqual(
+            result,
+            expected,
+        )
+
     def test_invalid_get_time_expression_arguments(self):
         with self.assertRaises(NotImplementedError):
             PinotEngineSpec.get_timestamp_expr(column("tstamp"), None, "P0.25Y")


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
A typo in the method name for `epoch_ms_to_dttm` (it was called `epoch_ms_to_dttm_`) in the Pinot DB Engine Spec caused `epoch_ms_to_dttm` to not be correctly overridden. This meant that the base method was called when processing Epoch MS timestamps and results of datetime conversions were incorrect.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Start a Pinot server and create a table with a datetime column that is storing data in Milliseconds from Epoch
2. Add that table as a data source to Superset
3. Choose any chart and make the time column the X-Axis and pick any function as the metric
4. Without this fix, the timestamps for data should incorrectly be shown as 1970.
5. With this fix, the timestamp will be correct.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
