### PR TITLE
feat(ci): unleash dependabot on our github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,11 @@
 version: 2
 updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+
   - package-ecosystem: "npm"
     ignore:
       # not until  node >= 18.12.0


### PR DESCRIPTION
recently I realized our github-actions version seemed fairly dated, bumped a few, but that's just another job for the lovely (and slightly annoying) dependabot
