### PR TITLE
fix: remove ephemeral docker build from required workflow

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -74,7 +74,6 @@ github:
           - test-postgres (3.9)
           - test-postgres (3.10)
           - test-sqlite (3.9)
-          - ephemeral-docker-build
           - docker-build (dev, linux/amd64)
           - docker-build (lean, linux/amd64)
           - docker-build (py310, linux/arm64)


### PR DESCRIPTION
### SUMMARY

Removes `ephemeral-docker-build` from a required workflow to unblock this PR: https://github.com/apache/superset/pull/26852 that is removing it

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
