### PR TITLE
fix(sqllab): autosync fail on migrated queryEditor

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -477,6 +477,7 @@ export function migrateQueryEditorFromLocalStorage(
         const newQueryEditor = {
           ...queryEditor,
           id: json.id.toString(),
+          inLocalStorage: false,
         };
         dispatch({
           type: MIGRATE_QUERY_EDITOR,

--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.js
@@ -937,12 +937,17 @@ describe('async actions', () => {
           { ...query, id: 'previewTwo' },
         ];
         const store = mockStore({});
+        const oldQueryEditor = { ...queryEditor, inLocalStorage: true };
         const expectedActions = [
           {
             type: actions.MIGRATE_QUERY_EDITOR,
-            oldQueryEditor: queryEditor,
+            oldQueryEditor,
             // new qe has a different id
-            newQueryEditor: { ...queryEditor, id: '1' },
+            newQueryEditor: {
+              ...oldQueryEditor,
+              id: '1',
+              inLocalStorage: false,
+            },
           },
           {
             type: actions.MIGRATE_TAB_HISTORY,
@@ -975,7 +980,7 @@ describe('async actions', () => {
         return store
           .dispatch(
             actions.migrateQueryEditorFromLocalStorage(
-              queryEditor,
+              oldQueryEditor,
               tables,
               queries,
             ),


### PR DESCRIPTION
### SUMMARY
Once `migrateQueryEditorFromLocalStorage` executes successfully, the queryEditor continues to retain `inLocalStorage` as `true`. (It is corrected once the browser is reloaded, but persists during the session.) Consequently, it is filtered out from the backend persist syncer. Furthermore, this action can be initiated multiple times, potentially storing the same query editor in the backend more than once, as the Single Page Application (SPA) navigation can trigger the componentDidMount.
This commit corrects the missing inLocalStorage update required for the hotfix.

### TESTING INSTRUCTIONS
test specs
- set BACKEND_PERSISTENCE_MODE false to true and then navigate back-and-forth to SQL Lab
- check the tab names

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
