### PR TITLE
chore(ci): run pre-commit across the repo

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,54 @@
+name: pre-commit checks
+
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: ["3.9"]
+    steps:
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: |
+            requirements/base.txt
+            requirements/integration.txt
+      - name: Install dependencies
+        uses: ./.github/actions/cached-dependencies
+        with:
+          run: |
+            apt-get-install
+            pip-upgrade
+            pip install wheel
+            pip install -r requirements/base.txt
+            pip install -r requirements/integration.txt
+      # Add brew to the path - see https://github.com/actions/runner-images/issues/6283
+      - name: Enable brew and helm-docs
+        run: |
+          echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          echo "HOMEBREW_PREFIX=$HOMEBREW_PREFIX" >>"${GITHUB_ENV}"
+          echo "HOMEBREW_CELLAR=$HOMEBREW_CELLAR" >>"${GITHUB_ENV}"
+          echo "HOMEBREW_REPOSITORY=$HOMEBREW_REPOSITORY" >>"${GITHUB_ENV}"
+          brew install norwoodj/tap/helm-docs
+      - name: pre-commit
+        run: |
+          if ! pre-commit run --all-files; then
+            git status
+            git diff
+            exit 1
+          fi

--- a/.github/workflows/superset-python-misc.yml
+++ b/.github/workflows/superset-python-misc.yml
@@ -52,51 +52,6 @@ jobs:
         # `-j 0` run Pylint in parallel
         run: pylint -j 0 superset
 
-  pre-commit:
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        python-version: ["3.9"]
-    steps:
-      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-          submodules: recursive
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-          cache-dependency-path: |
-            requirements/base.txt
-            requirements/integration.txt
-      - name: Install dependencies
-        uses: ./.github/actions/cached-dependencies
-        with:
-          run: |
-            apt-get-install
-            pip-upgrade
-            pip install wheel
-            pip install -r requirements/base.txt
-            pip install -r requirements/integration.txt
-      # Add brew to the path - see https://github.com/actions/runner-images/issues/6283
-      - name: Enable brew and helm-docs
-        run: |
-          echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
-          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          echo "HOMEBREW_PREFIX=$HOMEBREW_PREFIX" >>"${GITHUB_ENV}"
-          echo "HOMEBREW_CELLAR=$HOMEBREW_CELLAR" >>"${GITHUB_ENV}"
-          echo "HOMEBREW_REPOSITORY=$HOMEBREW_REPOSITORY" >>"${GITHUB_ENV}"
-          brew install norwoodj/tap/helm-docs
-      - name: pre-commit
-        run: |
-          if ! pre-commit run --all-files; then
-            git status
-            git diff
-            exit 1
-          fi
-
   babel-extract:
     runs-on: ubuntu-20.04
     strategy:


### PR DESCRIPTION
https://github.com/apache/superset/pull/26920 caught an issue that should have been picked up by pre-commit (by the user), but then re-caught by CI, preventing the merge.

The reason is was not caught was that the CI check is part of a group of python misc checks that trigger only where the python package's folder has changed. In reality, the python utility pre-commit we use here is used for much more than just Python files, so we should run it across the repo.

Here I simply factored out the check into its own GitHub Action that triggers for every single CI run. The code block in this PR is identical/unchanged