### PR TITLE
chore(dependencies): Push lockfile for monorepo updates on rebuild/rebase

### DIFF
--- a/.github/workflows/update-monorepo-lockfiles.yml
+++ b/.github/workflows/update-monorepo-lockfiles.yml
@@ -6,7 +6,7 @@ on:
       - 'superset-frontend/packages/**/package.json'
       - 'superset-frontend/plugins/**/package.json'
     # Trigger this workflow when Dependabot creates a pull request
-    types: [opened]
+    types: [opened, synchronize, reopened]
 
 jobs:
   update-lock-file:


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The action seems to mostly work... but doesn't work when you have Dependabot rebase/rebuild its PRs. This should fix that!

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
