### PR TITLE
feat(ci): kill duplicate CI jobs on PRs

### DIFF
--- a/.github/workflows/check_db_migration_confict.yml
+++ b/.github/workflows/check_db_migration_confict.yml
@@ -10,6 +10,11 @@ on:
       - "superset/migrations/**"
     types: [synchronize, opened, reopened, ready_for_review]
 
+# cancel previous workflow jobs for PRs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   check_db_migration_conflict:
     name: Check DB migration conflict

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,6 +13,11 @@ on:
   schedule:
     - cron: '0 4 * * *'
 
+# cancel previous workflow jobs for PRs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/embedded-sdk-test.yml
+++ b/.github/workflows/embedded-sdk-test.yml
@@ -6,6 +6,11 @@ on:
       - "superset-embedded-sdk/**"
     types: [synchronize, opened, reopened, ready_for_review]
 
+# cancel previous workflow jobs for PRs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   embedded-sdk-test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ephemeral-env.yml
+++ b/.github/workflows/ephemeral-env.yml
@@ -4,6 +4,11 @@ on:
   issue_comment:
     types: [created]
 
+# cancel previous workflow jobs for PRs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   config:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
 
+# cancel previous workflow jobs for PRs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   license_check:
     name: License Check

--- a/.github/workflows/no-hold-label.yml
+++ b/.github/workflows/no-hold-label.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [labeled, unlabeled, opened, reopened, synchronize]
 
+# cancel previous workflow jobs for PRs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   check-hold-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
 
+# cancel previous workflow jobs for PRs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     runs-on: ubuntu-20.04

--- a/.github/workflows/prefer-typescript.yml
+++ b/.github/workflows/prefer-typescript.yml
@@ -10,6 +10,12 @@ on:
     types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "superset-frontend/src/**"
+
+# cancel previous workflow jobs for PRs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   prefer_typescript:
     if: github.ref == 'ref/heads/master' && github.event_name == 'pull_request'

--- a/.github/workflows/superset-cli.yml
+++ b/.github/workflows/superset-cli.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
 
+# cancel previous workflow jobs for PRs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test-load-examples:
     runs-on: ubuntu-20.04

--- a/.github/workflows/superset-docs-verify.yml
+++ b/.github/workflows/superset-docs-verify.yml
@@ -5,6 +5,12 @@ on:
     paths:
       - "docs/**"
     types: [synchronize, opened, reopened, ready_for_review]
+
+# cancel previous workflow jobs for PRs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build-deploy:
     name: Build & Deploy

--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -11,6 +11,11 @@ on:
     paths:
       - "superset-frontend/**"
 
+# cancel previous workflow jobs for PRs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   frontend-build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/superset-helm-lint.yml
+++ b/.github/workflows/superset-helm-lint.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - "helm/**"
 
+# cancel previous workflow jobs for PRs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   lint-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/superset-python-misc.yml
+++ b/.github/workflows/superset-python-misc.yml
@@ -12,6 +12,11 @@ on:
     paths:
       - "superset/**"
 
+# cancel previous workflow jobs for PRs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   python-lint:
     runs-on: ubuntu-20.04

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -12,6 +12,11 @@ on:
     paths:
       - "superset/**"
 
+# cancel previous workflow jobs for PRs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test-postgres-presto:
     runs-on: ubuntu-20.04

--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -12,6 +12,11 @@ on:
     paths:
       - "superset/**"
 
+# cancel previous workflow jobs for PRs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   unit-tests:
     runs-on: ubuntu-20.04

--- a/.github/workflows/superset-translations.yml
+++ b/.github/workflows/superset-translations.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
 
+# cancel previous workflow jobs for PRs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   frontend-check:
     runs-on: ubuntu-20.04

--- a/.github/workflows/superset-websocket.yml
+++ b/.github/workflows/superset-websocket.yml
@@ -10,6 +10,11 @@ on:
       - "superset-websocket/**"
     types: [synchronize, opened, reopened, ready_for_review]
 
+# cancel previous workflow jobs for PRs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   app-checks:
     runs-on: ubuntu-20.04

--- a/.github/workflows/update-monorepo-lockfiles.yml
+++ b/.github/workflows/update-monorepo-lockfiles.yml
@@ -8,6 +8,11 @@ on:
     # Trigger this workflow when Dependabot creates a pull request
     types: [opened]
 
+# cancel previous workflow jobs for PRs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   update-lock-file:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Taking over https://github.com/apache/superset/pull/25243, where @sebastianliebscher did great work and submitted this idea. I'm re-opening under a new PR to accelerate things a bit. I've been triggering lots and lots of CI jobs while working on docker and feeling guilty about my carbon footprint.

Here I grepped for workflows that have pull_request events and copy pasted the exact same snippet everywhere except for one place and that's the comment-triggered ephemeral builds, where I reference the issue number instead of the PR number. This should allow for someone to oops and retrigger the ephemeral build, and the lastest one should always land first, fixing potential race conditions
