### PR TITLE
chore(tests): Load test users after initialization

### DIFF
--- a/scripts/python_tests.sh
+++ b/scripts/python_tests.sh
@@ -29,6 +29,7 @@ echo "Superset config module: $SUPERSET_CONFIG"
 
 superset db upgrade
 superset init
+superset load-test-users
 
 echo "Running tests"
 

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -123,10 +123,6 @@ def setup_sample_data() -> Any:
     with app.app_context():
         setup_presto_if_needed()
 
-        from superset.cli.test import load_test_users_run
-
-        load_test_users_run()
-
         from superset.examples.css_templates import load_css_templates
 
         load_css_templates()

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ ignore_basepython_conflict = true
 commands =
     superset db upgrade
     superset init
+    superset load-test-users
     # use -s to be able to use break pointers.
     # no args or tests/* can be passed as an argument to run all tests
     pytest -s {posargs}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Whilst running the Python unit tests locally I would run into issue where no users existed for specifiic roles. For the integration tests we explicitly load these test users, however this isn't the case for unit tests—even though said users are required.

I thought it would be prudent to make adding the test users a precursor to running all Python tests (be that unit or integration) either locally or remotely. 

Initially I added the step immediately after we run `superset db upgrade` but before we run `superset init` as is inline with the procedure outlined in `CONTRIBUTING.md` [here](https://github.com/apache/superset/blob/master/CONTRIBUTING.md?plain=1#L486-L492) however (for some weird reason the unit tests failed). Adding them after the initialization (akin to how they were invoked in the integration tests) ensured the tests passed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
