### PR TITLE
chore: harmonize python enum naming conventions

### DIFF
--- a/superset/commands/chart/update.py
+++ b/superset/commands/chart/update.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
+
 import logging
 from datetime import datetime
 from functools import partial

--- a/superset/commands/chart/update.py
+++ b/superset/commands/chart/update.py
@@ -63,7 +63,7 @@ class UpdateChartCommand(UpdateMixin, BaseCommand):
 
         # Update tags
         if (tags := self._properties.pop("tags", None)) is not None:
-            update_tags(ObjectType.chart, self._model.id, self._model.tags, tags)
+            update_tags(ObjectType.CHART, self._model.id, self._model.tags, tags)
 
         if self._properties.get("query_context_generation") is None:
             self._properties["last_saved_at"] = datetime.now()
@@ -79,6 +79,7 @@ class UpdateChartCommand(UpdateMixin, BaseCommand):
 
         # Validate if datasource_id is provided datasource_type is required
         datasource_id = self._properties.get("datasource_id")
+        datasource_type: str | None = None
         if datasource_id is not None:
             datasource_type = self._properties.get("datasource_type", "")
             if not datasource_type:
@@ -106,12 +107,12 @@ class UpdateChartCommand(UpdateMixin, BaseCommand):
 
         # validate tags
         try:
-            validate_tags(ObjectType.chart, self._model.tags, tag_ids)
+            validate_tags(ObjectType.CHART, self._model.tags, tag_ids)
         except ValidationError as ex:
             exceptions.append(ex)
 
         # Validate/Populate datasource
-        if datasource_id is not None:
+        if datasource_id is not None and datasource_type is not None:
             try:
                 datasource = get_datasource_by_id(datasource_id, datasource_type)
                 self._properties["datasource_name"] = datasource.name

--- a/superset/commands/dashboard/update.py
+++ b/superset/commands/dashboard/update.py
@@ -60,7 +60,7 @@ class UpdateDashboardCommand(UpdateMixin, BaseCommand):
 
         # Update tags
         if (tags := self._properties.pop("tags", None)) is not None:
-            update_tags(ObjectType.dashboard, self._model.id, self._model.tags, tags)
+            update_tags(ObjectType.DASHBOARD, self._model.id, self._model.tags, tags)
 
         dashboard = DashboardDAO.update(self._model, self._properties)
         if self._properties.get("json_metadata"):
@@ -103,7 +103,7 @@ class UpdateDashboardCommand(UpdateMixin, BaseCommand):
 
         # validate tags
         try:
-            validate_tags(ObjectType.dashboard, self._model.tags, tag_ids)
+            validate_tags(ObjectType.DASHBOARD, self._model.tags, tag_ids)
         except ValidationError as ex:
             exceptions.append(ex)
 

--- a/superset/commands/tag/create.py
+++ b/superset/commands/tag/create.py
@@ -75,7 +75,7 @@ class CreateCustomTagWithRelationshipsCommand(CreateMixin, BaseCommand):
         self.validate()
 
         tag_name = self._properties["name"]
-        tag = TagDAO.get_by_name(tag_name.strip(), TagType.custom)
+        tag = TagDAO.get_by_name(tag_name.strip(), TagType.CUSTOM)
         TagDAO.create_tag_relationship(
             objects_to_tag=self._properties.get("objects_to_tag", []),
             tag=tag,

--- a/superset/commands/tag/utils.py
+++ b/superset/commands/tag/utils.py
@@ -38,10 +38,10 @@ def to_object_type(object_type: Union[ObjectType, int, str]) -> Optional[ObjectT
 def to_object_model(
     object_type: ObjectType, object_id: int
 ) -> Optional[Union[Dashboard, SavedQuery, Slice]]:
-    if ObjectType.dashboard == object_type:
+    if ObjectType.DASHBOARD == object_type:
         return DashboardDAO.find_by_id(object_id)
-    if ObjectType.query == object_type:
+    if ObjectType.QUERY == object_type:
         return SavedQueryDAO.find_by_id(object_id)
-    if ObjectType.chart == object_type:
+    if ObjectType.CHART == object_type:
         return ChartDAO.find_by_id(object_id)
     return None

--- a/superset/commands/utils.py
+++ b/superset/commands/utils.py
@@ -130,7 +130,7 @@ def validate_tags(
         return
 
     # No changes in the list
-    current_custom_tags = [tag.id for tag in current_tags if tag.type == TagType.custom]
+    current_custom_tags = [tag.id for tag in current_tags if tag.type == TagType.CUSTOM]
     if Counter(current_custom_tags) == Counter(new_tag_ids):
         return
 
@@ -140,7 +140,7 @@ def validate_tags(
         or security_manager.can_access("can_tag", object_type.name.capitalize())
     ):
         validation_error = (
-            f"You do not have permission to manage tags on {object_type.name}s"
+            f"You do not have permission to manage tags on {object_type.name.lower()}s"
         )
         raise TagForbiddenError(validation_error)
 
@@ -169,9 +169,9 @@ def update_tags(
     :param new_tag_ids: list of tags specified in the update payload
     """
 
-    current_custom_tags = [tag for tag in current_tags if tag.type == TagType.custom]
+    current_custom_tags = [tag for tag in current_tags if tag.type == TagType.CUSTOM]
     current_custom_tag_ids = [
-        tag.id for tag in current_tags if tag.type == TagType.custom
+        tag.id for tag in current_tags if tag.type == TagType.CUSTOM
     ]
 
     tags_to_delete = [tag for tag in current_custom_tags if tag.id not in new_tag_ids]

--- a/superset/commands/utils.py
+++ b/superset/commands/utils.py
@@ -140,7 +140,7 @@ def validate_tags(
         or security_manager.can_access("can_tag", object_type.name.capitalize())
     ):
         validation_error = (
-            f"You do not have permission to manage tags on {object_type.name.lower()}s"
+            f"You do not have permission to manage tags of type {object_type.name}"
         )
         raise TagForbiddenError(validation_error)
 

--- a/superset/common/tags.py
+++ b/superset/common/tags.py
@@ -35,7 +35,7 @@ def add_types_to_charts(
             [
                 tag.c.id.label("tag_id"),
                 slices.c.id.label("object_id"),
-                literal(ObjectType.chart.name).label("object_type"),
+                literal(ObjectType.CHART.name).label("object_type"),
             ]
         )
         .select_from(
@@ -67,7 +67,7 @@ def add_types_to_dashboards(
             [
                 tag.c.id.label("tag_id"),
                 dashboard_table.c.id.label("object_id"),
-                literal(ObjectType.dashboard.name).label("object_type"),
+                literal(ObjectType.DASHBOARD.name).label("object_type"),
             ]
         )
         .select_from(
@@ -99,7 +99,7 @@ def add_types_to_saved_queries(
             [
                 tag.c.id.label("tag_id"),
                 saved_query.c.id.label("object_id"),
-                literal(ObjectType.query.name).label("object_type"),
+                literal(ObjectType.QUERY.name).label("object_type"),
             ]
         )
         .select_from(
@@ -131,7 +131,7 @@ def add_types_to_datasets(
             [
                 tag.c.id.label("tag_id"),
                 tables.c.id.label("object_id"),
-                literal(ObjectType.dataset.name).label("object_type"),
+                literal(ObjectType.DATASET.name).label("object_type"),
             ]
         )
         .select_from(
@@ -223,7 +223,7 @@ def add_types(metadata: MetaData) -> None:
     insert = tag.insert()
     for type_ in ObjectType.__members__:
         with contextlib.suppress(IntegrityError):  # already exists
-            db.session.execute(insert, name=f"type:{type_}", type=TagType.type)
+            db.session.execute(insert, name=f"type:{type_}", type=TagType.TYPE)
 
     add_types_to_charts(metadata, tag, tagged_object, columns)
     add_types_to_dashboards(metadata, tag, tagged_object, columns)
@@ -241,7 +241,7 @@ def add_owners_to_charts(
             [
                 tag.c.id.label("tag_id"),
                 slices.c.id.label("object_id"),
-                literal(ObjectType.chart.name).label("object_type"),
+                literal(ObjectType.CHART.name).label("object_type"),
             ]
         )
         .select_from(
@@ -277,7 +277,7 @@ def add_owners_to_dashboards(
             [
                 tag.c.id.label("tag_id"),
                 dashboard_table.c.id.label("object_id"),
-                literal(ObjectType.dashboard.name).label("object_type"),
+                literal(ObjectType.DASHBOARD.name).label("object_type"),
             ]
         )
         .select_from(
@@ -313,7 +313,7 @@ def add_owners_to_saved_queries(
             [
                 tag.c.id.label("tag_id"),
                 saved_query.c.id.label("object_id"),
-                literal(ObjectType.query.name).label("object_type"),
+                literal(ObjectType.QUERY.name).label("object_type"),
             ]
         )
         .select_from(
@@ -349,7 +349,7 @@ def add_owners_to_datasets(
             [
                 tag.c.id.label("tag_id"),
                 tables.c.id.label("object_id"),
-                literal(ObjectType.dataset.name).label("object_type"),
+                literal(ObjectType.DATASET.name).label("object_type"),
             ]
         )
         .select_from(
@@ -444,7 +444,7 @@ def add_owners(metadata: MetaData) -> None:
     insert = tag.insert()
     for (id_,) in db.session.execute(ids):
         with contextlib.suppress(IntegrityError):  # already exists
-            db.session.execute(insert, name=f"owner:{id_}", type=TagType.owner)
+            db.session.execute(insert, name=f"owner:{id_}", type=TagType.OWNER)
     add_owners_to_charts(metadata, tag, tagged_object, columns)
     add_owners_to_dashboards(metadata, tag, tagged_object, columns)
     add_owners_to_saved_queries(metadata, tag, tagged_object, columns)
@@ -482,7 +482,7 @@ def add_favorites(metadata: MetaData) -> None:
     insert = tag.insert()
     for (id_,) in db.session.execute(ids):
         with contextlib.suppress(IntegrityError):  # already exists
-            db.session.execute(insert, name=f"favorited_by:{id_}", type=TagType.type)
+            db.session.execute(insert, name=f"favorited_by:{id_}", type=TagType.TYPE)
     favstars = (
         select(
             [

--- a/superset/daos/tag.py
+++ b/superset/daos/tag.py
@@ -55,7 +55,7 @@ class TagDAO(BaseDAO[Tag]):
         clean_tag_names: set[str] = {tag.strip() for tag in tag_names}
 
         for name in clean_tag_names:
-            type_ = TagType.custom
+            type_ = TagType.CUSTOM
             tag = TagDAO.get_by_name(name, type_)
             tagged_objects.append(
                 TaggedObject(object_id=object_id, object_type=object_type, tag=tag)
@@ -117,7 +117,7 @@ class TagDAO(BaseDAO[Tag]):
             db.session.delete(tag)
 
     @staticmethod
-    def get_by_name(name: str, type_: TagType = TagType.custom) -> Tag:
+    def get_by_name(name: str, type_: TagType = TagType.CUSTOM) -> Tag:
         """
         returns a tag if one exists by that name, none otherwise.
         important!: Creates a tag by that name if the tag is not found.
@@ -182,7 +182,7 @@ class TagDAO(BaseDAO[Tag]):
                     TaggedObject,
                     and_(
                         TaggedObject.object_id == Dashboard.id,
-                        TaggedObject.object_type == ObjectType.dashboard,
+                        TaggedObject.object_type == ObjectType.DASHBOARD,
                     ),
                 )
                 .join(Tag, TaggedObject.tag_id == Tag.id)
@@ -192,7 +192,7 @@ class TagDAO(BaseDAO[Tag]):
             results.extend(
                 {
                     "id": obj.id,
-                    "type": ObjectType.dashboard.name,
+                    "type": ObjectType.DASHBOARD.name,
                     "name": obj.dashboard_title,
                     "url": obj.url,
                     "changed_on": obj.changed_on,
@@ -212,7 +212,7 @@ class TagDAO(BaseDAO[Tag]):
                     TaggedObject,
                     and_(
                         TaggedObject.object_id == Slice.id,
-                        TaggedObject.object_type == ObjectType.chart,
+                        TaggedObject.object_type == ObjectType.CHART,
                     ),
                 )
                 .join(Tag, TaggedObject.tag_id == Tag.id)
@@ -221,7 +221,7 @@ class TagDAO(BaseDAO[Tag]):
             results.extend(
                 {
                     "id": obj.id,
-                    "type": ObjectType.chart.name,
+                    "type": ObjectType.CHART.name,
                     "name": obj.slice_name,
                     "url": obj.url,
                     "changed_on": obj.changed_on,
@@ -241,7 +241,7 @@ class TagDAO(BaseDAO[Tag]):
                     TaggedObject,
                     and_(
                         TaggedObject.object_id == SavedQuery.id,
-                        TaggedObject.object_type == ObjectType.query,
+                        TaggedObject.object_type == ObjectType.QUERY,
                     ),
                 )
                 .join(Tag, TaggedObject.tag_id == Tag.id)
@@ -250,7 +250,7 @@ class TagDAO(BaseDAO[Tag]):
             results.extend(
                 {
                     "id": obj.id,
-                    "type": ObjectType.query.name,
+                    "type": ObjectType.QUERY.name,
                     "name": obj.label,
                     "url": obj.url(),
                     "changed_on": obj.changed_on,

--- a/superset/migrations/versions/2024-01-17_13-09_96164e3017c6_tagged_object_unique_constraint.py
+++ b/superset/migrations/versions/2024-01-17_13-09_96164e3017c6_tagged_object_unique_constraint.py
@@ -28,10 +28,10 @@ down_revision = "59a1450b3c10"
 
 class ObjectType(enum.Enum):
     # pylint: disable=invalid-name
-    query = 1
-    chart = 2
-    dashboard = 3
-    dataset = 4
+    QUERY = 1
+    CHART = 2
+    DASHBOARD = 3
+    DATASET = 4
 
 
 # Define the tagged_object table structure

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -153,7 +153,7 @@ class Dashboard(AuditMixinNullable, ImportExportMixin, Model):
         overlaps="objects,tag,tags",
         secondary="tagged_object",
         primaryjoin="and_(Dashboard.id == TaggedObject.object_id, "
-        "TaggedObject.object_type == 'dashboard')",
+        "TaggedObject.object_type == 'DASHBOARD')",
         secondaryjoin="TaggedObject.tag_id == Tag.id",
         viewonly=True,  # cascading deletion already handled by superset.tags.models.ObjectUpdater.after_delete
     )

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -105,7 +105,7 @@ class Slice(  # pylint: disable=too-many-public-methods
         secondary="tagged_object",
         overlaps="objects,tag,tags",
         primaryjoin="and_(Slice.id == TaggedObject.object_id, "
-        "TaggedObject.object_type == 'chart')",
+        "TaggedObject.object_type == 'CHART')",
         secondaryjoin="TaggedObject.tag_id == Tag.id",
         viewonly=True,  # cascading deletion already handled by superset.tags.models.ObjectUpdater.after_delete
     )

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -418,7 +418,7 @@ class SavedQuery(
         secondary="tagged_object",
         overlaps="objects,tag,tags",
         primaryjoin="and_(SavedQuery.id == TaggedObject.object_id, "
-        "TaggedObject.object_type == 'query')",
+        "TaggedObject.object_type == 'QUERY')",
         secondaryjoin="TaggedObject.tag_id == Tag.id",
         viewonly=True,  # cascading deletion already handled by superset.tags.models.ObjectUpdater.after_delete
     )

--- a/superset/tags/api.py
+++ b/superset/tags/api.py
@@ -47,6 +47,7 @@ from superset.tags.schemas import (
     openapi_spec_methods_override,
     TaggedObjectEntityResponseSchema,
     TagGetResponseSchema,
+    TagPostBulkResponseSchema,
     TagPostBulkSchema,
     TagPostSchema,
     TagPutSchema,
@@ -132,6 +133,8 @@ class TagRestApi(BaseSupersetModelRestApi):
     openapi_spec_component_schemas = (
         TagGetResponseSchema,
         TaggedObjectEntityResponseSchema,
+        TagPostBulkResponseSchema,
+        TagPostBulkSchema,
     )
     apispec_parameter_schemas = {
         "delete_tags_schema": delete_tags_schema,
@@ -211,40 +214,21 @@ class TagRestApi(BaseSupersetModelRestApi):
         """Bulk create tags and tagged objects
         ---
         post:
-          summary: Get all objects associated with a tag
-          parameters:
-          - in: path
-            schema:
-              type: integer
-            name: tag_id
+          summary: Bulk create tags and tagged objects
           requestBody:
             description: Tag schema
             required: true
             content:
               application/json:
                 schema:
-                  type: object
-                  properties:
-                    tags:
-                      description: list of tag names to add to object
-                      type: array
-                      items:
-                        type: string
-                    objects_to_tag:
-                      description: list of object names to add to object
-                      type: array
-                      items:
-                        type: array
+                  $ref: '#/components/schemas/TagPostBulkSchema'
           responses:
             200:
-              description: Tag added to favorites
+              description: Bulk created tags and tagged objects
               content:
                 application/json:
                   schema:
-                    type: object
-                    properties:
-                      result:
-                        type: object
+                    $ref: '#/components/schemas/TagPostBulkResponseSchema'
             302:
               description: Redirects to the current digest
             400:
@@ -267,6 +251,7 @@ class TagRestApi(BaseSupersetModelRestApi):
                 tagged_item: dict[str, Any] = self.add_model_schema.load(
                     {
                         "name": tag.get("name"),
+                        "description": tag.get("description"),
                         "objects_to_tag": tag.get("objects_to_tag"),
                     }
                 )

--- a/superset/tags/filters.py
+++ b/superset/tags/filters.py
@@ -42,9 +42,9 @@ class UserCreatedTagTypeFilter(BaseFilter):  # pylint: disable=too-few-public-me
 
     def apply(self, query: Query, value: bool) -> Query:
         if value:
-            return query.filter(Tag.type == TagType.custom)
+            return query.filter(Tag.type == TagType.CUSTOM)
         if value is False:
-            return query.filter(Tag.type != TagType.custom)
+            return query.filter(Tag.type != TagType.CUSTOM)
         return query
 
 

--- a/superset/tags/models.py
+++ b/superset/tags/models.py
@@ -69,22 +69,22 @@ class TagType(enum.Enum):
 
     # pylint: disable=invalid-name
     # explicit tags, added manually by the owner
-    custom = 1
+    CUSTOM = 1
 
     # implicit tags, generated automatically
-    type = 2
-    owner = 3
-    favorited_by = 4
+    TYPE = 2
+    OWNER = 3
+    FAVORITED_BY = 4
 
 
 class ObjectType(enum.Enum):
     """Object types."""
 
     # pylint: disable=invalid-name
-    query = 1
-    chart = 2
-    dashboard = 3
-    dataset = 4
+    QUERY = 1
+    CHART = 2
+    DASHBOARD = 3
+    DATASET = 4
 
 
 class Tag(Model, AuditMixinNullable):
@@ -146,10 +146,10 @@ def get_tag(
 
 def get_object_type(class_name: str) -> ObjectType:
     mapping = {
-        "slice": ObjectType.chart,
-        "dashboard": ObjectType.dashboard,
-        "query": ObjectType.query,
-        "dataset": ObjectType.dataset,
+        "slice": ObjectType.CHART,
+        "dashboard": ObjectType.DASHBOARD,
+        "query": ObjectType.QUERY,
+        "dataset": ObjectType.DATASET,
     }
     try:
         return mapping[class_name.lower()]
@@ -177,7 +177,7 @@ class ObjectUpdater:
         tag_ids = set()
         for owner_id in cls.get_owners_ids(target):
             name = f"owner:{owner_id}"
-            tag = get_tag(name, session, TagType.owner)
+            tag = get_tag(name, session, TagType.OWNER)
             tag_ids.add(tag.id)
         return tag_ids
 
@@ -189,7 +189,7 @@ class ObjectUpdater:
     ) -> None:
         for owner_id in cls.get_owners_ids(target):
             name: str = f"owner:{owner_id}"
-            tag = get_tag(name, session, TagType.owner)
+            tag = get_tag(name, session, TagType.OWNER)
             cls.add_tag_object_if_not_tagged(
                 session, tag_id=tag.id, object_id=target.id, object_type=cls.object_type
             )
@@ -229,7 +229,7 @@ class ObjectUpdater:
             cls._add_owners(session, target)
 
             # add `type:` tags
-            tag = get_tag(f"type:{cls.object_type}", session, TagType.type)
+            tag = get_tag(f"type:{cls.object_type}", session, TagType.TYPE)
             cls.add_tag_object_if_not_tagged(
                 session, tag_id=tag.id, object_id=target.id, object_type=cls.object_type
             )
@@ -250,7 +250,7 @@ class ObjectUpdater:
                 .filter(
                     TaggedObject.object_type == cls.object_type,
                     TaggedObject.object_id == target.id,
-                    Tag.type == TagType.owner,
+                    Tag.type == TagType.OWNER,
                 )
                 .all()
             )
@@ -330,7 +330,7 @@ class FavStarUpdater:
     ) -> None:
         with Session(bind=connection) as session:  # pylint: disable=disallowed-name
             name = f"favorited_by:{target.user_id}"
-            tag = get_tag(name, session, TagType.favorited_by)
+            tag = get_tag(name, session, TagType.FAVORITED_BY)
             tagged_object = TaggedObject(
                 tag_id=tag.id,
                 object_id=target.obj_id,
@@ -350,7 +350,7 @@ class FavStarUpdater:
                 .join(Tag)
                 .filter(
                     TaggedObject.object_id == target.obj_id,
-                    Tag.type == TagType.favorited_by,
+                    Tag.type == TagType.FAVORITED_BY,
                     Tag.name == name,
                 )
             )

--- a/superset/tags/models.py
+++ b/superset/tags/models.py
@@ -67,7 +67,6 @@ class TagType(enum.Enum):
     can find all their objects by querying for the tag `owner:alice`.
     """
 
-    # pylint: disable=invalid-name
     # explicit tags, added manually by the owner
     CUSTOM = 1
 
@@ -80,7 +79,6 @@ class TagType(enum.Enum):
 class ObjectType(enum.Enum):
     """Object types."""
 
-    # pylint: disable=invalid-name
     QUERY = 1
     CHART = 2
     DASHBOARD = 3

--- a/superset/tags/models.py
+++ b/superset/tags/models.py
@@ -290,7 +290,7 @@ class ObjectUpdater:
 
 
 class ChartUpdater(ObjectUpdater):
-    object_type = "chart"
+    object_type = "CHART"
 
     @classmethod
     def get_owners_ids(cls, target: Slice) -> list[int]:
@@ -298,7 +298,7 @@ class ChartUpdater(ObjectUpdater):
 
 
 class DashboardUpdater(ObjectUpdater):
-    object_type = "dashboard"
+    object_type = "DASHBOARD"
 
     @classmethod
     def get_owners_ids(cls, target: Dashboard) -> list[int]:
@@ -306,7 +306,7 @@ class DashboardUpdater(ObjectUpdater):
 
 
 class QueryUpdater(ObjectUpdater):
-    object_type = "query"
+    object_type = "QUERY"
 
     @classmethod
     def get_owners_ids(cls, target: Query) -> list[int]:
@@ -314,7 +314,7 @@ class QueryUpdater(ObjectUpdater):
 
 
 class DatasetUpdater(ObjectUpdater):
-    object_type = "dataset"
+    object_type = "DATASET"
 
     @classmethod
     def get_owners_ids(cls, target: SqlaTable) -> list[int]:

--- a/superset/tags/schemas.py
+++ b/superset/tags/schemas.py
@@ -53,21 +53,37 @@ class TaggedObjectEntityResponseSchema(Schema):
     changed_on = fields.DateTime()
     created_by = fields.Nested(UserSchema(exclude=["username"]))
     creator = fields.String()
-    tags = fields.List(fields.Nested(TagGetResponseSchema))
-    owners = fields.List(fields.Nested(UserSchema))
+    tags = fields.List(fields.Nested(TagGetResponseSchema()))
+    owners = fields.List(fields.Nested(UserSchema()))
+
+
+objects_to_tag_field = fields.List(
+    fields.Tuple(
+        (
+            fields.String(metadata={"description": "type of resource"}),
+            fields.Int(validate=Range(min=1), metadata={"description": "resource id"}),
+        ),
+    ),
+    metadata={
+        "description": "Objects to tag",
+    },
+    required=False,
+)
 
 
 class TagObjectSchema(Schema):
     name = fields.String(validate=Length(min=1))
     description = fields.String(required=False, allow_none=True)
-    objects_to_tag = fields.List(
-        fields.Tuple((fields.String(), fields.Int(validate=Range(min=1)))),
-        required=False,
-    )
+    objects_to_tag = objects_to_tag_field
 
 
 class TagPostBulkSchema(Schema):
-    tags = fields.List(fields.Nested(TagObjectSchema))
+    tags = fields.List(fields.Nested(TagObjectSchema()))
+
+
+class TagPostBulkResponseSchema(Schema):
+    objects_tagged = objects_to_tag_field
+    objects_skipped = objects_to_tag_field
 
 
 class TagPostSchema(TagObjectSchema):

--- a/superset/tasks/cache.py
+++ b/superset/tasks/cache.py
@@ -177,7 +177,7 @@ class DashboardTagsStrategy(Strategy):  # pylint: disable=too-few-public-methods
             db.session.query(TaggedObject)
             .filter(
                 and_(
-                    TaggedObject.object_type == "dashboard",
+                    TaggedObject.object_type == "DASHBOARD",
                     TaggedObject.tag_id.in_(tag_ids),
                 )
             )
@@ -196,7 +196,7 @@ class DashboardTagsStrategy(Strategy):  # pylint: disable=too-few-public-methods
             db.session.query(TaggedObject)
             .filter(
                 and_(
-                    TaggedObject.object_type == "chart",
+                    TaggedObject.object_type == "CHART",
                     TaggedObject.tag_id.in_(tag_ids),
                 )
             )

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -2268,7 +2268,8 @@ class TestChartApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
         rv = self.put_assert_metric(uri, update_payload, "put")
         assert rv.status_code == 403
         assert (
-            rv.json["message"] == "You do not have permission to manage tags on charts"
+            rv.json["message"]
+            == "You do not have permission to manage tags of type CHART"
         )
 
         security_manager.add_permission_role(alpha_role, write_tags_perm)
@@ -2298,7 +2299,8 @@ class TestChartApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
         rv = self.put_assert_metric(uri, update_payload, "put")
         assert rv.status_code == 403
         assert (
-            rv.json["message"] == "You do not have permission to manage tags on charts"
+            rv.json["message"]
+            == "You do not have permission to manage tags of type CHART"
         )
 
         security_manager.add_permission_role(alpha_role, write_tags_perm)

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -218,7 +218,7 @@ class TestChartApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
             tag = db.session.query(Tag).filter(Tag.name == "first_tag").first()
             tag_association = TaggedObject(
                 object_id=chart.id,
-                object_type=ObjectType.chart,
+                object_type=ObjectType.CHART,
                 tag=tag,
             )
 
@@ -263,22 +263,22 @@ class TestChartApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
             tag_associations = [
                 TaggedObject(
                     object_id=charts[0].id,
-                    object_type=ObjectType.chart,
+                    object_type=ObjectType.CHART,
                     tag=tags["first_tag"],
                 ),
                 TaggedObject(
                     object_id=charts[1].id,
-                    object_type=ObjectType.chart,
+                    object_type=ObjectType.CHART,
                     tag=tags["second_tag"],
                 ),
                 TaggedObject(
                     object_id=charts[2].id,
-                    object_type=ObjectType.chart,
+                    object_type=ObjectType.CHART,
                     tag=tags["first_tag"],
                 ),
                 TaggedObject(
                     object_id=charts[2].id,
-                    object_type=ObjectType.chart,
+                    object_type=ObjectType.CHART,
                     tag=tags["second_tag"],
                 ),
             ]
@@ -2136,7 +2136,7 @@ class TestChartApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
         new_tag = db.session.query(Tag).filter(Tag.name == "second_tag").one()
 
         # get existing tag and add a new one
-        new_tags = [tag.id for tag in chart.tags if tag.type == TagType.custom]
+        new_tags = [tag.id for tag in chart.tags if tag.type == TagType.CUSTOM]
         new_tags.append(new_tag.id)
         update_payload = {"tags": new_tags}
 
@@ -2146,7 +2146,7 @@ class TestChartApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
         model = db.session.query(Slice).get(chart.id)
 
         # Clean up system tags
-        tag_list = [tag.id for tag in model.tags if tag.type == TagType.custom]
+        tag_list = [tag.id for tag in model.tags if tag.type == TagType.CUSTOM]
         assert tag_list == new_tags
 
     @pytest.mark.usefixtures("create_chart_with_tag")
@@ -2162,7 +2162,7 @@ class TestChartApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
         )
 
         # get existing tag and add a new one
-        new_tags = [tag.id for tag in chart.tags if tag.type == TagType.custom]
+        new_tags = [tag.id for tag in chart.tags if tag.type == TagType.CUSTOM]
         new_tags.pop()
 
         update_payload = {"tags": new_tags}
@@ -2173,7 +2173,7 @@ class TestChartApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
         model = db.session.query(Slice).get(chart.id)
 
         # Clean up system tags
-        tag_list = [tag.id for tag in model.tags if tag.type == TagType.custom]
+        tag_list = [tag.id for tag in model.tags if tag.type == TagType.CUSTOM]
         assert tag_list == new_tags
 
     @pytest.mark.usefixtures("create_chart_with_tag")
@@ -2195,7 +2195,7 @@ class TestChartApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
         new_tag = db.session.query(Tag).filter(Tag.name == "second_tag").one()
 
         # get existing tag and add a new one
-        new_tags = [tag.id for tag in chart.tags if tag.type == TagType.custom]
+        new_tags = [tag.id for tag in chart.tags if tag.type == TagType.CUSTOM]
         new_tags.append(new_tag.id)
         update_payload = {"tags": new_tags}
 
@@ -2205,7 +2205,7 @@ class TestChartApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
         model = db.session.query(Slice).get(chart.id)
 
         # Clean up system tags
-        tag_list = [tag.id for tag in model.tags if tag.type == TagType.custom]
+        tag_list = [tag.id for tag in model.tags if tag.type == TagType.CUSTOM]
         assert tag_list == new_tags
 
         security_manager.add_permission_role(alpha_role, write_tags_perm)
@@ -2235,7 +2235,7 @@ class TestChartApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
         model = db.session.query(Slice).get(chart.id)
 
         # Clean up system tags
-        tag_list = [tag.id for tag in model.tags if tag.type == TagType.custom]
+        tag_list = [tag.id for tag in model.tags if tag.type == TagType.CUSTOM]
         assert tag_list == []
 
         security_manager.add_permission_role(alpha_role, write_tags_perm)
@@ -2260,7 +2260,7 @@ class TestChartApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
         new_tag = db.session.query(Tag).filter(Tag.name == "second_tag").one()
 
         # get existing tag and add a new one
-        new_tags = [tag.id for tag in chart.tags if tag.type == TagType.custom]
+        new_tags = [tag.id for tag in chart.tags if tag.type == TagType.CUSTOM]
         new_tags.append(new_tag.id)
         update_payload = {"tags": new_tags}
 
@@ -2321,7 +2321,7 @@ class TestChartApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
         chart = (
             db.session.query(Slice).filter(Slice.slice_name == "chart with tag").first()
         )
-        existing_tags = [tag.id for tag in chart.tags if tag.type == TagType.custom]
+        existing_tags = [tag.id for tag in chart.tags if tag.type == TagType.CUSTOM]
         update_payload = {"tags": existing_tags}
 
         uri = f"api/v1/chart/{chart.id}"

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -2944,7 +2944,7 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
         assert rv.status_code == 403
         assert (
             rv.json["message"]
-            == "You do not have permission to manage tags on dashboards"
+            == "You do not have permission to manage tags of type DASHBOARD"
         )
 
         security_manager.add_permission_role(gamma_role, write_tags_perm)
@@ -2978,7 +2978,7 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
         assert rv.status_code == 403
         assert (
             rv.json["message"]
-            == "You do not have permission to manage tags on dashboards"
+            == "You do not have permission to manage tags of type DASHBOARD"
         )
 
         security_manager.add_permission_role(gamma_role, write_tags_perm)

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -194,7 +194,7 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
             tag = db.session.query(Tag).filter(Tag.name == "first_tag").first()
             tag_association = TaggedObject(
                 object_id=dashboard.id,
-                object_type=ObjectType.dashboard,
+                object_type=ObjectType.DASHBOARD,
                 tag=tag,
             )
 
@@ -245,22 +245,22 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
             tag_associations = [
                 TaggedObject(
                     object_id=dashboards[0].id,
-                    object_type=ObjectType.chart,
+                    object_type=ObjectType.CHART,
                     tag=tags["first_tag"],
                 ),
                 TaggedObject(
                     object_id=dashboards[1].id,
-                    object_type=ObjectType.chart,
+                    object_type=ObjectType.CHART,
                     tag=tags["second_tag"],
                 ),
                 TaggedObject(
                     object_id=dashboards[2].id,
-                    object_type=ObjectType.chart,
+                    object_type=ObjectType.CHART,
                     tag=tags["first_tag"],
                 ),
                 TaggedObject(
                     object_id=dashboards[2].id,
-                    object_type=ObjectType.chart,
+                    object_type=ObjectType.CHART,
                     tag=tags["second_tag"],
                 ),
             ]
@@ -2804,7 +2804,7 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
         new_tag = db.session.query(Tag).filter(Tag.name == "second_tag").one()
 
         # get existing tag and add a new one
-        new_tags = [tag.id for tag in dashboard.tags if tag.type == TagType.custom]
+        new_tags = [tag.id for tag in dashboard.tags if tag.type == TagType.CUSTOM]
         new_tags.append(new_tag.id)
         update_payload = {"tags": new_tags}
 
@@ -2814,7 +2814,7 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
         model = db.session.query(Dashboard).get(dashboard.id)
 
         # Clean up system tags
-        tag_list = [tag.id for tag in model.tags if tag.type == TagType.custom]
+        tag_list = [tag.id for tag in model.tags if tag.type == TagType.CUSTOM]
         assert sorted(tag_list) == sorted(new_tags)
 
     @pytest.mark.usefixtures("create_dashboard_with_tag")
@@ -2832,7 +2832,7 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
         )
 
         # get existing tag and add a new one
-        new_tags = [tag.id for tag in dashboard.tags if tag.type == TagType.custom]
+        new_tags = [tag.id for tag in dashboard.tags if tag.type == TagType.CUSTOM]
         new_tags.pop()
 
         update_payload = {"tags": new_tags}
@@ -2843,7 +2843,7 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
         model = db.session.query(Dashboard).get(dashboard.id)
 
         # Clean up system tags
-        tag_list = [tag.id for tag in model.tags if tag.type == TagType.custom]
+        tag_list = [tag.id for tag in model.tags if tag.type == TagType.CUSTOM]
         assert tag_list == new_tags
 
     @pytest.mark.usefixtures("create_dashboard_with_tag")
@@ -2866,7 +2866,7 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
         new_tag = db.session.query(Tag).filter(Tag.name == "second_tag").one()
 
         # get existing tag and add a new one
-        new_tags = [tag.id for tag in dashboard.tags if tag.type == TagType.custom]
+        new_tags = [tag.id for tag in dashboard.tags if tag.type == TagType.CUSTOM]
         new_tags.append(new_tag.id)
         update_payload = {"tags": new_tags}
 
@@ -2876,7 +2876,7 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
         model = db.session.query(Dashboard).get(dashboard.id)
 
         # Clean up system tags
-        tag_list = [tag.id for tag in model.tags if tag.type == TagType.custom]
+        tag_list = [tag.id for tag in model.tags if tag.type == TagType.CUSTOM]
         assert sorted(tag_list) == sorted(new_tags)
 
         security_manager.add_permission_role(gamma_role, write_tags_perm)
@@ -2907,7 +2907,7 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
         model = db.session.query(Dashboard).get(dashboard.id)
 
         # Clean up system tags
-        tag_list = [tag.id for tag in model.tags if tag.type == TagType.custom]
+        tag_list = [tag.id for tag in model.tags if tag.type == TagType.CUSTOM]
         assert tag_list == []
 
         security_manager.add_permission_role(gamma_role, write_tags_perm)
@@ -2935,7 +2935,7 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
         new_tag = db.session.query(Tag).filter(Tag.name == "second_tag").one()
 
         # get existing tag and add a new one
-        new_tags = [tag.id for tag in dashboard.tags if tag.type == TagType.custom]
+        new_tags = [tag.id for tag in dashboard.tags if tag.type == TagType.CUSTOM]
         new_tags.append(new_tag.id)
         update_payload = {"tags": new_tags}
 
@@ -3004,7 +3004,7 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
             .filter(Dashboard.dashboard_title == "dash with tag")
             .first()
         )
-        existing_tags = [tag.id for tag in dashboard.tags if tag.type == TagType.custom]
+        existing_tags = [tag.id for tag in dashboard.tags if tag.type == TagType.CUSTOM]
         update_payload = {"tags": existing_tags}
 
         uri = f"api/v1/dashboard/{dashboard.id}"

--- a/tests/integration_tests/queries/saved_queries/api_tests.py
+++ b/tests/integration_tests/queries/saved_queries/api_tests.py
@@ -163,22 +163,22 @@ class TestSavedQueryApi(SupersetTestCase):
             tag_associations = [
                 TaggedObject(
                     object_id=queries[0].id,
-                    object_type=ObjectType.chart,
+                    object_type=ObjectType.CHART,
                     tag=tags["first_tag"],
                 ),
                 TaggedObject(
                     object_id=queries[1].id,
-                    object_type=ObjectType.chart,
+                    object_type=ObjectType.CHART,
                     tag=tags["second_tag"],
                 ),
                 TaggedObject(
                     object_id=queries[2].id,
-                    object_type=ObjectType.chart,
+                    object_type=ObjectType.CHART,
                     tag=tags["first_tag"],
                 ),
                 TaggedObject(
                     object_id=queries[2].id,
-                    object_type=ObjectType.chart,
+                    object_type=ObjectType.CHART,
                     tag=tags["second_tag"],
                 ),
             ]

--- a/tests/integration_tests/strategy_tests.py
+++ b/tests/integration_tests/strategy_tests.py
@@ -99,7 +99,7 @@ class TestCacheWarmUp(SupersetTestCase):
         "load_unicode_dashboard_with_slice", "load_birth_names_dashboard_with_slices"
     )
     def test_dashboard_tags_strategy(self):
-        tag1 = get_tag("tag1", db.session, TagType.custom)
+        tag1 = get_tag("tag1", db.session, TagType.CUSTOM)
         # delete first to make test idempotent
         self.reset_tag(tag1)
 
@@ -109,11 +109,11 @@ class TestCacheWarmUp(SupersetTestCase):
         assert result == expected
 
         # tag dashboard 'births' with `tag1`
-        tag1 = get_tag("tag1", db.session, TagType.custom)
+        tag1 = get_tag("tag1", db.session, TagType.CUSTOM)
         dash = self.get_dash_by_slug("births")
         tag1_urls = [{"chart_id": chart.id} for chart in dash.slices]
         tagged_object = TaggedObject(
-            tag_id=tag1.id, object_id=dash.id, object_type=ObjectType.dashboard
+            tag_id=tag1.id, object_id=dash.id, object_type=ObjectType.DASHBOARD
         )
         db.session.add(tagged_object)
         db.session.commit()
@@ -121,7 +121,7 @@ class TestCacheWarmUp(SupersetTestCase):
         self.assertCountEqual(strategy.get_payloads(), tag1_urls)  # noqa: PT009
 
         strategy = DashboardTagsStrategy(["tag2"])
-        tag2 = get_tag("tag2", db.session, TagType.custom)
+        tag2 = get_tag("tag2", db.session, TagType.CUSTOM)
         self.reset_tag(tag2)
 
         result = strategy.get_payloads()
@@ -134,7 +134,7 @@ class TestCacheWarmUp(SupersetTestCase):
         tag2_urls = [{"chart_id": chart.id}]
         object_id = chart.id
         tagged_object = TaggedObject(
-            tag_id=tag2.id, object_id=object_id, object_type=ObjectType.chart
+            tag_id=tag2.id, object_id=object_id, object_type=ObjectType.CHART
         )
         db.session.add(tagged_object)
         db.session.commit()

--- a/tests/integration_tests/tagging_tests.py
+++ b/tests/integration_tests/tagging_tests.py
@@ -71,9 +71,9 @@ class TestTagging(SupersetTestCase):
 
         # Test to make sure that a dataset tag was added to the tagged_object table
         tags = self.query_tagged_object_table()
-        assert 1 == len(tags)
-        assert "ObjectType.dataset" == str(tags[0].object_type)
-        assert test_dataset.id == tags[0].object_id
+        assert len(tags) == 1
+        assert str(tags[0].object_type) == "ObjectType.DATASET"
+        assert tags[0].object_id == test_dataset.id
 
         # Cleanup the db
         db.session.delete(test_dataset)
@@ -109,9 +109,9 @@ class TestTagging(SupersetTestCase):
 
         # Test to make sure that a chart tag was added to the tagged_object table
         tags = self.query_tagged_object_table()
-        assert 1 == len(tags)
-        assert "ObjectType.chart" == str(tags[0].object_type)
-        assert test_chart.id == tags[0].object_id
+        assert len(tags) == 1
+        assert "ObjectType.CHART" == str(tags[0].object_type)
+        assert tags[0].object_id == test_chart.id
 
         # Cleanup the db
         db.session.delete(test_chart)
@@ -145,9 +145,9 @@ class TestTagging(SupersetTestCase):
 
         # Test to make sure that a dashboard tag was added to the tagged_object table
         tags = self.query_tagged_object_table()
-        assert 1 == len(tags)
-        assert "ObjectType.dashboard" == str(tags[0].object_type)
-        assert test_dashboard.id == tags[0].object_id
+        assert len(tags) == 1
+        assert str(tags[0].object_type) == "ObjectType.DASHBOARD"
+        assert tags[0].object_id == test_dashboard.id
 
         # Cleanup the db
         db.session.delete(test_dashboard)
@@ -180,15 +180,15 @@ class TestTagging(SupersetTestCase):
 
         assert 2 == len(tags)
 
-        assert "ObjectType.query" == str(tags[0].object_type)
-        assert "owner:None" == str(tags[0].tag.name)
-        assert "TagType.owner" == str(tags[0].tag.type)
-        assert test_saved_query.id == tags[0].object_id
+        assert str(tags[0].object_type) == "ObjectType.QUERY"
+        assert str(tags[0].tag.name) == "owner:None"
+        assert str(tags[0].tag.type) == "TagType.OWNER"
+        assert tags[0].object_id == test_saved_query.id
 
-        assert "ObjectType.query" == str(tags[1].object_type)
-        assert "type:query" == str(tags[1].tag.name)
-        assert "TagType.type" == str(tags[1].tag.type)
-        assert test_saved_query.id == tags[1].object_id
+        assert str(tags[1].object_type) == "ObjectType.QUERY"
+        assert str(tags[1].tag.name) == "type:query"
+        assert str(tags[1].tag.type) == "TagType.TYPE"
+        assert tags[1].object_id == test_saved_query.id
 
         # Cleanup the db
         db.session.delete(test_saved_query)
@@ -218,9 +218,9 @@ class TestTagging(SupersetTestCase):
 
         # Test to make sure that a favorited object tag was added to the tagged_object table
         tags = self.query_tagged_object_table()
-        assert 1 == len(tags)
-        assert "ObjectType.chart" == str(tags[0].object_type)
-        assert test_saved_query.obj_id == tags[0].object_id
+        assert len(tags) == 1
+        assert str(tags[0].object_type) == "ObjectType.CHART"
+        assert tags[0].object_id == test_saved_query.obj_id
 
         # Cleanup the db
         db.session.delete(test_saved_query)

--- a/tests/integration_tests/tagging_tests.py
+++ b/tests/integration_tests/tagging_tests.py
@@ -94,7 +94,7 @@ class TestTagging(SupersetTestCase):
         self.clear_tagged_object_table()
 
         # Test to make sure nothing is in the tagged_object table
-        assert [] == self.query_tagged_object_table()
+        assert self.query_tagged_object_table() == []
 
         # Create a chart and add it to the db
         test_chart = Slice(
@@ -110,7 +110,7 @@ class TestTagging(SupersetTestCase):
         # Test to make sure that a chart tag was added to the tagged_object table
         tags = self.query_tagged_object_table()
         assert len(tags) == 1
-        assert "ObjectType.CHART" == str(tags[0].object_type)
+        assert str(tags[0].object_type) == "ObjectType.CHART"
         assert tags[0].object_id == test_chart.id
 
         # Cleanup the db
@@ -118,7 +118,7 @@ class TestTagging(SupersetTestCase):
         db.session.commit()
 
         # Test to make sure the tag is deleted when the associated object is deleted
-        assert [] == self.query_tagged_object_table()
+        assert self.query_tagged_object_table() == []
 
     @pytest.mark.usefixtures("with_tagging_system_feature")
     def test_dashboard_tagging(self):

--- a/tests/integration_tests/tags/api_tests.py
+++ b/tests/integration_tests/tags/api_tests.py
@@ -142,7 +142,7 @@ class TestTagApi(SupersetTestCase):
             "created_by": None,
             "id": tag.id,
             "name": "test get tag",
-            "type": TagType.custom.value,
+            "type": TagType.CUSTOM.value,
         }
         data = json.loads(rv.data.decode("utf-8"))
         for key, value in expected_result.items():
@@ -243,7 +243,7 @@ class TestTagApi(SupersetTestCase):
             .first()
         )
         dashboard_id = dashboard.id
-        dashboard_type = ObjectType.dashboard.value
+        dashboard_type = ObjectType.DASHBOARD.value
         uri = f"api/v1/tag/{dashboard_type}/{dashboard_id}/"
         example_tag_names = ["example_tag_1", "example_tag_2"]
         data = {"properties": {"tags": example_tag_names}}
@@ -258,7 +258,7 @@ class TestTagApi(SupersetTestCase):
         tagged_objects = db.session.query(TaggedObject).filter(
             TaggedObject.tag_id.in_(tag_ids),
             TaggedObject.object_id == dashboard_id,
-            TaggedObject.object_type == ObjectType.dashboard,
+            TaggedObject.object_type == ObjectType.DASHBOARD,
         )
         assert tagged_objects.count() == 2
         # clean up tags and tagged objects
@@ -276,7 +276,7 @@ class TestTagApi(SupersetTestCase):
     def test_delete_tagged_objects(self):
         self.login(ADMIN_USERNAME)
         dashboard_id = 1
-        dashboard_type = ObjectType.dashboard
+        dashboard_type = ObjectType.DASHBOARD
         tag_names = ["example_tag_1", "example_tag_2"]
         tags = db.session.query(Tag).filter(Tag.name.in_(tag_names))
         assert tags.count() == 2
@@ -346,7 +346,7 @@ class TestTagApi(SupersetTestCase):
             .first()
         )
         dashboard_id = dashboard.id
-        dashboard_type = ObjectType.dashboard
+        dashboard_type = ObjectType.DASHBOARD
         tag_names = ["example_tag_1", "example_tag_2"]
         tags = db.session.query(Tag).filter(Tag.name.in_(tag_names))
         for tag in tags:
@@ -382,7 +382,7 @@ class TestTagApi(SupersetTestCase):
             .first()
         )
         dashboard_id = dashboard.id
-        dashboard_type = ObjectType.dashboard
+        dashboard_type = ObjectType.DASHBOARD
         tag_names = ["example_tag_1", "example_tag_2"]
         tags = db.session.query(Tag).filter(Tag.name.in_(tag_names))
         for tag in tags:
@@ -531,7 +531,7 @@ class TestTagApi(SupersetTestCase):
         self.get_user(username="admin").get_id()  # noqa: F841
         tag = (
             db.session.query(Tag)
-            .filter(Tag.name == "my_tag", Tag.type == TagType.custom)
+            .filter(Tag.name == "my_tag", Tag.type == TagType.CUSTOM)
             .one_or_none()
         )
         assert tag is not None
@@ -630,8 +630,8 @@ class TestTagApi(SupersetTestCase):
             .join(Tag)
             .filter(
                 TaggedObject.object_id == dashboard.id,
-                TaggedObject.object_type == ObjectType.dashboard,
-                Tag.type == TagType.custom,
+                TaggedObject.object_type == ObjectType.DASHBOARD,
+                Tag.type == TagType.CUSTOM,
             )
         )
         assert tagged_objects.count() == 2
@@ -641,8 +641,8 @@ class TestTagApi(SupersetTestCase):
             .join(Tag)
             .filter(
                 TaggedObject.object_id == chart.id,
-                TaggedObject.object_type == ObjectType.chart,
-                Tag.type == TagType.custom,
+                TaggedObject.object_type == ObjectType.CHART,
+                Tag.type == TagType.CUSTOM,
             )
         )
         assert tagged_objects.count() == 2

--- a/tests/integration_tests/tags/api_tests.py
+++ b/tests/integration_tests/tags/api_tests.py
@@ -524,7 +524,7 @@ class TestTagApi(SupersetTestCase):
         )
         rv = self.client.post(
             uri,
-            json={"name": "my_tag", "objects_to_tag": [["dashboard", dashboard.id]]},
+            json={"name": "my_tag", "objects_to_tag": [["DASHBOARD", dashboard.id]]},
         )
 
         assert rv.status_code == 201
@@ -547,7 +547,7 @@ class TestTagApi(SupersetTestCase):
         )
         rv = self.client.post(
             uri,
-            json={"name": "", "objects_to_tag": [["dashboard", dashboard.id]]},
+            json={"name": "", "objects_to_tag": [["DASHBOARD", dashboard.id]]},
         )
 
         assert rv.status_code == 400
@@ -601,17 +601,17 @@ class TestTagApi(SupersetTestCase):
                     {
                         "name": "tag1",
                         "objects_to_tag": [
-                            ["dashboard", dashboard.id],
-                            ["chart", chart.id],
+                            ["DASHBOARD", dashboard.id],
+                            ["CHART", chart.id],
                         ],
                     },
                     {
                         "name": "tag2",
-                        "objects_to_tag": [["dashboard", dashboard.id]],
+                        "objects_to_tag": [["DASHBOARD", dashboard.id]],
                     },
                     {
                         "name": "tag3",
-                        "objects_to_tag": [["chart", chart.id]],
+                        "objects_to_tag": [["CHART", chart.id]],
                     },
                 ]
             },
@@ -619,10 +619,10 @@ class TestTagApi(SupersetTestCase):
 
         assert rv.status_code == 200
 
-        result = TagDAO.get_tagged_objects_for_tags(tags, ["dashboard"])
+        result = TagDAO.get_tagged_objects_for_tags(tags, ["DASHBOARD"])
         assert len(result) == 1
 
-        result = TagDAO.get_tagged_objects_for_tags(tags, ["chart"])
+        result = TagDAO.get_tagged_objects_for_tags(tags, ["CHART"])
         assert len(result) == 1
 
         tagged_objects = (
@@ -671,16 +671,16 @@ class TestTagApi(SupersetTestCase):
                     {
                         "name": "tag1",
                         "objects_to_tag": [
-                            ["dashboard", alpha_dash.id],
+                            ["DASHBOARD", alpha_dash.id],
                         ],
                     },
                     {
                         "name": "tag2",
-                        "objects_to_tag": [["dashboard", dashboard.id]],
+                        "objects_to_tag": [["DASHBOARD", dashboard.id]],
                     },
                     {
                         "name": "tag3",
-                        "objects_to_tag": [["chart", chart.id]],
+                        "objects_to_tag": [["CHART", chart.id]],
                     },
                 ]
             },

--- a/tests/integration_tests/tags/commands_tests.py
+++ b/tests/integration_tests/tags/commands_tests.py
@@ -65,9 +65,9 @@ class TestCreateCustomTagCommand(SupersetTestCase):
         example_dashboard = (
             db.session.query(Dashboard).filter_by(slug="world_health").one()
         )
-        example_tags = {"create custom tag example 1", "create custom tag example 2"}
+        example_tags = ["create custom tag example 1", "create custom tag example 2"]
         command = CreateCustomTagCommand(
-            ObjectType.dashboard.value, example_dashboard.id, example_tags
+            ObjectType.DASHBOARD.value, example_dashboard.id, example_tags
         )
         command.run()
 
@@ -76,7 +76,7 @@ class TestCreateCustomTagCommand(SupersetTestCase):
             .join(TaggedObject)
             .filter(
                 TaggedObject.object_id == example_dashboard.id,
-                Tag.type == TagType.custom,
+                Tag.type == TagType.CUSTOM,
             )
             .all()
         )
@@ -101,9 +101,9 @@ class TestDeleteTagsCommand(SupersetTestCase):
             .filter_by(dashboard_title="World Bank's Data")
             .one()
         )
-        example_tags = {"create custom tag example 1", "create custom tag example 2"}
+        example_tags = ["create custom tag example 1", "create custom tag example 2"]
         command = CreateCustomTagCommand(
-            ObjectType.dashboard.value, example_dashboard.id, example_tags
+            ObjectType.DASHBOARD.value, example_dashboard.id, example_tags
         )
         command.run()
 
@@ -112,7 +112,7 @@ class TestDeleteTagsCommand(SupersetTestCase):
             .join(TaggedObject)
             .filter(
                 TaggedObject.object_id == example_dashboard.id,
-                Tag.type == TagType.custom,
+                Tag.type == TagType.CUSTOM,
             )
             .order_by(Tag.name)
             .all()
@@ -134,9 +134,9 @@ class TestDeleteTaggedObjectCommand(SupersetTestCase):
         example_dashboard = (
             db.session.query(Dashboard).filter_by(slug="world_health").one()
         )
-        example_tags = {"create custom tag example 1", "create custom tag example 2"}
+        example_tags = ["create custom tag example 1", "create custom tag example 2"]
         command = CreateCustomTagCommand(
-            ObjectType.dashboard.value, example_dashboard.id, example_tags
+            ObjectType.DASHBOARD.value, example_dashboard.id, example_tags
         )
         command.run()
 
@@ -145,14 +145,14 @@ class TestDeleteTaggedObjectCommand(SupersetTestCase):
             .join(Tag)
             .filter(
                 TaggedObject.object_id == example_dashboard.id,
-                TaggedObject.object_type == ObjectType.dashboard.name,
+                TaggedObject.object_type == ObjectType.DASHBOARD.name,
                 Tag.name.in_(example_tags),
             )
         )
         assert tagged_objects.count() == 2
         # delete one of the tagged objects
         command = DeleteTaggedObjectCommand(
-            object_type=ObjectType.dashboard.value,
+            object_type=ObjectType.DASHBOARD.value,
             object_id=example_dashboard.id,
             tag=list(example_tags)[0],
         )
@@ -162,7 +162,7 @@ class TestDeleteTaggedObjectCommand(SupersetTestCase):
             .join(Tag)
             .filter(
                 TaggedObject.object_id == example_dashboard.id,
-                TaggedObject.object_type == ObjectType.dashboard.name,
+                TaggedObject.object_type == ObjectType.DASHBOARD.name,
                 Tag.name.in_(example_tags),
             )
         )

--- a/tests/integration_tests/tags/dao_tests.py
+++ b/tests/integration_tests/tags/dao_tests.py
@@ -112,7 +112,7 @@ class TestTagsDAO(SupersetTestCase):
                 tagged_objects.append(
                     self.insert_tagged_object(
                         object_id=dashboard_id,
-                        object_type=ObjectType.dashboard,
+                        object_type=ObjectType.DASHBOARD,
                         tag_id=tag.id,
                     )
                 )
@@ -125,21 +125,21 @@ class TestTagsDAO(SupersetTestCase):
     def test_create_tagged_objects(self):
         # test that a tag can be added if it has ':' in it
         TagDAO.create_custom_tagged_objects(
-            object_type=ObjectType.dashboard.name,
+            object_type=ObjectType.DASHBOARD,
             object_id=1,
             tag_names=["valid:example tag 1"],
         )
 
         # test that a tag can be added if it has ',' in it
         TagDAO.create_custom_tagged_objects(
-            object_type=ObjectType.dashboard.name,
+            object_type=ObjectType.DASHBOARD,
             object_id=1,
             tag_names=["example,tag,1"],
         )
 
         # test that a tag can be added if it has a valid name
         TagDAO.create_custom_tagged_objects(
-            object_type=ObjectType.dashboard.name,
+            object_type=ObjectType.DASHBOARD,
             object_id=1,
             tag_names=["example tag 1"],
         )
@@ -160,7 +160,7 @@ class TestTagsDAO(SupersetTestCase):
         dashboard_id = dashboard.id
         tag = db.session.query(Tag).filter_by(name="example_tag_1").one()
         self.insert_tagged_object(
-            object_id=dashboard_id, object_type=ObjectType.dashboard, tag_id=tag.id
+            object_id=dashboard_id, object_type=ObjectType.DASHBOARD, tag_id=tag.id
         )
         # get objects
         tagged_objects = TagDAO.get_tagged_objects_for_tags(
@@ -184,7 +184,7 @@ class TestTagsDAO(SupersetTestCase):
                 TaggedObject,
                 and_(
                     TaggedObject.object_id == Slice.id,
-                    TaggedObject.object_type == ObjectType.chart,
+                    TaggedObject.object_type == ObjectType.CHART,
                 ),
             )
             .join(Tag, TaggedObject.tag_id == Tag.id)
@@ -197,7 +197,7 @@ class TestTagsDAO(SupersetTestCase):
                 TaggedObject,
                 and_(
                     TaggedObject.object_id == Dashboard.id,
-                    TaggedObject.object_type == ObjectType.dashboard,
+                    TaggedObject.object_type == ObjectType.DASHBOARD,
                 ),
             )
             .join(Tag, TaggedObject.tag_id == Tag.id)
@@ -230,7 +230,7 @@ class TestTagsDAO(SupersetTestCase):
         tag_2 = db.session.query(Tag).filter_by(name="example_tag_2").one()
         tag_ids = [tag_1.id, tag_2.id]
         self.insert_tagged_object(
-            object_id=dashboard_id, object_type=ObjectType.dashboard, tag_id=tag_1.id
+            object_id=dashboard_id, object_type=ObjectType.DASHBOARD, tag_id=tag_1.id
         )
         # get objects
         tagged_objects = TagDAO.get_tagged_objects_by_tag_id(tag_ids)
@@ -253,7 +253,7 @@ class TestTagsDAO(SupersetTestCase):
     def test_find_tagged_object(self):
         tag = db.session.query(Tag).filter(Tag.name == "example_tag_1").first()
         tagged_object = TagDAO.find_tagged_object(
-            object_id=1, object_type=ObjectType.dashboard.name, tag_id=tag.id
+            object_id=1, object_type=ObjectType.DASHBOARD, tag_id=tag.id
         )
         assert tagged_object is not None
 
@@ -309,20 +309,20 @@ class TestTagsDAO(SupersetTestCase):
             .filter(
                 TaggedObject.tag_id == tag.id,
                 TaggedObject.object_id == 1,
-                TaggedObject.object_type == ObjectType.dashboard.name,
+                TaggedObject.object_type == ObjectType.DASHBOARD.name,
             )
             .first()
         )
         assert tagged_object is not None
         TagDAO.delete_tagged_object(
-            object_type=ObjectType.dashboard.name, object_id=1, tag_name=tag.name
+            object_type=ObjectType.DASHBOARD, object_id=1, tag_name=tag.name
         )
         tagged_object = (
             db.session.query(TaggedObject)
             .filter(
                 TaggedObject.tag_id == tag.id,
                 TaggedObject.object_id == 1,
-                TaggedObject.object_type == ObjectType.dashboard.name,
+                TaggedObject.object_type == ObjectType.DASHBOARD.name,
             )
             .first()
         )

--- a/tests/unit_tests/commands/test_utils.py
+++ b/tests/unit_tests/commands/test_utils.py
@@ -32,37 +32,37 @@ from superset.commands.utils import (
 )
 from superset.tags.models import ObjectType
 
-OBJECT_TYPES = {ObjectType.chart, ObjectType.chart}
+OBJECT_TYPES = {ObjectType.CHART, ObjectType.CHART}
 MOCK_TAGS = [
     Tag(
         id=1,
         name="first",
-        type=TagType.custom,
+        type=TagType.CUSTOM,
     ),
     Tag(
         id=2,
         name="second",
-        type=TagType.custom,
+        type=TagType.CUSTOM,
     ),
     Tag(
         id=3,
         name="third",
-        type=TagType.custom,
+        type=TagType.CUSTOM,
     ),
     Tag(
         id=4,
         name="type:dashboard",
-        type=TagType.type,
+        type=TagType.TYPE,
     ),
     Tag(
         id=4,
         name="owner:1",
-        type=TagType.owner,
+        type=TagType.OWNER,
     ),
     Tag(
         id=4,
         name="avorited_by:2",
-        type=TagType.favorited_by,
+        type=TagType.FAVORITED_BY,
     ),
 ]
 
@@ -256,7 +256,7 @@ def test_validate_tags_no_changes_can_write_on_tag(mock_sm, object_type):
     Test the ``validate_tags`` method when new_tags is equal to existing tags
     and user has permission to write on tag.
     """
-    new_tags = [tag.id for tag in MOCK_TAGS if tag.type == TagType.custom]
+    new_tags = [tag.id for tag in MOCK_TAGS if tag.type == TagType.CUSTOM]
     validate_tags(object_type, MOCK_TAGS, new_tags)
     mock_sm.can_access.assert_not_called()
 
@@ -268,7 +268,7 @@ def test_validate_tags_no_changes_can_tag_on_object(mock_sm, object_type):
     Test the ``validate_tags`` method when new_tags is equal to existing tags
     and user has permission to tag objects.
     """
-    new_tags = [tag.id for tag in MOCK_TAGS if tag.type == TagType.custom]
+    new_tags = [tag.id for tag in MOCK_TAGS if tag.type == TagType.CUSTOM]
     validate_tags(object_type, MOCK_TAGS, new_tags)
     mock_sm.can_access.assert_not_called()
 
@@ -280,7 +280,7 @@ def test_validate_tags_no_changes_missing_permission(mock_sm, object_type):
     Test the ``validate_tags`` method when new_tags is equal to existing tags
     the user doens't have the required perms.
     """
-    new_tags = [tag.id for tag in MOCK_TAGS if tag.type == TagType.custom]
+    new_tags = [tag.id for tag in MOCK_TAGS if tag.type == TagType.CUSTOM]
     validate_tags(object_type, MOCK_TAGS, new_tags)
     mock_sm.can_access.assert_not_called()
 
@@ -295,11 +295,11 @@ def test_validate_tags_add_new_tags_can_write_on_tag(
     Test the ``validate_tags`` method when new_tags are added and user has
     permission to write on tag.
     """
-    new_tag_ids = [tag.id for tag in MOCK_TAGS if tag.type == TagType.custom]
+    new_tag_ids = [tag.id for tag in MOCK_TAGS if tag.type == TagType.CUSTOM]
     new_tag = {
         "id": 10,
         "name": "New test tag",
-        "type": TagType.custom,
+        "type": TagType.CUSTOM,
     }
     new_tag_ids.append(new_tag["id"])
 
@@ -321,7 +321,7 @@ def test_validate_tags_add_new_tags_can_tag_on_object(
     Test the ``validate_tags`` method when new_tags are added and user has
     permission to tag objects.
     """
-    current_tags = [tag for tag in MOCK_TAGS if tag.type == TagType.custom]
+    current_tags = [tag for tag in MOCK_TAGS if tag.type == TagType.CUSTOM]
     new_tag = current_tags.pop()
     new_tag_ids = [tag.id for tag in current_tags]
     new_tag_ids.append(new_tag.id)
@@ -380,9 +380,9 @@ def test_update_tags_adding_tags(mock_tag_dao, object_type):
     """
     Test the ``update_tags`` method when adding tags.
     """
-    current_tags = [tag for tag in MOCK_TAGS if tag.type == TagType.custom]
+    current_tags = [tag for tag in MOCK_TAGS if tag.type == TagType.CUSTOM]
     new_tag = current_tags.pop()
-    new_tags = [tag for tag in MOCK_TAGS if tag.type == TagType.custom]
+    new_tags = [tag for tag in MOCK_TAGS if tag.type == TagType.CUSTOM]
     new_tag_ids = [tag.id for tag in new_tags]
 
     mock_tag_dao.find_by_ids.return_value = [new_tag]
@@ -402,7 +402,7 @@ def test_update_tags_removing_tags(mock_tag_dao, object_type):
     """
     Test the ``update_tags`` method when removing existing tags.
     """
-    new_tags = [tag for tag in MOCK_TAGS if tag.type == TagType.custom]
+    new_tags = [tag for tag in MOCK_TAGS if tag.type == TagType.CUSTOM]
     tag_to_be_removed = new_tags.pop()
     new_tag_ids = [tag.id for tag in new_tags]
 
@@ -420,9 +420,9 @@ def test_update_tags_adding_and_removing_tags(mock_tag_dao, object_type):
     """
     Test the ``update_tags`` method when adding and removing existing tags.
     """
-    new_tags = [tag for tag in MOCK_TAGS if tag.type == TagType.custom]
+    new_tags = [tag for tag in MOCK_TAGS if tag.type == TagType.CUSTOM]
     tag_to_be_removed = new_tags.pop()
-    new_tag = Tag(id=10, name="my new tag", type=TagType.custom)
+    new_tag = Tag(id=10, name="my new tag", type=TagType.CUSTOM)
     new_tags.append(new_tag)
     new_tag_ids = [tag.id for tag in new_tags]
 
@@ -451,7 +451,7 @@ def test_update_tags_removing_all_tags(mock_tag_dao, object_type):
         [
             call(object_type, 1, tag.name)
             for tag in MOCK_TAGS
-            if tag.type == TagType.custom
+            if tag.type == TagType.CUSTOM
         ]
     )
     mock_tag_dao.create_custom_tagged_objects.assert_not_called()
@@ -463,8 +463,8 @@ def test_update_tags_no_tags(mock_tag_dao, object_type):
     """
     Test the ``update_tags`` method when the asset only has system tags.
     """
-    system_tags = [tag for tag in MOCK_TAGS if tag.type != TagType.custom]
-    new_tags = [tag for tag in MOCK_TAGS if tag.type == TagType.custom]
+    system_tags = [tag for tag in MOCK_TAGS if tag.type != TagType.CUSTOM]
+    new_tags = [tag for tag in MOCK_TAGS if tag.type == TagType.CUSTOM]
     new_tag_ids = [tag.id for tag in new_tags]
     new_tag_names = [tag.name for tag in new_tags]
 

--- a/tests/unit_tests/dao/tag_test.py
+++ b/tests/unit_tests/dao/tag_test.py
@@ -149,9 +149,9 @@ def test_create_tag_relationship(mocker):
 
     # Define a list of objects to tag
     objects_to_tag = [
-        (ObjectType.query, 1),
-        (ObjectType.chart, 2),
-        (ObjectType.dashboard, 3),
+        (ObjectType.QUERY, 1),
+        (ObjectType.CHART, 2),
+        (ObjectType.DASHBOARD, 3),
     ]
 
     # Call the function

--- a/tests/unit_tests/tags/commands/create_test.py
+++ b/tests/unit_tests/tags/commands/create_test.py
@@ -86,9 +86,9 @@ def test_create_command_success(session_with_data: Session, mocker: MockerFixtur
     mocker.patch("superset.daos.query.SavedQueryDAO.find_by_id", return_value=query)
 
     objects_to_tag = [
-        (ObjectType.query, query.id),
-        (ObjectType.chart, chart.id),
-        (ObjectType.dashboard, dashboard.id),
+        (ObjectType.QUERY, query.id),
+        (ObjectType.CHART, chart.id),
+        (ObjectType.DASHBOARD, dashboard.id),
     ]
 
     CreateCustomTagWithRelationshipsCommand(
@@ -129,9 +129,9 @@ def test_create_command_success_clear(
     mocker.patch("superset.daos.query.SavedQueryDAO.find_by_id", return_value=query)
 
     objects_to_tag = [
-        (ObjectType.query, query.id),
-        (ObjectType.chart, chart.id),
-        (ObjectType.dashboard, dashboard.id),
+        (ObjectType.QUERY, query.id),
+        (ObjectType.CHART, chart.id),
+        (ObjectType.DASHBOARD, dashboard.id),
     ]
 
     CreateCustomTagWithRelationshipsCommand(

--- a/tests/unit_tests/tags/commands/update_test.py
+++ b/tests/unit_tests/tags/commands/update_test.py
@@ -91,7 +91,7 @@ def test_update_command_success(session_with_data: Session, mocker: MockerFixtur
     )
 
     objects_to_tag = [
-        (ObjectType.dashboard, dashboard.id),
+        (ObjectType.DASHBOARD, dashboard.id),
     ]
 
     tag_to_update = TagDAO.find_by_name("test_name")
@@ -132,7 +132,7 @@ def test_update_command_success_duplicates(
     )
 
     objects_to_tag = [
-        (ObjectType.dashboard, dashboard.id),
+        (ObjectType.DASHBOARD, dashboard.id),
     ]
 
     CreateCustomTagWithRelationshipsCommand(
@@ -142,7 +142,7 @@ def test_update_command_success_duplicates(
     tag_to_update = TagDAO.find_by_name("test_tag")
 
     objects_to_tag = [
-        (ObjectType.chart, chart.id),
+        (ObjectType.CHART, chart.id),
     ]
     changed_model = UpdateTagCommand(
         tag_to_update.id,
@@ -174,7 +174,7 @@ def test_update_command_failed_validation(
     dashboard = db.session.query(Dashboard).first()
     chart = db.session.query(Slice).first()
     objects_to_tag = [
-        (ObjectType.chart, chart.id),
+        (ObjectType.CHART, chart.id),
     ]
 
     mocker.patch(

--- a/tests/unit_tests/tags/filters_test.py
+++ b/tests/unit_tests/tags/filters_test.py
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from typing import Type
+
 import pytest
 from flask_appbuilder import Model
 from flask_appbuilder.models.sqla.interface import SQLAInterface
@@ -27,15 +29,17 @@ from superset.tags.filters import BaseTagIdFilter, BaseTagNameFilter
 
 FILTER_MODELS = [Slice, Dashboard, SavedQuery]
 OBJECT_TYPES = {
-    "dashboards": "dashboard",
-    "slices": "chart",
-    "saved_query": "query",
+    "dashboards": "DASHBOARD",
+    "slices": "CHART",
+    "saved_query": "QUERY",
 }
 
 
 @pytest.mark.parametrize("model", FILTER_MODELS)
 @pytest.mark.parametrize("name", ["my_tag", "test tag", "blaah"])
-def test_base_tag_filter_by_name(session: Session, model: Model, name: str) -> None:
+def test_base_tag_filter_by_name(
+    session: Session, model: Type[Model], name: str
+) -> None:
     table = model.__tablename__
     engine = session.get_bind()
     query = session.query(model)
@@ -61,7 +65,7 @@ def test_base_tag_filter_by_name(session: Session, model: Model, name: str) -> N
 
 @pytest.mark.parametrize("model", FILTER_MODELS)
 @pytest.mark.parametrize("id", [3, 5, 8])
-def test_base_tag_filter_by_id(session: Session, model: Model, id: int) -> None:
+def test_base_tag_filter_by_id(session: Session, model: Type[Model], id: int) -> None:
     table = model.__tablename__
     engine = session.get_bind()
     query = session.query(model)


### PR DESCRIPTION
### SUMMARY
This is a continuation of #26875, and refactors all Python enums to comply with the commonly used naming conventions of PascalCase for the class name, and UPPER_CASE for the names: https://docs.python.org/3/library/enum.html This exercise was quite a bit less painful than on the frontend. 😸 

Unfortunately I'm not aware of anything that would come close to ESLint for Python, so for now we'll just have to try to make sure everyone adheres to these conventions during code review. I believe something similar might be possible with pylint, but I wasn't able to scope it to only apply to enums, so I'll just leave it be. But if someone knows how this can be done, or can point me in the right direction, please do let me know.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
