### PR TITLE
fix(plugin-chart-table): Revert "fix(chart table in dashboard): improve screen reading of table (#26453)"

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 import React, {
   useCallback,
   useRef,

--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/hooks/useSticky.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/hooks/useSticky.tsx
@@ -110,7 +110,6 @@ const fixedTableLayout: CSSProperties = { tableLayout: 'fixed' };
 /**
  * An HOC for generating sticky header and fixed-height scrollable area
  */
-
 function StickyWrap({
   sticky = {},
   width: maxWidth,
@@ -216,8 +215,7 @@ function StickyWrap({
   let sizerTable: ReactElement | undefined;
   let headerTable: ReactElement | undefined;
   let footerTable: ReactElement | undefined;
-  let fullTable: ReactElement | undefined;
-
+  let bodyTable: ReactElement | undefined;
   if (needSizer) {
     const theadWithRef = React.cloneElement(thead, { ref: theadRef });
     const tfootWithRef = tfoot && React.cloneElement(tfoot, { ref: tfootRef });
@@ -255,7 +253,6 @@ function StickyWrap({
         style={{
           overflow: 'hidden',
         }}
-        aria-hidden="true"
       >
         {React.cloneElement(
           table,
@@ -293,18 +290,20 @@ function StickyWrap({
         scrollFooterRef.current.scrollLeft = e.currentTarget.scrollLeft;
       }
     };
-
-    fullTable = (
+    bodyTable = (
       <div
-        key="full-table"
+        key="body"
         ref={scrollBodyRef}
+        style={{
+          height: bodyHeight,
+          overflow: 'auto',
+        }}
         onScroll={sticky.hasHorizontalScroll ? onScroll : undefined}
       >
         {React.cloneElement(
           table,
           mergeStyleProp(table, fixedTableLayout),
           colgroup,
-          thead,
           tbody,
         )}
       </div>
@@ -316,11 +315,11 @@ function StickyWrap({
       style={{
         width: maxWidth,
         height: sticky.realHeight || maxHeight,
-        overflow: 'auto',
-        padding: '0',
+        overflow: 'hidden',
       }}
     >
-      {fullTable}
+      {headerTable}
+      {bodyTable}
       {footerTable}
       {sizerTable}
     </div>

--- a/superset-frontend/plugins/plugin-chart-table/src/Styles.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/Styles.tsx
@@ -32,13 +32,10 @@ export default styled.div`
     td {
       min-width: 4.3em;
     }
+
     thead > tr > th {
-      position: sticky;
-      top: -1px;
       padding-right: 0;
-      z-index: 100;
-      border-bottom: ${theme.gridUnit / 2}px solid
-        ${theme.colors.grayscale.light2};
+      position: relative;
       background: ${theme.colors.grayscale.light5};
       text-align: left;
     }


### PR DESCRIPTION
### SUMMARY
PR #26453 introduced important accessibility upgrades, but broke displaying table totals in sticky mode. Since the totals being always visible (sticky) is a key feature of the table chart, I think we should revert the accessibility PR and reopen it once the bug is fixed.

CC @ncar285 @eschutho 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before the revert:

https://github.com/apache/superset/assets/15073128/20cf0f7a-0601-4ff5-b172-4cf24ea04e51

After:

https://github.com/apache/superset/assets/15073128/e79efd86-7825-4e33-8239-a81e2bc0a723


### TESTING INSTRUCTIONS
1. Create a table chart with enough rows to enable scrolling
2. Check "Show totals"
3. Verify that totals row is sticky

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
