### PR TITLE
fix(plugin-chart-table): Prevent misalignment of totals and headers when scrollbar is visible

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/hooks/useSticky.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/hooks/useSticky.tsx
@@ -226,6 +226,7 @@ function StickyWrap({
           height: maxHeight,
           overflow: 'auto',
           visibility: 'hidden',
+          scrollbarGutter: 'stable',
         }}
       >
         {React.cloneElement(table, {}, theadWithRef, tbody, tfootWithRef)}
@@ -252,6 +253,7 @@ function StickyWrap({
         ref={scrollHeaderRef}
         style={{
           overflow: 'hidden',
+          scrollbarGutter: 'stable',
         }}
       >
         {React.cloneElement(
@@ -270,6 +272,7 @@ function StickyWrap({
         ref={scrollFooterRef}
         style={{
           overflow: 'hidden',
+          scrollbarGutter: 'stable',
         }}
       >
         {React.cloneElement(
@@ -297,6 +300,7 @@ function StickyWrap({
         style={{
           height: bodyHeight,
           overflow: 'auto',
+          scrollbarGutter: 'stable',
         }}
         onScroll={sticky.hasHorizontalScroll ? onScroll : undefined}
       >


### PR DESCRIPTION
### SUMMARY
In the table chart, when scrollbar is set to be always visible (on macOS Sonoma: System settings -> Appearance -> Show scroll bars -> Always), it takes some space in table's body and pushes its content to the left. That causes the totals and headers to appear misaligned with the body.
This problem doesn't occur on default scrollbar settings in macOS - in this case when the scrollbar appears, it is displayed over the scroll container and doesn't cause a layout shift.

`scrollbar-gutter: stable` (https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter) css declaration reserves the space required for the scrollbar to appear and not cause a layout shift and it works well for both scrollbar system settings (though in the auto mode we waste a few pixels). We add it to the body (scroll container), but also to the header and footer (totals) so that they both account for the layout shift that happens in body.

CC @vasu-ram

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="1051" alt="image" src="https://github.com/apache/superset/assets/15073128/372883ff-67a6-43ec-b85a-efe0b2b3d7c7">

After:

<img width="1728" alt="image" src="https://github.com/apache/superset/assets/15073128/bd4aad36-113e-4a73-9a7f-e92e7a36073d">

### TESTING INSTRUCTIONS
1. Create a table chart with a few columns and enough rows to trigger overflow
2. In Customize tab, align all columns to the left
3. Check "Show totals"
4. If you're using macOS - set the scrollbar to be always visible (System settings -> Appearance -> Show scroll bars -> Always)
5. Verify that values in table's body are aligned with headers and totals
6. Set the scrollbar to the default behaviour (System settings -> Appearance -> Show scroll bars -> Automatically based on mouse or trackpad)
7. Verify that everything's still aligned

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: fixes #26761 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
