### PR TITLE
fix(tags): Improve support for tags with colons

### DIFF
--- a/superset-frontend/src/components/Tags/utils.tsx
+++ b/superset-frontend/src/components/Tags/utils.tsx
@@ -56,7 +56,10 @@ export const loadTags = async (
 ) => {
   const searchColumn = 'name';
   const query = rison.encode({
-    filters: [{ col: searchColumn, opr: 'ct', value: search }],
+    filters: [
+      { col: searchColumn, opr: 'ct', value: search },
+      { col: 'type', opr: 'custom_tag', value: true },
+    ],
     page,
     page_size: pageSize,
     order_column: searchColumn,
@@ -78,9 +81,7 @@ export const loadTags = async (
       const data: {
         label: string;
         value: string | number;
-      }[] = response.json.result
-        .filter((item: Tag & { table_name: string }) => item.type === 1)
-        .map(tagToSelectOption);
+      }[] = response.json.result.map(tagToSelectOption);
       return {
         data,
         totalCount: response.json.count,

--- a/superset-frontend/src/features/tags/tags.ts
+++ b/superset-frontend/src/features/tags/tags.ts
@@ -94,11 +94,7 @@ export function fetchTags(
     endpoint: `/api/v1/${objectType}/${objectId}`,
   })
     .then(({ json }) =>
-      callback(
-        json.result.tags.filter(
-          (tag: Tag) => tag.name.indexOf(':') === -1 || includeTypes,
-        ),
-      ),
+      callback(json.result.tags.filter((tag: Tag) => tag.type === 1)),
     )
     .catch(response => error(response));
 }
@@ -167,9 +163,6 @@ export function addTag(
 ) {
   if (objectType === undefined || objectId === undefined) {
     throw new Error('Need to specify objectType and objectId');
-  }
-  if (tag.indexOf(':') !== -1 && !includeTypes) {
-    return;
   }
   const objectTypeId = map_object_type_to_id(objectType);
   SupersetClient.post({

--- a/superset-frontend/src/features/tags/tags.ts
+++ b/superset-frontend/src/features/tags/tags.ts
@@ -47,10 +47,15 @@ const map_object_type_to_id = (objectType: string) => {
 };
 
 export function fetchAllTags(
+  // fetch all tags (excluding system tags)
   callback: (json: JsonObject) => void,
   error: (response: Response) => void,
 ) {
-  SupersetClient.get({ endpoint: `/api/v1/tag` })
+  SupersetClient.get({
+    endpoint: `/api/v1/tag/?q=${rison.encode({
+      filters: [{ col: 'type', opr: 'custom_tag', value: true }],
+    })}`,
+  })
     .then(({ json }) => callback(json))
     .catch(response => error(response));
 }


### PR DESCRIPTION
### SUMMARY
This is a follow up to https://github.com/apache/superset/pull/26701, to rely on the API filter so that only tags created by users are returned in modals/etc, avoiding the need to filter for tags with `:`. This improves the support for user tags created with `:`. 

I checked all the methods updated by this PR and where they're used and these changes shouldn't affect other functionalities. Also confirmed that system tags are still being added as usual. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before**
* Adding a tag with `:` to an asset wouldn't persist from the asset list. 
* Tagging the asset via the Tags list would work, but then the tag wasn't included when accessing the asset properties.

https://github.com/apache/superset/assets/96086495/dec372bb-c48d-4d28-b837-cd6b97ca8bc8

**After**
* Tags with `:` can now be assigned from the assets list and are also returned when accessing the properties modal

https://github.com/apache/superset/assets/96086495/09e0e4e4-9428-458c-9877-024805b224ac

### TESTING INSTRUCTIONS
1. Create a tag named `test:tag`. 
2. Navigate to **Dashboards**.
3. Click on the pencil icon under the **Actions** column to modify any dashboard.
4. Add the `test:tag` to the asset and save changes.
5. Refresh the page, and validate that the tag is successfully associated with the asset.
6. Click on the pencil icon again to access the properties, and validate the tag persist to the dropdown. 

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Required feature flags: `TAGGING_SYSTEM`
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
