### PR TITLE
fix(actions): make tech debt uploader not block CI and skip w/o creds

### DIFF
--- a/.github/workflows/tech-debt.yml
+++ b/.github/workflows/tech-debt.yml
@@ -3,13 +3,28 @@ name: Upload Technical Debt Metrics to Google Sheets
 on:
   push:
     branches:
-      - main
+      # - main
       - master
 
 jobs:
-  process-and-upload:
-    runs-on: ubuntu-latest
+  config:
+    runs-on: "ubuntu-latest"
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
+    steps:
+      - name: "Check for secrets"
+        id: check
+        shell: bash
+        run: |
+          if [ -n "${{ (secrets.GSHEET_KEY != '' ) || '' }}" ]; then
+            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+          fi
 
+  process-and-upload:
+    needs: config
+    if: needs.config.outputs.has-secrets
+    runs-on: ubuntu-latest
+    name: Generate Reports
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
@@ -28,4 +43,5 @@ jobs:
           SPREADSHEET_ID: '1oABNnzxJYzwUrHjr_c9wfYEq9dFL1ScVof9LlaAdxvo'
           SERVICE_ACCOUNT_KEY: ${{ secrets.GSHEET_KEY }}
         run: npm run lint-stats
+        continue-on-error: true
         working-directory: ./superset-frontend

--- a/.github/workflows/tech-debt.yml
+++ b/.github/workflows/tech-debt.yml
@@ -3,7 +3,6 @@ name: Upload Technical Debt Metrics to Google Sheets
 on:
   push:
     branches:
-      # - main
       - master
 
 jobs:


### PR DESCRIPTION
…

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The action requires the GSheet credentials and will now skip without them (e.g. on forks)
It should also not block CI if the uploader script fails

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
