### PR TITLE
fix(ci): support action/script v5 breaking change

### DIFF
--- a/.github/workflows/ephemeral-env-pr-close.yml
+++ b/.github/workflows/ephemeral-env-pr-close.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           github-token: ${{github.token}}
           script: |
-            github.issues.createComment({
+            github.rest.issues.createComment({
               issue_number: ${{ github.event.number }},
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/ephemeral-env.yml
+++ b/.github/workflows/ephemeral-env.yml
@@ -76,7 +76,7 @@ jobs:
         github-token: ${{github.token}}
         script: |
           const errMsg = '@${{ github.event.comment.user.login }} Ephemeral environment creation is currently limited to committers.'
-          github.issues.createComment({
+          github.rest.issues.createComment({
             issue_number: ${{ github.event.issue.number }},
             owner: context.repo.owner,
             repo: context.repo.repo,
@@ -100,7 +100,7 @@ jobs:
                 pull_number: ${{ github.event.issue.number }},
             }
             core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`)
-            const pr = await github.pulls.get(request);
+            const pr = await github.rest.pulls.get(request);
             return pr.data;
 
       - name: Debug
@@ -194,7 +194,7 @@ jobs:
         github-token: ${{github.token}}
         script: |
           const errMsg = '@${{ github.event.comment.user.login }} Container image not yet published for this PR. Please try again when build is complete.'
-          github.issues.createComment({
+          github.rest.issues.createComment({
             issue_number: ${{ github.event.issue.number }},
             owner: context.repo.owner,
             repo: context.repo.repo,


### PR DESCRIPTION
### SUMMARY

actions/github-script@v5 has the following breaking change: https://github.com/actions/github-script?tab=readme-ov-file#v5

more info also: https://github.com/actions/github-script/issues/242

This PR changes all github REST API call from `github.<resource>.<action>` to `github.rest.<resource>.<action>`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
