### PR TITLE
fix(ci): typo in my bash script

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -59,6 +59,7 @@ jobs:
           persist-credentials: false
           submodules: recursive
           ref: ${{ github.ref }}
+          fetch-depth: 0
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -75,7 +75,7 @@ jobs:
           FORCE_LATEST=""
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             # in the case of a manually-triggered run, read release from input
-            RELEASE ="${{ github.event.inputs.release }}"
+            RELEASE="${{ github.event.inputs.release }}"
             if [ "${{ github.event.inputs.force-latest }}" = "true" ]; then
               FORCE_LATEST="--force-latest"
             fi

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -74,6 +74,7 @@ jobs:
         run: |
           RELEASE="${{ github.event.release.tag_name }}"
           FORCE_LATEST=""
+          EVENT="${{github.event_name}}"
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             # in the case of a manually-triggered run, read release from input
             RELEASE="${{ github.event.inputs.release }}"
@@ -84,10 +85,11 @@ jobs:
             cp ./scripts/build_docker.py /tmp
             git checkout "${{ github.event.inputs.git-ref }}"
             cp /tmp/build_docker.py scripts/
+            EVENT="release"
           fi
           pip install click
           ./scripts/build_docker.py \
             ${{ matrix.build_preset }} \
-            "${{ github.event_name }}" \
+            "$EVENT" \
             --build_context_ref "$RELEASE" \
             --platform ${{ matrix.platform }} $FORCE_LATEST


### PR DESCRIPTION
I couldn't fin a proper way to test the `workflow_dispatch` even, even from the gh CLI, so I had to test it using other events in my branch (on:pull_request), but never tested the inside of my `if` in bash.

Anyhow, was flying blind, but I think this time it should work.

More on the intricacies of testing these workflow_dispatch workflows here: https://stackoverflow.com/questions/63362126/github-actions-how-to-run-a-workflow-created-on-a-non-master-branch-from-the-wo

Figured it out here, though I think it has to run once first on master or it won't do it...
<img width="1080" alt="Screenshot 2024-02-01 at 6 32 16 PM" src="https://github.com/apache/superset/assets/487433/8f0d7409-b7c8-4db7-bdf3-234d454663a6">
