### PR TITLE
fix(cypress): resolving random dri3 error on cypress runner

### DIFF
--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -157,16 +157,18 @@ cypress-run() {
   local browser=${CYPRESS_BROWSER:-chrome}
 
   export TERM="xterm"
+  export ELECTRON_DISABLE_GPU=true # Attempt to disable GPU for Electron-based Cypress
 
   say "::group::Run Cypress for [$page]"
   if [[ -z $CYPRESS_KEY ]]; then
-    $cypress --spec "cypress/e2e/$page" --browser "$browser"
+    xvfb-run --auto-servernum --server-args='-screen 0, 1024x768x24' $cypress --spec "cypress/e2e/$page" --browser "$browser"
   else
     export CYPRESS_RECORD_KEY=$(echo $CYPRESS_KEY | base64 --decode)
     # additional flags for Cypress dashboard recording
-    $cypress --spec "cypress/e2e/$page" --browser "$browser" \
+    xvfb-run --auto-servernum --server-args='-screen 0, 1024x768x24' $cypress --spec "cypress/e2e/$page" --browser "$browser" \
       --record --group "$group" --tag "${GITHUB_REPOSITORY},${GITHUB_EVENT_NAME}" \
       --parallel --ci-build-id "${GITHUB_SHA:0:8}-${NONCE}"
+
   fi
 
   # don't add quotes to $record because we do want word splitting


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We keep seeing this error on E2E tests:

Opening Cypress...
  [7584:0130/220351.180871:ERROR:gpu_memory_buffer_support_x11.cc(44)] dri3 extension not supported.
  You passed the --parallel flag, but we do not parallelize tests across different environments.

Hopefully this disables GPU and this error will go away. Let's find out!!

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
