### PR TITLE
fix(plugins): Fix dashboard filter in Period Over Period KPI plugin

### DIFF
--- a/superset-frontend/plugins/plugin-chart-period-over-period-kpi/src/plugin/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-period-over-period-kpi/src/plugin/buildQuery.ts
@@ -217,7 +217,11 @@ function calculatePrev(
 }
 
 export default function buildQuery(formData: QueryFormData) {
-  const { cols: groupby, time_comparison: timeComparison } = formData;
+  const {
+    cols: groupby,
+    time_comparison: timeComparison,
+    extra_form_data: extraFormData,
+  } = formData;
 
   const queryContextA = buildQueryContext(formData, baseQueryObject => [
     {
@@ -244,9 +248,11 @@ export default function buildQuery(formData: QueryFormData) {
     'comparator' in timeFilter &&
     typeof timeFilter.comparator === 'string'
   ) {
-    [testSince, testUntil] = getSinceUntil(
-      timeFilter.comparator.toLocaleLowerCase(),
-    );
+    let timeRange = timeFilter.comparator.toLocaleLowerCase();
+    if (extraFormData?.time_range) {
+      timeRange = extraFormData.time_range;
+    }
+    [testSince, testUntil] = getSinceUntil(timeRange);
   }
 
   let formDataB: QueryFormData;
@@ -277,11 +283,13 @@ export default function buildQuery(formData: QueryFormData) {
     formDataB = {
       ...formData,
       adhoc_filters: queryBFilters,
+      extra_form_data: {},
     };
   } else {
     formDataB = {
       ...formData,
       adhoc_filters: formData.adhoc_custom,
+      extra_form_data: {},
     };
   }
 

--- a/superset-frontend/plugins/plugin-chart-period-over-period-kpi/src/plugin/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-period-over-period-kpi/src/plugin/transformProps.ts
@@ -112,9 +112,15 @@ export default function transformProps(chartProps: ChartProps) {
 
   let valueDifference: number | string = bigNumber - prevNumber;
 
-  const percentDifferenceNum = prevNumber
-    ? (bigNumber - prevNumber) / Math.abs(prevNumber)
-    : 0;
+  let percentDifferenceNum;
+
+  if (!bigNumber && !prevNumber) {
+    percentDifferenceNum = 0;
+  } else if (!bigNumber || !prevNumber) {
+    percentDifferenceNum = bigNumber ? 1 : -1;
+  } else {
+    percentDifferenceNum = (bigNumber - prevNumber) / Math.abs(prevNumber);
+  }
 
   const compType = compTitles[formData.timeComparison];
   bigNumber = numberFormatter(bigNumber);


### PR DESCRIPTION
### SUMMARY

When the PoP KPI chart is rendered in a dashboard and the dashboard has a time range filter, this filter is making the chart useless because it's overriding both queries thus no comparison is happening.

Also, previously if the bigNumber or the prev Number were zero, the % change would be zero when it should have been 100%.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Error:

https://github.com/apache/superset/assets/38889534/92ddc188-2aff-43b1-9f96-4af3ae4f06fa


Fix:

https://github.com/apache/superset/assets/38889534/4cf6162f-eba5-45f3-8d68-53834382f540



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
