### PR TITLE
fix(security manager): Users should not have access to all draft dashboards

### DIFF
--- a/tests/integration_tests/dashboards/security/security_rbac_tests.py
+++ b/tests/integration_tests/dashboards/security/security_rbac_tests.py
@@ -409,17 +409,23 @@ class TestDashboardRoleBasedSecurity(BaseTestDashboardSecurity):
         Dashboard API: Test get draft dashboard without roles by uuid
         """
         admin = self.get_user("admin")
-        dashboard = self.insert_dashboard("title", "slug1", [admin.id])
-        assert not dashboard.published
-        assert dashboard.roles == []
+
+        database = create_database_to_db(name="test_db")
+        table = create_datasource_table_to_db(
+            name="test_datasource", db_id=database.id, owners=[admin]
+        )
+        dashboard_to_access = create_dashboard_to_db(
+            dashboard_title="test_dashboard",
+            owners=[admin],
+            slices=[create_slice_to_db(datasource_id=table.id)],
+        )
+        assert not dashboard_to_access.published
+        assert dashboard_to_access.roles == []
 
         self.login(username="gamma")
-        uri = f"api/v1/dashboard/{dashboard.uuid}"
+        uri = f"api/v1/dashboard/{dashboard_to_access.uuid}"
         rv = self.client.get(uri)
         assert rv.status_code == 403
-        # rollback changes
-        db.session.delete(dashboard)
-        db.session.commit()
 
     def test_cannot_get_draft_dashboard_with_roles_by_uuid(self):
         """

--- a/tests/integration_tests/dashboards/security/security_rbac_tests.py
+++ b/tests/integration_tests/dashboards/security/security_rbac_tests.py
@@ -410,12 +410,12 @@ class TestDashboardRoleBasedSecurity(BaseTestDashboardSecurity):
         """
         admin = self.get_user("admin")
 
-        database = create_database_to_db(name="test_db")
+        database = create_database_to_db(name="test_db_rbac")
         table = create_datasource_table_to_db(
-            name="test_datasource", db_id=database.id, owners=[admin]
+            name="test_datasource_rbac", db_id=database.id, owners=[admin]
         )
         dashboard_to_access = create_dashboard_to_db(
-            dashboard_title="test_dashboard",
+            dashboard_title="test_dashboard_rbac",
             owners=[admin],
             slices=[create_slice_to_db(datasource_id=table.id)],
         )

--- a/tests/integration_tests/dashboards/security/security_rbac_tests.py
+++ b/tests/integration_tests/dashboards/security/security_rbac_tests.py
@@ -404,7 +404,7 @@ class TestDashboardRoleBasedSecurity(BaseTestDashboardSecurity):
         for dash in published_dashboards + draft_dashboards:
             revoke_access_to_dashboard(dash, "Public")
 
-    def test_get_draft_dashboard_without_roles_by_uuid(self):
+    def test_cannot_get_draft_dashboard_without_roles_by_uuid(self):
         """
         Dashboard API: Test get draft dashboard without roles by uuid
         """
@@ -416,7 +416,7 @@ class TestDashboardRoleBasedSecurity(BaseTestDashboardSecurity):
         self.login(username="gamma")
         uri = f"api/v1/dashboard/{dashboard.uuid}"
         rv = self.client.get(uri)
-        assert rv.status_code == 200
+        assert rv.status_code == 403
         # rollback changes
         db.session.delete(dashboard)
         db.session.commit()


### PR DESCRIPTION
### SUMMARY
The `DASHBOARD_RBAC` FF allows Organizations to manage dashboard access through roles (instead of managing via dataset access). According to the documentation and [recent PR](https://github.com/apache/superset/pull/23586), in case the dashboard has no roles associated with it, the regular dataset validation should happen.

This PR improves the security logic so that draft dashboard metadata isn't leaked. This was the previous logic:

``` python
if is_feature_enabled("DASHBOARD_RBAC") and dashboard.roles:
    if dashboard.published and {role.id for role in dashboard.roles} & {
        role.id for role in self.get_user_roles()
    }:
        return
elif (
    not dashboard.published
    or not dashboard.datasources
    or any(
        self.can_access_datasource(datasource)
        for datasource in dashboard.datasources
    )
):
    return
```

The `not dashboard.published` condition was leaking metadata for any draft dashboard to all users (regardless of the FF state). The actual chart data was not exposed due to dataset validation.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
1. Create a dashboard in draft state.
2. Access Superset with a user from a role that doesn't have access to the dashboard (either via `DASHBOARD_RBAC` or regular RBAC).
3. Access the dashboard URL.

The dashboard shouldn't load.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
