### PR TITLE
fix: safer error message in alerts

### DIFF
--- a/superset/commands/report/alert.py
+++ b/superset/commands/report/alert.py
@@ -150,7 +150,7 @@ class AlertCommand(BaseCommand):
                 rendered_sql, ALERT_SQL_LIMIT
             )
 
-            _, username = get_executor(
+            executor, username = get_executor(
                 executor_types=app.config["ALERT_REPORTS_EXECUTE_AS"],
                 model=self._report_schedule,
             )
@@ -169,7 +169,12 @@ class AlertCommand(BaseCommand):
             logger.warning("A timeout occurred while executing the alert query: %s", ex)
             raise AlertQueryTimeout() from ex
         except Exception as ex:
-            raise AlertQueryError(message=str(ex)) from ex
+            logger.exception("An error occurred when running alert query")
+            # The exception message here can reveal to much information to malicious
+            # users, so we raise a generic message.
+            raise AlertQueryError(
+                message=_("An error occurred when running alert query")
+            ) from ex
 
     def validate(self) -> None:
         """

--- a/superset/commands/report/alert.py
+++ b/superset/commands/report/alert.py
@@ -150,7 +150,7 @@ class AlertCommand(BaseCommand):
                 rendered_sql, ALERT_SQL_LIMIT
             )
 
-            executor, username = get_executor(
+            executor, username = get_executor(  # pylint: disable=unused-variable
                 executor_types=app.config["ALERT_REPORTS_EXECUTE_AS"],
                 model=self._report_schedule,
             )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When the query from an alert fails we currently reveal information from the error that could be used by malicious users. This PR changes the exception so that it shows only a generic error message, while the full stacktrace still gets logged in the server for the admin.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

<img width="507" alt="Screen Shot 2024-02-02 at 2 20 00 PM" src="https://github.com/apache/superset/assets/1534870/ac424b35-fe5d-4e93-8fc9-9e5a0361ee1c">

After:

<img width="361" alt="Screen Shot 2024-02-05 at 2 22 22 PM" src="https://github.com/apache/superset/assets/1534870/05429fb1-c2ac-41c6-aad5-30ced09b8969">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
