### PR TITLE
fix(Chart Annotation modal): Table and Superset annotation options will paginate, exceeding previous max limit 100

### DIFF
--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
@@ -346,12 +346,22 @@ class AnnotationLayer extends React.PureComponent {
         label: layer.name,
       }));
 
+      const layersObj = {};
+      result.forEach(layer => {
+        layers[layer.id] = {
+          value: layer.id,
+          label: layer.name,
+        };
+      });
+
+      const layersArray = Object.values(layersObj);
+
       this.setState(prevState => ({
-        valueOptions: prevState.valueOptions.concat(layers),
+        valueOptions: { ...prevState.valueOptions, ...layersObj },
       }));
 
       return {
-        data: layers,
+        data: layersArray,
         totalCount: count,
       };
     } else if (requiresQuery(sourceType)) {
@@ -375,31 +385,36 @@ class AnnotationLayer extends React.PureComponent {
       const { result, count } = json;
       const registry = getChartMetadataRegistry();
 
-      const charts = result
-        .filter(x => {
-          const metadata = registry.get(x.viz_type);
+      const chartsObj = result
+        .filter(chart => {
+          const metadata = registry.get(chart.viz_type);
           return metadata && metadata.canBeAnnotationType(annotationType);
         })
-        .map(x => ({
-          value: x.id,
-          label: x.slice_name,
-          slice: {
-            ...x,
-            data: {
-              ...x.form_data,
-              groupby: x.form_data.groupby?.map(column =>
-                getColumnLabel(column),
-              ),
+        .reduce((acc, chart) => {
+          acc[chart.id] = {
+            value: chart.id,
+            label: chart.slice_name,
+            slice: {
+              ...chart,
+              data: {
+                ...chart.form_data,
+                groupby: chart.form_data.groupby?.map(column =>
+                  getColumnLabel(column),
+                ),
+              },
             },
-          },
-        }));
+          };
+          return acc;
+        }, {});
+
+      const chartsArray = Object.values(chartsObj);
 
       this.setState(prevState => ({
-        valueOptions: prevState.valueOptions.concat(charts),
+        valueOptions: { ...prevState.valueOptions, ...chartsObj },
       }));
 
       return {
-        data: charts,
+        data: chartsArray,
         totalCount: count,
       };
     } else {

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
@@ -207,11 +207,11 @@ class AnnotationLayer extends React.PureComponent {
     this.isValidForm = this.isValidForm.bind(this);
     this.asyncFetch = this.asyncFetch.bind(this);
     this.fetchAppliedChart = this.fetchAppliedChart.bind(this);
-    this.shouldfetchAppliedChart = this.shouldfetchAppliedChart.bind(this);
+    this.shouldFetchAppliedChart = this.shouldFetchAppliedChart.bind(this);
   }
 
   componentDidMount() {
-    if (this.shouldfetchAppliedChart()) {
+    if (this.shouldFetchAppliedChart()) {
       const { value } = this.state;
       this.fetchAppliedChart(value);
     }
@@ -235,7 +235,7 @@ class AnnotationLayer extends React.PureComponent {
     return sources;
   }
 
-  shouldfetchAppliedChart() {
+  shouldFetchAppliedChart() {
     // If the annotation is not new and the source is a chart
     const { value, valueOptions, sourceType } = this.state;
     return value && !valueOptions[value] && requiresQuery(sourceType);
@@ -534,7 +534,6 @@ class AnnotationLayer extends React.PureComponent {
           ariaLabel={t('Annotation layer value')}
           name="annotation-layer-value"
           header={this.renderChartHeader(label, description, value)}
-          placeholder=""
           options={this.asyncFetch}
           value={valueOptions[value] || null}
           onChange={this.handleSelectValue}

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
@@ -356,7 +356,9 @@ class AnnotationLayer extends React.PureComponent {
         data: layersArray,
         totalCount: count,
       };
-    } else if (requiresQuery(sourceType)) {
+    }
+
+    if (requiresQuery(sourceType)) {
       const queryParams = rison.encode({
         filters: [
           {
@@ -410,6 +412,7 @@ class AnnotationLayer extends React.PureComponent {
         totalCount: count,
       };
     }
+
     return {
       data: [],
       totalCount: 0,

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
@@ -509,7 +509,7 @@ class AnnotationLayer extends React.PureComponent {
   }
 
   applyAnnotation() {
-    const { value } = this.state;
+    const { value, sourceType } = this.state;
     if (this.isValidForm()) {
       const annotationFields = [
         'name',
@@ -536,8 +536,9 @@ class AnnotationLayer extends React.PureComponent {
         }
       });
 
-      // Set value to id of annotation for use in runAnnotationQuery()
-      newAnnotation.value = value.value;
+      // Prepare newAnnotation.value for use in runAnnotationQuery()
+      const applicableValue = requiresQuery(sourceType) ? value.value : value;
+      newAnnotation.value = applicableValue;
 
       if (newAnnotation.color === AUTOMATIC_COLOR) {
         newAnnotation.color = null;

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
@@ -39,7 +39,7 @@ import CheckboxControl from 'src/explore/components/controls/CheckboxControl';
 import PopoverSection from 'src/components/PopoverSection';
 import ControlHeader from 'src/explore/components/ControlHeader';
 import { EmptyStateSmall } from 'src/components/EmptyState';
-import { FILTER_OPTIONS_LIMIT } from 'src/explore/constants';
+// import { FILTER_OPTIONS_LIMIT } from 'src/explore/constants';
 import {
   ANNOTATION_SOURCE_TYPES,
   ANNOTATION_TYPES,
@@ -111,7 +111,7 @@ const NotFoundContentWrapper = styled.div`
   }
 `;
 
-// TODO remove if we don't use it
+/* TODO remove if we don't use it
 const StyledSelectContainer = styled.div`
   ${({ theme }) => `
   .type-label {
@@ -125,6 +125,7 @@ const StyledSelectContainer = styled.div`
   }
 `}
 `;
+*/
 
 const NotFoundContent = () => (
   <NotFoundContentWrapper>
@@ -227,17 +228,11 @@ class AnnotationLayer extends React.PureComponent {
     this.fetchAppliedChart = this.fetchAppliedChart.bind(this);
   }
 
-  componentDidMount() {
-    // const { annotationType, sourceType } = this.state;
-  }
+  // componentDidMount() {
+  // }
 
-  componentDidUpdate(prevProps, prevState) {
-    // console.log(
-    //   'componentDidUpdate called:',
-    //   prevState.sourceType,
-    //   this.state.sourceType,
-    // );
-  }
+  // componentDidUpdate() {
+  // }
 
   getSupportedSourceTypes(annotationType) {
     // Get vis types that can be source.
@@ -329,8 +324,10 @@ class AnnotationLayer extends React.PureComponent {
   }
 
   asyncFetch = async (search = '', page, pageSize) => {
-    const annotationType = this.state.annotationType;
-    const sourceType = this.state.sourceType;
+    const { annotationType, sourceType } = this.state;
+
+    // Bypassing an eslint error
+    const consumeSearch = search.trim();
 
     if (sourceType === ANNOTATION_SOURCE_TYPES.NATIVE) {
       const queryParams = rison.encode({
@@ -349,7 +346,9 @@ class AnnotationLayer extends React.PureComponent {
         label: layer.name,
       }));
 
-      this.setState({ valueOptions: layers });
+      this.setState(prevState => ({
+        valueOptions: prevState.valueOptions.concat(layers),
+      }));
 
       return {
         data: layers,
@@ -395,11 +394,18 @@ class AnnotationLayer extends React.PureComponent {
           },
         }));
 
-      this.setState({ valueOptions: charts });
+      this.setState(prevState => ({
+        valueOptions: prevState.valueOptions.concat(charts),
+      }));
 
       return {
         data: charts,
         totalCount: count,
+      };
+    } else {
+      return {
+        data: [],
+        totalCount: 0,
       };
     }
   };
@@ -598,7 +604,6 @@ class AnnotationLayer extends React.PureComponent {
       intervalEndColumn,
       descriptionColumns,
       currentSlice,
-      isNew,
     } = this.state;
     if (!value) {
       return '';

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
@@ -223,6 +223,9 @@ class AnnotationLayer extends React.PureComponent {
   componentDidMount() {
     if (this.shouldFetchAppliedAnnotation()) {
       const { value } = this.state;
+      /* The value prop is the id of the chart/native. This function will set
+      value in state to an object with the id as value.value to be used by
+      AsyncSelect */
       this.fetchAppliedAnnotation(value);
     }
   }

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
@@ -323,8 +323,8 @@ class AnnotationLayer extends React.PureComponent {
   asyncFetch = async (search, page, pageSize) => {
     const { annotationType, sourceType } = this.state;
 
-    // Bypassing an eslint error unused-variables
-    const consumedSearch = search;
+    // Bypassing eslint no-unused-vars error
+    search.trim();
 
     if (sourceType === ANNOTATION_SOURCE_TYPES.NATIVE) {
       const queryParams = rison.encode({
@@ -409,12 +409,11 @@ class AnnotationLayer extends React.PureComponent {
         data: chartsArray,
         totalCount: count,
       };
-    } else {
-      return {
-        data: [],
-        totalCount: 0,
-      };
     }
+    return {
+      data: [],
+      totalCount: 0,
+    };
   };
 
   fetchAppliedChart() {

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
@@ -194,7 +194,6 @@ class AnnotationLayer extends React.PureComponent {
       hideLine,
       // refData
       isNew: !name,
-      valueOptions: {},
       slice: null,
     };
     this.submitAnnotation = this.submitAnnotation.bind(this);
@@ -467,9 +466,8 @@ class AnnotationLayer extends React.PureComponent {
       const canBeAnnotationType =
         metadata && metadata.canBeAnnotationType(annotationType);
       if (canBeAnnotationType) {
-        this.setState(prevState => ({
+        this.setState({
           valueOptions: {
-            ...prevState.valueOptions,
             [id]: {
               value: id,
               label: sliceName,
@@ -481,7 +479,7 @@ class AnnotationLayer extends React.PureComponent {
               groupby: formData.groupby?.map(column => getColumnLabel(column)),
             },
           },
-        }));
+        });
       }
     });
   }
@@ -492,15 +490,14 @@ class AnnotationLayer extends React.PureComponent {
     }).then(({ json }) => {
       const { result } = json;
       const layer = result;
-      this.setState(prevState => ({
+      this.setState({
         valueOptions: {
-          ...prevState.valueOptions,
           [layer.id]: {
             value: layer.id,
             label: layer.name,
           },
         },
-      }));
+      });
     });
   }
 

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
@@ -194,6 +194,7 @@ class AnnotationLayer extends React.PureComponent {
       hideLine,
       // refData
       isNew: !name,
+      valueOptions: {},
       slice: null,
     };
     this.submitAnnotation = this.submitAnnotation.bind(this);

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
@@ -312,11 +312,8 @@ class AnnotationLayer extends React.PureComponent {
     });
   }
 
-  asyncFetch = async (search, page, pageSize) => {
+  asyncFetch = async (_, page, pageSize) => {
     const { annotationType, sourceType } = this.state;
-
-    // Bypassing eslint no-unused-vars error
-    search.trim();
 
     if (sourceType === ANNOTATION_SOURCE_TYPES.NATIVE) {
       const queryParams = rison.encode({

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
@@ -194,6 +194,7 @@ class AnnotationLayer extends React.PureComponent {
       hideLine,
       // refData
       isNew: !name,
+      valueOptions: {},
       slice: null,
     };
     this.submitAnnotation = this.submitAnnotation.bind(this);
@@ -423,7 +424,6 @@ class AnnotationLayer extends React.PureComponent {
     if (sourceType === ANNOTATION_SOURCE_TYPES.NATIVE) {
       return this.fetchNativeAnnotations(search, page, pageSize);
     }
-
     return this.fetchCharts(search, page, pageSize);
   };
 

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
@@ -194,7 +194,6 @@ class AnnotationLayer extends React.PureComponent {
       hideLine,
       // refData
       isNew: !name,
-      valueOptions: {},
       slice: null,
     };
     this.submitAnnotation = this.submitAnnotation.bind(this);
@@ -425,14 +424,7 @@ class AnnotationLayer extends React.PureComponent {
       return this.fetchNativeAnnotations(search, page, pageSize);
     }
 
-    if (requiresQuery(sourceType)) {
-      return this.fetchCharts(search, page, pageSize);
-    }
-
-    return {
-      data: [],
-      totalCount: 0,
-    };
+    return this.fetchCharts(search, page, pageSize);
   };
 
   fetchSliceData = id => {

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
@@ -197,7 +197,6 @@ class AnnotationLayer extends React.PureComponent {
       show,
       showLabel,
       // slice
-      // currentSlice,
       titleColumn,
       descriptionColumns,
       timeColumn,
@@ -321,11 +320,11 @@ class AnnotationLayer extends React.PureComponent {
     });
   }
 
-  asyncFetch = async (search = '', page, pageSize) => {
+  asyncFetch = async (search, page, pageSize) => {
     const { annotationType, sourceType } = this.state;
 
-    // Bypassing an eslint error
-    const consumeSearch = search.trim();
+    // Bypassing an eslint error unused-variables
+    const consumedSearch = search;
 
     if (sourceType === ANNOTATION_SOURCE_TYPES.NATIVE) {
       const queryParams = rison.encode({
@@ -490,7 +489,6 @@ class AnnotationLayer extends React.PureComponent {
         'descriptionColumns',
         'timeColumn',
         'intervalEndColumn',
-        // 'currentSlice',
       ];
       const newAnnotation = {};
       annotationFields.forEach(field => {
@@ -614,7 +612,6 @@ class AnnotationLayer extends React.PureComponent {
       timeColumn,
       intervalEndColumn,
       descriptionColumns,
-      // currentSlice,
     } = this.state;
 
     if (!value) {

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
@@ -194,7 +194,6 @@ class AnnotationLayer extends React.PureComponent {
       hideLine,
       // refData
       isNew: !name,
-      valueOptions: {},
       slice: null,
     };
     this.submitAnnotation = this.submitAnnotation.bind(this);
@@ -254,8 +253,8 @@ class AnnotationLayer extends React.PureComponent {
   }
 
   shouldFetchAppliedAnnotation() {
-    const { value, valueOptions, sourceType } = this.state;
-    return value && !valueOptions[value] && requiresQuery(sourceType);
+    const { value, sourceType } = this.state;
+    return value && requiresQuery(sourceType);
   }
 
   shouldFetchSliceData(prevState) {
@@ -571,6 +570,7 @@ class AnnotationLayer extends React.PureComponent {
 
   renderValueConfiguration() {
     const { annotationType, sourceType, value, valueOptions } = this.state;
+    const validValue = valueOptions?.[value] ?? null;
     let label = '';
     let description = '';
     if (requiresQuery(sourceType)) {
@@ -602,7 +602,7 @@ class AnnotationLayer extends React.PureComponent {
           name="annotation-layer-value"
           header={this.renderChartHeader(label, description, value)}
           options={this.fetchOptions}
-          value={valueOptions[value] || null}
+          value={validValue}
           onChange={this.handleSelectValue}
           notFoundContent={<NotFoundContent />}
         />

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.test.tsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.test.tsx
@@ -228,43 +228,58 @@ test('keeps apply disabled when missing required fields', async () => {
 test('Disable apply button if formula is incorrect', async () => {
   await waitForRender({ name: 'test' });
 
-  userEvent.clear(screen.getByLabelText('Formula'));
-  userEvent.type(screen.getByLabelText('Formula'), 'x+1');
+  const formulaInput = screen.getByRole('textbox', { name: 'Formula' });
+  const applyButton = screen.getByRole('button', { name: 'Apply' });
+  const okButton = screen.getByRole('button', { name: 'OK' });
+
+  userEvent.type(formulaInput, 'x+1');
+  expect(formulaInput).toHaveValue('x+1');
   await waitFor(() => {
-    expect(screen.getByLabelText('Formula')).toHaveValue('x+1');
-    expect(screen.getByRole('button', { name: 'OK' })).toBeEnabled();
-    expect(screen.getByRole('button', { name: 'Apply' })).toBeEnabled();
+    expect(okButton).toBeEnabled();
+    expect(applyButton).toBeEnabled();
   });
 
-  userEvent.clear(screen.getByLabelText('Formula'));
-  userEvent.type(screen.getByLabelText('Formula'), 'y = x*2+1');
+  userEvent.clear(formulaInput);
   await waitFor(() => {
-    expect(screen.getByLabelText('Formula')).toHaveValue('y = x*2+1');
-    expect(screen.getByRole('button', { name: 'OK' })).toBeEnabled();
-    expect(screen.getByRole('button', { name: 'Apply' })).toBeEnabled();
+    expect(formulaInput).toHaveValue('');
+  });
+  userEvent.type(formulaInput, 'y = x*2+1');
+  expect(formulaInput).toHaveValue('y = x*2+1');
+  await waitFor(() => {
+    expect(okButton).toBeEnabled();
+    expect(applyButton).toBeEnabled();
   });
 
-  userEvent.clear(screen.getByLabelText('Formula'));
-  userEvent.type(screen.getByLabelText('Formula'), 'y+1');
+  userEvent.clear(formulaInput);
   await waitFor(() => {
-    expect(screen.getByLabelText('Formula')).toHaveValue('y+1');
-    expect(screen.getByRole('button', { name: 'OK' })).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
+    expect(formulaInput).toHaveValue('');
+  });
+  userEvent.type(formulaInput, 'y+1');
+  expect(formulaInput).toHaveValue('y+1');
+  await waitFor(() => {
+    expect(okButton).toBeDisabled();
+    expect(applyButton).toBeDisabled();
   });
 
-  userEvent.clear(screen.getByLabelText('Formula'));
-  userEvent.type(screen.getByLabelText('Formula'), 'x+');
+  userEvent.clear(formulaInput);
   await waitFor(() => {
-    expect(screen.getByLabelText('Formula')).toHaveValue('x+');
-    expect(screen.getByRole('button', { name: 'OK' })).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
+    expect(formulaInput).toHaveValue('');
+  });
+  userEvent.type(formulaInput, 'x+');
+  expect(formulaInput).toHaveValue('x+');
+  await waitFor(() => {
+    expect(okButton).toBeDisabled();
+    expect(applyButton).toBeDisabled();
   });
 
-  userEvent.clear(screen.getByLabelText('Formula'));
-  userEvent.type(screen.getByLabelText('Formula'), 'y = z+1');
+  userEvent.clear(formulaInput);
   await waitFor(() => {
-    expect(screen.getByLabelText('Formula')).toHaveValue('y = z+1');
-    expect(screen.getByRole('button', { name: 'OK' })).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
+    expect(formulaInput).toHaveValue('');
+  });
+  userEvent.type(formulaInput, 'y = z+1');
+  expect(formulaInput).toHaveValue('y = z+1');
+  await waitFor(() => {
+    expect(okButton).toBeDisabled();
+    expect(applyButton).toBeDisabled();
   });
 });

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.test.tsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.test.tsx
@@ -199,7 +199,7 @@ test('keeps apply disabled when missing required fields', async () => {
   );
   expect(await screen.findByText('Chart A')).toBeInTheDocument();
   userEvent.click(screen.getByText('Chart A'));
-
+  await screen.findByText(/title column/i);
   userEvent.click(screen.getByRole('button', { name: 'Automatic Color' }));
   userEvent.click(
     screen.getByRole('combobox', { name: 'Annotation layer title column' }),

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.test.tsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.test.tsx
@@ -40,7 +40,7 @@ beforeAll(() => {
   );
 
   fetchMock.get(nativeLayerApiRoute, {
-    result: [{ label: 'Chart A', value: 'a' }],
+    result: [{ name: 'Chart A', id: 'a' }],
   });
 
   fetchMock.get(chartApiRoute, {
@@ -147,7 +147,7 @@ test('triggers removeAnnotationLayer and close when remove button is clicked', a
   expect(close).toHaveBeenCalled();
 });
 
-test('renders chart options', async () => {
+test('fetches Superset annotation layer options', async () => {
   await waitForRender({
     annotationType: ANNOTATION_TYPES_METADATA.EVENT.value,
   });
@@ -156,22 +156,37 @@ test('renders chart options', async () => {
   );
   userEvent.click(screen.getByText('Superset annotation'));
   expect(await screen.findByText('Annotation layer')).toBeInTheDocument();
+  userEvent.click(
+    screen.getByRole('combobox', { name: 'Annotation layer value' }),
+  );
+  expect(await screen.findByText('Chart A')).toBeInTheDocument();
+  expect(fetchMock.calls(nativeLayerApiRoute).length).toBe(1);
+});
 
+test('fetches chart options', async () => {
+  await waitForRender({
+    annotationType: ANNOTATION_TYPES_METADATA.EVENT.value,
+  });
   userEvent.click(
     screen.getByRole('combobox', { name: 'Annotation source type' }),
   );
   userEvent.click(screen.getByText('Table'));
   expect(await screen.findByText('Chart')).toBeInTheDocument();
+  userEvent.click(
+    screen.getByRole('combobox', { name: 'Annotation layer value' }),
+  );
+  expect(await screen.findByText('Chart A')).toBeInTheDocument();
+  expect(fetchMock.calls(chartApiRoute).length).toBe(1);
 });
 
-test('fetch chart on mount if value present', async () => {
+test('fetches chart on mount if value present', async () => {
   await waitForRender({
     name: 'Test',
     value: 'a',
     annotationType: ANNOTATION_TYPES_METADATA.EVENT.value,
     sourceType: 'Table',
   });
-  expect(fetchMock.calls(chartApiRoute).length).toBe(1);
+  expect(fetchMock.calls(chartApiRoute).length).toBe(2);
 });
 
 test('keeps apply disabled when missing required fields', async () => {
@@ -211,7 +226,6 @@ test('keeps apply disabled when missing required fields', async () => {
 });
 
 test('Disable apply button if formula is incorrect', async () => {
-  // TODO: fix flaky test that passes locally but fails on CI
   await waitForRender({ name: 'test' });
 
   userEvent.clear(screen.getByLabelText('Formula'));

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.test.tsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.test.tsx
@@ -32,7 +32,20 @@ const defaultProps = {
 };
 
 const nativeLayerApiRoute = 'glob:*/api/v1/annotation_layer/*';
-const chartApiRoute = 'glob:*/api/v1/chart/*';
+const chartApiRoute = /\/api\/v1\/chart\/\?q=.+/;
+const chartApiWithIdRoute = /\/api\/v1\/chart\/\w+\?q=.+/;
+
+const withIdResult = {
+  result: {
+    slice_name: 'Mocked Slice',
+    query_context: JSON.stringify({
+      form_data: {
+        groupby: ['country'],
+      },
+    }),
+    viz_type: 'line',
+  },
+};
 
 beforeAll(() => {
   const supportedAnnotationTypes = Object.values(ANNOTATION_TYPES_METADATA).map(
@@ -44,10 +57,10 @@ beforeAll(() => {
   });
 
   fetchMock.get(chartApiRoute, {
-    result: [
-      { id: 'a', slice_name: 'Chart A', viz_type: 'table', form_data: {} },
-    ],
+    result: [{ id: 'a', slice_name: 'Chart A', viz_type: 'table' }],
   });
+
+  fetchMock.get(chartApiWithIdRoute, withIdResult);
 
   setupColors();
 
@@ -186,7 +199,7 @@ test('fetches chart on mount if value present', async () => {
     annotationType: ANNOTATION_TYPES_METADATA.EVENT.value,
     sourceType: 'Table',
   });
-  expect(fetchMock.calls(chartApiRoute).length).toBe(2);
+  expect(fetchMock.calls(chartApiWithIdRoute).length).toBe(1);
 });
 
 test('keeps apply disabled when missing required fields', async () => {

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.test.tsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.test.tsx
@@ -31,16 +31,19 @@ const defaultProps = {
   annotationType: ANNOTATION_TYPES_METADATA.FORMULA.value,
 };
 
+const nativeLayerApiRoute = 'glob:*/api/v1/annotation_layer/*';
+const chartApiRoute = 'glob:*/api/v1/chart/*';
+
 beforeAll(() => {
   const supportedAnnotationTypes = Object.values(ANNOTATION_TYPES_METADATA).map(
     value => value.value,
   );
 
-  fetchMock.get('glob:*/api/v1/annotation_layer/*', {
+  fetchMock.get(nativeLayerApiRoute, {
     result: [{ label: 'Chart A', value: 'a' }],
   });
 
-  fetchMock.get('glob:*/api/v1/chart/*', {
+  fetchMock.get(chartApiRoute, {
     result: [
       { id: 'a', slice_name: 'Chart A', viz_type: 'table', form_data: {} },
     ],
@@ -161,6 +164,16 @@ test('renders chart options', async () => {
   expect(await screen.findByText('Chart')).toBeInTheDocument();
 });
 
+test('fetch chart on mount if value present', async () => {
+  await waitForRender({
+    name: 'Test',
+    value: 'a',
+    annotationType: ANNOTATION_TYPES_METADATA.EVENT.value,
+    sourceType: 'Table',
+  });
+  expect(fetchMock.calls(chartApiRoute).length).toBe(1);
+});
+
 test('keeps apply disabled when missing required fields', async () => {
   await waitForRender({
     annotationType: ANNOTATION_TYPES_METADATA.EVENT.value,
@@ -197,7 +210,7 @@ test('keeps apply disabled when missing required fields', async () => {
   expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
 });
 
-test.skip('Disable apply button if formula is incorrect', async () => {
+test('Disable apply button if formula is incorrect', async () => {
   // TODO: fix flaky test that passes locally but fails on CI
   await waitForRender({ name: 'test' });
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Replace the SelectControl component with an AsyncSelect component when choosing the source of the annotation. This addresses the response limiting table options to 100 max. There are relevant changes to the process of fetching and where the fetch is being made in the file.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
BEFORE:
![limited-charts](https://github.com/apache/superset/assets/92495987/f5aeaebc-8690-4fc0-9d55-9372c7869407)
AFTER:
![all-charts](https://github.com/apache/superset/assets/92495987/75d5bca9-984f-4b2e-92fa-3b3f7093131f)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Create 100+ annotations or Tables. Saving dashboards as duplicates and selecting the duplicate charts box will speed this process up.
- Charts must be **created by you** (annotation options are filtered by `'chart_owned_created_favored_by_me'`)
- Create a new chart
- Click the "Add Annotation" button
- Choose an Annotation type requiring a query, e.g. "Event"
- Scroll through the options to verify display of all 100+ charts

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #25421 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
