### PR TITLE
fix(explore): allow free-form d3 format on custom column formatting

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -517,6 +517,7 @@ export type ControlFormItemSpec<T extends ControlType = ControlType> = {
   debounceDelay?: number;
 } & (T extends 'Select'
   ? {
+      allowNewOptions?: boolean;
       options: any;
       value?: string;
       defaultValue?: string;

--- a/superset-frontend/src/explore/components/controls/ColumnConfigControl/constants.tsx
+++ b/superset-frontend/src/explore/components/controls/ColumnConfigControl/constants.tsx
@@ -42,6 +42,7 @@ export type SharedColumnConfigProp =
   | 'currencyFormat';
 
 const d3NumberFormat: ControlFormItemSpec<'Select'> = {
+  allowNewOptions: true,
   controlType: 'Select',
   label: t('D3 format'),
   description: D3_FORMAT_DOCS,


### PR DESCRIPTION
### SUMMARY
Similar to other D3 formats that accept free-form values for various customization of number formatters, this commit enables the use of free-form D3 format values in custom column formatters.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://github.com/apache/superset/assets/1392866/560b9341-83d3-4407-abc3-8cbe3167c384

After:

https://github.com/apache/superset/assets/1392866/4b4aa866-f68f-400d-9c3c-77c2ed54febf

### TESTING INSTRUCTIONS
Go to explore and add a number column
Select "Customize" and the column to change the value format
Type a custom D3 format like `.2s` 

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
