### PR TITLE
fix(chart): add default format for quarter time grain

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -89,6 +89,7 @@ import {
 import { TIMEGRAIN_TO_TIMESTAMP, TIMESERIES_CONSTANTS } from '../constants';
 import { getDefaultTooltip } from '../utils/tooltip';
 import {
+  getTimeFormat,
   getTooltipTimeFormatter,
   getXAxisFormatter,
   getYAxisFormatter,
@@ -462,11 +463,11 @@ export default function transformProps(
 
   const tooltipFormatter =
     xAxisDataType === GenericDataType.Temporal
-      ? getTooltipTimeFormatter(tooltipTimeFormat)
+      ? getTooltipTimeFormatter(getTimeFormat(timeGrainSqla, tooltipTimeFormat))
       : String;
   const xAxisFormatter =
     xAxisDataType === GenericDataType.Temporal
-      ? getXAxisFormatter(xAxisTimeFormat)
+      ? getXAxisFormatter(getTimeFormat(timeGrainSqla, xAxisTimeFormat))
       : String;
 
   const addYAxisTitleOffset = !!(yAxisTitle || yAxisTitleSecondary);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -95,6 +95,7 @@ import {
 } from '../constants';
 import { getDefaultTooltip } from '../utils/tooltip';
 import {
+  getTimeFormat,
   getTooltipTimeFormatter,
   getXAxisFormatter,
   getYAxisFormatter,
@@ -411,11 +412,11 @@ export default function transformProps(
 
   const tooltipFormatter =
     xAxisDataType === GenericDataType.Temporal
-      ? getTooltipTimeFormatter(tooltipTimeFormat)
+      ? getTooltipTimeFormatter(getTimeFormat(timeGrainSqla, tooltipTimeFormat))
       : String;
   const xAxisFormatter =
     xAxisDataType === GenericDataType.Temporal
-      ? getXAxisFormatter(xAxisTimeFormat)
+      ? getXAxisFormatter(getTimeFormat(timeGrainSqla, xAxisTimeFormat))
       : String;
 
   const {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/formatters.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/formatters.ts
@@ -26,6 +26,7 @@ import {
   QueryFormMetric,
   smartDateDetailedFormatter,
   smartDateFormatter,
+  TimeGranularity,
   TimeFormatter,
   ValueFormatter,
 } from '@superset-ui/core';
@@ -78,4 +79,14 @@ export function getXAxisFormatter(
     return getTimeFormatter(format);
   }
   return String;
+}
+
+export function getTimeFormat(
+  timeGrainSqla: TimeGranularity | undefined,
+  timeFormat: string | undefined,
+): string | undefined {
+  if (timeGrainSqla === 'P3M' && timeFormat === 'smart_date') {
+    return '%Y-Q%q';
+  }
+  return timeFormat;
 }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When we create a time-series chart with a quarter time grain, the default formatting sometimes displays the year (YYYY) at the beginning of the year, such as '2023', while the remaining quarters display the first month of the quarter, such as 'Apr' or 'Jul'. This inconsistency in formatting can make the chart less readable and less consistent. To address this issue, I've made changes to adjust the default formatting. 
I'm not sure whether this solution is overly hard-coded or if there are more effective alternatives available. Please help suggest!

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
**Before:**
![Screenshot 2567-02-07 at 17 18 00](https://github.com/apache/superset/assets/96282005/6b2649dc-5dd4-4ff1-b9e1-45d75ae06753)

**After:**
![image](https://github.com/apache/superset/assets/96282005/ebfa5e19-a26c-4b11-ae09-abb9a764883d)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Create a time-series bar chart 
2. Set time grain to be Quarter and observe the date format


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
