### PR TITLE
Icon and Api Tasks

### DIFF
--- a/rocksetapistuff.txt
+++ b/rocksetapistuff.txt
@@ -1,0 +1,2 @@
+rockset_api_key: slzXRHem1lebeo13tDp9LqaeItDIJ201GWOhjcrbWelAQTxmHntftKWfntmvfwS5
+rockset_api_server: https://api.use1a1.rockset.com/

--- a/superset_text.yml
+++ b/superset_text.yml
@@ -18,7 +18,8 @@
 
 # To set the images of your preferred database, you may create a mapping here with engine and locations of the relevant images. The image can be hosted locally inside your static/file directory or online (e.g. S3)
 
-# DB_IMAGES:
+ DB_IMAGES:
 #   postgresql: "path/to/image/postgres.jpg"
 #   bigquery: "path/to/s3bucket/bigquery.jpg"
 #   snowflake: "path/to/image/snowflake.jpg"
+    mySQL: "https://i.ibb.co/QDXHzzJ/mysql.jpg"


### PR DESCRIPTION

Task 1: Replicate Superset Frontend Login To Generate Dynamic Forms
  To connect to external API resources
Task 2: Adding Custom Icons to Database Form
  To enhance user interface of the database connection form by adding custom icons for MySQL databases


### SUMMARY
Issues install superset, stuck on welcome page after logging in to Apache Superset and frontend could not be fully build due to npm ci command taking a very long time with no final output. The below includes instructions as well as steps would have been taken if these issues were not present.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Task 1: 
-Installed the database driver for rockset api: pip install rockset-sqlalchemy 
- login to apache superset 
- click database 
- click supported databases, then click other 
- in the SQLALCHEMY URI section, enter the connection string for rockset:
rockset://{slzXRHem1lebeo13tDp9LqaeItDIJ201GWOhjcrbWelAQTxmHntftKWfntmvfwS5}:@{api.use1a1.rockset.com}
- Use this as guide for other connection string formats for other APIs: https://superset.apache.org/docs/databases/installing-database-drivers/
- click test connection, then connect

Task 2:
- Added a link to the MySQL image in the superset_text.yml file : mysql.jpg
- superset/superset/config.py contained a section referring to the 'preferred_databases'. MySQL already mentioned in that part so no need to add it in
-go to database page, then to Connect a Database form
- enter parameters such as: localhost, host, database name
-click connect 
-restart (run dev-server)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Required feature flags:
- [x ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ x] Introduces new feature or API
- [ ] Removes existing feature or API
