### PR TITLE
feat(plugins): Update custom controls for BigNumber with Time Comparison chart

### DIFF
--- a/superset-frontend/plugins/plugin-chart-period-over-period-kpi/src/plugin/controlPanel.ts
+++ b/superset-frontend/plugins/plugin-chart-period-over-period-kpi/src/plugin/controlPanel.ts
@@ -16,11 +16,26 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t, validateNonEmpty } from '@superset-ui/core';
+import { ensureIsArray, t, validateNonEmpty } from '@superset-ui/core';
 import {
   ControlPanelConfig,
+  ControlPanelState,
+  ControlState,
   sharedControls,
 } from '@superset-ui/chart-controls';
+
+const validateTimeComparisonRangeValues = (
+  timeRangeValue?: any,
+  controlValue?: any,
+) => {
+  const isCustomTimeRange = timeRangeValue === 'c';
+  const isCustomControlEmpty = controlValue?.every(
+    (val: any) => ensureIsArray(val).length === 0,
+  );
+  return isCustomTimeRange && isCustomControlEmpty
+    ? [t('Filters for comparison must have a value')]
+    : [];
+};
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
@@ -54,6 +69,33 @@ const config: ControlPanelConfig = {
                 ['r', 'Range'],
                 ['c', 'Custom'],
               ],
+              rerender: ['adhoc_custom'],
+            },
+          },
+        ],
+        [
+          {
+            name: `adhoc_custom`,
+            config: {
+              ...sharedControls.adhoc_filters,
+              label: t('Filters for Comparison'),
+              description:
+                'This only applies when selecting the Range for Comparison Type: Custom',
+              visibility: ({ controls }) =>
+                controls?.time_comparison?.value === 'c',
+              mapStateToProps: (
+                state: ControlPanelState,
+                controlState: ControlState,
+              ) => ({
+                ...(sharedControls.adhoc_filters.mapStateToProps?.(
+                  state,
+                  controlState,
+                ) || {}),
+                externalValidationErrors: validateTimeComparisonRangeValues(
+                  state.controls?.time_comparison?.value,
+                  controlState.value,
+                ),
+              }),
             },
           },
         ],
@@ -61,23 +103,6 @@ const config: ControlPanelConfig = {
           {
             name: 'row_limit',
             config: sharedControls.row_limit,
-          },
-        ],
-      ],
-    },
-    {
-      label: t('Custom Time Range'),
-      expanded: true,
-      controlSetRows: [
-        [
-          {
-            name: `adhoc_custom`,
-            config: {
-              ...sharedControls.adhoc_filters,
-              label: t('FILTERS (Custom)'),
-              description:
-                'This only applies when selecting the Range for Comparison Type- Custom',
-            },
           },
         ],
       ],


### PR DESCRIPTION
### SUMMARY
In order to help users to navigate the new comparison controls of the plugin we are making the Custom time range part of the query section, also it's only visible if custom range is selected and if so, it's  a required field.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://github.com/apache/superset/assets/38889534/beb1f60e-ecb6-4763-b3e1-1b33f931933f



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
