### PR TITLE
feat(docker): allow for docker release builds to be multi-platform

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -75,10 +75,8 @@ jobs:
             fi
             # build_docker.py may not exist on that SHA, let's switcharoo to /tmp
             cp ./scripts/build_docker.py /tmp
-            cp ./Dockerfile /tmp
             git checkout "${{ github.event.inputs.git-ref }}"
             cp /tmp/build_docker.py scripts/
-            cp /tmp/Dockerfile ./
             EVENT="release"
           fi
           pip install click

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -2,7 +2,7 @@ name: Docker Publish Release
 
 on:
   release:
-    types: [published]
+    types: [published, edited]
 
   # Can be triggered manually
   workflow_dispatch:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -75,8 +75,10 @@ jobs:
             fi
             # build_docker.py may not exist on that SHA, let's switcharoo to /tmp
             cp ./scripts/build_docker.py /tmp
+            cp ./Dockerfile /tmp
             git checkout "${{ github.event.inputs.git-ref }}"
             cp /tmp/build_docker.py scripts/
+            cp /Dockerfile ./
             EVENT="release"
           fi
           pip install click

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -78,7 +78,7 @@ jobs:
             cp ./Dockerfile /tmp
             git checkout "${{ github.event.inputs.git-ref }}"
             cp /tmp/build_docker.py scripts/
-            cp /Dockerfile ./
+            cp /tmp/Dockerfile ./
             EVENT="release"
           fi
           pip install click

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -43,14 +43,6 @@ jobs:
     strategy:
       matrix:
         build_preset: ["dev", "lean", "py310", "websocket", "dockerize"]
-        platform: ["linux/amd64", "linux/arm64"]
-        exclude:
-          # disabling because slow! no python wheels for arm/py39 and
-          # QEMU is slow!
-          - build_preset: "dev"
-            platform: "linux/arm64"
-          - build_preset: "lean"
-            platform: "linux/arm64"
       fail-fast: false
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
@@ -88,8 +80,10 @@ jobs:
             EVENT="release"
           fi
           pip install click
+          # Make a multi-platform image
           ./scripts/build_docker.py \
             ${{ matrix.build_preset }} \
             "$EVENT" \
-            --build_context_ref "$RELEASE" \
-            --platform ${{ matrix.platform }} $FORCE_LATEST
+            --build_context_ref "$RELEASE" $FORCE_LATEST \
+            --platform "linux/arm64"
+            --platform "linux/amd64"

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -85,5 +85,5 @@ jobs:
             ${{ matrix.build_preset }} \
             "$EVENT" \
             --build_context_ref "$RELEASE" $FORCE_LATEST \
-            --platform "linux/arm64"
+            --platform "linux/arm64" \
             --platform "linux/amd64"

--- a/.github/workflows/ephemeral-env.yml
+++ b/.github/workflows/ephemeral-env.yml
@@ -101,7 +101,6 @@ jobs:
             }
             core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`)
             const pr = await github.rest.pulls.get(request);
-            console.log(pr.data);
             return pr.data;
 
       - name: Debug

--- a/.github/workflows/ephemeral-env.yml
+++ b/.github/workflows/ephemeral-env.yml
@@ -101,6 +101,7 @@ jobs:
             }
             core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`)
             const pr = await github.rest.pulls.get(request);
+            console.log(pr.data);
             return pr.data;
 
       - name: Debug
@@ -143,10 +144,9 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: superset-ci
-          SHA: ${{ steps.get-sha.outputs.sha }}
           IMAGE_TAG: apache/superset:${{ steps.get-sha.outputs.sha }}-ci
         run: |
-          docker tag $IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$SHA
+          docker tag $IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:pr-${{ github.event.issue.number }}-ci
           docker push -a $ECR_REGISTRY/$ECR_REPOSITORY
 
   ephemeral-env-up:
@@ -181,7 +181,7 @@ jobs:
         aws ecr describe-images \
         --registry-id $(echo "${{ steps.login-ecr.outputs.registry }}" | grep -Eo "^[0-9]+") \
         --repository-name superset-ci \
-        --image-ids imageTag=${{ steps.get-sha.outputs.sha }}
+        --image-ids imageTag=pr-${{ github.event.issue.number }}-ci
 
     - name: Fail on missing container image
       if: steps.check-image.outcome == 'failure'
@@ -204,7 +204,7 @@ jobs:
       with:
         task-definition: .github/workflows/ecs-task-definition.json
         container-name: superset-ci
-        image: ${{ steps.login-ecr.outputs.registry }}/superset-ci:pr-${{ github.event.issue.number }}
+        image: ${{ steps.login-ecr.outputs.registry }}/superset-ci:pr-${{ github.event.issue.number }}-ci
 
     - name: Update env vars in the Amazon ECS task definition
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,9 @@ FROM --platform=${BUILDPLATFORM} node:16-bookworm-slim AS superset-node
 
 ARG NPM_BUILD_CMD="build"
 
-RUN apt-get update -qq \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update -qq \
     && apt-get install -yqq --no-install-recommends \
         build-essential \
         python3
@@ -61,7 +63,9 @@ ENV LANG=C.UTF-8 \
     SUPERSET_HOME="/app/superset_home" \
     SUPERSET_PORT=8088
 
-RUN mkdir -p ${PYTHONPATH} superset/static superset-frontend apache_superset.egg-info requirements \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    mkdir -p ${PYTHONPATH} superset/static superset-frontend apache_superset.egg-info requirements \
     && useradd --user-group -d ${SUPERSET_HOME} -m --no-log-init --shell /bin/bash superset \
     && apt-get update -qq && apt-get install -yqq --no-install-recommends \
         build-essential \
@@ -111,7 +115,9 @@ ARG GECKODRIVER_VERSION=v0.33.0 \
 
 USER root
 
-RUN apt-get update -qq \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update -qq \
     && apt-get install -yqq --no-install-recommends \
         libnss3 \
         libdbus-glib-1-2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,11 +65,13 @@ ENV LANG=C.UTF-8 \
     SUPERSET_PORT=8088
 
 RUN \
+    mkdir -p ${PYTHONPATH} superset/static superset-frontend apache_superset.egg-info requirements \
+    && useradd --user-group -d ${SUPERSET_HOME} -m --no-log-init --shell /bin/bash superset
+
+RUN \
     --mount=type=cache,id=apt-cache-${TARGETARCH}-${TARGETVARIANT},sharing=locked,target=/var/lib/apt/lists \
     --mount=type=cache,id=apt-cache-${TARGETARCH}-${TARGETVARIANT},sharing=locked,target=/var/cache/apt \
-    mkdir -p ${PYTHONPATH} superset/static superset-frontend apache_superset.egg-info requirements \
-    && useradd --user-group -d ${SUPERSET_HOME} -m --no-log-init --shell /bin/bash superset \
-    && apt-get update -qq && apt-get install -yqq --no-install-recommends \
+    apt-get update -qq && apt-get install -yqq --no-install-recommends \
         build-essential \
         curl \
         default-libmysqlclient-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,9 @@ FROM --platform=${BUILDPLATFORM} node:16-bookworm-slim AS superset-node
 
 ARG NPM_BUILD_CMD="build"
 
-RUN --no-cache \
+RUN \
+    --mount=type=cache,id=apt-cache-${TARGETARCH}-${TARGETVARIANT},sharing=locked,target=/var/lib/apt/lists \
+    --mount=type=cache,id=apt-cache-${TARGETARCH}-${TARGETVARIANT},sharing=locked,target=/var/cache/apt \
     apt-get update -qq \
     && apt-get install -yqq --no-install-recommends \
         build-essential \
@@ -62,7 +64,9 @@ ENV LANG=C.UTF-8 \
     SUPERSET_HOME="/app/superset_home" \
     SUPERSET_PORT=8088
 
-RUN --no-cache \
+RUN \
+    --mount=type=cache,id=apt-cache-${TARGETARCH}-${TARGETVARIANT},sharing=locked,target=/var/lib/apt/lists \
+    --mount=type=cache,id=apt-cache-${TARGETARCH}-${TARGETVARIANT},sharing=locked,target=/var/cache/apt \
     mkdir -p ${PYTHONPATH} superset/static superset-frontend apache_superset.egg-info requirements \
     && useradd --user-group -d ${SUPERSET_HOME} -m --no-log-init --shell /bin/bash superset \
     && apt-get update -qq && apt-get install -yqq --no-install-recommends \
@@ -113,7 +117,9 @@ ARG GECKODRIVER_VERSION=v0.33.0 \
 
 USER root
 
-RUN --no-cache \
+RUN \
+    --mount=type=cache,id=apt-cache-${TARGETARCH}-${TARGETVARIANT},sharing=locked,target=/var/lib/apt/lists \
+    --mount=type=cache,id=apt-cache-${TARGETARCH}-${TARGETVARIANT},sharing=locked,target=/var/cache/apt \
     apt-get update -qq \
     && apt-get install -yqq --no-install-recommends \
         libnss3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,7 @@ FROM --platform=${BUILDPLATFORM} node:16-bookworm-slim AS superset-node
 
 ARG NPM_BUILD_CMD="build"
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+RUN --no-cache \
     apt-get update -qq \
     && apt-get install -yqq --no-install-recommends \
         build-essential \
@@ -63,8 +62,7 @@ ENV LANG=C.UTF-8 \
     SUPERSET_HOME="/app/superset_home" \
     SUPERSET_PORT=8088
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+RUN --no-cache \
     mkdir -p ${PYTHONPATH} superset/static superset-frontend apache_superset.egg-info requirements \
     && useradd --user-group -d ${SUPERSET_HOME} -m --no-log-init --shell /bin/bash superset \
     && apt-get update -qq && apt-get install -yqq --no-install-recommends \
@@ -115,8 +113,7 @@ ARG GECKODRIVER_VERSION=v0.33.0 \
 
 USER root
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+RUN --no-cache \
     apt-get update -qq \
     && apt-get install -yqq --no-install-recommends \
         libnss3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,7 @@ FROM --platform=${BUILDPLATFORM} node:16-bookworm-slim AS superset-node
 
 ARG NPM_BUILD_CMD="build"
 
-RUN \
-    --mount=type=cache,id=apt-cache-${TARGETARCH}-${TARGETVARIANT},sharing=locked,target=/var/lib/apt/lists \
-    --mount=type=cache,id=apt-cache-${TARGETARCH}-${TARGETVARIANT},sharing=locked,target=/var/cache/apt \
-    apt-get update -qq \
+RUN apt-get update -qq \
     && apt-get install -yqq --no-install-recommends \
         build-essential \
         python3
@@ -64,14 +61,9 @@ ENV LANG=C.UTF-8 \
     SUPERSET_HOME="/app/superset_home" \
     SUPERSET_PORT=8088
 
-RUN \
-    mkdir -p ${PYTHONPATH} superset/static superset-frontend apache_superset.egg-info requirements \
-    && useradd --user-group -d ${SUPERSET_HOME} -m --no-log-init --shell /bin/bash superset
-
-RUN \
-    --mount=type=cache,id=apt-cache-${TARGETARCH}-${TARGETVARIANT},sharing=locked,target=/var/lib/apt/lists \
-    --mount=type=cache,id=apt-cache-${TARGETARCH}-${TARGETVARIANT},sharing=locked,target=/var/cache/apt \
-    apt-get update -qq && apt-get install -yqq --no-install-recommends \
+RUN mkdir -p ${PYTHONPATH} superset/static superset-frontend apache_superset.egg-info requirements \
+    && useradd --user-group -d ${SUPERSET_HOME} -m --no-log-init --shell /bin/bash superset \
+    && apt-get update -qq && apt-get install -yqq --no-install-recommends \
         build-essential \
         curl \
         default-libmysqlclient-dev \
@@ -119,10 +111,7 @@ ARG GECKODRIVER_VERSION=v0.33.0 \
 
 USER root
 
-RUN \
-    --mount=type=cache,id=apt-cache-${TARGETARCH}-${TARGETVARIANT},sharing=locked,target=/var/lib/apt/lists \
-    --mount=type=cache,id=apt-cache-${TARGETARCH}-${TARGETVARIANT},sharing=locked,target=/var/cache/apt \
-    apt-get update -qq \
+RUN apt-get update -qq \
     && apt-get install -yqq --no-install-recommends \
         libnss3 \
         libdbus-glib-1-2 \

--- a/scripts/build_docker.py
+++ b/scripts/build_docker.py
@@ -222,6 +222,7 @@ def get_docker_command(
 )
 @click.option("--build_context_ref", help="a reference to the pr, release or branch")
 @click.option("--dry-run", is_flag=True, help="Run the command in dry-run mode.")
+@click.option("--verbose", is_flag=True, help="Print more info")
 @click.option(
     "--force-latest", is_flag=True, help="Force the 'latest' tag on the release"
 )
@@ -232,6 +233,7 @@ def main(
     platform: list[str],
     dry_run: bool,
     force_latest: bool,
+    verbose: bool,
 ) -> None:
     """
     This script executes docker build and push commands based on given arguments.
@@ -274,6 +276,8 @@ def main(
                 """
             )
         script = script + docker_build_command
+        if verbose:
+            run_cmd("cat Dockerfile")
         stdout = run_cmd(script)
     else:
         print("Dry Run - Docker Build Command:")

--- a/scripts/build_docker.py
+++ b/scripts/build_docker.py
@@ -40,6 +40,10 @@ def run_cmd(command: str) -> str:
             output += line
 
     process.wait()  # Wait for the subprocess to finish
+
+    if process.returncode != 0:
+        raise subprocess.CalledProcessError(process.returncode, command, output)
+
     return output
 
 

--- a/tests/unit_tests/scripts/docker_build.py
+++ b/tests/unit_tests/scripts/docker_build.py
@@ -56,12 +56,12 @@ def test_is_latest_release(release, expected_bool):
 
 
 @pytest.mark.parametrize(
-    "build_preset, build_platform, sha, build_context, build_context_ref, expected_tags",
+    "build_preset, build_platforms, sha, build_context, build_context_ref, expected_tags",
     [
         # PRs
         (
             "lean",
-            "linux/arm64",
+            ["linux/arm64"],
             SHA,
             "pull_request",
             PR_ID,
@@ -69,7 +69,7 @@ def test_is_latest_release(release, expected_bool):
         ),
         (
             "ci",
-            "linux/amd64",
+            ["linux/amd64"],
             SHA,
             "pull_request",
             PR_ID,
@@ -77,7 +77,7 @@ def test_is_latest_release(release, expected_bool):
         ),
         (
             "lean",
-            "linux/amd64",
+            ["linux/amd64"],
             SHA,
             "pull_request",
             PR_ID,
@@ -85,7 +85,7 @@ def test_is_latest_release(release, expected_bool):
         ),
         (
             "dev",
-            "linux/arm64",
+            ["linux/arm64"],
             SHA,
             "pull_request",
             PR_ID,
@@ -97,7 +97,7 @@ def test_is_latest_release(release, expected_bool):
         ),
         (
             "dev",
-            "linux/amd64",
+            ["linux/amd64"],
             SHA,
             "pull_request",
             PR_ID,
@@ -106,7 +106,7 @@ def test_is_latest_release(release, expected_bool):
         # old releases
         (
             "lean",
-            "linux/arm64",
+            ["linux/arm64"],
             SHA,
             "release",
             OLD_REL,
@@ -114,7 +114,7 @@ def test_is_latest_release(release, expected_bool):
         ),
         (
             "lean",
-            "linux/amd64",
+            ["linux/amd64"],
             SHA,
             "release",
             OLD_REL,
@@ -122,7 +122,7 @@ def test_is_latest_release(release, expected_bool):
         ),
         (
             "dev",
-            "linux/arm64",
+            ["linux/arm64"],
             SHA,
             "release",
             OLD_REL,
@@ -134,7 +134,7 @@ def test_is_latest_release(release, expected_bool):
         ),
         (
             "dev",
-            "linux/amd64",
+            ["linux/amd64"],
             SHA,
             "release",
             OLD_REL,
@@ -143,7 +143,7 @@ def test_is_latest_release(release, expected_bool):
         # new releases
         (
             "lean",
-            "linux/arm64",
+            ["linux/arm64"],
             SHA,
             "release",
             NEW_REL,
@@ -156,7 +156,7 @@ def test_is_latest_release(release, expected_bool):
         ),
         (
             "lean",
-            "linux/amd64",
+            ["linux/amd64"],
             SHA,
             "release",
             NEW_REL,
@@ -164,7 +164,7 @@ def test_is_latest_release(release, expected_bool):
         ),
         (
             "dev",
-            "linux/arm64",
+            ["linux/arm64"],
             SHA,
             "release",
             NEW_REL,
@@ -177,7 +177,7 @@ def test_is_latest_release(release, expected_bool):
         ),
         (
             "dev",
-            "linux/amd64",
+            ["linux/amd64"],
             SHA,
             "release",
             NEW_REL,
@@ -191,7 +191,7 @@ def test_is_latest_release(release, expected_bool):
         # merge on master
         (
             "lean",
-            "linux/arm64",
+            ["linux/arm64"],
             SHA,
             "push",
             "master",
@@ -199,7 +199,7 @@ def test_is_latest_release(release, expected_bool):
         ),
         (
             "lean",
-            "linux/amd64",
+            ["linux/amd64"],
             SHA,
             "push",
             "master",
@@ -207,7 +207,7 @@ def test_is_latest_release(release, expected_bool):
         ),
         (
             "dev",
-            "linux/arm64",
+            ["linux/arm64"],
             SHA,
             "push",
             "master",
@@ -219,7 +219,7 @@ def test_is_latest_release(release, expected_bool):
         ),
         (
             "dev",
-            "linux/amd64",
+            ["linux/amd64"],
             SHA,
             "push",
             "master",
@@ -228,21 +228,21 @@ def test_is_latest_release(release, expected_bool):
     ],
 )
 def test_get_docker_tags(
-    build_preset, build_platform, sha, build_context, build_context_ref, expected_tags
+    build_preset, build_platforms, sha, build_context, build_context_ref, expected_tags
 ):
     tags = docker_utils.get_docker_tags(
-        build_preset, build_platform, sha, build_context, build_context_ref
+        build_preset, build_platforms, sha, build_context, build_context_ref
     )
     for tag in expected_tags:
         assert tag in tags
 
 
 @pytest.mark.parametrize(
-    "build_preset, build_platform, is_authenticated, sha, build_context, build_context_ref, contains",
+    "build_preset, build_platforms, is_authenticated, sha, build_context, build_context_ref, contains",
     [
         (
             "lean",
-            "linux/amd64",
+            ["linux/amd64"],
             True,
             SHA,
             "push",
@@ -251,18 +251,28 @@ def test_get_docker_tags(
         ),
         (
             "dev",
-            "linux/amd64",
+            ["linux/amd64"],
             False,
             SHA,
             "push",
             "master",
             ["--load", f"-t {REPO}:master-dev "],
         ),
+        # multi-platform
+        (
+            "lean",
+            ["linux/arm64", "linux/amd64"],
+            True,
+            SHA,
+            "push",
+            "master",
+            [f"--platform linux/arm64,linux/amd64"],
+        ),
     ],
 )
 def test_get_docker_command(
     build_preset,
-    build_platform,
+    build_platforms,
     is_authenticated,
     sha,
     build_context,
@@ -271,7 +281,7 @@ def test_get_docker_command(
 ):
     cmd = docker_utils.get_docker_command(
         build_preset,
-        build_platform,
+        build_platforms,
         is_authenticated,
         sha,
         build_context,


### PR DESCRIPTION
### SUMMARY
Allow for release builds to be multi-platform

This PR:
- adds support for multi-platform builds to the `scripts/build_docker.py` CLI
- changes the GitHub Action `.github/workflows/docker-release.yml` to
  build multi-platform images that can be used in helm or docker-compose
  


closes https://github.com/apache/superset/discussions/27043

# Testing / validation

Testing using the `workflow_dispatch` here -> https://github.com/apache/superset/actions/runs/7835882887/job/21382286370

Validated the images look ok on Docker hub ->
<img width="711" alt="Screenshot 2024-02-08 at 1 06 54 PM" src="https://github.com/apache/superset/assets/487433/432077c4-4464-4893-a0b8-a8e0504be1d0">
