### PR TITLE
fix: Exclude header controls from dashboard PDF export

### DIFF
--- a/superset-frontend/src/types/dom-to-pdf.d.ts
+++ b/superset-frontend/src/types/dom-to-pdf.d.ts
@@ -27,6 +27,7 @@ declare module 'dom-to-pdf' {
     filename: string;
     image: Image;
     html2canvas: object;
+    excludeClassNames?: string[];
   }
 
   const domToPdf = (

--- a/superset-frontend/src/utils/downloadAsPdf.ts
+++ b/superset-frontend/src/utils/downloadAsPdf.ts
@@ -61,6 +61,7 @@ export default function downloadAsPdf(
       filename: `${generateFileStem(description)}.pdf`,
       image: { type: 'jpeg', quality: 1 },
       html2canvas: { scale: 2 },
+      excludeClassNames: ['header-controls'],
     };
     return domToPdf(elementToPrint, options)
       .then(() => {


### PR DESCRIPTION
### SUMMARY
Exclude `.header-controls` subtree from dashboard PDF export to make it consistent with downloading charts as images

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
