### PR TITLE
fix: Filters sidebar stretching dashboard height

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardWrapper.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardWrapper.tsx
@@ -25,6 +25,7 @@ import classNames from 'classnames';
 
 const StyledDiv = styled.div`
   ${({ theme }) => css`
+    position: relative;
     display: grid;
     grid-template-columns: auto 1fr;
     grid-template-rows: auto 1fr;


### PR DESCRIPTION
### SUMMARY
`ResizableWrapper` component was stretching the dashboard vertically. Due to `position: absolute`, its `height: 100%` style was relative to the whole page height instead of its wrapper. By adding `position: relative` to `DashboardWrapper` (parent of `ResizableWrapper`), the component now has correct height 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="1723" alt="image" src="https://github.com/apache/superset/assets/15073128/0c78ea89-4ac1-4ff7-9ccd-caffa4e635e2">

After:

<img width="1728" alt="image" src="https://github.com/apache/superset/assets/15073128/e625fd2a-c609-499e-92e7-627fa9106ce9">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
