### PR TITLE
fix(drill): no rows returned

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -154,7 +154,7 @@ setup(
         ],
         "db2": ["ibm-db-sa>0.3.8, <=0.4.0"],
         "dremio": ["sqlalchemy-dremio>=1.1.5, <1.3"],
-        "drill": ["sqlalchemy-drill==0.1.dev"],
+        "drill": ["sqlalchemy-drill>=1.1.4, <2"],
         "druid": ["pydruid>=0.6.5,<0.7"],
         "duckdb": ["duckdb-engine>=0.9.5, <0.10"],
         "dynamodb": ["pydynamodb>=0.4.2"],

--- a/superset/db_engine_specs/drill.py
+++ b/superset/db_engine_specs/drill.py
@@ -14,8 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+from __future__ import annotations
+
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 from urllib import parse
 
 from sqlalchemy import types
@@ -60,8 +63,8 @@ class DrillEngineSpec(BaseEngineSpec):
 
     @classmethod
     def convert_dttm(
-        cls, target_type: str, dttm: datetime, db_extra: Optional[dict[str, Any]] = None
-    ) -> Optional[str]:
+        cls, target_type: str, dttm: datetime, db_extra: dict[str, Any] | None = None
+    ) -> str | None:
         sqla_type = cls.get_sqla_column_type(target_type)
 
         if isinstance(sqla_type, types.Date):
@@ -76,8 +79,8 @@ class DrillEngineSpec(BaseEngineSpec):
         cls,
         uri: URL,
         connect_args: dict[str, Any],
-        catalog: Optional[str] = None,
-        schema: Optional[str] = None,
+        catalog: str | None = None,
+        schema: str | None = None,
     ) -> tuple[URL, dict[str, Any]]:
         if schema:
             uri = uri.set(database=parse.quote(schema.replace(".", "/"), safe=""))
@@ -89,7 +92,7 @@ class DrillEngineSpec(BaseEngineSpec):
         cls,
         sqlalchemy_uri: URL,
         connect_args: dict[str, Any],
-    ) -> Optional[str]:
+    ) -> str | None:
         """
         Return the configured schema.
         """
@@ -97,7 +100,7 @@ class DrillEngineSpec(BaseEngineSpec):
 
     @classmethod
     def get_url_for_impersonation(
-        cls, url: URL, impersonate_user: bool, username: Optional[str]
+        cls, url: URL, impersonate_user: bool, username: str | None
     ) -> URL:
         """
         Return a modified URL with the username set.
@@ -117,3 +120,23 @@ class DrillEngineSpec(BaseEngineSpec):
                 )
 
         return url
+
+    @classmethod
+    def fetch_data(
+        cls,
+        cursor: Any,
+        limit: int | None = None,
+    ) -> list[tuple[Any, ...]]:
+        """
+        Custom `fetch_data` for Drill.
+
+        When no rows are returned, Drill raises a `RuntimeError` with the message
+        "generator raised StopIteration". This method catches the exception and
+        returns an empty list instead.
+        """
+        try:
+            return super().fetch_data(cursor, limit)
+        except RuntimeError as ex:
+            if str(ex) == "generator raised StopIteration":
+                return []
+            raise


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The Drill engine spec currently shows an error when no rows are returned in SQL Lab:

![Screenshot 2024-02-09 at 15-53-10 Superset](https://github.com/apache/superset/assets/1534870/f9280e0b-4f7e-4796-ad9e-18083cf9618f)

This PR introduces a custom `fetch_data` method to the Drill engine spec, so that the correct response is returned:

![Screenshot 2024-02-09 at 15-53-24 Superset](https://github.com/apache/superset/assets/1534870/e2211772-234b-4218-821f-80ecd5d80337)

Fixes https://github.com/apache/superset/issues/27028.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

See above.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Run Drill on docker:

```bash
docker run -it --name drill -p 8047:8047 -p 31010:31010 apache/drill
```

2. Go to http://localhost:8047/storage and enable the RDBMS storage.
3. Update the storage and point it to the `examples` database in Postgres:

```json
{
  "type": "jdbc",
  "driver": "org.postgresql.Driver",
  "url": "jdbc:postgresql://host.docker.internal:5432/examples",
  "username": "beto",
  "sourceParameters": {
    "keepaliveTime": 0,
    "minimumIdle": 0,
    "idleTimeout": 3600000,
    "maximumPoolSize": 10,
    "maxLifetime": 21600000
  },
  "authMode": "SHARED_USER",
  "writerBatchSize": 10000,
  "enabled": true
}
```

4. Install the Postgres JDBC driver inside the container:

```bash
docker exec -it -u root drill bash
cd /opt/drill/jars/3rdparty/
wget https://jdbc.postgresql.org/download/postgresql-42.7.1.jar
exit
docker restart drill
```

5. Connect Superset to Drill using: `drill+sadrill://localhost:8047/cp?use_ssl=False`
6. Query the `bart_lines` from Superset (this assumes that the Postgres storage is called `rdbms`):

```sql
SELECT * FROM rdbms.bart_lines
```

7. Delete all rows from the `bart_lines` table — you can do this in Postgres directly, and you should be able to do it from Superset if you've enabled DML in the Drill database.
8. Run the query again. It should show:

![Screenshot 2024-02-09 at 15-59-35 Superset](https://github.com/apache/superset/assets/1534870/5647cfea-5f37-406a-9ebe-677cc62c2d24)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
