### PR TITLE
chore(docs): installing-superset-from-scratch guide gets complete, orderly

### DIFF
--- a/docs/docs/installation/installing-superset-from-scratch.mdx
+++ b/docs/docs/installation/installing-superset-from-scratch.mdx
@@ -87,28 +87,12 @@ These will now be available when pip installing requirements.
 
 ### Python Virtual Environment
 
-We highly recommend installing Superset inside of a virtual environment. Python ships with
-`virtualenv` out of the box. If you're using [pyenv](https://github.com/pyenv/pyenv), you can install [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv). Or you can install it with `pip`:
-
-```
-pip install virtualenv
-```
-
+We highly recommend installing Superset inside of a virtual environment.
 You can create and activate a virtual environment using:
 
 ```
-# virtualenv is shipped in Python 3.6+ as venv instead of pyvenv.
-# See https://docs.python.org/3.6/library/venv.html
-python3 -m venv venv
-. venv/bin/activate
-```
-
-Or with pyenv-virtualenv:
-
-```
-# Here we name the virtual env 'superset'
-pyenv virtualenv superset
-pyenv activate superset
+python3 -m venv "venv"
+source "venv/bin/activate"
 ```
 
 Once you activated your virtual environment, all of the Python packages you install or uninstall
@@ -117,27 +101,34 @@ command line.
 
 ### Installing and Initializing Superset
 
+:::tip
+Note that some configuration is mandatory for production instances of Superset. In particular, Superset will not start without a user-specified value of SECRET_KEY. Please see [Configuring Superset](/docs/installation/configuring-superset).
+:::
+
 First, start by installing `apache-superset`:
 
 ```
 pip install apache-superset
 ```
 
-Then, you need to initialize the database:
+Then, save some environmental variables needed by superset:
 
 ```
-superset db upgrade
+echo "FLASK_APP=superset" > superset_env
+echo "SUPERSET_SECRET_KEY=\"$(openssl rand -base64 42)\"" >> superset_env
+echo "export FLASK_APP SUPERSET_SECRET_KEY" >> superset_env
 ```
-
-:::tip
-Note that some configuration is mandatory for production instances of Superset. In particular, Superset will not start without a user-specified value of SECRET_KEY. Please see [Configuring Superset](/docs/installation/configuring-superset).
-:::
 
 Finish installing by running through the following commands:
 
 ```
+# Read these variables
+source superset_env
+
+# Initialize the database
+superset db upgrade
+
 # Create an admin user in your metadata database (use `admin` as username to be able to load the examples)
-export FLASK_APP=superset
 superset fab create-admin
 
 # Load some data to play with
@@ -150,5 +141,4 @@ superset init
 superset run -p 8088 --with-threads --reload --debugger
 ```
 
-If everything worked, you should be able to navigate to `hostname:port` in your browser (e.g.
-locally by default at `localhost:8088`) and login using the username and password you created.
+If everything worked, you should be able to navigate to <http://localhost:8088> in your browser and login using the admin username and password you created.

--- a/docs/docs/installation/installing-superset-from-scratch.mdx
+++ b/docs/docs/installation/installing-superset-from-scratch.mdx
@@ -91,7 +91,7 @@ We highly recommend installing Superset inside of a virtual environment.
 You can create and activate a virtual environment using:
 
 ```
-python3 -m venv "venv"
+python3 -m venv venv
 source "venv/bin/activate"
 ```
 

--- a/docs/docs/installation/installing-superset-from-scratch.mdx
+++ b/docs/docs/installation/installing-superset-from-scratch.mdx
@@ -111,7 +111,7 @@ First, start by installing `apache-superset`:
 pip install apache-superset
 ```
 
-Then, save some environmental variables needed by superset:
+Then save some environmental variables required by Superset.  Make note of this randomly-generated SUPERSET_SECRET_KEY, as without it you may be unable to decrypt the application's data in the future.
 
 ```
 echo "FLASK_APP=superset" > superset_env


### PR DESCRIPTION
Now guide can be followed directly: `venv` is the only Python environment mentioned, needed environmental variables are stored on a file and sourced from there. All `superset` commands can now be run without interruptions

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
