### PR TITLE
fix(ci): new PR comments cancel ongoing ephemeral builds

### DIFF
--- a/.github/workflows/ephemeral-env.yml
+++ b/.github/workflows/ephemeral-env.yml
@@ -4,11 +4,6 @@ on:
   issue_comment:
     types: [created]
 
-# cancel previous workflow jobs for PRs
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   config:
     runs-on: "ubuntu-latest"
@@ -25,6 +20,9 @@ jobs:
           fi
 
   ephemeral-env-comment:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.issue.number || github.run_id }}-comment
+      cancel-in-progress: true
     needs: config
     if: needs.config.outputs.has-secrets
     name: Evaluate ephemeral env comment trigger (/testenv)
@@ -85,6 +83,9 @@ jobs:
           core.setFailed(errMsg)
 
   ephemeral-docker-build:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.issue.number || github.run_id }}-build
+      cancel-in-progress: true
     needs: ephemeral-env-comment
     name: ephemeral-docker-build
     runs-on: ubuntu-latest


### PR DESCRIPTION
### SUMMARY
Currently ongoing ephemeral env builds can be canceled by new comments on a PR. Although the build is re-triggered again this can cause confusion and certainly delays on spinning up new ephemeral environments.

This is probably caused by the global concurrency group, splitting this group between comments and build should fix this issue.

Unfortunately it's hard to test this at the PR level since this workflow code will always use the latest commit on the default branch 

<br class="Apple-interchange-newline">


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
