### PR TITLE
feat(filter_state): Added @api and @has_access_api to all methods of filter_state API.

### DIFF
--- a/superset/dashboards/filter_state/api.py
+++ b/superset/dashboards/filter_state/api.py
@@ -18,6 +18,7 @@ import logging
 
 from flask import Response
 from flask_appbuilder.api import expose, protect, safe
+from flask_appbuilder.security.decorators import has_access_api
 
 from superset.commands.dashboard.filter_state.create import CreateFilterStateCommand
 from superset.commands.dashboard.filter_state.delete import DeleteFilterStateCommand
@@ -25,6 +26,7 @@ from superset.commands.dashboard.filter_state.get import GetFilterStateCommand
 from superset.commands.dashboard.filter_state.update import UpdateFilterStateCommand
 from superset.extensions import event_logger
 from superset.temporary_cache.api import TemporaryCacheRestApi
+from superset.views.base import api
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +48,8 @@ class DashboardFilterStateRestApi(TemporaryCacheRestApi):
     def get_delete_command(self) -> type[DeleteFilterStateCommand]:
         return DeleteFilterStateCommand
 
+    @api
+    @has_access_api
     @expose("/<int:pk>/filter_state", methods=("POST",))
     @protect()
     @safe
@@ -95,6 +99,8 @@ class DashboardFilterStateRestApi(TemporaryCacheRestApi):
         """
         return super().post(pk)
 
+    @api
+    @has_access_api
     @expose("/<int:pk>/filter_state/<string:key>", methods=("PUT",))
     @protect()
     @safe


### PR DESCRIPTION
### SUMMARY

The API of filter_state is already exposed but it doesn't look like other APIs. We had a problem gaining 403 Status Code when addressing this endpoint. It was because of the lack of role permissions but there were no messages in the logs. Introducing these decorators we add recording the problem to the log so it will be easier to investigate the problem.

#### Comment
This is a copy of https://github.com/apache/superset/pull/23282 because I've lost access to the company's repository and they are not working intensively on Superset now.