### PR TITLE
fix(ci): Docker master builds fail while checking version

### DIFF
--- a/scripts/build_docker.py
+++ b/scripts/build_docker.py
@@ -28,7 +28,7 @@ CACHE_REPO = f"{REPO}-cache"
 BASE_PY_IMAGE = "3.9-slim-bookworm"
 
 
-def run_cmd(command: str) -> str:
+def run_cmd(command: str, raise_on_failure: bool = True) -> str:
     process = subprocess.Popen(
         command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
     )
@@ -41,9 +41,8 @@ def run_cmd(command: str) -> str:
 
     process.wait()  # Wait for the subprocess to finish
 
-    if process.returncode != 0:
+    if process.returncode != 0 and raise_on_failure:
         raise subprocess.CalledProcessError(process.returncode, command, output)
-
     return output
 
 
@@ -73,7 +72,13 @@ def get_build_context_ref(build_context: str) -> str:
 
 
 def is_latest_release(release: str) -> bool:
-    output = run_cmd(f"./scripts/tag_latest_release.sh {release} --dry-run") or ""
+    output = (
+        run_cmd(
+            f"./scripts/tag_latest_release.sh {release} --dry-run",
+            raise_on_failure=False,
+        )
+        or ""
+    )
     return "SKIP_TAG::false" in output
 
 


### PR DESCRIPTION
### SUMMARY

In https://github.com/apache/superset/pull/27055, I broke the master
builds while making the `run_cmd` method raise if it gets a non-zero exit
status. Turned out to only fail while in the `pull_request` context.

This is the change: https://github.com/apache/superset/pull/27055/files#diff-3cf86f687684a2c690521532de75a831def641338f5a9ec1da8add94714def4cR44-R45

This is the observed error in master build

```
Traceback (most recent call last):
 {...REDACTED...}
  File "/home/runner/work/superset/superset/./scripts/build_docker.py", line 76, in is_latest_release
    output = run_cmd(f"./scripts/tag_latest_release.sh {release} --dry-run") or ""
  File "/home/runner/work/superset/superset/./scripts/build_docker.py", line 45, in run_cmd
    raise subprocess.CalledProcessError(process.returncode, command, output)
subprocess.CalledProcessError: Command './scripts/tag_latest_release.sh master --dry-run' returned non-zero exit status 1.
Error: Process completed with exit code 1.
```

This disregards the exit code the `tag_latest_release.sh` since it seems
to be return error codes in expected situations.

