### PR TITLE
chore: POC Upgrade to AntD v5 one component at a time.

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -124,6 +124,7 @@
     "abortcontroller-polyfill": "^1.1.9",
     "ace-builds": "^1.4.14",
     "antd": "4.10.3",
+    "antd-next": "npm:antd@5.4.0",
     "babel-plugin-typescript-to-proptypes": "^2.0.0",
     "bootstrap": "^3.4.1",
     "brace": "^0.11.1",

--- a/superset-frontend/src/components/CronPicker/CronPicker.tsx
+++ b/superset-frontend/src/components/CronPicker/CronPicker.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { ConfigProvider } from 'antd';
+import { ConfigProvider as ConfigProvider5 } from 'antd-next';
 import { styled, t } from '@superset-ui/core';
 import ReactCronPicker, { Locale, CronProps } from 'react-js-cron';
 
@@ -104,11 +104,14 @@ export const LOCALE: Locale = {
 };
 
 export const CronPicker = styled((props: CronProps) => (
-  <ConfigProvider
-    getPopupContainer={trigger => trigger.parentElement as HTMLElement}
+  <ConfigProvider5
+    prefixCls="ant5"
+    getPopupContainer={(trigger: HTMLElement) =>
+      trigger.parentElement as HTMLElement
+    }
   >
     <ReactCronPicker locale={LOCALE} {...props} />
-  </ConfigProvider>
+  </ConfigProvider5>
 ))`
   ${({ theme }) => `
 

--- a/superset-frontend/src/components/Popover/Popover.tsx
+++ b/superset-frontend/src/components/Popover/Popover.tsx
@@ -18,8 +18,8 @@
  */
 
 import React from 'react';
-import { Popover as AntdPopover } from 'antd';
-import type { PopoverProps as AntdPopoverProps } from 'antd/lib/popover';
+import { Popover as AntdPopover } from 'antd-next';
+import type { PopoverProps as AntdPopoverProps } from 'antd-next/lib/popover';
 
 export interface PopoverProps extends AntdPopoverProps {
   forceRender?: boolean;

--- a/superset-frontend/src/components/Popover/index.tsx
+++ b/superset-frontend/src/components/Popover/index.tsx
@@ -16,8 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-export type { PopoverProps } from 'antd/lib/popover';
-export type { TooltipPlacement } from 'antd/lib/tooltip';
+export type { PopoverProps } from 'antd-next/lib/popover';
+export type { TooltipPlacement } from 'antd-next/lib/tooltip';
 
 // Eventually Popover can be wrapped and customized in this file
 // for now we're just redirecting

--- a/superset-frontend/src/components/Select/AsyncSelect.tsx
+++ b/superset-frontend/src/components/Select/AsyncSelect.tsx
@@ -30,7 +30,7 @@ import React, {
   ClipboardEvent,
 } from 'react';
 import { ensureIsArray, t, usePrevious } from '@superset-ui/core';
-import { LabeledValue as AntdLabeledValue } from 'antd/lib/select';
+import { LabeledValue as AntdLabeledValue } from 'antd-next/lib/select';
 import { debounce, isEqual, uniq } from 'lodash';
 import Icons from 'src/components/Icons';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';

--- a/superset-frontend/src/components/Select/CustomTag.tsx
+++ b/superset-frontend/src/components/Select/CustomTag.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { Tag as AntdTag } from 'antd';
+import { Tag as AntdTag } from 'antd-next';
 import { styled, useCSSTextTruncation } from '@superset-ui/core';
 import { Tooltip } from '../Tooltip';
 import { CustomTagProps } from './types';

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -33,7 +33,7 @@ import {
   t,
   usePrevious,
 } from '@superset-ui/core';
-import AntdSelect, { LabeledValue as AntdLabeledValue } from 'antd/lib/select';
+import AntdSelect, { LabeledValue as AntdLabeledValue } from 'antd-next/lib/select';
 import { debounce, isEqual, uniq } from 'lodash';
 import { FAST_DEBOUNCE } from 'src/constants';
 import {

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -33,7 +33,9 @@ import {
   t,
   usePrevious,
 } from '@superset-ui/core';
-import AntdSelect, { LabeledValue as AntdLabeledValue } from 'antd-next/lib/select';
+import AntdSelect, {
+  LabeledValue as AntdLabeledValue,
+} from 'antd-next/lib/select';
 import { debounce, isEqual, uniq } from 'lodash';
 import { FAST_DEBOUNCE } from 'src/constants';
 import {

--- a/superset-frontend/src/components/Select/constants.ts
+++ b/superset-frontend/src/components/Select/constants.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { LabeledValue as AntdLabeledValue } from 'antd/lib/select';
+import { LabeledValue as AntdLabeledValue } from 'antd-next/lib/select';
 import { rankedSearchCompare } from 'src/utils/rankedSearchCompare';
 
 export const MAX_TAG_COUNT = 4;

--- a/superset-frontend/src/components/Select/styles.tsx
+++ b/superset-frontend/src/components/Select/styles.tsx
@@ -18,8 +18,8 @@
  */
 import { styled } from '@superset-ui/core';
 import Icons from 'src/components/Icons';
-import { Spin, Tag } from 'antd';
-import AntdSelect from 'antd/lib/select';
+import { Spin, Tag } from 'antd-next';
+import AntdSelect from 'antd-next/lib/select';
 
 export const StyledHeader = styled.span<{ headerPosition: string }>`
   ${({ theme, headerPosition }) => `

--- a/superset-frontend/src/components/Select/types.ts
+++ b/superset-frontend/src/components/Select/types.ts
@@ -26,8 +26,8 @@ import {
   SelectProps as AntdSelectProps,
   SelectValue as AntdSelectValue,
   LabeledValue as AntdLabeledValue,
-} from 'antd/lib/select';
-import { TagProps } from 'antd/lib/tag';
+} from 'antd-next/lib/select';
+import { TagProps } from 'antd-next/lib/tag';
 
 export type RawValue = string | number;
 

--- a/superset-frontend/src/components/Select/utils.tsx
+++ b/superset-frontend/src/components/Select/utils.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { ensureIsArray, t } from '@superset-ui/core';
-import AntdSelect, { LabeledValue as AntdLabeledValue } from 'antd/lib/select';
+import AntdSelect, { LabeledValue as AntdLabeledValue } from 'antd-next/lib/select';
 import React, { ReactElement, RefObject } from 'react';
 import Icons from 'src/components/Icons';
 import { StyledHelperText, StyledLoadingText, StyledSpin } from './styles';

--- a/superset-frontend/src/components/Select/utils.tsx
+++ b/superset-frontend/src/components/Select/utils.tsx
@@ -17,7 +17,9 @@
  * under the License.
  */
 import { ensureIsArray, t } from '@superset-ui/core';
-import AntdSelect, { LabeledValue as AntdLabeledValue } from 'antd-next/lib/select';
+import AntdSelect, {
+  LabeledValue as AntdLabeledValue,
+} from 'antd-next/lib/select';
 import React, { ReactElement, RefObject } from 'react';
 import Icons from 'src/components/Icons';
 import { StyledHelperText, StyledLoadingText, StyledSpin } from './styles';

--- a/superset-frontend/src/components/Table/index.tsx
+++ b/superset-frontend/src/components/Table/index.tsx
@@ -21,7 +21,7 @@ import AntTable, {
   ColumnsType,
   TableProps as AntTableProps,
 } from 'antd/lib/table';
-import ConfigProvider from 'antd/lib/config-provider';
+import { ConfigProvider as ConfigProvider5 } from 'antd-next';
 import { PaginationProps } from 'antd/lib/pagination';
 import { t, useTheme, logging, styled } from '@superset-ui/core';
 import Loading from 'src/components/Loading';
@@ -405,7 +405,7 @@ export function Table<RecordType extends object>(
   };
 
   return (
-    <ConfigProvider renderEmpty={renderEmpty}>
+    <ConfigProvider5 renderEmpty={renderEmpty} prefixCls="ant5">
       <div ref={wrapperRef}>
         {!virtualize && (
           <StyledTable
@@ -429,7 +429,7 @@ export function Table<RecordType extends object>(
           />
         )}
       </div>
-    </ConfigProvider>
+    </ConfigProvider5>
   );
 }
 

--- a/superset-frontend/src/components/index.ts
+++ b/superset-frontend/src/components/index.ts
@@ -63,13 +63,16 @@ export {
   Dropdown as AntdDropdown,
   Form as AntdForm,
   Input as AntdInput,
-  Modal as AntdModal,
   Select as AntdSelect,
   Slider as AntdSlider,
   Switch as AntdSwitch,
   Tabs as AntdTabs,
   Tooltip as AntdTooltip,
 } from 'antd';
+
+export {
+  Modal as AntdModal,
+} from 'antd-next';
 
 // Exported types
 export type { FormInstance } from 'antd/lib/form';

--- a/superset-frontend/src/components/index.ts
+++ b/superset-frontend/src/components/index.ts
@@ -70,9 +70,7 @@ export {
   Tooltip as AntdTooltip,
 } from 'antd';
 
-export {
-  Modal as AntdModal,
-} from 'antd-next';
+export { Modal as AntdModal } from 'antd-next';
 
 // Exported types
 export type { FormInstance } from 'antd/lib/form';


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Imports Antd 5 as an alias. This would allow us to:
* Migrate a single component from `antd` (v4) to `antd-next` (v5)
* Touch up styles/javascript/etc. using Superset and React Storybook as a guide (Appitools would help here too)
* Once that component looks good, move on to the next.
* When all components have been migrated, remove v4, remove the npm alias, and do a simple find/replace to change `antd-next` to `antd`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
