### PR TITLE
fix(deps): un-bumping dom-to-pdf ro resolve missing file warnings

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -134,7 +134,7 @@
     "core-js": "^3.6.5",
     "d3-scale": "^2.1.2",
     "dom-to-image-more": "^3.2.0",
-    "dom-to-pdf": "^0.3.2",
+    "dom-to-pdf": "^0.3.1",
     "emotion-rgba": "0.0.12",
     "fast-glob": "^3.2.7",
     "fontsource-fira-code": "^4.0.0",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
For some reason, a bump of this package seemed to cause these annoying errors
<img width="690" alt="image" src="https://github.com/apache/superset/assets/812905/1e03a7ed-b6b2-4f7f-84fe-c5b5e0ff80a6">

Taking it back down one patch version seems to resolve them :) 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: Fixes https://github.com/apache/superset/issues/27089
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
