### PR TITLE
fix(big_number): white-space: nowrap to prevent wrapping

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberViz.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberViz.tsx
@@ -354,6 +354,7 @@ export default styled(BigNumberVis)`
     .header-line {
       position: relative;
       line-height: 1em;
+      white-space: nowrap;
       span {
         position: absolute;
         bottom: 0;


### PR DESCRIPTION
### SUMMARY
A user reported that the big number was wrapping after the dollar sign and showing on two lines. A little CSS tweaks fixes it 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF


<img width="338" alt="Screenshot 2024-02-12 at 5 49 19 PM" src="https://github.com/apache/superset/assets/487433/4d990362-1362-4e53-aa70-2d162cec7bac">
<img width="313" alt="Screenshot 2024-02-12 at 5 49 04 PM" src="https://github.com/apache/superset/assets/487433/b2a7c77e-29e3-4261-be84-857f65daba7a">
