### PR TITLE
fix: try to fix cypress with magic

### DIFF
--- a/superset-frontend/cypress-base/cypress.config.ts
+++ b/superset-frontend/cypress-base/cypress.config.ts
@@ -51,6 +51,10 @@ export default defineConfig({
 
             return arg;
           });
+
+          launchOptions.args.push(
+            ...['--disable-dev-shm-usage', '--disable-gpu'],
+          );
         }
         return launchOptions;
       });


### PR DESCRIPTION
Cypress is crashing our builds on `master`
<img width="965" alt="Screenshot 2024-02-12 at 6 19 44 PM" src="https://github.com/apache/superset/assets/487433/9521683c-81d3-4cce-b1af-2cbff63edb14">

I'm trying this because it might have worked for someone on the internets
https://github.com/cypress-io/cypress/issues/7204

