### PR TITLE
fix(initialize): ModuleNotFoundError: No module named 'flask_cors'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(
         "flask-appbuilder>=4.3.11, <5.0.0",
         "flask-caching>=2.1.0, <3",
         "flask-compress>=1.13, <2.0",
+        "flask-cors>=4.0.0",
         "flask-talisman>=1.0.0, <2.0",
         "flask-login>=0.6.0, < 1.0",
         "flask-migrate>=3.1.0, <4.0",


### PR DESCRIPTION
Resolves #27102

### SUMMARY
This PR fixes bug described at #27102

### TESTING INSTRUCTIONS
```
superset fab create-admin
```

### ADDITIONAL INFORMATION

- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
