### PR TITLE
chore: Ensure local (tox) Python testing is somewhat akin to remote (GitHub actions)

### DIFF
--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Python integration tests (MySQL)
         if: steps.check.outcome == 'failure'
         run: |
-          ./scripts/python_tests.sh
+          ./scripts/python_tests.sh tests/integration_tests
       - name: Upload code coverage
         if: steps.check.outcome == 'failure'
         run: |
@@ -138,7 +138,7 @@ jobs:
       - name: Python integration tests (PostgreSQL)
         if: steps.check.outcome == 'failure'
         run: |
-          ./scripts/python_tests.sh
+          ./scripts/python_tests.sh tests/integration_tests
       - name: Upload code coverage
         if: steps.check.outcome == 'failure'
         run: |
@@ -198,7 +198,7 @@ jobs:
       - name: Python integration tests (SQLite)
         if: steps.check.outcome == 'failure'
         run: |
-          ./scripts/python_tests.sh
+          ./scripts/python_tests.sh tests/integration_tests
       - name: Upload code coverage
         if: steps.check.outcome == 'failure'
         run: |

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Python unit tests (PostgreSQL)
         if: steps.check.outcome == 'failure'
         run: |
-          ./scripts/python_tests.sh -m 'chart_data_flow or sql_json_flow'
+          ./scripts/python_tests.sh -m 'chart_data_flow or sql_json_flow' tests/integration_tests
       - name: Upload code coverage
         if: steps.check.outcome == 'failure'
         run: |
@@ -165,7 +165,7 @@ jobs:
       - name: Python unit tests (PostgreSQL)
         if: steps.check.outcome == 'failure'
         run: |
-          ./scripts/python_tests.sh -m 'chart_data_flow or sql_json_flow'
+          ./scripts/python_tests.sh -m 'chart_data_flow or sql_json_flow' tests/integration_tests
       - name: Upload code coverage
         if: steps.check.outcome == 'failure'
         run: |

--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -61,7 +61,7 @@ jobs:
         env:
           SUPERSET_TESTENV: true
         run: |
-          pytest --durations-min=0.5 --cov-report= --cov=superset ./tests/common ./tests/unit_tests --cache-clear
+          ./scripts/python_tests.sh tests/unit_tests
       - name: Upload code coverage
         if: steps.check.outcome == 'failure'
         run: |

--- a/scripts/python_tests.sh
+++ b/scripts/python_tests.sh
@@ -26,10 +26,13 @@ export LD_PRELOAD=/lib/x86_64-linux-gnu/libstdc++.so.6
 export SUPERSET_CONFIG=${SUPERSET_CONFIG:-tests.integration_tests.superset_test_config}
 export SUPERSET_TESTENV=true
 echo "Superset config module: $SUPERSET_CONFIG"
-
-superset db upgrade
-superset init
-
 echo "Running tests"
 
-pytest --durations-min=2 --maxfail=1 --cov-report= --cov=superset ./tests/integration_tests "$@"
+if [[ $@ =~ "integration_tests" ]]; then
+    superset db upgrade
+    superset init
+    superset load-test-users
+    pytest --durations-min=2 --maxfail=1 --cov-report= --cov=superset "$@"
+else
+    pytest --durations-min=0.5 --cov-report= --cov=superset "$@"
+fi

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -123,10 +123,6 @@ def setup_sample_data() -> Any:
     with app.app_context():
         setup_presto_if_needed()
 
-        from superset.cli.test import load_test_users_run
-
-        load_test_users_run()
-
         from superset.examples.css_templates import load_css_templates
 
         load_css_templates()

--- a/tox.ini
+++ b/tox.ini
@@ -21,11 +21,7 @@
 basepython = python3.9
 ignore_basepython_conflict = true
 commands =
-    superset db upgrade
-    superset init
-    # use -s to be able to use break pointers.
-    # no args or tests/* can be passed as an argument to run all tests
-    pytest -s {posargs}
+    {toxinidir}/scripts/python_tests.sh {posargs}
 deps =
     -rrequirements/testing.txt
 setenv =
@@ -51,6 +47,7 @@ usedevelop = true
 allowlist_externals =
     npm
     pkill
+    {toxinidir}/scripts/python_tests.sh
 
 [testenv:cypress]
 setenv =


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

It _really pains_ me that local and remote CI testing is quite different which results in numerous wasted cycles. A case in point is for major refactors I often run tests locally (which are invoked via `tox`), however when running the following (as part of another PR), 

```
 tox -e py39 -- tests/unit_tests/security/manager_test.py
```

the test would fail—due to a UNIQUE constraint violation—as the unit tests expect that the database schema/records are not defined, though the `tox` `testenv` environment runs the following commands prior to invoking `pytest`,

```
superset db upgrade
superset init
```

and thus one cannot [redefine](https://github.com/apache/superset/blob/master/tests/unit_tests/security/manager_test.py#L247-L263) the `Alpha` role.  Personally—per a line item I've added to the monthly Superset Meetup—I think we shouldn't differentiate between unit and integration tests and ensure that any setup works for any and all tests.

This PR simply ensures that all Python tests (be that local or remote) are invoked via the `python_tests.sh` script. This should work under the condition that you're running either the unit tests or integration tests, but not both.

Finally I've moved the loading of test users to leverage the `load-test-users` CLI command. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
