### PR TITLE
fix(docker): *-dev tags target right stage from Dockerfile

### DIFF
--- a/scripts/build_docker.py
+++ b/scripts/build_docker.py
@@ -204,6 +204,7 @@ def get_docker_command(
         {cache_to_arg} \\
         {build_arg} \\
         {platform_arg} \\
+        {target_argument} \\
         --label sha={sha} \\
         --label target={build_target} \\
         --label build_trigger={build_context} \\

--- a/tests/unit_tests/scripts/docker_build.py
+++ b/tests/unit_tests/scripts/docker_build.py
@@ -256,7 +256,7 @@ def test_get_docker_tags(
             SHA,
             "push",
             "master",
-            ["--load", f"-t {REPO}:master-dev "],
+            ["--load", f"-t {REPO}:master-dev ", "--target dev"],
         ),
         # multi-platform
         (


### PR DESCRIPTION
[Fixes this issue](https://github.com/apache/superset/issues/27111)

### SUMMARY
the [Dockerfile contains a dev stage](https://github.com/apache/superset/blob/13f1642c73920792c3c5671ec295cc859aa0856f/Dockerfile#L106) but this is not the stage that is targeted when building and releasing the *-dev tags (e.g.: [master-dev on Docker Hub](https://hub.docker.com/layers/apache/superset/master-dev/images/sha256-b14f0ac28ad6cfabc6273f2913dc9ca7e3f26c877894a41177a8713f6e774527).  
This PR fixes said behaviour, and also adds a test case for this issue.

### TESTING INSTRUCTIONS
`tox  -- ./tests/unit_tests/scripts/docker_build.py `
or
`pytest ./tests/unit_tests/scripts/docker_build.py`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/27111
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
