### PR TITLE
fix: removes old deprecated sqllab endpoints

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -28,6 +28,7 @@ assists people when migrating to a new version.
 
 ### Breaking Changes
 
+- [27117](https://github.com/apache/superset/pull/27117): Removes the following deprecated endpoints: `/superset/sqllab`, `/superset/sqllab/history`, `/sqllab/my_queries` use `/sqllab`, `/sqllab/history`, `/savedqueryview/list/?_flt_0_user={get_user_id()}` instead.
 - [26347](https://github.com/apache/superset/issues/26347): Removes the deprecated `VERSIONED_EXPORT` feature flag. The previous value of the feature flag was `True` and now the feature is permanently enabled.
 - [26328](https://github.com/apache/superset/issues/26328): Removes the deprecated Filter Box code and it's associated dependencies `react-select` and `array-move`. It also removes the `DeprecatedSelect` and `AsyncSelect` components that were exclusively used by filter boxes. Existing filter boxes will be automatically migrated to native filters.
 - [26330](https://github.com/apache/superset/issues/26330): Removes the deprecated `DASHBOARD_FILTERS_EXPERIMENTAL` feature flag. The previous value of the feature flag was `False` and now the feature is permanently removed.

--- a/superset-frontend/cypress-base/cypress/e2e/sqllab/query.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/sqllab/query.test.ts
@@ -123,9 +123,6 @@ describe('SqlLab query panel', () => {
       .eq(0) // save
       .click();
 
-    // visit saved queries
-    cy.visit('/sqllab/my_queries/');
-
     // first row contains most recent link, follow back to SqlLab
     cy.get('table tr:first-child a[href*="savedQueryId"').click();
 

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -185,7 +185,6 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         from superset.views.sql_lab.views import (
             SavedQueryView,
             SavedQueryViewApi,
-            SqlLab,
             TableSchemaView,
             TabStateView,
         )
@@ -310,7 +309,6 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         appbuilder.add_view_no_menu(SavedQueryView)
         appbuilder.add_view_no_menu(SavedQueryViewApi)
         appbuilder.add_view_no_menu(SliceAsync)
-        appbuilder.add_view_no_menu(SqlLab)
         appbuilder.add_view_no_menu(SqllabView)
         appbuilder.add_view_no_menu(SqlMetricInlineView)
         appbuilder.add_view_no_menu(Superset)

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -231,7 +231,6 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
     ACCESSIBLE_PERMS = {"can_userinfo", "resetmypassword", "can_recent_activity"}
 
     SQLLAB_ONLY_PERMISSIONS = {
-        ("can_my_queries", "SqlLab"),
         ("can_read", "SavedQuery"),
         ("can_write", "SavedQuery"),
         ("can_export", "SavedQuery"),

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -918,24 +918,6 @@ class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
 
     @has_access
     @event_logger.log_this
-    @expose(
-        "/sqllab/",
-        methods=(
-            "GET",
-            "POST",
-        ),
-    )
-    @deprecated(new_target="/sqllab")
-    def sqllab(self) -> FlaskResponse:
-        """SQL Editor"""
-        url = "/sqllab"
-        if url_params := request.args:
-            params = parse.urlencode(url_params)
-            url = f"{url}?{params}"
-        return redirect(url)
-
-    @has_access
-    @event_logger.log_this
     @expose("/sqllab/history/", methods=("GET",))
     @deprecated(new_target="/sqllab/history")
     def sqllab_history(self) -> FlaskResponse:

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -121,7 +121,7 @@ PARAMETER_MISSING_ERR = __(
 SqlResults = dict[str, Any]
 
 
-class Superset(BaseSupersetView):  # pylint: disable=too-many-public-methods
+class Superset(BaseSupersetView):
     """The base views for Superset!"""
 
     logger = logging.getLogger(__name__)

--- a/superset/views/sql_lab/views.py
+++ b/superset/views/sql_lab/views.py
@@ -264,16 +264,3 @@ class TableSchemaView(BaseSupersetView):
         db.session.commit()
         response = json.dumps({"id": table_schema_id, "expanded": payload})
         return json_success(response)
-
-
-class SqlLab(BaseSupersetView):
-    """The base views for Superset!"""
-
-    @expose("/my_queries/")
-    @has_access
-    def my_queries(self) -> FlaskResponse:
-        """Assigns a list of found users to the given role."""
-        logger.warning(
-            "This endpoint is deprecated and will be removed in the next major release"
-        )
-        return redirect(f"/savedqueryview/list/?_flt_0_user={get_user_id()}")

--- a/superset/views/sql_lab/views.py
+++ b/superset/views/sql_lab/views.py
@@ -17,7 +17,7 @@
 import logging
 
 import simplejson as json
-from flask import redirect, request, Response
+from flask import request, Response
 from flask_appbuilder import expose
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder.security.decorators import has_access, has_access_api

--- a/tests/integration_tests/core_tests.py
+++ b/tests/integration_tests/core_tests.py
@@ -1190,25 +1190,6 @@ class TestCore(SupersetTestCase):
             is True
         )
 
-    def test_redirect_new_sqllab(self):
-        self.login(username="admin")
-        resp = self.client.get(
-            "/superset/sqllab?savedQueryId=1&testParams=2",
-            follow_redirects=True,
-        )
-        assert resp.request.path == "/sqllab/"
-        assert (
-            resp.request.query_string.decode("utf-8") == "savedQueryId=1&testParams=2"
-        )
-
-        resp = self.client.post("/superset/sqllab/")
-        assert resp.status_code == 302
-
-    def test_redirect_new_sqllab_history(self):
-        self.login(username="admin")
-        resp = self.client.get("/superset/sqllab/history/")
-        assert resp.status_code == 302
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -1483,7 +1483,6 @@ class TestRolePermission(SupersetTestCase):
                 ("can_get", "TabStateView"),
                 ("can_get_results", "SQLLab"),
                 ("can_migrate_query", "TabStateView"),
-                ("can_my_queries", "SqlLab"),
                 ("can_sqllab_history", "Superset"),
                 ("can_put", "TabStateView"),
                 ("can_post", "TabStateView"),

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -1470,15 +1470,34 @@ class TestRolePermission(SupersetTestCase):
 
     def test_sql_lab_permissions(self):
         sql_lab_set = get_perm_tuples("sql_lab")
-        self.assertIn(("can_csv", "Superset"), sql_lab_set)
-        self.assertIn(("can_read", "Database"), sql_lab_set)
-        self.assertIn(("can_read", "SavedQuery"), sql_lab_set)
-        self.assertIn(("can_sqllab", "Superset"), sql_lab_set)
-
-        self.assertIn(("menu_access", "SQL Lab"), sql_lab_set)
-        self.assertIn(("menu_access", "SQL Editor"), sql_lab_set)
-        self.assertIn(("menu_access", "Saved Queries"), sql_lab_set)
-        self.assertIn(("menu_access", "Query Search"), sql_lab_set)
+        self.assertEqual(
+            sql_lab_set,
+            {
+                ("can_activate", "TabStateView"),
+                ("can_csv", "Superset"),
+                ("can_delete_query", "TabStateView"),
+                ("can_delete", "TabStateView"),
+                ("can_execute_sql_query", "SQLLab"),
+                ("can_export", "SavedQuery"),
+                ("can_export_csv", "SQLLab"),
+                ("can_get", "TabStateView"),
+                ("can_get_results", "SQLLab"),
+                ("can_migrate_query", "TabStateView"),
+                ("can_my_queries", "SqlLab"),
+                ("can_sqllab_history", "Superset"),
+                ("can_put", "TabStateView"),
+                ("can_post", "TabStateView"),
+                ("can_write", "SavedQuery"),
+                ("can_read", "Query"),
+                ("can_read", "Database"),
+                ("can_read", "SQLLab"),
+                ("can_read", "SavedQuery"),
+                ("menu_access", "Query Search"),
+                ("menu_access", "Saved Queries"),
+                ("menu_access", "SQL Editor"),
+                ("menu_access", "SQL Lab"),
+            },
+        )
 
         self.assert_cannot_alpha(sql_lab_set)
 


### PR DESCRIPTION
### SUMMARY
Removes and old deprecated endpoint `/superset/sqllab`. Also removes a false positive security issue identified by CodeQL

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
