### PR TITLE
docs(miscellaneous): Export Datasoruces: export datasources exports to ZIP

### DIFF
--- a/docs/docs/miscellaneous/importing-exporting-datasources.mdx
+++ b/docs/docs/miscellaneous/importing-exporting-datasources.mdx
@@ -34,7 +34,7 @@ You can print your current datasources to stdout by running:
 superset export_datasources
 ```
 
-To save your datasources to a file run:
+To save your datasources to a ZIP file run:
 
 ```
 superset export_datasources -f <filename>


### PR DESCRIPTION
### SUMMARY
Documentation did not say what file type is exported by `superset export_datasources -f`.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
