### PR TITLE
fix: bump grpcio, urllib3 and paramiko

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -364,7 +364,7 @@ tzdata==2023.3
     #   pandas
 url-normalize==1.4.3
     # via requests-cache
-urllib3==1.26.6
+urllib3==1.26.18
     # via
     #   requests
     #   requests-cache

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -236,7 +236,7 @@ packaging==23.1
     #   shillelagh
 pandas[performance]==2.0.3
     # via apache-superset
-paramiko==2.11.0
+paramiko==3.4.0
     # via sshtunnel
 parsedatetime==2.6
     # via apache-superset

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -60,12 +60,12 @@ googleapis-common-protos==1.59.0
     # via
     #   google-api-core
     #   grpcio-status
-grpcio==1.54.0
+grpcio==1.60.1
     # via
     #   google-api-core
     #   google-cloud-bigquery
     #   grpcio-status
-grpcio-status==1.54.0
+grpcio-status==1.60.1
     # via google-api-core
 iniconfig==2.0.0
     # via pytest


### PR DESCRIPTION
### SUMMARY

Bumps grpcio used by bigquery fixes: https://github.com/advisories/GHSA-p25m-jpj4-qcrr
paramiko 3.4.0 fixes: https://terrapin-attack.com
urllib3 fix: https://nvd.nist.gov/vuln/detail/CVE-2023-45803

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
