### PR TITLE
fix: RLS modal overflow

### DIFF
--- a/superset-frontend/src/features/rls/constants.ts
+++ b/superset-frontend/src/features/rls/constants.ts
@@ -19,7 +19,7 @@
 
 import { t } from '@superset-ui/core';
 
-export const FilterOptions = [
+export const FILTER_OPTIONS = [
   {
     label: t('Regular'),
     value: 'Regular',


### PR DESCRIPTION
### SUMMARY
Fixes https://github.com/apache/superset/issues/27079 and also adjusts the description input theme.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: modal was overflowing and the description input theme was not matching other inputs
<img width="516" alt="Screenshot 2024-02-15 at 11 16 53" src="https://github.com/apache/superset/assets/70410625/7d47fd23-aec8-483b-b4fe-21a42491c999">

After: modal correctly displays a scroll when needed and the input theme is fixed
<img width="522" alt="Screenshot 2024-02-15 at 11 14 40" src="https://github.com/apache/superset/assets/70410625/cd0fce57-5fa3-4629-aec9-f9c0a2af2e63">

### TESTING INSTRUCTIONS
Check that the RLS does not overflow and that the description input theme matches other inputs..

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
