### PR TITLE
fix: Plain error message when visiting a dashboard via permalink without permissions

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -46,6 +46,7 @@ from superset import (
 from superset.async_events.async_query_manager import AsyncQueryTokenException
 from superset.commands.chart.exceptions import ChartNotFoundError
 from superset.commands.chart.warm_up_cache import ChartWarmUpCacheCommand
+from superset.commands.dashboard.exceptions import DashboardAccessDeniedError
 from superset.commands.dashboard.permalink.get import GetDashboardPermalinkCommand
 from superset.commands.dataset.exceptions import DatasetNotFoundError
 from superset.commands.explore.form_data.create import CreateFormDataCommand
@@ -830,6 +831,9 @@ class Superset(BaseSupersetView):
         try:
             value = GetDashboardPermalinkCommand(key).run()
         except DashboardPermalinkGetFailedError as ex:
+            flash(__("Error: %(msg)s", msg=ex.message), "danger")
+            return redirect("/dashboard/list/")
+        except DashboardAccessDeniedError as ex:
             flash(__("Error: %(msg)s", msg=ex.message), "danger")
             return redirect("/dashboard/list/")
         if not value:


### PR DESCRIPTION
### SUMMARY
Fixes https://github.com/apache/superset/issues/26849 by redirecting users to the dashboard list and presenting a toast message when they try to access a dashboard via permalink without permissions.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1792" alt="300451016-62c9468c-db2f-4bfa-b89c-10aecb1b182d" src="https://github.com/apache/superset/assets/70410625/24523abe-9177-4c26-bf10-f84fc11d7f35">

<img width="1776" alt="Screenshot 2024-02-15 at 15 39 07" src="https://github.com/apache/superset/assets/70410625/eafa21b5-9137-4c10-85e7-b7477951c98e">

### TESTING INSTRUCTIONS
Check the original issue for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
