### PR TITLE
chore(tests): Remove unnecessary explicit Flask-SQLAlchemy session expunges

### DIFF
--- a/tests/integration_tests/base_tests.py
+++ b/tests/integration_tests/base_tests.py
@@ -199,11 +199,8 @@ class SupersetTestCase(TestCase):
     def login(self, username="admin", password="general"):
         return login(self.client, username, password)
 
-    def get_slice(self, slice_name: str, expunge_from_session: bool = True) -> Slice:
-        slc = db.session.query(Slice).filter_by(slice_name=slice_name).one()
-        if expunge_from_session:
-            db.session.expunge_all()
-        return slc
+    def get_slice(self, slice_name: str) -> Slice:
+        return db.session.query(Slice).filter_by(slice_name=slice_name).one()
 
     @staticmethod
     def get_table(

--- a/tests/integration_tests/core_tests.py
+++ b/tests/integration_tests/core_tests.py
@@ -199,7 +199,6 @@ class TestCore(SupersetTestCase):
             url.format(tbl_id, copy_name, "saveas"),
             data={"form_data": json.dumps(form_data)},
         )
-        db.session.expunge_all()
         new_slice_id = resp.json["form_data"]["slice_id"]
         slc = db.session.query(Slice).filter_by(id=new_slice_id).one()
 
@@ -221,7 +220,6 @@ class TestCore(SupersetTestCase):
             url.format(tbl_id, new_slice_name, "overwrite"),
             data={"form_data": json.dumps(form_data)},
         )
-        db.session.expunge_all()
         slc = db.session.query(Slice).filter_by(id=new_slice_id).one()
         self.assertEqual(slc.slice_name, new_slice_name)
         self.assertEqual(slc.viz.form_data, form_data)
@@ -240,10 +238,7 @@ class TestCore(SupersetTestCase):
     def test_slice_data(self):
         # slice data should have some required attributes
         self.login(username="admin")
-        slc = self.get_slice(
-            slice_name="Top 10 Girl Name Share",
-            expunge_from_session=False,
-        )
+        slc = self.get_slice(slice_name="Top 10 Girl Name Share")
         slc_data_attributes = slc.data.keys()
         assert "changed_on" in slc_data_attributes
         assert "modified" in slc_data_attributes

--- a/tests/integration_tests/security/guest_token_security_tests.py
+++ b/tests/integration_tests/security/guest_token_security_tests.py
@@ -257,9 +257,9 @@ class TestGuestUserDatasourceAccess(SupersetTestCase):
                 ],
             }
         )
-        self.chart = self.get_slice("Girls", expunge_from_session=False)
+        self.chart = self.get_slice("Girls")
         self.datasource = self.chart.datasource
-        self.other_chart = self.get_slice("Treemap", expunge_from_session=False)
+        self.other_chart = self.get_slice("Treemap")
         self.other_datasource = self.other_chart.datasource
         self.native_filter_datasource = (
             db.session.query(SqlaTable).filter_by(table_name="dummy_sql_table").first()

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -1722,11 +1722,11 @@ class TestSecurityManager(SupersetTestCase):
         mock_is_owner,
     ):
         births = self.get_dash_by_slug("births")
-        girls = self.get_slice("Girls", expunge_from_session=False)
+        girls = self.get_slice("Girls")
         birth_names = girls.datasource
 
         world_health = self.get_dash_by_slug("world_health")
-        treemap = self.get_slice("Treemap", expunge_from_session=False)
+        treemap = self.get_slice("Treemap")
 
         births.json_metadata = json.dumps(
             {
@@ -1871,8 +1871,6 @@ class TestSecurityManager(SupersetTestCase):
                         )
                     }
                 )
-
-            db.session.expunge_all()
 
     def test_get_user_roles(self):
         admin = security_manager.find_user("admin")


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

There's a few instances within our tests where we explicitly expunge either specific or all objects from the session, however this is unnecessary as the Flask-SQLAlchemy session is torn down after each test (verified via logging) in which the [current session is removed/closed](https://github.com/pallets-eco/flask-sqlalchemy/blob/42a36a3cb604fd39d81d00b54ab3988bbd0ad184/src/flask_sqlalchemy/extension.py#L448) and thus there's no need to explicitly expunge the records.

Note this change is a precursor to defining a "unit of work" as part of [SIP-99B](https://github.com/apache/superset/issues/25108). I've been struggling to get the various unit/integration tests to pass in my PoC—in part due to atypical testing patterns.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
