### PR TITLE
fix(plugins): Apply dashboard filters to comparison query in BigNumber with Time Comparison chart

### DIFF
--- a/superset-frontend/plugins/plugin-chart-period-over-period-kpi/src/plugin/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-period-over-period-kpi/src/plugin/buildQuery.ts
@@ -87,13 +87,19 @@ export default function buildQuery(formData: QueryFormData) {
     formDataB = {
       ...formData,
       adhoc_filters: queryBFilters,
-      extra_form_data: {},
+      extra_form_data: {
+        ...extraFormData,
+        time_range: undefined,
+      },
     };
   } else {
     formDataB = {
       ...formData,
       adhoc_filters: formData.adhoc_custom,
-      extra_form_data: {},
+      extra_form_data: {
+        ...extraFormData,
+        time_range: undefined,
+      },
     };
   }
 


### PR DESCRIPTION
### SUMMARY
The dashboard filters are being ignored from the comparison query in our BigNumber with Time Comparison chart. This PR is fixing that so such query can properly manage the filters while ignoring the time range filter becase it's set by the range set on the chart

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Error:
<img width="1721" alt="Screenshot 2024-02-16 at 09 04 59" src="https://github.com/apache/superset/assets/38889534/fa13c5d0-c650-488d-baa3-8bed38caa7f7">

Fix:
<img width="1721" alt="Screenshot 2024-02-16 at 08 55 56" src="https://github.com/apache/superset/assets/38889534/0151531b-07ef-4702-8ec1-2b9ebd6868ba">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

