### PR TITLE
fix: elasticsearch column type mapping

### DIFF
--- a/tests/integration_tests/db_engine_specs/elasticsearch_tests.py
+++ b/tests/integration_tests/db_engine_specs/elasticsearch_tests.py
@@ -41,3 +41,7 @@ class TestElasticsearchDbEngineSpec(TestDbEngineSpec):
             col=col, pdf=None, time_grain=time_grain
         )
         self.assertEqual(str(actual), expected_time_grain_expression)
+
+    def test_get_datatype(self):
+        self.assertEqual("NUMBER", ElasticSearchEngineSpec.get_datatype(2))
+        self.assertEqual("DATETIME", ElasticSearchEngineSpec.get_datatype(4))


### PR DESCRIPTION
The datetime field in the CursorDescriptionRow returned by elasticsearch-dbapi is identified as Type.DATETIME=4. 
During the creation of the `_type_dict`, the `db_engine_spec.get_datatype` method returns an incorrect type.
<img width="964" alt="image" src="https://github.com/apache/superset/assets/16112914/99bb57d7-ceec-405f-a270-2b1d76514f62">



### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Creating a dataset using Elasticsearch.
2. Use the following SQL: `select ins_date,cast(ins_date as datetime) as cast_ins_date from my_es`.
3. The column type will be correct type.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
