### PR TITLE
fix(ci): mypy pre-commit issues

### DIFF
--- a/superset/sqllab/api.py
+++ b/superset/sqllab/api.py
@@ -343,7 +343,9 @@ class SqlLabRestApi(BaseSupersetApi):
         # return the result without special encoding
         return json_success(
             json.dumps(
-                result, default=utils.json_iso_dttm_ser, ignore_nan=True, encoding=None
+                result,
+                default=utils.json_iso_dttm_ser,
+                ignore_nan=True,
             ),
             200,
         )

--- a/superset/sqllab/execution_context_convertor.py
+++ b/superset/sqllab/execution_context_convertor.py
@@ -60,7 +60,6 @@ class ExecutionContextConvertor:
                 ),
                 default=utils.pessimistic_json_iso_dttm_ser,
                 ignore_nan=True,
-                encoding=None,
             )
 
         return json.dumps(


### PR DESCRIPTION
### SUMMARY
Fixes mypy pre-commit errors:

```
superset/sqllab/execution_context_convertor.py:57: error: No overload variant of "dumps" matches argument types "Dict[str, Any]", "Callable[[Any], Any]", "bool", "None"  [call-overload]
superset/sqllab/api.py:345: error: No overload variant of "dumps" matches argument types "Dict[str, Any]", "Callable[[Any, bool], Any]", "bool", "None"  [call-overload]
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
