### PR TITLE
fix: unlock and bump werkzeug

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -116,7 +116,7 @@ flask-jwt-extended==4.3.1
     # via flask-appbuilder
 flask-limiter==3.3.1
     # via flask-appbuilder
-flask-login==0.6.0
+flask-login==0.6.3
     # via
     #   apache-superset
     #   flask-appbuilder

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -90,8 +90,6 @@ dnspython==2.1.0
     # via email-validator
 email-validator==1.1.3
     # via flask-appbuilder
-exceptiongroup==1.2.0
-    # via cattrs
 flask==2.2.5
     # via
     #   apache-superset
@@ -144,7 +142,7 @@ geopy==2.2.0
     # via apache-superset
 google-auth==2.27.0
     # via shillelagh
-greenlet==2.0.2
+greenlet==3.0.3
     # via shillelagh
 gunicorn==21.2.0
     # via apache-superset
@@ -159,10 +157,7 @@ idna==3.2
     #   email-validator
     #   requests
 importlib-metadata==6.6.0
-    # via
-    #   apache-superset
-    #   flask
-    #   shillelagh
+    # via apache-superset
 importlib-resources==5.12.0
     # via limits
 isodate==0.6.0
@@ -352,9 +347,7 @@ tabulate==0.8.9
 typing-extensions==4.4.0
     # via
     #   apache-superset
-    #   cattrs
     #   flask-limiter
-    #   kombu
     #   limits
     #   shillelagh
 tzdata==2023.3
@@ -375,9 +368,8 @@ vine==5.1.0
     #   kombu
 wcwidth==0.2.5
     # via prompt-toolkit
-werkzeug==2.3.3
+werkzeug==3.0.1
     # via
-    #   apache-superset
     #   flask
     #   flask-appbuilder
     #   flask-jwt-extended
@@ -395,9 +387,7 @@ wtforms-json==0.3.5
 xlsxwriter==3.0.7
     # via apache-superset
 zipp==3.15.0
-    # via
-    #   importlib-metadata
-    #   importlib-resources
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -130,7 +130,7 @@ flask-sqlalchemy==2.5.1
     #   flask-migrate
 flask-talisman==1.0.0
     # via apache-superset
-flask-wtf==1.1.1
+flask-wtf==1.2.1
     # via
     #   apache-superset
     #   flask-appbuilder

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -115,8 +115,6 @@ thrift==0.16.0
     #   thrift-sasl
 thrift-sasl==0.4.3
     # via pyhive
-tomli==2.0.1
-    # via pylint
 tomlkit==0.11.8
     # via pylint
 traitlets==5.9.0

--- a/requirements/integration.txt
+++ b/requirements/integration.txt
@@ -52,12 +52,6 @@ pyproject-hooks==1.0.0
     # via build
 pyyaml==6.0.1
     # via pre-commit
-tomli==2.0.1
-    # via
-    #   build
-    #   pip-tools
-    #   pyproject-api
-    #   tox
 toposort==1.10
     # via pip-compile-multi
 tox==4.6.4

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -87,7 +87,7 @@ parameterized==0.9.0
     # via -r requirements/testing.in
 pathable==0.4.3
     # via jsonschema-spec
-playwright==1.37.0
+playwright==1.41.2
     # via apache-superset
 prophet==1.1.5
     # via apache-superset
@@ -105,7 +105,7 @@ protobuf==4.23.0
     #   proto-plus
 pydata-google-auth==1.7.0
     # via pandas-gbq
-pyee==9.0.4
+pyee==11.0.1
     # via playwright
 pyfakefs==5.2.2
     # via -r requirements/testing.in

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,6 @@ setup(
         "tabulate>=0.8.9, <0.9",
         "typing-extensions>=4, <5",
         "waitress; sys_platform == 'win32'",
-        "werkzeug>=2.3.3, <3",
         "wtforms>=2.3.3, <4",
         "wtforms-json",
         "xlsxwriter>=3.0.7, <3.1",

--- a/tests/integration_tests/async_events/api_tests.py
+++ b/tests/integration_tests/async_events/api_tests.py
@@ -117,8 +117,6 @@ class TestAsyncEventApi(SupersetTestCase):
 
     def test_events_no_token(self):
         self.login(username="admin")
-        self.client.set_cookie(
-            app.config["GLOBAL_ASYNC_QUERIES_JWT_COOKIE_NAME"], ""
-        )
+        self.client.set_cookie(app.config["GLOBAL_ASYNC_QUERIES_JWT_COOKIE_NAME"], "")
         rv = self.fetch_events()
         assert rv.status_code == 401

--- a/tests/integration_tests/async_events/api_tests.py
+++ b/tests/integration_tests/async_events/api_tests.py
@@ -118,7 +118,7 @@ class TestAsyncEventApi(SupersetTestCase):
     def test_events_no_token(self):
         self.login(username="admin")
         self.client.set_cookie(
-            "localhost", app.config["GLOBAL_ASYNC_QUERIES_JWT_COOKIE_NAME"], ""
+            "localhost", app.config["GLOBAL_ASYNC_QUERIES_JWT_COOKIE_NAME"]
         )
         rv = self.fetch_events()
         assert rv.status_code == 401

--- a/tests/integration_tests/async_events/api_tests.py
+++ b/tests/integration_tests/async_events/api_tests.py
@@ -118,7 +118,7 @@ class TestAsyncEventApi(SupersetTestCase):
     def test_events_no_token(self):
         self.login(username="admin")
         self.client.set_cookie(
-            "localhost", app.config["GLOBAL_ASYNC_QUERIES_JWT_COOKIE_NAME"]
+            app.config["GLOBAL_ASYNC_QUERIES_JWT_COOKIE_NAME"], ""
         )
         rv = self.fetch_events()
         assert rv.status_code == 401

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -735,7 +735,7 @@ class TestPostChartDataApi(BaseTestChartDataApi):
         app._got_first_request = False
         async_query_manager_factory.init_app(app)
         test_client.set_cookie(
-            "localhost", app.config["GLOBAL_ASYNC_QUERIES_JWT_COOKIE_NAME"], "foo"
+            app.config["GLOBAL_ASYNC_QUERIES_JWT_COOKIE_NAME"], "foo"
         )
         rv = test_client.post(CHART_DATA_URI, json=self.query_context_payload)
         self.assertEqual(rv.status_code, 401)


### PR DESCRIPTION
### SUMMARY

Unlocks and bumps Werkzeug to 3.0.1.
Locked here: https://github.com/apache/superset/pull/23965

The following dependencies need to be bumped also to unlock Werkzeug:
- Flask-AppBuilder done [here](https://github.com/apache/superset/pull/27159)
- Flask-Login
- Flask-Wtf

Note:
Using OpenID (not OpenID connect) will not be compatible with this bump, but users will not be forced to do it. 
Flask-AppBuilder as deprecated this form of Auth. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
