### PR TITLE
fix: CSRF exempt unit_tests

### DIFF
--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -8,11 +8,13 @@ on:
     paths:
       - "superset/**"
       - "requirements/**"
+      - "tests/unit_tests/**"
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "superset/**"
       - "requirements/**"
+      - "tests/unit_tests/**"
 
 # cancel previous workflow jobs for PRs
 concurrency:

--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -7,10 +7,12 @@ on:
       - 'master'
     paths:
       - "superset/**"
+      - "requirements/**"
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "superset/**"
+      - "requirements/**"
 
 # cancel previous workflow jobs for PRs
 concurrency:

--- a/superset/app.py
+++ b/superset/app.py
@@ -25,7 +25,6 @@ from superset.initialization import SupersetAppInitializer
 
 logger = logging.getLogger(__name__)
 
-# Just a MARK to kick CI
 
 def create_app(superset_config_module: Optional[str] = None) -> Flask:
     app = SupersetApp(__name__)

--- a/superset/app.py
+++ b/superset/app.py
@@ -25,6 +25,7 @@ from superset.initialization import SupersetAppInitializer
 
 logger = logging.getLogger(__name__)
 
+# Just a MARK to kick CI
 
 def create_app(superset_config_module: Optional[str] = None) -> Flask:
     app = SupersetApp(__name__)

--- a/tests/unit_tests/security/api_test.py
+++ b/tests/unit_tests/security/api_test.py
@@ -28,4 +28,8 @@ def test_csrf_not_exempt(app_context: None) -> None:
     """
     Test that REST API is not exempt from CSRF.
     """
-    assert {blueprint.name for blueprint in csrf._exempt_blueprints} == {"MenuApi", "SecurityApi", "OpenApi"}
+    assert {blueprint.name for blueprint in csrf._exempt_blueprints} == {
+        "MenuApi",
+        "SecurityApi",
+        "OpenApi",
+    }

--- a/tests/unit_tests/security/api_test.py
+++ b/tests/unit_tests/security/api_test.py
@@ -28,4 +28,5 @@ def test_csrf_not_exempt(app_context: None) -> None:
     """
     Test that REST API is not exempt from CSRF.
     """
+    raise Exception(csrf._exempt_blueprints)
     assert csrf._exempt_blueprints == {"MenuApi", "SecurityApi", "OpenApi"}

--- a/tests/unit_tests/security/api_test.py
+++ b/tests/unit_tests/security/api_test.py
@@ -28,5 +28,4 @@ def test_csrf_not_exempt(app_context: None) -> None:
     """
     Test that REST API is not exempt from CSRF.
     """
-    raise Exception(csrf._exempt_blueprints)
-    assert csrf._exempt_blueprints == {"MenuApi", "SecurityApi", "OpenApi"}
+    assert {blueprint.name for blueprint in csrf._exempt_blueprints} == {"MenuApi", "SecurityApi", "OpenApi"}


### PR DESCRIPTION
### SUMMARY
Flask-WTF changed `csrf._exempt_blueprints` that we were asserting on our tests. It was not caught because github actions workflow for unit tests just runs when `superset/**` changes. This PR fixes both issues 


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
