### PR TITLE
chore: Updates CHANGELOG.md with 3.0.4 data

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -46,7 +46,7 @@ body:
       options:
         - master / latest-dev
         - "3.1.0"
-        - "3.0.3"
+        - "3.0.4"
     validations:
       required: true
   - type: dropdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,4 +35,5 @@ under the License.
 - [3.0.1](./CHANGELOG/3.0.1.md)
 - [3.0.2](./CHANGELOG/3.0.2.md)
 - [3.0.3](./CHANGELOG/3.0.3.md)
+- [3.0.4](./CHANGELOG/3.0.4.md)
 - [3.1.0](./CHANGELOG/3.1.0.md)

--- a/CHANGELOG/3.0.4.md
+++ b/CHANGELOG/3.0.4.md
@@ -1,0 +1,72 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+## Change Log
+
+### 3.0.4 (Mon Feb 12 19:09:13 2024 -0800)
+
+**Features**
+
+- [#25795](https://github.com/apache/superset/pull/25795) feat: support server-side sessions (@dpgaspar)
+
+**Fixes**
+
+- [#27096](https://github.com/apache/superset/pull/27096) fix(big_number): white-space: nowrap to prevent wrapping (@mistercrunch)
+- [#27066](https://github.com/apache/superset/pull/27066) fix: Drill by with GLOBAL_ASYNC_QUERIES (@kgabryje)
+- [#27039](https://github.com/apache/superset/pull/27039) fix: bump FAB to 4.3.11 (@dpgaspar)
+- [#26993](https://github.com/apache/superset/pull/26993) fix: chart import validation (@dpgaspar)
+- [#27073](https://github.com/apache/superset/pull/27073) fix(drill): no rows returned (@betodealmeida)
+- [#27069](https://github.com/apache/superset/pull/27069) fix: Filters sidebar stretching dashboard height (@kgabryje)
+- [#27041](https://github.com/apache/superset/pull/27041) fix(plugins): missing currency on small number format in table chart (@justinpark)
+- [#27023](https://github.com/apache/superset/pull/27023) fix(explore): allow free-form d3 format on custom column formatting (@justinpark)
+- [#27019](https://github.com/apache/superset/pull/27019) fix: safer error message in alerts (@betodealmeida)
+- [#27015](https://github.com/apache/superset/pull/27015) fix(security manager): Users should not have access to all draft dashboards (@Vitor-Avila)
+- [#26946](https://github.com/apache/superset/pull/26946) fix: column values with NaN (@betodealmeida)
+- [#26964](https://github.com/apache/superset/pull/26964) fix(plugin-chart-table): Prevent misalignment of totals and headers when scrollbar is visible (@kgabryje)
+- [#22849](https://github.com/apache/superset/pull/22849) fix(cache): remove unused webserver config & handle trailing slashes (@Usiel)
+- [#26889](https://github.com/apache/superset/pull/26889) fix: Allow exporting saved queries without schema information (@sbernauer)
+- [#26887](https://github.com/apache/superset/pull/26887) fix: dashboard import validation (@dpgaspar)
+- [#26911](https://github.com/apache/superset/pull/26911) fix: handle CRLF endings causing sqlglot failure (@mapledan)
+- [#26906](https://github.com/apache/superset/pull/26906) fix(pinot): typo in the name for epoch_ms_to_dttm (@ege-st)
+- [#26817](https://github.com/apache/superset/pull/26817) fix: Bar charts horizontal margin adjustment error (@michael-s-molina)
+- [#26749](https://github.com/apache/superset/pull/26749) fix: prevent guest user from modifying metrics (@betodealmeida)
+- [#25923](https://github.com/apache/superset/pull/25923) fix(deck.gl Multiple Layer Chart): Add Contour and Heatmap Layer as options (@Mattc1221)
+- [#26476](https://github.com/apache/superset/pull/26476) fix(sqlparse): improve table parsing (@betodealmeida)
+- [#26814](https://github.com/apache/superset/pull/26814) fix(time-series table): Can't compare from the beginning of the time range (@michael-s-molina)
+- [#26807](https://github.com/apache/superset/pull/26807) fix: Row limit hardcoded (@michael-s-molina)
+- [#26652](https://github.com/apache/superset/pull/26652) fix(import): only import FORMULA annotations (@mistercrunch)
+- [#26314](https://github.com/apache/superset/pull/26314) fix(logging): Filter out undefined columns (@john-bodley)
+- [#26461](https://github.com/apache/superset/pull/26461) fix(BigQuery): Support special characters in column/metric names used in ORDER BY (@Vitor-Avila)
+- [#26744](https://github.com/apache/superset/pull/26744) fix(db2): Improving support for ibm db2 connections (@Vitor-Avila)
+- [#26705](https://github.com/apache/superset/pull/26705) fix(legacy-charts): Show Time Grain control for legacy charts (@Vitor-Avila)
+- [#26709](https://github.com/apache/superset/pull/26709) fix: do not use lodash/memoize (@rusackas)
+- [#25550](https://github.com/apache/superset/pull/25550) fix: Catch ImportErrors for Google SDKs (@skion)
+- [#26645](https://github.com/apache/superset/pull/26645) fix(translation): correct translation errors for Chinese(zh) (@Waterkin)
+- [#26638](https://github.com/apache/superset/pull/26638) fix: Avoid 500 if end users write bad SQL (@Khrol)
+- [#26644](https://github.com/apache/superset/pull/26644) fix: unnecessary logic on CI ephemeral (@dpgaspar)
+- [#26625](https://github.com/apache/superset/pull/26625) fix: create virtual dataset validation (@dpgaspar)
+- [#26634](https://github.com/apache/superset/pull/26634) fix: RLS modal styling (@geido)
+- [#26469](https://github.com/apache/superset/pull/26469) fix(database): allow filtering by UUID (@betodealmeida)
+- [#26412](https://github.com/apache/superset/pull/26412) fix(embedded): Hide dashboard fullscreen option for embedded context (@Vitor-Avila)
+- [#26355](https://github.com/apache/superset/pull/26355) fix: Trino - handle table not found in SQLLab (@Khrol)
+
+**Others**
+
+- [#26716](https://github.com/apache/superset/pull/26716) build(deps): bump csstype from 2.6.9 to 3.1.3 in /superset-frontend (@dependabot[bot])
+- [#26431](https://github.com/apache/superset/pull/26431) chore: bump prophet to 1.1.5 (@villebro)


### PR DESCRIPTION
### SUMMARY
Updates `CHANGELOG.md` with [3.0.4](https://github.com/apache/superset/blob/3.0.4) data. It also updates the versions selector of the issue template.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
