### PR TITLE
chore(docs): change 'install from scratch' to 'install from PyPI'

### DIFF
--- a/docs/docs/contributing/local-backend.mdx
+++ b/docs/docs/contributing/local-backend.mdx
@@ -9,7 +9,7 @@ version: 1
 
 #### OS Dependencies
 
-Make sure your machine meets the [OS dependencies](/docs/installation/installing-superset-from-scratch#os-dependencies) before following these steps.
+Make sure your machine meets the [OS dependencies](/docs/installation/installing-superset-from-pypi#os-dependencies) before following these steps.
 You also need to install MySQL or [MariaDB](https://mariadb.com/downloads).
 
 Ensure that you are using Python version 3.9 or 3.10, then proceed with:

--- a/docs/docs/installation/installing-superset-from-pypi.mdx
+++ b/docs/docs/installation/installing-superset-from-pypi.mdx
@@ -1,11 +1,13 @@
 ---
-title: Installing From Scratch
+title: Installing from PyPI
 hide_title: true
 sidebar_position: 2
 version: 1
 ---
 
-## Installing Superset from Scratch
+## Installing Superset from PyPI
+
+This page describes how to install Superset using the `apache-superset` package [published on PyPI](https://pypi.org/project/apache-superset/).
 
 ### OS Dependencies
 

--- a/docs/docs/intro.mdx
+++ b/docs/docs/intro.mdx
@@ -13,15 +13,11 @@ geospatial charts.
 
 Here are a **few different ways you can get started with Superset**:
 
-- Install Superset [from scratch](/docs/installation/installing-superset-from-scratch/)
-- Deploy Superset locally with one command
-  [using Docker Compose](/docs/installation/installing-superset-using-docker-compose)
+- Try a [Quickstart deployment](/docs/quickstart), which runs a single Docker container
+- Install Superset [from PyPI](/docs/installation/installing-superset-from-pypi/)
+- Deploy Superset [using Docker Compose](/docs/installation/installing-superset-using-docker-compose)
 - Deploy Superset [with Kubernetes](/docs/installation/running-on-kubernetes)
-- Run a [Docker image](https://hub.docker.com/r/apache/superset) from Dockerhub
-- Download Superset [from Pypi here](https://pypi.org/project/apache-superset/)
-- Install the latest version of Superset
-  [from GitHub](https://github.com/apache/superset/tree/latest)
-- Download the [source from Apache Foundation's website](https://dist.apache.org/repos/dist/release/superset/)
+- Download the [source code from Apache Foundation's website](https://dist.apache.org/repos/dist/release/superset/)
 
 #### Video Overview
 


### PR DESCRIPTION
### SUMMARY
The docs working group agreed that "from PyPI" was clearer than "from scratch."  This is also how Apache Airflow describes this installation method.

I also tidied up the intro.mdx list of ways to install, removing redundancies and trimming links that aren't recommended install methods.