### PR TITLE
feat(docs): Adds an "Edit this page on GitHub" button to docs pages

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -139,7 +139,7 @@ const config = {
       ({
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl: 'https://github.com/apache/superset/tree/master/docs',
+          editUrl: 'https://github.com/apache/superset/edit/master/docs',
         },
         blog: {
           showReadingTime: true,

--- a/docs/src/styles/main.less
+++ b/docs/src/styles/main.less
@@ -259,3 +259,13 @@ a > span > svg {
     height: 28px;
   }
 }
+
+/* Edit Button */
+
+.edit-page-link {
+  position: sticky;
+  bottom: 0px;
+  right: 0px;
+  border-radius: 10px;
+  background-color: #ccc;
+}

--- a/docs/src/theme/DocItem/index.js
+++ b/docs/src/theme/DocItem/index.js
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 import React from 'react';
 import styled from '@emotion/styled';
 import DocItem from '@theme-original/DocItem';

--- a/docs/src/theme/DocItem/index.js
+++ b/docs/src/theme/DocItem/index.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import DocItem from '@theme-original/DocItem';
+
+const EditPageLink = styled('a')`
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  padding: 1rem;
+  padding-left: 4rem;
+  background-color: #444;
+  border-radius: 10px;
+  z-index: 9999;
+  background-image: url('/img/github-dark.png');
+  background-size: 2rem;
+  background-position: 1rem center;
+  background-repeat: no-repeat;
+  transition: background-color 0.3s; /* Smooth transition for hover effect */
+  bpx-shadow: 0 0 0 0 rgba(0,0,0,0); /* Smooth transition for hover effect */
+  scale: .9;
+  transition: all 0.3s;
+
+  &:hover {
+    background-color: #333;
+    box-shadow: 5px 5px 10px 0 rgba(0,0,0,0.3);
+    scale: 1;
+  }
+`;
+
+export default function DocItemWrapper(props) {
+  return (
+    <>
+      <EditPageLink href={props.content.metadata.editUrl} target="_blank" rel="noopener noreferrer">
+        Edit this page on GitHub
+      </EditPageLink>
+      <DocItem {...props} />
+    </>
+  );
+}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Changes Docusaurus config to take you to the _actual_ edit link, so you can edit a given page on GitHub (or open a PR easily)
* "Swizzles" the docs layout in order to add a new Edit button component. 
* Adds the component, as seen in this here GIF:

![edit button](https://github.com/apache/superset/assets/812905/1dca8dae-d699-493b-b1ce-e1d829576dbb)



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
