### PR TITLE
fix: Allow only dttm columns in comparison filter in Period over Period chart

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/controlPanel.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/controlPanel.ts
@@ -17,7 +17,9 @@
  * under the License.
  */
 import {
+  AdhocFilter,
   ComparisonTimeRangeType,
+  SimpleAdhocFilter,
   t,
   validateTimeComparisonRangeValues,
 } from '@superset-ui/core';
@@ -84,7 +86,12 @@ const config: ControlPanelConfig = {
                     controlState,
                   ) || {};
                 const columns = originalMapStateToPropsRes.columns.filter(
-                  (col: ColumnMeta) => col.is_dttm,
+                  (col: ColumnMeta) =>
+                    col.is_dttm &&
+                    (state.controls.adhoc_filters.value as AdhocFilter[]).some(
+                      (val: SimpleAdhocFilter) =>
+                        val.subject === col.column_name,
+                    ),
                 );
                 return {
                   ...originalMapStateToPropsRes,
@@ -146,6 +153,9 @@ const config: ControlPanelConfig = {
   controlOverrides: {
     y_axis_format: {
       label: t('Number format'),
+    },
+    adhoc_filters: {
+      rerender: ['adhoc_custom'],
     },
   },
   formDataOverrides: formData => ({

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/controlPanel.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/controlPanel.ts
@@ -22,6 +22,7 @@ import {
   validateTimeComparisonRangeValues,
 } from '@superset-ui/core';
 import {
+  ColumnMeta,
   ControlPanelConfig,
   ControlPanelState,
   ControlState,
@@ -76,16 +77,24 @@ const config: ControlPanelConfig = {
               mapStateToProps: (
                 state: ControlPanelState,
                 controlState: ControlState,
-              ) => ({
-                ...(sharedControls.adhoc_filters.mapStateToProps?.(
-                  state,
-                  controlState,
-                ) || {}),
-                externalValidationErrors: validateTimeComparisonRangeValues(
-                  state.controls?.time_comparison?.value,
-                  controlState.value,
-                ),
-              }),
+              ) => {
+                const originalMapStateToPropsRes =
+                  sharedControls.adhoc_filters.mapStateToProps?.(
+                    state,
+                    controlState,
+                  ) || {};
+                const columns = originalMapStateToPropsRes.columns.filter(
+                  (col: ColumnMeta) => col.is_dttm,
+                );
+                return {
+                  ...originalMapStateToPropsRes,
+                  columns,
+                  externalValidationErrors: validateTimeComparisonRangeValues(
+                    state.controls?.time_comparison?.value,
+                    controlState.value,
+                  ),
+                };
+              },
             },
           },
         ],

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
@@ -382,7 +382,18 @@ const DndFilterSelect = (props: DndFilterSelectProps) => {
     return new AdhocFilter(config);
   }, [droppedItem]);
 
-  const canDrop = useCallback(() => true, []);
+  const canDrop = useCallback(
+    (item: DatasourcePanelDndItem) => {
+      if (item.type === DndItemType.Column) {
+        return props.columns.some(
+          col => col.column_name === (item.value as ColumnMeta).column_name,
+        );
+      }
+      return true;
+    },
+    [props.columns],
+  );
+
   const handleDrop = useCallback(
     (item: DatasourcePanelDndItem) => {
       setDroppedItem(item.value);


### PR DESCRIPTION
### SUMMARY
When user selected Custom range for comparison on Big Number With Time Period Comparison chart, the filter control would accept any column. That worked but didn't make much sense, so this PR restricts the control to accept only dttm columns for filtering.
Please note that user can still write custom sql which will filter anything, so that's just a UX improvement.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF


https://github.com/apache/superset/assets/15073128/b4a63051-72f4-4a3c-900d-67aabcc79ba1


### TESTING INSTRUCTIONS
1. Create Big Number With Time Period Comparison chart
2. Select Custom range for comparison
3. Verify that you can drag only temporal columns
4. Verify that in the columns select in the popover you can only select temporal columns

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
