### PR TITLE
chore: add file extension on the file uploaded on slack

### DIFF
--- a/superset/reports/notifications/slack.py
+++ b/superset/reports/notifications/slack.py
@@ -184,13 +184,16 @@ Error: %(text)s
             client = WebClient(token=token, proxy=app.config["SLACK_PROXY"])
             # files_upload returns SlackResponse as we run it in sync mode.
             if files:
-                for file in files:
+                for idx, file in enumerate(files, 1):
+                    file_base = (title or "uploaded_file").split()[-1].replace(".", "_")
+                    file_suffix = "" if len(files) == 1 else f"_{idx}"
                     client.files_upload(
                         channels=channel,
                         file=file,
                         initial_comment=body,
                         title=title,
                         filetype=file_type,
+                        filename=f"{file_base}{file_suffix}.{file_type}",
                     )
             else:
                 client.chat_postMessage(channel=channel, text=body)


### PR DESCRIPTION
### SUMMARY
- I received a reported issue by our company members, that files downloaded through Slack are not opening properly.
- Upon investigation, I found that the problem is due to the absence of file extensions in the uploaded filenames on Slack. Consequently, the files are attempting to open with a default text editor.
- So, I added a simple logic to append file extension with argument of slack file_upload API
  - https://api.slack.com/methods/files.upload

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://github.com/apache/superset/assets/81631424/77ec2e92-fe47-4b0b-88a9-4bc423d7d5e6)

### TESTING INSTRUCTIONS
Just do make alerts of notification with attached image