### PR TITLE
chore: update cryptography to >= 42.0.5

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -78,7 +78,7 @@ cron-descriptor==1.2.24
     # via apache-superset
 croniter==1.0.15
     # via apache-superset
-cryptography==42.0.2
+cryptography==42.0.5
     # via
     #   apache-superset
     #   paramiko
@@ -90,6 +90,8 @@ dnspython==2.1.0
     # via email-validator
 email-validator==1.1.3
     # via flask-appbuilder
+exceptiongroup==1.2.0
+    # via cattrs
 flask==2.2.5
     # via
     #   apache-superset
@@ -351,6 +353,7 @@ tabulate==0.8.9
 typing-extensions==4.4.0
     # via
     #   apache-superset
+    #   cattrs
     #   flask-limiter
     #   limits
     #   shillelagh

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -10,8 +10,6 @@
     # via
     #   -r requirements/base.in
     #   -r requirements/development.in
-appnope==0.1.3
-    # via ipython
 astroid==2.15.8
     # via pylint
 asttokens==2.2.1
@@ -82,6 +80,10 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
+pure-sasl==0.6.2
+    # via
+    #   pyhive
+    #   thrift-sasl
 pydruid==0.6.5
     # via apache-superset
 pyhive[hive_pure_sasl]==0.7.0
@@ -105,7 +107,14 @@ tableschema==1.20.2
 tabulator==1.53.5
     # via tableschema
 thrift==0.16.0
-    # via apache-superset
+    # via
+    #   apache-superset
+    #   pyhive
+    #   thrift-sasl
+thrift-sasl==0.4.3
+    # via pyhive
+tomli==2.0.1
+    # via pylint
 tomlkit==0.11.8
     # via pylint
 traitlets==5.9.0

--- a/requirements/integration.txt
+++ b/requirements/integration.txt
@@ -52,6 +52,12 @@ pyproject-hooks==1.0.0
     # via build
 pyyaml==6.0.1
     # via pre-commit
+tomli==2.0.1
+    # via
+    #   build
+    #   pip-tools
+    #   pyproject-api
+    #   tox
 toposort==1.10
     # via pip-compile-multi
 tox==4.6.4

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -110,6 +110,8 @@ pyee==11.0.1
     # via playwright
 pyfakefs==5.2.2
     # via -r requirements/testing.in
+pyhive[presto]==0.7.0
+    # via apache-superset
 pytest==7.3.1
     # via
     #   -r requirements/testing.in

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         "croniter>=0.3.28",
         "cron-descriptor",
         # snowflake-connector-python as of 3.7.0 doesn't support >=42.* therefore lowering the min to 41.0.2
-        "cryptography>=41.0.5, <43.0.0",
+        "cryptography>=42.0.5, <43.0.0",
         "deprecation>=2.1.0, <2.2.0",
         "flask>=2.2.5, <3.0.0",
         "flask-appbuilder>=4.4.1, <5.0.0",

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         "croniter>=0.3.28",
         "cron-descriptor",
         # snowflake-connector-python as of 3.7.0 doesn't support >=42.* therefore lowering the min to 41.0.2
-        "cryptography>=41.0.2, <43.0.0",
+        "cryptography>=41.0.5, <43.0.0",
         "deprecation>=2.1.0, <2.2.0",
         "flask>=2.2.5, <3.0.0",
         "flask-appbuilder>=4.4.1, <5.0.0",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
cryptography has some high CVE findings which are fixed with newer version.
To fix this the min-version in setup.py should be updated to latest version (42.0.5)

CVE-2024-26130⁠ (CVSS 7.5)
CVE-2023-50782⁠ (CVSS 7.5)
CVE-2024-0727⁠ (CVSS 5.5)
CVE-2023-49083⁠ (CVSS 5.9)
(and some low)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://github.com/apache/superset/assets/102737855/a2783a89-8f6e-4ead-a247-6f78943ee0a5)


### TESTING INSTRUCTIONS
Open final build software and check that cryptography 41.0.5 (or newer) is inside

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
