### PR TITLE
chore: update redis to >= 4.6.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -90,6 +90,8 @@ dnspython==2.1.0
     # via email-validator
 email-validator==1.1.3
     # via flask-appbuilder
+exceptiongroup==1.2.0
+    # via cattrs
 flask==2.2.5
     # via
     #   apache-superset
@@ -297,7 +299,7 @@ pyyaml==6.0.1
     # via
     #   apache-superset
     #   apispec
-redis==4.5.4
+redis==4.6.0
     # via apache-superset
 requests==2.31.0
     # via
@@ -351,6 +353,7 @@ tabulate==0.8.9
 typing-extensions==4.4.0
     # via
     #   apache-superset
+    #   cattrs
     #   flask-limiter
     #   limits
     #   shillelagh

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -10,8 +10,6 @@
     # via
     #   -r requirements/base.in
     #   -r requirements/development.in
-appnope==0.1.3
-    # via ipython
 astroid==2.15.8
     # via pylint
 asttokens==2.2.1
@@ -82,6 +80,10 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
+pure-sasl==0.6.2
+    # via
+    #   pyhive
+    #   thrift-sasl
 pydruid==0.6.5
     # via apache-superset
 pyhive[hive_pure_sasl]==0.7.0
@@ -105,7 +107,14 @@ tableschema==1.20.2
 tabulator==1.53.5
     # via tableschema
 thrift==0.16.0
-    # via apache-superset
+    # via
+    #   apache-superset
+    #   pyhive
+    #   thrift-sasl
+thrift-sasl==0.4.3
+    # via pyhive
+tomli==2.0.1
+    # via pylint
 tomlkit==0.11.8
     # via pylint
 traitlets==5.9.0

--- a/requirements/integration.txt
+++ b/requirements/integration.txt
@@ -52,6 +52,12 @@ pyproject-hooks==1.0.0
     # via build
 pyyaml==6.0.1
     # via pre-commit
+tomli==2.0.1
+    # via
+    #   build
+    #   pip-tools
+    #   pyproject-api
+    #   tox
 toposort==1.10
     # via pip-compile-multi
 tox==4.6.4

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -110,6 +110,8 @@ pyee==11.0.1
     # via playwright
 pyfakefs==5.2.2
     # via -r requirements/testing.in
+pyhive[presto]==0.7.0
+    # via apache-superset
 pytest==7.3.1
     # via
     #   -r requirements/testing.in

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ setup(
         "pyarrow>=14.0.1, <15",
         "pyyaml>=6.0.0, <7.0.0",
         "PyJWT>=2.4.0, <3.0",
-        "redis>=4.5.4, <5.0",
+        "redis>=4.6.0, <5.0",
         "selenium>=3.141.0, <4.10.0",
         "shillelagh[gsheetsapi]>=1.2.10, <2.0",
         "shortid",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
redis has a fixable high finding in version 4.x
CVE-2023-31655 (7.5)

Depending this webpage version 4.6.0 should not be affected https://scout.docker.com/vulnerabilities/id/CVE-2023-31655?s=pypa&n=redis&t=pypi&vr=%3D4.5.4

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://github.com/apache/superset/assets/102737855/c9eec5b3-ff05-4068-bd23-84d660ab7b33)


### TESTING INSTRUCTIONS
redis 4.6.0 is installed after this change

### ADDITIONAL INFORMATION

Hint: CVE-2023-28859⁠ (6.5) is NOT part of this pull request as it is only fixable with redis V5.x.x which is outcluded in setup.py at the moment (<5.0)
Info is based on this page: https://scout.docker.com/vulnerabilities/id/CVE-2023-28859?s=pypa&n=redis&t=pypi&vr=%3C5.0.0b1  (fixed in V5.x)

<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
