### PR TITLE
chore: update docker base image from python 3.9-buster to 3.12-slim

### DIFF
--- a/RELEASING/Dockerfile.from_local_tarball
+++ b/RELEASING/Dockerfile.from_local_tarball
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM python:3.9-buster
+FROM python:3.12-slim
 
 RUN useradd --user-group --create-home --no-log-init --shell /bin/bash superset
 

--- a/RELEASING/Dockerfile.from_svn_tarball
+++ b/RELEASING/Dockerfile.from_svn_tarball
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM python:3.9-buster
+FROM python:3.12-slim
 
 RUN useradd --user-group --create-home --no-log-init --shell /bin/bash superset
 

--- a/RELEASING/Dockerfile.make_docs
+++ b/RELEASING/Dockerfile.make_docs
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM python:3.9-buster
+FROM python:3.12-slim
 ARG VERSION
 
 RUN git clone --depth 1 --branch ${VERSION} https://github.com/apache/superset.git /superset

--- a/RELEASING/Dockerfile.make_tarball
+++ b/RELEASING/Dockerfile.make_tarball
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM python:3.9-buster
+FROM python:3.12-slim
 
 RUN apt-get update -y
 RUN apt-get install -y jq


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
The base image python 3.9 has findings which are fixed with a newer python base version
If we update to 3.12-slim 1high and 1medium would be getting fixed

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://github.com/apache/superset/assets/102737855/da791fba-2fc9-4d28-9328-d70a703c910c)


### TESTING INSTRUCTIONS
newer base image is used

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
