### PR TITLE
feat: Add comparison time label to Big Number with Time Period plugin

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/sections/index.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/sections/index.ts
@@ -23,3 +23,4 @@ export * from './annotationsAndLayers';
 export * from './forecastInterval';
 export * from './chartTitle';
 export * from './echartsTimeSeriesQuery';
+export * from './timeComparison';

--- a/superset-frontend/packages/superset-ui-chart-controls/src/sections/timeComparison.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/sections/timeComparison.tsx
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { t, ComparisonType } from '@superset-ui/core';
+
+import { ControlPanelSectionConfig } from '../types';
+
+export const timeComparisonControls: ControlPanelSectionConfig = {
+  label: t('Time Comparison'),
+  tabOverride: 'data',
+  description: t(
+    'This section contains options ' +
+      'that allow for time comparison ' +
+      'of query results using some portions of the ' +
+      'existing advanced analytics section',
+  ),
+  controlSetRows: [
+    [
+      {
+        name: 'time_compare',
+        config: {
+          type: 'SelectControl',
+          multi: true,
+          freeForm: true,
+          label: t('Time shift'),
+          choices: [
+            ['1 day ago', t('1 day ago')],
+            ['1 week ago', t('1 week ago')],
+            ['28 days ago', t('28 days ago')],
+            ['30 days ago', t('30 days ago')],
+            ['52 weeks ago', t('52 weeks ago')],
+            ['1 year ago', t('1 year ago')],
+            ['104 weeks ago', t('104 weeks ago')],
+            ['2 years ago', t('2 years ago')],
+            ['156 weeks ago', t('156 weeks ago')],
+            ['3 years ago', t('3 years ago')],
+          ],
+          description: t(
+            'Overlay one or more timeseries from a ' +
+              'relative time period. Expects relative time deltas ' +
+              'in natural language (example:  24 hours, 7 days, ' +
+              '52 weeks, 365 days). Free text is supported.',
+          ),
+        },
+      },
+    ],
+    [
+      {
+        name: 'start_date_offset',
+        config: {
+          type: 'TimeOffsetControl',
+          label: t('shift start date'),
+        },
+      },
+    ],
+    ['time_grain_sqla'],
+    [
+      {
+        name: 'comparison_type',
+        config: {
+          type: 'SelectControl',
+          label: t('Calculation type'),
+          default: 'values',
+          choices: [
+            [ComparisonType.Values, t('Actual values')],
+            [ComparisonType.Difference, t('Difference')],
+            [ComparisonType.Percentage, t('Percentage change')],
+            [ComparisonType.Ratio, t('Ratio')],
+          ],
+          description: t(
+            'How to display time shifts: as individual lines; as the ' +
+              'difference between the main time series and each time shift; ' +
+              'as the percentage change; or as the ratio between series and time shifts.',
+          ),
+        },
+      },
+    ],
+  ],
+};

--- a/superset-frontend/packages/superset-ui-chart-controls/src/sections/timeComparison.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/sections/timeComparison.tsx
@@ -20,7 +20,9 @@ import { t, ComparisonType } from '@superset-ui/core';
 
 import { ControlPanelSectionConfig } from '../types';
 
-export const timeComparisonControls: ControlPanelSectionConfig = {
+export const timeComparisonControls: (
+  multi?: boolean,
+) => ControlPanelSectionConfig = (multi = true) => ({
   label: t('Time Comparison'),
   tabOverride: 'data',
   description: t(
@@ -35,7 +37,7 @@ export const timeComparisonControls: ControlPanelSectionConfig = {
         name: 'time_compare',
         config: {
           type: 'SelectControl',
-          multi: true,
+          multi,
           freeForm: true,
           label: t('Time shift'),
           choices: [
@@ -90,5 +92,14 @@ export const timeComparisonControls: ControlPanelSectionConfig = {
         },
       },
     ],
+    [
+      {
+        name: 'comparison_range_label',
+        config: {
+          type: 'ComparisonRangeLabel',
+          multi,
+        },
+      },
+    ],
   ],
-};
+});

--- a/superset-frontend/packages/superset-ui-core/src/time-comparison/fetchTimeRange.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-comparison/fetchTimeRange.ts
@@ -17,7 +17,11 @@
  * under the License.
  */
 import rison from 'rison';
-import { SupersetClient, getClientErrorObject } from '@superset-ui/core';
+import {
+  SupersetClient,
+  getClientErrorObject,
+  ComparisonTimeRangeType,
+} from '@superset-ui/core';
 
 export const SEPARATOR = ' : ';
 
@@ -42,9 +46,17 @@ export const formatTimeRange = (
 export const fetchTimeRange = async (
   timeRange: string,
   columnPlaceholder = 'col',
+  shift?: ComparisonTimeRangeType,
 ) => {
-  const query = rison.encode_uri(timeRange);
-  const endpoint = `/api/v1/time_range/?q=${query}`;
+  let query;
+  let endpoint;
+  if (shift) {
+    query = rison.encode_uri({ base_time_range: timeRange, shift });
+    endpoint = `/api/v1/relative_time_range/?q=${query}`;
+  } else {
+    query = rison.encode_uri(timeRange);
+    endpoint = `/api/v1/time_range/?q=${query}`;
+  }
   try {
     const response = await SupersetClient.get({ endpoint });
     const timeRangeString = buildTimeRangeString(

--- a/superset-frontend/packages/superset-ui-core/src/time-comparison/fetchTimeRange.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-comparison/fetchTimeRange.ts
@@ -18,7 +18,11 @@
  */
 import rison from 'rison';
 import { isEmpty } from 'lodash';
-import { SupersetClient, getClientErrorObject } from '@superset-ui/core';
+import {
+  SupersetClient,
+  getClientErrorObject,
+  ensureIsArray,
+} from '@superset-ui/core';
 
 export const SEPARATOR = ' : ';
 
@@ -64,11 +68,11 @@ export const fetchTimeRange = async (
   let query;
   let endpoint;
   if (!isEmpty(shifts)) {
-    const timeRanges = shifts?.map(shift => ({
+    const timeRanges = ensureIsArray(shifts).map(shift => ({
       timeRange,
       shift,
     }));
-    query = rison.encode_uri([{ timeRange }, ...(timeRanges || [])]);
+    query = rison.encode_uri([{ timeRange }, ...timeRanges]);
     endpoint = `/api/v1/time_range/?q=${query}`;
   } else {
     query = rison.encode_uri(timeRange);

--- a/superset-frontend/packages/superset-ui-core/test/time-comparison/fetchTimeRange.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-comparison/fetchTimeRange.test.ts
@@ -22,6 +22,7 @@ import { fetchTimeRange } from '@superset-ui/core';
 import {
   buildTimeRangeString,
   formatTimeRange,
+  formatTimeRangeComparison,
 } from '../../src/time-comparison/fetchTimeRange';
 
 afterEach(fetchMock.restore);
@@ -147,4 +148,23 @@ it('fetchTimeRange with shift', async () => {
       'temporal_col: 2021-04-13 to 2021-04-14 vs\n  2021-03-13 to 2021-03-14',
     ],
   });
+});
+
+it('formatTimeRangeComparison', () => {
+  expect(
+    formatTimeRangeComparison(
+      '2021-04-13T00:00:00 : 2021-04-14T00:00:00',
+      '2021-03-13T00:00:00 : 2021-03-14T00:00:00',
+    ),
+  ).toEqual('col: 2021-04-13 to 2021-04-14 vs\n  2021-03-13 to 2021-03-14');
+
+  expect(
+    formatTimeRangeComparison(
+      '2021-04-13T00:00:00 : 2021-04-14T00:00:00',
+      '2021-03-13T00:00:00 : 2021-03-14T00:00:00',
+      'col_name',
+    ),
+  ).toEqual(
+    'col_name: 2021-04-13 to 2021-04-14 vs\n  2021-03-13 to 2021-03-14',
+  );
 });

--- a/superset-frontend/packages/superset-ui-core/test/time-comparison/fetchTimeRange.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-comparison/fetchTimeRange.test.ts
@@ -18,7 +18,7 @@
  */
 
 import fetchMock from 'fetch-mock';
-import { ComparisonTimeRangeType, fetchTimeRange } from '@superset-ui/core';
+import { fetchTimeRange } from '@superset-ui/core';
 import {
   buildTimeRangeString,
   formatTimeRange,

--- a/superset-frontend/packages/superset-ui-core/test/time-comparison/fetchTimeRange.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-comparison/fetchTimeRange.test.ts
@@ -18,7 +18,7 @@
  */
 
 import fetchMock from 'fetch-mock';
-import { fetchTimeRange } from '@superset-ui/core';
+import { ComparisonTimeRangeType, fetchTimeRange } from '@superset-ui/core';
 import {
   buildTimeRangeString,
   formatTimeRange,
@@ -114,5 +114,30 @@ it('returns a formatted error message from response', async () => {
   timeRange = await fetchTimeRange('Last day');
   expect(timeRange).toEqual({
     error: 'Network error',
+  });
+});
+
+it('fetchTimeRange with shift', async () => {
+  fetchMock.getOnce(
+    "glob:*/api/v1/relative_time_range/?q=(base_time_range:'Last+day',shift%3Am)",
+    {
+      result: [
+        {
+          since: '2021-04-13T00:00:00',
+          until: '2021-04-14T00:00:00',
+          timeRange: 'Last day',
+        },
+      ],
+    },
+  );
+
+  const timeRange = await fetchTimeRange(
+    'Last day',
+    'temporal_col',
+    ComparisonTimeRangeType.Month,
+  );
+
+  expect(timeRange).toEqual({
+    value: '2021-04-13 ≤ temporal_col < 2021-04-14',
   });
 });

--- a/superset-frontend/packages/superset-ui-core/test/time-comparison/fetchTimeRange.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-comparison/fetchTimeRange.test.ts
@@ -119,25 +119,32 @@ it('returns a formatted error message from response', async () => {
 
 it('fetchTimeRange with shift', async () => {
   fetchMock.getOnce(
-    "glob:*/api/v1/relative_time_range/?q=(base_time_range:'Last+day',shift%3Am)",
+    "glob:*/api/v1/time_range/?q=!((timeRange:'Last+day'),(shift%3A'last%20month'%2CtimeRange%3A'Last%20day'))",
     {
       result: [
         {
           since: '2021-04-13T00:00:00',
           until: '2021-04-14T00:00:00',
           timeRange: 'Last day',
+          shift: null,
+        },
+        {
+          since: '2021-03-13T00:00:00',
+          until: '2021-03-14T00:00:00',
+          timeRange: 'Last day',
+          shift: 'last month',
         },
       ],
     },
   );
 
-  const timeRange = await fetchTimeRange(
-    'Last day',
-    'temporal_col',
-    ComparisonTimeRangeType.Month,
-  );
+  const timeRange = await fetchTimeRange('Last day', 'temporal_col', [
+    'last month',
+  ]);
 
   expect(timeRange).toEqual({
-    value: '2021-04-13 ≤ temporal_col < 2021-04-14',
+    value: [
+      'temporal_col: 2021-04-13 to 2021-04-14 vs\n  2021-03-13 to 2021-03-14',
+    ],
   });
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/buildQuery.ts
@@ -18,50 +18,38 @@
  */
 import {
   buildQueryContext,
-  getComparisonInfo,
-  ComparisonTimeRangeType,
   QueryFormData,
+  PostProcessingRule,
 } from '@superset-ui/core';
+import {
+  isTimeComparison,
+  timeCompareOperator,
+} from '@superset-ui/chart-controls';
 
 export default function buildQuery(formData: QueryFormData) {
-  const {
-    cols: groupby,
-    time_comparison: timeComparison,
-    extra_form_data: extraFormData,
-  } = formData;
+  const { cols: groupby, time_grain_sqla } = formData;
 
-  const queryContextA = buildQueryContext(formData, baseQueryObject => [
-    {
-      ...baseQueryObject,
-      groupby,
-    },
-  ]);
-
-  const comparisonFormData = getComparisonInfo(
-    formData,
-    timeComparison,
-    extraFormData,
-  );
-
-  const queryContextB = buildQueryContext(
-    comparisonFormData,
-    baseQueryObject => [
+  return buildQueryContext(formData, baseQueryObject => {
+    const postProcessing: PostProcessingRule[] = [];
+    postProcessing.push(timeCompareOperator(formData, baseQueryObject));
+    return [
       {
         ...baseQueryObject,
+        columns: [
+          {
+            timeGrain: time_grain_sqla || 'P1Y', // Group by year by default
+            columnType: 'BASE_AXIS',
+            sqlExpression: baseQueryObject.filters?.[0]?.col.toString() || '',
+            label: baseQueryObject.filters?.[0]?.col.toString() || '',
+            expressionType: 'SQL',
+          },
+        ],
         groupby,
-        extras: {
-          ...baseQueryObject.extras,
-          instant_time_comparison_range:
-            timeComparison !== ComparisonTimeRangeType.Custom
-              ? timeComparison
-              : undefined,
-        },
+        post_processing: postProcessing,
+        time_offsets: isTimeComparison(formData, baseQueryObject)
+          ? formData.time_compare
+          : [],
       },
-    ],
-  );
-
-  return {
-    ...queryContextA,
-    queries: [...queryContextA.queries, ...queryContextB.queries],
-  };
+    ];
+  });
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/buildQuery.ts
@@ -20,6 +20,7 @@ import {
   buildQueryContext,
   QueryFormData,
   PostProcessingRule,
+  ensureIsArray,
 } from '@superset-ui/core';
 import {
   isTimeComparison,
@@ -47,7 +48,7 @@ export default function buildQuery(formData: QueryFormData) {
         groupby,
         post_processing: postProcessing,
         time_offsets: isTimeComparison(formData, baseQueryObject)
-          ? formData.time_compare
+          ? ensureIsArray(formData.time_compare)
           : [],
       },
     ];

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/controlPanel.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/controlPanel.ts
@@ -16,20 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { t } from '@superset-ui/core';
 import {
-  AdhocFilter,
-  ComparisonTimeRangeType,
-  SimpleAdhocFilter,
-  t,
-  validateTimeComparisonRangeValues,
-} from '@superset-ui/core';
-import {
-  ColumnMeta,
   ControlPanelConfig,
-  ControlPanelState,
-  ControlState,
   getStandardizedControls,
   sharedControls,
+  sections,
 } from '@superset-ui/chart-controls';
 import { headerFontSize, subheaderFontSize } from '../sharedControls';
 import { ColorSchemeEnum } from './types';
@@ -42,76 +34,6 @@ const config: ControlPanelConfig = {
       controlSetRows: [
         ['metric'],
         ['adhoc_filters'],
-        [
-          {
-            name: 'time_comparison',
-            config: {
-              type: 'SelectControl',
-              label: t('Range for Comparison'),
-              default: 'r',
-              choices: [
-                ['r', 'Inherit range from time filters'],
-                ['y', 'Year'],
-                ['m', 'Month'],
-                ['w', 'Week'],
-                ['c', 'Custom'],
-              ],
-              rerender: ['adhoc_custom'],
-              description: t(
-                'Set the time range that will be used for the comparison metrics. ' +
-                  'For example, "Year" will compare to the same dates one year earlier. ' +
-                  'Use "Inherit range from time filters" to shift the comparison time range' +
-                  'by the same length as your time range and use "Custom" to set a custom comparison range.',
-              ),
-            },
-          },
-        ],
-        [
-          {
-            name: `adhoc_custom`,
-            config: {
-              ...sharedControls.adhoc_filters,
-              label: t('Filters for Comparison'),
-              description:
-                'This only applies when selecting the Range for Comparison Type: Custom',
-              visibility: ({ controls }) =>
-                controls?.time_comparison?.value ===
-                ComparisonTimeRangeType.Custom,
-              mapStateToProps: (
-                state: ControlPanelState,
-                controlState: ControlState,
-              ) => {
-                const originalMapStateToPropsRes =
-                  sharedControls.adhoc_filters.mapStateToProps?.(
-                    state,
-                    controlState,
-                  ) || {};
-                const columns = originalMapStateToPropsRes.columns.filter(
-                  (col: ColumnMeta) =>
-                    col.is_dttm &&
-                    (state.controls.adhoc_filters.value as AdhocFilter[]).some(
-                      (val: SimpleAdhocFilter) =>
-                        val.subject === col.column_name,
-                    ),
-                );
-                return {
-                  ...originalMapStateToPropsRes,
-                  columns,
-                  externalValidationErrors: validateTimeComparisonRangeValues(
-                    state.controls?.time_comparison?.value,
-                    controlState.value,
-                  ),
-                };
-              },
-            },
-          },
-        ],
-        [
-          {
-            name: 'comparison_range_label',
-            config: { type: 'ComparisonRangeLabel' },
-          },
-        ],
         [
           {
             name: 'row_limit',
@@ -186,13 +108,25 @@ const config: ControlPanelConfig = {
         ],
       ],
     },
+    {
+      ...sections.timeComparisonControls,
+      controlSetRows: [
+        ...sections.timeComparisonControls.controlSetRows,
+        [
+          {
+            name: 'comparison_range_label',
+            config: {
+              type: 'ComparisonRangeLabel',
+              multi: false,
+            },
+          },
+        ],
+      ],
+    },
   ],
   controlOverrides: {
     y_axis_format: {
       label: t('Number format'),
-    },
-    adhoc_filters: {
-      rerender: ['adhoc_custom'],
     },
   },
   formDataOverrides: formData => ({

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/controlPanel.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/controlPanel.ts
@@ -108,6 +108,12 @@ const config: ControlPanelConfig = {
         ],
         [
           {
+            name: 'comparison_range_label',
+            config: { type: 'ComparisonRangeLabel' },
+          },
+        ],
+        [
+          {
             name: 'row_limit',
             config: sharedControls.row_limit,
           },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/controlPanel.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/controlPanel.ts
@@ -108,21 +108,7 @@ const config: ControlPanelConfig = {
         ],
       ],
     },
-    {
-      ...sections.timeComparisonControls,
-      controlSetRows: [
-        ...sections.timeComparisonControls.controlSetRows,
-        [
-          {
-            name: 'comparison_range_label',
-            config: {
-              type: 'ComparisonRangeLabel',
-              multi: false,
-            },
-          },
-        ],
-      ],
-    },
+    sections.timeComparisonControls(false),
   ],
   controlOverrides: {
     y_axis_format: {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
@@ -22,7 +22,7 @@ import {
   getMetricLabel,
   getValueFormatter,
   getNumberFormatter,
-  formatTimeRange,
+  SimpleAdhocFilter,
 } from '@superset-ui/core';
 import { getComparisonFontSize, getHeaderFontSize } from './utils';
 
@@ -86,18 +86,33 @@ export default function transformProps(chartProps: ChartProps) {
     comparisonColorEnabled,
     percentDifferenceFormat,
   } = formData;
-  const { data: dataA = [] } = queriesData[0];
-  const {
-    data: dataB = [],
-    from_dttm: comparisonFromDatetime,
-    to_dttm: comparisonToDatetime,
-  } = queriesData[1];
-  const data = dataA;
+  const { data = [] } = queriesData[0];
   const metricName = getMetricLabel(metric);
+  const timeComparison = chartProps.rawFormData?.time_compare?.[0];
+  const startDateOffset = chartProps.rawFormData?.start_date_offset;
+  const currentTimeRangeFilter = chartProps.rawFormData?.adhoc_filters?.filter(
+    (adhoc_filter: SimpleAdhocFilter) =>
+      adhoc_filter.operator === 'TEMPORAL_RANGE',
+  )?.[0];
+
+  const { value1, value2 } = data.reduce(
+    (acc: { value1: number; value2: number }, curr: { [x: string]: any }) => {
+      Object.keys(curr).forEach(key => {
+        if (key.includes(`${metricName}__${timeComparison}`)) {
+          acc.value2 += curr[key];
+        } else if (key.includes(metricName)) {
+          acc.value1 += curr[key];
+        }
+      });
+      return acc;
+    },
+    { value1: 0, value2: 0 },
+  );
+
   let bigNumber: number | string =
-    data.length === 0 ? 0 : parseMetricValue(data[0][metricName]);
+    data.length === 0 ? 0 : parseMetricValue(value1);
   let prevNumber: number | string =
-    data.length === 0 ? 0 : parseMetricValue(dataB[0][metricName]);
+    data.length === 0 ? 0 : parseMetricValue(value2);
 
   const numberFormatter = getValueFormatter(
     metric,
@@ -133,10 +148,6 @@ export default function transformProps(chartProps: ChartProps) {
   prevNumber = numberFormatter(prevNumber);
   valueDifference = numberFormatter(valueDifference);
   const percentDifference: string = formatPercentChange(percentDifferenceNum);
-  const comparatorText = formatTimeRange('%Y-%m-%d', [
-    comparisonFromDatetime,
-    comparisonToDatetime,
-  ]);
 
   return {
     width,
@@ -155,6 +166,8 @@ export default function transformProps(chartProps: ChartProps) {
     comparisonColorEnabled,
     comparisonColorScheme,
     percentDifferenceNumber: percentDifferenceNum,
-    comparatorText,
+    currentTimeRangeFilter,
+    startDateOffset,
+    shift: timeComparison,
   };
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
@@ -23,6 +23,7 @@ import {
   getValueFormatter,
   getNumberFormatter,
   SimpleAdhocFilter,
+  ensureIsArray,
 } from '@superset-ui/core';
 import { getComparisonFontSize, getHeaderFontSize } from './utils';
 
@@ -88,7 +89,7 @@ export default function transformProps(chartProps: ChartProps) {
   } = formData;
   const { data = [] } = queriesData[0];
   const metricName = getMetricLabel(metric);
-  const timeComparison = chartProps.rawFormData?.time_compare?.[0];
+  const timeComparison = ensureIsArray(chartProps.rawFormData?.time_compare)[0];
   const startDateOffset = chartProps.rawFormData?.start_date_offset;
   const currentTimeRangeFilter = chartProps.rawFormData?.adhoc_filters?.filter(
     (adhoc_filter: SimpleAdhocFilter) =>

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/types.ts
@@ -21,6 +21,7 @@ import {
   supersetTheme,
   TimeseriesDataRecord,
   Metric,
+  SimpleAdhocFilter,
 } from '@superset-ui/core';
 
 export interface PopKPIStylesProps {
@@ -62,6 +63,9 @@ export type PopKPIProps = PopKPIStylesProps &
     percentDifferenceNumber: number;
     comparatorText: string;
     comparisonColorScheme?: string;
+    currentTimeRangeFilter?: SimpleAdhocFilter;
+    startDateOffset?: string;
+    shift: string;
   };
 
 export enum ColorSchemeEnum {

--- a/superset-frontend/src/explore/components/controls/ComparisonRangeLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/ComparisonRangeLabel.tsx
@@ -24,6 +24,7 @@ import moment from 'moment';
 import {
   BinaryAdhocFilter,
   css,
+  ensureIsArray,
   fetchTimeRange,
   SimpleAdhocFilter,
   t,
@@ -62,23 +63,27 @@ export const ComparisonRangeLabel = ({
   );
 
   useEffect(() => {
-    if (isEmpty(currentTimeRangeFilters) || (isEmpty(shifts) && !startDate)) {
+    const shiftsArray = ensureIsArray(shifts);
+    if (
+      isEmpty(currentTimeRangeFilters) ||
+      (isEmpty(shiftsArray) && !startDate)
+    ) {
       setLabels([]);
-    } else if (!isEmpty(shifts) || startDate) {
+    } else if (!isEmpty(shiftsArray) || startDate) {
       const promises = currentTimeRangeFilters.map(filter => {
         const startDateShift = moment(
           (filter as any).comparator.split(' : ')[0],
         ).diff(moment(startDate), 'days');
         const newShift = startDateShift
           ? [`${startDateShift} days ago`]
-          : shifts
-            ? shifts.slice(0, 1)
+          : shiftsArray
+            ? shiftsArray.slice(0, 1)
             : undefined;
 
         return fetchTimeRange(
           filter.comparator,
           filter.subject,
-          multi ? shifts : newShift,
+          multi ? shiftsArray : newShift,
         );
       });
       Promise.all(promises).then(res => {

--- a/superset-frontend/src/explore/components/controls/ComparisonRangeLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/ComparisonRangeLabel.tsx
@@ -28,6 +28,7 @@ import {
   t,
   fetchTimeRange,
 } from '@superset-ui/core';
+import ControlHeader from 'src/explore/components/ControlHeader';
 import { RootState } from 'src/views/store';
 import { Tooltip } from 'src/components/Tooltip';
 
@@ -84,7 +85,8 @@ export const ComparisonRangeLabel = () => {
   }, [currentTimeRangeFilters, shift]);
 
   return labels.length ? (
-    <Tooltip title={t('Actual time range for comparison')}>
+    <>
+      <ControlHeader label={t('Actual range for comparison')} />
       {labels.map((label, index) => (
         <div
           css={theme => css`
@@ -97,6 +99,6 @@ export const ComparisonRangeLabel = () => {
           {index < labels.length - 1 ? ',' : ''}
         </div>
       ))}
-    </Tooltip>
+    </>
   ) : null;
 };

--- a/superset-frontend/src/explore/components/controls/ComparisonRangeLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/ComparisonRangeLabel.tsx
@@ -83,19 +83,20 @@ export const ComparisonRangeLabel = () => {
     }
   }, [currentTimeRangeFilters, shift]);
 
-  return labels.length
-    ? labels.map((label, index) => (
-        <Tooltip title={t('Actual time range for comparison')} key={index}>
-          <div
-            css={theme => css`
-              font-size: ${theme.typography.sizes.m}px;
-              color: ${theme.colors.grayscale.dark1};
-            `}
-          >
-            {label}
-            {index < labels.length - 1 ? ',' : ''}
-          </div>
-        </Tooltip>
-      ))
-    : null;
+  return labels.length ? (
+    <Tooltip title={t('Actual time range for comparison')}>
+      {labels.map((label, index) => (
+        <div
+          css={theme => css`
+            font-size: ${theme.typography.sizes.m}px;
+            color: ${theme.colors.grayscale.dark1};
+          `}
+          key={index}
+        >
+          {label}
+          {index < labels.length - 1 ? ',' : ''}
+        </div>
+      ))}
+    </Tooltip>
+  ) : null;
 };

--- a/superset-frontend/src/explore/components/controls/ComparisonRangeLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/ComparisonRangeLabel.tsx
@@ -30,7 +30,6 @@ import {
 } from '@superset-ui/core';
 import ControlHeader from 'src/explore/components/ControlHeader';
 import { RootState } from 'src/views/store';
-import { Tooltip } from 'src/components/Tooltip';
 
 const isTimeRangeEqual = (
   left: BinaryAdhocFilter[],

--- a/superset-frontend/src/explore/components/controls/ComparisonRangeLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/ComparisonRangeLabel.tsx
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import {
+  ComparisonTimeRangeType,
+  css,
+  SimpleAdhocFilter,
+  t,
+  fetchTimeRange,
+} from '@superset-ui/core';
+import { RootState } from 'src/views/store';
+import { Tooltip } from 'src/components/Tooltip';
+
+export const ComparisonRangeLabel = () => {
+  const [label, setLabel] = useState('');
+  const currentTimeRange = useSelector<RootState, string>(
+    state =>
+      state.explore.form_data.adhoc_filters.filter(
+        (adhoc_filter: SimpleAdhocFilter) =>
+          adhoc_filter.operator === 'TEMPORAL_RANGE',
+      )[0]?.comparator,
+  );
+  const shift = useSelector<RootState, ComparisonTimeRangeType>(
+    state => state.explore.form_data.time_comparison,
+  );
+
+  useEffect(() => {
+    if (shift === ComparisonTimeRangeType.Custom) {
+      setLabel('');
+    }
+  }, [shift]);
+
+  useEffect(() => {
+    if (shift !== ComparisonTimeRangeType.Custom) {
+      fetchTimeRange(currentTimeRange, 'col', shift).then(res => {
+        setLabel(res.value ?? '');
+      });
+    }
+  }, [currentTimeRange, shift]);
+
+  return label ? (
+    <Tooltip title={t('Actual time range for comparison')}>
+      <span
+        css={theme => css`
+          font-size: ${theme.typography.sizes.m}px;
+          color: ${theme.colors.grayscale.base};
+        `}
+      >
+        {label}
+      </span>
+    </Tooltip>
+  ) : null;
+};

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/utils/dateFilterUtils.ts
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/utils/dateFilterUtils.ts
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 import { NO_TIME_RANGE, JsonObject } from '@superset-ui/core';
 import { useSelector } from 'react-redux';
 import {

--- a/superset-frontend/src/explore/components/controls/TimeOffsetControl.tsx
+++ b/superset-frontend/src/explore/components/controls/TimeOffsetControl.tsx
@@ -1,0 +1,112 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { ReactNode } from 'react';
+import { isEqual } from 'lodash';
+import moment, { Moment } from 'moment';
+import { BinaryAdhocFilter, SimpleAdhocFilter, css } from '@superset-ui/core';
+import { DatePicker } from 'antd';
+import { RangePickerProps } from 'antd/lib/date-picker';
+import { useSelector } from 'react-redux';
+
+import ControlHeader from 'src/explore/components/ControlHeader';
+import { RootState } from 'src/views/store';
+
+export interface TimeOffsetControlProps {
+  label?: ReactNode;
+  startDate?: string;
+  description?: string;
+  hovered?: boolean;
+  value?: Moment;
+  onChange: (datetime: string) => void;
+}
+const MOMENT_FORMAT = 'YYYY-MM-DD';
+const dttmToMoment = (dttm: string): Moment => {
+  if (dttm === 'now') {
+    return moment().utc().startOf('second');
+  }
+  if (dttm === 'today' || dttm === 'No filter') {
+    return moment().utc().startOf('day');
+  }
+  if (dttm === 'last week') {
+    return moment().utc().startOf('day').subtract(7, 'day');
+  }
+  if (dttm === 'last month') {
+    return moment().utc().startOf('day').subtract(1, 'month');
+  }
+  if (dttm === 'last quarter') {
+    return moment().utc().startOf('day').subtract(1, 'quarter');
+  }
+  if (dttm === 'last year') {
+    return moment().utc().startOf('day').subtract(1, 'year');
+  }
+  if (dttm === 'previous calendar week') {
+    return moment().utc().subtract(1, 'weeks').startOf('isoWeek');
+  }
+  if (dttm === 'previous calendar month') {
+    return moment().utc().subtract(1, 'months').startOf('month');
+  }
+  if (dttm === 'previous calendar year') {
+    return moment().utc().subtract(1, 'years').startOf('year');
+  }
+
+  return moment(dttm);
+};
+const isTimeRangeEqual = (
+  left: BinaryAdhocFilter[],
+  right: BinaryAdhocFilter[],
+) => isEqual(left, right);
+
+export default function TimeOffsetControl({
+  onChange,
+  ...props
+}: TimeOffsetControlProps) {
+  const currentTimeRangeFilters = useSelector<RootState, BinaryAdhocFilter[]>(
+    state =>
+      state.explore.form_data.adhoc_filters.filter(
+        (adhoc_filter: SimpleAdhocFilter) =>
+          adhoc_filter.operator === 'TEMPORAL_RANGE',
+      ),
+    isTimeRangeEqual,
+  );
+  const startDate = currentTimeRangeFilters[0]?.comparator.split(' : ')[0];
+
+  const formatedDate = startDate
+    ? dttmToMoment(startDate)
+    : dttmToMoment('now');
+  const disabledDate: RangePickerProps['disabledDate'] = current =>
+    current && current >= formatedDate;
+
+  return (
+    <div>
+      <ControlHeader {...props} />
+      <DatePicker
+        css={css`
+          width: 100%;
+        `}
+        onChange={(datetime: Moment) =>
+          onChange(datetime ? datetime.format(MOMENT_FORMAT) : '')
+        }
+        defaultPickerValue={
+          startDate ? moment(formatedDate).subtract(1, 'day') : undefined
+        }
+        disabledDate={disabledDate}
+      />
+    </div>
+  );
+}

--- a/superset-frontend/src/explore/components/controls/index.js
+++ b/superset-frontend/src/explore/components/controls/index.js
@@ -48,6 +48,7 @@ import DndColumnSelectControl, {
 import XAxisSortControl from './XAxisSortControl';
 import CurrencyControl from './CurrencyControl';
 import ColumnConfigControl from './ColumnConfigControl';
+import { ComparisonRangeLabel } from './ComparisonRangeLabel';
 
 const controlMap = {
   AnnotationLayerControl,
@@ -80,6 +81,7 @@ const controlMap = {
   ConditionalFormattingControl,
   XAxisSortControl,
   ContourControl,
+  ComparisonRangeLabel,
   ...sharedControlComponents,
 };
 export default controlMap;

--- a/superset-frontend/src/explore/components/controls/index.js
+++ b/superset-frontend/src/explore/components/controls/index.js
@@ -49,6 +49,7 @@ import XAxisSortControl from './XAxisSortControl';
 import CurrencyControl from './CurrencyControl';
 import ColumnConfigControl from './ColumnConfigControl';
 import { ComparisonRangeLabel } from './ComparisonRangeLabel';
+import TimeOffsetControl from './TimeOffsetControl';
 
 const controlMap = {
   AnnotationLayerControl,
@@ -82,6 +83,7 @@ const controlMap = {
   XAxisSortControl,
   ContourControl,
   ComparisonRangeLabel,
+  TimeOffsetControl,
   ...sharedControlComponents,
 };
 export default controlMap;

--- a/superset/views/api.py
+++ b/superset/views/api.py
@@ -41,10 +41,6 @@ if TYPE_CHECKING:
     from superset.common.query_context_factory import QueryContextFactory
 
 
-get_relative_time_range_schema = {
-    "type": "object",
-    "properties": {"base_time_range": {"type": "string"}, "shift": {"type": "string"}},
-}
 get_time_range_schema = {
     "type": ["string", "array"],
     "items": {

--- a/superset/views/api.py
+++ b/superset/views/api.py
@@ -142,12 +142,14 @@ class Api(BaseSupersetView):
             since, until = get_since_until(
                 time_range=base_time_range, instant_time_comparison_range=shift
             )
-            result = {
-                "since": since.isoformat() if since else "",
-                "until": until.isoformat() if until else "",
-                "baseTimeRange": base_time_range,
-                "shift": shift,
-            }
+            result = [
+                {
+                    "since": since.isoformat() if since else "",
+                    "until": until.isoformat() if until else "",
+                    "baseTimeRange": base_time_range,
+                    "shift": shift,
+                }
+            ]
             return self.json_response({"result": result})
         except (ValueError, TimeRangeParseFailError, TimeRangeAmbiguousError) as error:
             error_msg = {"message": _("Unexpected time range: %(error)s", error=error)}

--- a/superset/views/api.py
+++ b/superset/views/api.py
@@ -131,7 +131,7 @@ class Api(BaseSupersetView):
     @api
     @handle_api_exception
     @has_access_api
-    @rison(ger_relative_time_range_schema)
+    @rison(get_relative_time_range_schema)
     @expose("/v1/relative_time_range/", methods=("GET",))
     def relative_time_range(self, **kwargs: Any) -> FlaskResponse:
         """Get actual time range shifted by InstantTimeComparison value from

--- a/superset/views/api.py
+++ b/superset/views/api.py
@@ -115,42 +115,19 @@ class Api(BaseSupersetView):
 
             rv = []
             for time_range in time_ranges:
-                since, until = get_since_until(time_range["timeRange"])
+                since, until = get_since_until(
+                    time_range=time_range["timeRange"],
+                    time_shift=time_range.get("shift"),
+                )
                 rv.append(
                     {
                         "since": since.isoformat() if since else "",
                         "until": until.isoformat() if until else "",
                         "timeRange": time_range["timeRange"],
+                        "shift": time_range.get("shift"),
                     }
                 )
             return self.json_response({"result": rv})
-        except (ValueError, TimeRangeParseFailError, TimeRangeAmbiguousError) as error:
-            error_msg = {"message": _("Unexpected time range: %(error)s", error=error)}
-            return self.json_response(error_msg, 400)
-
-    @api
-    @handle_api_exception
-    @has_access_api
-    @rison(get_relative_time_range_schema)
-    @expose("/v1/relative_time_range/", methods=("GET",))
-    def relative_time_range(self, **kwargs: Any) -> FlaskResponse:
-        """Get actual time range shifted by InstantTimeComparison value from
-        human-readable string or datetime expression.
-        Accepted values for shift - constants.py::InstantTimeComparison"""
-        base_time_range, shift = kwargs["rison"].values()
-        try:
-            since, until = get_since_until(
-                time_range=base_time_range, instant_time_comparison_range=shift
-            )
-            result = [
-                {
-                    "since": since.isoformat() if since else "",
-                    "until": until.isoformat() if until else "",
-                    "baseTimeRange": base_time_range,
-                    "shift": shift,
-                }
-            ]
-            return self.json_response({"result": result})
         except (ValueError, TimeRangeParseFailError, TimeRangeAmbiguousError) as error:
             error_msg = {"message": _("Unexpected time range: %(error)s", error=error)}
             return self.json_response(error_msg, 400)

--- a/superset/views/api.py
+++ b/superset/views/api.py
@@ -134,7 +134,9 @@ class Api(BaseSupersetView):
     @rison(ger_relative_time_range_schema)
     @expose("/v1/relative_time_range/", methods=("GET",))
     def relative_time_range(self, **kwargs: Any) -> FlaskResponse:
-        """Get actually time range from human-readable string or datetime expression."""
+        """Get actual time range shifted by InstantTimeComparison value from
+        human-readable string or datetime expression.
+        Accepted values for shift - constants.py::InstantTimeComparison"""
         base_time_range, shift = kwargs["rison"].values()
         try:
             since, until = get_since_until(

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -1505,7 +1505,7 @@ class TestChartApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
         rv = self.client.get(uri)
         data = json.loads(rv.data.decode("utf-8"))
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(len(data["result"]), 4)
+        self.assertEqual(len(data["result"][0]), 4)
 
     def test_query_form_data(self):
         """

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -31,6 +31,7 @@ from sqlalchemy.sql import func
 from superset.commands.chart.data.get_data_command import ChartDataCommand
 from superset.commands.chart.exceptions import ChartDataQueryFailedError
 from superset.connectors.sqla.models import SqlaTable
+from superset.constants import InstantTimeComparison
 from superset.extensions import cache_manager, db, security_manager
 from superset.models.core import Database, FavStar, FavStarClassName
 from superset.models.dashboard import Dashboard
@@ -1491,6 +1492,20 @@ class TestChartApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
         assert "since" in data["result"][0]
         assert "until" in data["result"][0]
         assert "timeRange" in data["result"][0]
+
+    def test_get_relative_time_range(self):
+        """
+        Chart API: Test get shifted time range from human readable string
+        """
+        self.login(username="admin")
+        humanize_time_range = "100 years ago : now"
+        shift = InstantTimeComparison.YEAR
+
+        uri = f'api/v1/relative_time_range/?q={prison.dumps({ "base_time_range": humanize_time_range, "shift": shift })}'
+        rv = self.client.get(uri)
+        data = json.loads(rv.data.decode("utf-8"))
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(len(data["result"]), 4)
 
     def test_query_form_data(self):
         """

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -1493,19 +1493,19 @@ class TestChartApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
         assert "until" in data["result"][0]
         assert "timeRange" in data["result"][0]
 
-    def test_get_relative_time_range(self):
-        """
-        Chart API: Test get shifted time range from human readable string
-        """
-        self.login(username="admin")
-        humanize_time_range = "100 years ago : now"
-        shift = InstantTimeComparison.YEAR
-
-        uri = f'api/v1/relative_time_range/?q={prison.dumps({ "base_time_range": humanize_time_range, "shift": shift })}'
+        humanize_time_range = [
+            {"timeRange": "2021-01-01 : 2022-02-01", "shift": "1 year ago"},
+            {"timeRange": "2022-01-01 : 2023-02-01", "shift": "2 year ago"},
+        ]
+        uri = f"api/v1/time_range/?q={prison.dumps(humanize_time_range)}"
         rv = self.client.get(uri)
         data = json.loads(rv.data.decode("utf-8"))
-        self.assertEqual(rv.status_code, 200)
-        self.assertEqual(len(data["result"][0]), 4)
+        assert rv.status_code == 200
+        assert len(data["result"]) == 2
+        assert "since" in data["result"][0]
+        assert "until" in data["result"][0]
+        assert "timeRange" in data["result"][0]
+        assert "shift" in data["result"][0]
 
     def test_query_form_data(self):
         """


### PR DESCRIPTION
### SUMMARY
Add a custom control to Big Number with Time Period Comparison plugin, which adds a label with actual time range for comparison below the range for comparison selector.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://github.com/apache/superset/assets/15073128/2829e113-c320-451f-aa27-45a24f8ec7cc


### TESTING INSTRUCTIONS
1. Create a Big Number with Time Period Comparison chart
2. Add some time filter
3. Select range for comparison
4. Verify that the label updates whenever the time filter or range for comparison changes
5. Run query
6. Verify that the label matches the time filter in second query

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
