### PR TITLE
fix(docs site): Opening up CSP for 3rd party frame content.

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -261,6 +261,7 @@ const config = {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
       },
+      metadata: [{name: 'Content-Security-Policy', content: "default-src 'self'; frame-src 'https://calendar.google.com/' 'https://preset.io/' 'https://sidebar.bugherd.com/';"}],
     }),
   scripts: [
     '/script/matomo.js',


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Opens up the CSP for the Superset website to allow connections for embedded frame content. Allows Preset.io (for Superset Community Newsletters), Google (for the Community Calendar) and for BugHerd (docs issue ticketing).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:

<img width="963" alt="image" src="https://github.com/apache/superset/assets/812905/167ee985-4109-47cf-81f8-77193a66acb0">

After:

<img width="885" alt="image" src="https://github.com/apache/superset/assets/812905/d8a25e45-9306-447d-868a-9c11e5f41438">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
