### PR TITLE
fix(alerts/reports): implementing custom_width as an Antd number input

### DIFF
--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -1549,7 +1549,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                 <InputNumber
                   type="number"
                   name="custom_width"
-                  value={currentAlert?.custom_width ?? null}
+                  value={currentAlert?.custom_width || undefined}
                   min={600}
                   max={2400}
                   placeholder={t('Input custom width in pixels')}

--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -873,7 +873,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
     updateAlertState(name, parsedValue);
   };
 
-  const onCustomWidthChange = (value: number | null) => {
+  const onCustomWidthChange = (value: number | null | undefined) => {
     updateAlertState('custom_width', value);
   };
 
@@ -1549,7 +1549,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                 <InputNumber
                   type="number"
                   name="custom_width"
-                  value={currentAlert?.custom_width}
+                  value={currentAlert?.custom_width ?? null}
                   min={600}
                   max={2400}
                   placeholder={t('Input custom width in pixels')}

--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -36,7 +36,7 @@ import {
 import rison from 'rison';
 import { useSingleViewResource } from 'src/views/CRUD/hooks';
 
-import { Input } from 'src/components/Input';
+import { InputNumber } from 'src/components/Input';
 import { Switch } from 'src/components/Switch';
 import Modal from 'src/components/Modal';
 import Collapse from 'src/components/Collapse';
@@ -873,6 +873,10 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
     updateAlertState(name, parsedValue);
   };
 
+  const onCustomWidthChange = (value: number | null) => {
+    updateAlertState('custom_width', value);
+  };
+
   const onTimeoutVerifyChange = (
     event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,
   ) => {
@@ -1542,12 +1546,14 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
             >
               <div className="control-label">{t('Screenshot width')}</div>
               <div className="input-container">
-                <Input
+                <InputNumber
                   type="number"
                   name="custom_width"
-                  value={currentAlert?.custom_width || ''}
+                  value={currentAlert?.custom_width}
+                  min={600}
+                  max={2400}
                   placeholder={t('Input custom width in pixels')}
-                  onChange={onInputChange}
+                  onChange={onCustomWidthChange}
                 />
               </div>
             </StyledInputContainer>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The behavior of the custom_width input on alerts and reports used to be a numeric input. This PR implements the antd NumberInput behavior. It also implements min and max at 600 and 2400x to prevent users from inputting invalid values.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
https://www.loom.com/share/05786eb33da74f3385f8e08fc0bb6427?sid=21aa2e2b-5cc4-4075-aae4-72cc9ce13217

After:
https://www.loom.com/share/cadf7b979abb48e79afd75893fb80f0e?sid=81bae2c6-b553-4725-a8dc-f4104820f665

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Create or open an existing alert or report. Ensure that the custom width input is a numeric input.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Required feature flags: ALERTS_REPORTS=true
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
