### PR TITLE
fix: docker CI job doesn't trigger on master

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         build_preset: |
-          ${{ fromJson(github.event_name == 'pull_request' ? '["ci"]' : '["dev", "lean", "py310", "websocket", "dockerize"]') }}
+          ${{ fromJson(github.event_name === 'pull_request' ? '["ci"]' : '["dev", "lean", "py310", "websocket", "dockerize"]') }}
       fail-fast: false
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,13 +13,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  setup_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix_config: ${{ steps.set_matrix.outputs.matrix_config }}
+    steps:
+      - id: set_matrix
+        run: |
+          MATRIX_CONFIG=$(if [ "${{ github.event_name }}" == "pull_request" ]; then echo '["ci"]'; else echo '["dev", "lean", "py310", "websocket", "dockerize"]'; fi)
+          echo "matrix_config=${MATRIX_CONFIG}" >> $GITHUB_OUTPUT
+          echo $GITHUB_OUTPUT
+
   docker-build:
     name: docker-build
+    needs: setup_matrix
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        build_preset: |
-          ${{ fromJson(github.event_name == 'pull_request' ? "[\"ci\"]" : "[\"dev\", \"lean\", \"py310\", \"websocket\", \"dockerize\"]") }}
+        build_preset: ${{fromJson(needs.setup_matrix.outputs.matrix_config)}}
       fail-fast: false
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         build_preset: |
-          ${{ fromJson(github.event_name === 'pull_request' ? '["ci"]' : '["dev", "lean", "py310", "websocket", "dockerize"]') }}
+          ${{ fromJson(github.event_name == 'pull_request' ? "[\"ci\"]" : "[\"dev\", \"lean\", \"py310\", \"websocket\", \"dockerize\"]") }}
       fail-fast: false
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"

--- a/.github/workflows/no-op.yml
+++ b/.github/workflows/no-op.yml
@@ -52,20 +52,3 @@ jobs:
         run: |
           echo "This is a no-op step for python-lint to ensure a successful status."
           exit 0
-  # section to be deleted after master merge
-  docker-build:
-    strategy:
-      matrix:
-        build_preset: ["dev", "lean", "py310", "websocket", "dockerize"]
-        platform: ["linux/amd64", "linux/arm64"]
-        exclude:
-          - build_preset: "dev"
-            platform: "linux/arm64"
-          - build_preset: "lean"
-            platform: "linux/arm64"
-    runs-on: ubuntu-latest
-    steps:
-      - name: No-op for docker
-        run: |
-          echo "No-op to get rid of the docker-build checks reqs in .asf.yml"
-          exit 0


### PR DESCRIPTION
I noticed that the docker builds don't trigger anymore since https://github.com/apache/superset/pull/27146 even though the intention was to build different matrix. Somehow the parseJson trick doesn't seem to work properly, so fixing it here

<img width="885" alt="Screenshot 2024-02-26 at 5 49 55 PM" src="https://github.com/apache/superset/assets/487433/739e7148-c177-436b-ad05-65cef0edf278">

## also
disabling the no-op checks

