### PR TITLE
fix(Alerts & Reports): Fixing bug that resets cron value to default when empty  

### DIFF
--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -1581,7 +1581,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
           key="schedule"
         >
           <AlertReportCronScheduler
-            value={currentAlert?.crontab || ALERT_REPORTS_DEFAULT_CRON_VALUE}
+            value={currentAlert?.crontab || ''}
             onChange={newVal => updateAlertState('crontab', newVal)}
           />
           <StyledInputContainer>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In either alerts or reports, when backspacing the value in cron schedule input field, the input will repopulate with the default cron value when the input becomes an empty string.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before: 
https://github.com/apache/superset/assets/41238731/30be8978-5122-410e-84ec-fd170100ac1c

After:
https://www.loom.com/share/31dd1e0b67174cc38de376419e99c6ff?sid=0261ed05-48f4-49af-acae-7fe6280141ad


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Navigate to an existing or new alert/report.
Open the Schedule section.
Under schedule type, select CRON schedule
Where it says a schedule (default is "0 0 * * *"), backspace until the field is empty.
If it remains empty, that is desired behavior.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Required feature flags: ALERT_REPORT=true
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
