### PR TITLE
fix: Inoperable dashboard filter slider when range is <= 1

### DIFF
--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
@@ -308,7 +308,7 @@ export default function RangeFilterPlugin(props: PluginFilterRangeProps) {
     return Math.min(1, parseFloat(normalizedStepSize));
   };
 
-  const step = stepHeuristic(min, max);
+  const step = max - min <= 1 ? stepHeuristic(min, max) : 1;
 
   return (
     <FilterPluginStyle height={height} width={width}>

--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
@@ -300,6 +300,16 @@ export default function RangeFilterPlugin(props: PluginFilterRangeProps) {
     }
   }, [enableSingleExactValue]);
 
+  const MIN_NUM_STEPS = 20;
+  const stepHeuristic = (min: number, max: number) => {
+    const maxStepSize = (max - min) / MIN_NUM_STEPS;
+    // normalizedStepSize: .06 -> .01, .003 -> .001
+    const normalizedStepSize = '1E' + Math.floor(Math.log10(maxStepSize));
+    return Math.min(1, parseFloat(normalizedStepSize));
+  };
+
+  const step = stepHeuristic(min, max);
+
   return (
     <FilterPluginStyle height={height} width={width}>
       {Number.isNaN(Number(min)) || Number.isNaN(Number(max)) ? (
@@ -323,6 +333,7 @@ export default function RangeFilterPlugin(props: PluginFilterRangeProps) {
               <AntdSlider
                 min={min}
                 max={max}
+                step={step}
                 value={minMax[maxIndex]}
                 tipFormatter={tipFormatter}
                 marks={marks}
@@ -335,6 +346,7 @@ export default function RangeFilterPlugin(props: PluginFilterRangeProps) {
                 validateStatus={filterState.validateStatus}
                 min={min}
                 max={max}
+                step={step}
                 value={minMax[minIndex]}
                 tipFormatter={tipFormatter}
                 marks={marks}
@@ -346,6 +358,7 @@ export default function RangeFilterPlugin(props: PluginFilterRangeProps) {
               <AntdSlider
                 min={min}
                 max={max}
+                step={step}
                 included={false}
                 value={minMax[minIndex]}
                 tipFormatter={tipFormatter}
@@ -359,6 +372,7 @@ export default function RangeFilterPlugin(props: PluginFilterRangeProps) {
                 range
                 min={min}
                 max={max}
+                step={step}
                 value={minMax}
                 onAfterChange={handleAfterChange}
                 onChange={handleChange}

--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
@@ -304,7 +304,7 @@ export default function RangeFilterPlugin(props: PluginFilterRangeProps) {
   const stepHeuristic = (min: number, max: number) => {
     const maxStepSize = (max - min) / MIN_NUM_STEPS;
     // normalizedStepSize: .06 -> .01, .003 -> .001
-    const normalizedStepSize = '1E' + Math.floor(Math.log10(maxStepSize));
+    const normalizedStepSize = `1E${Math.floor(Math.log10(maxStepSize))}`;
     return Math.min(1, parseFloat(normalizedStepSize));
   };
 


### PR DESCRIPTION
### SUMMARY
https://github.com/apache/superset/pull/24012 made a fix to Ant Design's slider. During the review phase we suggested a change which was never addressed by the PR author. Given that the original PR does not allow edits from maintainers, I'm opening this PR which contains the same content of the original PR with the suggested change. Credits to @jfrancos-mai for the fix.

Fixes https://github.com/apache/superset/issues/24010

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Check the original PR.

### TESTING INSTRUCTIONS
Check the original PR.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
