### PR TITLE
fix: Navigating to an invalid page index in lists

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,10 +3,10 @@ name: Docker
 on:
   push:
     branches:
-      - 'master'
+      - "master"
   pull_request:
     branches:
-      - 'master'
+      - "master"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
@@ -51,9 +51,17 @@ jobs:
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           pip install click
-          ./scripts/build_docker.py \
-            ${{ matrix.build_preset }} \
-            ${{ github.event_name }} \
-            --build_context_ref "$RELEASE" $FORCE_LATEST \
-            --platform "linux/arm64" \
-            --platform "linux/amd64"
+          if [ "${{ github.event_name }}" = "push" ]; then
+            ./scripts/build_docker.py \
+              ${{ matrix.build_preset }} \
+              ${{ github.event_name }} \
+              --build_context_ref "$RELEASE" $FORCE_LATEST \
+              --platform "linux/arm64" \
+              --platform "linux/amd64"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            ./scripts/build_docker.py \
+              ${{ matrix.build_preset }} \
+              ${{ github.event_name }} \
+              --build_context_ref "$RELEASE" $FORCE_LATEST \
+              --platform "linux/amd64"
+          fi

--- a/superset-frontend/src/components/ListView/ListView.test.tsx
+++ b/superset-frontend/src/components/ListView/ListView.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { render, waitFor } from 'spec/helpers/testing-library';
+import ListView from './ListView';
+
+const mockedProps = {
+  title: 'Data Table',
+  columns: [
+    {
+      accessor: 'id',
+      Header: 'ID',
+      sortable: true,
+    },
+    {
+      accessor: 'age',
+      Header: 'Age',
+    },
+    {
+      accessor: 'name',
+      Header: 'Name',
+    },
+    {
+      accessor: 'time',
+      Header: 'Time',
+    },
+  ],
+  data: [
+    { id: 1, name: 'data 1', age: 10, time: '2020-11-18T07:53:45.354Z' },
+    { id: 2, name: 'data 2', age: 1, time: '2020-11-18T07:53:45.354Z' },
+  ],
+  count: 2,
+  pageSize: 1,
+  loading: false,
+  refreshData: jest.fn(),
+  addSuccessToast: jest.fn(),
+  addDangerToast: jest.fn(),
+};
+
+test('redirects to first page when page index is invalid', async () => {
+  const fetchData = jest.fn();
+  window.history.pushState({}, '', '/?pageIndex=9');
+  render(<ListView {...mockedProps} fetchData={fetchData} />, {
+    useRouter: true,
+    useQueryParams: true,
+  });
+  await waitFor(() => {
+    expect(window.location.search).toEqual('?pageIndex=0');
+    expect(fetchData).toBeCalledTimes(2);
+    expect(fetchData).toHaveBeenCalledWith(
+      expect.objectContaining({ pageIndex: 9 }),
+    );
+    expect(fetchData).toHaveBeenCalledWith(
+      expect.objectContaining({ pageIndex: 0 }),
+    );
+  });
+  fetchData.mockClear();
+});

--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -322,6 +322,12 @@ function ListView<T extends object = any>({
     if (!bulkSelectEnabled) toggleAllRowsSelected(false);
   }, [bulkSelectEnabled, toggleAllRowsSelected]);
 
+  useEffect(() => {
+    if (!loading && pageIndex > pageCount - 1 && pageCount > 0) {
+      gotoPage(0);
+    }
+  }, [gotoPage, loading, pageCount, pageIndex]);
+
   return (
     <ListViewStyles>
       {allowBulkTagActions && (
@@ -463,7 +469,7 @@ function ListView<T extends object = any>({
         <div className="pagination-container">
           <Pagination
             totalPages={pageCount || 0}
-            currentPage={pageCount ? pageIndex + 1 : 0}
+            currentPage={pageCount && pageIndex < pageCount ? pageIndex + 1 : 0}
             onChange={(p: number) => gotoPage(p - 1)}
             hideFirstAndLastPageLinks
           />


### PR DESCRIPTION
### SUMMARY
This PR fixes a bug when navigating to an invalid page index in lists (charts/dashboards/etc). The problem happened when manually inputing an invalid page index or when deleting all assets of a particular page. Now the application detects an invalid page index and redirects the user to the first page.

Fixes https://github.com/apache/superset/issues/27224

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://github.com/apache/superset/assets/70410625/4f1ed46f-999d-4ca2-8999-0f7c1c097c57

https://github.com/apache/superset/assets/70410625/9fe5d451-a0ec-4de2-b068-d0078b3502cd

### TESTING INSTRUCTIONS
Check the original issue for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
