### PR TITLE
chore: bump cryptography minimum to 42.0.4

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -78,7 +78,7 @@ cron-descriptor==1.2.24
     # via apache-superset
 croniter==1.0.15
     # via apache-superset
-cryptography==42.0.2
+cryptography==42.0.4
     # via
     #   apache-superset
     #   paramiko

--- a/setup.py
+++ b/setup.py
@@ -80,8 +80,7 @@ setup(
         "colorama",
         "croniter>=0.3.28",
         "cron-descriptor",
-        # snowflake-connector-python as of 3.7.0 doesn't support >=42.* therefore lowering the min to 41.0.2
-        "cryptography>=41.0.2, <43.0.0",
+        "cryptography>=42.0.0, <43.0.0",
         "deprecation>=2.1.0, <2.2.0",
         "flask>=2.2.5, <3.0.0",
         "flask-appbuilder>=4.4.1, <5.0.0",

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         "colorama",
         "croniter>=0.3.28",
         "cron-descriptor",
-        "cryptography>=42.0.0, <43.0.0",
+        "cryptography>=42.0.4, <43.0.0",
         "deprecation>=2.1.0, <2.2.0",
         "flask>=2.2.5, <3.0.0",
         "flask-appbuilder>=4.4.1, <5.0.0",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
We lowered the minimum for cryptography in https://github.com/apache/superset/pull/27129 because `snowflake-connector-python` didn't support version 42.0.0 of cryptography. They recently released version 3.7.1 that does support it so bumping the cryptography minimum in setup.py again

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
