### PR TITLE
fix(ci): docker builds don't work from remote forks

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,9 +51,17 @@ jobs:
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           pip install click
-          ./scripts/build_docker.py \
-            ${{ matrix.build_preset }} \
-            ${{ github.event_name }} \
-            --build_context_ref "$RELEASE" $FORCE_LATEST \
-            --platform "linux/arm64" \
-            --platform "linux/amd64"
+          if [ "${{ github.event_name }}" = "push" ]; then
+            ./scripts/build_docker.py \
+              ${{ matrix.build_preset }} \
+              ${{ github.event_name }} \
+              --build_context_ref "$RELEASE" $FORCE_LATEST \
+              --platform "linux/arm64" \
+              --platform "linux/amd64"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            ./scripts/build_docker.py \
+              ${{ matrix.build_preset }} \
+              ${{ github.event_name }} \
+              --build_context_ref "$RELEASE" $FORCE_LATEST \
+              --platform "linux/amd64"
+          fi


### PR DESCRIPTION
### SUMMARY
Fix issues relate to multi-platform builds not working with `--load`.

Lots of intricacies around multi-platform builds somehow (doesn't work on OSx, doesn't work with `--load`, and somehow can't `--push` from remote forks, ...)
