### PR TITLE
fix(dataset): Address database options prepopulated with stale option

### DIFF
--- a/superset-frontend/src/features/datasets/AddDataset/LeftPanel/index.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/LeftPanel/index.tsx
@@ -28,6 +28,7 @@ import {
   DatasetObject,
 } from 'src/features/datasets/AddDataset/types';
 import { Table } from 'src/hooks/apiResources';
+import { useLocation } from 'react-router-dom';
 
 interface LeftPanelProps {
   setDataset: Dispatch<SetStateAction<object>>;
@@ -122,6 +123,9 @@ export default function LeftPanel({
   datasetNames,
 }: LeftPanelProps) {
   const { addDangerToast } = useToasts();
+  const location = useLocation();
+
+  const isAddingDataSet = location.pathname.includes('/dataset/add');
 
   const setDatabase = useCallback(
     (db: Partial<DatabaseObject>) => {
@@ -144,6 +148,7 @@ export default function LeftPanel({
     });
   };
   useEffect(() => {
+    // TODO: storing and fetching the last selected database from local storage is potentially technical debt
     const currentUserSelectedDb = getItem(
       LocalStorageKeys.Database,
       null,
@@ -174,7 +179,7 @@ export default function LeftPanel({
   return (
     <LeftPanelStyle>
       <TableSelector
-        database={dataset?.db}
+        database={isAddingDataSet ? null : dataset?.db}
         handleError={addDangerToast}
         emptyState={emptyStateComponent(false)}
         onDbChange={setDatabase}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dataset-add datasource): do not pass db as prop when creating a new dataset
-->

### SUMMARY
- the previous practice involves auto auto populate database (stored in local storage) into the newly created dataset, which will create bugs when database name changes, database is deleted, or when database meta is changed.
- the practice of saving and fetching latest modified database through localStorage is a potentially technical debut, making it easy to introduce regression that cannot be tracked. looking to potential bugs next.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
- stale database data in localStorage 
![2024-02-27_20-37](https://github.com/apache/superset/assets/25937657/89c87daa-d8b7-4c82-b184-33b5d83da60c)
- after fix demo
https://github.com/apache/superset/assets/25937657/8a20d1dc-cdb9-47a2-8cac-7d84b16eaa5a



### TESTING INSTRUCTIONS
- connect a database of your choice, 
- rename your database
- create a new dataset, and you will see the option not prepopulated.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ x] Has associated issue: Fix #27266
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
