### PR TITLE
docs(import_datasources): Remove legacy documentation and update current use

### DIFF
--- a/docs/docs/miscellaneous/importing-exporting-datasources.mdx
+++ b/docs/docs/miscellaneous/importing-exporting-datasources.mdx
@@ -61,42 +61,17 @@ superset export_datasource_schema
 
 As a reminder, you can use the `-b` flag to include back references.
 
-### Importing Datasources from YAML
+### Importing Datasources
 
-In order to import datasources from a YAML file(s), run:
-
-```
-superset import_datasources -p <path or filename>
-```
-
-If you supply a path all files ending with **yaml** or **yml** will be parsed. You can apply
-additional flags (e.g. to search the supplied path recursively):
+In order to import datasources from a ZIP file, run:
 
 ```
-superset import_datasources -p <path> -r
+superset import_datasources -p <path / filename>
 ```
 
-The sync flag **-s** takes parameters in order to sync the supplied elements with your file. Be
+The username flag **-u** sets the user used for the datasource import. The default is 'admin'. in order to sync the supplied elements with your file. Be
 careful this can delete the contents of your meta database. Example:
 
 ```
-superset import_datasources -p <path / filename> -s columns,metrics
-```
-
-This will sync all metrics and columns for all datasources found in the `<path /filename>` in the
-Superset meta database. This means columns and metrics not specified in YAML will be deleted. If you
-would add tables to columns,metrics those would be synchronised as well.
-
-If you don’t supply the sync flag (**-s**) importing will only add and update (override) fields.
-E.g. you can add a verbose_name to the column ds in the table random_time_series from the example
-datasets by saving the following YAML to file and then running the **import_datasources** command.
-
-```
-databases:
-- database_name: main
-  tables:
-  - table_name: random_time_series
-    columns:
-    - column_name: ds
-      verbose_name: datetime
+superset import_datasources -p <path / filename> -u 'admin'
 ```

--- a/docs/docs/miscellaneous/importing-exporting-datasources.mdx
+++ b/docs/docs/miscellaneous/importing-exporting-datasources.mdx
@@ -79,7 +79,7 @@ superset import_datasources -p <path / filename> -u 'admin'
 
 #### From older versions of Superset to current version
 
-When using Superset version 4.x.x to import from an older version (2.x.x or 3.x.x) importing is supported as the command `legacy_import_datasources` and expects a JSON or directory of JSONs. The options are `-r` for recursive and `-u` for specifying a user. Example:
+When using Superset version 4.x.x to import from an older version (2.x.x or 3.x.x) importing is supported as the command `legacy_import_datasources` and expects a JSON or directory of JSONs. The options are `-r` for recursive and `-u` for specifying a user. Example of legacy import without options:
 
 ```
 superset legacy_import_datasources -p <path or filename>
@@ -87,7 +87,7 @@ superset legacy_import_datasources -p <path or filename>
 
 #### From older versions of Superset to older versions
 
-When using an older Superset version (2.x.x & 3.x.x) of Superset, the command is `import_datasources`.  ZIP and YAML files are supported and to switch between them the feature flag `VERSIONED_EXPORT` is used. When `VERSIONED_EXPORT` is `True`, `import_datasources` expects a ZIP file, otherwise YAML. Example:
+When using an older Superset version (2.x.x & 3.x.x) of Superset, the command is `import_datasources`. ZIP and YAML files are supported and to switch between them the feature flag `VERSIONED_EXPORT` is used. When `VERSIONED_EXPORT` is `True`, `import_datasources` expects a ZIP file, otherwise YAML. Example:
 
 ```
 superset import_datasources -p <path or filename>

--- a/docs/docs/miscellaneous/importing-exporting-datasources.mdx
+++ b/docs/docs/miscellaneous/importing-exporting-datasources.mdx
@@ -75,9 +75,19 @@ The optional username flag **-u** sets the user used for the datasource import. 
 superset import_datasources -p <path / filename> -u 'admin'
 ```
 
-### Legacy Importing Datasources from YAML
+### Legacy Importing Datasources
 
-In Superset version 4.x.x the older way of datasource importing is supported as the command `legacy_import_datasources`. In older versions (2.x.x & 3.x.x) of Superset, to switch between ZIP and YAML files, the feature flag `VERSIONED_EXPORT` is used. When `VERSIONED_EXPORT` is `True`, `import_datasources` expects a ZIP file, otherwise YAML. Example:
+#### From older versions of Superset to current version
+
+When using Superset version 4.x.x to import from an older version (2.x.x or 3.x.x) importing is supported as the command `legacy_import_datasources` and expects a JSON or directory of JSONs. The options are `-r` for recursive and `-u` for specifying a user. Example:
+
+```
+superset legacy_import_datasources -p <path or filename>
+```
+
+#### From older versions of Superset to older versions
+
+When using an older Superset version (2.x.x & 3.x.x) of Superset, ZIP and YAML files are supported, and to switch between them the feature flag `VERSIONED_EXPORT` is used. When `VERSIONED_EXPORT` is `True`, `import_datasources` expects a ZIP file, otherwise YAML. Example:
 
 ```
 superset import_datasources -p <path or filename>

--- a/docs/docs/miscellaneous/importing-exporting-datasources.mdx
+++ b/docs/docs/miscellaneous/importing-exporting-datasources.mdx
@@ -77,7 +77,7 @@ superset import_datasources -p <path / filename> -u 'admin'
 
 ### Legacy Importing Datasources from YAML
 
-In Superset 4 the older way of datasource importing is supported as `legacy_import_datasources`. In older versions (2 & 3) of Superset, to switch between ZIP and YAML files, the feature flag `VERSIONED_EXPORT` is used. When `VERSIONED_EXPORT` is `True`, `import_datasources` expects a ZIP file, otherwise YAML. Example:
+In Superset version 4.x.x the older way of datasource importing is supported as the command `legacy_import_datasources`. In older versions (2.x.x & 3.x.x) of Superset, to switch between ZIP and YAML files, the feature flag `VERSIONED_EXPORT` is used. When `VERSIONED_EXPORT` is `True`, `import_datasources` expects a ZIP file, otherwise YAML. Example:
 
 ```
 superset import_datasources -p <path or filename>

--- a/docs/docs/miscellaneous/importing-exporting-datasources.mdx
+++ b/docs/docs/miscellaneous/importing-exporting-datasources.mdx
@@ -77,7 +77,7 @@ superset import_datasources -p <path / filename> -u 'admin'
 
 ### Legacy Importing Datasources from YAML
 
-In Superset 4 the older way of datasource importing is supported as `legacy_import_datasources`. In older versions (2 & 3) of Superset, to switch between ZIP and YAML files, the feature flag `VERSIONED_EXPORT` is used. When `True` `import_datasources` expects a ZIP file, otherwise YAML. Example:
+In Superset 4 the older way of datasource importing is supported as `legacy_import_datasources`. In older versions (2 & 3) of Superset, to switch between ZIP and YAML files, the feature flag `VERSIONED_EXPORT` is used. When `VERSIONED_EXPORT` is `True`, `import_datasources` expects a ZIP file, otherwise YAML. Example:
 
 ```
 superset import_datasources -p <path or filename>

--- a/docs/docs/miscellaneous/importing-exporting-datasources.mdx
+++ b/docs/docs/miscellaneous/importing-exporting-datasources.mdx
@@ -87,7 +87,7 @@ superset legacy_import_datasources -p <path or filename>
 
 #### From older versions of Superset to older versions
 
-When using an older Superset version (2.x.x & 3.x.x) of Superset, ZIP and YAML files are supported, and to switch between them the feature flag `VERSIONED_EXPORT` is used. When `VERSIONED_EXPORT` is `True`, `import_datasources` expects a ZIP file, otherwise YAML. Example:
+When using an older Superset version (2.x.x & 3.x.x) of Superset, the command is `import_datasources`.  ZIP and YAML files are supported and to switch between them the feature flag `VERSIONED_EXPORT` is used. When `VERSIONED_EXPORT` is `True`, `import_datasources` expects a ZIP file, otherwise YAML. Example:
 
 ```
 superset import_datasources -p <path or filename>

--- a/docs/docs/miscellaneous/importing-exporting-datasources.mdx
+++ b/docs/docs/miscellaneous/importing-exporting-datasources.mdx
@@ -69,7 +69,7 @@ In order to import datasources from a ZIP file, run:
 superset import_datasources -p <path / filename>
 ```
 
-The username flag **-u** sets the user used for the datasource import. The default is 'admin'. Example:
+The optional username flag **-u** sets the user used for the datasource import. The default is 'admin'. Example:
 
 ```
 superset import_datasources -p <path / filename> -u 'admin'

--- a/docs/docs/miscellaneous/importing-exporting-datasources.mdx
+++ b/docs/docs/miscellaneous/importing-exporting-datasources.mdx
@@ -69,9 +69,48 @@ In order to import datasources from a ZIP file, run:
 superset import_datasources -p <path / filename>
 ```
 
-The username flag **-u** sets the user used for the datasource import. The default is 'admin'. in order to sync the supplied elements with your file. Be
-careful this can delete the contents of your meta database. Example:
+The username flag **-u** sets the user used for the datasource import. The default is 'admin'. Example:
 
 ```
 superset import_datasources -p <path / filename> -u 'admin'
+```
+
+### Legacy Importing Datasources from YAML
+
+In Superset 4 the older way of datasource importing is supported as `legacy_import_datasources`. In older versions (2 & 3) of Superset, to switch between ZIP and YAML files, the feature flag `VERSIONED_EXPORT` is used. When `True` `import_datasources` expects a ZIP file, otherwise YAML. Example:
+
+```
+superset import_datasources -p <path or filename>
+```
+
+When `VERSIONED_EXPORT` is `False`, if you supply a path all files ending with **yaml** or **yml** will be parsed. You can apply
+additional flags (e.g. to search the supplied path recursively):
+
+```
+superset import_datasources -p <path> -r
+```
+
+The sync flag **-s** takes parameters in order to sync the supplied elements with your file. Be
+careful this can delete the contents of your meta database. Example:
+
+```
+superset import_datasources -p <path / filename> -s columns,metrics
+```
+
+This will sync all metrics and columns for all datasources found in the `<path /filename>` in the
+Superset meta database. This means columns and metrics not specified in YAML will be deleted. If you
+would add tables to columns,metrics those would be synchronised as well.
+
+If you don’t supply the sync flag (**-s**) importing will only add and update (override) fields.
+E.g. you can add a verbose_name to the column ds in the table random_time_series from the example
+datasets by saving the following YAML to file and then running the **import_datasources** command.
+
+```
+databases:
+- database_name: main
+  tables:
+  - table_name: random_time_series
+    columns:
+    - column_name: ds
+      verbose_name: datetime
 ```


### PR DESCRIPTION
### SUMMARY
The documentation was still referencing the "legacy_import_datasources". I updated to the current expected use for ZIP files and `--username` option based on #27154.

I have removed the documentation which was for `legacy_import_datasources` based on the assumption that this is not expected to be supported. 

If we would like to keep supporting the `legacy_import_datasources` I can add it back into the docs with it's own titled section. 

Please let me know what works best.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
