### PR TITLE
feat(logs context): Adding dashboard id to logs context

### DIFF
--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -431,6 +431,7 @@ class ChartDataRestApi(ChartRestApi):
         self, form_data: dict[str, Any]
     ) -> dict[str, Any]:
         return {
+            "dashboard_id": form_data.get("form_data", {}).get("dashboardId"),
             "dataset_id": form_data.get("datasource", {}).get("id")
             if isinstance(form_data.get("datasource"), dict)
             and form_data.get("datasource", {}).get("type")

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -134,7 +134,7 @@ class TestPostChartDataApi(BaseTestChartDataApi):
             ChartDataRestApi, self.query_context_payload
         )
         # assert
-        assert response == {"dataset_id": 1, "slice_id": None}
+        assert response == {"dashboard_id": None, "dataset_id": 1, "slice_id": None}
 
         # takes malformed content without raising an error
         self.query_context_payload["datasource"] = "1__table"
@@ -143,7 +143,7 @@ class TestPostChartDataApi(BaseTestChartDataApi):
             ChartDataRestApi, self.query_context_payload
         )
         # assert
-        assert response == {"dataset_id": None, "slice_id": None}
+        assert response == {"dashboard_id": None, "dataset_id": None, "slice_id": None}
 
         # takes a slice id
         self.query_context_payload["datasource"] = None
@@ -153,7 +153,7 @@ class TestPostChartDataApi(BaseTestChartDataApi):
             ChartDataRestApi, self.query_context_payload
         )
         # assert
-        assert response == {"dataset_id": None, "slice_id": 1}
+        assert response == {"dashboard_id": None, "dataset_id": None, "slice_id": 1}
 
         # takes missing slice id
         self.query_context_payload["datasource"] = None
@@ -163,7 +163,35 @@ class TestPostChartDataApi(BaseTestChartDataApi):
             ChartDataRestApi, self.query_context_payload
         )
         # assert
-        assert response == {"dataset_id": None, "slice_id": None}
+        assert response == {"dashboard_id": None, "dataset_id": None, "slice_id": None}
+
+        # takes a dashboard id
+        self.query_context_payload["form_data"] = {"dashboardId": 1}
+        # act
+        response = ChartDataRestApi._map_form_data_datasource_to_dataset_id(
+            ChartDataRestApi, self.query_context_payload
+        )
+        # assert
+        assert response == {"dashboard_id": 1, "dataset_id": None, "slice_id": None}
+
+        # takes a dashboard id and a slice id
+        self.query_context_payload["form_data"] = {"dashboardId": 1, "slice_id": 2}
+        # act
+        response = ChartDataRestApi._map_form_data_datasource_to_dataset_id(
+            ChartDataRestApi, self.query_context_payload
+        )
+        # assert
+        assert response == {"dashboard_id": 1, "dataset_id": None, "slice_id": 2}
+
+        # takes a dashboard id, slice id and a dataset id
+        self.query_context_payload["datasource"] = {"id": 3, "type": "table"}
+        self.query_context_payload["form_data"] = {"dashboardId": 1, "slice_id": 2}
+        # act
+        response = ChartDataRestApi._map_form_data_datasource_to_dataset_id(
+            ChartDataRestApi, self.query_context_payload
+        )
+        # assert
+        assert response == {"dashboard_id": 1, "dataset_id": 3, "slice_id": 2}
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     @mock.patch("superset.utils.decorators.g")


### PR DESCRIPTION
### SUMMARY
Includes the `dashboard_id` information to the logs context, so that it can be included in the sql mutator. Refer to below links for additional context:
* https://github.com/apache/superset/pull/26418
* https://github.com/apache/superset/pull/26443.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
1. Update the sql mutator logic to get data from the logs context. For example:
``` python
def mutator(sql: str, **kwargs: Any) -> str:
    if dashboard_id := g.logs_context.get("dashboard_id"):
        output = (
            f"-- Metadata:\n"
            + f"-- dashboard_id: {dashboard_id}\n"
        )
        return output + f"{sql}"
    return sql
```
2. Access a dashboard, and click on the three ellipses for any chart > **View query**.
3. Validate that the dashboard ID is included in the query comments.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [x] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
