### PR TITLE
fix: Incorrect data type on import page

### DIFF
--- a/superset/views/database/forms.py
+++ b/superset/views/database/forms.py
@@ -146,7 +146,8 @@ class CsvToDatabaseForm(UploadToDatabaseForm):
         description=_(
             "A dictionary with column names and their data types"
             " if you need to change the defaults."
-            ' Example: {"user_id":"integer"}'
+            ' Example: {"user_id":"int"}. '
+            "Check Python's Pandas library for supported data types."
         ),
         validators=[Optional()],
         widget=BS3TextFieldWidget(),


### PR DESCRIPTION
### SUMMARY
Fixes an incorrect data type on the import page. It also adds a reference to Python's Pandas library to help users check supported types.

Fixes https://github.com/apache/superset/issues/27305

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Column Data Types is referencing `integer` which is invalid.
<img width="1154" alt="Screenshot 2024-02-29 at 09 11 28" src="https://github.com/apache/superset/assets/70410625/1b0cb363-fd6c-45b6-b5b2-918d952eb5b4">

Column Data Types is referencing `int` which is valid.
<img width="1151" alt="Screenshot 2024-02-29 at 09 17 07" src="https://github.com/apache/superset/assets/70410625/f2226d18-e55c-44e5-8f73-7f39135500d3">

### TESTING INSTRUCTIONS
Check that the type is correct.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
