### PR TITLE
fix(dashboard): table chart drag preview overflowing container

### DIFF
--- a/superset-frontend/src/dashboard/components/dnd/DragDroppable.jsx
+++ b/superset-frontend/src/dashboard/components/dnd/DragDroppable.jsx
@@ -77,6 +77,11 @@ const defaultProps = {
 const DragDroppableStyles = styled.div`
   ${({ theme }) => css`
     position: relative;
+    /*
+      Next line is a workaround for a bug in react-dnd where the drag
+      preview expands outside of the bounds of the drag source card, see:
+      https://github.com/react-dnd/react-dnd/issues/832#issuecomment-442071628
+    */
     transform: translate3d(0, 0, 0);
 
     &.dragdroppable--dragging {

--- a/superset-frontend/src/dashboard/components/dnd/DragDroppable.jsx
+++ b/superset-frontend/src/dashboard/components/dnd/DragDroppable.jsx
@@ -77,6 +77,7 @@ const defaultProps = {
 const DragDroppableStyles = styled.div`
   ${({ theme }) => css`
     position: relative;
+    transform: translate3d(0, 0, 0);
 
     &.dragdroppable--dragging {
       opacity: 0.2;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Table charts were creating preview sizes much larger than intended causing surrounding objects to be cropped into the preview when dragging. This is a known issue with `react-dnd` on chromium browsers, see [here](https://github.com/react-dnd/react-dnd/issues/832). This is a simple style fix to the parent element.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
B:
![drag-overflow-ezgif com-optimize](https://github.com/apache/superset/assets/92495987/4d5318fc-314a-46af-be6a-24d333deca39)
A:
![dnd-overflow-fix-ezgif com-optimize](https://github.com/apache/superset/assets/92495987/ebfec809-2738-4662-be13-6c26878747c2)



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

- Edit a dashboard containing table charts
- Drag a table chart card that has scroll bars

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #26873 
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
