### PR TITLE
fix(sqllab): Missing empty query result state

### DIFF
--- a/superset-frontend/src/SqlLab/components/SouthPane/Results.tsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/Results.tsx
@@ -29,7 +29,7 @@ import { LOCALSTORAGE_MAX_QUERY_AGE_MS } from '../../constants';
 const EXTRA_HEIGHT_RESULTS = 8; // we need extra height in RESULTS tab. because the height from props was calculated based on PREVIEW tab.
 
 type Props = {
-  latestQueryId: string;
+  latestQueryId?: string;
   height: number;
   displayLimit: number;
   defaultQueryLimit: number;

--- a/superset-frontend/src/SqlLab/components/SouthPane/SouthPane.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/SouthPane.test.tsx
@@ -123,6 +123,19 @@ test('should render offline when the state is offline', async () => {
   expect(getByText(STATUS_OPTIONS.offline)).toBeVisible();
 });
 
+test('should render empty result state when latestQuery is empty', () => {
+  const { getAllByRole } = render(
+    <SouthPane {...mockedProps} latestQueryId={undefined} />,
+    {
+      useRedux: true,
+      initialState: mockState,
+    },
+  );
+
+  const resultPanel = getAllByRole('tabpanel')[0];
+  expect(resultPanel).toHaveTextContent('Run a query to display results');
+});
+
 test('should render tabs for table preview queries', () => {
   const { getAllByRole } = render(<SouthPane {...mockedProps} />, {
     useRedux: true,

--- a/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
@@ -144,14 +144,12 @@ const SouthPane = ({
         animated={false}
       >
         <Tabs.TabPane tab={t('Results')} key="Results">
-          {latestQueryId && (
-            <Results
-              height={innerTabContentHeight}
-              latestQueryId={latestQueryId}
-              displayLimit={displayLimit}
-              defaultQueryLimit={defaultQueryLimit}
-            />
-          )}
+          <Results
+            height={innerTabContentHeight}
+            latestQueryId={latestQueryId}
+            displayLimit={displayLimit}
+            defaultQueryLimit={defaultQueryLimit}
+          />
         </Tabs.TabPane>
         <Tabs.TabPane tab={t('Query history')} key="History">
           <QueryHistory


### PR DESCRIPTION
Fixes #27311 

### SUMMARY
This commit fixes the missing empty query result placeholder.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![Screenshot 2024-02-29 at 4 48 18 PM](https://github.com/apache/superset/assets/1392866/86984b4b-2efc-46b1-b78a-45cc21f77364)

After:
![Screenshot 2024-02-29 at 4 43 02 PM](https://github.com/apache/superset/assets/1392866/953763d0-e9f5-4a38-8a6e-90c009488e84)

### TESTING INSTRUCTIONS
Open a new tab in SQL Lab and check the result panel message

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
