### PR TITLE
fix: Migration for single metric in Big Number with Time Comparison

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
@@ -143,7 +143,6 @@ export default function transformProps(chartProps: ChartProps) {
     width,
     height,
     data,
-    metric,
     metricName,
     bigNumber,
     prevNumber,

--- a/superset/migrations/versions/2024-03-01_10-47_be1b217cd8cd_big_number_kpi_single_metric.py
+++ b/superset/migrations/versions/2024-03-01_10-47_be1b217cd8cd_big_number_kpi_single_metric.py
@@ -1,0 +1,93 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""big_number_kpi_single_metric
+
+Revision ID: be1b217cd8cd
+Revises: 17fcea065655
+Create Date: 2024-03-01 10:47:42.373508
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "be1b217cd8cd"
+down_revision = "17fcea065655"
+
+
+import json
+
+from alembic import op
+from sqlalchemy import Column, Integer, String, Text
+from sqlalchemy.ext.declarative import declarative_base
+
+from superset import db
+from superset.migrations.shared.utils import paginated_update
+
+Base = declarative_base()
+
+
+class Slice(Base):
+    __tablename__ = "slices"
+
+    id = Column(Integer, primary_key=True)
+    params = Column(Text)
+    viz_type = Column(String(250))
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    for slc in paginated_update(
+        session.query(Slice).filter(Slice.viz_type == "pop_kpi")
+    ):
+        try:
+            params = json.loads(slc.params)
+
+            if "metrics" in params:
+                if params["metrics"]:
+                    params["metric"] = params["metrics"][0]
+
+                del params["metrics"]
+                slc.params = json.dumps(params, sort_keys=True)
+        except Exception:
+            pass
+
+    session.commit()
+    session.close()
+
+
+def downgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    for slc in paginated_update(
+        session.query(Slice).filter(Slice.viz_type == "pop_kpi")
+    ):
+        try:
+            params = json.loads(slc.params)
+
+            if "metric" in params:
+                if params["metric"]:
+                    params["metrics"] = [params["metric"]]
+
+                del params["metric"]
+                slc.params = json.dumps(params, sort_keys=True)
+        except Exception:
+            pass
+
+    session.commit()
+    session.close()


### PR DESCRIPTION
### SUMMARY
Due to changing `metrics` control to `metric` in Big Number with Time Comparison chart, the existing charts were broken due to missing `metric` in form data. This PR adds a migration which takes the first item from `metrics` and applies it to the new `metric` control.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Revert commit fd4f9ac (`feat: Use standardized controls in Big Number with Time Comparison`)
2. Create a Big Number with Time Comparison chart and save it
3. Un-revert the commit
4. Verify that now the chart is broken - no metric is added
5. Run the migration
6. Verify that the chart now works and `metric` control has a value

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided
Current: 0.13 s
10+: 0.12 s
100+: 0.12 s
1000+: 0.20 s
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
