### PR TITLE
fix: Heatmap numeric sorting

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-heatmap/src/Heatmap.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-heatmap/src/Heatmap.js
@@ -177,15 +177,12 @@ function Heatmap(element, props) {
     }
   }
 
-  function ordScale(k, rangeBands, sortMethod) {
+  function ordScale(k, rangeBands, sortMethod, formatter) {
     let domain = {};
-    const actualKeys = {}; // hack to preserve type of keys when number
     records.forEach(d => {
       domain[d[k]] = (domain[d[k]] || 0) + d.v;
-      actualKeys[d[k]] = d[k];
     });
-    // Not using object.keys() as it converts to strings
-    const keys = Object.keys(actualKeys).map(s => actualKeys[s]);
+    const keys = Object.keys(domain).map(k => formatter(k));
     if (sortMethod === 'alpha_asc') {
       domain = keys.sort(cmp);
     } else if (sortMethod === 'alpha_desc') {
@@ -252,10 +249,10 @@ function Heatmap(element, props) {
 
   const fp = getNumberFormatter(NumberFormats.PERCENT_2_POINT);
 
-  const xScale = ordScale('x', null, sortXAxis);
-  const yScale = ordScale('y', null, sortYAxis);
-  const xRbScale = ordScale('x', [0, hmWidth], sortXAxis);
-  const yRbScale = ordScale('y', [hmHeight, 0], sortYAxis);
+  const xScale = ordScale('x', null, sortXAxis, xAxisFormatter);
+  const yScale = ordScale('y', null, sortYAxis, yAxisFormatter);
+  const xRbScale = ordScale('x', [0, hmWidth], sortXAxis, xAxisFormatter);
+  const yRbScale = ordScale('y', [hmHeight, 0], sortYAxis, yAxisFormatter);
   const X = 0;
   const Y = 1;
   const heatmapDim = [xRbScale.domain().length, yRbScale.domain().length];

--- a/superset-frontend/plugins/legacy-plugin-chart-heatmap/src/transformProps.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-heatmap/src/transformProps.js
@@ -57,11 +57,15 @@ export default function transformProps(chartProps) {
   const xAxisFormatter =
     coltypes[0] === GenericDataType.Temporal
       ? getTimeFormatter(timeFormat)
-      : String;
+      : coltypes[0] === GenericDataType.Numeric
+        ? Number
+        : String;
   const yAxisFormatter =
     coltypes[1] === GenericDataType.Temporal
       ? getTimeFormatter(timeFormat)
-      : String;
+      : coltypes[1] === GenericDataType.Numeric
+        ? Number
+        : String;
   return {
     width,
     height,


### PR DESCRIPTION
### SUMMARY
Fixes a bug in Heatmap charts where the sorting was not working for numerical X and Y axis.

Fixes https://github.com/apache/superset/issues/27357

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1456" alt="Screenshot 2024-03-01 at 10 58 19" src="https://github.com/apache/superset/assets/70410625/2f096dc6-416a-432a-8db8-ba53c3b0de4c">
<img width="1457" alt="Screenshot 2024-03-01 at 10 57 16" src="https://github.com/apache/superset/assets/70410625/7ab61131-c713-4cb3-a676-d1e9ab9cf6f2">

### TESTING INSTRUCTIONS
Check that numerical X and Y axis are sorted correctly.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
