### PR TITLE
fix: Missing SQL Lab permission

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -756,6 +756,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         self.add_permission_view_menu("can_csv", "Superset")
         self.add_permission_view_menu("can_share_dashboard", "Superset")
         self.add_permission_view_menu("can_share_chart", "Superset")
+        self.add_permission_view_menu("can_sqllab", "Superset")
         self.add_permission_view_menu("can_view_query", "Dashboard")
         self.add_permission_view_menu("can_view_chart_as_table", "Dashboard")
 

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -1483,6 +1483,7 @@ class TestRolePermission(SupersetTestCase):
                 ("can_get", "TabStateView"),
                 ("can_get_results", "SQLLab"),
                 ("can_migrate_query", "TabStateView"),
+                ("can_sqllab", "Superset"),
                 ("can_sqllab_history", "Superset"),
                 ("can_put", "TabStateView"),
                 ("can_post", "TabStateView"),


### PR DESCRIPTION
### SUMMARY
https://github.com/apache/superset/pull/27117 removed the following deprecated endpoint:

```
@deprecated(new_target="/sqllab")
def sqllab(self) -> FlaskResponse:
```

Which was registered in Superset's initialization:

```
appbuilder.add_view_no_menu(SqlLab)
```

`superset init` uses the registered views to dynamically generate the permissions, in that case, `can_sqllab` was generated from that entry and it does not exist anymore in a fresh installation of Superset. Searching for [can_sqllab](https://github.com/search?q=repo%3Aapache%2Fsuperset%20can_sqllab&type=code) we can still find many references to it in the codebase, including the menu item that is missing. This PR adds that permission back using custom permissions.

I also did a diff between 3.1 and 4.0 and found that the following permissions were removed:

```
can_import_dashboards
can_my_queries
can_profile
can_sqllab
```

The only permission that is still referenced in the codebase is `can_sqllab`.

Fixes https://github.com/apache/superset/issues/27310

### TESTING INSTRUCTIONS
Check that the `SQL query` option appears in the global + menu.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
