### PR TITLE
fix(API): Updating assets via the API should preserve ownership configuration

### DIFF
--- a/superset/commands/base.py
+++ b/superset/commands/base.py
@@ -19,7 +19,7 @@ from typing import Any, Optional
 
 from flask_appbuilder.security.sqla.models import User
 
-from superset.commands.utils import populate_owners
+from superset.commands.utils import populate_owners, update_owner_list
 
 
 class BaseCommand(ABC):
@@ -70,3 +70,17 @@ class UpdateMixin:  # pylint: disable=too-few-public-methods
         :returns: Final list of owners
         """
         return populate_owners(owner_ids, default_to_user=False)
+
+    @staticmethod
+    def update_owner_list(
+        current_owners: list[User],
+        new_owners: Optional[list[int]],
+    ) -> list[User]:
+        """
+        Handle list of owners for update events.
+
+        :param current_owners: list of current owners
+        :param new_owners: list of new owners specified in the update payload
+        :returns: Final list of owners
+        """
+        return update_owner_list(current_owners, new_owners)

--- a/superset/commands/base.py
+++ b/superset/commands/base.py
@@ -19,7 +19,7 @@ from typing import Any, Optional
 
 from flask_appbuilder.security.sqla.models import User
 
-from superset.commands.utils import populate_owner_list, update_owner_list
+from superset.commands.utils import compute_owner_list, populate_owner_list
 
 
 class BaseCommand(ABC):
@@ -72,7 +72,7 @@ class UpdateMixin:  # pylint: disable=too-few-public-methods
         return populate_owner_list(owner_ids, default_to_user=False)
 
     @staticmethod
-    def update_owners(
+    def compute_owners(
         current_owners: Optional[list[User]],
         new_owners: Optional[list[int]],
     ) -> list[User]:
@@ -83,4 +83,4 @@ class UpdateMixin:  # pylint: disable=too-few-public-methods
         :param new_owners: list of new owners specified in the update payload
         :returns: Final list of owners
         """
-        return update_owner_list(current_owners, new_owners)
+        return compute_owner_list(current_owners, new_owners)

--- a/superset/commands/base.py
+++ b/superset/commands/base.py
@@ -73,7 +73,7 @@ class UpdateMixin:  # pylint: disable=too-few-public-methods
 
     @staticmethod
     def update_owner_list(
-        current_owners: list[User],
+        current_owners: Optional[list[User]],
         new_owners: Optional[list[int]],
     ) -> list[User]:
         """

--- a/superset/commands/base.py
+++ b/superset/commands/base.py
@@ -19,7 +19,7 @@ from typing import Any, Optional
 
 from flask_appbuilder.security.sqla.models import User
 
-from superset.commands.utils import populate_owners, update_owner_list
+from superset.commands.utils import populate_owner_list, update_owner_list
 
 
 class BaseCommand(ABC):
@@ -55,7 +55,7 @@ class CreateMixin:  # pylint: disable=too-few-public-methods
         :raises OwnersNotFoundValidationError: if at least one owner can't be resolved
         :returns: Final list of owners
         """
-        return populate_owners(owner_ids, default_to_user=True)
+        return populate_owner_list(owner_ids, default_to_user=True)
 
 
 class UpdateMixin:  # pylint: disable=too-few-public-methods
@@ -69,10 +69,10 @@ class UpdateMixin:  # pylint: disable=too-few-public-methods
         :raises OwnersNotFoundValidationError: if at least one owner can't be resolved
         :returns: Final list of owners
         """
-        return populate_owners(owner_ids, default_to_user=False)
+        return populate_owner_list(owner_ids, default_to_user=False)
 
     @staticmethod
-    def update_owner_list(
+    def update_owners(
         current_owners: Optional[list[User]],
         new_owners: Optional[list[int]],
     ) -> list[User]:

--- a/superset/commands/chart/update.py
+++ b/superset/commands/chart/update.py
@@ -90,7 +90,10 @@ class UpdateChartCommand(UpdateMixin, BaseCommand):
         if not is_query_context_update(self._properties):
             try:
                 security_manager.raise_for_ownership(self._model)
-                owners = self.populate_owners(owner_ids)
+                owners = self.update_owner_list(
+                    self._model.owners,
+                    owner_ids,
+                )
                 self._properties["owners"] = owners
             except SupersetSecurityException as ex:
                 raise ChartForbiddenError() from ex

--- a/superset/commands/chart/update.py
+++ b/superset/commands/chart/update.py
@@ -90,7 +90,7 @@ class UpdateChartCommand(UpdateMixin, BaseCommand):
         if not is_query_context_update(self._properties):
             try:
                 security_manager.raise_for_ownership(self._model)
-                owners = self.update_owners(
+                owners = self.compute_owners(
                     self._model.owners,
                     owner_ids,
                 )

--- a/superset/commands/chart/update.py
+++ b/superset/commands/chart/update.py
@@ -90,7 +90,7 @@ class UpdateChartCommand(UpdateMixin, BaseCommand):
         if not is_query_context_update(self._properties):
             try:
                 security_manager.raise_for_ownership(self._model)
-                owners = self.update_owner_list(
+                owners = self.update_owners(
                     self._model.owners,
                     owner_ids,
                 )

--- a/superset/commands/dashboard/update.py
+++ b/superset/commands/dashboard/update.py
@@ -66,7 +66,7 @@ class UpdateDashboardCommand(UpdateMixin, BaseCommand):
 
     def validate(self) -> None:
         exceptions: list[ValidationError] = []
-        owners_ids: Optional[list[int]] = self._properties.get("owners")
+        owner_ids: Optional[list[int]] = self._properties.get("owners")
         roles_ids: Optional[list[int]] = self._properties.get("roles")
         slug: Optional[str] = self._properties.get("slug")
 
@@ -85,10 +85,11 @@ class UpdateDashboardCommand(UpdateMixin, BaseCommand):
             exceptions.append(DashboardSlugExistsValidationError())
 
         # Validate/Populate owner
-        if owners_ids is None:
-            owners_ids = [owner.id for owner in self._model.owners]
         try:
-            owners = self.populate_owners(owners_ids)
+            owners = self.update_owner_list(
+                self._model.owners,
+                owner_ids,
+            )
             self._properties["owners"] = owners
         except ValidationError as ex:
             exceptions.append(ex)

--- a/superset/commands/dashboard/update.py
+++ b/superset/commands/dashboard/update.py
@@ -86,7 +86,7 @@ class UpdateDashboardCommand(UpdateMixin, BaseCommand):
 
         # Validate/Populate owner
         try:
-            owners = self.update_owners(
+            owners = self.compute_owners(
                 self._model.owners,
                 owner_ids,
             )

--- a/superset/commands/dashboard/update.py
+++ b/superset/commands/dashboard/update.py
@@ -86,7 +86,7 @@ class UpdateDashboardCommand(UpdateMixin, BaseCommand):
 
         # Validate/Populate owner
         try:
-            owners = self.update_owner_list(
+            owners = self.update_owners(
                 self._model.owners,
                 owner_ids,
             )

--- a/superset/commands/dataset/update.py
+++ b/superset/commands/dataset/update.py
@@ -100,7 +100,7 @@ class UpdateDatasetCommand(UpdateMixin, BaseCommand):
             exceptions.append(DatabaseChangeValidationError())
         # Validate/Populate owner
         try:
-            owners = self.update_owner_list(
+            owners = self.update_owners(
                 self._model.owners,
                 owner_ids,
             )

--- a/superset/commands/dataset/update.py
+++ b/superset/commands/dataset/update.py
@@ -100,7 +100,7 @@ class UpdateDatasetCommand(UpdateMixin, BaseCommand):
             exceptions.append(DatabaseChangeValidationError())
         # Validate/Populate owner
         try:
-            owners = self.update_owners(
+            owners = self.compute_owners(
                 self._model.owners,
                 owner_ids,
             )

--- a/superset/commands/dataset/update.py
+++ b/superset/commands/dataset/update.py
@@ -100,7 +100,10 @@ class UpdateDatasetCommand(UpdateMixin, BaseCommand):
             exceptions.append(DatabaseChangeValidationError())
         # Validate/Populate owner
         try:
-            owners = self.populate_owners(owner_ids)
+            owners = self.update_owner_list(
+                self._model.owners,
+                owner_ids,
+            )
             self._properties["owners"] = owners
         except ValidationError as ex:
             exceptions.append(ex)

--- a/superset/commands/report/update.py
+++ b/superset/commands/report/update.py
@@ -119,7 +119,7 @@ class UpdateReportScheduleCommand(UpdateMixin, BaseReportScheduleCommand):
 
         # Validate/Populate owner
         try:
-            owners = self.update_owners(
+            owners = self.compute_owners(
                 self._model.owners,
                 owner_ids,
             )

--- a/superset/commands/report/update.py
+++ b/superset/commands/report/update.py
@@ -119,7 +119,7 @@ class UpdateReportScheduleCommand(UpdateMixin, BaseReportScheduleCommand):
 
         # Validate/Populate owner
         try:
-            owners = self.update_owner_list(
+            owners = self.update_owners(
                 self._model.owners,
                 owner_ids,
             )

--- a/superset/commands/report/update.py
+++ b/superset/commands/report/update.py
@@ -118,10 +118,11 @@ class UpdateReportScheduleCommand(UpdateMixin, BaseReportScheduleCommand):
             raise ReportScheduleForbiddenError() from ex
 
         # Validate/Populate owner
-        if owner_ids is None:
-            owner_ids = [owner.id for owner in self._model.owners]
         try:
-            owners = self.populate_owners(owner_ids)
+            owners = self.update_owner_list(
+                self._model.owners,
+                owner_ids,
+            )
             self._properties["owners"] = owners
         except ValidationError as ex:
             exceptions.append(ex)

--- a/superset/commands/utils.py
+++ b/superset/commands/utils.py
@@ -62,6 +62,24 @@ def populate_owners(
     return owners
 
 
+def update_owner_list(
+    current_owners: list[User],
+    new_owners: list[int] | None,
+) -> list[User]:
+    """
+    Helper function for update commands, to properly handle the owners list.
+    Preserve the previous configuration unless included in the update payload.
+
+    :param current_owners: list of current owners
+    :param new_owners: list of new owners specified in the update payload
+    :returns: Final list of owners
+    """
+    owners_ids = (
+        [owner.id for owner in current_owners] if new_owners is None else new_owners
+    )
+    return populate_owners(owners_ids, default_to_user=False)
+
+
 def populate_roles(role_ids: list[int] | None = None) -> list[Role]:
     """
     Helper function for commands, will fetch all roles from roles id's

--- a/superset/commands/utils.py
+++ b/superset/commands/utils.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     from superset.connectors.sqla.models import BaseDatasource
 
 
-def populate_owners(
+def populate_owner_list(
     owner_ids: list[int] | None,
     default_to_user: bool,
 ) -> list[User]:
@@ -78,7 +78,7 @@ def update_owner_list(
     owners_ids = (
         [owner.id for owner in current_owners] if new_owners is None else new_owners
     )
-    return populate_owners(owners_ids, default_to_user=False)
+    return populate_owner_list(owners_ids, default_to_user=False)
 
 
 def populate_roles(role_ids: list[int] | None = None) -> list[Role]:

--- a/superset/commands/utils.py
+++ b/superset/commands/utils.py
@@ -62,7 +62,7 @@ def populate_owner_list(
     return owners
 
 
-def update_owner_list(
+def compute_owner_list(
     current_owners: list[User] | None,
     new_owners: list[int] | None,
 ) -> list[User]:

--- a/superset/commands/utils.py
+++ b/superset/commands/utils.py
@@ -63,7 +63,7 @@ def populate_owners(
 
 
 def update_owner_list(
-    current_owners: list[User],
+    current_owners: list[User] | None,
     new_owners: list[int] | None,
 ) -> list[User]:
     """
@@ -74,6 +74,7 @@ def update_owner_list(
     :param new_owners: list of new owners specified in the update payload
     :returns: Final list of owners
     """
+    current_owners = current_owners or []
     owners_ids = (
         [owner.id for owner in current_owners] if new_owners is None else new_owners
     )

--- a/superset/views/datasource/views.py
+++ b/superset/views/datasource/views.py
@@ -31,7 +31,7 @@ from superset.commands.dataset.exceptions import (
     DatasetForbiddenError,
     DatasetNotFoundError,
 )
-from superset.commands.utils import populate_owners
+from superset.commands.utils import populate_owner_list
 from superset.connectors.sqla.models import SqlaTable
 from superset.connectors.sqla.utils import get_physical_table_metadata
 from superset.daos.datasource import DatasourceDAO
@@ -94,7 +94,7 @@ class Datasource(BaseSupersetView):
             except SupersetSecurityException as ex:
                 raise DatasetForbiddenError() from ex
 
-        datasource_dict["owners"] = populate_owners(
+        datasource_dict["owners"] = populate_owner_list(
             datasource_dict["owners"], default_to_user=False
         )
 

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -736,9 +736,58 @@ class TestChartApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
         db.session.commit()
 
     @pytest.mark.usefixtures("add_dashboard_to_chart")
+    def test_update_chart_preserve_ownership(self):
+        """
+        Chart API: Test update chart preserves owner list (if un-changed)
+        """
+        chart_data = {
+            "slice_name": "title1_changed",
+        }
+        admin = self.get_user("admin")
+        self.login(username="admin")
+        uri = f"api/v1/chart/{self.chart.id}"
+        rv = self.put_assert_metric(uri, chart_data, "put")
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual([admin], self.chart.owners)
+
+    @pytest.mark.usefixtures("add_dashboard_to_chart")
+    def test_update_chart_clear_owner_list(self):
+        """
+        Chart API: Test update chart admin can clear owner list
+        """
+        chart_data = {"slice_name": "title1_changed", "owners": []}
+        admin = self.get_user("admin")
+        self.login(username="admin")
+        uri = f"api/v1/chart/{self.chart.id}"
+        rv = self.put_assert_metric(uri, chart_data, "put")
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual([], self.chart.owners)
+
+    def test_update_chart_populate_owner(self):
+        """
+        Chart API: Test update admin can update chart with
+        no owners to a different owner
+        """
+        gamma = self.get_user("gamma")
+        admin = self.get_user("admin")
+        chart_id = self.insert_chart("title", [], 1).id
+        model = db.session.query(Slice).get(chart_id)
+        self.assertEqual(model.owners, [])
+        chart_data = {"owners": [gamma.id]}
+        self.login(username="admin")
+        uri = f"api/v1/chart/{chart_id}"
+        rv = self.put_assert_metric(uri, chart_data, "put")
+        self.assertEqual(rv.status_code, 200)
+        model_updated = db.session.query(Slice).get(chart_id)
+        self.assertNotIn(admin, model_updated.owners)
+        self.assertIn(gamma, model_updated.owners)
+        db.session.delete(model_updated)
+        db.session.commit()
+
+    @pytest.mark.usefixtures("add_dashboard_to_chart")
     def test_update_chart_new_dashboards(self):
         """
-        Chart API: Test update set new owner to current user
+        Chart API: Test update chart associating it with new dashboard
         """
         chart_data = {
             "slice_name": "title1_changed",
@@ -754,7 +803,7 @@ class TestChartApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
     @pytest.mark.usefixtures("add_dashboard_to_chart")
     def test_not_update_chart_none_dashboards(self):
         """
-        Chart API: Test update set new owner to current user
+        Chart API: Test update chart without changing dashboards configuration
         """
         chart_data = {"slice_name": "title1_changed_again"}
         self.login(username="admin")

--- a/tests/unit_tests/commands/test_utils.py
+++ b/tests/unit_tests/commands/test_utils.py
@@ -19,100 +19,100 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from superset.commands.utils import populate_owners, update_owner_list, User
+from superset.commands.utils import populate_owner_list, update_owner_list, User
 
 
 @patch("superset.commands.utils.g")
-def test_populate_owners_default_to_user(mock_user):
-    owner_list = populate_owners([], True)
+def test_populate_owner_list_default_to_user(mock_user):
+    owner_list = populate_owner_list([], True)
     assert owner_list == [mock_user.user]
 
 
 @patch("superset.commands.utils.g")
-def test_populate_owners_default_to_user_handle_none(mock_user):
-    owner_list = populate_owners(None, True)
+def test_populate_owner_list_default_to_user_handle_none(mock_user):
+    owner_list = populate_owner_list(None, True)
     assert owner_list == [mock_user.user]
 
 
 @patch("superset.commands.utils.g")
 @patch("superset.commands.utils.security_manager")
 @patch("superset.commands.utils.get_user_id")
-def test_populate_owners_admin(mock_user_id, mock_sm, mock_g):
+def test_populate_owner_list_admin_user(mock_user_id, mock_sm, mock_g):
     test_user = User(id=1, first_name="First", last_name="Last")
     mock_g.user = User(id=4, first_name="Admin", last_name="User")
     mock_user_id.return_value = 4
     mock_sm.is_admin = MagicMock(return_value=True)
     mock_sm.get_user_by_id = MagicMock(return_value=test_user)
 
-    owner_list = populate_owners([1], False)
+    owner_list = populate_owner_list([1], False)
     assert owner_list == [test_user]
 
 
 @patch("superset.commands.utils.g")
 @patch("superset.commands.utils.security_manager")
 @patch("superset.commands.utils.get_user_id")
-def test_populate_owners_admin_empty_list(mock_user_id, mock_sm, mock_g):
+def test_populate_owner_list_admin_user_empty_list(mock_user_id, mock_sm, mock_g):
     mock_g.user = User(id=4, first_name="Admin", last_name="User")
     mock_user_id.return_value = 4
     mock_sm.is_admin = MagicMock(return_value=True)
-    owner_list = populate_owners([], False)
+    owner_list = populate_owner_list([], False)
     assert owner_list == []
 
 
 @patch("superset.commands.utils.g")
 @patch("superset.commands.utils.security_manager")
 @patch("superset.commands.utils.get_user_id")
-def test_populate_owners_non_admin(mock_user_id, mock_sm, mock_g):
+def test_populate_owner_list_non_admin(mock_user_id, mock_sm, mock_g):
     test_user = User(id=1, first_name="First", last_name="Last")
     mock_g.user = User(id=4, first_name="Non", last_name="admin")
     mock_user_id.return_value = 4
     mock_sm.is_admin = MagicMock(return_value=False)
     mock_sm.get_user_by_id = MagicMock(return_value=test_user)
 
-    owner_list = populate_owners([1], False)
+    owner_list = populate_owner_list([1], False)
     assert owner_list == [mock_g.user, test_user]
 
 
-@patch("superset.commands.utils.populate_owners")
-def test_update_owner_list_new_owners(mock_populate_owners):
+@patch("superset.commands.utils.populate_owner_list")
+def test_update_owner_list_new_owners(mock_populate_owner_list):
     current_owners = [User(id=1), User(id=2), User(id=3)]
     new_owners = [4, 5, 6]
 
     update_owner_list(current_owners, new_owners)
-    mock_populate_owners.assert_called_once_with(new_owners, default_to_user=False)
+    mock_populate_owner_list.assert_called_once_with(new_owners, default_to_user=False)
 
 
-@patch("superset.commands.utils.populate_owners")
-def test_update_owner_list_no_new_owners(mock_populate_owners):
+@patch("superset.commands.utils.populate_owner_list")
+def test_update_owner_list_no_new_owners(mock_populate_owner_list):
     current_owners = [User(id=1), User(id=2), User(id=3)]
     new_owners = None
 
     update_owner_list(current_owners, new_owners)
-    mock_populate_owners.assert_called_once_with([1, 2, 3], default_to_user=False)
+    mock_populate_owner_list.assert_called_once_with([1, 2, 3], default_to_user=False)
 
 
-@patch("superset.commands.utils.populate_owners")
-def test_update_owner_list_new_owner_empty_list(mock_populate_owners):
+@patch("superset.commands.utils.populate_owner_list")
+def test_update_owner_list_new_owner_empty_list(mock_populate_owner_list):
     current_owners = [User(id=1), User(id=2), User(id=3)]
     new_owners = []
 
     update_owner_list(current_owners, new_owners)
-    mock_populate_owners.assert_called_once_with(new_owners, default_to_user=False)
+    mock_populate_owner_list.assert_called_once_with(new_owners, default_to_user=False)
 
 
-@patch("superset.commands.utils.populate_owners")
-def test_update_owner_list_no_owners(mock_populate_owners):
+@patch("superset.commands.utils.populate_owner_list")
+def test_update_owner_list_no_owners(mock_populate_owner_list):
     current_owners = []
     new_owners = [4, 5, 6]
 
     update_owner_list(current_owners, new_owners)
-    mock_populate_owners.assert_called_once_with(new_owners, default_to_user=False)
+    mock_populate_owner_list.assert_called_once_with(new_owners, default_to_user=False)
 
 
-@patch("superset.commands.utils.populate_owners")
-def test_update_owner_list_no_owners_handle_none(mock_populate_owners):
+@patch("superset.commands.utils.populate_owner_list")
+def test_update_owner_list_no_owners_handle_none(mock_populate_owner_list):
     current_owners = None
     new_owners = [4, 5, 6]
 
     update_owner_list(current_owners, new_owners)
-    mock_populate_owners.assert_called_once_with(new_owners, default_to_user=False)
+    mock_populate_owner_list.assert_called_once_with(new_owners, default_to_user=False)

--- a/tests/unit_tests/commands/test_utils.py
+++ b/tests/unit_tests/commands/test_utils.py
@@ -19,7 +19,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from superset.commands.utils import populate_owner_list, update_owner_list, User
+from superset.commands.utils import compute_owner_list, populate_owner_list, User
 
 
 @patch("superset.commands.utils.g")
@@ -74,45 +74,45 @@ def test_populate_owner_list_non_admin(mock_user_id, mock_sm, mock_g):
 
 
 @patch("superset.commands.utils.populate_owner_list")
-def test_update_owner_list_new_owners(mock_populate_owner_list):
+def test_compute_owner_list_new_owners(mock_populate_owner_list):
     current_owners = [User(id=1), User(id=2), User(id=3)]
     new_owners = [4, 5, 6]
 
-    update_owner_list(current_owners, new_owners)
+    compute_owner_list(current_owners, new_owners)
     mock_populate_owner_list.assert_called_once_with(new_owners, default_to_user=False)
 
 
 @patch("superset.commands.utils.populate_owner_list")
-def test_update_owner_list_no_new_owners(mock_populate_owner_list):
+def test_compute_owner_list_no_new_owners(mock_populate_owner_list):
     current_owners = [User(id=1), User(id=2), User(id=3)]
     new_owners = None
 
-    update_owner_list(current_owners, new_owners)
+    compute_owner_list(current_owners, new_owners)
     mock_populate_owner_list.assert_called_once_with([1, 2, 3], default_to_user=False)
 
 
 @patch("superset.commands.utils.populate_owner_list")
-def test_update_owner_list_new_owner_empty_list(mock_populate_owner_list):
+def test_compute_owner_list_new_owner_empty_list(mock_populate_owner_list):
     current_owners = [User(id=1), User(id=2), User(id=3)]
     new_owners = []
 
-    update_owner_list(current_owners, new_owners)
+    compute_owner_list(current_owners, new_owners)
     mock_populate_owner_list.assert_called_once_with(new_owners, default_to_user=False)
 
 
 @patch("superset.commands.utils.populate_owner_list")
-def test_update_owner_list_no_owners(mock_populate_owner_list):
+def test_compute_owner_list_no_owners(mock_populate_owner_list):
     current_owners = []
     new_owners = [4, 5, 6]
 
-    update_owner_list(current_owners, new_owners)
+    compute_owner_list(current_owners, new_owners)
     mock_populate_owner_list.assert_called_once_with(new_owners, default_to_user=False)
 
 
 @patch("superset.commands.utils.populate_owner_list")
-def test_update_owner_list_no_owners_handle_none(mock_populate_owner_list):
+def test_compute_owner_list_no_owners_handle_none(mock_populate_owner_list):
     current_owners = None
     new_owners = [4, 5, 6]
 
-    update_owner_list(current_owners, new_owners)
+    compute_owner_list(current_owners, new_owners)
     mock_populate_owner_list.assert_called_once_with(new_owners, default_to_user=False)

--- a/tests/unit_tests/commands/test_utils.py
+++ b/tests/unit_tests/commands/test_utils.py
@@ -1,0 +1,118 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from superset.commands.utils import populate_owners, update_owner_list, User
+
+
+@patch("superset.commands.utils.g")
+def test_populate_owners_default_to_user(mock_user):
+    owner_list = populate_owners([], True)
+    assert owner_list == [mock_user.user]
+
+
+@patch("superset.commands.utils.g")
+def test_populate_owners_default_to_user_handle_none(mock_user):
+    owner_list = populate_owners(None, True)
+    assert owner_list == [mock_user.user]
+
+
+@patch("superset.commands.utils.g")
+@patch("superset.commands.utils.security_manager")
+@patch("superset.commands.utils.get_user_id")
+def test_populate_owners_admin(mock_user_id, mock_sm, mock_g):
+    test_user = User(id=1, first_name="First", last_name="Last")
+    mock_g.user = User(id=4, first_name="Admin", last_name="User")
+    mock_user_id.return_value = 4
+    mock_sm.is_admin = MagicMock(return_value=True)
+    mock_sm.get_user_by_id = MagicMock(return_value=test_user)
+
+    owner_list = populate_owners([1], False)
+    assert owner_list == [test_user]
+
+
+@patch("superset.commands.utils.g")
+@patch("superset.commands.utils.security_manager")
+@patch("superset.commands.utils.get_user_id")
+def test_populate_owners_admin_empty_list(mock_user_id, mock_sm, mock_g):
+    mock_g.user = User(id=4, first_name="Admin", last_name="User")
+    mock_user_id.return_value = 4
+    mock_sm.is_admin = MagicMock(return_value=True)
+    owner_list = populate_owners([], False)
+    assert owner_list == []
+
+
+@patch("superset.commands.utils.g")
+@patch("superset.commands.utils.security_manager")
+@patch("superset.commands.utils.get_user_id")
+def test_populate_owners_non_admin(mock_user_id, mock_sm, mock_g):
+    test_user = User(id=1, first_name="First", last_name="Last")
+    mock_g.user = User(id=4, first_name="Non", last_name="admin")
+    mock_user_id.return_value = 4
+    mock_sm.is_admin = MagicMock(return_value=False)
+    mock_sm.get_user_by_id = MagicMock(return_value=test_user)
+
+    owner_list = populate_owners([1], False)
+    assert owner_list == [mock_g.user, test_user]
+
+
+@patch("superset.commands.utils.populate_owners")
+def test_update_owner_list_new_owners(mock_populate_owners):
+    current_owners = [User(id=1), User(id=2), User(id=3)]
+    new_owners = [4, 5, 6]
+
+    update_owner_list(current_owners, new_owners)
+    mock_populate_owners.assert_called_once_with(new_owners, default_to_user=False)
+
+
+@patch("superset.commands.utils.populate_owners")
+def test_update_owner_list_no_new_owners(mock_populate_owners):
+    current_owners = [User(id=1), User(id=2), User(id=3)]
+    new_owners = None
+
+    update_owner_list(current_owners, new_owners)
+    mock_populate_owners.assert_called_once_with([1, 2, 3], default_to_user=False)
+
+
+@patch("superset.commands.utils.populate_owners")
+def test_update_owner_list_new_owner_empty_list(mock_populate_owners):
+    current_owners = [User(id=1), User(id=2), User(id=3)]
+    new_owners = []
+
+    update_owner_list(current_owners, new_owners)
+    mock_populate_owners.assert_called_once_with(new_owners, default_to_user=False)
+
+
+@patch("superset.commands.utils.populate_owners")
+def test_update_owner_list_no_owners(mock_populate_owners):
+    current_owners = []
+    new_owners = [4, 5, 6]
+
+    update_owner_list(current_owners, new_owners)
+    mock_populate_owners.assert_called_once_with(new_owners, default_to_user=False)
+
+
+@patch("superset.commands.utils.populate_owners")
+def test_update_owner_list_no_owners_handle_none(mock_populate_owners):
+    current_owners = None
+    new_owners = [4, 5, 6]
+
+    update_owner_list(current_owners, new_owners)
+    mock_populate_owners.assert_called_once_with(new_owners, default_to_user=False)


### PR DESCRIPTION
### SUMMARY
The current behavior for updating assets via the API is inconsistent:
* When updating dashboards and reports, the `owners` information wouldn't be modified unless it's part of the update payload
* When updating datasets and charts, the `owners` information would be lost unless if included in the update payload

This scenario introduces issues as for example an admin updating the dataset description via the API would remove all owners.

This PR centralizes this logic to ensure consistency across charts, dashboards, datasets and reports (also DRYer).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
Tests added. To test through the UI:
1. Create a new chart. 
2. Update its description via the API.
3. Validate the `owners` configuration was not affected.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
