### PR TITLE
fix: Results section in Explore shows an infinite spinner

### DIFF
--- a/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.tsx
@@ -123,7 +123,8 @@ export const DataTablesPane = ({
     if (
       panelOpen &&
       activeTabKey.startsWith(ResultTypes.Results) &&
-      chartStatus === 'rendered'
+      chartStatus &&
+      chartStatus !== 'loading'
     ) {
       setIsRequest({
         results: true,


### PR DESCRIPTION
### SUMMARY
Fixes a bug where the results panel implementation in Explore was not considering all chart status and could display an infinite spinner.

Fixes https://github.com/apache/superset/issues/27365.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://github.com/apache/superset/assets/70410625/fab808d1-48d0-47a3-9f4e-97a6b12b8486

https://github.com/apache/superset/assets/70410625/ab74ab36-f8f6-42af-9abb-c0acdf97abcd

@sadpandajoe 

### TESTING INSTRUCTIONS
Check the original issue for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
