### PR TITLE
fix(utils): fix off-by-one error in how rolling window's min_periods truncates dataframe

### DIFF
--- a/superset/utils/pandas_postprocessing/rolling.py
+++ b/superset/utils/pandas_postprocessing/rolling.py
@@ -97,5 +97,5 @@ def rolling(  # pylint: disable=too-many-arguments
     df_rolling = _append_columns(df, df_rolling, columns)
 
     if min_periods:
-        df_rolling = df_rolling[min_periods-1:]
+        df_rolling = df_rolling[min_periods - 1 :]
     return df_rolling

--- a/superset/utils/pandas_postprocessing/rolling.py
+++ b/superset/utils/pandas_postprocessing/rolling.py
@@ -97,5 +97,5 @@ def rolling(  # pylint: disable=too-many-arguments
     df_rolling = _append_columns(df, df_rolling, columns)
 
     if min_periods:
-        df_rolling = df_rolling[min_periods:]
+        df_rolling = df_rolling[min_periods-1:]
     return df_rolling

--- a/tests/unit_tests/pandas_postprocessing/test_rolling.py
+++ b/tests/unit_tests/pandas_postprocessing/test_rolling.py
@@ -107,7 +107,7 @@ def test_rolling():
         )
 
 
-def test_rolling_should_empty_df():
+def test_rolling_min_periods_trims_correctly():
     pivot_df = pp.pivot(
         df=single_metric_df,
         index=["dttm"],
@@ -121,7 +121,7 @@ def test_rolling_should_empty_df():
         min_periods=2,
         columns={"sum_metric": "sum_metric"},
     )
-    assert rolling_df.empty is True
+    assert len(rolling_df) == 1
 
 
 def test_rolling_after_pivot_with_single_metric():


### PR DESCRIPTION
### SUMMARY
In Advanced Analytics, if the Min Periods value is 5, the first row in the resulting `df_rolling` with a valid result will be row 4 (since counting starts at 0).  Right now the line `df_rolling = df_rolling[min_periods:]` truncates rows 0-4 -- that is, five rows -- throwing out the first rolling value that satisfies the min_periods requirement.

Currently the tooltip for Min Periods is misleading, this will make it true.

### SCREENSHOTS
Here in Superset 3.1.1 you can see that the 5th bar should be eligible for a rolling average since Min Periods is 5.  But it's only beginning on the 6th bar that the line appears.
![image](https://github.com/apache/superset/assets/7569808/aefae835-fb29-4c8c-985d-74c798798ed9)

When I tell Superset to use 5-Period averages for the rolling window and min of 4 periods, this truncates the first 4 rows (due to the buggy off-by-one I'm fixing) and serves what I wanted.  27.4 is indeed the average of the first 5 periods and a valid result.
![image](https://github.com/apache/superset/assets/7569808/e98dd0c5-dc25-48fe-91b7-c9da1a600e40)


### TESTING INSTRUCTIONS
Build a chart with rolling average in an ephemeral environment.