### PR TITLE
fix: Missing sql_editor_id index

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -80,6 +80,7 @@ assists people when migrating to a new version.
 ### Potential Downtime
 
 - [26416](https://github.com/apache/superset/pull/26416): Adds two database indexes to the `report_execution_log` table and one database index to the `report_recipient` to improve performance. Scheduled downtime may be required for large deployments.
+- [27392](https://github.com/apache/superset/pull/27392): adds sql_editor_id index to query to improve performance, this may cause downtime on large deployments.
 
 ## 3.1.0
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -48,6 +48,10 @@ assists people when migrating to a new version.
   listing all databases in CRUD-view and dropdown and didn't provide access to data as it
   seemed the name would imply.
 
+### Potential Downtime
+
+- [27392](https://github.com/apache/superset/pull/27392): Adds an index to `query.sql_editor_id` to improve performance. This may cause downtime on large deployments.
+
 ## 4.0.0
 
 - [27119](https://github.com/apache/superset/pull/27119): Updates various database columns to use the `MediumText` type, potentially requiring a table lock on MySQL dbs or taking some time to complete on large deployments.
@@ -80,7 +84,6 @@ assists people when migrating to a new version.
 ### Potential Downtime
 
 - [26416](https://github.com/apache/superset/pull/26416): Adds two database indexes to the `report_execution_log` table and one database index to the `report_recipient` to improve performance. Scheduled downtime may be required for large deployments.
-- [27392](https://github.com/apache/superset/pull/27392): Adds an index to `query.sql_editor_id` to improve performance. This may cause downtime on large deployments.
 
 ## 3.1.0
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -80,7 +80,7 @@ assists people when migrating to a new version.
 ### Potential Downtime
 
 - [26416](https://github.com/apache/superset/pull/26416): Adds two database indexes to the `report_execution_log` table and one database index to the `report_recipient` to improve performance. Scheduled downtime may be required for large deployments.
-- [27392](https://github.com/apache/superset/pull/27392): adds sql_editor_id index to query to improve performance, this may cause downtime on large deployments.
+- [27392](https://github.com/apache/superset/pull/27392): Adds an index to `query.sql_editor_id` to improve performance. This may cause downtime on large deployments.
 
 ## 3.1.0
 

--- a/superset/migrations/shared/utils.py
+++ b/superset/migrations/shared/utils.py
@@ -51,6 +51,23 @@ def table_has_column(table: str, column: str) -> bool:
         return False
 
 
+def table_has_index(table: str, index: str) -> bool:
+    """
+    Checks if an index exists in a given table.
+
+    :param table: A table name
+    :param index: A index name
+    :returns: True if the index exists in the table
+    """
+
+    insp = inspect(op.get_context().bind)
+
+    try:
+        return any(ind["name"] == index for ind in insp.get_indexes(table))
+    except NoSuchTableError:
+        return False
+
+
 uuid_by_dialect = {
     MySQLDialect: "UNHEX(REPLACE(CONVERT(UUID() using utf8mb4), '-', ''))",
     PGDialect: "uuid_in(md5(random()::text || clock_timestamp()::text)::cstring)",

--- a/superset/migrations/versions/2024-03-04_14-48_efb7a20ff8d8_add_query_sql_editor_id_index.py
+++ b/superset/migrations/versions/2024-03-04_14-48_efb7a20ff8d8_add_query_sql_editor_id_index.py
@@ -23,17 +23,21 @@ Create Date: 2024-03-04 14:48:16.998927
 """
 
 # revision identifiers, used by Alembic.
-revision = 'efb7a20ff8d8'
-down_revision = 'be1b217cd8cd'
+revision = "efb7a20ff8d8"
+down_revision = "be1b217cd8cd"
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
+
 
 def upgrade():
     op.create_index(
-        op.f("ix_query_sql_editor_id"), "query", ["sql_editor_id"], unique=False
+        op.f("ix_query_user_id_sql_editor_id"),
+        "query",
+        ["user_id", "sql_editor_id"],
+        unique=False,
     )
 
 
 def downgrade():
-    op.drop_index(op.f("ix_query_sql_editor_id"), table_name="query")
+    op.drop_index(op.f("ix_query_user_id_sql_editor_id"), table_name="query")

--- a/superset/migrations/versions/2024-03-04_14-48_efb7a20ff8d8_add_query_sql_editor_id_index.py
+++ b/superset/migrations/versions/2024-03-04_14-48_efb7a20ff8d8_add_query_sql_editor_id_index.py
@@ -26,18 +26,24 @@ Create Date: 2024-03-04 14:48:16.998927
 revision = "efb7a20ff8d8"
 down_revision = "be1b217cd8cd"
 
-import sqlalchemy as sa
 from alembic import op
+
+from superset.migrations.shared.utils import table_has_index
+
+table = "query"
+index = "ix_query_user_id_sql_editor_id"
 
 
 def upgrade():
-    op.create_index(
-        op.f("ix_query_user_id_sql_editor_id"),
-        "query",
-        ["user_id", "sql_editor_id"],
-        unique=False,
-    )
+    if not table_has_index(table, index):
+        op.create_index(
+            op.f(index),
+            table,
+            ["user_id", "sql_editor_id"],
+            unique=False,
+        )
 
 
 def downgrade():
-    op.drop_index(op.f("ix_query_user_id_sql_editor_id"), table_name="query")
+    if table_has_index(table, index):
+        op.drop_index(op.f(index), table_name=table)

--- a/superset/migrations/versions/2024-03-04_14-48_efb7a20ff8d8_add_query_sql_editor_id_index.py
+++ b/superset/migrations/versions/2024-03-04_14-48_efb7a20ff8d8_add_query_sql_editor_id_index.py
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""add_query_sql_editor_id_index
+
+Revision ID: efb7a20ff8d8
+Revises: be1b217cd8cd
+Create Date: 2024-03-04 14:48:16.998927
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'efb7a20ff8d8'
+down_revision = 'be1b217cd8cd'
+
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade():
+    op.create_index(
+        op.f("ix_query_sql_editor_id"), "query", ["sql_editor_id"], unique=False
+    )
+
+
+def downgrade():
+    op.drop_index(op.f("ix_query_sql_editor_id"), table_name="query")

--- a/superset/migrations/versions/2024-05-02_13-40_3dfd0e78650e_add_query_sql_editor_id_index.py
+++ b/superset/migrations/versions/2024-05-02_13-40_3dfd0e78650e_add_query_sql_editor_id_index.py
@@ -16,22 +16,22 @@
 # under the License.
 """add_query_sql_editor_id_index
 
-Revision ID: efb7a20ff8d8
-Revises: be1b217cd8cd
-Create Date: 2024-03-04 14:48:16.998927
+Revision ID: 3dfd0e78650e
+Revises: 5f57af97bc3f
+Create Date: 2024-05-02 13:40:23.126659
 
 """
 
 # revision identifiers, used by Alembic.
-revision = "efb7a20ff8d8"
-down_revision = "be1b217cd8cd"
+revision = '3dfd0e78650e'
+down_revision = '5f57af97bc3f'
 
 from alembic import op
 
 from superset.migrations.shared.utils import table_has_index
 
 table = "query"
-index = "ix_query_user_id_sql_editor_id"
+index = "ix_sql_editor_id"
 
 
 def upgrade():
@@ -39,7 +39,7 @@ def upgrade():
         op.create_index(
             op.f(index),
             table,
-            ["user_id", "sql_editor_id"],
+            ["sql_editor_id"],
             unique=False,
         )
 

--- a/superset/migrations/versions/2024-05-02_13-40_3dfd0e78650e_add_query_sql_editor_id_index.py
+++ b/superset/migrations/versions/2024-05-02_13-40_3dfd0e78650e_add_query_sql_editor_id_index.py
@@ -26,9 +26,9 @@ Create Date: 2024-05-02 13:40:23.126659
 revision = "3dfd0e78650e"
 down_revision = "5f57af97bc3f"
 
-from alembic import op
+from alembic import op  # noqa: E402
 
-from superset.migrations.shared.utils import table_has_index
+from superset.migrations.shared.utils import table_has_index  # noqa: E402
 
 table = "query"
 index = "ix_sql_editor_id"

--- a/superset/migrations/versions/2024-05-02_13-40_3dfd0e78650e_add_query_sql_editor_id_index.py
+++ b/superset/migrations/versions/2024-05-02_13-40_3dfd0e78650e_add_query_sql_editor_id_index.py
@@ -23,8 +23,8 @@ Create Date: 2024-05-02 13:40:23.126659
 """
 
 # revision identifiers, used by Alembic.
-revision = '3dfd0e78650e'
-down_revision = '5f57af97bc3f'
+revision = "3dfd0e78650e"
+down_revision = "5f57af97bc3f"
 
 from alembic import op
 

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -107,7 +107,7 @@ class Query(
     user_id = Column(Integer, ForeignKey("ab_user.id"), nullable=True)
     status = Column(String(16), default=QueryStatus.PENDING)
     tab_name = Column(String(256))
-    sql_editor_id = Column(String(256))
+    sql_editor_id = Column(String(256), index=True)
     schema = Column(String(256))
     catalog = Column(String(256), nullable=True, default=None)
     sql = Column(MediumText())

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -107,7 +107,7 @@ class Query(
     user_id = Column(Integer, ForeignKey("ab_user.id"), nullable=True)
     status = Column(String(16), default=QueryStatus.PENDING)
     tab_name = Column(String(256))
-    sql_editor_id = Column(String(256), index=True)
+    sql_editor_id = Column(String(256))
     schema = Column(String(256))
     catalog = Column(String(256), nullable=True, default=None)
     sql = Column(MediumText())
@@ -150,7 +150,10 @@ class Query(
     )
     user = relationship(security_manager.user_model, foreign_keys=[user_id])
 
-    __table_args__ = (sqla.Index("ti_user_id_changed_on", user_id, changed_on),)
+    __table_args__ = (
+        sqla.Index("ti_user_id_changed_on", user_id, changed_on),
+        sqla.Index("ix_query_user_id_sql_editor_id", user_id, sql_editor_id),
+    )
 
     def get_template_processor(self, **kwargs: Any) -> BaseTemplateProcessor:
         return get_template_processor(query=self, database=self.database, **kwargs)

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -107,7 +107,7 @@ class Query(
     user_id = Column(Integer, ForeignKey("ab_user.id"), nullable=True)
     status = Column(String(16), default=QueryStatus.PENDING)
     tab_name = Column(String(256))
-    sql_editor_id = Column(String(256))
+    sql_editor_id = Column(String(256), index=True)
     schema = Column(String(256))
     catalog = Column(String(256), nullable=True, default=None)
     sql = Column(MediumText())
@@ -150,10 +150,7 @@ class Query(
     )
     user = relationship(security_manager.user_model, foreign_keys=[user_id])
 
-    __table_args__ = (
-        sqla.Index("ti_user_id_changed_on", user_id, changed_on),
-        sqla.Index("ix_query_user_id_sql_editor_id", user_id, sql_editor_id),
-    )
+    __table_args__ = (sqla.Index("ti_user_id_changed_on", user_id, changed_on),)
 
     def get_template_processor(self, **kwargs: Any) -> BaseTemplateProcessor:
         return get_template_processor(query=self, database=self.database, **kwargs)


### PR DESCRIPTION
### SUMMARY
As titled, it adds the index for `sql_editor_id` in query table which seems to have caused a slowdown in the [sqllab_bootstrap](https://github.com/apache/superset/blob/d2f7dec208cfa31583310f96a9f387853af0fbc8/superset/sqllab/utils.py#L109-L113) query.

### TESTING INSTRUCTIONS
locally test `superset db upgrade`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
