### PR TITLE
fix: typescript errors in 4.0

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/query/api/v1/makeApi.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/api/v1/makeApi.ts
@@ -115,11 +115,11 @@ export default function makeApi<
         jsonPayload: undefined as JsonObject | undefined,
       };
       if (requestType === 'search') {
-        requestConfig.searchParams = payload as URLSearchParams;
+        requestConfig.searchParams = payload as unknown as URLSearchParams;
       } else if (requestType === 'rison') {
         requestConfig.endpoint = `${endpoint}?q=${rison.encode(payload)}`;
       } else if (requestType === 'form') {
-        requestConfig.postPayload = payload as FormData;
+        requestConfig.postPayload = payload as unknown as FormData;
       } else {
         requestConfig.jsonPayload = payload as JsonObject;
       }

--- a/superset-frontend/src/components/AlteredSliceTag/AlteredSliceTagMocks.ts
+++ b/superset-frontend/src/components/AlteredSliceTag/AlteredSliceTagMocks.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { QueryFormData } from '@superset-ui/core';
-import { ControlPanelConfig } from 'packages/superset-ui-chart-controls/src/types';
+import { ControlPanelConfig } from '@superset-ui/chart-controls';
 import { DiffType, RowType } from './index';
 
 export const defaultProps: Record<string, Partial<QueryFormData>> = {

--- a/superset-frontend/src/components/AlteredSliceTag/index.tsx
+++ b/superset-frontend/src/components/AlteredSliceTag/index.tsx
@@ -179,7 +179,7 @@ class AlteredSliceTag extends React.Component<
         return '[]';
       }
       return value
-        .map(v => {
+        .map((v: FilterItemType) => {
           const filterVal =
             v.comparator && v.comparator.constructor === Array
               ? `[${v.comparator.join(', ')}]`
@@ -198,14 +198,14 @@ class AlteredSliceTag extends React.Component<
       return value.map(v => safeStringify(v)).join(', ');
     }
     if (controlsMap[key]?.type === 'MetricsControl' && Array.isArray(value)) {
-      const formattedValue = value.map(v => v?.label ?? v);
+      const formattedValue = value.map((v: FilterItemType) => v?.label ?? v);
       return formattedValue.length ? formattedValue.join(', ') : '[]';
     }
     if (typeof value === 'boolean') {
       return value ? 'true' : 'false';
     }
     if (Array.isArray(value)) {
-      const formattedValue = value.map(v => v?.label ?? v);
+      const formattedValue = value.map((v: FilterItemType) => v?.label ?? v);
       return formattedValue.length ? formattedValue.join(', ') : '[]';
     }
     if (typeof value === 'string' || typeof value === 'number') {

--- a/superset-frontend/src/components/TelemetryPixel/index.tsx
+++ b/superset-frontend/src/components/TelemetryPixel/index.tsx
@@ -47,6 +47,7 @@ const TelemetryPixel = ({
   const pixelPath = `https://apachesuperset.gateway.scarf.sh/pixel/${PIXEL_ID}/${version}/${sha}/${build}`;
   return process.env.SCARF_ANALYTICS === 'false' ? null : (
     <img
+      // @ts-ignore
       referrerPolicy="no-referrer-when-downgrade"
       src={pixelPath}
       width={0}


### PR DESCRIPTION
### SUMMARY
This fixes the a bunch of typescript errors in `4.0`.

1. makeApi.ts (from #26693)
```
@superset-ui/core/src/query/api/v1/makeApi.ts:118:38 - error TS2352: Conversion of type 'Payload' to type 'URLSearchParams' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.

118         requestConfig.searchParams = payload as URLSearchParams;
                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~

@superset-ui/core/src/query/api/v1/makeApi.ts:122:37 - error TS2352: Conversion of type 'Payload' to type 'FormData' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.

122         requestConfig.postPayload = payload as FormData;
                                        ~~~~~~~~~~~~~~~~~~~
```

2. AlteredSliceTagMocks.ts (from #27030)
```
superset-frontend/src/components/AlteredSliceTag/AlteredSliceTagMocks.ts:20:36 - error TS2307: Cannot find module 'packages/superset-ui-chart-controls/src/types' or its corresponding type declarations.

20 import { ControlPanelConfig } from 'packages/superset-ui-chart-controls/src/types';
                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

3. AlteredSliceTag/index.tsx (from #27030)
```
superset-frontend/src/components/AlteredSliceTag/index.tsx:184:15 - error TS2339: Property 'comparator' does not exist on type 'string | number | FilterItemType | Record<string | number, any>'.
  Property 'comparator' does not exist on type 'string'.

184             v.comparator && v.comparator.constructor === Array
                  ~~~~~~~~~~

superset-frontend/src/components/AlteredSliceTag/index.tsx:184:31 - error TS2339: Property 'comparator' does not exist on type 'string | number | FilterItemType | Record<string | number, any>'.
  Property 'comparator' does not exist on type 'string'.

184             v.comparator && v.comparator.constructor === Array
                                  ~~~~~~~~~~

superset-frontend/src/components/AlteredSliceTag/index.tsx:185:23 - error TS2339: Property 'comparator' does not exist on type 'string | number | FilterItemType | Record<string | number, any>'.
  Property 'comparator' does not exist on type 'string'.

185               ? `[${v.comparator.join(', ')}]`
                          ~~~~~~~~~~

superset-frontend/src/components/AlteredSliceTag/index.tsx:186:19 - error TS2339: Property 'comparator' does not exist on type 'string | number | FilterItemType | Record<string | number, any>'.
  Property 'comparator' does not exist on type 'string'.

186               : v.comparator;
                      ~~~~~~~~~~

../../../apache-superset/superset-frontend/src/components/AlteredSliceTag/index.tsx:187:23 - error TS2339: Property 'subject' does not exist on type 'string | number | FilterItemType | Record<string | number, any>'.
  Property 'subject' does not exist on type 'string'.

187           return `${v.subject} ${v.operator} ${filterVal}`;
                          ~~~~~~~

superset-frontend/src/components/AlteredSliceTag/index.tsx:187:36 - error TS2339: Property 'operator' does not exist on type 'string | number | FilterItemType | Record<string | number, any>'.
  Property 'operator' does not exist on type 'string'.

187           return `${v.subject} ${v.operator} ${filterVal}`;
                                       ~~~~~~~~

superset-frontend/src/components/AlteredSliceTag/index.tsx:201:48 - error TS2339: Property 'label' does not exist on type 'string | number | FilterItemType | Record<string | number, any>'.
  Property 'label' does not exist on type 'string'.

201       const formattedValue = value.map(v => v?.label ?? v);
                                                   ~~~~~

superset-frontend/src/components/AlteredSliceTag/index.tsx:208:48 - error TS2339: Property 'label' does not exist on type 'string | number | FilterItemType | Record<string | number, any>'.
  Property 'label' does not exist on type 'string'.

208       const formattedValue = value.map(v => v?.label ?? v);
                                                   ~~~~~
```

4. TelemetryPixel/index.tsx

```
superset-frontend/src/components/TelemetryPixel/index.tsx:50:7 - error TS2322: Type '"no-referrer-when-downgrade"' is not assignable to type '"no-referrer" | "origin" | "unsafe-url" | undefined'.

50       referrerPolicy="no-referrer-when-downgrade"
         ~~~~~~~~~~~~~~

  superset-frontend/node_modules/@types/react/index.d.ts:2046:9
    2046         referrerPolicy?: "no-referrer" | "origin" | "unsafe-url";
                 ~~~~~~~~~~~~~~
```

### TESTING INSTRUCTIONS
npm run type

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
