### PR TITLE
fix: missing shared color in mixed timeseries

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -411,7 +411,8 @@ export default function transformProps(
   rawSeriesB.forEach(entry => {
     const entryName = String(entry.name || '');
     const seriesName = `${inverted[entryName] || entryName} (1)`;
-    const colorScaleKey = getOriginalSeries(seriesName, array);
+    const colorScaleSeriesName = inverted[entryName] || entryName;
+    const colorScaleKey = getOriginalSeries(colorScaleSeriesName, array);
 
     const seriesFormatter = getFormatter(
       customFormattersSecondary,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -410,9 +410,9 @@ export default function transformProps(
 
   rawSeriesB.forEach(entry => {
     const entryName = String(entry.name || '');
-    const seriesName = `${inverted[entryName] || entryName} (1)`;
-    const colorScaleSeriesName = inverted[entryName] || entryName;
-    const colorScaleKey = getOriginalSeries(colorScaleSeriesName, array);
+    const seriesEntry = inverted[entryName] || entryName;
+    const seriesName = `${seriesEntry} (1)`;
+    const colorScaleKey = getOriginalSeries(seriesEntry, array);
 
     const seriesFormatter = getFormatter(
       customFormattersSecondary,


### PR DESCRIPTION
### SUMMARY
When a shared label color is used in the mixed series chart, there seems to be an issue where the label color, particularly in the 2nd series label, is not accurately rendered. This occurs because the mixed series passes the label color name with a ` (1)` suffix, which is not necessary according to the color algorithm.
This commit aims to address this issue by removing this redundant suffix from the color scale key. 

|![Screenshot 2024-03-05 at 4 28 04 PM](https://github.com/apache/superset/assets/1392866/4d3bac15-f933-4ae0-b01d-f080f886e155)|![Screenshot 2024-03-05 at 4 30 14 PM](https://github.com/apache/superset/assets/1392866/1a4d7325-05c3-491e-b31f-a1daa577612b)|
|--|--|
|![Screenshot 2024-03-05 at 4 31 26 PM](https://github.com/apache/superset/assets/1392866/1afbe0fd-7337-48e9-886a-d6a3347b6bec)|![Screenshot 2024-03-05 at 4 31 14 PM](https://github.com/apache/superset/assets/1392866/6e3bd693-f023-4133-9482-3ce90c0896fd)|

### TESTING INSTRUCTIONS
storybook

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
