### PR TITLE
fix(excel/csv filename on chart download): downloads zip file and excel/csv file with chart name.

### DIFF
--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -361,10 +361,13 @@ class ChartDataRestApi(ChartRestApi):
 
         if result_format in ChartDataResultFormat.table_like():
             # Get chart name from slice_id
-            slice_obj = (
-                db.session.query(Slice).filter_by(id=form_data["slice_id"]).first()
-            )
-            chart_name = slice_obj.chart
+            if form_data is not None:
+                slice_obj = (
+                    db.session.query(Slice).filter_by(id=form_data["slice_id"]).first()
+                )
+                chart_name = slice_obj.chart
+            else:
+                chart_name = "query"
             # Verify user has permission to export file
             if not security_manager.can_access("can_csv", "Superset"):
                 return self.response_403()


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:

-->
fix(excel/csv filename on chart download): downloads zip file and excel/csv file with chart name.
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When we download any chart as excel/csv file, the file doesn't have appropriate name. So for filename its like
*  if the report is paginated it downloads zip folder, whose name is just timestamp for that we can make it like reportName_timstamp.zip.
     * Inside that zip comes 2 files, one which contains the data that can be named as reportname_timestamp.csv and other one reportname_rowcount_timestamp.csv
* In case report is not paginated we can directly name the file as reportname_timestamp.csv.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before
![image](https://github.com/apache/superset/assets/48522685/c109e299-83c6-4df1-ab74-9fbc33089a1a)
After
![image](https://github.com/apache/superset/assets/48522685/db7d5768-c300-4f8b-bd26-866ac7382e91)
![image](https://github.com/apache/superset/assets/48522685/22da02ca-d814-40ae-bb3b-20fecd48f2da)

<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
* Clone the repo, checkout to this branch.
* Run superset > navigate to any dashboard > click on three dots > download excel / download csv > View the filename
* The filename should be same as chart name.
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #21859 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Hi @sfirke as we discussed over [slack](https://apache-superset.slack.com/archives/C0170U650CQ/p1708620763042799?thread_ts=1708406517.357759&cid=C0170U650CQ),I have made the changes and tested manually on my local.
* For formatting I ran below command
``` 
tox -e pre-commit
tox -e pylint
```
* But while running test cases using pytest as below
```pytest  tests/integration_tests/charts/data/api_tests.py```
I am getting below error and unable to find root cause for it
```ERROR tests/integration_tests/charts/data/api_tests.py::test_chart_data_subquery_allowed[200-extras3] - sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such table: dbs```