### PR TITLE
fix(cypress): enabling Cypress experimentalMemoryManagement setting

### DIFF
--- a/superset-frontend/cypress-base/cypress.config.ts
+++ b/superset-frontend/cypress-base/cypress.config.ts
@@ -65,5 +65,6 @@ export default defineConfig({
     baseUrl: 'http://localhost:8088',
     excludeSpecPattern: ['**/*.applitools.test.ts'],
     specPattern: ['cypress/e2e/**/*.{js,jsx,ts,tsx}'],
+    experimentalMemoryManagement: true,
   },
 });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We keep seeing this error in Cypress:

```
We detected that the Chromium Renderer process just crashed.
  
  This is the equivalent to seeing the 'sad face' when Chrome dies.
  
  This can happen for a number of different reasons:
  
  - You wrote an endless loop and you must fix your own code
  - You are running Docker (there is an easy fix for this: see link below)
  - You are running lots of tests on a memory intense application
  - You are running in a memory starved VM environment
  - There are problems with your GPU / GPU drivers
  - There are browser bugs in Chromium
  
  You can learn more including how to fix Docker here:
  
  https://on.cypress.io/renderer-process-crashed
```

When I go to [that URL](https://on.cypress.io/renderer-process-crashed), it doesn't actually say anything about how to fix Docker, but it does suggest turning on the `experimentalMemoryManagement` flag for Chromium based browsers. So... well... here goes nothing!

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Well, CI should pass without that error, that's for sure!

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
