### PR TITLE
feat(time-comparison-table): show and hide time comparison columns

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/Dropdown.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/Dropdown.tsx
@@ -16,24 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import * as sectionsModule from './sections';
 
-export * from './utils';
-export * from './constants';
-export * from './operators';
-
-// can't do `export * as sections from './sections'`, babel-transformer will fail
-export const sections = sectionsModule;
-
-export * from './components/InfoTooltipWithTrigger';
-export * from './components/ColumnOption';
-export * from './components/ColumnTypeLabel/ColumnTypeLabel';
-export * from './components/ControlSubSectionHeader';
-export * from './components/Dropdown';
-export * from './components/Menu';
-export * from './components/MetricOption';
-export * from './components/Tooltip';
-
-export * from './shared-controls';
-export * from './types';
-export * from './fixtures';
+export { Dropdown } from 'antd';
+export type { DropDownProps } from 'antd/lib/dropdown';

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/Menu.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/Menu.tsx
@@ -16,24 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import * as sectionsModule from './sections';
 
-export * from './utils';
-export * from './constants';
-export * from './operators';
-
-// can't do `export * as sections from './sections'`, babel-transformer will fail
-export const sections = sectionsModule;
-
-export * from './components/InfoTooltipWithTrigger';
-export * from './components/ColumnOption';
-export * from './components/ColumnTypeLabel/ColumnTypeLabel';
-export * from './components/ControlSubSectionHeader';
-export * from './components/Dropdown';
-export * from './components/Menu';
-export * from './components/MetricOption';
-export * from './components/Tooltip';
-
-export * from './shared-controls';
-export * from './types';
-export * from './fixtures';
+export { Menu } from 'antd';
+export type { MenuProps } from 'antd/lib/menu';

--- a/superset-frontend/plugins/plugin-chart-table/package.json
+++ b/superset-frontend/plugins/plugin-chart-table/package.json
@@ -37,6 +37,7 @@
     "xss": "^1.0.14"
   },
   "peerDependencies": {
+    "@ant-design/icons": "^5.0.1",
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
     "@testing-library/dom": "^7.29.4",

--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
@@ -362,7 +362,9 @@ export default typedMemo(function DataTable<D extends object>({
       {hasGlobalControl ? (
         <div ref={globalControlRef} className="form-inline dt-controls">
           <div className="row">
-            <div className="col-sm-5">
+            <div
+              className={renderTimeComparisonDropdown ? 'col-sm-5' : 'col-sm-6'}
+            >
               {hasPagination ? (
                 <SelectPageSize
                   total={resultsSize}
@@ -378,7 +380,11 @@ export default typedMemo(function DataTable<D extends object>({
               ) : null}
             </div>
             {searchInput ? (
-              <div className="col-sm-5">
+              <div
+                className={
+                  renderTimeComparisonDropdown ? 'col-sm-5' : 'col-sm-6'
+                }
+              >
                 <GlobalFilter<D>
                   searchInput={
                     typeof searchInput === 'boolean' ? undefined : searchInput

--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
@@ -68,6 +68,7 @@ export interface DataTableProps<D extends object> extends TableOptions<D> {
   wrapperRef?: MutableRefObject<HTMLDivElement>;
   onColumnOrderChange: () => void;
   renderGroupingHeaders?: () => JSX.Element;
+  renderTimeComparisonDropdown?: () => JSX.Element;
 }
 
 export interface RenderHTMLCellProps extends HTMLProps<HTMLTableCellElement> {
@@ -101,6 +102,7 @@ export default typedMemo(function DataTable<D extends object>({
   wrapperRef: userWrapperRef,
   onColumnOrderChange,
   renderGroupingHeaders,
+  renderTimeComparisonDropdown,
   ...moreUseTableOptions
 }: DataTableProps<D>): JSX.Element {
   const tableHooks: PluginHook<D>[] = [
@@ -117,7 +119,8 @@ export default typedMemo(function DataTable<D extends object>({
   const sortByRef = useRef([]); // cache initial `sortby` so sorting doesn't trigger page reset
   const pageSizeRef = useRef([initialPageSize, resultsSize]);
   const hasPagination = initialPageSize > 0 && resultsSize > 0; // pageSize == 0 means no pagination
-  const hasGlobalControl = hasPagination || !!searchInput;
+  const hasGlobalControl =
+    hasPagination || !!searchInput || renderTimeComparisonDropdown;
   const initialState = {
     ...initialState_,
     // zero length means all pages, the `usePagination` plugin does not
@@ -359,7 +362,7 @@ export default typedMemo(function DataTable<D extends object>({
       {hasGlobalControl ? (
         <div ref={globalControlRef} className="form-inline dt-controls">
           <div className="row">
-            <div className="col-sm-6">
+            <div className="col-sm-5">
               {hasPagination ? (
                 <SelectPageSize
                   total={resultsSize}
@@ -375,7 +378,7 @@ export default typedMemo(function DataTable<D extends object>({
               ) : null}
             </div>
             {searchInput ? (
-              <div className="col-sm-6">
+              <div className="col-sm-5">
                 <GlobalFilter<D>
                   searchInput={
                     typeof searchInput === 'boolean' ? undefined : searchInput
@@ -384,6 +387,11 @@ export default typedMemo(function DataTable<D extends object>({
                   setGlobalFilter={setGlobalFilter}
                   filterValue={filterValue}
                 />
+              </div>
+            ) : null}
+            {renderTimeComparisonDropdown ? (
+              <div className="col-sm-2" style={{ float: 'right' }}>
+                {renderTimeComparisonDropdown()}
               </div>
             ) : null}
           </div>

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -265,9 +265,10 @@ export default function TableChart<D extends DataRecord = DataRecord>(
   });
   // keep track of whether column order changed, so that column widths can too
   const [columnOrderToggle, setColumnOrderToggle] = useState(false);
-  const [showTimeComparisonDropdown, setShowTimeComparisonDropdown] =
-    useState(false);
-  const [selectedKeys, setSelectedKeys] = useState([comparisonColumns[0].key]);
+  const [showComparisonDropdown, setShowComparisonDropdown] = useState(false);
+  const [selectedComparisonColumns, setSelectedComparisonColumns] = useState([
+    comparisonColumns[0].key,
+  ]);
   const [hideComparisonKeys, setHideComparisonKeys] = useState<string[]>([]);
   const theme = useTheme();
 
@@ -395,7 +396,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
     }
     const allColumns = comparisonColumns[0].key;
     const main = comparisonLabels[0];
-    const showAllColumns = selectedKeys.includes(allColumns);
+    const showAllColumns = selectedComparisonColumns.includes(allColumns);
 
     return columnsMeta.filter(({ label, key }) => {
       // Extract the key portion after the space, assuming the format is always "label key"
@@ -404,12 +405,11 @@ export default function TableChart<D extends DataRecord = DataRecord>(
       const isLableMain = label === main;
 
       return (
-        (isKeyHidded && isLableMain) ||
+        isLableMain ||
         (!isKeyHidded &&
-          (isLableMain ||
-            !comparisonLabels.includes(label) ||
+          (!comparisonLabels.includes(label) ||
             showAllColumns ||
-            selectedKeys.includes(label)))
+            selectedComparisonColumns.includes(label)))
       );
     });
   }, [
@@ -418,7 +418,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
     comparisonLabels,
     enableTimeComparison,
     hideComparisonKeys,
-    selectedKeys,
+    selectedComparisonColumns,
   ]);
 
   const handleContextMenu =
@@ -501,38 +501,38 @@ export default function TableChart<D extends DataRecord = DataRecord>(
       const { key } = data;
       // Toggle 'All' key selection
       if (key === allKey) {
-        setSelectedKeys([allKey]);
-      } else if (selectedKeys.includes(allKey)) {
-        setSelectedKeys([key]);
+        setSelectedComparisonColumns([allKey]);
+      } else if (selectedComparisonColumns.includes(allKey)) {
+        setSelectedComparisonColumns([key]);
       } else {
         // Toggle selection for other keys
-        setSelectedKeys(
-          selectedKeys.includes(key)
-            ? selectedKeys.filter(k => k !== key) // Deselect if already selected
-            : [...selectedKeys, key],
+        setSelectedComparisonColumns(
+          selectedComparisonColumns.includes(key)
+            ? selectedComparisonColumns.filter(k => k !== key) // Deselect if already selected
+            : [...selectedComparisonColumns, key],
         ); // Select if not already selected
       }
     };
 
     const handleOnBlur = () => {
-      if (selectedKeys.length === 3) {
-        setSelectedKeys([comparisonColumns[0].key]);
+      if (selectedComparisonColumns.length === 3) {
+        setSelectedComparisonColumns([comparisonColumns[0].key]);
       }
     };
 
     return (
       <Dropdown
         placement="bottomRight"
-        visible={showTimeComparisonDropdown}
+        visible={showComparisonDropdown}
         onVisibleChange={(flag: boolean) => {
-          setShowTimeComparisonDropdown(flag);
+          setShowComparisonDropdown(flag);
         }}
         overlay={
           <Menu
             multiple
             onClick={handleOnClick}
             onBlur={handleOnBlur}
-            selectedKeys={selectedKeys}
+            selectedKeys={selectedComparisonColumns}
           >
             <div
               css={css`
@@ -561,7 +561,9 @@ export default function TableChart<D extends DataRecord = DataRecord>(
                     font-size: ${theme.typography.sizes.s}px;
                   `}
                 >
-                  {selectedKeys.includes(column.key) && <CheckOutlined />}
+                  {selectedComparisonColumns.includes(column.key) && (
+                    <CheckOutlined />
+                  )}
                 </span>
               </Menu.Item>
             ))}

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -606,7 +606,9 @@ export default function TableChart<D extends DataRecord = DataRecord>(
           <span
             css={css`
               float: right;
-              color: ${theme.colors.grayscale.base};
+              & svg {
+                color: ${theme.colors.grayscale.base} !important;
+              }
             `}
           >
             {hideComparisonKeys.includes(key) ? (


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add a dropdown in the top-right to select time comparison columns to display. Include '-' and '+' buttons in all columns for visibility control:
- Dropdown: Selects columns to show.
- '-' Button: Hides all time comparison columns.
- '+' Button: Shows selected columns based on the dropdown choice.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![time-comparison](https://github.com/apache/superset/assets/5705598/bc486ad9-6382-4b3e-85e8-e53e5b6b0174)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
