### PR TITLE
fix(package-lock): node_modules/@react/types to 16.9.53

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -80,7 +80,7 @@
     "last 3 edge versions"
   ],
   "dependencies": {
-    "@ant-design/icons": "^5.2.6",
+    "@ant-design/icons": "^5.0.1",
     "@emotion/babel-preset-css-prop": "^11.11.0",
     "@emotion/cache": "^11.4.0",
     "@emotion/react": "^11.4.1",

--- a/superset-frontend/src/components/TelemetryPixel/index.tsx
+++ b/superset-frontend/src/components/TelemetryPixel/index.tsx
@@ -47,7 +47,6 @@ const TelemetryPixel = ({
   const pixelPath = `https://apachesuperset.gateway.scarf.sh/pixel/${PIXEL_ID}/${version}/${sha}/${build}`;
   return process.env.SCARF_ANALYTICS === 'false' ? null : (
     <img
-      // @ts-ignore
       referrerPolicy="no-referrer-when-downgrade"
       src={pixelPath}
       width={0}


### PR DESCRIPTION
### SUMMARY
During the implementation of [#26011](https://github.com/apache/superset/pull/26011/files#diff-535054a5c3b273a1f8a602847fd9d9a0b881058725b3565b590f08c0dabac187R19622), @types/react was upgraded to `16.9.53`, and as a result, package-lock selected the `16.14.51` version.

![feat_telemetry___Adding_Scarf_based_telemetry_to_Superset___26011__·_apache_superset_8437a23](https://github.com/apache/superset/assets/1392866/95622d6a-87c8-4c4b-9486-30506ccee9d9)

Here at Airbnb, our internal dependencies are not yet compatible with `types/react@16.14.51`, thereby posing a hurdle for our release. We intend to explore compatibility with 16.14.51 in Superset 5.0 or later versions, although the timing is not ideal right now.

This commit modifies the `package-lock` to reflect the same version number as outlined in #26011.
Simultaneously, we've also lowered @ant-design/icons@5.2.6 (#26727) to 5.0.1, due to its incompatibility with 16.9.53.

### TESTING INSTRUCTIONS
npm run type

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
