### PR TITLE
fix(postprocessing): resample with holes

### DIFF
--- a/superset/utils/pandas_postprocessing/resample.py
+++ b/superset/utils/pandas_postprocessing/resample.py
@@ -43,13 +43,16 @@ def resample(
         raise InvalidPostProcessingError(_("Resample operation requires DatetimeIndex"))
     if method not in RESAMPLE_METHOD:
         raise InvalidPostProcessingError(
-            _("Resample method should in ") + ", ".join(RESAMPLE_METHOD) + "."
+            _("Resample method should be in ") + ", ".join(RESAMPLE_METHOD) + "."
         )
 
     if method == "asfreq" and fill_value is not None:
         _df = df.resample(rule).asfreq(fill_value=fill_value)
+        _df = _df.fillna(fill_value)
     elif method == "linear":
         _df = df.resample(rule).interpolate()
     else:
         _df = getattr(df.resample(rule), method)()
+        if method in ("ffill", "bfill"):
+            _df = _df.fillna(method=method)
     return _df

--- a/tests/unit_tests/fixtures/dataframes.py
+++ b/tests/unit_tests/fixtures/dataframes.py
@@ -135,6 +135,15 @@ timeseries_with_gap_df = DataFrame(
     data={"label": ["x", "y", "z", "q"], "y": [1.0, 2.0, None, 4.0]},
 )
 
+timeseries_with_gap_df2 = DataFrame(
+    index=to_datetime(["2019-01-01", "2019-01-02", "2019-01-05", "2019-01-07"]),
+    data={
+        "label": ["x", None, "z", "q"],
+        "y": [1.0, 2.0, None, 4.0],
+        "z": [2.0, None, 10.0, 8.0],
+    },
+)
+
 timeseries_df2 = DataFrame(
     index=to_datetime(["2019-01-01", "2019-01-02", "2019-01-05", "2019-01-07"]),
     data={

--- a/tests/unit_tests/fixtures/dataframes.py
+++ b/tests/unit_tests/fixtures/dataframes.py
@@ -135,15 +135,6 @@ timeseries_with_gap_df = DataFrame(
     data={"label": ["x", "y", "z", "q"], "y": [1.0, 2.0, None, 4.0]},
 )
 
-timeseries_with_gap_df2 = DataFrame(
-    index=to_datetime(["2019-01-01", "2019-01-02", "2019-01-05", "2019-01-07"]),
-    data={
-        "label": ["x", None, "z", "q"],
-        "y": [1.0, 2.0, None, 4.0],
-        "z": [2.0, None, 10.0, 8.0],
-    },
-)
-
 timeseries_df2 = DataFrame(
     index=to_datetime(["2019-01-01", "2019-01-02", "2019-01-05", "2019-01-07"]),
     data={

--- a/tests/unit_tests/pandas_postprocessing/test_resample.py
+++ b/tests/unit_tests/pandas_postprocessing/test_resample.py
@@ -24,7 +24,7 @@ from superset.utils import pandas_postprocessing as pp
 from tests.unit_tests.fixtures.dataframes import (
     categories_df,
     timeseries_df,
-    timeseries_with_gap_df2,
+    timeseries_with_gap_df,
 )
 
 
@@ -68,7 +68,7 @@ def test_resample():
 
 
 def test_resample_ffill_with_gaps():
-    post_df = pp.resample(df=timeseries_with_gap_df2, rule="1D", method="ffill")
+    post_df = pp.resample(df=timeseries_with_gap_df, rule="1D", method="ffill")
     assert post_df.equals(
         pd.DataFrame(
             index=pd.to_datetime(
@@ -83,9 +83,8 @@ def test_resample_ffill_with_gaps():
                 ]
             ),
             data={
-                "label": ["x", "x", "x", "x", "z", "z", "q"],
+                "label": ["x", "y", "y", "y", "z", "z", "q"],
                 "y": [1.0, 2.0, 2.0, 2.0, 2.0, 2.0, 4.0],
-                "z": [2.0, 2.0, 2.0, 2.0, 10.0, 10.0, 8.0],
             },
         )
     )
@@ -116,7 +115,7 @@ def test_resample_zero_fill():
 
 def test_resample_zero_fill_with_gaps():
     post_df = pp.resample(
-        df=timeseries_with_gap_df2, rule="1D", method="asfreq", fill_value=0
+        df=timeseries_with_gap_df, rule="1D", method="asfreq", fill_value=0
     )
     assert post_df.equals(
         pd.DataFrame(
@@ -132,9 +131,8 @@ def test_resample_zero_fill_with_gaps():
                 ]
             ),
             data={
-                "label": ["x", 0, 0, 0, "z", 0, "q"],
+                "label": ["x", "y", 0, 0, "z", 0, "q"],
                 "y": [1.0, 2.0, 0, 0, 0, 0, 4.0],
-                "z": [2.0, 0, 0, 0, 10.0, 0, 8.0],
             },
         )
     )

--- a/tests/unit_tests/pandas_postprocessing/test_resample.py
+++ b/tests/unit_tests/pandas_postprocessing/test_resample.py
@@ -21,7 +21,11 @@ from pandas import to_datetime
 
 from superset.exceptions import InvalidPostProcessingError
 from superset.utils import pandas_postprocessing as pp
-from tests.unit_tests.fixtures.dataframes import categories_df, timeseries_df
+from tests.unit_tests.fixtures.dataframes import (
+    categories_df,
+    timeseries_df,
+    timeseries_with_gap_df2,
+)
 
 
 def test_resample_should_not_side_effect():
@@ -63,6 +67,30 @@ def test_resample():
     )
 
 
+def test_resample_ffill_with_gaps():
+    post_df = pp.resample(df=timeseries_with_gap_df2, rule="1D", method="ffill")
+    assert post_df.equals(
+        pd.DataFrame(
+            index=pd.to_datetime(
+                [
+                    "2019-01-01",
+                    "2019-01-02",
+                    "2019-01-03",
+                    "2019-01-04",
+                    "2019-01-05",
+                    "2019-01-06",
+                    "2019-01-07",
+                ]
+            ),
+            data={
+                "label": ["x", "x", "x", "x", "z", "z", "q"],
+                "y": [1.0, 2.0, 2.0, 2.0, 2.0, 2.0, 4.0],
+                "z": [2.0, 2.0, 2.0, 2.0, 10.0, 10.0, 8.0],
+            },
+        )
+    )
+
+
 def test_resample_zero_fill():
     post_df = pp.resample(df=timeseries_df, rule="1D", method="asfreq", fill_value=0)
     assert post_df.equals(
@@ -81,6 +109,32 @@ def test_resample_zero_fill():
             data={
                 "label": ["x", "y", 0, 0, "z", 0, "q"],
                 "y": [1.0, 2.0, 0, 0, 3.0, 0, 4.0],
+            },
+        )
+    )
+
+
+def test_resample_zero_fill_with_gaps():
+    post_df = pp.resample(
+        df=timeseries_with_gap_df2, rule="1D", method="asfreq", fill_value=0
+    )
+    assert post_df.equals(
+        pd.DataFrame(
+            index=pd.to_datetime(
+                [
+                    "2019-01-01",
+                    "2019-01-02",
+                    "2019-01-03",
+                    "2019-01-04",
+                    "2019-01-05",
+                    "2019-01-06",
+                    "2019-01-07",
+                ]
+            ),
+            data={
+                "label": ["x", 0, 0, 0, "z", 0, "q"],
+                "y": [1.0, 2.0, 0, 0, 0, 0, 4.0],
+                "z": [2.0, 0, 0, 0, 10.0, 0, 8.0],
             },
         )
     )


### PR DESCRIPTION
### SUMMARY
Currently zero imputation, forward values and backwards values in advanced analytics only works correctly if the time index is completely missing - if the index is present, and there are null values for a specific series, they will not be imputed correctly.

When doing zero imputation for a single series and the time index for the intermediate values is missing, the imputation works as expected:
<img width="1338" alt="image" src="https://github.com/apache/superset/assets/33317356/2f3a2888-5289-45b9-b101-95e0284352f7">

However, with multiple series, it no longer works if the intermediate values are missing in one series for certain indices, but are present for the other. Notice the missing imputation for "boy" series:

### BEFORE

Zero imputation:
<img width="1335" alt="image" src="https://github.com/apache/superset/assets/33317356/33d40e99-011f-405f-bf18-ae0b37c565cc">

Forward values:
<img width="1333" alt="image" src="https://github.com/apache/superset/assets/33317356/40a45807-38b8-4609-801e-b5a2665e2af3">

Backward values:
<img width="1330" alt="image" src="https://github.com/apache/superset/assets/33317356/3bbbdb38-22e0-4a12-b257-fb742f6ae2ab">

### AFTER
Now the zero, backfill and forward fill are imputed correctly.

Zero imputation:
<img width="1336" alt="image" src="https://github.com/apache/superset/assets/33317356/e3008e1a-7732-41f3-8513-3c52d195e434">

Forward values:
<img width="1336" alt="image" src="https://github.com/apache/superset/assets/33317356/7e26b0e6-c614-4c66-bf5f-607c5beadfb2">

Backward values:
<img width="1341" alt="image" src="https://github.com/apache/superset/assets/33317356/d6ead2d4-46d4-44fe-9830-d9c68903f6bd">

Note, other methods, like linear interpolation were already working as expected.

### TESTING INSTRUCTIONS
1. Create a temporal chart with multiple series, where at least one temporal index is missing for one series
2. Perform zero imputation, forward values or backward values filling
3. Notice it doesn't work.
4. Make the series with the missing indices the only series in the chart, and notice all above mentioned imputation methods work as expected.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
