### PR TITLE
fix(big-number-chart): number format is not applying to percentage number of the time comparison

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/controlPanel.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/controlPanel.ts
@@ -118,6 +118,15 @@ const config: ControlPanelConfig = {
       expanded: true,
       controlSetRows: [
         ['y_axis_format'],
+        [
+          {
+            name: 'percentDifferenceFormat',
+            config: {
+              ...sharedControls.y_axis_format,
+              label: t('Percent Difference format'),
+            },
+          },
+        ],
         ['currency_format'],
         [
           {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
@@ -21,7 +21,6 @@ import {
   ChartProps,
   getMetricLabel,
   getValueFormatter,
-  NumberFormats,
   getNumberFormatter,
   formatTimeRange,
 } from '@superset-ui/core';

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
@@ -84,6 +84,7 @@ export default function transformProps(chartProps: ChartProps) {
     currencyFormat,
     subheaderFontSize,
     comparisonColorEnabled,
+    percentDifferenceFormat,
   } = formData;
   const { data: dataA = [] } = queriesData[0];
   const {
@@ -113,9 +114,7 @@ export default function transformProps(chartProps: ChartProps) {
     w: 'Week' as string,
   };
 
-  const formatPercentChange = getNumberFormatter(
-    NumberFormats.PERCENT_SIGNED_1_POINT,
-  );
+  const formatPercentChange = getNumberFormatter(percentDifferenceFormat);
 
   let valueDifference: number | string = bigNumber - prevNumber;
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR is a following up pr for this https://github.com/apache/superset/pull/27052#issuecomment-1938874539 and fixes an issue where number formatting was not applied to percentage differences. A new formatting option for percentage differences has been added for this fix.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
After:
![time-comparison](https://github.com/apache/superset/assets/5705598/a45b0c16-1db4-4702-b2b8-71eb0255233a)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
