### PR TITLE
fix: docker builds in master fail

### DIFF
--- a/.github/supersetbot/src/docker.js
+++ b/.github/supersetbot/src/docker.js
@@ -79,7 +79,7 @@ export function getDockerTags({
 }
 
 export function getDockerCommand({
-  preset, platform, isAuthenticated, buildContext, buildContextRef, forceLatest = false,
+  preset, platform, buildContext, buildContextRef, forceLatest = false,
 }) {
   const platforms = platform;
 
@@ -113,6 +113,8 @@ export function getDockerCommand({
   const tags = getDockerTags({
     preset, platforms, sha, buildContext, buildContextRef: ref, forceLatest,
   }).map((tag) => `-t ${tag}`).join(' \\\n        ');
+  const isAuthenticated = !!(process.env.DOCKERHUB_TOKEN && process.env.DOCKERHUB_USER);
+
   const dockerArgs = isAuthenticated ? '--push' : '--load';
   const targetArgument = buildTarget ? `--target ${buildTarget}` : '';
   const cacheRef = `${CACHE_REPO}:${pyVer}`;


### PR DESCRIPTION
Bug slipped through for logic that executes only post-merge. This should
fix the issue observed here
https://github.com/apache/superset/actions/runs/8272961124/job/22635811674

For context I recently translated the docker-build logic from python to
JS so that I'd all be under `supersetbot`

