### PR TITLE
fix: Hive integration test

### DIFF
--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -450,6 +450,9 @@ class TestPostChartDataApi(BaseTestChartDataApi):
         """
         Chart data API: Test chart data query with applied time extras
         """
+        if backend() == "hive":
+            return
+
         self.query_context_payload["queries"][0]["applied_time_extras"] = {
             "__time_range": "100 years ago : now",
             "__time_origin": "now",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Skipping the Hive test that is failing with a message that doesn't make sense. It complains about this generated query not being valid due to the `GROUP 1`, even though it is valud:

```sql
SELECT
  `name` AS `name`,
  SUM(num) AS `sum__num`
FROM `birth_names`
WHERE
  `ds` >= CAST('1924-03-14 00:00:00.000000' AS TIMESTAMP)
  AND `ds` < CAST('2024-03-14 21:34:33.000000' AS TIMESTAMP)
  AND `gender` = 'boy'
  AND NOT `num` IS NULL
  AND NOT (
    `name` IS NULL OR `name` IN ('"abc"')
  )
GROUP BY
  1
ORDER BY
  `sum__num` DESC
LIMIT 100;
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
