### PR TITLE
feat(plugins):  add color options for big number with time comparison

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/PopKPI.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/PopKPI.tsx
@@ -20,6 +20,7 @@ import React, { useMemo } from 'react';
 import { css, styled, t, useTheme } from '@superset-ui/core';
 import { Tooltip } from '@superset-ui/chart-controls';
 import {
+  ColorSchemeEnum,
   PopKPIComparisonSymbolStyleProps,
   PopKPIComparisonValueStyleProps,
   PopKPIProps,
@@ -66,6 +67,7 @@ export default function PopKPI(props: PopKPIProps) {
     headerFontSize,
     subheaderFontSize,
     comparisonColorEnabled,
+    comparisonColorScheme,
     percentDifferenceNumber,
     comparatorText,
   } = props;
@@ -90,8 +92,18 @@ export default function PopKPI(props: PopKPIProps) {
   `;
 
   const getArrowIndicatorColor = () => {
-    if (!comparisonColorEnabled) return theme.colors.grayscale.base;
-    return percentDifferenceNumber > 0
+    if (!comparisonColorEnabled || percentDifferenceNumber === 0) {
+      return theme.colors.grayscale.base;
+    }
+
+    if (percentDifferenceNumber > 0) {
+      // Positive difference
+      return comparisonColorScheme === ColorSchemeEnum.Green
+        ? theme.colors.success.base
+        : theme.colors.error.base;
+    }
+    // Negative difference
+    return comparisonColorScheme === ColorSchemeEnum.Red
       ? theme.colors.success.base
       : theme.colors.error.base;
   };
@@ -106,23 +118,32 @@ export default function PopKPI(props: PopKPIProps) {
   const { backgroundColor, textColor } = useMemo(() => {
     let bgColor = defaultBackgroundColor;
     let txtColor = defaultTextColor;
-    if (percentDifferenceNumber > 0) {
-      if (comparisonColorEnabled) {
-        bgColor = theme.colors.success.light2;
-        txtColor = theme.colors.success.base;
-      }
-    } else if (percentDifferenceNumber < 0) {
-      if (comparisonColorEnabled) {
-        bgColor = theme.colors.error.light2;
-        txtColor = theme.colors.error.base;
-      }
+    if (comparisonColorEnabled && percentDifferenceNumber !== 0) {
+      const useSuccess =
+        (percentDifferenceNumber > 0 &&
+          comparisonColorScheme === ColorSchemeEnum.Green) ||
+        (percentDifferenceNumber < 0 &&
+          comparisonColorScheme === ColorSchemeEnum.Red);
+
+      // Set background and text colors based on the conditions
+      bgColor = useSuccess
+        ? theme.colors.success.light2
+        : theme.colors.error.light2;
+      txtColor = useSuccess
+        ? theme.colors.success.base
+        : theme.colors.error.base;
     }
 
     return {
       backgroundColor: bgColor,
       textColor: txtColor,
     };
-  }, [theme, comparisonColorEnabled, percentDifferenceNumber]);
+  }, [
+    theme,
+    comparisonColorScheme,
+    comparisonColorEnabled,
+    percentDifferenceNumber,
+  ]);
 
   const SYMBOLS_WITH_VALUES = useMemo(
     () => [

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/controlPanel.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/controlPanel.ts
@@ -32,6 +32,7 @@ import {
   sharedControls,
 } from '@superset-ui/chart-controls';
 import { headerFontSize, subheaderFontSize } from '../sharedControls';
+import { ColorSchemeEnum } from './types';
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
@@ -153,6 +154,27 @@ const config: ControlPanelConfig = {
               renderTrigger: true,
               default: false,
               description: t('Add color for positive/negative change'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'comparison_color_scheme',
+            config: {
+              type: 'SelectControl',
+              label: t('color scheme for comparison'),
+              default: ColorSchemeEnum.Green,
+              renderTrigger: true,
+              choices: [
+                [ColorSchemeEnum.Green, 'Green for increase, red for decrease'],
+                [ColorSchemeEnum.Red, 'Red for increase, green for decrease'],
+              ],
+              visibility: ({ controls }) =>
+                controls?.comparison_color_enabled?.value === true,
+              description: t(
+                ' Adds color to the chart symbols based on the positive or' +
+                  'negative change from the comparison value.',
+              ),
             },
           },
         ],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/controlPanel.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/controlPanel.ts
@@ -172,7 +172,7 @@ const config: ControlPanelConfig = {
               visibility: ({ controls }) =>
                 controls?.comparison_color_enabled?.value === true,
               description: t(
-                ' Adds color to the chart symbols based on the positive or' +
+                'Adds color to the chart symbols based on the positive or ' +
                   'negative change from the comparison value.',
               ),
             },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
@@ -82,6 +82,7 @@ export default function transformProps(chartProps: ChartProps) {
     yAxisFormat,
     currencyFormat,
     subheaderFontSize,
+    comparisonColorScheme,
     comparisonColorEnabled,
     percentDifferenceFormat,
   } = formData;
@@ -152,6 +153,7 @@ export default function transformProps(chartProps: ChartProps) {
     headerText,
     compType,
     comparisonColorEnabled,
+    comparisonColorScheme,
     percentDifferenceNumber: percentDifferenceNum,
     comparatorText,
   };

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/types.ts
@@ -61,4 +61,10 @@ export type PopKPIProps = PopKPIStylesProps &
     compType: string;
     percentDifferenceNumber: number;
     comparatorText: string;
+    comparisonColorScheme?: string;
   };
+
+export enum ColorSchemeEnum {
+  Green = 'Green',
+  Red = 'Red',
+}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This pull request adds a feature to the Big number with time comparison chart, allowing users to color-code positive and negative changes. It introduces a dropdown menu for selecting between two color schemes: the default "Green for increase, Red for decrease" or  "Red for increase, Green for decrease." Users can switch between these options, and the chart will update automatically to reflect the change.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
After:
![time-comparison](https://github.com/apache/superset/assets/5705598/40c82ab8-a444-479e-85a9-32ee36e9e5a8)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
