### PR TITLE
chore(docs): fix last broken Slack join link in docs

### DIFF
--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -53,7 +53,7 @@ $ docker exec -it superset superset db upgrade &&
 :::tip
 This step can take some time. While you wait, feel free to join the official Slack channel to check for new releases,
 ask questions, and engage with the community.
-[Click here to join.](https://apache-superset.slack.com/join/shared_invite/zt-26ol9ge4y-kzUnSo9inRepOay0ufBTsA#/shared-invite/email)
+[Click here to join.](http://bit.ly/join-superset-slack)
 :::
 
 ### 5. Start using Superset


### PR DESCRIPTION
### SUMMARY
We've generally migrated from Slack join links that expire to a bit.ly that stays updated thanks to Evan.  This is one more case of that, and the last in the docs as far as I can find.
