### PR TITLE
docs: make k8s top item in Installation section

### DIFF
--- a/docs/docs/installation/installing-superset-using-docker-compose.mdx
+++ b/docs/docs/installation/installing-superset-using-docker-compose.mdx
@@ -16,7 +16,10 @@ below. It's also the easiest way to launch a fully functioning **development env
 :::caution
 Since `docker-compose` is primarily designed to run a set of containers on **a single host**
 and can't credibly support **high availability** as a result, we do not support nor recommend
-using our `docker-compose` constructs to support production-type use-cases.
+using our `docker-compose` constructs to support production-type use-cases. For single host
+environments, we recommend using [minikube](https://minikube.sigs.k8s.io/docs/start/) along
+our [installing on k8s](https://superset.apache.org/docs/installation/running-on-kubernetes)
+documentation.
 :::
 
 Note that there are 3 major ways we support to run docker-compose:

--- a/docs/docs/installation/installing-superset-using-docker-compose.mdx
+++ b/docs/docs/installation/installing-superset-using-docker-compose.mdx
@@ -1,21 +1,23 @@
 ---
 title: Installing Locally Using Docker Compose
 hide_title: true
-sidebar_position: 1
+sidebar_position: 3
 version: 1
 ---
 
 ## Using Docker Compose
 
-The fastest way to try Superset locally is using Docker and Docker Compose on a Linux or Mac OSX
-computer. Superset does not have official support for Windows, so we have provided a VM workaround
-below.
-
-It's **not** typical, nor recommended to use docker-compose to productionize an
-application like Superset. docker-compose should be used for local development
-or testing the app.
-
 **DO NOT USE THIS FOR PRODUCTION!**
+
+The fastest way to try Superset locally is using Docker Compose on a Linux or Mac OSX
+computer. Superset does not have official support for Windows, so we have provided a VM workaround
+below. It's also the easiest way to launch a fully functioning **development environment** quickly.
+
+:::caution
+Since `docker-compose` is primarily designed to run a set of containers on **a single host**
+and can't credibly support **high availability** as a result, we do not support nor recommend
+using our `docker-compose` constructs to support production-type use-cases.
+:::
 
 Note that there are 3 major ways we support to run docker-compose:
 1. **docker-compose.yml:** for interactive development, where we mount your local folder with the

--- a/docs/docs/installation/running-on-kubernetes.mdx
+++ b/docs/docs/installation/running-on-kubernetes.mdx
@@ -7,12 +7,20 @@ version: 1
 
 ## Installing on Kubernetes
 
-Running Superset on Kubernetes is supported with the provided [Helm](https://helm.sh/) chart found in the official [Superset helm repository](https://apache.github.io/superset/index.yaml).
+Running Superset on Kubernetes is supported with the provided [Helm](https://helm.sh/) chart
+found in the official [Superset helm repository](https://apache.github.io/superset/index.yaml).
 
 ### Prerequisites
 
 - A Kubernetes cluster
 - Helm installed
+
+:::note
+For simpler, single host environments, we recommend using
+[minikube](https://minikube.sigs.k8s.io/docs/start/) which is easy to setup on many platforms
+and works fantastically well with the Helm chart referenced here.
+:::
+
 
 ### Running
 

--- a/docs/docs/installation/running-on-kubernetes.mdx
+++ b/docs/docs/installation/running-on-kubernetes.mdx
@@ -1,7 +1,7 @@
 ---
 title: Installing on Kubernetes
 hide_title: true
-sidebar_position: 3
+sidebar_position: 1
 version: 1
 ---
 

--- a/docs/docs/intro.mdx
+++ b/docs/docs/intro.mdx
@@ -15,7 +15,6 @@ Here are a **few different ways you can get started with Superset**:
 
 - Try a [Quickstart deployment](/docs/quickstart), which runs a single Docker container
 - Install Superset [from PyPI](/docs/installation/installing-superset-from-pypi/)
-- Deploy Superset [using Docker Compose](/docs/installation/installing-superset-using-docker-compose)
 - Deploy Superset [with Kubernetes](/docs/installation/running-on-kubernetes)
 - Download the [source code from Apache Foundation's website](https://dist.apache.org/repos/dist/release/superset/)
 


### PR DESCRIPTION
Also clarify our stance against using our docker-compose assets in production

tested minikube and provided pointers in the docs