### PR TITLE
fix(AlertsReports): making log retention "None" option valid 

### DIFF
--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -1622,11 +1622,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                 ariaLabel={t('Log retention')}
                 placeholder={t('Log retention')}
                 onChange={onLogRetentionChange}
-                value={
-                  typeof currentAlert?.log_retention === 'number'
-                    ? currentAlert?.log_retention
-                    : ALERT_REPORTS_DEFAULT_RETENTION
-                }
+                value={currentAlert?.log_retention}
                 options={RETENTION_OPTIONS}
                 sortComparator={propertyComparator('value')}
               />

--- a/superset/commands/report/log_prune.py
+++ b/superset/commands/report/log_prune.py
@@ -48,6 +48,7 @@ class AsyncPruneReportScheduleLogCommand(BaseCommand):
                     row_count = ReportScheduleDAO.bulk_delete_logs(
                         report_schedule, from_date, commit=False
                     )
+                    db.session.commit()
                     logger.info(
                         "Deleted %s logs for report schedule id: %s",
                         str(row_count),

--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -320,7 +320,7 @@ class ReportSchedulePutSchema(Schema):
     log_retention = fields.Integer(
         metadata={"description": log_retention_description, "example": 90},
         required=False,
-        validate=[Range(min=1, error=_("Value must be greater than 0"))],
+        validate=[Range(min=0, error=_("Value must be 0 or greater"))],
     )
     grace_period = fields.Integer(
         metadata={"description": grace_period_description, "example": 60 * 60 * 4},


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR implements two changes:
1. Default behavior of log retention was to never commit session changes when log_prune runs. This behavior has been changed to ensure that logs are in fact deleted when log_prune runs.
2. When a value of "None" was selected from the dropdown options, the backend would return a validation error "log_retention must be greater than 0." The changes attempt to fix this so that a log retention of 0 days results in all logs being deleted.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![image](https://github.com/apache/superset/assets/41238731/8ffc1f46-2166-41e8-9397-6d0c456d20f6)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Required feature flags: ALERTS_REPORTS
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
