### PR TITLE
fix(AlertReports): preventing reset of notification settings when method does not change

### DIFF
--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -76,6 +76,9 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
   }
 
   const onMethodChange = (method: NotificationMethodOption) => {
+    if (method === setting.method) {
+      return;
+    }
     // Since we're swapping the method, reset the recipients
     setRecipientValue('');
     if (onUpdate) {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When selecting a method for notification settings in the alerts and reports modal, the notification settings are deleted when the same method is selected. This PR addresses this issue by preventing an update to the notificationSettings when no the method value has not changed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
https://www.loom.com/share/9f9829e8877a444db074e6f8ce0f669f?sid=1e4fe88d-4075-4b6a-9dc0-50749316baa2

After:
https://www.loom.com/share/906d409dfbd14d56ab2e4e0ee0f1c799?sid=8464d755-954b-4787-a9d1-4942258b2f49

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Required feature flags: ALERT_REPORTS
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
