### PR TITLE
fix(explore): drag and drop indicator UX

### DIFF
--- a/superset-frontend/src/explore/components/ExploreContainer/ExploreContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreContainer/ExploreContainer.test.tsx
@@ -21,6 +21,7 @@ import { fireEvent, render } from 'spec/helpers/testing-library';
 import { OptionControlLabel } from 'src/explore/components/controls/OptionControls';
 
 import ExploreContainer, { DraggingContext } from '.';
+import OptionWrapper from '../controls/DndColumnSelectControl/OptionWrapper';
 
 const MockChildren = () => {
   const dragging = React.useContext(DraggingContext);
@@ -59,10 +60,12 @@ test('should update the style on dragging state', () => {
         index={1}
         label={<span>Label 1</span>}
       />
-      <OptionControlLabel
+      <OptionWrapper
         {...defaultProps}
         index={2}
-        label={<span>Label 2</span>}
+        label="Label 2"
+        clickClose={() => {}}
+        onShiftOptions={() => {}}
       />
       <MockChildren />
     </ExploreContainer>,
@@ -75,5 +78,8 @@ test('should update the style on dragging state', () => {
   fireEvent.dragStart(getByText('Label 1'));
   expect(container.getElementsByClassName('dragging')).toHaveLength(1);
   fireEvent.dragEnd(getByText('Label 1'));
+  expect(container.getElementsByClassName('dragging')).toHaveLength(0);
+  // don't show dragging state for the sorting item
+  fireEvent.dragStart(getByText('Label 2'));
   expect(container.getElementsByClassName('dragging')).toHaveLength(0);
 });

--- a/superset-frontend/src/explore/components/ExploreContainer/ExploreContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreContainer/ExploreContainer.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { fireEvent, render } from 'spec/helpers/testing-library';
+import { OptionControlLabel } from 'src/explore/components/controls/OptionControls';
+
+import ExploreContainer, { DraggingContext } from '.';
+
+const MockChildren = () => {
+  const dragging = React.useContext(DraggingContext);
+  return (
+    <div data-test="mock-children" className={dragging ? 'dragging' : ''}>
+      {dragging ? 'dragging' : 'not dragging'}
+    </div>
+  );
+};
+
+test('should render children', () => {
+  const { getByTestId, getByText } = render(
+    <ExploreContainer>
+      <MockChildren />
+    </ExploreContainer>,
+    { useRedux: true, useDnd: true },
+  );
+  expect(getByTestId('mock-children')).toBeInTheDocument();
+  expect(getByText('not dragging')).toBeInTheDocument();
+});
+
+test('should update the style on dragging state', () => {
+  const defaultProps = {
+    label: <span>Test label</span>,
+    tooltipTitle: 'This is a tooltip title',
+    onRemove: jest.fn(),
+    onMoveLabel: jest.fn(),
+    onDropLabel: jest.fn(),
+    type: 'test',
+    index: 0,
+  };
+  const { container, getByText } = render(
+    <ExploreContainer>
+      <OptionControlLabel
+        {...defaultProps}
+        index={1}
+        label={<span>Label 1</span>}
+      />
+      <OptionControlLabel
+        {...defaultProps}
+        index={2}
+        label={<span>Label 2</span>}
+      />
+      <MockChildren />
+    </ExploreContainer>,
+    {
+      useRedux: true,
+      useDnd: true,
+    },
+  );
+  expect(container.getElementsByClassName('dragging')).toHaveLength(0);
+  fireEvent.dragStart(getByText('Label 1'));
+  expect(container.getElementsByClassName('dragging')).toHaveLength(1);
+  fireEvent.dragEnd(getByText('Label 1'));
+  expect(container.getElementsByClassName('dragging')).toHaveLength(0);
+});

--- a/superset-frontend/src/explore/components/ExploreContainer/index.tsx
+++ b/superset-frontend/src/explore/components/ExploreContainer/index.tsx
@@ -36,6 +36,11 @@ const ExploreContainer: React.FC<{}> = ({ children }) => {
   useEffect(() => {
     const monitor = dragDropManager.getMonitor();
     const unsub = monitor.subscribeToStateChange(() => {
+      const item = monitor.getItem() || {};
+      // don't show dragging state for the sorting item
+      if ('dragIndex' in item) {
+        return;
+      }
       const isDragging = monitor.isDragging();
       setDragging(isDragging);
     });

--- a/superset-frontend/src/explore/components/ExploreContainer/index.tsx
+++ b/superset-frontend/src/explore/components/ExploreContainer/index.tsx
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { useEffect } from 'react';
+import { styled } from '@superset-ui/core';
+import { useDragDropManager } from 'react-dnd';
+
+export const DraggingContext = React.createContext(false);
+const StyledDiv = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+`;
+const ExploreContainer: React.FC<{}> = ({ children }) => {
+  const dragDropManager = useDragDropManager();
+  const [dragging, setDragging] = React.useState(
+    dragDropManager.getMonitor().isDragging(),
+  );
+
+  useEffect(() => {
+    const monitor = dragDropManager.getMonitor();
+    const unsub = monitor.subscribeToStateChange(() => {
+      const isDragging = monitor.isDragging();
+      setDragging(isDragging);
+    });
+
+    return () => {
+      unsub();
+    };
+  }, [dragDropManager]);
+
+  return (
+    <DraggingContext.Provider value={dragging}>
+      <StyledDiv>{children}</StyledDiv>
+    </DraggingContext.Provider>
+  );
+};
+
+export default ExploreContainer;

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -68,6 +68,7 @@ import ConnectedControlPanelsContainer from '../ControlPanelsContainer';
 import SaveModal from '../SaveModal';
 import DataSourcePanel from '../DatasourcePanel';
 import ConnectedExploreChartHeader from '../ExploreChartHeader';
+import ExploreContainer from '../ExploreContainer';
 
 const propTypes = {
   ...ExploreChartPanel.propTypes,
@@ -89,13 +90,6 @@ const propTypes = {
   saveAction: PropTypes.string,
   isSaveModalVisible: PropTypes.bool,
 };
-
-const ExploreContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  min-height: 0;
-`;
 
 const ExplorePanelContainer = styled.div`
   ${({ theme }) => css`

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.tsx
@@ -44,12 +44,14 @@ export type DndSelectLabelProps = {
   valuesRenderer: () => ReactNode;
   displayGhostButton?: boolean;
   onClickGhostButton: () => void;
+  isLoading?: boolean;
 };
 
 export default function DndSelectLabel({
   displayGhostButton = true,
   accept,
   valuesRenderer,
+  isLoading,
   ...props
 }: DndSelectLabelProps) {
   const theme = useTheme();
@@ -97,6 +99,7 @@ export default function DndSelectLabel({
         canDrop={canDrop}
         isOver={isOver}
         isDragging={isDragging}
+        isLoading={isLoading}
       >
         {values}
         {displayGhostButton && renderGhostButton()}

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.tsx
@@ -57,7 +57,7 @@ export default function DndSelectLabel({
   const theme = useTheme();
 
   const [{ isOver, canDrop }, datasourcePanelDrop] = useDrop({
-    accept,
+    accept: isLoading ? [] : accept,
 
     drop: (item: DatasourcePanelDndItem) => {
       props.onDrop(item);

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { ReactNode, useMemo } from 'react';
+import React, { ReactNode, useContext, useMemo } from 'react';
 import { useDrop } from 'react-dnd';
 import { t, useTheme } from '@superset-ui/core';
 import ControlHeader from 'src/explore/components/ControlHeader';
@@ -31,6 +31,7 @@ import {
 } from 'src/explore/components/DatasourcePanel/types';
 import Icons from 'src/components/Icons';
 import { DndItemType } from '../../DndItemType';
+import { DraggingContext } from '../../ExploreContainer';
 
 export type DndSelectLabelProps = {
   name: string;
@@ -70,6 +71,7 @@ export default function DndSelectLabel({
       type: monitor.getItemType(),
     }),
   });
+  const isDragging = useContext(DraggingContext);
 
   const values = useMemo(() => valuesRenderer(), [valuesRenderer]);
 
@@ -94,6 +96,7 @@ export default function DndSelectLabel({
         data-test="dnd-labels-container"
         canDrop={canDrop}
         isOver={isOver}
+        isDragging={isDragging}
       >
         {values}
         {displayGhostButton && renderGhostButton()}

--- a/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
+++ b/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
@@ -129,8 +129,8 @@ export const DndLabelsContainer = styled.div<{
     display: ${({ isDragging }) => (isDragging ? 'block' : 'none')};
     background-color: ${({ theme, canDrop }) =>
       canDrop ? theme.colors.primary.base : theme.colors.error.light1};
-    z-index: 10;
-    opacity: 0.2;
+    z-index: ${({ theme }) => theme.zIndex.aboveDashboardCharts};
+    opacity: ${({ theme }) => theme.opacity.light};
     top: 1px;
     right: 1px;
     bottom: 1px;
@@ -139,12 +139,12 @@ export const DndLabelsContainer = styled.div<{
   &:after {
     display: ${({ isOver, canDrop }) => (canDrop && isOver ? 'block' : 'none')};
     background-color: ${({ theme }) => theme.colors.primary.base};
-    z-index: 10;
-    opacity: 0.3;
-    top: -4px;
-    right: -4px;
-    bottom: -4px;
-    left: -4px;
+    z-index: ${({ theme }) => theme.zIndex.dropdown};
+    opacity: ${({ theme }) => theme.opacity.mediumLight};
+    top: ${({ theme }) => -theme.gridUnit}px;
+    right: ${({ theme }) => -theme.gridUnit}px;
+    bottom: ${({ theme }) => -theme.gridUnit}px;
+    left: ${({ theme }) => -theme.gridUnit}px;
   }
 `;
 

--- a/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
+++ b/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
@@ -104,8 +104,17 @@ export const LabelsContainer = styled.div`
 `;
 
 const borderPulse = keyframes`
-  to {
-    background-size: 100% 0px
+  0% {
+    right: 100%;
+  }
+  50% {
+    left: 4px;
+  }
+  90% {
+    right: 4px;
+  }
+  100% {
+    left: 100%;
   }
 `;
 
@@ -157,8 +166,9 @@ export const DndLabelsContainer = styled.div<{
     ${({ theme, isLoading }) =>
       isLoading &&
       css`
-        animation: ${borderPulse} 3s ease-out infinite;
+        animation: ${borderPulse} 2s ease-in infinite;
         background: linear-gradient(currentColor 0 0) 0 100%/0% 3px no-repeat;
+        background-size: 100% ${theme.gridUnit / 2}px;
         top: auto;
         right: ${theme.gridUnit}px;
         left: ${theme.gridUnit}px;

--- a/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
+++ b/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
@@ -106,7 +106,7 @@ export const LabelsContainer = styled.div`
 export const DndLabelsContainer = styled.div<{
   canDrop?: boolean;
   isOver?: boolean;
-  isDragging: boolean;
+  isDragging?: boolean;
 }>`
   position: relative;
   padding: ${({ theme }) => theme.gridUnit}px;

--- a/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
+++ b/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
@@ -18,7 +18,7 @@
  */
 import React, { useRef } from 'react';
 import { useDrag, useDrop, DropTargetMonitor } from 'react-dnd';
-import { styled, t, useTheme } from '@superset-ui/core';
+import { styled, t, useTheme, keyframes, css } from '@superset-ui/core';
 import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
 import { Tooltip } from 'src/components/Tooltip';
 import Icons from 'src/components/Icons';
@@ -103,10 +103,17 @@ export const LabelsContainer = styled.div`
   border-radius: ${({ theme }) => theme.gridUnit}px;
 `;
 
+const borderPulse = keyframes`
+  to {
+    background-size: 100% 0px
+  }
+`;
+
 export const DndLabelsContainer = styled.div<{
   canDrop?: boolean;
   isOver?: boolean;
   isDragging?: boolean;
+  isLoading?: boolean;
 }>`
   position: relative;
   padding: ${({ theme }) => theme.gridUnit}px;
@@ -137,7 +144,8 @@ export const DndLabelsContainer = styled.div<{
     left: 1px;
   }
   &:after {
-    display: ${({ isOver, canDrop }) => (canDrop && isOver ? 'block' : 'none')};
+    display: ${({ isOver, canDrop, isLoading }) =>
+      isLoading || (canDrop && isOver) ? 'block' : 'none'};
     background-color: ${({ theme }) => theme.colors.primary.base};
     z-index: ${({ theme }) => theme.zIndex.dropdown};
     opacity: ${({ theme }) => theme.opacity.mediumLight};
@@ -145,6 +153,18 @@ export const DndLabelsContainer = styled.div<{
     right: ${({ theme }) => -theme.gridUnit}px;
     bottom: ${({ theme }) => -theme.gridUnit}px;
     left: ${({ theme }) => -theme.gridUnit}px;
+
+    ${({ theme, isLoading }) =>
+      isLoading &&
+      css`
+        animation: ${borderPulse} 3s ease-out infinite;
+        background: linear-gradient(currentColor 0 0) 0 100%/0% 3px no-repeat;
+        top: auto;
+        right: ${theme.gridUnit}px;
+        left: ${theme.gridUnit}px;
+        bottom: -${theme.gridUnit / 2}px;
+        height: ${theme.gridUnit / 2}px;
+      `}
   }
 `;
 

--- a/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
+++ b/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
@@ -126,13 +126,17 @@ export const DndLabelsContainer = styled.div<{
 }>`
   position: relative;
   padding: ${({ theme }) => theme.gridUnit}px;
-  border: ${({ canDrop, isDragging, theme }) => {
-    if (isDragging) {
+  border: ${({ canDrop, isDragging, isLoading, theme }) => {
+    if (!isLoading && isDragging) {
       return `dashed 1px ${
         canDrop ? theme.colors.info.dark1 : theme.colors.error.dark1
       }`;
     }
-    return `solid 1px ${theme.colors.grayscale.light2}`;
+    return `solid 1px ${
+      isLoading && isDragging
+        ? theme.colors.warning.light1
+        : theme.colors.grayscale.light2
+    }`;
   }};
   border-radius: ${({ theme }) => theme.gridUnit}px;
   &:before,
@@ -142,7 +146,8 @@ export const DndLabelsContainer = styled.div<{
     border-radius: ${({ theme }) => theme.gridUnit}px;
   }
   &:before {
-    display: ${({ isDragging }) => (isDragging ? 'block' : 'none')};
+    display: ${({ isDragging, isLoading }) =>
+      isDragging || isLoading ? 'block' : 'none'};
     background-color: ${({ theme, canDrop }) =>
       canDrop ? theme.colors.primary.base : theme.colors.error.light1};
     z-index: ${({ theme }) => theme.zIndex.aboveDashboardCharts};
@@ -151,17 +156,6 @@ export const DndLabelsContainer = styled.div<{
     right: 1px;
     bottom: 1px;
     left: 1px;
-  }
-  &:after {
-    display: ${({ isOver, canDrop, isLoading }) =>
-      isLoading || (canDrop && isOver) ? 'block' : 'none'};
-    background-color: ${({ theme }) => theme.colors.primary.base};
-    z-index: ${({ theme }) => theme.zIndex.dropdown};
-    opacity: ${({ theme }) => theme.opacity.mediumLight};
-    top: ${({ theme }) => -theme.gridUnit}px;
-    right: ${({ theme }) => -theme.gridUnit}px;
-    bottom: ${({ theme }) => -theme.gridUnit}px;
-    left: ${({ theme }) => -theme.gridUnit}px;
 
     ${({ theme, isLoading }) =>
       isLoading &&
@@ -175,6 +169,19 @@ export const DndLabelsContainer = styled.div<{
         bottom: -${theme.gridUnit / 2}px;
         height: ${theme.gridUnit / 2}px;
       `}
+  }
+  &:after {
+    display: ${({ isOver, canDrop, isLoading }) =>
+      isLoading || (canDrop && isOver) ? 'block' : 'none'};
+    background-color: ${({ theme, isLoading }) =>
+      isLoading ? theme.colors.grayscale.light3 : theme.colors.primary.base};
+    z-index: ${({ theme }) => theme.zIndex.dropdown};
+    opacity: ${({ theme }) => theme.opacity.mediumLight};
+    top: ${({ theme }) => -theme.gridUnit}px;
+    right: ${({ theme }) => -theme.gridUnit}px;
+    bottom: ${({ theme }) => -theme.gridUnit}px;
+    left: ${({ theme }) => -theme.gridUnit}px;
+    cursor: ${({ isLoading }) => (isLoading ? 'wait' : 'auto')};
   }
 `;
 

--- a/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
+++ b/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
@@ -106,18 +106,46 @@ export const LabelsContainer = styled.div`
 export const DndLabelsContainer = styled.div<{
   canDrop?: boolean;
   isOver?: boolean;
+  isDragging: boolean;
 }>`
+  position: relative;
   padding: ${({ theme }) => theme.gridUnit}px;
-  border: ${({ canDrop, isOver, theme }) => {
-    if (canDrop) {
-      return `dashed 1px ${theme.colors.info.dark1}`;
-    }
-    if (isOver && !canDrop) {
-      return `dashed 1px ${theme.colors.error.dark1}`;
+  border: ${({ canDrop, isDragging, theme }) => {
+    if (isDragging) {
+      return `dashed 1px ${
+        canDrop ? theme.colors.info.dark1 : theme.colors.error.dark1
+      }`;
     }
     return `solid 1px ${theme.colors.grayscale.light2}`;
   }};
   border-radius: ${({ theme }) => theme.gridUnit}px;
+  &:before,
+  &:after {
+    content: ' ';
+    position: absolute;
+    border-radius: ${({ theme }) => theme.gridUnit}px;
+  }
+  &:before {
+    display: ${({ isDragging }) => (isDragging ? 'block' : 'none')};
+    background-color: ${({ theme, canDrop }) =>
+      canDrop ? theme.colors.primary.base : theme.colors.error.light1};
+    z-index: 10;
+    opacity: 0.2;
+    top: 1px;
+    right: 1px;
+    bottom: 1px;
+    left: 1px;
+  }
+  &:after {
+    display: ${({ isOver, canDrop }) => (canDrop && isOver ? 'block' : 'none')};
+    background-color: ${({ theme }) => theme.colors.primary.base};
+    z-index: 10;
+    opacity: 0.3;
+    top: -4px;
+    right: -4px;
+    bottom: -4px;
+    left: -4px;
+  }
 `;
 
 export const AddControlLabel = styled.div<{

--- a/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
+++ b/superset-frontend/src/explore/components/controls/OptionControls/index.tsx
@@ -124,39 +124,55 @@ export const DndLabelsContainer = styled.div<{
   isDragging?: boolean;
   isLoading?: boolean;
 }>`
+  ${({ theme, isLoading, canDrop, isDragging, isOver }) => `
   position: relative;
-  padding: ${({ theme }) => theme.gridUnit}px;
-  border: ${({ canDrop, isDragging, isLoading, theme }) => {
-    if (!isLoading && isDragging) {
-      return `dashed 1px ${
-        canDrop ? theme.colors.info.dark1 : theme.colors.error.dark1
-      }`;
-    }
-    return `solid 1px ${
-      isLoading && isDragging
-        ? theme.colors.warning.light1
-        : theme.colors.grayscale.light2
-    }`;
-  }};
-  border-radius: ${({ theme }) => theme.gridUnit}px;
+  padding: ${theme.gridUnit}px;
+  border: ${
+    !isLoading && isDragging
+      ? `dashed 1px ${
+          canDrop ? theme.colors.info.dark1 : theme.colors.error.dark1
+        }`
+      : `solid 1px ${
+          isLoading && isDragging
+            ? theme.colors.warning.light1
+            : theme.colors.grayscale.light2
+        }`
+  };
+  border-radius: ${theme.gridUnit}px;
   &:before,
   &:after {
     content: ' ';
     position: absolute;
-    border-radius: ${({ theme }) => theme.gridUnit}px;
+    border-radius: ${theme.gridUnit}px;
   }
   &:before {
-    display: ${({ isDragging, isLoading }) =>
-      isDragging || isLoading ? 'block' : 'none'};
-    background-color: ${({ theme, canDrop }) =>
-      canDrop ? theme.colors.primary.base : theme.colors.error.light1};
-    z-index: ${({ theme }) => theme.zIndex.aboveDashboardCharts};
-    opacity: ${({ theme }) => theme.opacity.light};
+    display: ${isDragging || isLoading ? 'block' : 'none'};
+    background-color: ${
+      canDrop ? theme.colors.primary.base : theme.colors.error.light1
+    };
+    z-index: ${theme.zIndex.aboveDashboardCharts};
+    opacity: ${theme.opacity.light};
     top: 1px;
     right: 1px;
     bottom: 1px;
     left: 1px;
+  }
+  &:after {
+    display: ${isLoading || (canDrop && isOver) ? 'block' : 'none'};
+    background-color: ${
+      isLoading ? theme.colors.grayscale.light3 : theme.colors.primary.base
+    };
+    z-index: ${theme.zIndex.dropdown};
+    opacity: ${theme.opacity.mediumLight};
+    top: ${-theme.gridUnit}px;
+    right: ${-theme.gridUnit}px;
+    bottom: ${-theme.gridUnit}px;
+    left: ${-theme.gridUnit}px;
+    cursor: ${isLoading ? 'wait' : 'auto'};
+  }
+  `}
 
+  &:before {
     ${({ theme, isLoading }) =>
       isLoading &&
       css`
@@ -168,20 +184,7 @@ export const DndLabelsContainer = styled.div<{
         left: ${theme.gridUnit}px;
         bottom: -${theme.gridUnit / 2}px;
         height: ${theme.gridUnit / 2}px;
-      `}
-  }
-  &:after {
-    display: ${({ isOver, canDrop, isLoading }) =>
-      isLoading || (canDrop && isOver) ? 'block' : 'none'};
-    background-color: ${({ theme, isLoading }) =>
-      isLoading ? theme.colors.grayscale.light3 : theme.colors.primary.base};
-    z-index: ${({ theme }) => theme.zIndex.dropdown};
-    opacity: ${({ theme }) => theme.opacity.mediumLight};
-    top: ${({ theme }) => -theme.gridUnit}px;
-    right: ${({ theme }) => -theme.gridUnit}px;
-    bottom: ${({ theme }) => -theme.gridUnit}px;
-    left: ${({ theme }) => -theme.gridUnit}px;
-    cursor: ${({ isLoading }) => (isLoading ? 'wait' : 'auto')};
+      `};
   }
 `;
 

--- a/superset-frontend/src/pages/Chart/Chart.test.tsx
+++ b/superset-frontend/src/pages/Chart/Chart.test.tsx
@@ -65,6 +65,7 @@ describe('ChartPage', () => {
     const { getByTestId } = render(<ChartPage />, {
       useRouter: true,
       useRedux: true,
+      useDnd: true,
     });
     await waitFor(() =>
       expect(fetchMock.calls(exploreApiRoute).length).toBe(1),
@@ -110,6 +111,7 @@ describe('ChartPage', () => {
       const { getByTestId } = render(<ChartPage />, {
         useRouter: true,
         useRedux: true,
+        useDnd: true,
       });
       await waitFor(() =>
         expect(fetchMock.calls(exploreApiRoute).length).toBe(1),
@@ -156,6 +158,7 @@ describe('ChartPage', () => {
         {
           useRouter: true,
           useRedux: true,
+          useDnd: true,
         },
       );
       await waitFor(() =>


### PR DESCRIPTION
### SUMMARY
The current explore drag-and-drop (DND) indicator only highlights the drop allow zone, and users can recognize the disallowed zone when they try to drop an item there. However, this UX can be challenging when the current dragging item is not droppable in the entire zone, as there is no highlighting to indicate this.

https://github.com/apache/superset/assets/1392866/68d359bf-e8b7-44ff-bafb-e1b2055a0d48

This lack of feedback can lead users to believe that the DND functionality is not working, until they mouse over the zone.

This commit aims to address this UX issue by implementing changes. Now, all droppable zones will be highlighted when dragging, and a different color scheme will indicate which zones are available and which are unavailable for dropping. 

https://github.com/apache/superset/assets/1392866/0f795241-9eeb-4a53-92c2-00a6a8d3d282

Additionally, the commit also updates the drag over feedback to align with the changes made to the dashboard's DND UX(#26699). This way, users can have a consistent and improved drag-and-drop experience, with clear usability feedback.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://github.com/apache/superset/assets/1392866/7b0a92b6-78f3-4aec-b679-023a048f90ab

After:

https://github.com/apache/superset/assets/1392866/6c796977-ae3d-478e-acf7-b4485e6eebe9

### TESTING INSTRUCTIONS
Create a "Table" chart
Select RAW RECORDS and then drag the Metrics to check where is droppable zone

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
