### PR TITLE
feat(supersetbot): label PRs and issues with author's public org

### DIFF
--- a/.github/supersetbot/src/context.js
+++ b/.github/supersetbot/src/context.js
@@ -37,7 +37,7 @@ class Context {
     const optionValue = options[optionName];
     if (optionValue === undefined || optionValue === null) {
       this.logError(`option [${optionName}] is required`);
-      // this.exit(1);
+      this.exit(1);
     }
   }
 

--- a/.github/workflows/issue_creation.yml
+++ b/.github/workflows/issue_creation.yml
@@ -1,8 +1,10 @@
 name: supersetbot org label based on author
 
 on:
-  # Note that this includes both issues and PRs
   issues:
+    types: [created]
+
+  pull_request:
     types: [created]
 
 jobs:
@@ -18,7 +20,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # First, label the issue with the appropriate org
+          # Labbel the issue with the appropriate org using supersetbot
           # - this requires for the author to be publicly associated with their org
           # - and for the org to be listed in `supersetbot/src/metadata.js`
           superset orglabel --issue ${{ github.event.issue.number }} --repo ${{ github.repository }}

--- a/.github/workflows/issue_creation.yml
+++ b/.github/workflows/issue_creation.yml
@@ -23,4 +23,4 @@ jobs:
           # Label the issue with the appropriate org using supersetbot
           # - this requires for the author to be publicly associated with their org
           # - and for the org to be listed in `supersetbot/src/metadata.js`
-          supersetbot orglabel --issue ${{ github.event.issue.number }} --repo ${{ github.repository }}
+          supersetbot orglabel --issue ${{ github.event.number }} --repo ${{ github.repository }}

--- a/.github/workflows/issue_creation.yml
+++ b/.github/workflows/issue_creation.yml
@@ -2,10 +2,10 @@ name: supersetbot org label based on author
 
 on:
   issues:
-    types: [created]
+    types: [created, edited]
 
   pull_request:
-    types: [created]
+    types: [created, edited]
 
 jobs:
   supersetbot:

--- a/.github/workflows/issue_creation.yml
+++ b/.github/workflows/issue_creation.yml
@@ -1,0 +1,24 @@
+name: supersetbot org label based on author
+
+on:
+  # Note that this includes both issues and PRs
+  issues:
+    types: [created]
+
+jobs:
+  supersetbot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Execute SupersetBot Command
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm install supersetbot
+      - name: Execute custom Node.js script
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # First, label the issue with the appropriate org
+          # - this requires for the author to be publicly associated with their org
+          # - and for the org to be listed in `supersetbot/src/metadata.js`
+          superset orglabel --issue ${{ github.event.issue.number }} --repo ${{ github.repository }}

--- a/.github/workflows/issue_creation.yml
+++ b/.github/workflows/issue_creation.yml
@@ -1,4 +1,4 @@
-name: supersetbot org label based on author
+name: supersetbot orglabel based on author
 
 on:
   issues:
@@ -8,7 +8,7 @@ on:
     types: [created, edited]
 
 jobs:
-  supersetbot:
+  superbot-orglabel:
     runs-on: ubuntu-latest
     steps:
       - name: Execute SupersetBot Command
@@ -23,4 +23,4 @@ jobs:
           # Label the issue with the appropriate org using supersetbot
           # - this requires for the author to be publicly associated with their org
           # - and for the org to be listed in `supersetbot/src/metadata.js`
-          superset orglabel --issue ${{ github.event.issue.number }} --repo ${{ github.repository }}
+          supersetbot orglabel --issue ${{ github.event.issue.number }} --repo ${{ github.repository }}

--- a/.github/workflows/issue_creation.yml
+++ b/.github/workflows/issue_creation.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - run: npm install supersetbot
+      - run: npm install -g supersetbot
       - name: Execute custom Node.js script
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue_creation.yml
+++ b/.github/workflows/issue_creation.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Labbel the issue with the appropriate org using supersetbot
+          # Label the issue with the appropriate org using supersetbot
           # - this requires for the author to be publicly associated with their org
           # - and for the org to be listed in `supersetbot/src/metadata.js`
           superset orglabel --issue ${{ github.event.issue.number }} --repo ${{ github.repository }}

--- a/.github/workflows/no-op.yml
+++ b/.github/workflows/no-op.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           echo "This is a no-op step for test-postgres-postgres to ensure a successful status when skipped."
           exit 0
-  test-postgres-postgres:
+  test-postgres-presto:
     runs-on: ubuntu-latest
     steps:
       - name: No-op for frontend-build

--- a/.github/workflows/no-op.yml
+++ b/.github/workflows/no-op.yml
@@ -52,3 +52,24 @@ jobs:
         run: |
           echo "This is a no-op step for python-lint to ensure a successful status."
           exit 0
+  test-postgres-hive:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op for frontend-build
+        run: |
+          echo "This is a no-op step for test-postgres-postgres to ensure a successful status when skipped."
+          exit 0
+  test-postgres-postgres:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op for frontend-build
+        run: |
+          echo "This is a no-op step for test-postgres-postgres to ensure a successful status when skipped."
+          exit 0
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op for frontend-build
+        run: |
+          echo "This is a no-op step for unit-tests to ensure a successful status when skipped."
+          exit 0

--- a/.github/workflows/no-op.yml
+++ b/.github/workflows/no-op.yml
@@ -53,6 +53,9 @@ jobs:
           echo "This is a no-op step for python-lint to ensure a successful status."
           exit 0
   test-postgres-hive:
+    strategy:
+      matrix:
+        python-version: ["3.9"]
     runs-on: ubuntu-latest
     steps:
       - name: No-op for frontend-build
@@ -60,6 +63,9 @@ jobs:
           echo "This is a no-op step for test-postgres-postgres to ensure a successful status when skipped."
           exit 0
   test-postgres-presto:
+    strategy:
+      matrix:
+        python-version: ["3.9"]
     runs-on: ubuntu-latest
     steps:
       - name: No-op for frontend-build
@@ -67,6 +73,9 @@ jobs:
           echo "This is a no-op step for test-postgres-postgres to ensure a successful status when skipped."
           exit 0
   unit-tests:
+    strategy:
+      matrix:
+        python-version: ["3.9"]
     runs-on: ubuntu-latest
     steps:
       - name: No-op for frontend-build


### PR DESCRIPTION
`supersetbot` has a CLI subcommand `orglabel` that looks at an
issue or pr's author, their public association to organizations
if one or many of these orgs are in a specific list, will add the
org's name as a label on the PR.

This PR hooks up this command to issue/pr creation as a github action.

I also fix a bug where some line had been commented that shouldn't have
been. 
