### PR TITLE
fix: bump sqlglot to support materialized CTEs

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,92 +6,54 @@
 #    pip-compile-multi
 #
 -e file:.
-    # via
-    #   -c requirements/development.txt
-    #   -r requirements/base.in
+    # via -r requirements/base.in
 alembic==1.6.5
-    # via
-    #   -c requirements/development.txt
-    #   flask-migrate
+    # via flask-migrate
 amqp==5.1.1
-    # via
-    #   -c requirements/development.txt
-    #   kombu
+    # via kombu
 apispec[yaml]==6.3.0
-    # via
-    #   -c requirements/development.txt
-    #   flask-appbuilder
+    # via flask-appbuilder
 apsw==3.42.0.1
-    # via
-    #   -c requirements/development.txt
-    #   shillelagh
+    # via shillelagh
 async-timeout==4.0.2
-    # via
-    #   -c requirements/development.txt
-    #   redis
+    # via redis
 attrs==23.1.0
     # via
-    #   -c requirements/development.txt
     #   cattrs
     #   jsonschema
     #   requests-cache
 babel==2.9.1
-    # via
-    #   -c requirements/development.txt
-    #   flask-babel
+    # via flask-babel
 backoff==1.11.1
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 bcrypt==4.0.1
-    # via
-    #   -c requirements/development.txt
-    #   paramiko
+    # via paramiko
 billiard==4.2.0
-    # via
-    #   -c requirements/development.txt
-    #   celery
+    # via celery
 bottleneck==1.3.7
-    # via
-    #   -c requirements/development.txt
-    #   pandas
+    # via pandas
 brotli==1.0.9
-    # via
-    #   -c requirements/development.txt
-    #   flask-compress
+    # via flask-compress
 cachelib==0.9.0
     # via
-    #   -c requirements/development.txt
     #   flask-caching
     #   flask-session
 cachetools==5.3.2
-    # via
-    #   -c requirements/development.txt
-    #   google-auth
+    # via google-auth
 cattrs==23.2.1
-    # via
-    #   -c requirements/development.txt
-    #   requests-cache
+    # via requests-cache
 celery==5.3.6
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 certifi==2023.7.22
-    # via
-    #   -c requirements/development.txt
-    #   requests
+    # via requests
 cffi==1.15.1
     # via
-    #   -c requirements/development.txt
     #   cryptography
     #   pynacl
 charset-normalizer==3.2.0
-    # via
-    #   -c requirements/development.txt
-    #   requests
+    # via requests
 click==8.1.3
     # via
-    #   -c requirements/development.txt
     #   apache-superset
     #   celery
     #   click-didyoumean
@@ -101,62 +63,37 @@ click==8.1.3
     #   flask
     #   flask-appbuilder
 click-didyoumean==0.3.0
-    # via
-    #   -c requirements/development.txt
-    #   celery
+    # via celery
 click-option-group==0.5.5
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 click-plugins==1.1.1
-    # via
-    #   -c requirements/development.txt
-    #   celery
+    # via celery
 click-repl==0.2.0
-    # via
-    #   -c requirements/development.txt
-    #   celery
+    # via celery
 colorama==0.4.6
     # via
-    #   -c requirements/development.txt
     #   apache-superset
     #   flask-appbuilder
 cron-descriptor==1.2.24
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 croniter==1.0.15
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 cryptography==42.0.4
     # via
-    #   -c requirements/development.txt
     #   apache-superset
     #   paramiko
 deprecated==1.2.13
-    # via
-    #   -c requirements/development.txt
-    #   limits
+    # via limits
 deprecation==2.1.0
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 dnspython==2.1.0
-    # via
-    #   -c requirements/development.txt
-    #   email-validator
+    # via email-validator
 email-validator==1.1.3
-    # via
-    #   -c requirements/development.txt
-    #   flask-appbuilder
+    # via flask-appbuilder
 exceptiongroup==1.2.0
-    # via
-    #   -c requirements/development.txt
-    #   cattrs
+    # via cattrs
 flask==2.2.5
     # via
-    #   -c requirements/development.txt
     #   apache-superset
     #   flask-appbuilder
     #   flask-babel
@@ -170,194 +107,120 @@ flask==2.2.5
     #   flask-sqlalchemy
     #   flask-wtf
 flask-appbuilder==4.4.1
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 flask-babel==1.0.0
-    # via
-    #   -c requirements/development.txt
-    #   flask-appbuilder
+    # via flask-appbuilder
 flask-caching==2.1.0
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 flask-compress==1.13
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 flask-jwt-extended==4.3.1
-    # via
-    #   -c requirements/development.txt
-    #   flask-appbuilder
+    # via flask-appbuilder
 flask-limiter==3.3.1
-    # via
-    #   -c requirements/development.txt
-    #   flask-appbuilder
+    # via flask-appbuilder
 flask-login==0.6.3
     # via
-    #   -c requirements/development.txt
     #   apache-superset
     #   flask-appbuilder
 flask-migrate==3.1.0
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 flask-session==0.5.0
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 flask-sqlalchemy==2.5.1
     # via
-    #   -c requirements/development.txt
     #   flask-appbuilder
     #   flask-migrate
 flask-talisman==1.0.0
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 flask-wtf==1.2.1
     # via
-    #   -c requirements/development.txt
     #   apache-superset
     #   flask-appbuilder
 func-timeout==4.3.5
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 geographiclib==1.52
-    # via
-    #   -c requirements/development.txt
-    #   geopy
+    # via geopy
 geopy==2.2.0
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 google-auth==2.27.0
-    # via
-    #   -c requirements/development.txt
-    #   shillelagh
+    # via shillelagh
 greenlet==3.0.3
     # via
-    #   -c requirements/development.txt
     #   shillelagh
+    #   sqlalchemy
 gunicorn==21.2.0
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 hashids==1.3.1
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 holidays==0.25
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 humanize==3.11.0
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 idna==3.2
     # via
-    #   -c requirements/development.txt
     #   email-validator
     #   requests
 importlib-metadata==6.6.0
     # via
-    #   -c requirements/development.txt
     #   apache-superset
     #   flask
     #   shillelagh
 importlib-resources==5.12.0
-    # via
-    #   -c requirements/development.txt
-    #   limits
+    # via limits
 isodate==0.6.0
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 itsdangerous==2.1.2
     # via
-    #   -c requirements/development.txt
     #   flask
     #   flask-wtf
 jinja2==3.1.3
     # via
-    #   -c requirements/development.txt
     #   flask
     #   flask-babel
 jsonschema==4.17.3
-    # via
-    #   -c requirements/development.txt
-    #   flask-appbuilder
+    # via flask-appbuilder
 kombu==5.3.4
-    # via
-    #   -c requirements/development.txt
-    #   celery
+    # via celery
 korean-lunar-calendar==0.3.1
-    # via
-    #   -c requirements/development.txt
-    #   holidays
+    # via holidays
 limits==3.4.0
-    # via
-    #   -c requirements/development.txt
-    #   flask-limiter
+    # via flask-limiter
 llvmlite==0.40.1
-    # via
-    #   -c requirements/development.txt
-    #   numba
+    # via numba
 mako==1.2.4
     # via
-    #   -c requirements/development.txt
     #   alembic
     #   apache-superset
 markdown==3.3.4
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 markdown-it-py==2.2.0
-    # via
-    #   -c requirements/development.txt
-    #   rich
+    # via rich
 markupsafe==2.1.1
     # via
-    #   -c requirements/development.txt
     #   jinja2
     #   mako
     #   werkzeug
     #   wtforms
 marshmallow==3.19.0
     # via
-    #   -c requirements/development.txt
     #   flask-appbuilder
     #   marshmallow-sqlalchemy
 marshmallow-sqlalchemy==0.23.1
-    # via
-    #   -c requirements/development.txt
-    #   flask-appbuilder
+    # via flask-appbuilder
 mdurl==0.1.2
-    # via
-    #   -c requirements/development.txt
-    #   markdown-it-py
+    # via markdown-it-py
 msgpack==1.0.2
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 nh3==0.2.11
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 numba==0.57.1
-    # via
-    #   -c requirements/development.txt
-    #   pandas
+    # via pandas
 numexpr==2.9.0
     # via
-    #   -c requirements/development.txt
     #   -r requirements/base.in
     #   pandas
 numpy==1.23.5
     # via
-    #   -c requirements/development.txt
     #   apache-superset
     #   bottleneck
     #   numba
@@ -365,12 +228,9 @@ numpy==1.23.5
     #   pandas
     #   pyarrow
 ordered-set==4.1.0
-    # via
-    #   -c requirements/development.txt
-    #   flask-limiter
+    # via flask-limiter
 packaging==23.1
     # via
-    #   -c requirements/development.txt
     #   apache-superset
     #   apispec
     #   deprecation
@@ -379,80 +239,48 @@ packaging==23.1
     #   marshmallow
     #   shillelagh
 pandas[performance]==2.0.3
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 paramiko==3.4.0
     # via
-    #   -c requirements/development.txt
     #   apache-superset
     #   sshtunnel
 parsedatetime==2.6
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 pgsanity==0.2.9
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 platformdirs==3.8.1
-    # via
-    #   -c requirements/development.txt
-    #   requests-cache
+    # via requests-cache
 polyline==2.0.0
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 prison==0.2.1
-    # via
-    #   -c requirements/development.txt
-    #   flask-appbuilder
+    # via flask-appbuilder
 prompt-toolkit==3.0.38
-    # via
-    #   -c requirements/development.txt
-    #   click-repl
+    # via click-repl
 pyarrow==14.0.1
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 pyasn1==0.5.1
     # via
-    #   -c requirements/development.txt
     #   pyasn1-modules
     #   rsa
 pyasn1-modules==0.3.0
-    # via
-    #   -c requirements/development.txt
-    #   google-auth
+    # via google-auth
 pycparser==2.20
-    # via
-    #   -c requirements/development.txt
-    #   cffi
+    # via cffi
 pygments==2.15.0
-    # via
-    #   -c requirements/development.txt
-    #   rich
+    # via rich
 pyjwt==2.4.0
     # via
-    #   -c requirements/development.txt
     #   apache-superset
     #   flask-appbuilder
     #   flask-jwt-extended
 pynacl==1.5.0
-    # via
-    #   -c requirements/development.txt
-    #   paramiko
+    # via paramiko
 pyparsing==3.0.6
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 pyrsistent==0.20.0
-    # via
-    #   -c requirements/development.txt
-    #   jsonschema
+    # via jsonschema
 python-dateutil==2.8.2
     # via
-    #   -c requirements/development.txt
     #   alembic
     #   apache-superset
     #   celery
@@ -462,68 +290,42 @@ python-dateutil==2.8.2
     #   pandas
     #   shillelagh
 python-dotenv==0.19.0
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 python-editor==1.0.4
-    # via
-    #   -c requirements/development.txt
-    #   alembic
+    # via alembic
 python-geohash==0.8.5
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 pytz==2021.3
     # via
-    #   -c requirements/development.txt
     #   babel
     #   flask-babel
     #   pandas
 pyyaml==6.0.1
     # via
-    #   -c requirements/development.txt
     #   apache-superset
     #   apispec
 redis==4.6.0
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 requests==2.31.0
     # via
-    #   -c requirements/development.txt
     #   requests-cache
     #   shillelagh
 requests-cache==1.1.1
-    # via
-    #   -c requirements/development.txt
-    #   shillelagh
+    # via shillelagh
 rich==13.3.4
-    # via
-    #   -c requirements/development.txt
-    #   flask-limiter
+    # via flask-limiter
 rsa==4.9
-    # via
-    #   -c requirements/development.txt
-    #   google-auth
+    # via google-auth
 selenium==3.141.0
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 shillelagh[gsheetsapi]==1.2.10
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 shortid==0.1.2
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 simplejson==3.17.3
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 six==1.16.0
     # via
-    #   -c requirements/development.txt
     #   click-repl
     #   isodate
     #   prison
@@ -531,12 +333,9 @@ six==1.16.0
     #   url-normalize
     #   wtforms-json
 slack-sdk==3.21.3
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 sqlalchemy==1.4.36
     # via
-    #   -c requirements/development.txt
     #   alembic
     #   apache-superset
     #   flask-appbuilder
@@ -546,28 +345,18 @@ sqlalchemy==1.4.36
     #   sqlalchemy-utils
 sqlalchemy-utils==0.38.3
     # via
-    #   -c requirements/development.txt
     #   apache-superset
     #   flask-appbuilder
-sqlglot==20.8.0
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+sqlglot==23.0.2
+    # via apache-superset
 sqlparse==0.4.4
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 sshtunnel==0.4.0
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 tabulate==0.8.9
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 typing-extensions==4.4.0
     # via
-    #   -c requirements/development.txt
     #   apache-superset
     #   cattrs
     #   flask-limiter
@@ -576,60 +365,44 @@ typing-extensions==4.4.0
     #   shillelagh
 tzdata==2023.3
     # via
-    #   -c requirements/development.txt
     #   celery
     #   pandas
 url-normalize==1.4.3
-    # via
-    #   -c requirements/development.txt
-    #   requests-cache
+    # via requests-cache
 urllib3==1.26.18
     # via
-    #   -c requirements/development.txt
     #   -r requirements/base.in
     #   requests
     #   requests-cache
     #   selenium
 vine==5.1.0
     # via
-    #   -c requirements/development.txt
     #   amqp
     #   celery
     #   kombu
 wcwidth==0.2.5
-    # via
-    #   -c requirements/development.txt
-    #   prompt-toolkit
+    # via prompt-toolkit
 werkzeug==3.0.1
     # via
-    #   -c requirements/development.txt
     #   -r requirements/base.in
     #   flask
     #   flask-appbuilder
     #   flask-jwt-extended
     #   flask-login
 wrapt==1.15.0
-    # via
-    #   -c requirements/development.txt
-    #   deprecated
+    # via deprecated
 wtforms==2.3.3
     # via
-    #   -c requirements/development.txt
     #   apache-superset
     #   flask-appbuilder
     #   flask-wtf
     #   wtforms-json
 wtforms-json==0.3.5
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 xlsxwriter==3.0.7
-    # via
-    #   -c requirements/development.txt
-    #   apache-superset
+    # via apache-superset
 zipp==3.15.0
     # via
-    #   -c requirements/development.txt
     #   importlib-metadata
     #   importlib-resources
 

--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ setup(
         "slack_sdk>=3.19.0, <4",
         "sqlalchemy>=1.4, <2",
         "sqlalchemy-utils>=0.38.3, <0.39",
-        "sqlglot>=20,<21",
+        "sqlglot>=23.0.2,<24",
         "sqlparse>=0.4.4, <0.5",
         "tabulate>=0.8.9, <0.9",
         "typing-extensions>=4, <5",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Bump sqlglot to the version that supports `MATERIALIZED` CTEs for Postgres.

Fixes https://github.com/apache/superset/issues/27549.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
