### PR TITLE
feat(bar_chart): Stacked Bar chart with Time comparison in separated stacks

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -308,6 +308,7 @@ export default function transformProps(
         sliceId,
         isHorizontal,
         lineStyle,
+        timeCompare: array,
       },
     );
     if (transformedSeries) {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -62,7 +62,7 @@ import {
   formatAnnotationLabel,
   parseAnnotationOpacity,
 } from '../utils/annotation';
-import { getChartPadding } from '../utils/series';
+import { getChartPadding, getTimeCompareStackId } from '../utils/series';
 import {
   OpacityEnum,
   StackControlsValue,
@@ -164,6 +164,7 @@ export function transformSeries(
     isHorizontal?: boolean;
     lineStyle?: LineStyleOption;
     queryIndex?: number;
+    timeCompare?: string[];
   },
 ): SeriesOption | undefined {
   const { name } = series;
@@ -188,6 +189,7 @@ export function transformSeries(
     sliceId,
     isHorizontal = false,
     queryIndex = 0,
+    timeCompare = [],
   } = opts;
   const contexts = seriesContexts[name || ''] || [];
   const hasForecast =
@@ -217,9 +219,9 @@ export function transformSeries(
   } else if (stack && isObservation) {
     // the suffix of the observation series is '' (falsy), which disables
     // stacking. Therefore we need to set something that is truthy.
-    stackId = 'obs';
+    stackId = getTimeCompareStackId('obs', timeCompare, name);
   } else if (stack && isTrend) {
-    stackId = forecastSeries.type;
+    stackId = getTimeCompareStackId(forecastSeries.type, timeCompare, name);
   }
   let plotType;
   if (

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -35,7 +35,7 @@ import {
 } from '@superset-ui/core';
 import { SortSeriesType } from '@superset-ui/chart-controls';
 import { format, LegendComponentOption, SeriesOption } from 'echarts';
-import { maxBy, meanBy, minBy, orderBy, sumBy } from 'lodash';
+import { isEmpty, maxBy, meanBy, minBy, orderBy, sumBy } from 'lodash';
 import {
   NULL_STRING,
   StackControlsValue,
@@ -603,4 +603,31 @@ export function getMinAndMaxFromBounds(
     return ret;
   }
   return {};
+}
+
+/**
+ * Returns the stackId used in stacked series.
+ * It will return the defaultId if the chart is not using time comparison.
+ * If time comparison is used, it will return the time comparison value as the stackId
+ * if the name includes the time comparison value.
+ *
+ * @param {string} defaultId The default stackId.
+ * @param {string[]} timeCompare The time comparison values.
+ * @param {string | number} name The name of the serie.
+ *
+ * @returns {string} The stackId.
+ */
+export function getTimeCompareStackId(
+  defaultId: string,
+  timeCompare: string[],
+  name?: string | number,
+): string {
+  if (isEmpty(timeCompare)) {
+    return defaultId;
+  }
+  // Each timeCompare is its own stack so it doesn't stack on top of original ones
+  return (
+    timeCompare.find(value => name?.toString().includes(value.toString())) ||
+    defaultId
+  );
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -627,7 +627,11 @@ export function getTimeCompareStackId(
   }
   // Each timeCompare is its own stack so it doesn't stack on top of original ones
   return (
-    timeCompare.find(value => name?.toString().includes(value.toString())) ||
-    defaultId
+    timeCompare.find(value => {
+      if (typeof name === 'string') {
+        return name.includes(`__${value}`);
+      }
+      return name?.toString().includes(value.toString());
+    }) || defaultId
   );
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -629,9 +629,14 @@ export function getTimeCompareStackId(
   return (
     timeCompare.find(value => {
       if (typeof name === 'string') {
-        return name.includes(`__${value}`);
+        // offset is represented as <offset>, group by list
+        return (
+          name.includes(`${value},`) ||
+          // offset is represented as <metric>__<offset>
+          name.includes(`__${value}`)
+        );
       }
-      return name?.toString().includes(value.toString());
+      return name?.toString().includes(value);
     }) || defaultId
   );
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -40,6 +40,7 @@ import {
   sanitizeHtml,
   sortAndFilterSeries,
   sortRows,
+  getTimeCompareStackId,
 } from '../../src/utils/series';
 import {
   EchartsTimeseriesSeriesType,
@@ -1039,5 +1040,35 @@ test('getMinAndMaxFromBounds returns automatic lower bound when truncating', () 
   ).toEqual({
     max: 100,
     scale: true,
+  });
+});
+
+describe('getTimeCompareStackId', () => {
+  it('returns the defaultId when timeCompare is empty', () => {
+    const result = getTimeCompareStackId('default', []);
+    expect(result).toEqual('default');
+  });
+
+  it('returns the defaultId when no value in timeCompare is included in name', () => {
+    const result = getTimeCompareStackId(
+      'default',
+      ['compare1', 'compare2'],
+      'test_name',
+    );
+    expect(result).toEqual('default');
+  });
+
+  it('returns the first value in timeCompare that is included in name', () => {
+    const result = getTimeCompareStackId(
+      'default',
+      ['compare1', 'compare2'],
+      'test_compare1',
+    );
+    expect(result).toEqual('compare1');
+  });
+
+  it('handles name being a number', () => {
+    const result = getTimeCompareStackId('default', ['123', '456'], 123);
+    expect(result).toEqual('123');
   });
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -1053,7 +1053,7 @@ describe('getTimeCompareStackId', () => {
     const result = getTimeCompareStackId(
       'default',
       ['compare1', 'compare2'],
-      'test_name',
+      'test__name',
     );
     expect(result).toEqual('default');
   });
@@ -1062,7 +1062,7 @@ describe('getTimeCompareStackId', () => {
     const result = getTimeCompareStackId(
       'default',
       ['compare1', 'compare2'],
-      'test_compare1',
+      'test__compare1',
     );
     expect(result).toEqual('compare1');
   });


### PR DESCRIPTION
### SUMMARY
When using the bar chart in stacked mode, the time comparison series are displayed on top of the original ones, making the chart render just one bar with all series.

This PR separates each time compare if any into its own stack so users can properly visualize the comparison data vs original ones.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Current:
![error](https://github.com/apache/superset/assets/38889534/ad633714-b14e-4e77-8912-03c9c80c4d4c)



New version with different stacks:
![new](https://github.com/apache/superset/assets/38889534/9ee22404-5c04-4398-872d-fc87486deac5)


### TESTING INSTRUCTIONS
Set up a bar chart with Style = Stacked
Add a time shift

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
