### PR TITLE
fix(Dashboard): Add border to row when hovering HoverMenu in edit mode

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -186,6 +186,11 @@ const DashboardContentWrapper = styled.div`
         pointer-events: none;
       }
 
+      .grid-row.grid-row--hovered:after,
+      .dashboard-component-tabs > .grid-row--hovered:after {
+        border: 2px dashed ${theme.colors.primary.base};
+      }
+
       .resizable-container {
         & .dashboard-component-chart-holder {
           .dashboard-chart {

--- a/superset-frontend/src/dashboard/components/gridComponents/Row.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Row.jsx
@@ -135,6 +135,7 @@ class Row extends React.PureComponent {
     this.state = {
       isFocused: false,
       isInView: false,
+      hoverMenuHovered: false,
     };
     this.handleDeleteComponent = this.handleDeleteComponent.bind(this);
     this.handleUpdateMeta = this.handleUpdateMeta.bind(this);
@@ -143,6 +144,7 @@ class Row extends React.PureComponent {
       'background',
     );
     this.handleChangeFocus = this.handleChangeFocus.bind(this);
+    this.handleMenuHover = this.handleMenuHover.bind(this);
     this.setVerticalEmptyContainerHeight = debounce(
       this.setVerticalEmptyContainerHeight.bind(this),
       FAST_DEBOUNCE,
@@ -235,6 +237,12 @@ class Row extends React.PureComponent {
     deleteComponent(component.id, parentId);
   }
 
+  handleMenuHover() {
+    this.setState(prevState => ({
+      hoverMenuHovered: !prevState.hoverMenuHovered,
+    }));
+  }
+
   render() {
     const {
       component: rowComponent,
@@ -252,7 +260,7 @@ class Row extends React.PureComponent {
       onChangeTab,
       isComponentVisible,
     } = this.props;
-    const { containerHeight } = this.state;
+    const { containerHeight, hoverMenuHovered } = this.state;
 
     const rowItems = rowComponent.children || [];
 
@@ -287,7 +295,11 @@ class Row extends React.PureComponent {
             editMode={editMode}
           >
             {editMode && (
-              <HoverMenu innerRef={dragSourceRef} position="left">
+              <HoverMenu
+                innerRef={dragSourceRef}
+                position="left"
+                onHover={this.handleMenuHover}
+              >
                 <DragHandle position="left" />
                 <DeleteComponentButton onDelete={this.handleDeleteComponent} />
                 <IconButton
@@ -300,6 +312,7 @@ class Row extends React.PureComponent {
               className={cx(
                 'grid-row',
                 rowItems.length === 0 && 'grid-row--empty',
+                hoverMenuHovered && 'grid-row--hovered',
                 backgroundStyle.className,
               )}
               data-test={`grid-row-${backgroundStyle.className}`}

--- a/superset-frontend/src/dashboard/components/gridComponents/Row.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Row.jsx
@@ -144,13 +144,13 @@ class Row extends React.PureComponent {
       'background',
     );
     this.handleChangeFocus = this.handleChangeFocus.bind(this);
-    this.handleMenuHover = this.handleMenuHover.bind(this);
     this.setVerticalEmptyContainerHeight = debounce(
       this.setVerticalEmptyContainerHeight.bind(this),
       FAST_DEBOUNCE,
     );
 
     this.containerRef = React.createRef();
+    this.hoverRef = React.createRef();
     this.observerEnabler = null;
     this.observerDisabler = null;
   }
@@ -193,6 +193,13 @@ class Row extends React.PureComponent {
 
   componentDidUpdate() {
     this.setVerticalEmptyContainerHeight();
+    console.log('old State', this.state.hoverMenuHovered);
+    console.log('old Ref', this.hoverRef.current?.hoveredState);
+    if (this.hoverRef.current) {
+      this.setState({ hoverMenuHovered: this.hoverRef.current.hovered });
+      console.log('State', this.state.hoverMenuHovered);
+      console.log('Ref', this.hoverRef.current?.hovered);
+    }
   }
 
   setVerticalEmptyContainerHeight() {
@@ -235,12 +242,6 @@ class Row extends React.PureComponent {
   handleDeleteComponent() {
     const { deleteComponent, component, parentId } = this.props;
     deleteComponent(component.id, parentId);
-  }
-
-  handleMenuHover() {
-    this.setState(prevState => ({
-      hoverMenuHovered: !prevState.hoverMenuHovered,
-    }));
   }
 
   render() {
@@ -297,8 +298,8 @@ class Row extends React.PureComponent {
             {editMode && (
               <HoverMenu
                 innerRef={dragSourceRef}
+                hoverRef={this.hoverRef}
                 position="left"
-                onHover={this.handleMenuHover}
               >
                 <DragHandle position="left" />
                 <DeleteComponentButton onDelete={this.handleDeleteComponent} />

--- a/superset-frontend/src/dashboard/components/gridComponents/Row.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Row.jsx
@@ -238,7 +238,8 @@ class Row extends React.PureComponent {
   }
 
   handleMenuHover = hovered => {
-    this.setState(() => ({ hoverMenuHovered: hovered }));
+    const { isHovered } = hovered;
+    this.setState(() => ({ hoverMenuHovered: isHovered }));
   };
 
   render() {

--- a/superset-frontend/src/dashboard/components/gridComponents/Row.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Row.jsx
@@ -144,13 +144,13 @@ class Row extends React.PureComponent {
       'background',
     );
     this.handleChangeFocus = this.handleChangeFocus.bind(this);
+    this.handleMenuHover = this.handleMenuHover.bind(this);
     this.setVerticalEmptyContainerHeight = debounce(
       this.setVerticalEmptyContainerHeight.bind(this),
       FAST_DEBOUNCE,
     );
 
     this.containerRef = React.createRef();
-    this.hoverRef = React.createRef();
     this.observerEnabler = null;
     this.observerDisabler = null;
   }
@@ -193,13 +193,6 @@ class Row extends React.PureComponent {
 
   componentDidUpdate() {
     this.setVerticalEmptyContainerHeight();
-    console.log('old State', this.state.hoverMenuHovered);
-    console.log('old Ref', this.hoverRef.current?.hoveredState);
-    if (this.hoverRef.current) {
-      this.setState({ hoverMenuHovered: this.hoverRef.current.hovered });
-      console.log('State', this.state.hoverMenuHovered);
-      console.log('Ref', this.hoverRef.current?.hovered);
-    }
   }
 
   setVerticalEmptyContainerHeight() {
@@ -243,6 +236,10 @@ class Row extends React.PureComponent {
     const { deleteComponent, component, parentId } = this.props;
     deleteComponent(component.id, parentId);
   }
+
+  handleMenuHover = hovered => {
+    this.setState(() => ({ hoverMenuHovered: hovered }));
+  };
 
   render() {
     const {
@@ -297,8 +294,8 @@ class Row extends React.PureComponent {
           >
             {editMode && (
               <HoverMenu
+                onHover={this.handleMenuHover}
                 innerRef={dragSourceRef}
-                hoverRef={this.hoverRef}
                 position="left"
               >
                 <DragHandle position="left" />

--- a/superset-frontend/src/dashboard/components/menu/HoverMenu.test.tsx
+++ b/superset-frontend/src/dashboard/components/menu/HoverMenu.test.tsx
@@ -17,11 +17,25 @@
  * under the License.
  */
 import React from 'react';
-import { render } from 'spec/helpers/testing-library';
+import { render, screen } from 'spec/helpers/testing-library';
+import userEvent from '@testing-library/user-event';
 
 import HoverMenu from 'src/dashboard/components/menu/HoverMenu';
 
 test('should render a div.hover-menu', () => {
   const { container } = render(<HoverMenu />);
   expect(container.querySelector('.hover-menu')).toBeInTheDocument();
+});
+
+test('should call onHover when mouse enters and leaves', () => {
+  const onHover = jest.fn();
+  render(<HoverMenu onHover={onHover} />);
+
+  const hoverMenu = screen.getByTestId('hover-menu');
+
+  userEvent.hover(hoverMenu);
+  expect(onHover).toBeCalledWith({ isHovered: true });
+
+  userEvent.unhover(hoverMenu);
+  expect(onHover).toBeCalledWith({ isHovered: false });
 });

--- a/superset-frontend/src/dashboard/components/menu/HoverMenu.tsx
+++ b/superset-frontend/src/dashboard/components/menu/HoverMenu.tsx
@@ -99,6 +99,7 @@ export default class HoverMenu extends React.PureComponent<HoverMenuProps> {
           )}
           onMouseEnter={this.handleMouseEnter}
           onMouseLeave={this.handleMouseLeave}
+          data-test="hover-menu"
         >
           {children}
         </div>

--- a/superset-frontend/src/dashboard/components/menu/HoverMenu.tsx
+++ b/superset-frontend/src/dashboard/components/menu/HoverMenu.tsx
@@ -25,6 +25,7 @@ interface HoverMenuProps {
   position: 'left' | 'top';
   innerRef: RefObject<HTMLDivElement>;
   children: React.ReactNode;
+  onHover?: (isHovered: boolean) => void;
 }
 
 const HoverStyleOverrides = styled.div`
@@ -71,21 +72,16 @@ export default class HoverMenu extends React.PureComponent<HoverMenuProps> {
     children: null,
   };
 
-  constructor(props: HoverMenuProps) {
-    super(props);
-    // Disabling unused state rule as it is used in Row.jsx by hoverRef
-    // eslint-disable-next-line
-    this.state = {
-      hovered: false,
-    };
-  }
-
   handleMouseEnter = () => {
-    this.setState({ hovered: true });
+    if (this.props.onHover) {
+      this.props.onHover(true);
+    }
   };
 
   handleMouseLeave = () => {
-    this.setState({ hovered: false });
+    if (this.props.onHover) {
+      this.props.onHover(false);
+    }
   };
 
   render() {

--- a/superset-frontend/src/dashboard/components/menu/HoverMenu.tsx
+++ b/superset-frontend/src/dashboard/components/menu/HoverMenu.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-unused-state */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -23,7 +24,6 @@ import cx from 'classnames';
 interface HoverMenuProps {
   position: 'left' | 'top';
   innerRef: RefObject<HTMLDivElement>;
-  onHover?: () => void;
   children: React.ReactNode;
 }
 
@@ -71,8 +71,25 @@ export default class HoverMenu extends React.PureComponent<HoverMenuProps> {
     children: null,
   };
 
+  constructor(props: HoverMenuProps) {
+    super(props);
+    // Disabling unused state rule as it is used in Row.jsx by hoverRef
+    // eslint-disable-next-line
+    this.state = {
+      hovered: false,
+    };
+  }
+
+  handleMouseEnter = () => {
+    this.setState({ hovered: true });
+  };
+
+  handleMouseLeave = () => {
+    this.setState({ hovered: false });
+  };
+
   render() {
-    const { innerRef, position, onHover, children } = this.props;
+    const { innerRef, position, children } = this.props;
     return (
       <HoverStyleOverrides className="hover-menu-container">
         <div
@@ -82,8 +99,8 @@ export default class HoverMenu extends React.PureComponent<HoverMenuProps> {
             position === 'left' && 'hover-menu--left',
             position === 'top' && 'hover-menu--top',
           )}
-          onMouseEnter={onHover}
-          onMouseLeave={onHover}
+          onMouseEnter={this.handleMouseEnter}
+          onMouseLeave={this.handleMouseLeave}
         >
           {children}
         </div>

--- a/superset-frontend/src/dashboard/components/menu/HoverMenu.tsx
+++ b/superset-frontend/src/dashboard/components/menu/HoverMenu.tsx
@@ -23,6 +23,7 @@ import cx from 'classnames';
 interface HoverMenuProps {
   position: 'left' | 'top';
   innerRef: RefObject<HTMLDivElement>;
+  onHover?: () => void;
   children: React.ReactNode;
 }
 
@@ -71,7 +72,7 @@ export default class HoverMenu extends React.PureComponent<HoverMenuProps> {
   };
 
   render() {
-    const { innerRef, position, children } = this.props;
+    const { innerRef, position, onHover, children } = this.props;
     return (
       <HoverStyleOverrides className="hover-menu-container">
         <div
@@ -81,6 +82,8 @@ export default class HoverMenu extends React.PureComponent<HoverMenuProps> {
             position === 'left' && 'hover-menu--left',
             position === 'top' && 'hover-menu--top',
           )}
+          onMouseEnter={onHover}
+          onMouseLeave={onHover}
         >
           {children}
         </div>

--- a/superset-frontend/src/dashboard/components/menu/HoverMenu.tsx
+++ b/superset-frontend/src/dashboard/components/menu/HoverMenu.tsx
@@ -25,7 +25,7 @@ interface HoverMenuProps {
   position: 'left' | 'top';
   innerRef: RefObject<HTMLDivElement>;
   children: React.ReactNode;
-  onHover?: (isHovered: boolean) => void;
+  onHover?: (data: { isHovered: boolean }) => void;
 }
 
 const HoverStyleOverrides = styled.div`
@@ -73,14 +73,16 @@ export default class HoverMenu extends React.PureComponent<HoverMenuProps> {
   };
 
   handleMouseEnter = () => {
-    if (this.props.onHover) {
-      this.props.onHover(true);
+    const { onHover } = this.props;
+    if (onHover) {
+      onHover({ isHovered: true });
     }
   };
 
   handleMouseLeave = () => {
-    if (this.props.onHover) {
-      this.props.onHover(false);
+    const { onHover } = this.props;
+    if (onHover) {
+      onHover({ isHovered: false });
     }
   };
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This adds a distinction to the context of the hover menu icons being a full row of the dashboard editor rather than the left most chart. It's purpose is to avoid confusion as to what these icons would affect.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
B:
<img width="1792" alt="row icons" src="https://github.com/apache/superset/assets/92495987/6063ffe2-5184-403c-b1dc-387e01a6849f">
A:
![new-hover](https://github.com/apache/superset/assets/92495987/34087f09-ffe3-4690-9a84-6acd66e8a9a1)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Edit a dashboard then hover over the menu icons to the left of any row

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
