### PR TITLE
fix: issue #27463: Mixed time series chart throw error with Elasticsearch backend

### DIFF
--- a/superset/db_engine_specs/elasticsearch.py
+++ b/superset/db_engine_specs/elasticsearch.py
@@ -46,13 +46,12 @@ class ElasticSearchEngineSpec(BaseEngineSpec):  # pylint: disable=abstract-metho
 
     _time_grain_expressions = {
         None: "{col}",
-        TimeGrain.SECOND: "{func}('second', {col})",
-        TimeGrain.MINUTE: "{func}('minute', {col})",
-        TimeGrain.HOUR: "{func}('hour', {col})",
-        TimeGrain.DAY: "{func}('day', {col})",
-        TimeGrain.WEEK: "{func}('week', {col})",
-        TimeGrain.MONTH: "{func}('month', {col})",
-        TimeGrain.YEAR: "{func}('year', {col})",
+        TimeGrain.SECOND: "HISTOGRAM({col}, INTERVAL 1 SECOND)",
+        TimeGrain.MINUTE: "HISTOGRAM({col}, INTERVAL 1 MINUTE)",
+        TimeGrain.HOUR: "HISTOGRAM({col}, INTERVAL 1 HOUR)",
+        TimeGrain.DAY: "HISTOGRAM({col}, INTERVAL 1 DAY)",
+        TimeGrain.MONTH: "HISTOGRAM({col}, INTERVAL 1 MONTH)",
+        TimeGrain.YEAR: "HISTOGRAM({col}, INTERVAL 1 YEAR)",
     }
 
     type_code_map: dict[int, str] = {}  # loaded from get_datatype only if needed


### PR DESCRIPTION
### SUMMARY
This PR fixes issue #27463 which reports errors with Elasticsearch backends when used in Timeseries charts.

### TESTING INSTRUCTIONS
Create Timeseries chart type with an Elasticsearch back-end and verify that no errors are thrown

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #27463 
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
