### PR TITLE
fix(dashboard,css): center align 'waiting on database'

### DIFF
--- a/superset-frontend/src/components/Chart/Chart.jsx
+++ b/superset-frontend/src/components/Chart/Chart.jsx
@@ -133,6 +133,7 @@ const LoadingDiv = styled.div`
   position: absolute;
   left: 50%;
   top: 50%;
+  width: 80%;
   transform: translate(-50%, -50%);
 `;
 

--- a/superset-frontend/src/components/Chart/Chart.jsx
+++ b/superset-frontend/src/components/Chart/Chart.jsx
@@ -105,6 +105,7 @@ const defaultProps = {
 const Styles = styled.div`
   min-height: ${p => p.height}px;
   position: relative;
+  text-align: center;
 
   .chart-tooltip {
     opacity: 0.75;


### PR DESCRIPTION
### SUMMARY
center-align the text under the loading spinner withing charts in a dashbaord

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### before
<img width="427" alt="Screenshot 2024-03-21 at 12 25 46 PM" src="https://github.com/apache/superset/assets/487433/49ad47f2-6c1f-47fb-ab92-b4810b20489b">

#### after
<img width="415" alt="Screenshot 2024-03-21 at 12 22 12 PM" src="https://github.com/apache/superset/assets/487433/9b594c95-7a26-4cda-8bd9-d8602b254413">
