### PR TITLE
docs: simplify the Quickstart guide

### DIFF
--- a/docs/docs/installation/installing-superset-using-docker-compose.mdx
+++ b/docs/docs/installation/installing-superset-using-docker-compose.mdx
@@ -163,10 +163,10 @@ CPU, so you may want to disable it on a resource-constrained device.
 :::note
 Users often want to connect to other databases from Superset. Currently, the easiest way to
 do this is to modify the `docker-compose-non-dev.yml` file and add your database as a service that
-    the other services depend on (via `x-superset-depends-on`). Others have attempted to set
-    `network_mode: host` on the Superset services, but these generally break the installation,
-    because the configuration requires use of the Docker Compose DNS resolver for the service names.
-    If you have a good solution for this, let us know!
+the other services depend on (via `x-superset-depends-on`). Others have attempted to set
+`network_mode: host` on the Superset services, but these generally break the installation,
+because the configuration requires use of the Docker Compose DNS resolver for the service names.
+If you have a good solution for this, let us know!
 :::
 
 :::note

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -4,61 +4,38 @@ hide_title: false
 sidebar_position: 2
 ---
 
-**Ready to give Apache Superset a try?** This quickstart will help you run Superset on your local machine in
-**5 simple steps**. It assumes that you have [Docker](https://www.docker.com) installed.
+**Ready to give Apache Superset a try?** This quickstart guide will help you
+get up and running on your local machine in **5 simple steps**. Note that
+it assumes that you have [Docker](https://www.docker.com),
+[docker-compose](https://docs.docker.com/compose/), and
+[git](https://git-scm.com/) installed.
+
+:::caution
+While we recommend using `docker-compose` for a quick start in a sandbox-type
+environment and for other development-type use cases, we
+do not recommend this setup for production. For this purpose please
+refer to our
+[Installing on Kubernetes](/docs/installation/running-on-kubernetes/)
+page.
+:::
 
 ### 1. Get Superset
-To get started, set the `SUPERSET_VERSION` environment variable with the latest Superset version.
-[Click here](https://github.com/apache/superset/releases) to check the latest version.
 
-```
-$ export SUPERSET_VERSION=<latest_version>
+```bash
+$ git clone git@github.com:apache/superset.git
 ```
 
-Pull the Superset image from Docker Hub:
+### 2. Start the latest official release of Superset
 
 ```
-$ docker pull apache/superset:$SUPERSET_VERSION
+$ docker-compose -f docker-compose-image-tag.yml up
 ```
+This may take a moment as docker-compose will fetch the underlying
+docker images and will load up some examples. Once all containers
+are downloaded and the output settles, you're ready to log in.
 
-### 2. Start Superset
-:::tip
-Note that some configuration is mandatory for Superset in order to start. In particular, Superset will not start without
-a user-specified value of `SECRET_KEY` in a Superset configuration file or `SUPERSET_SECRET_KEY` as an environment variable.
-Please see [Configuring Superset](/docs/installation/configuring-superset/) for more details.
-:::
-```
-$ docker run -d -p 8080:8088 \
-             -e "SUPERSET_SECRET_KEY=$(openssl rand -base64 42)" \
-             -e "TALISMAN_ENABLED=False" \
-             --name superset apache/superset:$SUPERSET_VERSION
-```
-
-### 3. Create an account
-```
-$ docker exec -it superset superset fab create-admin \
-              --username admin \
-              --firstname Admin \
-              --lastname Admin \
-              --email admin@localhost \
-              --password admin
-```
-
-### 4. Configure Superset
-```
-$ docker exec -it superset superset db upgrade &&
-         docker exec -it superset superset load_examples &&
-         docker exec -it superset superset init
-```
-:::tip
-This step can take some time. While you wait, feel free to join the official Slack channel to check for new releases,
-ask questions, and engage with the community.
-[Click here to join.](http://bit.ly/join-superset-slack)
-:::
-
-### 5. Start using Superset
-After configuring your fresh instance, head over to [http://localhost:8080](http://localhost:8080) and
-log in with the default created account:
+### 3. Start using Superset
+Now head over to [http://localhost:8080](http://localhost:8080) and log in with the default created account:
 ```
 username: admin
 password: admin
@@ -69,7 +46,7 @@ password: admin
 ### Wrapping Up
 Once you're done with Superset, you can stop and remove it just like any other container:
 ```
-$ docker container rm -f superset
+$ docker-compose down
 ```
 :::tip
 You can use the same container more than once, as Superset will persist data locally. However, make sure to properly stop all
@@ -81,6 +58,13 @@ processes by running Docker `stop` command. By doing so, you can avoid data corr
 From this point on, you can head on to:
 - [Create your first Dashboard](/docs/creating-charts-dashboards/creating-your-first-dashboard)
 - [Connect to a Database](/docs/databases/installing-database-drivers)
-- [Configure Superset](/docs/installation/configuring-superset/)
+- [Using Docker Compose](/docs/installation/installing-superset-using-docker-compose): find
+  out more about how to install docker & docker-compose, how to point to different Superset
+  version, or how to set up your development environment.
+- [Configure Superset](/docs/installation/configuring-superset/): Superset is highly configurable.
+  Find out what the options are here.
+- [Installing on Kubernetes](/docs/installation/running-on-kubernetes/): if you'd like to setup
+  Superset in a production environment, we recommend using [Kubernetes](https://kubernetes.io/)
+  and our official [Helm Chart](https://github.com/apache/superset/tree/master/helm/superset).
 
-Or just explore our Documentation!
+Or just explore our [Documentation](https://superset.apache.org/docs/intro)!

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -39,7 +39,7 @@ docker images and will load up some examples. Once all containers
 are downloaded and the output settles, you're ready to log in.
 
 ### 3. Log into Superset
-Now head over to [http://localhost:8080](http://localhost:8080) and log in with the default created account:
+Now head over to [http://localhost:8088](http://localhost:8088) and log in with the default created account:
 ```
 username: admin
 password: admin

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -22,19 +22,23 @@ page.
 ### 1. Get Superset
 
 ```bash
-$ git clone git@github.com:apache/superset.git
+$ git clone https://github.com/apache/superset
 ```
 
 ### 2. Start the latest official release of Superset
 
 ```
+# Enter the repository you just clone
+$ cd superset
+
+# Fire up Superset using docker-compose
 $ docker-compose -f docker-compose-image-tag.yml up
 ```
 This may take a moment as docker-compose will fetch the underlying
 docker images and will load up some examples. Once all containers
 are downloaded and the output settles, you're ready to log in.
 
-### 3. Start using Superset
+### 3. Log into Superset
 Now head over to [http://localhost:8080](http://localhost:8080) and log in with the default created account:
 ```
 username: admin

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -5,7 +5,7 @@ sidebar_position: 2
 ---
 
 **Ready to give Apache Superset a try?** This quickstart guide will help you
-get up and running on your local machine in **5 simple steps**. Note that
+get up and running on your local machine in **3 simple steps**. Note that
 it assumes that you have [Docker](https://www.docker.com),
 [docker-compose](https://docs.docker.com/compose/), and
 [git](https://git-scm.com/) installed.

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -28,7 +28,7 @@ $ git clone https://github.com/apache/superset
 ### 2. Start the latest official release of Superset
 
 ```
-# Enter the repository you just clone
+# Enter the repository you just cloned
 $ cd superset
 
 # Fire up Superset using docker-compose

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -12,8 +12,8 @@ it assumes that you have [Docker](https://www.docker.com),
 
 :::caution
 While we recommend using `docker-compose` for a quick start in a sandbox-type
-environment and for other development-type use cases, we
-do not recommend this setup for production. For this purpose please
+environment and for other development-type use cases, **we
+do not recommend this setup for production**. For this purpose please
 refer to our
 [Installing on Kubernetes](/docs/installation/running-on-kubernetes/)
 page.


### PR DESCRIPTION
For a true quickstart, let's direct people towards `docker-compose`
where they can get a multi-container instance setup with 2 shell
commands.

The current docker setup is limited and forces the user to run
an extra set of commands to load examples, create a user, ...
and they end up in a slower single-container instance.

On docker compose, we have all this setup as well as the pointer
to the latest release by default.

It also looks like the current setup is also sqlite(?) and isn't persisted (?)
Having a Postgres and some persistence in the image should be
a positive upgrade here too.