### PR TITLE
feat: use the local supersetbot

### DIFF
--- a/.github/actions/setup-supersetbot/action.yml
+++ b/.github/actions/setup-supersetbot/action.yml
@@ -3,8 +3,6 @@ description: 'Sets up supersetbot npm lib from the repo'
 runs:
   using: 'composite'
   steps:
-    - name: checkout repo
-      uses: actions/checkout@v4
     - name: Install dependencies
       shell: bash
       run: |

--- a/.github/actions/setup-supersetbot/action.yml
+++ b/.github/actions/setup-supersetbot/action.yml
@@ -3,9 +3,11 @@ description: 'Sets up supersetbot npm lib from the repo'
 runs:
   using: 'composite'
   steps:
+    - name: checkout repo
+      uses: actions/checkout@v4
     - name: Install dependencies
+      shell: bash
       run: |
         cd .github/supersetbot
         npm install
         npm link
-      shell: bash

--- a/.github/actions/setup-supersetbot/action.yml
+++ b/.github/actions/setup-supersetbot/action.yml
@@ -1,0 +1,11 @@
+name: 'Setup supersetbot'
+description: 'Sets up supersetbot npm lib from the repo'
+runs:
+  using: 'composite'
+  steps:
+    - name: Install dependencies
+      run: |
+        cd .github/supersetbot
+        npm install
+        npm link
+      shell: bash

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -55,7 +55,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - run: npm install -g supersetbot
+
+      - name: Setup supersetbot
+        uses: ./.github/actions/setup-supersetbot/
+
       - name: Execute custom Node.js script
         env:
           DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -56,6 +56,9 @@ jobs:
         with:
           node-version: '20'
 
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@v4
+
       - name: Setup supersetbot
         uses: ./.github/actions/setup-supersetbot/
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,9 +56,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - name: install supersetbot
-        run: |
-          npm install -g supersetbot
+
+      - name: Setup supersetbot
+        uses: ./.github/actions/setup-supersetbot/
 
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,13 +57,13 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Setup supersetbot
-        uses: ./.github/actions/setup-supersetbot/
-
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+
+      - name: Setup supersetbot
+        uses: ./.github/actions/setup-supersetbot/
 
       - name: Build Docker Image
         shell: bash

--- a/.github/workflows/issue_creation.yml
+++ b/.github/workflows/issue_creation.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           node-version: '20'
 
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@v4
+
       - name: Setup supersetbot
         uses: ./.github/actions/setup-supersetbot/
 

--- a/.github/workflows/issue_creation.yml
+++ b/.github/workflows/issue_creation.yml
@@ -15,7 +15,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - run: npm install -g supersetbot
+
+      - name: Setup supersetbot
+        uses: ./.github/actions/setup-supersetbot/
+
       - name: Execute custom Node.js script
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/supersetbot.yml
+++ b/.github/workflows/supersetbot.yml
@@ -35,7 +35,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - run: npm install supersetbot
+
+      - name: Setup supersetbot
+        uses: ./.github/actions/setup-supersetbot/
+
       - name: Execute custom Node.js script
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/supersetbot.yml
+++ b/.github/workflows/supersetbot.yml
@@ -36,6 +36,9 @@ jobs:
         with:
           node-version: '20'
 
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@v4
+
       - name: Setup supersetbot
         uses: ./.github/actions/setup-supersetbot/
 


### PR DESCRIPTION
### SUMMARY

`supersetbot` was designed to support CI workflow, and we've been doing this by doing a quick `npm install supersetbot` which downloads and uses the latest **published** version. But now, instead of using this approach, I'd like to install the local one instead from the repo using `npm link` so that PRs that need to touch it are always consistent with the version needed.

This came up as there's an open PR upgrading python to 3.10 globally in repo, but upgrading supersetbot didn't take effect as expected.

About the code, note that using a local reusable GHA requires running a checkout, which is pretty cheap so I think it's ok