### PR TITLE
chore: fix master builds + bump python library "cryptography"

### DIFF
--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -24,6 +24,7 @@ runs:
         cache: ${{ inputs.cache }}
     - name: Install dependencies
       run: |
+        sudo apt-get update && sudo apt-get -y install libldap2-dev libsasl2-dev
         pip install --upgrade pip setuptools wheel
         if [ "${{ inputs.requirements-type }}" = "dev" ]; then
           pip install -r requirements/development.txt

--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -31,22 +31,6 @@ say() {
   fi
 }
 
-# default command to run when the `run` input is empty
-default-setup-command() {
-  apt-get-install
-  pip-upgrade
-}
-
-apt-get-install() {
-  say "::group::apt-get install dependencies"
-  sudo apt-get update && sudo apt-get install --yes \
-    libsasl2-dev \
-    libldap2-dev \
-    libffi-dev \
-    libssl-dev
-  say "::endgroup::"
-}
-
 pip-upgrade() {
   say "::group::Upgrade pip"
   pip install --upgrade pip

--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -42,6 +42,7 @@ apt-get-install() {
   sudo apt-get update && sudo apt-get install --yes \
     libsasl2-dev \
     libldap2-dev \
+    libffi-dev \
     libssl-dev
   say "::endgroup::"
 }

--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -41,7 +41,8 @@ apt-get-install() {
   say "::group::apt-get install dependencies"
   sudo apt-get update && sudo apt-get install --yes \
     libsasl2-dev \
-    libldap2-dev
+    libldap2-dev \
+    libssl-dev
   say "::endgroup::"
 }
 

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -68,14 +68,6 @@ jobs:
         continue-on-error: true
         run: ./scripts/ci_check_no_file_changes.sh python frontend
       - name: Setup Python
-        if: steps.check.outcome == 'failure'
-        uses: ./.github/actions/setup-backend/
-      - name: OS dependencies
-        if: steps.check.outcome == 'failure'
-        uses: ./.github/actions/cached-dependencies
-        with:
-          run: apt-get-install
-      - name: Setup Python
         uses: ./.github/actions/setup-backend/
         if: steps.check.outcome == 'failure'
       - name: Setup postgres

--- a/.github/workflows/superset-translations.yml
+++ b/.github/workflows/superset-translations.yml
@@ -50,12 +50,5 @@ jobs:
         uses: ./.github/actions/setup-backend/
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        uses: ./.github/actions/cached-dependencies
-        with:
-          run: |
-            apt-get-install
-            pip-upgrade
-            pip install -r requirements/base.txt
       - name: Test babel extraction
         run: ./scripts/babel_update.sh

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -78,7 +78,7 @@ cron-descriptor==1.2.24
     # via apache-superset
 croniter==1.0.15
     # via apache-superset
-cryptography==42.0.4
+cryptography==42.0.5
     # via
     #   apache-superset
     #   paramiko
@@ -145,9 +145,7 @@ geopy==2.2.0
 google-auth==2.27.0
     # via shillelagh
 greenlet==3.0.3
-    # via
-    #   shillelagh
-    #   sqlalchemy
+    # via shillelagh
 gunicorn==21.2.0
     # via apache-superset
 hashids==1.3.1


### PR DESCRIPTION
Originally generated by @supersetbot 🤖

@mistercrunch here taking over after noticing that the `master` builds were having some issue, and addressing here while bumping this library.

This is pushing the reusable action `setup-backend` I started in a previous PR to bring things together in a simpler way. 