### PR TITLE
fix: Provide more inclusive error handling for saved queries

### DIFF
--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -30,6 +30,7 @@ from flask_appbuilder import Model
 from flask_appbuilder.models.decorators import renders
 from flask_babel import gettext as __
 from humanize import naturaltime
+from jinja2.exceptions import TemplateError
 from sqlalchemy import (
     Boolean,
     Column,
@@ -76,7 +77,7 @@ class SqlTablesMixin:  # pylint: disable=too-few-public-methods
                     self.database.db_engine_spec.engine,  # type: ignore
                 )
             )
-        except SupersetSecurityException:
+        except (SupersetSecurityException, TemplateError):
             return []
 
 

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -1525,6 +1525,7 @@ def extract_tables_from_jinja_sql(sql: str, engine: str | None = None) -> set[Ta
     :param engine: The associated database engine
     :returns: The set of tables referenced in the SQL statement
     :raises SupersetSecurityException: If SQLGlot is unable to parse the SQL statement
+    :raises jinja2.exceptions.TemplateError: If the Jinjafied SQL could not be rendered
     """
 
     from superset.jinja_context import (  # pylint: disable=import-outside-toplevel

--- a/tests/unit_tests/models/sql_lab_test.py
+++ b/tests/unit_tests/models/sql_lab_test.py
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from unittest.mock import MagicMock
+
+import pytest
+from flask_appbuilder import Model
+from jinja2.exceptions import TemplateError
+from pytest_mock import MockFixture
+
+from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
+from superset.exceptions import SupersetSecurityException
+from superset.models.sql_lab import Query, SavedQuery, SqlTablesMixin
+
+
+@pytest.mark.parametrize(
+    "klass",
+    [
+        Query,
+        SavedQuery,
+    ],
+)
+@pytest.mark.parametrize(
+    "exception",
+    [
+        SupersetSecurityException(
+            SupersetError(
+                error_type=SupersetErrorType.QUERY_SECURITY_ACCESS_ERROR,
+                message="",
+                level=ErrorLevel.ERROR,
+            )
+        ),
+        TemplateError,
+    ],
+)
+def test_sql_tables_mixin_sql_tables_exception(
+    klass: type[Model],
+    exception: Exception,
+    mocker: MockFixture,
+) -> None:
+    mocker.patch(
+        "superset.models.sql_lab.extract_tables_from_jinja_sql",
+        side_effect=exception,
+    )
+
+    assert klass(sql="SELECT 1", database=MagicMock()).sql_tables == []


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

When extracting a user's Saved Queries there maybe an issue rendering the the Jinja template, i.e., fields maybe undefined. This PR ensures that the `SqlTablesMixin.sql_tables` method additionally captures any Jinja templating errors.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
