### PR TITLE
chore(🤖): bump python "tabulate==0.8.10"

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -145,9 +145,7 @@ geopy==2.2.0
 google-auth==2.27.0
     # via shillelagh
 greenlet==3.0.3
-    # via
-    #   shillelagh
-    #   sqlalchemy
+    # via shillelagh
 gunicorn==21.2.0
     # via apache-superset
 hashids==1.3.1
@@ -351,7 +349,7 @@ sqlparse==0.4.4
     # via apache-superset
 sshtunnel==0.4.0
     # via apache-superset
-tabulate==0.8.9
+tabulate==0.8.10
     # via apache-superset
 typing-extensions==4.4.0
     # via


### PR DESCRIPTION
Updates the python "tabulate" library version. 

Generated by @supersetbot 🤖