### PR TITLE
chore(🤖): bump python "sqlalchemy==1.4.52"

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -145,9 +145,7 @@ geopy==2.2.0
 google-auth==2.27.0
     # via shillelagh
 greenlet==3.0.3
-    # via
-    #   shillelagh
-    #   sqlalchemy
+    # via shillelagh
 gunicorn==21.2.0
     # via apache-superset
 hashids==1.3.1
@@ -332,7 +330,7 @@ six==1.16.0
     #   wtforms-json
 slack-sdk==3.21.3
     # via apache-superset
-sqlalchemy==1.4.36
+sqlalchemy==1.4.52
     # via
     #   alembic
     #   apache-superset


### PR DESCRIPTION
Updates the python "sqlalchemy" library version. 

Generated by @supersetbot 🤖