### PR TITLE
feat(db_engine): Add custom_user_agent when connecting to MotherDuck

### DIFF
--- a/superset/db_engine_specs/duckdb.py
+++ b/superset/db_engine_specs/duckdb.py
@@ -89,7 +89,7 @@ class DuckDBEngineSpec(BaseEngineSpec):
         """
         Add a user agent to be used in the requests.
         """
-        extra: dict[str, Any] = BaseEngineSpec.get_extra_params(database)
+        extra: dict[str, Any] = super().get_extra_params(database)
         engine_params: dict[str, Any] = extra.setdefault("engine_params", {})
         connect_args: dict[str, Any] = engine_params.setdefault("connect_args", {})
         config: dict[str, Any] = connect_args.setdefault("config", {})

--- a/superset/db_engine_specs/duckdb.py
+++ b/superset/db_engine_specs/duckdb.py
@@ -96,7 +96,7 @@ class DuckDBEngineSpec(BaseEngineSpec):
         config: dict[str, Any] = connect_args.setdefault("config", {})
         custom_user_agent = config.pop("custom_user_agent", "")
         delim = " " if custom_user_agent else ""
-        user_agent = f"{USER_AGENT}/{VERSION_STRING}{delim}{custom_user_agent}"
+        user_agent = f"{USER_AGENT.lower().replace(" ", "-")}/{VERSION_STRING}{delim}{custom_user_agent}"
         config.setdefault("custom_user_agent", user_agent)
 
         return extra

--- a/superset/db_engine_specs/duckdb.py
+++ b/superset/db_engine_specs/duckdb.py
@@ -22,6 +22,7 @@ from re import Pattern
 from typing import Any, TYPE_CHECKING
 
 from flask_babel import gettext as __
+from pytz import VERSION
 from sqlalchemy import types
 from sqlalchemy.engine.reflection import Inspector
 
@@ -82,13 +83,6 @@ class DuckDBEngineSpec(BaseEngineSpec):
     ) -> set[str]:
         return set(inspector.get_table_names(schema))
 
-
-class MotherDuckEngineSpec(DuckDBEngineSpec):
-    engine = "duckdb"
-    engine_name = "MotherDuck"
-
-    sqlalchemy_uri_placeholder = "duckdb:///md:{SERVICE_TOKEN}@{database_name}"
-
     @staticmethod
     def get_extra_params(database: "Database") -> dict[str, Any]:
         """
@@ -100,6 +94,14 @@ class MotherDuckEngineSpec(DuckDBEngineSpec):
         config: dict[str, Any] = connect_args.setdefault("config", {})
         custom_user_agent = config.pop("custom_user_agent", "")
         delim = " " if custom_user_agent else ""
-        config.setdefault("custom_user_agent", f"{USER_AGENT}/{VERSION_STRING}{delim}{custom_user_agent}")
+        user_agent = f"{USER_AGENT}/{VERSION_STRING}{delim}{custom_user_agent}"
+        config.setdefault("custom_user_agent", user_agent)
 
         return extra
+
+
+class MotherDuckEngineSpec(DuckDBEngineSpec):
+    engine = "duckdb"
+    engine_name = "MotherDuck"
+
+    sqlalchemy_uri_placeholder = "duckdb:///md:{SERVICE_TOKEN}@{database_name}"

--- a/superset/db_engine_specs/duckdb.py
+++ b/superset/db_engine_specs/duckdb.py
@@ -96,7 +96,8 @@ class DuckDBEngineSpec(BaseEngineSpec):
         config: dict[str, Any] = connect_args.setdefault("config", {})
         custom_user_agent = config.pop("custom_user_agent", "")
         delim = " " if custom_user_agent else ""
-        user_agent = f"{USER_AGENT.lower().replace(" ", "-")}/{VERSION_STRING}{delim}{custom_user_agent}"
+        user_agent = USER_AGENT.replace(" ", "-").lower()
+        user_agent = f"{user_agent}/{VERSION_STRING}{delim}{custom_user_agent}"
         config.setdefault("custom_user_agent", user_agent)
 
         return extra

--- a/superset/db_engine_specs/duckdb.py
+++ b/superset/db_engine_specs/duckdb.py
@@ -22,7 +22,6 @@ from re import Pattern
 from typing import Any, TYPE_CHECKING
 
 from flask_babel import gettext as __
-from pytz import VERSION
 from sqlalchemy import types
 from sqlalchemy.engine.reflection import Inspector
 

--- a/superset/db_engine_specs/duckdb.py
+++ b/superset/db_engine_specs/duckdb.py
@@ -89,7 +89,7 @@ class DuckDBEngineSpec(BaseEngineSpec):
         """
         Add a user agent to be used in the requests.
         """
-        extra: dict[str, Any] = super().get_extra_params(database)
+        extra: dict[str, Any] = BaseEngineSpec.get_extra_params(database)
         engine_params: dict[str, Any] = extra.setdefault("engine_params", {})
         connect_args: dict[str, Any] = engine_params.setdefault("connect_args", {})
         config: dict[str, Any] = connect_args.setdefault("config", {})

--- a/superset/db_engine_specs/duckdb.py
+++ b/superset/db_engine_specs/duckdb.py
@@ -43,6 +43,8 @@ class DuckDBEngineSpec(BaseEngineSpec):
     engine = "duckdb"
     engine_name = "DuckDB"
 
+    sqlalchemy_uri_placeholder = "duckdb:////path/to/duck.db"
+
     _time_grain_expressions = {
         None: "{col}",
         TimeGrain.SECOND: "DATE_TRUNC('second', {col})",
@@ -104,4 +106,4 @@ class MotherDuckEngineSpec(DuckDBEngineSpec):
     engine = "duckdb"
     engine_name = "MotherDuck"
 
-    sqlalchemy_uri_placeholder = "duckdb:///md:{SERVICE_TOKEN}@{database_name}"
+    sqlalchemy_uri_placeholder = "duckdb:///md:{database_name}?motherduck_token={SERVICE_TOKEN}"

--- a/superset/db_engine_specs/duckdb.py
+++ b/superset/db_engine_specs/duckdb.py
@@ -86,7 +86,7 @@ class DuckDBEngineSpec(BaseEngineSpec):
         return set(inspector.get_table_names(schema))
 
     @staticmethod
-    def get_extra_params(database: "Database") -> dict[str, Any]:
+    def get_extra_params(database: Database) -> dict[str, Any]:
         """
         Add a user agent to be used in the requests.
         """
@@ -107,4 +107,6 @@ class MotherDuckEngineSpec(DuckDBEngineSpec):
     engine = "duckdb"
     engine_name = "MotherDuck"
 
-    sqlalchemy_uri_placeholder = "duckdb:///md:{database_name}?motherduck_token={SERVICE_TOKEN}"
+    sqlalchemy_uri_placeholder = (
+        "duckdb:///md:{database_name}?motherduck_token={SERVICE_TOKEN}"
+    )

--- a/tests/unit_tests/db_engine_specs/test_duckdb.py
+++ b/tests/unit_tests/db_engine_specs/test_duckdb.py
@@ -55,7 +55,7 @@ def test_get_extra_params_motherduck(mocker: MockerFixture) -> None:
     assert MotherDuckEngineSpec.get_extra_params(database) == {
         "engine_params": {
             "connect_args": {
-                "config": {"custom_user_agent": f"Apache Superset/{VERSION_STRING}"}
+                "config": {"custom_user_agent": f"apache-superset/{VERSION_STRING}"}
             }
         }
     }
@@ -67,7 +67,7 @@ def test_get_extra_params_motherduck(mocker: MockerFixture) -> None:
         "engine_params": {
             "connect_args": {
                 "config": {
-                    "custom_user_agent": f"Apache Superset/{VERSION_STRING} My app"
+                    "custom_user_agent": f"apache-superset/{VERSION_STRING} My app"
                 }
             }
         }

--- a/tests/unit_tests/db_engine_specs/test_duckdb.py
+++ b/tests/unit_tests/db_engine_specs/test_duckdb.py
@@ -43,16 +43,16 @@ def test_convert_dttm(
     assert_convert_dttm(spec, target_type, expected_result, dttm)
 
 
-def test_get_extra_params_motherduck(mocker: MockerFixture) -> None:
+def test_get_extra_params(mocker: MockerFixture) -> None:
     """
     Test the ``get_extra_params`` method.
     """
-    from superset.db_engine_specs.duckdb import MotherDuckEngineSpec
+    from superset.db_engine_specs.duckdb import DuckDBEngineSpec
 
     database = mocker.MagicMock()
 
     database.extra = {}
-    assert MotherDuckEngineSpec.get_extra_params(database) == {
+    assert DuckDBEngineSpec.get_extra_params(database) == {
         "engine_params": {
             "connect_args": {
                 "config": {"custom_user_agent": f"apache-superset/{VERSION_STRING}"}
@@ -63,7 +63,7 @@ def test_get_extra_params_motherduck(mocker: MockerFixture) -> None:
     database.extra = json.dumps(
         {"engine_params": {"connect_args": {"config": {"custom_user_agent": "My app"}}}}
     )
-    assert MotherDuckEngineSpec.get_extra_params(database) == {
+    assert DuckDBEngineSpec.get_extra_params(database) == {
         "engine_params": {
             "connect_args": {
                 "config": {

--- a/tests/unit_tests/db_engine_specs/test_duckdb.py
+++ b/tests/unit_tests/db_engine_specs/test_duckdb.py
@@ -61,13 +61,13 @@ def test_get_extra_params(mocker: MockerFixture) -> None:
     }
 
     database.extra = json.dumps(
-        {"engine_params": {"connect_args": {"config": {"custom_user_agent": "My app"}}}}
+        {"engine_params": {"connect_args": {"config": {"custom_user_agent": "my-app"}}}}
     )
     assert DuckDBEngineSpec.get_extra_params(database) == {
         "engine_params": {
             "connect_args": {
                 "config": {
-                    "custom_user_agent": f"apache-superset/{VERSION_STRING} My app"
+                    "custom_user_agent": f"apache-superset/{VERSION_STRING} my-app"
                 }
             }
         }

--- a/tests/unit_tests/db_engine_specs/test_duckdb.py
+++ b/tests/unit_tests/db_engine_specs/test_duckdb.py
@@ -15,16 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import json
 from datetime import datetime
 from typing import Optional
 
 import pytest
-import json
-
 from pytest_mock import MockerFixture
 
 from superset.config import VERSION_STRING
-
 from tests.unit_tests.db_engine_specs.utils import assert_convert_dttm
 from tests.unit_tests.fixtures.common import dttm
 
@@ -44,6 +42,7 @@ def test_convert_dttm(
 
     assert_convert_dttm(spec, target_type, expected_result, dttm)
 
+
 def test_get_extra_params_motherduck(mocker: MockerFixture) -> None:
     """
     Test the ``get_extra_params`` method.
@@ -54,14 +53,22 @@ def test_get_extra_params_motherduck(mocker: MockerFixture) -> None:
 
     database.extra = {}
     assert MotherDuckEngineSpec.get_extra_params(database) == {
-        "engine_params": {"connect_args": {"config": {"custom_user_agent": f"Apache Superset/{VERSION_STRING}"}}}
+        "engine_params": {
+            "connect_args": {
+                "config": {"custom_user_agent": f"Apache Superset/{VERSION_STRING}"}
+            }
+        }
     }
 
     database.extra = json.dumps(
-        {
-            "engine_params": {"connect_args": {"config": {"custom_user_agent": "My app"}}}
-        }
+        {"engine_params": {"connect_args": {"config": {"custom_user_agent": "My app"}}}}
     )
     assert MotherDuckEngineSpec.get_extra_params(database) == {
-        "engine_params": {"connect_args": {"config": {"custom_user_agent": f"Apache Superset/{VERSION_STRING} My app"}}}
+        "engine_params": {
+            "connect_args": {
+                "config": {
+                    "custom_user_agent": f"Apache Superset/{VERSION_STRING} My app"
+                }
+            }
+        }
     }


### PR DESCRIPTION
### SUMMARY
This PR adds a `custom_user_agent` key to the config that is passed to the SQLAlchemy engine for DuckDB. This is needed for MotherDuck so we can track usage of Superset.
The PR also updates the `sqlalchemy_uri_placeholder` for DuckDB and MotherDuck.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
User agent before:
```
duckdb/v0.9.2(osx_arm64) python duckdb_engine/0.11.2(sqlalchemy/1.4.36)
```

User agent after:
```
duckdb/v0.9.2(osx_arm64) python duckdb_engine/0.11.2(sqlalchemy/1.4.36) apache-superset/0.0.0-dev
```

`sqlalchemy_uri_placeholder` before:
<img width="499" alt="Screenshot 2024-03-26 at 10 29 20 AM" src="https://github.com/apache/superset/assets/4041805/18d74ce8-036b-4c3c-bf25-489ca156c526">
<img width="502" alt="Screenshot 2024-03-26 at 10 29 33 AM" src="https://github.com/apache/superset/assets/4041805/15108b86-0ec6-4c27-9f75-cb60c8ada53c">

`sqlalchemy_uri_placeholder` after:
<img width="500" alt="Screenshot 2024-03-26 at 10 28 46 AM" src="https://github.com/apache/superset/assets/4041805/aca3d7cc-7261-4fd0-b641-a74a085968d9">
<img width="502" alt="Screenshot 2024-03-26 at 10 28 59 AM" src="https://github.com/apache/superset/assets/4041805/627e746f-54b6-4de2-81b5-4531860ab306">

### TESTING INSTRUCTIONS
Run unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
