### PR TITLE
fix: useTruncation infinite loop, reenable dashboard cross links on ChartList

### DIFF
--- a/superset-frontend/cypress-base/cypress/e2e/chart_list/list.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/chart_list/list.test.ts
@@ -112,7 +112,7 @@ describe('Charts list', () => {
       cy.getBySel('sort-header').eq(1).contains('Name');
       cy.getBySel('sort-header').eq(2).contains('Type');
       cy.getBySel('sort-header').eq(3).contains('Dataset');
-      cy.getBySel('sort-header').eq(4).contains('Dashboards added to');
+      cy.getBySel('sort-header').eq(4).contains('On dashboards');
       cy.getBySel('sort-header').eq(5).contains('Owners');
       cy.getBySel('sort-header').eq(6).contains('Last modified');
       cy.getBySel('sort-header').eq(7).contains('Actions');

--- a/superset-frontend/cypress-base/cypress/e2e/chart_list/list.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/chart_list/list.test.ts
@@ -54,7 +54,7 @@ function visitChartList() {
 }
 
 describe('Charts list', () => {
-  describe.skip('Cross-referenced dashboards', () => {
+  describe('Cross-referenced dashboards', () => {
     beforeEach(() => {
       cy.createSampleDashboards([0, 1, 2, 3]);
       cy.createSampleCharts([0]);
@@ -112,9 +112,10 @@ describe('Charts list', () => {
       cy.getBySel('sort-header').eq(1).contains('Name');
       cy.getBySel('sort-header').eq(2).contains('Type');
       cy.getBySel('sort-header').eq(3).contains('Dataset');
-      cy.getBySel('sort-header').eq(4).contains('Owners');
-      cy.getBySel('sort-header').eq(5).contains('Last modified');
-      cy.getBySel('sort-header').eq(6).contains('Actions');
+      cy.getBySel('sort-header').eq(4).contains('Dashboards added to');
+      cy.getBySel('sort-header').eq(5).contains('Owners');
+      cy.getBySel('sort-header').eq(6).contains('Last modified');
+      cy.getBySel('sort-header').eq(7).contains('Actions');
     });
 
     it('should sort correctly in list mode', () => {

--- a/superset-frontend/cypress-base/cypress/e2e/explore/chart.test.js
+++ b/superset-frontend/cypress-base/cypress/e2e/explore/chart.test.js
@@ -31,13 +31,13 @@ const SAMPLE_DASHBOARDS_INDEXES = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 function openDashboardsAddedTo() {
   cy.getBySel('actions-trigger').click();
   cy.get('.ant-dropdown-menu-submenu-title')
-    .contains('Dashboards added to')
+    .contains('On dashboards')
     .trigger('mouseover', { force: true });
 }
 
 function closeDashboardsAddedTo() {
   cy.get('.ant-dropdown-menu-submenu-title')
-    .contains('Dashboards added to')
+    .contains('On dashboards')
     .trigger('mouseout', { force: true });
   cy.getBySel('actions-trigger').click();
 }

--- a/superset-frontend/packages/superset-ui-core/src/hooks/useTruncation/useChildElementTruncation.ts
+++ b/superset-frontend/packages/superset-ui-core/src/hooks/useTruncation/useChildElementTruncation.ts
@@ -83,7 +83,9 @@ const useChildElementTruncation = () => {
 
     onResize();
 
-    return obs.disconnect;
+    return () => {
+      obs.disconnect();
+    };
   }, [plusRef.current]); // plus is rendered dynamically - the component rerenders the hook when plus appears, this makes sure that useLayoutEffect is rerun
 
   return [elementRef, plusRef, elementsTruncated, hasHiddenElements] as const;

--- a/superset-frontend/packages/superset-ui-core/src/hooks/useTruncation/useChildElementTruncation.ts
+++ b/superset-frontend/packages/superset-ui-core/src/hooks/useTruncation/useChildElementTruncation.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { RefObject, useLayoutEffect, useState, useRef } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 
 /**
  * This hook encapsulates logic to support truncation of child HTML
@@ -27,92 +27,67 @@ import { RefObject, useLayoutEffect, useState, useRef } from 'react';
  * (including those completely hidden) and whether any elements
  * are completely hidden.
  */
-const useChildElementTruncation = (
-  elementRef: RefObject<HTMLElement>,
-  plusRef?: RefObject<HTMLElement>,
-) => {
+const useChildElementTruncation = () => {
   const [elementsTruncated, setElementsTruncated] = useState(0);
   const [hasHiddenElements, setHasHiddenElements] = useState(false);
-
-  const previousEffectInfoRef = useRef({
-    scrollWidth: 0,
-    parentElementWidth: 0,
-    plusRefWidth: 0,
-  });
+  const elementRef = useRef<HTMLDivElement>(null);
+  const plusRef = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
-    const currentElement = elementRef.current;
-    const plusRefElement = plusRef?.current;
-
-    if (!currentElement) {
-      return;
-    }
-
-    const { scrollWidth, clientWidth, childNodes } = currentElement;
-
-    // By using the result of this effect to truncate content
-    // we're effectively changing it's size.
-    // That will trigger another pass at this effect.
-    // Depending on the content elements width, that second rerender could
-    // yield a different truncate count, thus potentially leading to a
-    // rendering loop.
-    // There's only a need to recompute if the parent width or the width of
-    // the child nodes changes.
-    const previousEffectInfo = previousEffectInfoRef.current;
-    const parentElementWidth = currentElement.parentElement?.clientWidth || 0;
-    const plusRefWidth = plusRefElement?.offsetWidth || 0;
-    previousEffectInfoRef.current = {
-      scrollWidth,
-      parentElementWidth,
-      plusRefWidth,
-    };
-
-    if (
-      previousEffectInfo.parentElementWidth === parentElementWidth &&
-      previousEffectInfo.scrollWidth === scrollWidth &&
-      previousEffectInfo.plusRefWidth === plusRefWidth
-    ) {
-      return;
-    }
-
-    if (scrollWidth > clientWidth) {
-      // "..." is around 6px wide
-      const truncationWidth = 6;
-      const plusSize = plusRefElement?.offsetWidth || 0;
-      const maxWidth = clientWidth - truncationWidth;
-      const elementsCount = childNodes.length;
-
-      let width = 0;
-      let hiddenElements = 0;
-      for (let i = 0; i < elementsCount; i += 1) {
-        const itemWidth = (childNodes[i] as HTMLElement).offsetWidth;
-        const remainingWidth = maxWidth - truncationWidth - width - plusSize;
-
-        // assures it shows +{number} only when the item is not visible
-        if (remainingWidth <= 0) {
-          hiddenElements += 1;
-        }
-        width += itemWidth;
+    const onResize = () => {
+      const currentElement = elementRef.current;
+      if (!currentElement) {
+        return;
       }
+      const plusRefElement = plusRef.current;
+      const { scrollWidth, clientWidth, childNodes } = currentElement;
 
-      if (elementsCount > 1 && hiddenElements) {
-        setHasHiddenElements(true);
-        setElementsTruncated(hiddenElements);
+      if (scrollWidth > clientWidth) {
+        // "..." is around 6px wide
+        const truncationWidth = 6;
+        const plusSize = plusRefElement?.offsetWidth || 0;
+        const maxWidth = clientWidth - truncationWidth;
+        const elementsCount = childNodes.length;
+
+        let width = 0;
+        let hiddenElements = 0;
+        for (let i = 0; i < elementsCount; i += 1) {
+          const itemWidth = (childNodes[i] as HTMLElement).offsetWidth;
+          const remainingWidth = maxWidth - width - plusSize;
+
+          // assures it shows +{number} only when the item is not visible
+          if (remainingWidth <= 0) {
+            hiddenElements += 1;
+          }
+          width += itemWidth;
+        }
+
+        if (elementsCount > 1 && hiddenElements) {
+          setHasHiddenElements(true);
+          setElementsTruncated(hiddenElements);
+        } else {
+          setHasHiddenElements(false);
+          setElementsTruncated(1);
+        }
       } else {
         setHasHiddenElements(false);
-        setElementsTruncated(1);
+        setElementsTruncated(0);
       }
-    } else {
-      setHasHiddenElements(false);
-      setElementsTruncated(0);
-    }
-  }, [
-    elementRef.current?.offsetWidth,
-    elementRef.current?.clientWidth,
-    elementRef,
-  ]);
+    };
+    const obs = new ResizeObserver(onResize);
 
-  return [elementsTruncated, hasHiddenElements];
+    const element = elementRef.current?.parentElement;
+    if (element) {
+      obs.observe(element);
+    }
+
+    // onResize();
+    return () => {
+      obs.disconnect();
+    };
+  }, [plusRef.current]); // plus is rendered dynamically - the component rerenders the hook when plus appears, this makes sure that useLayoutEffect is rerun
+
+  return [elementRef, plusRef, elementsTruncated, hasHiddenElements] as const;
 };
 
 export default useChildElementTruncation;

--- a/superset-frontend/packages/superset-ui-core/src/hooks/useTruncation/useChildElementTruncation.ts
+++ b/superset-frontend/packages/superset-ui-core/src/hooks/useTruncation/useChildElementTruncation.ts
@@ -81,7 +81,8 @@ const useChildElementTruncation = () => {
       obs.observe(element);
     }
 
-    // onResize();
+    onResize();
+
     return () => {
       obs.disconnect();
     };

--- a/superset-frontend/packages/superset-ui-core/src/hooks/useTruncation/useChildElementTruncation.ts
+++ b/superset-frontend/packages/superset-ui-core/src/hooks/useTruncation/useChildElementTruncation.ts
@@ -83,9 +83,7 @@ const useChildElementTruncation = () => {
 
     onResize();
 
-    return () => {
-      obs.disconnect();
-    };
+    return obs.disconnect;
   }, [plusRef.current]); // plus is rendered dynamically - the component rerenders the hook when plus appears, this makes sure that useLayoutEffect is rerun
 
   return [elementRef, plusRef, elementsTruncated, hasHiddenElements] as const;

--- a/superset-frontend/src/components/ListView/CrossLinks.tsx
+++ b/superset-frontend/src/components/ListView/CrossLinks.tsx
@@ -76,12 +76,7 @@ function CrossLinks({
     () => (
       <span className="truncated" ref={crossLinksRef} data-test="crosslinks">
         {crossLinks.map((link, index) => (
-          <Link
-            key={link.id}
-            to={linkPrefix + link.id}
-            target="_blank"
-            rel="noreferer noopener"
-          >
+          <Link key={link.id} to={linkPrefix + link.id}>
             {index === 0 ? link.title : `, ${link.title}`}
           </Link>
         ))}

--- a/superset-frontend/src/components/ListView/CrossLinks.tsx
+++ b/superset-frontend/src/components/ListView/CrossLinks.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useMemo, useRef } from 'react';
+import React, { useMemo } from 'react';
 import { styled, useTruncation } from '@superset-ui/core';
 import { Link } from 'react-router-dom';
 import CrossLinksTooltip from './CrossLinksTooltip';
@@ -60,17 +60,13 @@ const StyledCrossLinks = styled.div`
   `}
 `;
 
-export default function CrossLinks({
+function CrossLinks({
   crossLinks,
   maxLinks = 20,
   linkPrefix = '/superset/dashboard/',
 }: CrossLinksProps) {
-  const crossLinksRef = useRef<HTMLDivElement>(null);
-  const plusRef = useRef<HTMLDivElement>(null);
-  const [elementsTruncated, hasHiddenElements] = useTruncation(
-    crossLinksRef,
-    plusRef,
-  );
+  const [crossLinksRef, plusRef, elementsTruncated, hasHiddenElements] =
+    useTruncation();
   const hasMoreItems = useMemo(
     () =>
       crossLinks.length > maxLinks ? crossLinks.length - maxLinks : undefined,
@@ -91,7 +87,7 @@ export default function CrossLinks({
         ))}
       </span>
     ),
-    [crossLinks],
+    [crossLinks, crossLinksRef, linkPrefix],
   );
   const tooltipLinks = useMemo(
     () =>
@@ -99,7 +95,7 @@ export default function CrossLinks({
         title: l.title,
         to: linkPrefix + l.id,
       })),
-    [crossLinks, maxLinks],
+    [crossLinks, linkPrefix, maxLinks],
   );
 
   return (
@@ -119,3 +115,5 @@ export default function CrossLinks({
     </StyledCrossLinks>
   );
 }
+
+export default React.memo(CrossLinks);

--- a/superset-frontend/src/components/ListView/DashboardCrossLinks.tsx
+++ b/superset-frontend/src/components/ListView/DashboardCrossLinks.tsx
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import React, { useMemo } from 'react';
 import { ensureIsArray } from '@superset-ui/core';
 import { ChartLinkedDashboard } from 'src/types/Chart';

--- a/superset-frontend/src/components/ListView/DashboardCrossLinks.tsx
+++ b/superset-frontend/src/components/ListView/DashboardCrossLinks.tsx
@@ -1,0 +1,18 @@
+import React, { useMemo } from 'react';
+import { ensureIsArray } from '@superset-ui/core';
+import { ChartLinkedDashboard } from 'src/types/Chart';
+import CrossLinks from './CrossLinks';
+
+export const DashboardCrossLinks = React.memo(
+  ({ dashboards }: { dashboards: ChartLinkedDashboard[] }) => {
+    const crossLinks = useMemo(
+      () =>
+        ensureIsArray(dashboards).map((d: ChartLinkedDashboard) => ({
+          title: d.dashboard_title,
+          id: d.id,
+        })),
+      [dashboards],
+    );
+    return <CrossLinks crossLinks={crossLinks} />;
+  },
+);

--- a/superset-frontend/src/components/TruncatedList/index.tsx
+++ b/superset-frontend/src/components/TruncatedList/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { ReactNode, useMemo, useRef } from 'react';
+import React, { ReactNode, useMemo } from 'react';
 import { styled, t, useTruncation } from '@superset-ui/core';
 import { Tooltip } from '../Tooltip';
 
@@ -99,12 +99,8 @@ export default function TruncatedList<ListItemType>({
   getKey = item => item as unknown as React.Key,
   maxLinks = 20,
 }: TruncatedListProps<ListItemType>) {
-  const itemsNotInTooltipRef = useRef<HTMLDivElement>(null);
-  const plusRef = useRef<HTMLDivElement>(null);
-  const [elementsTruncated, hasHiddenElements] = useTruncation(
-    itemsNotInTooltipRef,
-    plusRef,
-  ) as [number, boolean];
+  const [itemsNotInTooltipRef, plusRef, elementsTruncated, hasHiddenElements] =
+    useTruncation();
 
   const nMoreItems = useMemo(
     () => (items.length > maxLinks ? items.length - maxLinks : undefined),

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/DependenciesRow.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/DependenciesRow.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import { css, t, useTheme, useTruncation } from '@superset-ui/core';
 import Icons from 'src/components/Icons';
@@ -53,12 +53,8 @@ const DependencyValue = ({
 
 export const DependenciesRow = React.memo(({ filter }: FilterCardRowProps) => {
   const dependencies = useFilterDependencies(filter);
-  const dependenciesRef = useRef<HTMLDivElement>(null);
-  const plusRef = useRef<HTMLDivElement>(null);
-  const [elementsTruncated, hasHiddenElements] = useTruncation(
-    dependenciesRef,
-    plusRef,
-  );
+  const [dependenciesRef, plusRef, elementsTruncated, hasHiddenElements] =
+    useTruncation();
   const theme = useTheme();
 
   const tooltipText = useMemo(

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/NameRow.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/NameRow.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useRef } from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
 import { css, SupersetTheme, useTheme, useTruncation } from '@superset-ui/core';
 import Icons from 'src/components/Icons';
@@ -31,8 +31,7 @@ export const NameRow = ({
   hidePopover,
 }: FilterCardRowProps & { hidePopover: () => void }) => {
   const theme = useTheme();
-  const filterNameRef = useRef<HTMLElement>(null);
-  const [elementsTruncated] = useTruncation(filterNameRef);
+  const [filterNameRef, , elementsTruncated] = useTruncation();
   const dashboardId = useSelector<RootState, number>(
     ({ dashboardInfo }) => dashboardInfo.id,
   );

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/ScopeRow.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/ScopeRow.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useMemo, useRef } from 'react';
+import React, { useMemo } from 'react';
 import { t, useTruncation } from '@superset-ui/core';
 import { useFilterScope } from './useFilterScope';
 import {
@@ -44,13 +44,9 @@ const getTooltipSection = (items: string[] | undefined, label: string) =>
 
 export const ScopeRow = React.memo(({ filter }: FilterCardRowProps) => {
   const scope = useFilterScope(filter);
-  const scopeRef = useRef<HTMLDivElement>(null);
-  const plusRef = useRef<HTMLDivElement>(null);
 
-  const [elementsTruncated, hasHiddenElements] = useTruncation(
-    scopeRef,
-    plusRef,
-  );
+  const [scopeRef, plusRef, elementsTruncated, hasHiddenElements] =
+    useTruncation();
   const tooltipText = useMemo(() => {
     if (elementsTruncated === 0 || !scope) {
       return null;
@@ -81,7 +77,7 @@ export const ScopeRow = React.memo(({ filter }: FilterCardRowProps) => {
                 ))
             : t('None')}
         </RowValue>
-        {hasHiddenElements > 0 && (
+        {hasHiddenElements && (
           <RowTruncationCount ref={plusRef}>
             +{elementsTruncated}
           </RowTruncationCount>

--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/DashboardsSubMenu.test.tsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/DashboardsSubMenu.test.tsx
@@ -30,7 +30,7 @@ const asyncRender = (numberOfItems: number) =>
     }
     render(
       <Menu openKeys={['menu']}>
-        <Menu.SubMenu title="Dashboards added to" key="menu">
+        <Menu.SubMenu title="On dashboards" key="menu">
           <DashboardItems key="menu" dashboards={dashboards} />
         </Menu.SubMenu>
       </Menu>,

--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
@@ -310,7 +310,7 @@ export const useExploreAdditionalActionsMenu = (
             </Menu.Item>
           )}
           <Menu.SubMenu
-            title={t('Dashboards added to')}
+            title={t('On dashboards')}
             key={MENU_KEYS.DASHBOARDS_ADDED_TO}
           >
             <DashboardsSubMenu

--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -17,7 +17,6 @@
  * under the License.
  */
 import {
-  ensureIsArray,
   isFeatureEnabled,
   FeatureFlag,
   getChartMetadataRegistry,
@@ -53,13 +52,12 @@ import ListView, {
   ListViewProps,
   SelectOption,
 } from 'src/components/ListView';
-import CrossLinks from 'src/components/ListView/CrossLinks';
 import Loading from 'src/components/Loading';
 import { dangerouslyGetItemDoNotUse } from 'src/utils/localStorageHelpers';
 import withToasts from 'src/components/MessageToasts/withToasts';
 import PropertiesModal from 'src/explore/components/PropertiesModal';
 import ImportModelsModal from 'src/components/ImportModal/index';
-import Chart, { ChartLinkedDashboard } from 'src/types/Chart';
+import Chart from 'src/types/Chart';
 import Tag from 'src/types/TagType';
 import { Tooltip } from 'src/components/Tooltip';
 import Icons from 'src/components/Icons';
@@ -72,6 +70,7 @@ import FacePile from 'src/components/FacePile';
 import ChartCard from 'src/features/charts/ChartCard';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
 import { findPermission } from 'src/utils/findPermission';
+import { DashboardCrossLinks } from 'src/components/ListView/DashboardCrossLinks';
 import { ModifiedInfo } from 'src/components/AuditInfo';
 import { QueryObjectColumns } from 'src/views/CRUD/types';
 
@@ -156,20 +155,6 @@ interface ChartListProps {
 const StyledActions = styled.div`
   color: ${({ theme }) => theme.colors.grayscale.base};
 `;
-
-const DashboardCrossLinks = React.memo(
-  ({ dashboards }: { dashboards: ChartLinkedDashboard[] }) => {
-    const crossLinks = useMemo(
-      () =>
-        ensureIsArray(dashboards).map((d: ChartLinkedDashboard) => ({
-          title: d.dashboard_title,
-          id: d.id,
-        })),
-      [dashboards],
-    );
-    return <CrossLinks crossLinks={crossLinks} />;
-  },
-);
 
 function ChartList(props: ChartListProps) {
   const {

--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -390,7 +390,7 @@ function ChartList(props: ChartListProps) {
             original: { dashboards },
           },
         }: any) => <DashboardCrossLinks dashboards={dashboards} />,
-        Header: t('Dashboards added to'),
+        Header: t('On dashboards'),
         accessor: 'dashboards',
         disableSortBy: true,
         size: 'xxl',

--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -157,6 +157,20 @@ const StyledActions = styled.div`
   color: ${({ theme }) => theme.colors.grayscale.base};
 `;
 
+const DashboardCrossLinks = React.memo(
+  ({ dashboards }: { dashboards: ChartLinkedDashboard[] }) => {
+    const crossLinks = useMemo(
+      () =>
+        ensureIsArray(dashboards).map((d: ChartLinkedDashboard) => ({
+          title: d.dashboard_title,
+          id: d.id,
+        })),
+      [dashboards],
+    );
+    return <CrossLinks crossLinks={crossLinks} />;
+  },
+);
+
 function ChartList(props: ChartListProps) {
   const {
     addDangerToast,
@@ -390,21 +404,11 @@ function ChartList(props: ChartListProps) {
           row: {
             original: { dashboards },
           },
-        }: any) => (
-          <CrossLinks
-            crossLinks={ensureIsArray(dashboards).map(
-              (d: ChartLinkedDashboard) => ({
-                title: d.dashboard_title,
-                id: d.id,
-              }),
-            )}
-          />
-        ),
+        }: any) => <DashboardCrossLinks dashboards={dashboards} />,
         Header: t('Dashboards added to'),
         accessor: 'dashboards',
         disableSortBy: true,
         size: 'xxl',
-        hidden: true,
       },
       {
         Cell: ({


### PR DESCRIPTION
### SUMMARY
Due to a bug in `useChildElementTruncation`, there was an edge case which could trigger an infinite loop of rerenders. The bug occurs when the difference in width of subsequent numbers after the plus sign (e.g. +4 and +5) is just big enough to change the truncation state to the other number. This PR ensures that the calculation is performed only once, and if the edge case is triggered, we simply accept the off-by-one error.
This PR also implements a ResizeObserver which recalculates the truncations if the container size changes. Previously we relied on the width values from references in `useLayoutEffect`'s dependency array, which was not a correct approach, since the changes of those values would not trigger a rerender.

This change allowed us to bring back the feature that relied on the truncation logic, which is dashboard cross links on Chart List page. The feature adds a column to the list which displays the dashboards that given chart is added to.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before (occurred long ago when "dashboards added to" column was not yet hidden):

<img width="1728" alt="image" src="https://github.com/apache/superset/assets/15073128/d68fb59d-c890-4887-bd3b-99d1d7dbaab7">

After:

<img width="1728" alt="image" src="https://github.com/apache/superset/assets/15073128/226ad653-7222-4302-bb3e-1ed350e23c6a">


### TESTING INSTRUCTIONS
1. Visit ChartList
2. Verify that "Dashboards added to" column is visible and that it correctly displays the dashboards. Dashboard names should be clickable and navigate to given dashboard. Truncated dashboards should appear in a tooltip

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
