### PR TITLE
fix(chore): Removed hardcode of admin role from permission utils

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
@@ -79,6 +79,7 @@ export type FeatureFlagMap = {
 declare global {
   interface Window {
     featureFlags: FeatureFlagMap;
+    adminRole: string;
   }
 }
 

--- a/superset-frontend/src/dashboard/util/permissionUtils.ts
+++ b/superset-frontend/src/dashboard/util/permissionUtils.ts
@@ -25,7 +25,7 @@ import {
 import { Dashboard } from 'src/types/Dashboard';
 import { findPermission } from 'src/utils/findPermission';
 
-const ADMIN_ROLE_NAME = window.adminRole;
+const ADMIN_ROLE_NAME = window.adminRole || 'Admin';
 
 export const isUserAdmin = (
   user?: UserWithPermissionsAndRoles | UndefinedUser,

--- a/superset-frontend/src/dashboard/util/permissionUtils.ts
+++ b/superset-frontend/src/dashboard/util/permissionUtils.ts
@@ -25,16 +25,14 @@ import {
 import { Dashboard } from 'src/types/Dashboard';
 import { findPermission } from 'src/utils/findPermission';
 
-// this should really be a config value,
-// but is hardcoded in backend logic already, so...
-const ADMIN_ROLE_NAME = 'admin';
+const ADMIN_ROLE_NAME = window.adminRole;
 
 export const isUserAdmin = (
   user?: UserWithPermissionsAndRoles | UndefinedUser,
 ) =>
   isUserWithPermissionsAndRoles(user) &&
   Object.keys(user.roles || {}).some(
-    role => role.toLowerCase() === ADMIN_ROLE_NAME,
+    role => role.toLowerCase() === ADMIN_ROLE_NAME.toLowerCase(),
   );
 
 const isUserDashboardOwner = (

--- a/superset-frontend/src/preamble.ts
+++ b/superset-frontend/src/preamble.ts
@@ -52,6 +52,11 @@ if (typeof window !== 'undefined') {
 // Configure feature flags
 initFeatureFlags(bootstrapData.common.feature_flags);
 
+// Set admin role
+if (window.adminRole !== bootstrapData.common.conf.AUTH_ROLE_ADMIN) {
+  window.adminRole = bootstrapData.common.conf.AUTH_ROLE_ADMIN;
+}
+
 // Setup SupersetClient
 setupClient();
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -314,8 +314,7 @@ FAB_API_SWAGGER_UI = True
 # AUTH_REMOTE_USER : Is for using REMOTE_USER from web server
 AUTH_TYPE = AUTH_DB
 
-# Uncomment to setup Full admin role name
-# AUTH_ROLE_ADMIN = 'Admin'
+AUTH_ROLE_ADMIN = "Admin"
 
 # Uncomment to setup Public role name, no authentication needed
 # AUTH_ROLE_PUBLIC = 'Public'

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -84,6 +84,7 @@ from superset.utils.filters import get_dataset_access_filters
 from .utils import bootstrap_user_data
 
 FRONTEND_CONF_KEYS = (
+    "AUTH_ROLE_ADMIN",
     "SUPERSET_WEBSERVER_TIMEOUT",
     "SUPERSET_DASHBOARD_POSITION_DATA_LIMIT",
     "SUPERSET_DASHBOARD_PERIODICAL_REFRESH_LIMIT",


### PR DESCRIPTION
### SUMMARY
Just removed hardcode of admin role from perm utils and using `AUTH_ROLE_ADMIN` constant in the Superset config instead.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
