### PR TITLE
fix: Select onChange is fired when the same item is selected in single mode

### DIFF
--- a/superset-frontend/src/components/Select/AsyncSelect.test.tsx
+++ b/superset-frontend/src/components/Select/AsyncSelect.test.tsx
@@ -939,6 +939,18 @@ test('pasting an existing option does not duplicate it in multiple mode', async 
   expect(await findAllSelectOptions()).toHaveLength(4);
 });
 
+test('does not fire onChange if the same value is selected in single mode', async () => {
+  const onChange = jest.fn();
+  render(<AsyncSelect {...defaultProps} onChange={onChange} />);
+  const optionText = 'Emma';
+  await open();
+  expect(onChange).toHaveBeenCalledTimes(0);
+  userEvent.click(await findSelectOption(optionText));
+  expect(onChange).toHaveBeenCalledTimes(1);
+  userEvent.click(await findSelectOption(optionText));
+  expect(onChange).toHaveBeenCalledTimes(1);
+});
+
 /*
  TODO: Add tests that require scroll interaction. Needs further investigation.
  - Fetches more data when scrolling and more data is available

--- a/superset-frontend/src/components/Select/AsyncSelect.tsx
+++ b/superset-frontend/src/components/Select/AsyncSelect.tsx
@@ -50,7 +50,7 @@ import {
   mapOptions,
   getOption,
   isObject,
-  equalValues,
+  isEqual as utilsIsEqual,
 } from './utils';
 import {
   AsyncSelectProps,
@@ -223,9 +223,10 @@ const AsyncSelect = forwardRef(
     const handleOnSelect: SelectProps['onSelect'] = (selectedItem, option) => {
       if (isSingleMode) {
         // on select is fired in single value mode if the same value is selected
-        const valueChanged = !equalValues(
+        const valueChanged = !utilsIsEqual(
           selectedItem,
           selectValue as RawValue | AntdLabeledValue,
+          'value',
         );
         setSelectValue(selectedItem);
         if (valueChanged) {

--- a/superset-frontend/src/components/Select/AsyncSelect.tsx
+++ b/superset-frontend/src/components/Select/AsyncSelect.tsx
@@ -50,10 +50,12 @@ import {
   mapOptions,
   getOption,
   isObject,
+  equalValues,
 } from './utils';
 import {
   AsyncSelectProps,
   AsyncSelectRef,
+  RawValue,
   SelectOptionsPagePromise,
   SelectOptionsType,
   SelectOptionsTypePage,
@@ -220,7 +222,15 @@ const AsyncSelect = forwardRef(
 
     const handleOnSelect: SelectProps['onSelect'] = (selectedItem, option) => {
       if (isSingleMode) {
+        // on select is fired in single value mode if the same value is selected
+        const valueChanged = !equalValues(
+          selectedItem,
+          selectValue as RawValue | AntdLabeledValue,
+        );
         setSelectValue(selectedItem);
+        if (valueChanged) {
+          fireOnChange();
+        }
       } else {
         setSelectValue(previousState => {
           const array = ensureIsArray(previousState);
@@ -234,8 +244,8 @@ const AsyncSelect = forwardRef(
           }
           return previousState;
         });
+        fireOnChange();
       }
-      fireOnChange();
       onSelect?.(selectedItem, option);
     };
 

--- a/superset-frontend/src/components/Select/Select.test.tsx
+++ b/superset-frontend/src/components/Select/Select.test.tsx
@@ -1053,6 +1053,18 @@ test('pasting an existing option does not duplicate it in multiple mode', async 
   expect(await findAllSelectOptions()).toHaveLength(4);
 });
 
+test('does not fire onChange if the same value is selected in single mode', async () => {
+  const onChange = jest.fn();
+  render(<Select {...defaultProps} onChange={onChange} />);
+  const optionText = 'Emma';
+  await open();
+  expect(onChange).toHaveBeenCalledTimes(0);
+  userEvent.click(await findSelectOption(optionText));
+  expect(onChange).toHaveBeenCalledTimes(1);
+  userEvent.click(await findSelectOption(optionText));
+  expect(onChange).toHaveBeenCalledTimes(1);
+});
+
 /*
  TODO: Add tests that require scroll interaction. Needs further investigation.
  - Fetches more data when scrolling and more data is available

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -53,7 +53,7 @@ import {
   hasCustomLabels,
   getOption,
   isObject,
-  equalValues,
+  isEqual as utilsIsEqual,
 } from './utils';
 import { RawValue, SelectOptionsType, SelectProps } from './types';
 import {
@@ -229,9 +229,10 @@ const Select = forwardRef(
     const handleOnSelect: SelectProps['onSelect'] = (selectedItem, option) => {
       if (isSingleMode) {
         // on select is fired in single value mode if the same value is selected
-        const valueChanged = !equalValues(
+        const valueChanged = !utilsIsEqual(
           selectedItem,
           selectValue as RawValue | AntdLabeledValue,
+          'value',
         );
         setSelectValue(selectedItem);
         if (valueChanged) {

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -53,6 +53,7 @@ import {
   hasCustomLabels,
   getOption,
   isObject,
+  equalValues,
 } from './utils';
 import { RawValue, SelectOptionsType, SelectProps } from './types';
 import {
@@ -227,7 +228,15 @@ const Select = forwardRef(
 
     const handleOnSelect: SelectProps['onSelect'] = (selectedItem, option) => {
       if (isSingleMode) {
+        // on select is fired in single value mode if the same value is selected
+        const valueChanged = !equalValues(
+          selectedItem,
+          selectValue as RawValue | AntdLabeledValue,
+        );
         setSelectValue(selectedItem);
+        if (valueChanged) {
+          fireOnChange();
+        }
       } else {
         setSelectValue(previousState => {
           const array = ensureIsArray(previousState);
@@ -259,8 +268,8 @@ const Select = forwardRef(
           }
           return previousState;
         });
+        fireOnChange();
       }
-      fireOnChange();
       onSelect?.(selectedItem, option);
     };
 

--- a/superset-frontend/src/components/Select/utils.tsx
+++ b/superset-frontend/src/components/Select/utils.tsx
@@ -49,9 +49,9 @@ export function getValue(
   return isLabeledValue(option) ? option.value : option;
 }
 
-export function equalValues(a: V | LabeledValue, b: V | LabeledValue) {
-  const actualA = isObject(a) && 'value' in a ? a.value : a;
-  const actualB = isObject(b) && 'value' in b ? b.value : b;
+export function isEqual(a: V | LabeledValue, b: V | LabeledValue, key: string) {
+  const actualA = isObject(a) && key in a ? a[key] : a;
+  const actualB = isObject(b) && key in b ? b[key] : b;
   // When comparing the values we use the equality
   // operator to automatically convert different types
   // eslint-disable-next-line eqeqeq
@@ -66,8 +66,7 @@ export function getOption(
   const optionsArray = ensureIsArray(options);
   return optionsArray.find(
     x =>
-      equalValues(x, value) ||
-      (checkLabel && isObject(x) && 'label' in x && x.label === value),
+      isEqual(x, value, 'value') || (checkLabel && isEqual(x, value, 'label')),
   );
 }
 

--- a/superset-frontend/src/components/Select/utils.tsx
+++ b/superset-frontend/src/components/Select/utils.tsx
@@ -49,22 +49,25 @@ export function getValue(
   return isLabeledValue(option) ? option.value : option;
 }
 
+export function equalValues(a: V | LabeledValue, b: V | LabeledValue) {
+  const actualA = isObject(a) && 'value' in a ? a.value : a;
+  const actualB = isObject(b) && 'value' in b ? b.value : b;
+  // When comparing the values we use the equality
+  // operator to automatically convert different types
+  // eslint-disable-next-line eqeqeq
+  return actualA == actualB;
+}
+
 export function getOption(
   value: V,
   options?: V | LabeledValue | (V | LabeledValue)[],
   checkLabel = false,
 ): V | LabeledValue {
   const optionsArray = ensureIsArray(options);
-  // When comparing the values we use the equality
-  // operator to automatically convert different types
   return optionsArray.find(
     x =>
-      // eslint-disable-next-line eqeqeq
-      x == value ||
-      (isObject(x) &&
-        // eslint-disable-next-line eqeqeq
-        (('value' in x && x.value == value) ||
-          (checkLabel && 'label' in x && x.label === value))),
+      equalValues(x, value) ||
+      (checkLabel && isObject(x) && 'label' in x && x.label === value),
   );
 }
 


### PR DESCRIPTION
### SUMMARY
Prevents Select's `onChange` from being fired when the same item is selected in single mode. 

Fixes https://github.com/apache/superset/issues/27668.

### TESTING INSTRUCTIONS
CI.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
