### PR TITLE
chore(🦾): bump python flask-session 0.5.0 -> 0.8.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -126,7 +126,7 @@ flask-login==0.6.3
     #   flask-appbuilder
 flask-migrate==3.1.0
     # via apache-superset
-flask-session==0.5.0
+flask-session==0.8.0
     # via apache-superset
 flask-sqlalchemy==2.5.1
     # via
@@ -147,9 +147,7 @@ geopy==2.4.1
 google-auth==2.27.0
     # via shillelagh
 greenlet==3.0.3
-    # via
-    #   shillelagh
-    #   sqlalchemy
+    # via shillelagh
 gunicorn==21.2.0
     # via apache-superset
 hashids==1.3.1
@@ -214,6 +212,8 @@ mdurl==0.1.2
     # via markdown-it-py
 msgpack==1.0.8
     # via apache-superset
+msgspec==0.18.6
+    # via flask-session
 nh3==0.2.17
     # via apache-superset
 numba==0.57.1


### PR DESCRIPTION
Updates the python "flask-session" library version from 0.5.0 to 0.8.0. 

Generated by @supersetbot 🦾