### PR TITLE
feat(plugin): color option for table with time comparison

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -699,7 +699,9 @@ export default function TableChart<D extends DataRecord = DataRecord>(
         columnColorFormatters.length > 0;
 
       const hasBasicColorFormatters =
-        Array.isArray(basicColorFormatters) && basicColorFormatters.length > 0;
+        enableTimeComparison &&
+        Array.isArray(basicColorFormatters) &&
+        basicColorFormatters.length > 0;
 
       const valueRange =
         !hasBasicColorFormatters &&

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -253,6 +253,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
     emitCrossFilters,
     enableTimeComparison,
     basicColorFormatters,
+    basicColorColumnFormatters,
   } = props;
   const comparisonColumns = [
     { key: 'all', label: t('Display all') },
@@ -762,6 +763,19 @@ export default function TableChart<D extends DataRecord = DataRecord>(
               });
           }
 
+          if (
+            basicColorColumnFormatters &&
+            basicColorColumnFormatters?.length > 0
+          ) {
+            backgroundColor =
+              basicColorColumnFormatters[row.index][column.key]
+                ?.backgroundColor || backgroundColor;
+            arrow =
+              column.label === comparisonLabels[0]
+                ? basicColorColumnFormatters[row.index][column.key]?.mainArrow
+                : '';
+          }
+
           const StyledCell = styled.td`
             text-align: ${sharedStyle.textAlign};
             white-space: ${value instanceof Date ? 'nowrap' : undefined};
@@ -793,7 +807,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
               `}
           `;
 
-          const arrowStyles = css`
+          let arrowStyles = css`
             color: ${basicColorFormatters &&
             basicColorFormatters[row.index][originKey]?.arrowColor ===
               ColorSchemeEnum.Green
@@ -801,6 +815,19 @@ export default function TableChart<D extends DataRecord = DataRecord>(
               : theme.colors.error.base};
             margin-right: ${theme.gridUnit}px;
           `;
+
+          if (
+            basicColorColumnFormatters &&
+            basicColorColumnFormatters?.length > 0
+          ) {
+            arrowStyles = css`
+              color: ${basicColorColumnFormatters[row.index][column.key]
+                ?.arrowColor === ColorSchemeEnum.Green
+                ? theme.colors.success.base
+                : theme.colors.error.base};
+              margin-right: ${theme.gridUnit}px;
+            `;
+          }
 
           const cellProps = {
             // show raw number in title in case of numeric values

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -252,7 +252,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
     onContextMenu,
     emitCrossFilters,
     enableTimeComparison,
-    basicColorFormatter,
+    basicColorFormatters,
   } = props;
   const comparisonColumns = [
     { key: 'all', label: t('Display all') },
@@ -697,11 +697,11 @@ export default function TableChart<D extends DataRecord = DataRecord>(
         Array.isArray(columnColorFormatters) &&
         columnColorFormatters.length > 0;
 
-      const hasBasicColorFormatter =
-        Array.isArray(basicColorFormatter) && basicColorFormatter.length > 0;
+      const hasBasicColorFormatters =
+        Array.isArray(basicColorFormatters) && basicColorFormatters.length > 0;
 
       const valueRange =
-        !hasBasicColorFormatter &&
+        !hasBasicColorFormatters &&
         !hasColumnColorFormatters &&
         (config.showCellBars === undefined
           ? showCellBars
@@ -739,12 +739,12 @@ export default function TableChart<D extends DataRecord = DataRecord>(
           let backgroundColor;
           let arrow = '';
           const originKey = column.key.substring(column.label.length).trim();
-          if (!hasColumnColorFormatters && hasBasicColorFormatter) {
+          if (!hasColumnColorFormatters && hasBasicColorFormatters) {
             backgroundColor =
-              basicColorFormatter[row.index][originKey]?.backgroundColor;
+              basicColorFormatters[row.index][originKey]?.backgroundColor;
             arrow =
               column.label === comparisonLabels[0]
-                ? basicColorFormatter[row.index][originKey]?.mainArrow
+                ? basicColorFormatters[row.index][originKey]?.mainArrow
                 : '';
           }
 
@@ -794,8 +794,8 @@ export default function TableChart<D extends DataRecord = DataRecord>(
           `;
 
           const arrowStyles = css`
-            color: ${basicColorFormatter &&
-            basicColorFormatter[row.index][originKey]?.arrowColor ===
+            color: ${basicColorFormatters &&
+            basicColorFormatters[row.index][originKey]?.arrowColor ===
               ColorSchemeEnum.Green
               ? theme.colors.success.base
               : theme.colors.error.base};

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -479,44 +479,6 @@ const config: ControlPanelConfig = {
               description: t('Whether to include a client-side search box'),
             },
           },
-          {
-            name: 'show_cell_bars',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Cell bars'),
-              renderTrigger: true,
-              default: true,
-              description: t(
-                'Whether to display a bar chart background in table columns',
-              ),
-            },
-          },
-        ],
-        [
-          {
-            name: 'align_pn',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Align +/-'),
-              renderTrigger: true,
-              default: false,
-              description: t(
-                'Whether to align background charts with both positive and negative values at 0',
-              ),
-            },
-          },
-          {
-            name: 'color_pn',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Color +/-'),
-              renderTrigger: true,
-              default: true,
-              description: t(
-                'Whether to colorize numeric values by whether they are positive or negative',
-              ),
-            },
-          },
         ],
         [
           {
@@ -555,6 +517,54 @@ const config: ControlPanelConfig = {
                     | undefined,
                 };
               },
+            },
+          },
+        ],
+      ],
+    },
+    {
+      label: t('Visual formatting'),
+      expanded: true,
+      controlSetRows: [
+        [
+          {
+            name: 'show_cell_bars',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Show Cell bars'),
+              renderTrigger: true,
+              default: true,
+              description: t(
+                'Whether to display a bar chart background in table columns',
+              ),
+            },
+          },
+        ],
+        [
+          {
+            name: 'align_pn',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Align +/-'),
+              renderTrigger: true,
+              default: false,
+              description: t(
+                'Whether to align background charts with both positive and negative values at 0',
+              ),
+            },
+          },
+        ],
+        [
+          {
+            name: 'color_pn',
+            config: {
+              type: 'CheckboxControl',
+              label: t('add colors to cell bars for +/-'),
+              renderTrigger: true,
+              default: true,
+              description: t(
+                'Whether to colorize numeric values by whether they are positive or negative',
+              ),
             },
           },
         ],

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -628,7 +628,8 @@ const config: ControlPanelConfig = {
                 [ColorSchemeEnum.Red, 'Red for increase, green for decrease'],
               ],
               visibility: ({ controls }) =>
-                controls?.comparison_color_enabled?.value === true,
+                Boolean(controls?.enable_time_comparison?.value) &&
+                Boolean(controls?.comparison_color_enabled?.value),
               description: t(
                 'Adds color to the chart symbols based on the positive or ' +
                   'negative change from the comparison value.',

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -665,9 +665,8 @@ const config: ControlPanelConfig = {
                         }))
                     : [];
 
-                const columnOptions = Boolean(
-                  explore?.controls?.enable_time_comparison?.value,
-                )
+                const columnOptions = explore?.controls?.enable_time_comparison
+                  ?.value
                   ? processComparisonColumns(numericColumns || [])
                   : numericColumns;
 

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -643,7 +643,16 @@ const config: ControlPanelConfig = {
               type: 'ConditionalFormattingControl',
               renderTrigger: true,
               label: t('Custom Conditional Formatting'),
-              multi: true,
+              extraColorChoices: [
+                {
+                  value: ColorSchemeEnum.Green,
+                  label: t('Green for increase, red for decrease'),
+                },
+                {
+                  value: ColorSchemeEnum.Red,
+                  label: t('Red for increase, green for decrease'),
+                },
+              ],
               description: t(
                 'Apply conditional color formatting to numeric columns',
               ),

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -601,10 +601,17 @@ const config: ControlPanelConfig = {
             name: 'comparison_color_enabled',
             config: {
               type: 'CheckboxControl',
-              label: t('basic conditional formatting for comparison '),
+              label: t('basic conditional formatting'),
               renderTrigger: true,
+              visibility: ({ controls }) =>
+                Boolean(controls?.enable_time_comparison?.value) &&
+                isFeatureEnabled(FeatureFlag.ChartPluginsExperimental),
               default: false,
-              description: t('Add color for positive/negative change'),
+              description: t(
+                'This will be applied to the whole table. Arrows (↑ and ↓) will be added to ' +
+                  'main columns for increase and decrease. Basic conditional formatting can be ' +
+                  'overwritten by conditional formatting below.',
+              ),
             },
           },
         ],
@@ -613,7 +620,7 @@ const config: ControlPanelConfig = {
             name: 'comparison_color_scheme',
             config: {
               type: 'SelectControl',
-              label: t('color scheme for comparison'),
+              label: t('color type'),
               default: ColorSchemeEnum.Green,
               renderTrigger: true,
               choices: [

--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -477,16 +477,14 @@ const transformProps = (
     originalColumns: DataColumnMeta[],
     conditionalFormatting?: ConditionalFormattingConfig[],
   ) => {
-    const selectedColumns =
-      conditionalFormatting &&
-      conditionalFormatting.filter(
-        (config: ConditionalFormattingConfig) =>
-          config.column &&
-          (config.colorScheme === ColorSchemeEnum.Green ||
-            config.colorScheme === ColorSchemeEnum.Red),
-      );
+    const selectedColumns = conditionalFormatting?.filter(
+      (config: ConditionalFormattingConfig) =>
+        config.column &&
+        (config.colorScheme === ColorSchemeEnum.Green ||
+          config.colorScheme === ColorSchemeEnum.Red),
+    );
 
-    return selectedColumns && selectedColumns.length
+    return selectedColumns?.length
       ? getBasicColorFormatter(originalData, originalColumns, selectedColumns)
       : undefined;
   };

--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -475,16 +475,18 @@ const transformProps = (
   const getBasicColorFormatterForColumn = (
     originalData: DataRecord[] | undefined,
     originalColumns: DataColumnMeta[],
-    conditionalFormatting: ConditionalFormattingConfig[],
+    conditionalFormatting?: ConditionalFormattingConfig[],
   ) => {
-    const selectedColumns = conditionalFormatting.filter(
-      (config: ConditionalFormattingConfig) =>
-        config.column &&
-        (config.colorScheme === ColorSchemeEnum.Green ||
-          config.colorScheme === ColorSchemeEnum.Red),
-    );
+    const selectedColumns =
+      conditionalFormatting &&
+      conditionalFormatting.filter(
+        (config: ConditionalFormattingConfig) =>
+          config.column &&
+          (config.colorScheme === ColorSchemeEnum.Green ||
+            config.colorScheme === ColorSchemeEnum.Red),
+      );
 
-    return selectedColumns.length
+    return selectedColumns && selectedColumns.length
       ? getBasicColorFormatter(originalData, originalColumns, selectedColumns)
       : undefined;
   };

--- a/superset-frontend/plugins/plugin-chart-table/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/types.ts
@@ -144,6 +144,7 @@ export interface TableChartTransformedProps<D extends DataRecord = DataRecord> {
   ) => void;
   enableTimeComparison?: boolean;
   basicColorFormatters?: { [Key: string]: BasicColorFormatterType }[];
+  basicColorColumnFormatters?: { [Key: string]: BasicColorFormatterType }[];
 }
 
 export enum ColorSchemeEnum {

--- a/superset-frontend/plugins/plugin-chart-table/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/types.ts
@@ -108,6 +108,7 @@ export type BasicColorFormatterType = {
   arrowColor: string;
   mainArrow: string;
 };
+
 export interface TableChartTransformedProps<D extends DataRecord = DataRecord> {
   timeGrain?: TimeGranularity;
   height: number;

--- a/superset-frontend/plugins/plugin-chart-table/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/types.ts
@@ -137,6 +137,12 @@ export interface TableChartTransformedProps<D extends DataRecord = DataRecord> {
     filters?: ContextMenuFilters,
   ) => void;
   enableTimeComparison?: boolean;
+  basicColorFormatter?: any;
+}
+
+export enum ColorSchemeEnum {
+  'Green' = 'Green',
+  'Red' = 'Red',
 }
 
 export default {};

--- a/superset-frontend/plugins/plugin-chart-table/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/types.ts
@@ -103,6 +103,11 @@ export interface TableChartProps extends ChartProps {
   queriesData: ChartDataResponseResult[];
 }
 
+export type BasicColorFormatterType = {
+  backgroundColor: string;
+  arrowColor: string;
+  mainArrow: string;
+};
 export interface TableChartTransformedProps<D extends DataRecord = DataRecord> {
   timeGrain?: TimeGranularity;
   height: number;
@@ -137,7 +142,7 @@ export interface TableChartTransformedProps<D extends DataRecord = DataRecord> {
     filters?: ContextMenuFilters,
   ) => void;
   enableTimeComparison?: boolean;
-  basicColorFormatter?: any;
+  basicColorFormatters?: { [Key: string]: BasicColorFormatterType }[];
 }
 
 export enum ColorSchemeEnum {

--- a/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/ConditionalFormattingControl.tsx
+++ b/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/ConditionalFormattingControl.tsx
@@ -71,6 +71,7 @@ const ConditionalFormattingControl = ({
   columnOptions,
   verboseMap,
   removeIrrelevantConditions,
+  extraColorChoices,
   ...props
 }: ConditionalFormattingControlProps) => {
   const theme = useTheme();
@@ -155,6 +156,7 @@ const ConditionalFormattingControl = ({
                 onEdit(newConfig, index)
               }
               destroyTooltipOnHide
+              extraColorChoices={extraColorChoices}
             >
               <OptionControlContainer withCaret>
                 <Label>{createLabel(config)}</Label>
@@ -170,6 +172,7 @@ const ConditionalFormattingControl = ({
           columns={columnOptions}
           onChange={onSave}
           destroyTooltipOnHide
+          extraColorChoices={extraColorChoices}
         >
           <AddControlLabel>
             <Icons.PlusSmall iconColor={theme.colors.grayscale.light1} />

--- a/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopover.tsx
@@ -27,6 +27,7 @@ export const FormattingPopover = ({
   onChange,
   config,
   children,
+  extraColorChoices,
   ...props
 }: FormattingPopoverProps) => {
   const [visible, setVisible] = useState(false);
@@ -47,6 +48,7 @@ export const FormattingPopover = ({
           onChange={handleSave}
           config={config}
           columns={columns}
+          extraColorChoices={extraColorChoices}
         />
       }
       visible={visible}

--- a/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
+++ b/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
@@ -16,8 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
+import React, { useState } from 'react';
 import { styled, SupersetTheme, t, useTheme } from '@superset-ui/core';
+import { ColorSchemeEnum } from '@superset-ui/plugin-chart-table';
 import {
   Comparator,
   MultipleValueComparators,
@@ -123,21 +124,24 @@ const shouldFormItemUpdate = (
   isOperatorMultiValue(prevValues.operator) !==
     isOperatorMultiValue(currentValues.operator);
 
-const operatorField = (
+const operatorField = (showOnlyNone?: boolean) => (
   <FormItem
     name="operator"
     label={t('Operator')}
     rules={rulesRequired}
     initialValue={operatorOptions[0].value}
   >
-    <Select ariaLabel={t('Operator')} options={operatorOptions} />
+    <Select
+      ariaLabel={t('Operator')}
+      options={showOnlyNone ? [operatorOptions[0]] : operatorOptions}
+    />
   </FormItem>
 );
 
 const renderOperatorFields = ({ getFieldValue }: GetFieldValue) =>
   isOperatorNone(getFieldValue('operator')) ? (
     <Row gutter={12}>
-      <Col span={6}>{operatorField}</Col>
+      <Col span={6}>{operatorField()}</Col>
     </Row>
   ) : isOperatorMultiValue(getFieldValue('operator')) ? (
     <Row gutter={12}>
@@ -186,13 +190,26 @@ export const FormattingPopoverContent = ({
   config,
   onChange,
   columns = [],
+  extraColorChoices = [],
 }: {
   config?: ConditionalFormattingConfig;
   onChange: (config: ConditionalFormattingConfig) => void;
   columns: { label: string; value: string }[];
+  extraColorChoices?: { label: string; value: string }[];
 }) => {
   const theme = useTheme();
   const colorScheme = colorSchemeOptions(theme);
+  const [showOperatorFields, setShowOperatorFields] = useState(
+    config === undefined ||
+      (config?.colorScheme !== ColorSchemeEnum.Green &&
+        config?.colorScheme !== ColorSchemeEnum.Red),
+  );
+  const handleChange = (event: any) => {
+    setShowOperatorFields(
+      !(event === ColorSchemeEnum.Green || event === ColorSchemeEnum.Red),
+    );
+  };
+
   return (
     <Form
       onFinish={onChange}
@@ -218,12 +235,22 @@ export const FormattingPopoverContent = ({
             rules={rulesRequired}
             initialValue={colorScheme[0].value}
           >
-            <Select ariaLabel={t('Color scheme')} options={colorScheme} />
+            <Select
+              onChange={event => handleChange(event)}
+              ariaLabel={t('Color scheme')}
+              options={[...colorScheme, ...extraColorChoices]}
+            />
           </FormItem>
         </Col>
       </Row>
       <FormItem noStyle shouldUpdate={shouldFormItemUpdate}>
-        {renderOperatorFields}
+        {showOperatorFields ? (
+          renderOperatorFields
+        ) : (
+          <Row gutter={12}>
+            <Col span={6}>{operatorField(true)}</Col>
+          </Row>
+        )}
       </FormItem>
       <FormItem>
         <JustifyEnd>

--- a/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/types.ts
+++ b/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/types.ts
@@ -38,6 +38,7 @@ export type ConditionalFormattingControlProps = ControlComponentProps<
   verboseMap: Record<string, string>;
   label: string;
   description: string;
+  extraColorChoices?: { label: string; value: string }[];
 };
 
 export type FormattingPopoverProps = PopoverProps & {
@@ -46,4 +47,5 @@ export type FormattingPopoverProps = PopoverProps & {
   config?: ConditionalFormattingConfig;
   title: string;
   children: ReactNode;
+  extraColorChoices?: { label: string; value: string }[];
 };


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding color option for table with time comparison
- Create a new collapsible section titled "Visual formatting."
- Inside, include a subsection called "Cell bars" with:
   - Cell bars
   - Color +/- (renamed to "Add colors to cell bars for +/-")
   - Align +/-
- Add a "Conditional formatting" section:
   - Enable a checkbox for "Basic conditional formatting for comparison" when comparison is active.
   - Upon selecting the checkbox, reveal "Color Scheme for comparison" option.
      - Default color scheme: "Green for increase, red for decrease."
      - Alternative option: "Red for decrease, green for increase."

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![time-comparison-color](https://github.com/apache/superset/assets/5705598/f35df732-127e-40c8-8552-3b79883ed41e)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
