### PR TITLE
chore(explore): Hide non-droppable metric and column list

### DIFF
--- a/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanelItem.test.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanelItem.test.tsx
@@ -39,6 +39,8 @@ const mockData = {
   onCollapseMetricsChange: jest.fn(),
   collapseColumns: false,
   onCollapseColumnsChange: jest.fn(),
+  hiddenMetricCount: 0,
+  hiddenColumnCount: 0,
 };
 
 test('renders each item accordingly', () => {
@@ -165,4 +167,33 @@ test('can collapse metrics and columns', () => {
     />,
   );
   expect(queryByText('Columns')).toBeInTheDocument();
+});
+
+test('shows ineligible items count', () => {
+  const hiddenColumnCount = 3;
+  const hiddenMetricCount = 1;
+  const dataWithHiddenItems = {
+    ...mockData,
+    hiddenColumnCount,
+    hiddenMetricCount,
+  };
+  const { getByText, rerender } = render(
+    <DatasourcePanelItem index={1} data={dataWithHiddenItems} style={{}} />,
+    { useDnd: true },
+  );
+  expect(
+    getByText(`${hiddenMetricCount} ineligible item(s) are hidden`),
+  ).toBeInTheDocument();
+
+  const startIndexOfColumnSection = mockData.metricSlice.length + 3;
+  rerender(
+    <DatasourcePanelItem
+      index={startIndexOfColumnSection + 1}
+      data={dataWithHiddenItems}
+      style={{}}
+    />,
+  );
+  expect(
+    getByText(`${hiddenColumnCount} ineligible item(s) are hidden`),
+  ).toBeInTheDocument();
 });

--- a/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanelItem.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanelItem.tsx
@@ -51,6 +51,8 @@ type Props = {
     onCollapseMetricsChange: (collapse: boolean) => void;
     collapseColumns: boolean;
     onCollapseColumnsChange: (collapse: boolean) => void;
+    hiddenMetricCount: number;
+    hiddenColumnCount: number;
   };
 };
 
@@ -130,6 +132,16 @@ const SectionHeader = styled.span`
   `}
 `;
 
+const Box = styled.div`
+  ${({ theme }) => `
+    border: 1px ${theme.colors.grayscale.light4} solid;
+    border-radius: ${theme.gridUnit}px;
+    font-size: ${theme.typography.sizes.s}px;
+    padding: ${theme.gridUnit}px;
+    color: ${theme.colors.grayscale.light1};
+  `}
+`;
+
 const DatasourcePanelItem: React.FC<Props> = ({ index, style, data }) => {
   const {
     metricSlice: _metricSlice,
@@ -145,6 +157,8 @@ const DatasourcePanelItem: React.FC<Props> = ({ index, style, data }) => {
     onCollapseMetricsChange,
     collapseColumns,
     onCollapseColumnsChange,
+    hiddenMetricCount,
+    hiddenColumnCount,
   } = data;
   const metricSlice = collapseMetrics ? [] : _metricSlice;
 
@@ -169,6 +183,7 @@ const DatasourcePanelItem: React.FC<Props> = ({ index, style, data }) => {
     ? onShowAllColumnsChange
     : onShowAllMetricsChange;
   const theme = useTheme();
+  const hiddenCount = isColumnSection ? hiddenColumnCount : hiddenMetricCount;
 
   return (
     <div
@@ -190,10 +205,22 @@ const DatasourcePanelItem: React.FC<Props> = ({ index, style, data }) => {
         </SectionHeaderButton>
       )}
       {index === SUBTITLE_LINE && !collapsed && (
-        <div className="field-length">
-          {isColumnSection
-            ? t(`Showing %s of %s`, columnSlice?.length, totalColumns)
-            : t(`Showing %s of %s`, metricSlice?.length, totalMetrics)}
+        <div
+          css={css`
+            display: flex;
+            gap: ${theme.gridUnit * 2}px;
+            justify-content: space-between;
+            align-items: baseline;
+          `}
+        >
+          <div className="field-length">
+            {isColumnSection
+              ? t(`Showing %s of %s`, columnSlice?.length, totalColumns)
+              : t(`Showing %s of %s`, metricSlice?.length, totalMetrics)}
+          </div>
+          {hiddenCount > 0 && (
+            <Box>{t(`%s ineligible item(s) are hidden`, hiddenCount)}</Box>
+          )}
         </div>
       )}
       {index > SUBTITLE_LINE && index < BOTTOM_LINE && (

--- a/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanelItem.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanelItem.tsx
@@ -139,6 +139,9 @@ const Box = styled.div`
     font-size: ${theme.typography.sizes.s}px;
     padding: ${theme.gridUnit}px;
     color: ${theme.colors.grayscale.light1};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
   `}
 `;
 
@@ -213,7 +216,12 @@ const DatasourcePanelItem: React.FC<Props> = ({ index, style, data }) => {
             align-items: baseline;
           `}
         >
-          <div className="field-length">
+          <div
+            className="field-length"
+            css={css`
+              flex-shrink: 0;
+            `}
+          >
             {isColumnSection
               ? t(`Showing %s of %s`, columnSlice?.length, totalColumns)
               : t(`Showing %s of %s`, metricSlice?.length, totalMetrics)}

--- a/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
@@ -176,6 +176,8 @@ export default function DataSourcePanel({
     );
   }, [dropzones, metrics]);
 
+  const hiddenColumnCount = _columns.length - allowedColumns.length;
+  const hiddenMetricCount = metrics.length - allowedMetrics.length;
   const [showSaveDatasetModal, setShowSaveDatasetModal] = useState(false);
   const [inputValue, setInputValue] = useState('');
   const [showAllMetrics, setShowAllMetrics] = useState(false);
@@ -346,6 +348,8 @@ export default function DataSourcePanel({
                   onCollapseMetricsChange: setCollapseMetrics,
                   collapseColumns,
                   onCollapseColumnsChange: setCollapseColumns,
+                  hiddenMetricCount,
+                  hiddenColumnCount,
                 }}
                 overscanCount={5}
               >

--- a/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useContext, useMemo, useState } from 'react';
 import {
   css,
   DatasourceType,
@@ -30,7 +30,7 @@ import { ControlConfig } from '@superset-ui/chart-controls';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { FixedSizeList as List } from 'react-window';
 
-import { debounce, isArray } from 'lodash';
+import { isArray } from 'lodash';
 import { matchSorter, rankings } from 'match-sorter';
 import Alert from 'src/components/Alert';
 import { SaveDatasetModal } from 'src/SqlLab/components/SaveDatasetModal';
@@ -39,12 +39,16 @@ import { Input } from 'src/components/Input';
 import { FAST_DEBOUNCE } from 'src/constants';
 import { ExploreActions } from 'src/explore/actions/exploreActions';
 import Control from 'src/explore/components/Control';
+import { useDebounceValue } from 'src/hooks/useDebounceValue';
 import DatasourcePanelItem, {
   ITEM_HEIGHT,
   DataSourcePanelColumn,
   DEFAULT_MAX_COLUMNS_LENGTH,
   DEFAULT_MAX_METRICS_LENGTH,
 } from './DatasourcePanelItem';
+import { DndItemType } from '../DndItemType';
+import { DndItemValue } from './types';
+import { DropzoneContext } from '../ExploreContainer';
 
 interface DatasourceControl extends ControlConfig {
   datasource?: IDatasource;
@@ -122,6 +126,9 @@ const StyledInfoboxWrapper = styled.div`
 
 const BORDER_WIDTH = 2;
 
+const sortCertifiedFirst = (slice: DataSourcePanelColumn[]) =>
+  slice.sort((a, b) => (b?.is_certified ?? 0) - (a?.is_certified ?? 0));
+
 export default function DataSourcePanel({
   datasource,
   formData,
@@ -129,11 +136,26 @@ export default function DataSourcePanel({
   actions,
   width,
 }: Props) {
+  const [dropzones] = useContext(DropzoneContext);
   const { columns: _columns, metrics } = datasource;
+
+  const allowedColumns = useMemo(() => {
+    const validators = Object.values(dropzones);
+    if (!isArray(_columns)) return [];
+    return _columns.filter(column =>
+      validators.some(validator =>
+        validator({
+          value: column as DndItemValue,
+          type: DndItemType.Column,
+        }),
+      ),
+    );
+  }, [dropzones, _columns]);
+
   // display temporal column first
   const columns = useMemo(
     () =>
-      [...(isArray(_columns) ? _columns : [])].sort((col1, col2) => {
+      [...allowedColumns].sort((col1, col2) => {
         if (col1?.is_dttm && !col2?.is_dttm) {
           return -1;
         }
@@ -142,106 +164,100 @@ export default function DataSourcePanel({
         }
         return 0;
       }),
-    [_columns],
+    [allowedColumns],
   );
+
+  const allowedMetrics = useMemo(() => {
+    const validators = Object.values(dropzones);
+    return metrics.filter(metric =>
+      validators.some(validator =>
+        validator({ value: metric, type: DndItemType.Metric }),
+      ),
+    );
+  }, [dropzones, metrics]);
 
   const [showSaveDatasetModal, setShowSaveDatasetModal] = useState(false);
   const [inputValue, setInputValue] = useState('');
-  const [lists, setList] = useState({
-    columns,
-    metrics,
-  });
   const [showAllMetrics, setShowAllMetrics] = useState(false);
   const [showAllColumns, setShowAllColumns] = useState(false);
   const [collapseMetrics, setCollapseMetrics] = useState(false);
   const [collapseColumns, setCollapseColumns] = useState(false);
+  const searchKeyword = useDebounceValue(inputValue, FAST_DEBOUNCE);
 
-  const search = useMemo(
-    () =>
-      debounce((value: string) => {
-        if (value === '') {
-          setList({ columns, metrics });
-          return;
-        }
-        setList({
-          columns: matchSorter(columns, value, {
-            keys: [
-              {
-                key: 'verbose_name',
-                threshold: rankings.CONTAINS,
-              },
-              {
-                key: 'column_name',
-                threshold: rankings.CONTAINS,
-              },
-              {
-                key: item =>
-                  [item?.description ?? '', item?.expression ?? ''].map(
-                    x => x?.replace(/[_\n\s]+/g, ' ') || '',
-                  ),
-                threshold: rankings.CONTAINS,
-                maxRanking: rankings.CONTAINS,
-              },
-            ],
-            keepDiacritics: true,
-          }),
-          metrics: matchSorter(metrics, value, {
-            keys: [
-              {
-                key: 'verbose_name',
-                threshold: rankings.CONTAINS,
-              },
-              {
-                key: 'metric_name',
-                threshold: rankings.CONTAINS,
-              },
-              {
-                key: item =>
-                  [item?.description ?? '', item?.expression ?? ''].map(
-                    x => x?.replace(/[_\n\s]+/g, ' ') || '',
-                  ),
-                threshold: rankings.CONTAINS,
-                maxRanking: rankings.CONTAINS,
-              },
-            ],
-            keepDiacritics: true,
-            baseSort: (a, b) =>
-              Number(b?.item?.is_certified ?? 0) -
-                Number(a?.item?.is_certified ?? 0) ||
-              String(a?.rankedValue ?? '').localeCompare(b?.rankedValue ?? ''),
-          }),
-        });
-      }, FAST_DEBOUNCE),
-    [columns, metrics],
-  );
-
-  useEffect(() => {
-    setList({
-      columns,
-      metrics,
+  const filteredColumns = useMemo(() => {
+    if (!searchKeyword) {
+      return columns ?? [];
+    }
+    return matchSorter(columns, searchKeyword, {
+      keys: [
+        {
+          key: 'verbose_name',
+          threshold: rankings.CONTAINS,
+        },
+        {
+          key: 'column_name',
+          threshold: rankings.CONTAINS,
+        },
+        {
+          key: item =>
+            [item?.description ?? '', item?.expression ?? ''].map(
+              x => x?.replace(/[_\n\s]+/g, ' ') || '',
+            ),
+          threshold: rankings.CONTAINS,
+          maxRanking: rankings.CONTAINS,
+        },
+      ],
+      keepDiacritics: true,
     });
-    setInputValue('');
-  }, [columns, datasource, metrics]);
+  }, [columns, searchKeyword]);
 
-  const sortCertifiedFirst = (slice: DataSourcePanelColumn[]) =>
-    slice.sort((a, b) => (b?.is_certified ?? 0) - (a?.is_certified ?? 0));
+  const filteredMetrics = useMemo(() => {
+    if (!searchKeyword) {
+      return allowedMetrics ?? [];
+    }
+    return matchSorter(allowedMetrics, searchKeyword, {
+      keys: [
+        {
+          key: 'verbose_name',
+          threshold: rankings.CONTAINS,
+        },
+        {
+          key: 'metric_name',
+          threshold: rankings.CONTAINS,
+        },
+        {
+          key: item =>
+            [item?.description ?? '', item?.expression ?? ''].map(
+              x => x?.replace(/[_\n\s]+/g, ' ') || '',
+            ),
+          threshold: rankings.CONTAINS,
+          maxRanking: rankings.CONTAINS,
+        },
+      ],
+      keepDiacritics: true,
+      baseSort: (a, b) =>
+        Number(b?.item?.is_certified ?? 0) -
+          Number(a?.item?.is_certified ?? 0) ||
+        String(a?.rankedValue ?? '').localeCompare(b?.rankedValue ?? ''),
+    });
+  }, [allowedMetrics, searchKeyword]);
 
   const metricSlice = useMemo(
     () =>
       showAllMetrics
-        ? lists?.metrics
-        : lists?.metrics?.slice?.(0, DEFAULT_MAX_METRICS_LENGTH),
-    [lists?.metrics, showAllMetrics],
+        ? filteredMetrics
+        : filteredMetrics?.slice?.(0, DEFAULT_MAX_METRICS_LENGTH),
+    [filteredMetrics, showAllMetrics],
   );
 
   const columnSlice = useMemo(
     () =>
       showAllColumns
-        ? sortCertifiedFirst(lists?.columns)
+        ? sortCertifiedFirst(filteredColumns)
         : sortCertifiedFirst(
-            lists?.columns?.slice?.(0, DEFAULT_MAX_COLUMNS_LENGTH),
+            filteredColumns?.slice?.(0, DEFAULT_MAX_COLUMNS_LENGTH),
           ),
-    [lists.columns, showAllColumns],
+    [filteredColumns, showAllColumns],
   );
 
   const showInfoboxCheck = () => {
@@ -268,13 +284,12 @@ export default function DataSourcePanel({
           allowClear
           onChange={evt => {
             setInputValue(evt.target.value);
-            search(evt.target.value);
           }}
           value={inputValue}
           className="form-control input-md"
           placeholder={t('Search Metrics & Columns')}
         />
-        <div className="field-selections">
+        <div className="field-selections" data-test="fieldSelections">
           {datasourceIsSaveable && showInfoboxCheck() && (
             <StyledInfoboxWrapper>
               <Alert
@@ -321,8 +336,8 @@ export default function DataSourcePanel({
                   metricSlice,
                   columnSlice,
                   width,
-                  totalMetrics: lists?.metrics.length,
-                  totalColumns: lists?.columns.length,
+                  totalMetrics: filteredMetrics.length,
+                  totalColumns: filteredColumns.length,
                   showAllMetrics,
                   onShowAllMetricsChange: setShowAllMetrics,
                   showAllColumns,
@@ -345,10 +360,9 @@ export default function DataSourcePanel({
     [
       columnSlice,
       inputValue,
-      lists.columns.length,
-      lists?.metrics?.length,
+      filteredColumns.length,
+      filteredMetrics.length,
       metricSlice,
-      search,
       showAllColumns,
       showAllMetrics,
       collapseMetrics,

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.test.tsx
@@ -23,6 +23,7 @@ import { DndItemType } from 'src/explore/components/DndItemType';
 import DndSelectLabel, {
   DndSelectLabelProps,
 } from 'src/explore/components/controls/DndColumnSelectControl/DndSelectLabel';
+import ExploreContainer, { DropzoneContext } from '../../ExploreContainer';
 
 const defaultProps: DndSelectLabelProps = {
   name: 'Column',
@@ -32,6 +33,23 @@ const defaultProps: DndSelectLabelProps = {
   valuesRenderer: () => <span />,
   ghostButtonText: 'Drop columns here or click',
   onClickGhostButton: jest.fn(),
+};
+const MockChildren = () => {
+  const [zones] = React.useContext(DropzoneContext);
+  return (
+    <>
+      {Object.keys(zones).map(key => (
+        <div key={key} data-test={`mock-result-${key}`}>
+          {String(
+            zones[key]({
+              value: { column_name: 'test' },
+              type: DndItemType.Column,
+            }),
+          )}
+        </div>
+      ))}
+    </>
+  );
 };
 
 test('renders with default props', () => {
@@ -61,4 +79,26 @@ test('Handles ghost button click', () => {
   render(<DndSelectLabel {...defaultProps} />, { useDnd: true });
   userEvent.click(screen.getByText('Drop columns here or click'));
   expect(defaultProps.onClickGhostButton).toHaveBeenCalled();
+});
+
+test('updates dropValidator on changes', () => {
+  const { getByTestId, rerender } = render(
+    <ExploreContainer>
+      <DndSelectLabel {...defaultProps} />
+      <MockChildren />
+    </ExploreContainer>,
+    { useDnd: true },
+  );
+  expect(getByTestId(`mock-result-${defaultProps.name}`)).toHaveTextContent(
+    'false',
+  );
+  rerender(
+    <ExploreContainer>
+      <DndSelectLabel {...defaultProps} canDrop={() => true} />
+      <MockChildren />
+    </ExploreContainer>,
+  );
+  expect(getByTestId(`mock-result-${defaultProps.name}`)).toHaveTextContent(
+    'true',
+  );
 });

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndSelectLabel.tsx
@@ -16,7 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { ReactNode, useContext, useMemo } from 'react';
+import React, {
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+} from 'react';
 import { useDrop } from 'react-dnd';
 import { t, useTheme } from '@superset-ui/core';
 import ControlHeader from 'src/explore/components/ControlHeader';
@@ -31,7 +37,7 @@ import {
 } from 'src/explore/components/DatasourcePanel/types';
 import Icons from 'src/components/Icons';
 import { DndItemType } from '../../DndItemType';
-import { DraggingContext } from '../../ExploreContainer';
+import { DraggingContext, DropzoneContext } from '../../ExploreContainer';
 
 export type DndSelectLabelProps = {
   name: string;
@@ -55,6 +61,14 @@ export default function DndSelectLabel({
   ...props
 }: DndSelectLabelProps) {
   const theme = useTheme();
+  const canDropProp = props.canDrop;
+  const canDropValueProp = props.canDropValue;
+
+  const dropValidator = useCallback(
+    (item: DatasourcePanelDndItem) =>
+      canDropProp(item) && (canDropValueProp?.(item.value) ?? true),
+    [canDropProp, canDropValueProp],
+  );
 
   const [{ isOver, canDrop }, datasourcePanelDrop] = useDrop({
     accept: isLoading ? [] : accept,
@@ -64,8 +78,7 @@ export default function DndSelectLabel({
       props.onDropValue?.(item.value);
     },
 
-    canDrop: (item: DatasourcePanelDndItem) =>
-      props.canDrop(item) && (props.canDropValue?.(item.value) ?? true),
+    canDrop: dropValidator,
 
     collect: monitor => ({
       isOver: monitor.isOver(),
@@ -73,6 +86,16 @@ export default function DndSelectLabel({
       type: monitor.getItemType(),
     }),
   });
+
+  const dispatch = useContext(DropzoneContext)[1];
+
+  useEffect(() => {
+    dispatch({ key: props.name, canDrop: dropValidator });
+    return () => {
+      dispatch({ key: props.name });
+    };
+  }, [dispatch, props.name, dropValidator]);
+
   const isDragging = useContext(DraggingContext);
 
   const values = useMemo(() => valuesRenderer(), [valuesRenderer]);


### PR DESCRIPTION
### SUMMARY
There can be certain items that cannot be accepted in all options. (For instance, metrics cannot be accepted in the columns selection. In cases where the controls solely consist of the columns selection, none of the metrics will be accepted in the overall dropzone, as shown in the screenshot below.)

To address this, the commit takes a step forward by checking the eligibility of each filter and hiding the item when there are no eligible options available.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://github.com/apache/superset/assets/1392866/3d3e6b92-c461-49ba-ad24-f23528acf22c

After:

https://github.com/apache/superset/assets/1392866/7bc72d2d-f9b8-4603-b607-926c49af9004


### TESTING INSTRUCTIONS

- Create a table chart with the dataset
- Switch to "Raw Records" and then "Metrics" should be hidden

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
