### PR TITLE
fix: Removes filter plugins from viz gallery

### DIFF
--- a/superset-frontend/src/constants.ts
+++ b/superset-frontend/src/constants.ts
@@ -189,3 +189,11 @@ export const DEFAULT_COMMON_BOOTSTRAP_DATA: CommonBootstrapData = {
 export const DEFAULT_BOOTSTRAP_DATA: BootstrapData = {
   common: DEFAULT_COMMON_BOOTSTRAP_DATA,
 };
+
+export enum FilterPlugins {
+  Select = 'filter_select',
+  Range = 'filter_range',
+  Time = 'filter_time',
+  TimeColumn = 'filter_timecolumn',
+  TimeGrain = 'filter_timegrain',
+}

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/index.tsx
@@ -28,6 +28,7 @@ import { usePluginContext } from 'src/components/DynamicPlugins';
 import Modal from 'src/components/Modal';
 import { noOp } from 'src/utils/common';
 import getBootstrapData from 'src/utils/getBootstrapData';
+import { FilterPlugins } from 'src/constants';
 import VizTypeGallery, {
   MAX_ADVISABLE_VIZ_GALLERY_WIDTH,
 } from './VizTypeGallery';
@@ -43,7 +44,9 @@ interface VizTypeControlProps {
 }
 
 const bootstrapData = getBootstrapData();
-const denyList: string[] = bootstrapData.common.conf.VIZ_TYPE_DENYLIST || [];
+const denyList: string[] = (
+  bootstrapData.common.conf.VIZ_TYPE_DENYLIST || []
+).concat(Object.values(FilterPlugins));
 const metadataRegistry = getChartMetadataRegistry();
 
 export const VIZ_TYPE_CONTROL_TEST_ID = 'viz-type-control';

--- a/superset-frontend/src/pages/ChartCreation/index.tsx
+++ b/superset-frontend/src/pages/ChartCreation/index.tsx
@@ -27,7 +27,7 @@ import {
   t,
 } from '@superset-ui/core';
 import { getUrlParam } from 'src/utils/urlUtils';
-import { URL_PARAMS } from 'src/constants';
+import { FilterPlugins, URL_PARAMS } from 'src/constants';
 import { Link, withRouter, RouteComponentProps } from 'react-router-dom';
 import Button from 'src/components/Button';
 import { AsyncSelect, Steps } from 'src/components';
@@ -60,7 +60,9 @@ const ESTIMATED_NAV_HEIGHT = 56;
 const ELEMENTS_EXCEPT_VIZ_GALLERY = ESTIMATED_NAV_HEIGHT + 250;
 
 const bootstrapData = getBootstrapData();
-const denyList: string[] = bootstrapData.common.conf.VIZ_TYPE_DENYLIST || [];
+const denyList: string[] = (
+  bootstrapData.common.conf.VIZ_TYPE_DENYLIST || []
+).concat(Object.values(FilterPlugins));
 
 const StyledContainer = styled.div`
   ${({ theme }) => `

--- a/superset-frontend/src/visualizations/presets/MainPreset.js
+++ b/superset-frontend/src/visualizations/presets/MainPreset.js
@@ -77,6 +77,7 @@ import {
 } from 'src/filters/components';
 import { PivotTableChartPlugin as PivotTableChartPluginV2 } from '@superset-ui/plugin-chart-pivot-table';
 import { HandlebarsChartPlugin } from '@superset-ui/plugin-chart-handlebars';
+import { FilterPlugins } from 'src/constants';
 import TimeTableChartPlugin from '../TimeTable';
 
 export default class MainPreset extends Preset {
@@ -157,11 +158,15 @@ export default class MainPreset extends Preset {
         new EchartsWaterfallChartPlugin().configure({
           key: 'waterfall',
         }),
-        new SelectFilterPlugin().configure({ key: 'filter_select' }),
-        new RangeFilterPlugin().configure({ key: 'filter_range' }),
-        new TimeFilterPlugin().configure({ key: 'filter_time' }),
-        new TimeColumnFilterPlugin().configure({ key: 'filter_timecolumn' }),
-        new TimeGrainFilterPlugin().configure({ key: 'filter_timegrain' }),
+        new SelectFilterPlugin().configure({ key: FilterPlugins.Select }),
+        new RangeFilterPlugin().configure({ key: FilterPlugins.Range }),
+        new TimeFilterPlugin().configure({ key: FilterPlugins.Time }),
+        new TimeColumnFilterPlugin().configure({
+          key: FilterPlugins.TimeColumn,
+        }),
+        new TimeGrainFilterPlugin().configure({
+          key: FilterPlugins.TimeGrain,
+        }),
         new EchartsTreeChartPlugin().configure({ key: 'tree_chart' }),
         new EchartsSunburstChartPlugin().configure({ key: 'sunburst_v2' }),
         new HandlebarsChartPlugin().configure({ key: 'handlebars' }),


### PR DESCRIPTION
### SUMMARY
This PR creates a enum to register the filter plugins and use that enum to remove this type of plugin from the viz gallery.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1088" alt="Screenshot 2024-03-28 at 10 24 09" src="https://github.com/apache/superset/assets/70410625/9e78dd8e-5a00-4747-887c-c64f112b1a11">
<img width="1089" alt="Screenshot 2024-03-28 at 10 41 14" src="https://github.com/apache/superset/assets/70410625/dc4298d4-efa7-417a-a66b-f49249af1dad">

### TESTING INSTRUCTIONS
Check that filter plugins are not displayed in the viz gallery

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
