### PR TITLE
feat: Adds Heatmap chart migration logic

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -10,6 +10,8 @@
     # via
     #   -r requirements/base.in
     #   -r requirements/development.in
+appnope==0.1.4
+    # via ipython
 astroid==2.15.8
     # via pylint
 asttokens==2.2.1
@@ -193,6 +195,10 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
+pure-sasl==0.6.2
+    # via
+    #   pyhive
+    #   thrift-sasl
 pydata-google-auth==1.7.0
     # via pandas-gbq
 pydruid==0.6.6
@@ -201,7 +207,7 @@ pyee==11.0.1
     # via playwright
 pyfakefs==5.2.2
     # via -r requirements/development.in
-pyhive[presto]==0.7.0
+pyhive[hive_pure_sasl]==0.7.0
     # via apache-superset
 pyinstrument==4.4.0
     # via -r requirements/development.in
@@ -243,7 +249,12 @@ statsd==4.0.1
 tableschema==1.20.10
     # via apache-superset
 thrift==0.20.0
-    # via apache-superset
+    # via
+    #   apache-superset
+    #   pyhive
+    #   thrift-sasl
+thrift-sasl==0.4.3
+    # via pyhive
 tomli==2.0.1
     # via
     #   build

--- a/superset/cli/viz_migrations.py
+++ b/superset/cli/viz_migrations.py
@@ -28,6 +28,7 @@ class VizType(str, Enum):
     BUBBLE = "bubble"
     DUAL_LINE = "dual_line"
     LINE = "line"
+    HEATMAP = "heatmap"
     PIVOT_TABLE = "pivot_table"
     SUNBURST = "sunburst"
     TREEMAP = "treemap"
@@ -80,6 +81,7 @@ def migrate(viz_type: VizType, is_downgrade: bool = False) -> None:
         MigrateBubbleChart,
         MigrateDualLine,
         MigrateLineChart,
+        MigrateHeatmapChart,
         MigratePivotTable,
         MigrateSunburst,
         MigrateTreeMap,
@@ -90,6 +92,7 @@ def migrate(viz_type: VizType, is_downgrade: bool = False) -> None:
         VizType.BUBBLE: MigrateBubbleChart,
         VizType.DUAL_LINE: MigrateDualLine,
         VizType.LINE: MigrateLineChart,
+        VizType.HEATMAP: MigrateHeatmapChart,
         VizType.PIVOT_TABLE: MigratePivotTable,
         VizType.SUNBURST: MigrateSunburst,
         VizType.TREEMAP: MigrateTreeMap,

--- a/superset/cli/viz_migrations.py
+++ b/superset/cli/viz_migrations.py
@@ -27,8 +27,8 @@ class VizType(str, Enum):
     AREA = "area"
     BUBBLE = "bubble"
     DUAL_LINE = "dual_line"
-    LINE = "line"
     HEATMAP = "heatmap"
+    LINE = "line"
     PIVOT_TABLE = "pivot_table"
     SUNBURST = "sunburst"
     TREEMAP = "treemap"
@@ -80,8 +80,8 @@ def migrate(viz_type: VizType, is_downgrade: bool = False) -> None:
         MigrateAreaChart,
         MigrateBubbleChart,
         MigrateDualLine,
-        MigrateLineChart,
         MigrateHeatmapChart,
+        MigrateLineChart,
         MigratePivotTable,
         MigrateSunburst,
         MigrateTreeMap,
@@ -91,8 +91,8 @@ def migrate(viz_type: VizType, is_downgrade: bool = False) -> None:
         VizType.AREA: MigrateAreaChart,
         VizType.BUBBLE: MigrateBubbleChart,
         VizType.DUAL_LINE: MigrateDualLine,
-        VizType.LINE: MigrateLineChart,
         VizType.HEATMAP: MigrateHeatmapChart,
+        VizType.LINE: MigrateLineChart,
         VizType.PIVOT_TABLE: MigratePivotTable,
         VizType.SUNBURST: MigrateSunburst,
         VizType.TREEMAP: MigrateTreeMap,

--- a/superset/migrations/shared/migrate_viz/processors.py
+++ b/superset/migrations/shared/migrate_viz/processors.py
@@ -213,3 +213,18 @@ class MigrateBubbleChart(MigrateViz):
 
         # Truncate y-axis by default to preserve layout
         self.data["y_axis_showminmax"] = True
+
+
+class MigrateHeatmapChart(MigrateViz):
+    source_viz_type = "heatmap"
+    target_viz_type = "heatmap_v2"
+    rename_keys = {
+        "all_columns_x": "x_axis",
+        "all_columns_y": "groupby",
+        "y_axis_bounds": "value_bounds",
+        "show_perc": "show_percentage",
+    }
+    remove_keys = {"sort_by_metric", "canvas_image_rendering"}
+
+    def _pre_action(self) -> None:
+        self.data["legend_type"] = "continuous"

--- a/tests/unit_tests/migrations/viz/heatmap_v1_v2_test.py
+++ b/tests/unit_tests/migrations/viz/heatmap_v1_v2_test.py
@@ -1,0 +1,78 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Any
+
+from superset.migrations.shared.migrate_viz import MigrateHeatmapChart
+from tests.unit_tests.migrations.viz.utils import migrate_and_assert
+
+SOURCE_FORM_DATA: dict[str, Any] = {
+    "any_other_key": "untouched",
+    "all_columns_x": ["category"],
+    "all_columns_y": ["product"],
+    "metric": ["sales"],
+    "adhoc_filters": [],
+    "row_limit": 100,
+    "sort_by_metric": True,
+    "linear_color_scheme": "blue",
+    "xscale_interval": 2,
+    "yscale_interval": 2,
+    "canvas_image_rendering": "auto",
+    "normalize_across": "x",
+    "left_margin": 50,
+    "bottom_margin": 50,
+    "y_axis_bounds": [0, 100],
+    "y_axis_format": "SMART_NUMBER",
+    "currency_format": "USD",
+    "sort_x_axis": "alpha_asc",
+    "sort_y_axis": "alpha_asc",
+    "show_legend": True,
+    "show_perc": True,
+    "show_values": True,
+    "normalized": True,
+    "viz_type": "heatmap",
+}
+
+TARGET_FORM_DATA: dict[str, Any] = {
+    "any_other_key": "untouched",
+    "x_axis": ["category"],
+    "groupby": ["product"],
+    "metric": ["sales"],
+    "adhoc_filters": [],
+    "row_limit": 100,
+    "legend_type": "continuous",
+    "linear_color_scheme": "blue",
+    "xscale_interval": 2,
+    "yscale_interval": 2,
+    "normalize_across": "x",
+    "left_margin": 50,
+    "bottom_margin": 50,
+    "value_bounds": [0, 100],
+    "y_axis_format": "SMART_NUMBER",
+    "currency_format": "USD",
+    "sort_x_axis": "alpha_asc",
+    "sort_y_axis": "alpha_asc",
+    "show_legend": True,
+    "show_percentage": True,
+    "show_values": True,
+    "normalized": True,
+    "viz_type": "heatmap_v2",
+    "form_data_bak": SOURCE_FORM_DATA,
+}
+
+
+def test_migration() -> None:
+    migrate_and_assert(MigrateHeatmapChart, SOURCE_FORM_DATA, TARGET_FORM_DATA)


### PR DESCRIPTION
### SUMMARY
This PR adds the Heatmap chart migration logic (legacy ➡️ ECharts). Users can execute this migration using the [CLI command](https://github.com/apache/superset/pull/25304) and disable the legacy version with the [VIZ_TYPE_DENYLIST](https://github.com/apache/superset/blob/ec6191023263ac5f8292dd37f037805c3196e029/superset/config.py#L829) configuration.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1468" alt="Screenshot 2024-03-28 at 16 56 49" src="https://github.com/apache/superset/assets/70410625/62445fca-ff6f-4157-ba4a-8012b743baff">
<img width="1465" alt="Screenshot 2024-03-28 at 16 47 52" src="https://github.com/apache/superset/assets/70410625/e34100f9-7769-4b95-8cef-6f52cfbd80b8">

### TESTING INSTRUCTIONS
1 - Upgrade a Heatmap chart using the CLI command
2 - Check the new chart
3 - Downgrade a Heatmap chart using the CLI command
4 - Check the legacy chart

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
