### PR TITLE
chore: Cleanup table access check naming

### DIFF
--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -63,7 +63,7 @@ from superset.commands.importers.exceptions import (
 from superset.commands.importers.v1.utils import get_contents_from_bundle
 from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP, RouteMethod
 from superset.daos.database import DatabaseDAO, DatabaseUserOAuth2TokensDAO
-from superset.databases.decorators import check_datasource_access
+from superset.databases.decorators import check_table_access
 from superset.databases.filters import DatabaseFilter, DatabaseUploadEnabledFilter
 from superset.databases.schemas import (
     database_schemas_query_schema,
@@ -694,7 +694,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
 
     @expose("/<int:pk>/table/<path:table_name>/<schema_name>/", methods=("GET",))
     @protect()
-    @check_datasource_access
+    @check_table_access
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
@@ -757,7 +757,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
 
     @expose("/<int:pk>/table_extra/<path:table_name>/<schema_name>/", methods=("GET",))
     @protect()
-    @check_datasource_access
+    @check_table_access
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
@@ -820,7 +820,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @expose("/<int:pk>/select_star/<path:table_name>/", methods=("GET",))
     @expose("/<int:pk>/select_star/<path:table_name>/<schema_name>/", methods=("GET",))
     @protect()
-    @check_datasource_access
+    @check_table_access
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(

--- a/superset/databases/decorators.py
+++ b/superset/databases/decorators.py
@@ -30,9 +30,9 @@ from superset.views.base_api import BaseSupersetModelRestApi
 logger = logging.getLogger(__name__)
 
 
-def check_datasource_access(f: Callable[..., Any]) -> Callable[..., Any]:
+def check_table_access(f: Callable[..., Any]) -> Callable[..., Any]:
     """
-    A Decorator that checks if a user has datasource access
+    A Decorator that checks if a user has access to a table in a database.
     """
 
     def wraps(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Whilst spelunking through the code to try to track down a potential issue with access checks I realized there were two methods named `check_datasource_access`:

1. [`superset.explore.utils.check_datasource_access`](https://github.com/apache/superset/blob/546d48adbb84b1354d6a3d4ae88dbeba0ad14d44/superset/explore/utils.py#L67-L75)
2. [`superset.databases.decorators.check_datasource_access`](https://github.com/apache/superset/blob/546d48adbb84b1354d6a3d4ae88dbeba0ad14d44/superset/databases/decorators.py#L33-L69)

The later is somewhat of a misnomer, i.e., it checks whether the current user has access to a physical table/view in the underlying database rather than a Superset datasource. 

This PR remains (2) to be `check_table_access`—which calls `superset.security_manager.can_access_table`—to more accurately reflect what the decorator does.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
