### PR TITLE
fix(DnD): Add scrolling when resizing a chart on a dashboard

### DIFF
--- a/superset-frontend/src/dashboard/components/resizable/ResizableContainer.jsx
+++ b/superset-frontend/src/dashboard/components/resizable/ResizableContainer.jsx
@@ -198,15 +198,12 @@ const ResizableContainer = ({
   const scrollTimer = useRef(null);
   const initialScrollTop = useRef(0);
   const scrollDirection = useRef(null);
-  // const updatedSize = useRef({ width: 0, height: 0 });
 
   const handleScroll = mouseY => {
     if (mouseY < THRESHOLD * 2) {
       scrollDirection.current = 'up';
-      // window.scrollBy(0, -1);
     } else if (mouseY > window.innerHeight - THRESHOLD) {
       scrollDirection.current = 'down';
-      // window.scrollBy(0, 1);
     } else {
       scrollDirection.current = null;
     }
@@ -232,8 +229,6 @@ const ResizableContainer = ({
       onResize({ id, direction, ref });
     }
     handleScroll(event.clientY);
-    // const { width, height } = resizableRef.current.state;
-    // updatedSize.current = { width, height };
     const scrollDelta = window.scrollY - initialScrollTop.current;
     resizableRef.current.updateSize({
       height: resizableRef.current.state.height + scrollDelta,
@@ -241,7 +236,6 @@ const ResizableContainer = ({
   };
 
   const handleResizeStop = (event, direction, ref, delta) => {
-    // const { width, height } = resizableRef.current.state;
     if (onResizeStop) {
       const nextWidthMultiple =
         widthMultiple + Math.round(delta.width / (widthStep + gutterWidth));

--- a/superset-frontend/src/dashboard/components/resizable/ResizableContainer.jsx
+++ b/superset-frontend/src/dashboard/components/resizable/ResizableContainer.jsx
@@ -198,6 +198,7 @@ const ResizableContainer = ({
   const scrollTimer = useRef(null);
   const initialScrollTop = useRef(0);
   const scrollDirection = useRef(null);
+  const prevScrollY = useRef(0);
 
   const handleScroll = mouseY => {
     if (mouseY < THRESHOLD * 2) {
@@ -219,7 +220,12 @@ const ResizableContainer = ({
 
     scrollTimer.current = setInterval(() => {
       if (scrollDirection.current) {
+        prevScrollY.current = window.scrollY;
         window.scrollBy(0, scrollDirection.current === 'down' ? 1 : -1);
+        const scrollDelta = window.scrollY - prevScrollY.current;
+        resizableRef.current.updateSize({
+          height: resizableRef.current.state.height + scrollDelta,
+        });
       }
     }, 1);
   };
@@ -229,10 +235,10 @@ const ResizableContainer = ({
       onResize({ id, direction, ref });
     }
     handleScroll(event.clientY);
-    const scrollDelta = window.scrollY - initialScrollTop.current;
-    resizableRef.current.updateSize({
-      height: resizableRef.current.state.height + scrollDelta,
-    });
+    // const scrollDelta = window.scrollY - initialScrollTop.current;
+    // resizableRef.current.updateSize({
+    //   height: resizableRef.current.state.height + scrollDelta,
+    // });
   };
 
   const handleResizeStop = (event, direction, ref, delta) => {

--- a/superset-frontend/src/dashboard/components/resizable/ResizableContainer.jsx
+++ b/superset-frontend/src/dashboard/components/resizable/ResizableContainer.jsx
@@ -179,6 +179,7 @@ class ResizableContainer extends React.PureComponent {
     this.handleResizeStart = this.handleResizeStart.bind(this);
     this.handleResize = this.handleResize.bind(this);
     this.handleResizeStop = this.handleResizeStop.bind(this);
+    this.handleScroll = this.handleScroll.bind(this);
   }
 
   handleResizeStart(event, direction, ref) {
@@ -189,6 +190,9 @@ class ResizableContainer extends React.PureComponent {
     }
 
     this.setState(() => ({ isResizing: true }));
+
+    document.addEventListener('mousemove', this.handleMouseMove);
+    document.addEventListener('scroll', this.handleScroll);
   }
 
   handleResize(event, direction, ref) {
@@ -224,8 +228,35 @@ class ResizableContainer extends React.PureComponent {
       });
 
       this.setState(() => ({ isResizing: false }));
+
+      document.removeEventListener('mousemove', this.handleMouseMove);
+      document.removeEventListener('scroll', this.handleScroll);
     }
   }
+
+  handleMouseMove = e => {
+    if (this.state.isResizing) {
+      const windowHeight = window.innerHeight;
+      const bottomThreshold = windowHeight - 100;
+      if (e.clientY > bottomThreshold) {
+        window.scrollBy(0, 1);
+        console.log('scrolling down', {
+          windowHeight,
+          bottomThreshold,
+          clientY: e.clientY,
+        });
+      }
+    }
+  };
+
+  handleScroll = () => {
+    const { isResizing } = this.state;
+    if (isResizing) {
+      if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
+        window.scrollBy(0, 1); // Scroll down by 1 pixel
+      }
+    }
+  };
 
   render() {
     const {
@@ -274,6 +305,10 @@ class ResizableContainer extends React.PureComponent {
     const { isResizing } = this.state;
 
     return (
+      // <div
+      //   onMouseMove={this.handleMouseMove}
+      //   className="window-scroll-detector"
+      // >
       <StyledResizable
         enable={enableConfig}
         grid={SNAP_TO_GRID}
@@ -317,6 +352,7 @@ class ResizableContainer extends React.PureComponent {
       >
         {children}
       </StyledResizable>
+      // </div>
     );
   }
 }

--- a/superset-frontend/src/dashboard/components/resizable/handleScroll.tsx
+++ b/superset-frontend/src/dashboard/components/resizable/handleScroll.tsx
@@ -1,0 +1,35 @@
+const THRESHOLD = 50;
+
+function getScrollDirection(
+  mouseY: number | undefined,
+  upperBounds = Infinity,
+  lowerBounds = -Infinity,
+) {
+  if (mouseY === undefined) {
+    return 'hold';
+  }
+  if (mouseY > lowerBounds - THRESHOLD) {
+    return 'bottom';
+  }
+  if (mouseY < upperBounds + THRESHOLD) {
+    return 'top';
+  }
+  return 'hold';
+}
+
+export function handleScroll(allowScroll: boolean, mouseY: number | undefined) {
+  console.log(mouseY, window.innerHeight);
+  const scrollSpeed = 1;
+  let scrollTimer: NodeJS.Timeout;
+  const handleScrollInterval = () => {
+    const bounds = window.innerHeight;
+    const direction = getScrollDirection(mouseY, 0, bounds);
+    if (direction !== 'hold' && allowScroll) {
+      window.scrollBy(0, scrollSpeed * (direction === 'top' ? -1 : 1));
+    } else {
+      clearInterval(scrollTimer);
+    }
+  };
+  scrollTimer = setInterval(handleScrollInterval, 1);
+  return () => clearInterval(scrollTimer as NodeJS.Timeout);
+}

--- a/superset-frontend/src/dashboard/components/resizable/handleScroll.tsx
+++ b/superset-frontend/src/dashboard/components/resizable/handleScroll.tsx
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 const THRESHOLD = 50;
 
 function getScrollDirection(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Allow the page to scroll as you drag the cursor to the top or bottom of the screen when resizing.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
