### PR TITLE
fix: default logging

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -47,6 +47,8 @@ assists people when migrating to a new version.
   set `SLACK_API_TOKEN` to fetch and serve Slack avatar links
 - [28134](https://github.com/apache/superset/pull/28134/) The default logging level was changed
   from DEBUG to INFO - which is the normal/sane default logging level for most software.
+- [27777](https://github.com/apache/superset/pull/27777) Moves debug logging logic to config.py.
+  See `LOG_LEVEL` in `superset/config.py` for the recommended default.
 - [28205](https://github.com/apache/superset/pull/28205) The permission `all_database_access` now
   more clearly provides access to all databases, as specified in its name. Before it only allowed
   listing all databases in CRUD-view and dropdown and didn't provide access to data as it

--- a/superset/config.py
+++ b/superset/config.py
@@ -893,7 +893,7 @@ LOGGING_CONFIGURATOR = DefaultLoggingConfigurator()
 # Console Log Settings
 
 LOG_FORMAT = "%(asctime)s:%(levelname)s:%(name)s:%(message)s"
-LOG_LEVEL = logging.INFO
+LOG_LEVEL = logging.DEBUG if DEBUG else logging.INFO
 
 # ---------------------------------------------------
 # Enable Time Rotate Log Handler
@@ -901,7 +901,7 @@ LOG_LEVEL = logging.INFO
 # LOG_LEVEL = DEBUG, INFO, WARNING, ERROR, CRITICAL
 
 ENABLE_TIME_ROTATE = False
-TIME_ROTATE_LOG_LEVEL = logging.INFO
+TIME_ROTATE_LOG_LEVEL = logging.DEBUG if DEBUG else logging.INFO
 FILENAME = os.path.join(DATA_DIR, "superset.log")
 ROLLOVER = "midnight"
 INTERVAL = 1
@@ -1180,7 +1180,7 @@ ENABLE_CHUNK_ENCODING = False
 # Whether to bump the logging level to ERROR on the flask_appbuilder package
 # Set to False if/when debugging FAB related issues like
 # permission management
-SILENCE_FAB = True
+SILENCE_FAB = not DEBUG
 
 FAB_ADD_SECURITY_VIEWS = True
 FAB_ADD_SECURITY_PERMISSION_VIEW = False

--- a/superset/config.py
+++ b/superset/config.py
@@ -1180,7 +1180,7 @@ ENABLE_CHUNK_ENCODING = False
 # Whether to bump the logging level to ERROR on the flask_appbuilder package
 # Set to False if/when debugging FAB related issues like
 # permission management
-SILENCE_FAB = not DEBUG
+SILENCE_FAB = True
 
 FAB_ADD_SECURITY_VIEWS = True
 FAB_ADD_SECURITY_PERMISSION_VIEW = False

--- a/superset/utils/logging_configurator.py
+++ b/superset/utils/logging_configurator.py
@@ -41,19 +41,13 @@ class DefaultLoggingConfigurator(  # pylint: disable=too-few-public-methods
         if app_config["SILENCE_FAB"]:
             logging.getLogger("flask_appbuilder").setLevel(logging.ERROR)
 
-        # configure superset app logger
-        superset_logger = logging.getLogger("superset")
-        if debug_mode:
-            superset_logger.setLevel(logging.DEBUG)
-        else:
-            # In production mode, add log handler to sys.stderr.
-            superset_logger.addHandler(logging.StreamHandler())
-            superset_logger.setLevel(logging.INFO)
-
         logging.getLogger("pyhive.presto").setLevel(logging.INFO)
 
+        # basicConfig() will set up a default StreamHandler on stderr
         logging.basicConfig(format=app_config["LOG_FORMAT"])
-        logging.getLogger().setLevel(app_config["LOG_LEVEL"])
+        logging.getLogger().setLevel(
+            logging.DEBUG if debug_mode else app_config["LOG_LEVEL"]
+        )
 
         if app_config["ENABLE_TIME_ROTATE"]:
             logging.getLogger().setLevel(app_config["TIME_ROTATE_LOG_LEVEL"])

--- a/superset/utils/logging_configurator.py
+++ b/superset/utils/logging_configurator.py
@@ -41,8 +41,6 @@ class DefaultLoggingConfigurator(  # pylint: disable=too-few-public-methods
         if app_config["SILENCE_FAB"]:
             logging.getLogger("flask_appbuilder").setLevel(logging.ERROR)
 
-        logging.getLogger("pyhive.presto").setLevel(logging.INFO)
-
         # basicConfig() will set up a default StreamHandler on stderr
         logging.basicConfig(format=app_config["LOG_FORMAT"])
         logging.getLogger().setLevel(

--- a/superset/utils/logging_configurator.py
+++ b/superset/utils/logging_configurator.py
@@ -43,9 +43,7 @@ class DefaultLoggingConfigurator(  # pylint: disable=too-few-public-methods
 
         # basicConfig() will set up a default StreamHandler on stderr
         logging.basicConfig(format=app_config["LOG_FORMAT"])
-        logging.getLogger().setLevel(
-            logging.DEBUG if debug_mode else app_config["LOG_LEVEL"]
-        )
+        logging.getLogger().setLevel(app_config["LOG_LEVEL"])
 
         if app_config["ENABLE_TIME_ROTATE"]:
             logging.getLogger().setLevel(app_config["TIME_ROTATE_LOG_LEVEL"])


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR makes default logging work as expected:
- Fixes duplicate logging.
- Allows `DEBUG` level logging in production.
- Makes logging respect `LOG_LEVEL` and `LOG_FORMAT` in config.
- ~~Sets the `LOG_LEVEL` to `INFO` to match what we currently hardcode (theoretically a breaking change.)~~

I'm not sure what the initial goals were but by default we are logging `DEBUG` level everything but `superset`, which is set to `INFO` level (without regard to `LOG_LEVEL`,) and logging `superset` a second time without regard to the `LOG_FORMAT` config setting. This doesn't seem desirable for anybody.

This change makes default logging work as expected.

Resolves https://github.com/apache/superset/issues/21646
I think also resolves https://github.com/apache/superset/issues/4785

#### Cause of duplicate logging:

Python loggers output via handlers, the issue is we are adding handlers twice, once here:

https://github.com/apache/superset/blob/c0f8dfc7f99a0e83a8c9b3c083288c76f50aa662/superset/utils/logging_configurator.py#L50

And unintuitively also when we call logging.basicConfig() which by default adds a StreamHandler on root:

https://github.com/apache/superset/blob/c0f8dfc7f99a0e83a8c9b3c083288c76f50aa662/superset/utils/logging_configurator.py#L55

Minimum reproduction of the bug:

```python
>>> import logging
>>> # No need to set BasicConfig, as logging.lastResort will be used by default
>>> logging.basicConfig()
>>> logging.warning('test')
WARNING:root:test
>>> sublogger = logging.getLogger('sublogger')
>>> sublogger.addHandler(logging.StreamHandler())
>>> sublogger.warning('test')
test
WARNING:sublogger:test
>>>
```

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Inspect startup log messages, trigger a log if need be.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: 
  - https://github.com/apache/superset/issues/21646
  - https://github.com/apache/superset/issues/4785
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
