### PR TITLE
fix: status 500 thrown when creating a dataset due to invalid sql

### DIFF
--- a/superset/commands/dataset/create.py
+++ b/superset/commands/dataset/create.py
@@ -32,7 +32,8 @@ from superset.commands.dataset.exceptions import (
 )
 from superset.daos.dataset import DatasetDAO
 from superset.daos.exceptions import DAOCreateFailedError
-from superset.exceptions import SupersetSecurityException
+from superset.exceptions import SupersetSecurityException, \
+    SupersetGenericDBErrorException
 from superset.extensions import db, security_manager
 from superset.sql_parse import Table
 
@@ -52,7 +53,8 @@ class CreateDatasetCommand(CreateMixin, BaseCommand):
             # Updates columns and metrics from the dataset
             dataset.fetch_metadata(commit=False)
             db.session.commit()
-        except (SQLAlchemyError, DAOCreateFailedError) as ex:
+        except (SQLAlchemyError, DAOCreateFailedError,
+                SupersetGenericDBErrorException) as ex:
             logger.warning(ex, exc_info=True)
             db.session.rollback()
             raise DatasetCreateFailedError() from ex

--- a/superset/commands/dataset/create.py
+++ b/superset/commands/dataset/create.py
@@ -32,8 +32,10 @@ from superset.commands.dataset.exceptions import (
 )
 from superset.daos.dataset import DatasetDAO
 from superset.daos.exceptions import DAOCreateFailedError
-from superset.exceptions import SupersetSecurityException, \
-    SupersetGenericDBErrorException
+from superset.exceptions import (
+    SupersetGenericDBErrorException,
+    SupersetSecurityException,
+)
 from superset.extensions import db, security_manager
 from superset.sql_parse import Table
 
@@ -53,8 +55,11 @@ class CreateDatasetCommand(CreateMixin, BaseCommand):
             # Updates columns and metrics from the dataset
             dataset.fetch_metadata(commit=False)
             db.session.commit()
-        except (SQLAlchemyError, DAOCreateFailedError,
-                SupersetGenericDBErrorException) as ex:
+        except (
+            SQLAlchemyError,
+            DAOCreateFailedError,
+            SupersetGenericDBErrorException,
+        ) as ex:
             logger.warning(ex, exc_info=True)
             db.session.rollback()
             raise DatasetCreateFailedError() from ex

--- a/superset/connectors/sqla/utils.py
+++ b/superset/connectors/sqla/utils.py
@@ -123,16 +123,12 @@ def get_virtual_table_metadata(dataset: SqlaTable) -> list[ResultSetColumnType]:
                 level=ErrorLevel.ERROR,
             )
         )
-    return get_columns_description(
-        dataset.database,
-        dataset.catalog,
-        dataset.schema,
-        statements[0],
-    )
-
     try:
         column_description = get_columns_description(
-            dataset.database, dataset.schema, statements[0]
+            dataset.database,
+            dataset.catalog,
+            dataset.schema,
+            statements[0],
         )
         return column_description
 

--- a/superset/connectors/sqla/utils.py
+++ b/superset/connectors/sqla/utils.py
@@ -130,6 +130,16 @@ def get_virtual_table_metadata(dataset: SqlaTable) -> list[ResultSetColumnType]:
         statements[0],
     )
 
+    try:
+        column_description = get_columns_description(dataset.database, dataset.schema,
+                                                     statements[0])
+        return column_description
+
+    except SupersetGenericDBErrorException as ex:
+        raise SupersetGenericDBErrorException(
+            message=_(ex.message),
+        ) from ex
+
 
 def get_columns_description(
     database: Database,

--- a/superset/connectors/sqla/utils.py
+++ b/superset/connectors/sqla/utils.py
@@ -131,8 +131,9 @@ def get_virtual_table_metadata(dataset: SqlaTable) -> list[ResultSetColumnType]:
     )
 
     try:
-        column_description = get_columns_description(dataset.database, dataset.schema,
-                                                     statements[0])
+        column_description = get_columns_description(
+            dataset.database, dataset.schema, statements[0]
+        )
         return column_description
 
     except SupersetGenericDBErrorException as ex:

--- a/tests/integration_tests/datasets/commands_tests.py
+++ b/tests/integration_tests/datasets/commands_tests.py
@@ -26,6 +26,7 @@ from superset import db, security_manager
 from superset.commands.database.importers.v1 import ImportDatabasesCommand
 from superset.commands.dataset.create import CreateDatasetCommand
 from superset.commands.dataset.exceptions import (
+    DatasetCreateFailedError,
     DatasetInvalidError,
     DatasetNotFoundError,
     WarmUpCacheTableNotFoundError,
@@ -598,6 +599,18 @@ class TestCreateDatasetCommand(SupersetTestCase):
                 _ = CreateDatasetCommand(
                     {
                         "sql": "select * from ab_user",
+                        "database": examples_db.id,
+                        "table_name": "exp1",
+                    }
+                ).run()
+
+    def test_create_dataset_invalid_sql(self):
+        examples_db = get_example_database()
+        with override_user(security_manager.find_user("admin")):
+            with self.assertRaises(DatasetCreateFailedError):
+                CreateDatasetCommand(
+                    {
+                        "sql": "select * from invalid_table",
                         "database": examples_db.id,
                         "table_name": "exp1",
                     }


### PR DESCRIPTION
<!---
fix fatal error being thrown when creating a dataset, if a invalid SQL is being passed 
-->

### SUMMARY

previously when a dataset is being created, supersetGenericDB error can be thrown at the db_engine layer if a sql statement is invalid

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

before 

https://github.com/apache/superset/assets/25937657/7ee03388-6928-4edd-9770-5acf9b4afb6d

after 

https://github.com/apache/superset/assets/25937657/57e6b335-f5cc-4324-9fe1-0fd963aabb9d



### TESTING INSTRUCTIONS
- enable sqllab in database configuration
- open sqllab
- type invalid sql 
- click save as dataset 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
