### PR TITLE
fix: Address database options prepopulated with stale option, in dataset component

### DIFF
--- a/superset-frontend/src/features/datasets/AddDataset/LeftPanel/LeftPanel.test.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/LeftPanel/LeftPanel.test.tsx
@@ -22,6 +22,7 @@ import userEvent from '@testing-library/user-event';
 import { render, screen, waitFor } from 'spec/helpers/testing-library';
 import LeftPanel from 'src/features/datasets/AddDataset/LeftPanel';
 import { exampleDataset } from 'src/features/datasets/AddDataset/DatasetPanel/fixtures';
+import { MemoryRouter } from 'react-router-dom';
 
 const databasesEndpoint = 'glob:*/api/v1/database/?q*';
 const schemasEndpoint = 'glob:*/api/v1/database/*/schemas*';
@@ -154,16 +155,26 @@ afterEach(() => {
 const mockFun = jest.fn();
 
 test('should render', async () => {
-  render(<LeftPanel setDataset={mockFun} />, {
-    useRedux: true,
-  });
+  render(
+    <MemoryRouter>
+      <LeftPanel setDataset={mockFun} />
+    </MemoryRouter>,
+    {
+      useRedux: true,
+    },
+  );
   expect(
     await screen.findByText(/Select database or type to search databases/i),
   ).toBeInTheDocument();
 });
 
 test('should render schema selector, database selector container, and selects', async () => {
-  render(<LeftPanel setDataset={mockFun} />, { useRedux: true });
+  render(
+    <MemoryRouter>
+      <LeftPanel setDataset={mockFun} />
+    </MemoryRouter>,
+    { useRedux: true },
+  );
 
   expect(
     await screen.findByText(/Select database or type to search databases/i),
@@ -180,7 +191,12 @@ test('should render schema selector, database selector container, and selects', 
 });
 
 test('does not render blank state if there is nothing selected', async () => {
-  render(<LeftPanel setDataset={mockFun} />, { useRedux: true });
+  render(
+    <MemoryRouter>
+      <LeftPanel setDataset={mockFun} />{' '}
+    </MemoryRouter>,
+    { useRedux: true },
+  );
 
   expect(
     await screen.findByText(/Select database or type to search databases/i),
@@ -190,9 +206,14 @@ test('does not render blank state if there is nothing selected', async () => {
 });
 
 test('renders list of options when user clicks on schema', async () => {
-  render(<LeftPanel setDataset={mockFun} dataset={exampleDataset[0]} />, {
-    useRedux: true,
-  });
+  render(
+    <MemoryRouter>
+      <LeftPanel setDataset={mockFun} dataset={exampleDataset[0]} />
+    </MemoryRouter>,
+    {
+      useRedux: true,
+    },
+  );
 
   // Click 'test-postgres' database to access schemas
   const databaseSelect = screen.getByRole('combobox', {
@@ -212,9 +233,14 @@ test('renders list of options when user clicks on schema', async () => {
 });
 
 test('searches for a table name', async () => {
-  render(<LeftPanel setDataset={mockFun} dataset={exampleDataset[0]} />, {
-    useRedux: true,
-  });
+  render(
+    <MemoryRouter>
+      <LeftPanel setDataset={mockFun} dataset={exampleDataset[0]} />
+    </MemoryRouter>,
+    {
+      useRedux: true,
+    },
+  );
 
   // Click 'test-postgres' database to access schemas
   const databaseSelect = screen.getByRole('combobox', {
@@ -270,11 +296,13 @@ test('searches for a table name', async () => {
 
 test('renders a warning icon when a table name has a pre-existing dataset', async () => {
   render(
-    <LeftPanel
-      setDataset={mockFun}
-      dataset={exampleDataset[0]}
-      datasetNames={['Sheet2']}
-    />,
+    <MemoryRouter>
+      <LeftPanel
+        setDataset={mockFun}
+        dataset={exampleDataset[0]}
+        datasetNames={['Sheet2']}
+      />
+    </MemoryRouter>,
     {
       useRedux: true,
     },

--- a/superset-frontend/src/features/datasets/AddDataset/LeftPanel/index.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/LeftPanel/index.tsx
@@ -28,6 +28,7 @@ import {
   DatasetObject,
 } from 'src/features/datasets/AddDataset/types';
 import { Table } from 'src/hooks/apiResources';
+import { useLocation } from 'react-router-dom';
 
 interface LeftPanelProps {
   setDataset: Dispatch<SetStateAction<object>>;
@@ -122,6 +123,9 @@ export default function LeftPanel({
   datasetNames,
 }: LeftPanelProps) {
   const { addDangerToast } = useToasts();
+  const location = useLocation();
+
+  const isAddingDataSet = location.pathname.includes('/dataset/add');
 
   const setDatabase = useCallback(
     (db: Partial<DatabaseObject>) => {
@@ -144,6 +148,7 @@ export default function LeftPanel({
     });
   };
   useEffect(() => {
+    // TODO: storing and fetching the last selected database from local storage is potentially technical debt
     const currentUserSelectedDb = getItem(
       LocalStorageKeys.Database,
       null,
@@ -174,7 +179,7 @@ export default function LeftPanel({
   return (
     <LeftPanelStyle>
       <TableSelector
-        database={dataset?.db}
+        database={isAddingDataSet ? null : dataset?.db}
         handleError={addDangerToast}
         emptyState={emptyStateComponent(false)}
         onDbChange={setDatabase}

--- a/superset-frontend/src/features/datasets/AddDataset/LeftPanel/index.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/LeftPanel/index.tsx
@@ -125,7 +125,7 @@ export default function LeftPanel({
   const { addDangerToast } = useToasts();
   const location = useLocation();
 
-  const isAddingDataSet = location.pathname.includes('/dataset/add');
+  const isAddingDataSet = location.pathname.includes('/dataset/add') ?? false;
 
   const setDatabase = useCallback(
     (db: Partial<DatabaseObject>) => {


### PR DESCRIPTION
**SUMMARY**
- the previous practice involves auto auto populate database (stored in local storage) into the newly created dataset, which will create bugs when database name changes, database is deleted, or when database meta is changed.
- the practice of saving and fetching latest modified database through localStorage is a potentially technical debut, making it easy to introduce regression that cannot be tracked. looking to potential bugs next.
**BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF**
stale database data in localStorage
![image](https://github.com/apache/superset/assets/25937657/b481506e-691b-40fa-889f-18562d9945c9)

**after fix demo**
https://github.com/apache/superset/assets/25937657/8a20d1dc-cdb9-47a2-8cac-7d84b16eaa5a
**TESTING INSTRUCTIONS**
connect a database of your choice,
rename your database
create a new dataset, and you will see the option not prepopulated.
**ADDITIONAL INFORMATION**
[ x] Has associated issue: Fix https://github.com/apache/superset/issues/27266
 Required feature flags:
 Changes UI
 Includes DB Migration (follow approval process in https://github.com/apache/superset/issues/13351)
 Migration is atomic, supports rollback & is backwards-compatible
 Confirm DB migration upgrade and downgrade tested
 Runtime estimates and downtime expectations provided
 Introduces new feature or API
 Removes existing feature or API