### PR TITLE
build: fixed pkg-config dependency in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,6 +119,7 @@ RUN apt-get update -qq \
         libasound2 \
         libxtst6 \
         wget \
+        pkg-config \
     # Install GeckoDriver WebDriver
     && wget -q https://github.com/mozilla/geckodriver/releases/download/${GECKODRIVER_VERSION}/geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz -O - | tar xfz - -C /usr/local/bin \
     # Install Firefox


### PR DESCRIPTION
### SUMMARY
Fixed inability to build Docker image as described in issue [#27792](https://github.com/apache/superset/issues/27792)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
According to the [documentation](https://superset.apache.org/docs/installation/installing-superset-using-docker-compose), pull the repository and build image with command:

`docker compose -f docker-compose-non-dev.yml up`

closes https://github.com/apache/superset/issues/27792

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
