### PR TITLE
chore(sql_parse): Strip leading/trailing whitespace in Jinja macro extraction

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -1548,7 +1548,7 @@ def extract_tables_from_jinja_sql(sql: str, database: Database) -> set[Table]:
             tables.add(
                 Table(
                     *[
-                        remove_quotes(part)
+                        remove_quotes(part.strip())
                         for part in node.args[0].value.split(".")[::-1]
                         if len(node.args) == 1
                     ]

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -1937,6 +1937,7 @@ def test_sqlstatement() -> None:
     "macro",
     [
         "latest_partition('foo.bar')",
+        "latest_partition(' foo.bar ')",  # Non-atypical user error which works
         "latest_sub_partition('foo.bar', baz='qux')",
     ],
 )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

It seems like it's not uncommon for users to use the `latest[_sub]_partition` Jinja macros wrongly in terms of including a leading or trailing whitespace, i.e., `latest_partition(' foo.bar ')` which actually works as this table name is extracted and injected into SQL where additional leading/trailing whitespace is allowed.

This PR makes sure that when we extract the table name from the Jinja macro we strip any leading/trailing whitespace.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
