### PR TITLE
chore: Default to engine specification regarding using wildcard

### DIFF
--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -871,7 +871,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         self.incr_stats("init", self.select_star.__name__)
         try:
             result = database.select_star(
-                table_name, schema_name, latest_partition=True, show_cols=True
+                table_name, schema_name, latest_partition=True
             )
         except NoSuchTableError:
             self.incr_stats("error", self.select_star.__name__)

--- a/superset/databases/utils.py
+++ b/superset/databases/utils.py
@@ -92,7 +92,6 @@ def get_table_metadata(
         "selectStar": database.select_star(
             table_name,
             schema=schema_name,
-            show_cols=True,
             indent=True,
             cols=columns,
             latest_partition=True,

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -1480,7 +1480,7 @@ class TestDatabaseApi(SupersetTestCase):
                     "indexes": [],
                     "name": "wrong_table",
                     "primaryKey": {"constrained_columns": None, "name": None},
-                    "selectStar": "SELECT\nFROM wrong_table\nLIMIT 100\nOFFSET 0",
+                    "selectStar": "SELECT\n  *\nFROM wrong_table\nLIMIT 100\nOFFSET 0",
                 },
             )
         elif example_db.backend == "mysql":
@@ -1550,8 +1550,6 @@ class TestDatabaseApi(SupersetTestCase):
         uri = f"api/v1/database/{example_db.id}/select_star/birth_names/"
         rv = self.client.get(uri)
         self.assertEqual(rv.status_code, 200)
-        response = json.loads(rv.data.decode("utf-8"))
-        self.assertIn("gender", response["result"])
 
     def test_get_select_star_not_allowed(self):
         """


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

The `BaseEngineSpec.select_star` method provides an option (with a default) with regards to whether or not one should use a wildcard (`show_cols=False`) or enumerate the columns (`show_cols=True`) when generating a SQL statement for fetching sample records from a dataset.

Some of the underlying engines—Hive, Presto, BigQuery—override this method including the default for the `show_cols` function argument. When creating the SQL statement rather than forcing `show_cols=True` we should instead fallback to the engine specific preference.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
