### PR TITLE
fix: alembic's 'superset db migrate' fails with CompileError

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -2055,7 +2055,10 @@ class RowLevelSecurityFilter(Model, AuditMixinNullable):
     name = Column(String(255), unique=True, nullable=False)
     description = Column(Text)
     filter_type = Column(
-        Enum(*[filter_type.value for filter_type in utils.RowLevelSecurityFilterType])
+        Enum(
+            *[filter_type.value for filter_type in utils.RowLevelSecurityFilterType],
+            name="filter_type_enum",
+        ),
     )
     group_key = Column(String(255), nullable=True)
     roles = relationship(


### PR DESCRIPTION
When running on the latest `master`
running a simple `superset db migrate` within `docker-compose exec superset bash` to generate a new
database migration fails with error

```
sqlalchemy.exc.CompileError: PostgreSQL ENUM type requires a name.
```

This PR addresses the issue by giving a name to that particular enum.

From my understanding, this particular enum wasn't created in
a given migration script, so it may not be enforced at the database
level, probably by choice/design. Having the name here simply
allows for alembic's migrate subcommand to run.

