### PR TITLE
feat(reports): allowing the email mutator to update recipients

### DIFF
--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -902,6 +902,8 @@ def send_email_smtp(  # pylint: disable=invalid-name,too-many-arguments,too-many
     msg_mutator = config["EMAIL_HEADER_MUTATOR"]
     # the base notification returns the message without any editing.
     new_msg = msg_mutator(msg, **(header_data or {}))
+    if new_msg["To"].split(", ") != recipients:
+        recipients = new_msg["To"].split(", ")
     send_mime_email(smtp_mail_from, recipients, new_msg, config, dryrun=dryrun)
 
 

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -852,6 +852,7 @@ def send_email_smtp(  # pylint: disable=invalid-name,too-many-arguments,too-many
         msg["CC"] = ", ".join(smtp_mail_cc)
         recipients = recipients + smtp_mail_cc
 
+    smtp_mail_bcc = []
     if bcc:
         # don't add bcc in header
         smtp_mail_bcc = get_email_address_list(bcc)
@@ -902,8 +903,11 @@ def send_email_smtp(  # pylint: disable=invalid-name,too-many-arguments,too-many
     msg_mutator = config["EMAIL_HEADER_MUTATOR"]
     # the base notification returns the message without any editing.
     new_msg = msg_mutator(msg, **(header_data or {}))
-    if new_msg["To"].split(", ") != recipients:
-        recipients = new_msg["To"].split(", ")
+    new_to = new_msg["To"].split(", ") if "To" in new_msg else []
+    new_cc = new_msg["Cc"].split(", ") if "Cc" in new_msg else []
+    new_recipients = new_to + new_cc + smtp_mail_bcc
+    if set(new_recipients) != set(recipients):
+        recipients = new_recipients
     send_mime_email(smtp_mail_from, recipients, new_msg, config, dryrun=dryrun)
 
 

--- a/tests/integration_tests/email_tests.py
+++ b/tests/integration_tests/email_tests.py
@@ -90,6 +90,36 @@ class TestEmailSmtp(SupersetTestCase):
         app.config["EMAIL_HEADER_MUTATOR"] = base_email_mutator
 
     @mock.patch("superset.utils.core.send_mime_email")
+    def test_send_smtp_with_email_mutator_changing_recipients(self, mock_send_mime):
+        attachment = tempfile.NamedTemporaryFile()
+        attachment.write(b"attachment")
+        attachment.seek(0)
+
+        # putting this into a variable so that we can reset after the test
+        base_email_mutator = app.config["EMAIL_HEADER_MUTATOR"]
+
+        def mutator(msg, **kwargs):
+            msg.replace_header("To", "mutated")
+            return msg
+
+        app.config["EMAIL_HEADER_MUTATOR"] = mutator
+        utils.send_email_smtp(
+            "to", "subject", "content", app.config, files=[attachment.name]
+        )
+        assert mock_send_mime.called
+        call_args = mock_send_mime.call_args[0]
+        logger.debug(call_args)
+        assert call_args[0] == app.config["SMTP_MAIL_FROM"]
+        assert call_args[1] == ["mutated"]
+        msg = call_args[2]
+        assert msg["Subject"] == "subject"
+        assert msg["From"] == app.config["SMTP_MAIL_FROM"]
+        assert len(msg.get_payload()) == 2
+        mimeapp = MIMEApplication("attachment")
+        assert msg.get_payload()[-1].get_payload() == mimeapp.get_payload()
+        app.config["EMAIL_HEADER_MUTATOR"] = base_email_mutator
+
+    @mock.patch("superset.utils.core.send_mime_email")
     def test_send_smtp_data(self, mock_send_mime):
         utils.send_email_smtp(
             "to", "subject", "content", app.config, data={"1.txt": b"data"}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
We use the `EMAIL_HEADER_MUTATOR` to detect errors in reports sent to our external clients. Currently, when an error is detected we send an alert to an internal Slack channel and replace the contents of the notification with a generic message saying `There has been an issue generating your report...`. However, our account managers have asked us not to send the report. Unfortunately, there is no way to prevent the reports from being sent beyond causing an `Exception` to be raised, which causes issues.

This PR allows users to use `msg.replace_header("To", <superset_admin/empty_string>)` as part of the `EMAIL_HEADER_MUTATOR` in the config to replace the list of recipients. We plan to either replace the recipients with an empty string or send it to an internal email so we are notified of the results. 

I [opened an Idea ](https://github.com/apache/superset/discussions/26886)previously for this but it has not been picked up.

### TESTING INSTRUCTIONS
I have added an additional unit test in the relevant section of the tests repo. Additionally, in your local setup you can add the following to your `superset_config.py`

```python
def EMAIL_HEADER_MUTATOR(msg, **kwargs):
  msg.replace_header("To", "fake@email.com")
  return msg
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
