### PR TITLE
[DO NOT MERGE] DEMO fix(time_comparison):Use Join queries when using time comparison

### DIFF
--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -26,6 +26,7 @@ from marshmallow.validate import Length, Range
 
 from superset import app
 from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
+from superset.constants import InstantTimeComparison
 from superset.db_engine_specs.base import builtin_time_grains
 from superset.tags.models import TagType
 from superset.utils import pandas_postprocessing, schema as utils
@@ -948,6 +949,14 @@ class ChartDataFilterSchema(Schema):
     )
 
 
+class InstantTimeComparisonInfoSchema(Schema):
+    range = fields.String(
+        metadata={"description": "Type of time comparison to be used"},
+        validate=validate.OneOf(choices=[ran.value for ran in InstantTimeComparison]),
+    )
+    filter = fields.Nested(ChartDataFilterSchema, allow_none=True)
+
+
 class ChartDataExtrasSchema(Schema):
     relative_start = fields.String(
         metadata={
@@ -995,6 +1004,14 @@ class ChartDataExtrasSchema(Schema):
             "description": "This is only set using the new time comparison controls "
             "that is made available in some plugins behind the experimental "
             "feature flag."
+        },
+        allow_none=True,
+    )
+    instant_time_comparison_info = fields.Nested(
+        InstantTimeComparisonInfoSchema,
+        metadata={
+            "description": "Extra parameters to use instant time comparison"
+            " with JOINs using a single query"
         },
         allow_none=True,
     )

--- a/superset/constants.py
+++ b/superset/constants.py
@@ -44,10 +44,11 @@ LRU_CACHE_MAX_SIZE = 256
 
 # Used when calculating the time shift for time comparison
 class InstantTimeComparison(StrEnum):
+    CUSTOM = "c"
     INHERITED = "r"
-    YEAR = "y"
     MONTH = "m"
     WEEK = "w"
+    YEAR = "y"
 
 
 class RouteMethod:  # pylint: disable=too-few-public-methods

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1049,6 +1049,18 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
             is_feature_enabled("CHART_PLUGINS_EXPERIMENTAL")
             and instant_time_comparison_info
         ):
+            # Check that only DBs that support JOINs and Subqueries use this feature
+            if (
+                self.database is not None
+                and self.database.db_engine_spec is not None
+                and (
+                    not self.database.db_engine_spec.allows_joins
+                    or not self.database.db_engine_spec.allows_subqueries
+                )
+            ):
+                raise QueryObjectValidationError(
+                    _("Instant time comparison is not supported for this database")
+                )
             (
                 final_query_sql,
                 labels_expected,

--- a/tests/unit_tests/connectors/test_models.py
+++ b/tests/unit_tests/connectors/test_models.py
@@ -1,0 +1,386 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import datetime
+
+from sqlalchemy.orm.session import Session
+
+from superset import db
+from tests.unit_tests.conftest import with_feature_flags
+
+
+class TestInstantTimeComparisonQueryGeneration:
+    @staticmethod
+    def base_setup(session: Session):
+        from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn
+        from superset.models.core import Database
+
+        engine = db.session.get_bind()
+        SqlaTable.metadata.create_all(engine)  # pylint: disable=no-member
+
+        table = SqlaTable(
+            table_name="my_table",
+            schema="my_schema",
+            database=Database(database_name="my_database", sqlalchemy_uri="sqlite://"),
+        )
+
+        # Common columns
+        columns = [
+            {"column_name": "ds", "type": "DATETIME"},
+            {"column_name": "gender", "type": "VARCHAR(255)"},
+            {"column_name": "name", "type": "VARCHAR(255)"},
+            {"column_name": "state", "type": "VARCHAR(255)"},
+        ]
+
+        # Add columns to the table
+        for col in columns:
+            TableColumn(column_name=col["column_name"], type=col["type"], table=table)
+
+        # Common metrics
+        metrics = [
+            {"metric_name": "count", "expression": "count(*)"},
+            {"metric_name": "sum_sum", "expression": "SUM"},
+        ]
+
+        # Add metrics to the table
+        for metric in metrics:
+            SqlMetric(
+                metric_name=metric["metric_name"],
+                expression=metric["expression"],
+                table=table,
+            )
+
+        db.session.add(table)
+        db.session.flush()
+
+        return table
+
+    @staticmethod
+    def generate_base_query_obj():
+        return {
+            "apply_fetch_values_predicate": False,
+            "columns": ["name"],
+            "extras": {
+                "having": "",
+                "where": "",
+                "instant_time_comparison_info": {
+                    "range": "y",
+                },
+            },
+            "filter": [
+                {"op": "TEMPORAL_RANGE", "val": "1984-01-01 : 2024-02-14", "col": "ds"}
+            ],
+            "from_dttm": datetime.datetime(1984, 1, 1, 0, 0),
+            "granularity": None,
+            "inner_from_dttm": None,
+            "inner_to_dttm": None,
+            "is_rowcount": False,
+            "is_timeseries": False,
+            "order_desc": True,
+            "orderby": [("SUM(num_boys)", False)],
+            "row_limit": 10,
+            "row_offset": 0,
+            "series_columns": [],
+            "series_limit": 0,
+            "series_limit_metric": None,
+            "to_dttm": datetime.datetime(2024, 2, 14, 0, 0),
+            "time_shift": None,
+            "metrics": [
+                {
+                    "aggregate": "SUM",
+                    "column": {
+                        "column_name": "num_boys",
+                        "type": "BIGINT",
+                        "filterable": True,
+                        "groupby": True,
+                        "id": 334,
+                        "is_certified": False,
+                        "is_dttm": False,
+                        "type_generic": 0,
+                    },
+                    "datasourceWarning": False,
+                    "expressionType": "SIMPLE",
+                    "hasCustomLabel": False,
+                    "label": "SUM(num_boys)",
+                    "optionName": "metric_gzp6eq9g1lc_d8o0mj0mhq4",
+                    "sqlExpression": None,
+                },
+                {
+                    "aggregate": "SUM",
+                    "column": {
+                        "column_name": "num_girls",
+                        "type": "BIGINT",
+                        "filterable": True,
+                        "groupby": True,  # Note: This will need adjustment in some cases
+                        "id": 335,
+                        "is_certified": False,
+                        "is_dttm": False,
+                        "type_generic": 0,
+                    },
+                    "datasourceWarning": False,
+                    "expressionType": "SIMPLE",
+                    "hasCustomLabel": False,
+                    "label": "SUM(num_girls)",
+                    "optionName": "metric_5gyhtmyfw1t_d42py86jpco",
+                    "sqlExpression": None,
+                },
+            ],
+        }
+
+    @with_feature_flags(CHART_PLUGINS_EXPERIMENTAL=True)
+    def test_creates_time_comparison_query(session: Session):
+        table = TestInstantTimeComparisonQueryGeneration.base_setup(session)
+        query_obj = TestInstantTimeComparisonQueryGeneration.generate_base_query_obj()
+        str = table.get_query_str_extended(query_obj)
+        expected_str = """
+            WITH query_a_results AS
+            (SELECT name AS name,
+                    sum(num_boys) AS "SUM(num_boys)",
+                    sum(num_girls) AS "SUM(num_girls)"
+            FROM my_schema.my_table
+            WHERE ds >= '1984-01-01 00:00:00'
+                AND ds < '2024-02-14 00:00:00'
+            GROUP BY name
+            ORDER BY "SUM(num_boys)" DESC
+            LIMIT 10
+            OFFSET 0)
+            SELECT query_a_results.name AS name,
+                query_a_results."SUM(num_boys)" AS "SUM(num_boys)",
+                query_a_results."SUM(num_girls)" AS "SUM(num_girls)",
+                anon_1."SUM(num_boys)" AS "prev_SUM(num_boys)",
+                anon_1."SUM(num_girls)" AS "prev_SUM(num_girls)"
+            FROM
+            (SELECT name AS name,
+                    sum(num_boys) AS "SUM(num_boys)",
+                    sum(num_girls) AS "SUM(num_girls)"
+            FROM my_schema.my_table
+            WHERE ds >= '1983-01-01 00:00:00'
+                AND ds < '2023-02-14 00:00:00'
+            GROUP BY name
+            ORDER BY "SUM(num_boys)" DESC) AS anon_1
+            JOIN query_a_results ON anon_1.name = query_a_results.name
+        """
+        simplified_query1 = " ".join(str.sql.split()).lower()
+        simplified_query2 = " ".join(expected_str.split()).lower()
+        assert table.id == 1
+        assert simplified_query1 == simplified_query2
+
+    @with_feature_flags(CHART_PLUGINS_EXPERIMENTAL=True)
+    def test_creates_time_comparison_query_no_columns(session: Session):
+        table = TestInstantTimeComparisonQueryGeneration.base_setup(session)
+        query_obj = TestInstantTimeComparisonQueryGeneration.generate_base_query_obj()
+        query_obj["columns"] = []
+        query_obj["metrics"][0]["column"]["groupby"] = False
+        query_obj["metrics"][1]["column"]["groupby"] = False
+
+        str = table.get_query_str_extended(query_obj)
+        expected_str = """
+            WITH query_a_results AS
+            (SELECT sum(num_boys) AS "SUM(num_boys)",
+                    sum(num_girls) AS "SUM(num_girls)"
+            FROM my_schema.my_table
+            WHERE ds >= '1984-01-01 00:00:00'
+                AND ds < '2024-02-14 00:00:00'
+            ORDER BY "SUM(num_boys)" DESC
+            LIMIT 10
+            OFFSET 0)
+            SELECT query_a_results."SUM(num_boys)" AS "SUM(num_boys)",
+                query_a_results."SUM(num_girls)" AS "SUM(num_girls)",
+                anon_1."SUM(num_boys)" AS "prev_SUM(num_boys)",
+                anon_1."SUM(num_girls)" AS "prev_SUM(num_girls)"
+            FROM
+            (SELECT sum(num_boys) AS "SUM(num_boys)",
+                    sum(num_girls) AS "SUM(num_girls)"
+            FROM my_schema.my_table
+            WHERE ds >= '1983-01-01 00:00:00'
+                AND ds < '2023-02-14 00:00:00'
+            ORDER BY "SUM(num_boys)" DESC) AS anon_1
+            JOIN query_a_results ON 1 = 1
+        """
+        simplified_query1 = " ".join(str.sql.split()).lower()
+        simplified_query2 = " ".join(expected_str.split()).lower()
+        assert table.id == 1
+        assert simplified_query1 == simplified_query2
+
+    @with_feature_flags(CHART_PLUGINS_EXPERIMENTAL=True)
+    def test_creates_time_comparison_rowcount_query(session: Session):
+        table = TestInstantTimeComparisonQueryGeneration.base_setup(session)
+        query_obj = TestInstantTimeComparisonQueryGeneration.generate_base_query_obj()
+        query_obj["is_rowcount"] = True
+        str = table.get_query_str_extended(query_obj)
+        expected_str = """
+            WITH query_a_results AS
+        (SELECT COUNT(*) AS rowcount
+        FROM
+            (SELECT name AS name,
+                    sum(num_boys) AS "SUM(num_boys)",
+                    sum(num_girls) AS "SUM(num_girls)"
+            FROM my_schema.my_table
+            WHERE ds >= '1984-01-01 00:00:00'
+                AND ds < '2024-02-14 00:00:00'
+            GROUP BY name
+            ORDER BY "SUM(num_boys)" DESC
+            LIMIT 10
+            OFFSET 0) AS rowcount_qry)
+        SELECT query_a_results.rowcount AS rowcount,
+            anon_1.rowcount AS prev_rowcount
+        FROM
+        (SELECT COUNT(*) AS rowcount
+        FROM
+            (SELECT name AS name,
+                    sum(num_boys) AS "SUM(num_boys)",
+                    sum(num_girls) AS "SUM(num_girls)"
+            FROM my_schema.my_table
+            WHERE ds >= '1983-01-01 00:00:00'
+                AND ds < '2023-02-14 00:00:00'
+            GROUP BY name
+            ORDER BY "SUM(num_boys)" DESC) AS rowcount_qry) AS anon_1
+        JOIN query_a_results ON 1 = 1
+        """
+        simplified_query1 = " ".join(str.sql.split()).lower()
+        simplified_query2 = " ".join(expected_str.split()).lower()
+        assert table.id == 1
+        assert simplified_query1 == simplified_query2
+
+    @with_feature_flags(CHART_PLUGINS_EXPERIMENTAL=True)
+    def test_creates_query_without_time_comparison(session: Session):
+        table = TestInstantTimeComparisonQueryGeneration.base_setup(session)
+        query_obj = TestInstantTimeComparisonQueryGeneration.generate_base_query_obj()
+        query_obj["extras"]["instant_time_comparison_info"] = None
+        str = table.get_query_str_extended(query_obj)
+        expected_str = """
+            SELECT name AS name,
+                sum(num_boys) AS "SUM(num_boys)",
+                sum(num_girls) AS "SUM(num_girls)"
+            FROM my_schema.my_table
+            WHERE ds >= '1984-01-01 00:00:00'
+            AND ds < '2024-02-14 00:00:00'
+            GROUP BY name
+            ORDER BY "SUM(num_boys)" DESC
+            LIMIT 10
+            OFFSET 0
+        """
+        simplified_query1 = " ".join(str.sql.split()).lower()
+        simplified_query2 = " ".join(expected_str.split()).lower()
+        assert table.id == 1
+        assert simplified_query1 == simplified_query2
+
+    @with_feature_flags(CHART_PLUGINS_EXPERIMENTAL=True)
+    def test_creates_time_comparison_query_custom_filters(session: Session):
+        table = TestInstantTimeComparisonQueryGeneration.base_setup(session)
+        query_obj = TestInstantTimeComparisonQueryGeneration.generate_base_query_obj()
+        query_obj["extras"]["instant_time_comparison_info"] = {
+            "range": "c",
+            "filter": {
+                "op": "TEMPORAL_RANGE",
+                "val": "1900-01-01 : 1950-02-14",
+                "col": "ds",
+            },
+        }
+        str = table.get_query_str_extended(query_obj)
+        expected_str = """
+            WITH query_a_results AS
+            (SELECT name AS name,
+                    sum(num_boys) AS "SUM(num_boys)",
+                    sum(num_girls) AS "SUM(num_girls)"
+            FROM my_schema.my_table
+            WHERE ds >= '1984-01-01 00:00:00'
+                AND ds < '2024-02-14 00:00:00'
+            GROUP BY name
+            ORDER BY "SUM(num_boys)" DESC
+            LIMIT 10
+            OFFSET 0)
+            SELECT query_a_results.name AS name,
+                query_a_results."SUM(num_boys)" AS "SUM(num_boys)",
+                query_a_results."SUM(num_girls)" AS "SUM(num_girls)",
+                anon_1."SUM(num_boys)" AS "prev_SUM(num_boys)",
+                anon_1."SUM(num_girls)" AS "prev_SUM(num_girls)"
+            FROM
+            (SELECT name AS name,
+                    sum(num_boys) AS "SUM(num_boys)",
+                    sum(num_girls) AS "SUM(num_girls)"
+            FROM my_schema.my_table
+            WHERE ds >= '1900-01-01 00:00:00'
+                AND ds < '1950-02-14 00:00:00'
+            GROUP BY name
+            ORDER BY "SUM(num_boys)" DESC) AS anon_1
+            JOIN query_a_results ON anon_1.name = query_a_results.name
+        """
+        simplified_query1 = " ".join(str.sql.split()).lower()
+        simplified_query2 = " ".join(expected_str.split()).lower()
+        assert table.id == 1
+        assert simplified_query1 == simplified_query2
+
+    @with_feature_flags(CHART_PLUGINS_EXPERIMENTAL=True)
+    def test_creates_time_comparison_query_paginated(session: Session):
+        table = TestInstantTimeComparisonQueryGeneration.base_setup(session)
+        query_obj = TestInstantTimeComparisonQueryGeneration.generate_base_query_obj()
+        query_obj["row_offset"] = 20
+        str = table.get_query_str_extended(query_obj)
+        expected_str = """
+            WITH query_a_results AS
+            (SELECT name AS name,
+                    sum(num_boys) AS "SUM(num_boys)",
+                    sum(num_girls) AS "SUM(num_girls)"
+            FROM my_schema.my_table
+            WHERE ds >= '1984-01-01 00:00:00'
+                AND ds < '2024-02-14 00:00:00'
+            GROUP BY name
+            ORDER BY "SUM(num_boys)" DESC
+            LIMIT 10
+            OFFSET 20)
+            SELECT query_a_results.name AS name,
+                query_a_results."SUM(num_boys)" AS "SUM(num_boys)",
+                query_a_results."SUM(num_girls)" AS "SUM(num_girls)",
+                anon_1."SUM(num_boys)" AS "prev_SUM(num_boys)",
+                anon_1."SUM(num_girls)" AS "prev_SUM(num_girls)"
+            FROM
+            (SELECT name AS name,
+                    sum(num_boys) AS "SUM(num_boys)",
+                    sum(num_girls) AS "SUM(num_girls)"
+            FROM my_schema.my_table
+            WHERE ds >= '1983-01-01 00:00:00'
+                AND ds < '2023-02-14 00:00:00'
+            GROUP BY name
+            ORDER BY "SUM(num_boys)" DESC) AS anon_1
+            JOIN query_a_results ON anon_1.name = query_a_results.name
+        """
+        simplified_query1 = " ".join(str.sql.split()).lower()
+        simplified_query2 = " ".join(expected_str.split()).lower()
+        assert table.id == 1
+        assert simplified_query1 == simplified_query2
+
+    @with_feature_flags(CHART_PLUGINS_EXPERIMENTAL=False)
+    def test_ignore_if_ff_off(session: Session):
+        table = TestInstantTimeComparisonQueryGeneration.base_setup(session)
+        query_obj = TestInstantTimeComparisonQueryGeneration.generate_base_query_obj()
+        str = table.get_query_str_extended(query_obj)
+        expected_str = """
+            SELECT name AS name,
+                sum(num_boys) AS "SUM(num_boys)",
+                sum(num_girls) AS "SUM(num_girls)"
+            FROM my_schema.my_table
+            WHERE ds >= '1984-01-01 00:00:00'
+            AND ds < '2024-02-14 00:00:00'
+            GROUP BY name
+            ORDER BY "SUM(num_boys)" DESC
+            LIMIT 10
+            OFFSET 0
+        """
+        simplified_query1 = " ".join(str.sql.split()).lower()
+        simplified_query2 = " ".join(expected_str.split()).lower()
+        assert table.id == 1
+        assert simplified_query1 == simplified_query2


### PR DESCRIPTION
### SUMMARY
To facilitate the discussion related our experimental feature for time comparison, we're extracting out form [the original PR](https://github.com/apache/superset/pull/27355) all the back end changes related to how to create left outer join queries when time comparison is needed. Using JOIN statement would help tackling issues related to `Row Limit` [discussed in this issue](https://github.com/apache/superset/issues/27504). Right now we are raising an exception message to users that try to generate these joined queries on databases where JOINs are not supported.

Known limitations:

- This approach only supports one time comparison at the time and doesn't rely on the `time_offset` property in the `QueryObject`, meaning that it's not compatible with existing API that allows for multiple ranges using such property.
- We are raising en exception when JOINs are not supported, we should instead fallback to `time_offset` API that applies the joins on DataFrame level



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
