### PR TITLE
chore(sql_parse): Provide more meaningful SQLGlot errors

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -752,11 +752,21 @@ class ParsedQuery:
             statements = parse(self.stripped(), dialect=self._dialect)
         except SqlglotError as ex:
             logger.warning("Unable to parse SQL (%s): %s", self._dialect, self.sql)
-            dialect = self._dialect or "generic"
+
+            message = (
+                "Error parsing near '{highlight}' at line {line}:{col}".format(  # pylint: disable=consider-using-f-string
+                    **ex.errors[0]
+                )
+                if isinstance(ex, ParseError)
+                else str(ex)
+            )
+
             raise SupersetSecurityException(
                 SupersetError(
                     error_type=SupersetErrorType.QUERY_SECURITY_ACCESS_ERROR,
-                    message=__(f"Unable to parse SQL ({dialect}): {self.sql}"),
+                    message=__(
+                        f"You may have an error in your SQL statement. {message}"
+                    ),
                     level=ErrorLevel.ERROR,
                 )
             ) from ex

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -277,26 +277,30 @@ def test_extract_tables_illdefined() -> None:
     with pytest.raises(SupersetSecurityException) as excinfo:
         extract_tables("SELECT * FROM schemaname.")
     assert (
-        str(excinfo.value) == "Unable to parse SQL (generic): SELECT * FROM schemaname."
+        str(excinfo.value)
+        == "You may have an error in your SQL statement. Error parsing near '.' at line 1:25"
     )
 
     with pytest.raises(SupersetSecurityException) as excinfo:
         extract_tables("SELECT * FROM catalogname.schemaname.")
     assert (
         str(excinfo.value)
-        == "Unable to parse SQL (generic): SELECT * FROM catalogname.schemaname."
+        == "You may have an error in your SQL statement. Error parsing near '.' at line 1:37"
     )
 
     with pytest.raises(SupersetSecurityException) as excinfo:
         extract_tables("SELECT * FROM catalogname..")
     assert (
         str(excinfo.value)
-        == "Unable to parse SQL (generic): SELECT * FROM catalogname.."
+        == "You may have an error in your SQL statement. Error parsing near '.' at line 1:27"
     )
 
     with pytest.raises(SupersetSecurityException) as excinfo:
         extract_tables('SELECT * FROM "tbname')
-    assert str(excinfo.value) == 'Unable to parse SQL (generic): SELECT * FROM "tbname'
+    assert (
+        str(excinfo.value)
+        == "You may have an error in your SQL statement. Error tokenizing 'SELECT * FROM \"tbnam'"
+    )
 
     # odd edge case that works
     assert extract_tables("SELECT * FROM catalogname..tbname") == {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

https://github.com/apache/superset/pull/26767 replaced the non-validating `sqlparse` parser with the pseudo-validating `SQLGlot` parser to aid with SQL parsing. The main use case for SQL parsing—from a security perspective—is to identify/extract the underlying tables/views referenced in the statement and checking whether the user is authorized to access them.

Previously, given the non-validating nature of `sqlparse`, virtually all SQL statements could be parsed—irrespective of whether they were valid—which meant that any syntax errors were reported by the underlying engine in a pseudo-meaningful manner. Now however, given that `SQLGlot` is more opinionated, syntax errors are detected by `SQLGlot` during the table/view extraction phase meaning that the query is never run and thus the engine's parser is never run resulting in a non-actionable error, i.e., it merely stated that the SQL could not be parsed. This is especially problematic in SQL Lab where freeform SQL is the norm and can be rather lengthy.

The TL;DR is now SQL statements which contain a syntax error are _likely_ going to be captured by `SQLGlot` upstream of being executed by the engine.

This PR proposes leveraging the messaging from `SQLGlot`'s `ParseError` or `TokenError` ([example](https://github.com/tobymao/sqlglot/blob/main/README.md#parser-errors)) to provide a more meaningful (and thus actionable) error message to the user.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### PREVIOUS 

Prior to https://github.com/apache/superset/pull/26767 `sqlparse` was able to "parse" the SQL statement—missing an `AND` after the `key = 'foobar'` clause—which was then executed by the Trino engine (given that the user had access to the `datainfra.one_row` table) resulting in the following Trino error,

<img width="1440" alt="Screenshot 2024-04-02 at 10 47 11 AM" src="https://github.com/apache/superset/assets/4567245/44e5f6ef-0030-41fa-bbb4-4b0f2101df0a">

which detected the error was around the `1` token.

#### CURRENT

After https://github.com/apache/superset/pull/26767 `SQLGlot` was (rightfully) unable to parse the SQL statement and thus could not extract the underlying tables which halted the execution flow. The resulting error message isn't overly helpful as it doesn't inform the user where the actual syntax error is.

<img width="1440" alt="Screenshot 2024-04-02 at 12 09 58 PM" src="https://github.com/apache/superset/assets/4567245/09198f62-0988-43e6-9966-bc0ca7d27370">

#### PROPOSED

Leveraging `SQLGlot`'s `ParseError` et al. exceptions to provide a more meaningful error message,

<img width="1440" alt="Screenshot 2024-04-02 at 3 42 47 PM" src="https://github.com/apache/superset/assets/4567245/8035ad26-07da-42ec-8349-76917988e2b4">

which correctly detected the error was around the `1` token. The messaging is loosely based on how MySQL presents errors.

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
