### PR TITLE
feat: GHA to bump python packages using supersetbot

### DIFF
--- a/.github/actions/setup-supersetbot/action.yml
+++ b/.github/actions/setup-supersetbot/action.yml
@@ -37,5 +37,4 @@ runs:
 
     - name: echo supersetbot version
       shell: bash
-      working-directory: supersetbot
       run: supersetbot version

--- a/.github/actions/setup-supersetbot/action.yml
+++ b/.github/actions/setup-supersetbot/action.yml
@@ -34,3 +34,8 @@ runs:
         # simple trick to install globally with dependencies
         npm pack
         npm install -g ./supersetbot*.tgz
+
+    - name: echo supersetbot version
+      shell: bash
+      working-directory: supersetbot
+      run: supersetbot version

--- a/.github/workflows/bump-python-package.yml
+++ b/.github/workflows/bump-python-package.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Setup supersetbot
         uses: ./.github/actions/setup-supersetbot/
+        with:
+          from-npm: 'false'
 
       - name: Set up Python ${{ inputs.python-version }}
         uses: actions/setup-python@v5
@@ -44,7 +46,7 @@ jobs:
 
       - name: supersetbot bump-python -p "${{ github.event.inputs.package }}"
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/bump-python-package.yml
+++ b/.github/workflows/bump-python-package.yml
@@ -33,8 +33,6 @@ jobs:
 
       - name: Setup supersetbot
         uses: ./.github/actions/setup-supersetbot/
-        with:
-          from-npm: 'false'
 
       - name: Set up Python ${{ inputs.python-version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/bump-python-package.yml
+++ b/.github/workflows/bump-python-package.yml
@@ -14,6 +14,7 @@ on:
         required: true
         description: Max number of PRs to open (0 for no limit)
         default: 5
+  pull_request: {}
 jobs:
   bump-python-package:
     runs-on: ubuntu-latest

--- a/.github/workflows/bump-python-package.yml
+++ b/.github/workflows/bump-python-package.yml
@@ -29,7 +29,7 @@ jobs:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4
         with:
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Setup supersetbot
         uses: ./.github/actions/setup-supersetbot/

--- a/.github/workflows/bump-python-package.yml
+++ b/.github/workflows/bump-python-package.yml
@@ -14,7 +14,7 @@ on:
         required: true
         description: Max number of PRs to open (0 for no limit)
         default: 5
-  pull_request: {}
+
 jobs:
   bump-python-package:
     runs-on: ubuntu-latest
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Python ${{ inputs.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Install pip-compile-multi
         run: pip install pip-compile-multi

--- a/.github/workflows/bump-python-package.yml
+++ b/.github/workflows/bump-python-package.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: true
-          fetch-depth: 0
+          ref: master
 
       - name: Setup supersetbot
         uses: ./.github/actions/setup-supersetbot/

--- a/.github/workflows/bump-python-package.yml
+++ b/.github/workflows/bump-python-package.yml
@@ -14,7 +14,6 @@ on:
         required: true
         description: Max number of PRs to open (0 for no limit)
         default: 5
-  pull_request: {}
 
 jobs:
   bump-python-package:
@@ -30,6 +29,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: true
+          fetch-depth: 0
 
       - name: Setup supersetbot
         uses: ./.github/actions/setup-supersetbot/

--- a/.github/workflows/bump-python-package.yml
+++ b/.github/workflows/bump-python-package.yml
@@ -14,6 +14,7 @@ on:
         required: true
         description: Max number of PRs to open (0 for no limit)
         default: 5
+  pull_request: {}
 
 jobs:
   bump-python-package:

--- a/.github/workflows/bump-python-package.yml
+++ b/.github/workflows/bump-python-package.yml
@@ -1,0 +1,65 @@
+name: Bump Python Package
+
+on:
+  # Can be triggered manually
+  workflow_dispatch:
+    inputs:
+      package:
+        required: false
+        description: The python package to bump (all if empty)
+      group:
+        required: false
+        description: The optional dependency group to bump (as defined in pyproject.toml)
+      limit:
+        required: true
+        description: Max number of PRs to open (0 for no limit)
+        default: 5
+jobs:
+  bump-python-package:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+      checks: write
+    steps:
+
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup supersetbot
+        uses: ./.github/actions/setup-supersetbot/
+
+      - name: Set up Python ${{ inputs.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.10
+
+      - name: Install pip-compile-multi
+        run: pip install pip-compile-multi
+
+      - name: supersetbot bump-python -p "${{ github.event.inputs.package }}"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
+          PACKAGE_OPT=""
+          if [ -n "${{ github.event.inputs.package }}" ]; then
+            PACKAGE_OPT="-p ${{ github.event.inputs.package }}"
+          fi
+
+          GROUP_OPT=""
+          if [ -n "${{ github.event.inputs.group }}" ]; then
+            GROUP_OPT="-g ${{ github.event.inputs.group }}"
+          fi
+
+          supersetbot bump-python \
+            --verbose \
+            --use-current-repo \
+            --limit ${{ github.event.inputs.limit }} \
+            $PACKAGE_OPT \
+            $GROUP_OPT

--- a/.github/workflows/bump-python-package.yml
+++ b/.github/workflows/bump-python-package.yml
@@ -64,6 +64,7 @@ jobs:
           supersetbot bump-python \
             --verbose \
             --use-current-repo \
+            --include-subpackages \
             --limit ${{ github.event.inputs.limit }} \
             $PACKAGE_OPT \
             $GROUP_OPT


### PR DESCRIPTION
This PR has a GHA that calls supersetbot to generate PRs that
bump python packages, dependabot-style, in a way that integrates
with pip-compile-multi and our complex setup for dependency
management.

I moved the supersetbot to its own repo, here's the related logic:
https://github.com/apache-superset/supersetbot/blob/main/src/cli.js#L156-L170