### PR TITLE
fix(models.core:Database): Allocate a SQLA engine once per process per URL.

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -407,7 +407,9 @@ class Database(
         return (
             username
             if (username := get_username())
-            else object_url.username if self.impersonate_user else None
+            else object_url.username
+            if self.impersonate_user
+            else None
         )
 
     @contextmanager

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -125,12 +125,11 @@ class EngineManager:  # pylint: disable=R0903
     """
 
     _lock = threading.Lock()
-    _sqla_engines: dict[tuple[str, tuple], Engine] = {}
+    _sqla_engines: dict[tuple[str, tuple[Any, ...]], Engine] = {}
 
     @classmethod
-    def create_engine(cls, sqlalchemy_url: str, **params) -> Engine:
-
-        def dict_to_sortedtuple(cparams: dict[str, Any]) -> tuple:
+    def create_engine(cls, sqlalchemy_url: str, **params: Any) -> Engine:
+        def dict_to_sortedtuple(cparams: dict[str, Any]) -> tuple[Any, ...]:
             return tuple(
                 (k, dict_to_sortedtuple(v) if isinstance(v, dict) else v)
                 for k, v in sorted(cparams.items())

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -23,6 +23,7 @@ import builtins
 import json
 import logging
 import textwrap
+import threading
 from ast import literal_eval
 from contextlib import closing, contextmanager, nullcontext, suppress
 from copy import deepcopy
@@ -111,6 +112,32 @@ class CssTemplate(Model, AuditMixinNullable):
 class ConfigurationMethod(StrEnum):
     SQLALCHEMY_FORM = "sqlalchemy_form"
     DYNAMIC_FORM = "dynamic_form"
+
+
+class EngineManager:
+    """
+    Allocate an engine once per process as per API documentation
+    https://docs.sqlalchemy.org/en/20/core/connections.html
+
+    Quote:
+      The typical usage of create_engine() is once per particular database URL,
+      held globally for the lifetime of a single application process
+    """
+
+    _lock = threading.Lock()
+    _sqla_engines: dict[str, tuple[Engine, dict]] = {}
+
+    @classmethod
+    def create_engine(cls, sqlalchemy_url: str, **params) -> Engine:
+        with cls._lock:
+            tpl = cls._sqla_engines.get(sqlalchemy_url)
+            if tpl is not None:
+                engine, cparams = tpl
+                if cparams == params:
+                    return engine
+            engine = create_engine(sqlalchemy_url, **params)
+            cls._sqla_engines[sqlalchemy_url] = (engine, params)
+        return engine
 
 
 class Database(
@@ -376,9 +403,7 @@ class Database(
         return (
             username
             if (username := get_username())
-            else object_url.username
-            if self.impersonate_user
-            else None
+            else object_url.username if self.impersonate_user else None
         )
 
     @contextmanager
@@ -513,7 +538,7 @@ class Database(
                 source,
             )
         try:
-            return create_engine(sqlalchemy_url, **params)
+            return EngineManager.create_engine(sqlalchemy_url, **params)
         except Exception as ex:
             raise self.db_engine_spec.get_dbapi_mapped_exception(ex)
 

--- a/tests/integration_tests/model_tests.py
+++ b/tests/integration_tests/model_tests.py
@@ -37,7 +37,7 @@ import tests.integration_tests.test_app
 from superset import app, db as metadata_db
 from superset.db_engine_specs.postgres import PostgresEngineSpec
 from superset.common.db_query_status import QueryStatus
-from superset.models.core import Database
+from superset.models.core import Database, EngineManager
 from superset.models.slice import Slice
 from superset.utils.database import get_example_database
 
@@ -52,6 +52,10 @@ class TestDatabaseModel(SupersetTestCase):
     @unittest.skipUnless(
         SupersetTestCase.is_module_installed("requests"), "requests not installed"
     )
+    def tearDown(self):
+        EngineManager._sqla_engines.clear()
+        super().tearDown()
+
     def test_database_schema_presto(self):
         sqlalchemy_uri = "presto://presto.airbnb.io:8080/hive/default"
         model = Database(database_name="test_database", sqlalchemy_uri=sqlalchemy_uri)


### PR DESCRIPTION
### SUMMARY
As per issue #27897,  SqlAlchemy recommends that 

"""
The typical usage of [create_engine()](https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.create_engine) is once per particular database URL, held globally for the lifetime of a single application process. A single [Engine](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Engine) manages many individual [DBAPI](https://docs.sqlalchemy.org/en/20/glossary.html#term-DBAPI) connections on behalf of the process and is intended to be called upon in a concurrent fashion. The [Engine](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Engine) is not synonymous to the DBAPI connect() function, which represents just one connection resource - the [Engine](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Engine) is most efficient when created just once at the module level of an application, not per-object or per-function call.
"""

The superset.models.core::Database class is currently allocating Engine objects whenever a Database object is instantiated which happens twice(?) per 'api/v1/chart/data' API access. This is not the intended usage of the SQL Alchemy API and causes mechanisms such as connection pooling not to work correctly.

Connection pooling is an important feature in order to control access to databases. For instance when using 'duckdb', it is recommended that one uses a small number of concurrent requests (or a single concurrent request) and instead take advantage of the inherent parallelism in the database engine. Other engines will have other ideal settings.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Configure a connection pool using the `DB_CONNECTION_MUTATOR` hook.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
