### PR TITLE
docs: replace broken david badges with libraries.io

### DIFF
--- a/superset-embedded-sdk/README.md
+++ b/superset-embedded-sdk/README.md
@@ -17,6 +17,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 
+[![Version](https://img.shields.io/npm/v/%40superset-ui%2Fembedded-sdk?style=flat)](https://www.npmjs.com/package/@superset-ui/embedded-sdk)
+[![Libraries.io](https://img.shields.io/librariesio/release/npm/%40superset-ui%2Fembedded-sdk?style=flat)](https://libraries.io/npm/@superset-ui%2Fembedded-sdk)
+
 # Superset Embedded SDK
 
 The Embedded SDK allows you to embed dashboards from Superset into your own app,

--- a/superset-frontend/packages/generator-superset/README.md
+++ b/superset-frontend/packages/generator-superset/README.md
@@ -20,7 +20,7 @@ under the License.
 # generator-superset
 
 [![Version](https://img.shields.io/npm/v/@superset-ui/generator-superset.svg?style=flat)](https://www.npmjs.com/package/@superset-ui/generator-superset)
-[![David (path)](https://img.shields.io/david/apache-superset/superset-ui.svg?path=packages%2Fgenerator-superset&style=flat-square)](https://david-dm.org/apache-superset/superset-ui?path=packages/generator-superset)
+[![Libraries.io](https://img.shields.io/librariesio/release/npm/%40superset-ui%2Fgenerator-superset)](https://libraries.io/npm/@superset-ui%2Fgenerator-superset)
 
 > Scaffolder for Superset
 

--- a/superset-frontend/packages/superset-ui-chart-controls/README.md
+++ b/superset-frontend/packages/superset-ui-chart-controls/README.md
@@ -20,7 +20,7 @@ under the License.
 ## @superset-ui/chart-controls
 
 [![Version](https://img.shields.io/npm/v/@superset-ui/chart-controls.svg?style=flat)](https://www.npmjs.com/package/@superset-ui/chart-controls)
-[![David (path)](https://img.shields.io/david/apache-superset/superset-ui.svg?path=packages%2Fsuperset-ui-chart-controls&style=flat-square)](https://david-dm.org/apache-superset/superset-ui?path=packages/superset-ui-chart-controls)
+[![Libraries.io](https://img.shields.io/librariesio/release/npm/%40superset-ui%2Fchart-controls)](https://libraries.io/npm/@superset-ui%2Fchart-controls)
 
 Description
 

--- a/superset-frontend/packages/superset-ui-core/README.md
+++ b/superset-frontend/packages/superset-ui-core/README.md
@@ -20,7 +20,7 @@ under the License.
 ## @superset-ui/core
 
 [![Version](https://img.shields.io/npm/v/@superset-ui/core.svg?style=flat)](https://www.npmjs.com/package/@superset-ui/core)
-[![David (path)](https://img.shields.io/david/apache-superset/superset-ui.svg?path=packages%2Fsuperset-ui-core&style=flat-square)](https://david-dm.org/apache-superset/superset-ui?path=packages/superset-ui-core)
+[![Libraries.io](https://img.shields.io/librariesio/release/npm/%40superset-ui%2Fcore?style=flat)](https://libraries.io/npm/@superset-ui%2Fcore)
 
 Description
 

--- a/superset-frontend/packages/superset-ui-demo/README.md
+++ b/superset-frontend/packages/superset-ui-demo/README.md
@@ -19,8 +19,7 @@ under the License.
 
 ## @superset-ui/demo
 
-[![Version](https://img.shields.io/npm/v/@superset-ui/demo.svg?style=flat)](https://www.npmjs.com/package/@superset-ui/demo)
-[![David (path)](https://img.shields.io/david/apache-superset/superset-ui.svg?path=packages%2Fsuperset-ui-demo&style=flat-square)](https://david-dm.org/apache-superset/superset-ui?path=packages/superset-ui-demo)
+[![Version](https://img.shields.io/github/package-json/v/apache/superset?filename=superset-frontend%2Fpackages%2Fsuperset-ui-demo%2Fpackage.json&style=flat)](https://github.com/apache/superset/blob/master/superset-frontend/packages/superset-ui-demo/package.json)
 
 Storybook of `@superset-ui` packages. See it live at
 [apache-superset.github.io/superset-ui](https://apache-superset.github.io/superset-ui)

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/README.md
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/README.md
@@ -19,8 +19,8 @@ under the License.
 
 ## @superset-ui/legacy-plugin-chart-calendar
 
-[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-calendar.svg?style=flat-square)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-calendar)
-[![David (path)](https://img.shields.io/david/apache-superset/superset-ui-plugins.svg?path=packages%2Fsuperset-ui-legacy-plugin-chart-calendar&style=flat-square)](https://david-dm.org/apache-superset/superset-ui-plugins?path=packages/superset-ui-legacy-plugin-chart-calendar)
+[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-calendar.svg?style=flat)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-calendar)
+[![Libraries.io](https://img.shields.io/librariesio/release/npm/%40superset-ui%2Flegacy-plugin-chart-calendar?style=flat)](https://libraries.io/npm/@superset-ui%2Flegacy-plugin-chart-calendar)
 
 This plugin provides Calendar Heatmap for Superset.
 

--- a/superset-frontend/plugins/legacy-plugin-chart-chord/README.md
+++ b/superset-frontend/plugins/legacy-plugin-chart-chord/README.md
@@ -19,8 +19,8 @@ under the License.
 
 ## @superset-ui/legacy-plugin-chart-chord
 
-[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-chord.svg?style=flat-square)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-chord)
-[![David (path)](https://img.shields.io/david/apache-superset/superset-ui-plugins.svg?path=packages%2Fsuperset-ui-legacy-plugin-chart-chord&style=flat-square)](https://david-dm.org/apache-superset/superset-ui-plugins?path=packages/superset-ui-legacy-plugin-chart-chord)
+[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-chord.svg?style=flat)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-chord)
+[![Libraries.io](https://img.shields.io/librariesio/release/npm/%40superset-ui%2Flegacy-plugin-chart-chord?style=flat)](https://libraries.io/npm/@superset-ui%2Flegacy-plugin-chart-chord)
 
 This plugin provides Chord Diagram for Superset.
 

--- a/superset-frontend/plugins/legacy-plugin-chart-country-map/README.md
+++ b/superset-frontend/plugins/legacy-plugin-chart-country-map/README.md
@@ -19,8 +19,8 @@ under the License.
 
 ## @superset-ui/legacy-plugin-chart-country-map
 
-[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-country-map.svg?style=flat-square)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-country-map)
-[![David (path)](https://img.shields.io/david/apache-superset/superset-ui-plugins.svg?path=packages%2Fsuperset-ui-legacy-plugin-chart-country-map&style=flat-square)](https://david-dm.org/apache-superset/superset-ui-plugins?path=packages/superset-ui-legacy-plugin-chart-country-map)
+[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-country-map.svg?style=flat)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-country-map)
+[![Libraries.io](https://img.shields.io/librariesio/release/npm/%40superset-ui%2Flegacy-plugin-chart-country-map?style=flat)](https://libraries.io/npm/@superset-ui%2Flegacy-plugin-chart-country-map)
 
 This plugin provides Country Map for Superset.
 

--- a/superset-frontend/plugins/legacy-plugin-chart-event-flow/README.md
+++ b/superset-frontend/plugins/legacy-plugin-chart-event-flow/README.md
@@ -19,8 +19,8 @@ under the License.
 
 ## @superset-ui/legacy-plugin-chart-event-flow
 
-[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-event-flow.svg?style=flat-square)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-event-flow)
-[![David (path)](https://img.shields.io/david/apache-superset/superset-ui-plugins.svg?path=packages%2Fsuperset-ui-legacy-plugin-chart-event-flow&style=flat-square)](https://david-dm.org/apache-superset/superset-ui-plugins?path=packages/superset-ui-legacy-plugin-chart-event-flow)
+[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-event-flow.svg?style=flat)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-event-flow)
+[![Libraries.io](https://img.shields.io/librariesio/release/npm/%40superset-ui%2Flegacy-plugin-chart-event-flow?style=flat)](https://libraries.io/npm/@superset-ui%2Flegacy-plugin-chart-event-flow)
 
 This plugin provides Event Flow for Superset.
 

--- a/superset-frontend/plugins/legacy-plugin-chart-heatmap/README.md
+++ b/superset-frontend/plugins/legacy-plugin-chart-heatmap/README.md
@@ -19,8 +19,8 @@ under the License.
 
 ## @superset-ui/legacy-plugin-chart-heatmap
 
-[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-heatmap.svg?style=flat-square)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-heatmap)
-[![David (path)](https://img.shields.io/david/apache-superset/superset-ui-plugins.svg?path=packages%2Fsuperset-ui-legacy-plugin-chart-heatmap&style=flat-square)](https://david-dm.org/apache-superset/superset-ui-plugins?path=packages/superset-ui-legacy-plugin-chart-heatmap)
+[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-heatmap.svg?style=flat)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-heatmap)
+[![Libraries.io](https://img.shields.io/librariesio/release/npm/%40superset-ui%2Flegacy-plugin-chart-heatmap?style=flat)](https://libraries.io/npm/@superset-ui%2Flegacy-plugin-chart-heatmap)
 
 This plugin provides Heatmap for Superset.
 

--- a/superset-frontend/plugins/legacy-plugin-chart-histogram/README.md
+++ b/superset-frontend/plugins/legacy-plugin-chart-histogram/README.md
@@ -19,8 +19,8 @@ under the License.
 
 ## @superset-ui/legacy-plugin-chart-histogram
 
-[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-histogram.svg?style=flat-square)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-histogram)
-[![David (path)](https://img.shields.io/david/apache-superset/superset-ui-plugins.svg?path=packages%2Fsuperset-ui-legacy-plugin-chart-histogram&style=flat-square)](https://david-dm.org/apache-superset/superset-ui-plugins?path=packages/superset-ui-legacy-plugin-chart-histogram)
+[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-histogram.svg?style=flat)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-histogram)
+[![Libraries.io](https://img.shields.io/librariesio/release/npm/%40superset-ui%2Flegacy-plugin-chart-histogram?style=flat)](https://libraries.io/npm/@superset-ui%2Flegacy-plugin-chart-histogram)
 
 This plugin provides Histogram for Superset.
 

--- a/superset-frontend/plugins/legacy-plugin-chart-horizon/README.md
+++ b/superset-frontend/plugins/legacy-plugin-chart-horizon/README.md
@@ -19,8 +19,8 @@ under the License.
 
 ## @superset-ui/legacy-plugin-chart-horizon
 
-[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-horizon.svg?style=flat-square)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-horizon)
-[![David (path)](https://img.shields.io/david/apache-superset/superset-ui-plugins.svg?path=packages%2Fsuperset-ui-legacy-plugin-chart-horizon&style=flat-square)](https://david-dm.org/apache-superset/superset-ui-plugins?path=packages/superset-ui-legacy-plugin-chart-horizon)
+[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-horizon.svg?style=flat)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-horizon)
+[![Libraries.io](https://img.shields.io/librariesio/release/npm/%40superset-ui%2Flegacy-plugin-chart-horizon?style=flat)](https://libraries.io/npm/@superset-ui%2Flegacy-plugin-chart-horizon)
 
 This plugin provides Horizon for Superset.
 

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/README.md
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/README.md
@@ -19,8 +19,8 @@ under the License.
 
 ## @superset-ui/legacy-plugin-chart-map-box
 
-[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-map-box.svg?style=flat-square)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-map-box)
-[![David (path)](https://img.shields.io/david/apache-superset/superset-ui-plugins.svg?path=packages%2Fsuperset-ui-legacy-plugin-chart-map-box&style=flat-square)](https://david-dm.org/apache-superset/superset-ui-plugins?path=packages/superset-ui-legacy-plugin-chart-map-box)
+[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-map-box.svg?style=flat)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-map-box)
+[![Libraries.io](https://img.shields.io/librariesio/release/npm/%40superset-ui%2Flegacy-plugin-chart-map-box?style=flat)](https://libraries.io/npm/@superset-ui%2Flegacy-plugin-chart-map-box)
 
 This plugin provides MapBox for Superset.
 

--- a/superset-frontend/plugins/legacy-plugin-chart-paired-t-test/README.md
+++ b/superset-frontend/plugins/legacy-plugin-chart-paired-t-test/README.md
@@ -19,8 +19,8 @@ under the License.
 
 ## @superset-ui/legacy-plugin-chart-paired-t-test
 
-[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-paired-t-test.svg?style=flat-square)](hhttps://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-paired-t-test)
-[![David (path)](https://img.shields.io/david/apache-superset/superset-ui-plugins.svg?path=packages%2Fsuperset-ui-legacy-plugin-chart-paired-t-test&style=flat-square)](https://david-dm.org/apache-superset/superset-ui-plugins?path=packages/superset-ui-legacy-plugin-chart-paired-t-test)
+[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-paired-t-test.svg?style=flat)](hhttps://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-paired-t-test)
+[![Libraries.io](https://img.shields.io/librariesio/release/npm/%40superset-ui%2Flegacy-plugin-chart-paired-t-test?style=flat)](https://libraries.io/npm/@superset-ui%2Flegacy-plugin-chart-paired-t-test)
 
 This plugin provides Paired T Test for Superset.
 

--- a/superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/README.md
+++ b/superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/README.md
@@ -19,8 +19,8 @@ under the License.
 
 ## @superset-ui/legacy-plugin-chart-parallel-coordinates
 
-[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-parallel-coordinates.svg?style=flat-square)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-parallel-coordinates)
-[![David (path)](https://img.shields.io/david/apache-superset/superset-ui-plugins.svg?path=packages%2Fsuperset-ui-legacy-plugin-chart-parallel-coordinates&style=flat-square)](https://david-dm.org/apache-superset/superset-ui-plugins?path=packages/superset-ui-legacy-plugin-chart-parallel-coordinates)
+[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-parallel-coordinates.svg?style=flat)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-parallel-coordinates)
+[![Libraries.io](https://img.shields.io/librariesio/release/npm/%40superset-ui%2Flegacy-plugin-chart-parallel-coordinates?style=flat)](https://libraries.io/npm/@superset-ui%2Flegacy-plugin-chart-parallel-coordinates)
 
 This plugin provides Parallel Coordinates for Superset.
 

--- a/superset-frontend/plugins/legacy-plugin-chart-partition/README.md
+++ b/superset-frontend/plugins/legacy-plugin-chart-partition/README.md
@@ -19,8 +19,8 @@ under the License.
 
 ## @superset-ui/legacy-plugin-chart-partition
 
-[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-partition.svg?style=flat-square)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-partition)
-[![David (path)](https://img.shields.io/david/apache-superset/superset-ui-plugins.svg?path=packages%2Fsuperset-ui-legacy-plugin-chart-partition&style=flat-square)](https://david-dm.org/apache-superset/superset-ui-plugins?path=packages/superset-ui-legacy-plugin-chart-partition)
+[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-partition.svg?style=flat)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-partition)
+[![Libraries.io](https://img.shields.io/librariesio/release/npm/%40superset-ui%2Flegacy-plugin-chart-partition?style=flat)](https://libraries.io/npm/@superset-ui%2Flegacy-plugin-chart-partition)
 
 This plugin provides Partition for Superset.
 

--- a/superset-frontend/plugins/legacy-plugin-chart-rose/README.md
+++ b/superset-frontend/plugins/legacy-plugin-chart-rose/README.md
@@ -19,8 +19,8 @@ under the License.
 
 ## @superset-ui/legacy-plugin-chart-rose
 
-[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-rose.svg?style=flat-square)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-rose)
-[![David (path)](https://img.shields.io/david/apache-superset/superset-ui-plugins.svg?path=packages%2Fsuperset-ui-legacy-plugin-chart-rose&style=flat-square)](https://david-dm.org/apache-superset/superset-ui-plugins?path=packages/superset-ui-legacy-plugin-chart-rose)
+[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-rose.svg?style=flat)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-rose)
+[![Libraries.io](https://img.shields.io/librariesio/release/npm/%40superset-ui%2Flegacy-plugin-chart-rose?style=flat)](https://libraries.io/npm/@superset-ui%2Flegacy-plugin-chart-rose)
 
 This plugin provides Nightingale Rose Diagram for Superset.
 

--- a/superset-frontend/plugins/legacy-plugin-chart-sankey-loop/README.md
+++ b/superset-frontend/plugins/legacy-plugin-chart-sankey-loop/README.md
@@ -19,8 +19,8 @@ under the License.
 
 ## @superset-ui/legacy-plugin-chart-sankey-loop
 
-[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-sankey.svg?style=flat-square)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-sankey)
-[![David (path)](https://img.shields.io/david/apache-superset/superset-ui-plugins.svg?path=packages%2Fsuperset-ui-legacy-plugin-chart-sankey&style=flat-square)](https://david-dm.org/apache-superset/superset-ui-plugins?path=packages/superset-ui-legacy-plugin-chart-sankey)
+[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-sankey.svg?style=flat)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-sankey)
+[![Libraries.io](https://img.shields.io/librariesio/release/npm/%40superset-ui%2Flegacy-plugin-chart-sankey-loop?style=flat)](https://libraries.io/npm/@superset-ui%2Flegacy-plugin-chart-sankey-loop)
 
 This plugin provides Sankey Diagram with loops for Superset.
 

--- a/superset-frontend/plugins/legacy-plugin-chart-sankey/README.md
+++ b/superset-frontend/plugins/legacy-plugin-chart-sankey/README.md
@@ -19,8 +19,8 @@ under the License.
 
 ## @superset-ui/legacy-plugin-chart-sankey
 
-[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-sankey.svg?style=flat-square)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-sankey)
-[![David (path)](https://img.shields.io/david/apache-superset/superset-ui-plugins.svg?path=packages%2Fsuperset-ui-legacy-plugin-chart-sankey&style=flat-square)](https://david-dm.org/apache-superset/superset-ui-plugins?path=packages/superset-ui-legacy-plugin-chart-sankey)
+[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-sankey.svg?style=flat)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-sankey)
+[![Libraries.io](https://img.shields.io/librariesio/release/npm/%40superset-ui%2Flegacy-plugin-chart-sankey?style=flat)](https://libraries.io/npm/@superset-ui%2Flegacy-plugin-chart-sankey)
 
 This plugin provides Sankey Diagram for Superset.
 

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/README.md
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/README.md
@@ -19,8 +19,8 @@ under the License.
 
 ## @superset-ui/legacy-plugin-chart-world-map
 
-[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-world-map.svg?style=flat-square)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-world-map)
-[![David (path)](https://img.shields.io/david/apache-superset/superset-ui-plugins.svg?path=packages%2Fsuperset-ui-legacy-plugin-chart-world-map&style=flat-square)](https://david-dm.org/apache-superset/superset-ui-plugins?path=packages/superset-ui-legacy-plugin-chart-world-map)
+[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-plugin-chart-world-map.svg?style=flat)](https://www.npmjs.com/package/@superset-ui/legacy-plugin-chart-world-map)
+[![Libraries.io](https://img.shields.io/librariesio/release/npm/%40superset-ui%2Flegacy-plugin-chart-world-map?style=flat)](https://libraries.io/npm/@superset-ui%2Flegacy-plugin-chart-world-map)
 
 This plugin provides World Map for Superset.
 

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/README.md
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/README.md
@@ -19,8 +19,8 @@ under the License.
 
 ## @superset-ui/legacy-preset-chart-deckgl
 
-[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-preset-chart-deckgl.svg?style=flat-square)](https://img.shields.io/npm/v/@superset-ui/legacy-preset-chart-deckgl.svg?style=flat-square)
-[![David (path)](https://img.shields.io/david/apache-superset/superset-ui-plugins.svg?path=packages%2Fsuperset-ui-legacy-preset-chart-deckgl&style=flat-square)](https://david-dm.org/apache-superset/superset-ui-plugins?path=packages/superset-ui-legacy-preset-chart-deckgl)
+[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-preset-chart-deckgl.svg?style=flat)](https://img.shields.io/npm/v/@superset-ui/legacy-preset-chart-deckgl.svg?style=flat-square)
+[![Libraries.io](https://img.shields.io/librariesio/release/npm/%40superset-ui%2Flegacy-preset-chart-deckgl?style=flat)](https://libraries.io/npm/@superset-ui%2Flegacy-preset-chart-deckgl)
 
 This plugin provides `deck.gl` for Superset.
 

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/README.md
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/README.md
@@ -19,8 +19,8 @@ under the License.
 
 ## @superset-ui/legacy-preset-chart-nvd3
 
-[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-preset-chart-nvd3.svg?style=flat-square)](https://www.npmjs.com/package/@superset-ui/legacy-preset-chart-nvd3)
-[![David (path)](https://img.shields.io/david/apache-superset/superset-ui-plugins.svg?path=packages%2Fsuperset-ui-legacy-preset-chart-nvd3&style=flat-square)](https://david-dm.org/apache-superset/superset-ui-plugins?path=packages/superset-ui-legacy-preset-chart-nvd3)
+[![Version](https://img.shields.io/npm/v/@superset-ui/legacy-preset-chart-nvd3.svg?style=flat)](https://www.npmjs.com/package/@superset-ui/legacy-preset-chart-nvd3)
+[![Libraries.io](https://img.shields.io/librariesio/release/npm/%40superset-ui%2Flegacy-preset-chart-nvd3?style=flat)](https://libraries.io/npm/@superset-ui%2Flegacy-preset-chart-nvd3)
 
 This plugin provides Big Number for Superset.
 

--- a/superset-frontend/plugins/plugin-chart-echarts/README.md
+++ b/superset-frontend/plugins/plugin-chart-echarts/README.md
@@ -19,8 +19,8 @@ under the License.
 
 ## @superset-ui/plugin-chart-echarts
 
-[![Version](https://img.shields.io/npm/v/@superset-ui/plugin-chart-echarts.svg?style=flat-square)](https://www.npmjs.com/package/@superset-ui/plugin-chart-echarts)
-[![David (path)](https://img.shields.io/david/apache-superset/superset-ui.svg?path=packages%2Fsuperset-ui-plugin-chart-echarts&style=flat-square)](https://david-dm.org/apache-superset/superset-ui?path=packages/superset-ui-plugin-chart-echarts)
+[![Version](https://img.shields.io/npm/v/@superset-ui/plugin-chart-echarts.svg?style=flat)](https://www.npmjs.com/package/@superset-ui/plugin-chart-echarts)
+[![Libraries.io](https://img.shields.io/librariesio/release/npm/%40superset-ui%2Fplugin-chart-echarts?style=flat)](https://libraries.io/npm/@superset-ui%2Fplugin-chart-echarts)
 
 This plugin provides Echarts viz plugins for Superset:
 

--- a/superset-frontend/plugins/plugin-chart-handlebars/README.md
+++ b/superset-frontend/plugins/plugin-chart-handlebars/README.md
@@ -19,7 +19,8 @@ under the License.
 
 ## @superset-ui/plugin-chart-handlebars
 
-[![Version](https://img.shields.io/npm/v/@superset-ui/plugin-chart-handlebars.svg?style=flat-square)](https://www.npmjs.com/package/@superset-ui/plugin-chart-handlebars)
+[![Version](https://img.shields.io/npm/v/@superset-ui/plugin-chart-handlebars.svg?style=flat)](https://www.npmjs.com/package/@superset-ui/plugin-chart-handlebars)
+[![Libraries.io](https://img.shields.io/librariesio/release/npm/%40superset-ui%2Fplugin-chart-handlebars?style=flat)](https://libraries.io/npm/@superset-ui%2Fplugin-chart-handlebars)
 
 This plugin renders the data using a handlebars template.
 

--- a/superset-frontend/plugins/plugin-chart-pivot-table/README.md
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/README.md
@@ -19,7 +19,8 @@ under the License.
 
 ## @superset-ui/plugin-chart-pivot-table
 
-[![Version](https://img.shields.io/npm/v/@superset-ui/plugin-chart-pivot-table.svg?style=flat-square)](https://www.npmjs.com/package/@superset-ui/plugin-chart-pivot-table)
+[![Version](https://img.shields.io/npm/v/@superset-ui/plugin-chart-pivot-table.svg?style=flat)](https://www.npmjs.com/package/@superset-ui/plugin-chart-pivot-table)
+[![Libraries.io](https://img.shields.io/librariesio/release/npm/%40superset-ui%2Fplugin-chart-pivot-table?style=flat)](https://libraries.io/npm/@superset-ui%2Fplugin-chart-pivot-table)
 
 This plugin provides Pivot Table for Superset.
 

--- a/superset-frontend/plugins/plugin-chart-table/README.md
+++ b/superset-frontend/plugins/plugin-chart-table/README.md
@@ -19,8 +19,8 @@ under the License.
 
 ## @superset-ui/plugin-chart-table
 
-[![Version](https://img.shields.io/npm/v/@superset-ui/plugin-chart-table.svg?style=flat-square)](https://www.npmjs.com/package/@superset-ui/plugin-chart-table)
-[![David (path)](https://img.shields.io/david/apache-superset/superset-ui-plugins.svg?path=packages%2Fsuperset-ui-plugin-chart-table&style=flat-square)](https://david-dm.org/apache-superset/superset-ui-plugins?path=plugins/superset-ui-plugin-chart-table)
+[![Version](https://img.shields.io/npm/v/@superset-ui/plugin-chart-table.svg?style=flat)](https://www.npmjs.com/package/@superset-ui/plugin-chart-table)
+[![Libraries.io](https://img.shields.io/librariesio/release/npm/%40superset-ui%2Fplugin-chart-table?style=flat)](https://libraries.io/npm/@superset-ui%2Fplugin-chart-table)
 
 This plugin provides Table chart for Superset.
 

--- a/superset-frontend/plugins/plugin-chart-word-cloud/README.md
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/README.md
@@ -19,8 +19,8 @@ under the License.
 
 ## @superset-ui/plugin-chart-word-cloud
 
-[![Version](https://img.shields.io/npm/v/@superset-ui/plugin-chart-word-cloud.svg?style=flat-square)](https://www.npmjs.com/package/@superset-ui/plugin-chart-word-cloud)
-[![David (path)](https://img.shields.io/david/apache-superset/superset-ui-plugins.svg?path=packages%2Fsuperset-ui-plugin-chart-word-cloud&style=flat-square)](https://david-dm.org/apache-superset/superset-ui-plugins?path=packages/superset-ui-plugin-chart-word-cloud)
+[![Version](https://img.shields.io/npm/v/@superset-ui/plugin-chart-word-cloud.svg?style=flat)](https://www.npmjs.com/package/@superset-ui/plugin-chart-word-cloud)
+[![Libraries.io](https://img.shields.io/librariesio/release/npm/%40superset-ui%2Fplugin-chart-word-cloud?style=flat)](https://libraries.io/npm/@superset-ui%2Fplugin-chart-word-cloud)
 
 This plugin provides Word Cloud for Superset.
 


### PR DESCRIPTION
### SUMMARY

Many of the packages had broken badges left still trying to use david-dm.org for dependency tracking.

### TESTING INSTRUCTIONS

View the rich diff

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
