### PR TITLE
fix: retain non-ascii characters in result sets

### DIFF
--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -69,15 +69,14 @@ def stringify_values(array: NDArray[Any]) -> NDArray[Any]:
 
     with np.nditer(result, flags=["refs_ok"], op_flags=[["readwrite"]]) as it:
         for obj in it:
-            if pd.isna(obj.item()):  # Correctly check for pandas NA or numpy NaN values
-                obj[
-                    ...
-                ] = None  # Directly assign None to handle missing values appropriately
+            item = obj.item()  # Extract the scalar value for manipulation
+            if pd.isna(item):  # Handle missing values by setting them to None
+                obj[...] = None
             else:
                 try:
                     # Convert only if the string is fully ASCII, otherwise leave as is
                     if obj.item().encode("ascii", "ignore").decode() == obj.item():
-                        obj[...] = obj.astype(str)
+                        obj[...] = str(item)
                 except (ValueError, UnicodeEncodeError):
                     # Catch exceptions for non-ASCII or other conversion issues,
                     # leaving them unchanged

--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -72,21 +72,11 @@ def stringify_values(array: NDArray[Any]) -> NDArray[Any]:
             item = obj.item()  # Extract the scalar value for manipulation
             if pd.isna(item):  # Handle missing values by setting them to None
                 obj[...] = None
+            elif isinstance(item, (dict, list)):  # Serialize dicts and lists to JSON
+                obj[...] = json.dumps(item, ensure_ascii=False)
             else:
-                if isinstance(item, str):  # Apply ASCII check only to strings
-                    try:
-                        if item.encode("ascii", "ignore").decode() == item:
-                            obj[...] = item  # It's fully ASCII, leave as is
-                        else:
-                            obj[...] = item  # It's a non-ASCII string, leave as is
-                    except UnicodeEncodeError:
-                        obj[...] = item  # Handle potential encoding issues
-                elif isinstance(
-                    item, (dict, list)
-                ):  # Serialize dicts and lists to JSON
-                    obj[...] = json.dumps(item)
-                else:
-                    obj[...] = str(item)  # Convert other types to string
+                # Directly convert item to string, bypassing redundant ASCII checks
+                obj[...] = str(item)
     return result
 
 

--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -79,7 +79,8 @@ def stringify_values(array: NDArray[Any]) -> NDArray[Any]:
                     if obj.item().encode("ascii", "ignore").decode() == obj.item():
                         obj[...] = obj.astype(str)
                 except (ValueError, UnicodeEncodeError):
-                    # Catch exceptions for non-ASCII or other conversion issues, leaving them unchanged
+                    # Catch exceptions for non-ASCII or other conversion issues,
+                    # leaving them unchanged
                     continue
 
     return result

--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -73,15 +73,20 @@ def stringify_values(array: NDArray[Any]) -> NDArray[Any]:
             if pd.isna(item):  # Handle missing values by setting them to None
                 obj[...] = None
             else:
-                try:
-                    # Convert only if the string is fully ASCII, otherwise leave as is
-                    if obj.item().encode("ascii", "ignore").decode() == obj.item():
-                        obj[...] = str(item)
-                except (ValueError, UnicodeEncodeError):
-                    # Catch exceptions for non-ASCII or other conversion issues,
-                    # leaving them unchanged
-                    continue
-
+                if isinstance(item, str):  # Apply ASCII check only to strings
+                    try:
+                        if item.encode("ascii", "ignore").decode() == item:
+                            obj[...] = item  # It's fully ASCII, leave as is
+                        else:
+                            obj[...] = item  # It's a non-ASCII string, leave as is
+                    except UnicodeEncodeError:
+                        obj[...] = item  # Handle potential encoding issues
+                elif isinstance(
+                    item, (dict, list)
+                ):  # Serialize dicts and lists to JSON
+                    obj[...] = json.dumps(item)
+                else:
+                    obj[...] = str(item)  # Convert other types to string
     return result
 
 

--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -70,11 +70,13 @@ def stringify_values(array: NDArray[Any]) -> NDArray[Any]:
     with np.nditer(result, flags=["refs_ok"], op_flags=[["readwrite"]]) as it:
         for obj in it:
             if pd.isna(obj.item()):  # Correctly check for pandas NA or numpy NaN values
-                obj[...] = None  # Directly assign None to handle missing values appropriately
+                obj[
+                    ...
+                ] = None  # Directly assign None to handle missing values appropriately
             else:
                 try:
                     # Convert only if the string is fully ASCII, otherwise leave as is
-                    if obj.item().encode('ascii', 'ignore').decode() == obj.item():
+                    if obj.item().encode("ascii", "ignore").decode() == obj.item():
                         obj[...] = obj.astype(str)
                 except (ValueError, UnicodeEncodeError):
                     # Catch exceptions for non-ASCII or other conversion issues, leaving them unchanged

--- a/tests/unit_tests/result_set_test.py
+++ b/tests/unit_tests/result_set_test.py
@@ -84,8 +84,8 @@ def test_stringify_with_null_integers():
 
     data = [
         ("foo", "bar", pd.NA, None),
-        ("foo", "bar", pd.NA, True),
-        ("foo", "bar", pd.NA, None),
+        ("你好", "bar", pd.NA, True),
+        ("foo", "你好", pd.NA, False),
     ]
     numpy_dtype = [
         ("id", "object"),
@@ -101,10 +101,10 @@ def test_stringify_with_null_integers():
 
     expected = np.array(
         [
-            array(["foo", "foo", "foo"], dtype=object),
-            array(["bar", "bar", "bar"], dtype=object),
+            array(["foo", "你好", "foo"], dtype=object),
+            array(["bar", "bar", "你好"], dtype=object),
             array([None, None, None], dtype=object),
-            array([None, "True", None], dtype=object),
+            array([None, "True", "False"], dtype=object),
         ]
     )
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
_Hopefully_ this will leave Chinese characters alone, rather than converting them to ascii representations of unicode characters. 

Fixes: https://github.com/apache/superset/issues/19388
Fixes: https://github.com/apache/superset/issues/19982
Fixes: https://github.com/apache/superset/issues/22904

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
