### PR TITLE
chore: [proposal] de-matrix python-version in GHAs

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -76,7 +76,7 @@ github:
           - test-postgres-presto
           - test-sqlite
           - unit-tests (current)
-          - unit-tests (netxt)
+          - unit-tests (next)
 
       required_pull_request_reviews:
         dismiss_stale_reviews: false

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -70,7 +70,8 @@ github:
           - pre-commit
           - python-lint
           - test-mysql
-          - test-postgres
+          - test-postgres (current)
+          - test-postgres (future)
           - test-postgres-hive
           - test-postgres-presto
           - test-sqlite

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -67,15 +67,14 @@ github:
           - cypress-matrix (2, chrome)
           - cypress-matrix (3, chrome)
           - frontend-build
-          - pre-commit (3.10)
-          - python-lint (3.10)
-          - test-mysql (3.10)
-          - test-postgres (3.10)
-          - test-postgres (3.11)
-          - test-postgres-hive (3.10)
-          - test-postgres-presto (3.10)
-          - test-sqlite (3.10)
-          - unit-tests (3.10)
+          - pre-commit
+          - python-lint
+          - test-mysql
+          - test-postgres
+          - test-postgres-hive
+          - test-postgres-presto
+          - test-sqlite
+          - unit-tests
 
       required_pull_request_reviews:
         dismiss_stale_reviews: false

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -75,7 +75,8 @@ github:
           - test-postgres-hive
           - test-postgres-presto
           - test-sqlite
-          - unit-tests
+          - unit-tests (current)
+          - unit-tests (netxt)
 
       required_pull_request_reviews:
         dismiss_stale_reviews: false

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -71,7 +71,7 @@ github:
           - python-lint
           - test-mysql
           - test-postgres (current)
-          - test-postgres (future)
+          - test-postgres (next)
           - test-postgres-hive
           - test-postgres-presto
           - test-sqlite

--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'Type of requirements to install. Options: base, development, default'
     required: false
     default: 'dev'
+  install-superset:
+    description: 'Whether to install Superset itself. If false, only python is installed'
+    required: false
+    default: 'true'
 
 runs:
   using: 'composite'
@@ -24,11 +28,13 @@ runs:
         cache: ${{ inputs.cache }}
     - name: Install dependencies
       run: |
-        sudo apt-get update && sudo apt-get -y install libldap2-dev libsasl2-dev
-        pip install --upgrade pip setuptools wheel
-        if [ "${{ inputs.requirements-type }}" = "dev" ]; then
-          pip install -r requirements/development.txt
-        elif [ "${{ inputs.requirements-type }}" = "base" ]; then
-          pip install -r requirements/base.txt
+        if [ "${{ inputs.install-superset }}" = "true" ]; then
+          sudo apt-get update && sudo apt-get -y install libldap2-dev libsasl2-dev
+          pip install --upgrade pip setuptools wheel
+          if [ "${{ inputs.requirements-type }}" = "dev" ]; then
+            pip install -r requirements/development.txt
+          elif [ "${{ inputs.requirements-type }}" = "base" ]; then
+            pip install -r requirements/base.txt
+          fi
         fi
       shell: bash

--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -2,7 +2,7 @@ name: 'Setup Python Environment'
 description: 'Set up Python and install dependencies with optional configurations.'
 inputs:
   python-version:
-    description: 'Python version to set up. Accepts a version number, "current", or "future".'
+    description: 'Python version to set up. Accepts a version number, "current", or "next".'
     required: true
     default: 'current'
   cache:
@@ -27,7 +27,7 @@ runs:
       run: |
         if [ "${{ inputs.python-version }}" = "current" ]; then
           echo "PYTHON_VERSION=3.10" >> $GITHUB_ENV
-        elif [ "${{ inputs.python-version }}" = "future" ]; then
+        elif [ "${{ inputs.python-version }}" = "next" ]; then
           echo "PYTHON_VERSION=3.11" >> $GITHUB_ENV
         else
           echo "PYTHON_VERSION=${{ inputs.python-version }}" >> $GITHUB_ENV

--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -2,9 +2,9 @@ name: 'Setup Python Environment'
 description: 'Set up Python and install dependencies with optional configurations.'
 inputs:
   python-version:
-    description: 'Python version to set up.'
+    description: 'Python version to set up. Accepts a version number, "current", or "future".'
     required: true
-    default: '3.10'
+    default: 'current'
   cache:
     description: 'Cache dependencies. Options: pip'
     required: false
@@ -21,10 +21,21 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Set up Python ${{ inputs.python-version }}
+    - name: Interpret Python Version
+      id: set-python-version
+      shell: bash
+      run: |
+        if [ "${{ inputs.python-version }}" = "current" ]; then
+          echo "PYTHON_VERSION=3.10" >> $GITHUB_ENV
+        elif [ "${{ inputs.python-version }}" = "future" ]; then
+          echo "PYTHON_VERSION=3.11" >> $GITHUB_ENV
+        else
+          echo "PYTHON_VERSION=${{ inputs.python-version }}" >> $GITHUB_ENV
+        fi
+    - name: Set up Python ${{ env.PYTHON_VERSION }}
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ inputs.python-version }}
+        python-version: ${{ env.PYTHON_VERSION }}
         cache: ${{ inputs.cache }}
     - name: Install dependencies
       run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,6 +73,8 @@ jobs:
       - name: Build Docker Image
         if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Single platform builds in pull_request context to speed things up
           if [ "${{ github.event_name }}" = "push" ]; then

--- a/.github/workflows/no-op.yml
+++ b/.github/workflows/no-op.yml
@@ -1,0 +1,96 @@
+# no-op.yml
+#
+# Purpose:
+# This workflow provides a workaround for the "required status checks" feature in GitHub Actions
+# when using path-specific conditions in other workflows. Required checks might remain in a "Pending"
+# state if the conditions are not met, thus blocking pull requests from being merged.
+# This no-op (no operation) workflow provides dummy success statuses for these required jobs when
+# the real jobs do not run due to path-specific conditions.
+#
+# How it works:
+# - It defines jobs with the same names as the required jobs in the main workflows.
+# - These jobs simply execute a command (`exit 0`) to succeed immediately.
+# - When a pull request is created or updated, both this no-op workflow and the main workflows are triggered.
+# - If the main workflows' jobs don't run (due to path conditions), these no-op jobs provide successful statuses.
+# - If the main workflows' jobs do run and fail, their failure statuses take precedence,
+#   ensuring that pull requests are not merged with failing checks.
+#
+# Usage:
+# - Ensure that the job names in this workflow match exactly the names of the corresponding jobs in the main workflows.
+# - This workflow should be kept as-is, without path-specific conditions.
+
+name: no-op Checks
+on: pull_request
+
+jobs:
+  frontend-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op for frontend-build
+        run: exit 0
+
+  pre-commit:
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op for pre-commit
+        run: exit 0
+
+  python-lint:
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op for python-lint
+        run: exit 0
+  test-postgres-hive:
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op for frontend-build
+        run: exit 0
+  test-postgres-presto:
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op for frontend-build
+        run: exit 0
+  unit-tests:
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op for frontend-build
+        run: exit 0
+  test-mysql:
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op for test-mysql
+        run: exit 0
+  test-postgres:
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op for test-postgres
+        run: exit 0
+  test-sqlite:
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op for test-sqlite
+        run: exit 0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,9 +16,6 @@ concurrency:
 jobs:
   pre-commit:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        python-version: ["3.10"]
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4

--- a/.github/workflows/superset-cli.yml
+++ b/.github/workflows/superset-cli.yml
@@ -16,9 +16,6 @@ concurrency:
 jobs:
   test-load-examples:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        python-version: ["3.10"]
     env:
       PYTHONPATH: ${{ github.workspace }}
       SUPERSET_CONFIG: tests.integration_tests.superset_test_config

--- a/.github/workflows/superset-helm-lint.yml
+++ b/.github/workflows/superset-helm-lint.yml
@@ -27,9 +27,10 @@ jobs:
         with:
           version: v3.5.4
 
-      - uses: actions/setup-python@v5
+      - name: Setup Python
+        uses: ./.github/actions/setup-backend/
         with:
-          python-version: "3.10"
+          install-superset: 'false'
 
       - name: Set up chart-testing
         uses: ./.github/actions/chart-testing-action

--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -66,6 +66,9 @@ jobs:
           bash .github/workflows/codecov.sh -c -F python -F mysql
   test-postgres:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+      python-version: ["current", "future"]
     env:
       PYTHONPATH: ${{ github.workspace }}
       SUPERSET_CONFIG: tests.integration_tests.superset_test_config
@@ -99,6 +102,8 @@ jobs:
       - name: Setup Python
         uses: ./.github/actions/setup-backend/
         if: steps.check.outputs.python
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Setup Postgres
         if: steps.check.outputs.python
         uses: ./.github/actions/cached-dependencies

--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -16,9 +16,6 @@ concurrency:
 jobs:
   test-mysql:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        python-version: ["3.10"]
     env:
       PYTHONPATH: ${{ github.workspace }}
       SUPERSET_CONFIG: tests.integration_tests.superset_test_config
@@ -50,9 +47,13 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Python
         uses: ./.github/actions/setup-backend/
+<<<<<<< HEAD
         if: steps.check.outputs.python
         with:
           python-version: ${{ matrix.python-version }}
+=======
+        if: steps.check.outcome == 'failure'
+>>>>>>> a4e39cdaaf (chore: [proposal] de-matrix python-version in GHAs)
       - name: Setup MySQL
         if: steps.check.outputs.python
         uses: ./.github/actions/cached-dependencies
@@ -72,9 +73,6 @@ jobs:
           bash .github/workflows/codecov.sh -c -F python -F mysql
   test-postgres:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11"]
     env:
       PYTHONPATH: ${{ github.workspace }}
       SUPERSET_CONFIG: tests.integration_tests.superset_test_config
@@ -107,9 +105,13 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Python
         uses: ./.github/actions/setup-backend/
+<<<<<<< HEAD
         if: steps.check.outputs.python
         with:
           python-version: ${{ matrix.python-version }}
+=======
+        if: steps.check.outcome == 'failure'
+>>>>>>> a4e39cdaaf (chore: [proposal] de-matrix python-version in GHAs)
       - name: Setup Postgres
         if: steps.check.outputs.python
         uses: ./.github/actions/cached-dependencies
@@ -130,9 +132,6 @@ jobs:
 
   test-sqlite:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        python-version: ["3.10"]
     env:
       PYTHONPATH: ${{ github.workspace }}
       SUPERSET_CONFIG: tests.integration_tests.superset_test_config
@@ -160,8 +159,6 @@ jobs:
       - name: Setup Python
         uses: ./.github/actions/setup-backend/
         if: steps.check.outputs.python
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         if: steps.check.outputs.python
         uses: ./.github/actions/cached-dependencies

--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-      python-version: ["current", "future"]
+        python-version: ["current", "future"]
     env:
       PYTHONPATH: ${{ github.workspace }}
       SUPERSET_CONFIG: tests.integration_tests.superset_test_config

--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["current", "future"]
+        python-version: ["current", "next"]
     env:
       PYTHONPATH: ${{ github.workspace }}
       SUPERSET_CONFIG: tests.integration_tests.superset_test_config

--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -47,19 +47,12 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Python
         uses: ./.github/actions/setup-backend/
-<<<<<<< HEAD
         if: steps.check.outputs.python
-        with:
-          python-version: ${{ matrix.python-version }}
-=======
-        if: steps.check.outcome == 'failure'
->>>>>>> a4e39cdaaf (chore: [proposal] de-matrix python-version in GHAs)
       - name: Setup MySQL
         if: steps.check.outputs.python
         uses: ./.github/actions/cached-dependencies
         with:
-          run: |
-            setup-mysql
+          run: setup-mysql
       - name: Run celery
         if: steps.check.outputs.python
         run: celery --app=superset.tasks.celery_app:app worker -Ofair -c 2 &
@@ -105,13 +98,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Python
         uses: ./.github/actions/setup-backend/
-<<<<<<< HEAD
         if: steps.check.outputs.python
-        with:
-          python-version: ${{ matrix.python-version }}
-=======
-        if: steps.check.outcome == 'failure'
->>>>>>> a4e39cdaaf (chore: [proposal] de-matrix python-version in GHAs)
       - name: Setup Postgres
         if: steps.check.outputs.python
         uses: ./.github/actions/cached-dependencies

--- a/.github/workflows/superset-python-misc.yml
+++ b/.github/workflows/superset-python-misc.yml
@@ -17,9 +17,6 @@ concurrency:
 jobs:
   python-lint:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        python-version: ["3.10"]
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4
@@ -34,8 +31,6 @@ jobs:
       - name: Setup Python
         uses: ./.github/actions/setup-backend/
         if: steps.check.outputs.python
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: pylint
         if: steps.check.outputs.python
         # `-j 0` run Pylint in parallel
@@ -43,9 +38,6 @@ jobs:
 
   babel-extract:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        python-version: ["3.10"]
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4
@@ -60,8 +52,6 @@ jobs:
       - name: Setup Python
         if: steps.check.outputs.python
         uses: ./.github/actions/setup-backend/
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Test babel extraction
         if: steps.check.outputs.python
         run: flask fab babel-extract --target superset/translations --output superset/translations/messages.pot --config superset/translations/babel.cfg -k _,__,t,tn,tct

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -17,9 +17,6 @@ concurrency:
 jobs:
   test-postgres-presto:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        python-version: ["3.10"]
     env:
       PYTHONPATH: ${{ github.workspace }}
       SUPERSET_CONFIG: tests.integration_tests.superset_test_config
@@ -84,9 +81,6 @@ jobs:
 
   test-postgres-hive:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        python-version: ["3.10"]
     env:
       PYTHONPATH: ${{ github.workspace }}
       SUPERSET_CONFIG: tests.integration_tests.superset_test_config

--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -17,6 +17,9 @@ concurrency:
 jobs:
   unit-tests:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: ["current", "next"]
     env:
       PYTHONPATH: ${{ github.workspace }}
     steps:
@@ -33,6 +36,8 @@ jobs:
       - name: Setup Python
         uses: ./.github/actions/setup-backend/
         if: steps.check.outputs.python
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Python unit tests
         if: steps.check.outputs.python
         env:

--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -17,9 +17,6 @@ concurrency:
 jobs:
   unit-tests:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11"]
     env:
       PYTHONPATH: ${{ github.workspace }}
     steps:
@@ -36,8 +33,6 @@ jobs:
       - name: Setup Python
         uses: ./.github/actions/setup-backend/
         if: steps.check.outputs.python
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Python unit tests
         if: steps.check.outputs.python
         env:

--- a/.github/workflows/superset-translations.yml
+++ b/.github/workflows/superset-translations.yml
@@ -47,9 +47,6 @@ jobs:
 
   babel-extract:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        python-version: ["3.10"]
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4
@@ -65,8 +62,6 @@ jobs:
       - name: Setup Python
         if: steps.check.outputs.python
         uses: ./.github/actions/setup-backend/
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Test babel extraction
         if: steps.check.outputs.python
         run: ./scripts/babel_update.sh


### PR DESCRIPTION
### SUMMARY

In this PR:
- introducing the notion of a python-version named 'current' and 'next' for the `setup-backend` GHA, and using those semantics in the matrix + required checks.  `setup-backend` is the only place where we install python now, so it's DRY and allowing us to bump in one place in the future, with required checks names staying consistent
- run pytest against the next version of python as @villebro suggested, same as we've been doing for integration tests
- simplifying the single-item matrix (python-version) to NOT using a matrix. I'm guessing the reason we currently have a single-item matrix is an artifact of supporting multiple version in the past, and/or making it easy to go multi-python-version checks in the future, but there's a burden associated, especially around how this relates to "required checks" specified in .asf.yml
- fixing/simplifying the related no-op workflows. We'll need new ones, but will be able to deprecate a bunch and simplify things. For instance, when we migrate to 3.11 in the future, we won't have to manage a bunch of python-version-specific no-ops

About supporting multiple/future version of python, I'd argue that we should focus on a single one for a given CI run, and that if/when we need to CI against multiple version, we run a FULL test suite punctually in a dedicate PR/branch/ref. Point being, it's expensive for every commit to validate multiple versions of python and in many ways its not necessary.

Currently our multi-python-version support is dubious at best, with only few checks that run against multiple versions. I really think we should pick a single version and support it very well. If/when we want to upgrade python version, we'd cut a PR and run CI for that purpose.

If we want to continuously, actively support multiple python versions (and I don't think we should!), I'd suggest either
a release-specific procedure (release manager using release branch, running full CI for that version/release) and/or a nightly job that would keep an eye on that version of python.


