### PR TITLE
feat(dbview): Add token request button to DuckDB and MotherDuck database modal

### DIFF
--- a/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
+++ b/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
@@ -150,13 +150,19 @@ const LabeledErrorBoundInput = ({
         <StyledInput {...props} {...validationMethods} />
       )}
       {props.name === 'access_token' ? (
-        <Button type="link" htmlType="button" onClick={(o: any) => {
-          const href = 'https://app.motherduck.com/token-request?appName=Superset&close=y';
-          window.open(href);
-          return true;
-        }}>
-            Get token
-          </Button>
+        <Button
+          type="link"
+          htmlType="button"
+          onClick={() => {
+            const href =
+              'https://app.motherduck.com/token-request?appName=Superset&close=y';
+            window.open(href);
+            console.log(props);
+            return true;
+          }}
+        >
+          Get token
+        </Button>
       ) : (
         <br />
       )}

--- a/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
+++ b/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
@@ -110,6 +110,7 @@ const LabeledErrorBoundInput = ({
   className,
   visibilityToggle,
   get_url,
+  description,
   ...props
 }: LabeledErrorBoundInputProps) => (
   <StyledFormGroup className={className}>
@@ -150,17 +151,16 @@ const LabeledErrorBoundInput = ({
       ) : (
         <StyledInput {...props} {...validationMethods} />
       )}
-      {props.name === 'access_token' ? (
+      {get_url && description ? (
         <Button
           type="link"
           htmlType="button"
           onClick={() => {
-            const href = get_url;
-            window.open(href);
+            window.open(get_url);
             return true;
           }}
         >
-          Get token
+          Get {description}
         </Button>
       ) : (
         <br />

--- a/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
+++ b/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { Input, Tooltip } from 'antd';
+import { Input, Tooltip, Button } from 'antd';
 import { styled, css, SupersetTheme, t } from '@superset-ui/core';
 import InfoTooltip from 'src/components/InfoTooltip';
 import Icons from 'src/components/Icons';
@@ -148,6 +148,17 @@ const LabeledErrorBoundInput = ({
         />
       ) : (
         <StyledInput {...props} {...validationMethods} />
+      )}
+      {props.name === 'access_token' ? (
+        <Button type="link" htmlType="button" onClick={(o: any) => {
+          const href = 'https://app.motherduck.com/token-request?appName=Superset&close=y';
+          window.open(href);
+          return true;
+        }}>
+            Get token
+          </Button>
+      ) : (
+        <br />
       )}
     </FormItem>
   </StyledFormGroup>

--- a/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
+++ b/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
@@ -17,10 +17,11 @@
  * under the License.
  */
 import React from 'react';
-import { Input, Tooltip, Button } from 'antd';
+import { Input, Tooltip } from 'antd';
 import { styled, css, SupersetTheme, t } from '@superset-ui/core';
 import InfoTooltip from 'src/components/InfoTooltip';
 import Icons from 'src/components/Icons';
+import Button from 'src/components/Button';
 import errorIcon from 'src/assets/images/icons/error.svg';
 import FormItem from './FormItem';
 import FormLabel from './FormLabel';
@@ -155,6 +156,7 @@ const LabeledErrorBoundInput = ({
         <Button
           type="link"
           htmlType="button"
+          buttonStyle="default"
           onClick={() => {
             window.open(get_url);
             return true;

--- a/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
+++ b/superset-frontend/src/components/Form/LabeledErrorBoundInput.tsx
@@ -109,6 +109,7 @@ const LabeledErrorBoundInput = ({
   id,
   className,
   visibilityToggle,
+  get_url,
   ...props
 }: LabeledErrorBoundInputProps) => (
   <StyledFormGroup className={className}>
@@ -154,10 +155,8 @@ const LabeledErrorBoundInput = ({
           type="link"
           htmlType="button"
           onClick={() => {
-            const href =
-              'https://app.motherduck.com/token-request?appName=Superset&close=y';
+            const href = get_url;
             window.open(href);
-            console.log(props);
             return true;
           }}
         >

--- a/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/CommonParameters.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/CommonParameters.tsx
@@ -164,6 +164,7 @@ export const accessTokenField = ({
   db,
   isEditMode,
   default_value,
+  description,
 }: FieldPropTypes) => (
   <ValidatedInput
     id="access_token"
@@ -174,7 +175,12 @@ export const accessTokenField = ({
     validationMethods={{ onBlur: getValidation }}
     errorMessage={validationErrors?.access_token}
     placeholder={t('Paste your access token here')}
-    get_url={default_value}
+    get_url={
+      typeof default_value === 'string' && default_value.includes('https://')
+        ? default_value
+        : null
+    }
+    description={description}
     label={t('Access token')}
     onChange={changeMethods.onParametersChange}
   />

--- a/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/CommonParameters.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/CommonParameters.tsx
@@ -163,6 +163,7 @@ export const accessTokenField = ({
   validationErrors,
   db,
   isEditMode,
+  default_value,
 }: FieldPropTypes) => (
   <ValidatedInput
     id="access_token"
@@ -173,6 +174,7 @@ export const accessTokenField = ({
     validationMethods={{ onBlur: getValidation }}
     errorMessage={validationErrors?.access_token}
     placeholder={t('Paste your access token here')}
+    get_url={default_value}
     label={t('Access token')}
     onChange={changeMethods.onParametersChange}
   />

--- a/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/CommonParameters.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/CommonParameters.tsx
@@ -172,7 +172,7 @@ export const accessTokenField = ({
     value={db?.parameters?.access_token}
     validationMethods={{ onBlur: getValidation }}
     errorMessage={validationErrors?.access_token}
-    placeholder={t('e.g. ********')}
+    placeholder={t('Paste your access token here')}
     label={t('Access token')}
     onChange={changeMethods.onParametersChange}
   />

--- a/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/index.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/index.tsx
@@ -169,6 +169,7 @@ const DatabaseConnectionForm = ({
               db,
               key: field,
               field,
+              default_value: parameters.properties[field]?.default,
               isEditMode,
               sslForced,
               editNewDb,

--- a/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/index.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/index.tsx
@@ -170,6 +170,7 @@ const DatabaseConnectionForm = ({
               key: field,
               field,
               default_value: parameters.properties[field]?.default,
+              description: parameters.properties[field]?.description,
               isEditMode,
               sslForced,
               editNewDb,

--- a/superset-frontend/src/features/databases/DatabaseModal/ModalHeader.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/ModalHeader.tsx
@@ -149,8 +149,7 @@ const ModalHeader = ({
             target="_blank"
             rel="noopener noreferrer"
           >
-            {t('connecting to %(dbModelName)s', { dbModelName: dbModel.name })}
-            .
+            {t('connecting to %(dbModelName)s', { dbModelName: dbModel.name })}.
           </a>
         </p>
       </StyledFormHeader>

--- a/superset-frontend/src/features/databases/DatabaseModal/ModalHeader.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/ModalHeader.tsx
@@ -149,7 +149,7 @@ const ModalHeader = ({
             target="_blank"
             rel="noopener noreferrer"
           >
-            {t('connecting to %(dbModelName)s.', { dbModelName: dbModel.name })}
+            {t('connecting to %(dbModelName)s', { dbModelName: dbModel.name })}
             .
           </a>
         </p>

--- a/superset-frontend/src/features/databases/types.ts
+++ b/superset-frontend/src/features/databases/types.ts
@@ -292,6 +292,7 @@ export interface FieldPropTypes {
   dbModel?: DatabaseForm;
   field: string;
   default_value?: any;
+  description?: string;
   isEditMode?: boolean;
   sslForced?: boolean;
   defaultDBName?: string;

--- a/superset-frontend/src/features/databases/types.ts
+++ b/superset-frontend/src/features/databases/types.ts
@@ -291,6 +291,7 @@ export interface FieldPropTypes {
   db?: DatabaseObject;
   dbModel?: DatabaseForm;
   field: string;
+  default_value?: any;
   isEditMode?: boolean;
   sslForced?: boolean;
   defaultDBName?: string;

--- a/superset/databases/utils.py
+++ b/superset/databases/utils.py
@@ -104,7 +104,7 @@ def get_table_metadata(
     }
 
 
-def make_url_safe(raw_url: Union[str, URL]) -> Any:
+def make_url_safe(raw_url: Union[str, URL]) -> URL:
     """
     Wrapper for SQLAlchemy's make_url(), which tends to raise too detailed of
     errors, which inevitably find their way into server logs. ArgumentErrors

--- a/superset/databases/utils.py
+++ b/superset/databases/utils.py
@@ -117,11 +117,6 @@ def make_url_safe(raw_url: Union[str, URL]) -> Any:
         url = raw_url.strip()
         try:
             return make_url(url)  # noqa
-        except ValueError:
-            if "duckdb" in url:
-                from superset.db_engine_specs.duckdb import MDURI
-                return MDURI.from_str(url)
-            raise DatabaseInvalidError()
         except Exception:
             raise DatabaseInvalidError()  # pylint: disable=raise-missing-from
 

--- a/superset/databases/utils.py
+++ b/superset/databases/utils.py
@@ -117,6 +117,11 @@ def make_url_safe(raw_url: Union[str, URL]) -> URL:
         url = raw_url.strip()
         try:
             return make_url(url)  # noqa
+        except ValueError:
+            if "duckdb" in url:
+                from superset.db_engine_specs.duckdb import MDURI
+                return MDURI.from_str(url)
+            raise DatabaseInvalidError()
         except Exception:
             raise DatabaseInvalidError()  # pylint: disable=raise-missing-from
 

--- a/superset/databases/utils.py
+++ b/superset/databases/utils.py
@@ -104,7 +104,7 @@ def get_table_metadata(
     }
 
 
-def make_url_safe(raw_url: Union[str, URL]) -> URL:
+def make_url_safe(raw_url: Union[str, URL]) -> Any:
     """
     Wrapper for SQLAlchemy's make_url(), which tends to raise too detailed of
     errors, which inevitably find their way into server logs. ArgumentErrors

--- a/superset/db_engine_specs/duckdb.py
+++ b/superset/db_engine_specs/duckdb.py
@@ -30,10 +30,22 @@ from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.engine.url import URL
 
 from superset.config import VERSION_STRING
-from superset.constants import TimeGrain, USER_AGENT
+from superset.constants import TimeGrain, USER_AGENT, PASSWORD_MASK
 from superset.db_engine_specs.base import BaseEngineSpec
 from superset.errors import SupersetErrorType
 from superset.errors import SupersetError
+
+from apispec import APISpec
+from apispec.ext.marshmallow import MarshmallowPlugin
+from flask_babel import gettext as __, lazy_gettext as _
+from marshmallow import fields, Schema
+from marshmallow.validate import Range
+from sqlalchemy.engine.reflection import Inspector
+from sqlalchemy.engine.url import URL
+from sqlalchemy import util
+from superset.databases.utils import make_url_safe
+from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
+from superset.utils.network import is_hostname_valid, is_port_open
 
 if TYPE_CHECKING:
     # prevent circular imports
@@ -43,9 +55,266 @@ if TYPE_CHECKING:
 COLUMN_DOES_NOT_EXIST_REGEX = re.compile("no such column: (?P<column_name>.+)")
 
 
-class DuckDBEngineSpec(BaseEngineSpec):
+class MDURI(util.namedtuple(
+        "MDURI",
+        [
+            "password",
+            "database",
+            "motherduck_token",
+            "query",
+        ],
+    )):
+    drivername = "duckdb"
+
+    def __str__(self):
+        query = ""
+        if self.motherduck_token:
+            query += f"?motherduck_token={self.motherduck_token}"
+        else:
+            query += "?"
+        query += "&".join([f"{key}={value}" for key, value in self.query.items()])
+        return f"{DuckDBEngineSpec.engine}:///{self.database}{query}"
+
+
+    @classmethod
+    def from_str(cls, name: str):
+        pattern = re.compile(
+            r"""
+                (?P<driver_name>[\w\+]+):///
+                (?:
+                    (md:(?P<database>[^/\?]*))?
+                )?
+                (?:\?(?P<query>.*))?
+                """,
+            re.X,
+        )
+        m = pattern.match(name)
+        if m is not None:
+            components = m.groupdict()
+            if components["query"] is not None:
+                query = {}
+
+                for key, value in util.parse_qsl(components["query"]):
+                    if util.py2k:
+                        key = key.encode("ascii")
+                    if key in query:
+                        query[key] = util.to_list(query[key])
+                        query[key].append(value)
+                    else:
+                        query[key] = value
+            else:
+                query = None
+            if query is not None:
+                token = query.pop("motherduck_token")
+            else:
+                token = None
+
+            components["query"] = query
+
+            return cls(
+                password=token,
+                database=components.get("database"),
+                motherduck_token=token,
+                query=query
+            )
+
+    def strip(self):
+        return self
+    
+    def set(
+        self,
+        password=None,
+        database=None,
+        query=None,
+    ):
+        """return a new :class:`_engine.URL` object with modifications.
+
+        Values are used if they are non-None.  To set a value to ``None``
+        explicitly, use the :meth:`MDURI._replace` method adapted
+        from ``namedtuple``.
+
+        :param password: new password
+        :param database: new database
+        :param query: new query parameters, passed a dict of string keys
+         referring to string or sequence of string values.  Fully
+         replaces the previous list of arguments.
+
+        :return: new :class:`_engine.URL` object.
+
+        .. versionadded:: 1.4
+
+        .. seealso::
+
+            :meth:`_engine.URL.update_query_dict`
+
+        """
+
+        kw = {}
+        if password is not None:
+            kw["password"] = password
+        if database is not None:
+            kw["database"] = database
+        if query is not None:
+            kw["query"] = query
+
+        return self._replace(**kw)
+    
+    def get_backend_name(self):
+        """Return the backend name.
+
+        This is the name that corresponds to the database backend in
+        use, and is the portion of the :attr:`_engine.URL.drivername`
+        that is to the left of the plus sign.
+
+        """
+        return self.drivername
+
+    def get_driver_name(self):
+        """Return the backend name.
+
+        This is the name that corresponds to the DBAPI driver in
+        use, and is the portion of the :attr:`_engine.URL.drivername`
+        that is to the right of the plus sign.
+
+        If the :attr:`_engine.URL.drivername` does not include a plus sign,
+        then the default :class:`_engine.Dialect` for this :class:`_engine.URL`
+        is imported in order to get the driver name.
+
+        """
+        return self.drivername
+
+# schema for adding a database by providing parameters instead of the
+# full SQLAlchemy URI
+class DuckDBParametersSchema(Schema):
+    access_token = fields.String(allow_none=True, metadata={"description": __("MotherDuck token")})
+    database = fields.String(
+        required=True, metadata={"description": __("Database name")}
+    )
+    query = fields.Dict(
+        keys=fields.Str(),
+        values=fields.Raw(),
+        metadata={"description": __("Additional parameters")},
+    )
+
+
+class DuckDBParametersType(TypedDict, total=False):
+    access_token: str | None
+    database: str
+    query: dict[str, Any]
+
+
+class DuckDBPropertiesType(TypedDict):
+    parameters: DuckDBParametersType
+
+
+class DuckDBParametersMixin:
+    """
+    Mixin for configuring DB engine specs via a dictionary.
+
+    With this mixin the SQLAlchemy engine can be configured through
+    individual parameters, instead of the full SQLAlchemy URI. This
+    mixin is for DuckDB:
+
+        duckdb:///file_path[?key=value&key=value...]
+        duckdb:///md:database[?key=value&key=value...]
+
+    """
+
+    # schema describing the parameters used to configure the DB
+    parameters_schema = DuckDBParametersSchema()
+
+    # recommended driver name for the DB engine spec
+    default_driver = ""
+
+    # query parameter to enable encryption in the database connection
+    # for Postgres this would be `{"sslmode": "verify-ca"}`, eg.
+    encryption_parameters: dict[str, str] = {}
+
+    @classmethod
+    def build_sqlalchemy_uri(  # pylint: disable=unused-argument
+        cls,
+        parameters: DuckDBParametersType,
+        encrypted_extra: dict[str, str] | None = None,
+    ) -> str:
+        # make a copy so that we don't update the original
+        query = parameters.get("query", {}).copy()
+        token = parameters.get("access_token", "")
+        database = parameters.get("database", "")
+
+        if database or token:
+            database = "md:" + database
+
+        return MDURI(token, database, token, query)
+    
+    @classmethod
+    def get_parameters_from_uri(  # pylint: disable=unused-argument
+        cls, uri: str, encrypted_extra: dict[str, Any] | None = None
+    ) -> DuckDBParametersType:
+        url = make_url_safe(uri)
+        query = {
+            key: value
+            for (key, value) in url.query.items()
+            if (key, value) not in cls.encryption_parameters.items()
+        }
+        encryption = all(
+            item in url.query.items() for item in cls.encryption_parameters.items()
+        )
+        return {
+            "access_token": url.access_token,
+            "database": url.database,
+            "query": query,
+        }
+
+    @classmethod
+    def validate_parameters(
+        cls, properties: DuckDBPropertiesType
+    ) -> list[SupersetError]:
+        """
+        Validates any number of parameters, for progressive validation.
+
+        If only the hostname is present it will check if the name is resolvable. As more
+        parameters are present in the request, more validation is done.
+        """
+        errors: list[SupersetError] = []
+
+        required = {"access_token"}
+        parameters = properties.get("parameters", {})
+        present = {key for key in parameters if parameters.get(key, ())}
+
+        if missing := sorted(required - present):
+            errors.append(
+                SupersetError(
+                    message=f'One or more parameters are missing: {", ".join(missing)}',
+                    error_type=SupersetErrorType.CONNECTION_MISSING_PARAMETERS_ERROR,
+                    level=ErrorLevel.WARNING,
+                    extra={"missing": missing},
+                ),
+            )
+
+        return errors
+
+    @classmethod
+    def parameters_json_schema(cls) -> Any:
+        """
+        Return configuration parameters as OpenAPI.
+        """
+        if not cls.parameters_schema:
+            return None
+
+        spec = APISpec(
+            title="Database Parameters",
+            version="1.0.0",
+            openapi_version="3.0.2",
+            plugins=[MarshmallowPlugin()],
+        )
+        spec.components.schema(cls.__name__, schema=cls.parameters_schema)
+        return spec.to_dict()["components"]["schemas"][cls.__name__]
+
+
+class DuckDBEngineSpec(DuckDBParametersMixin, BaseEngineSpec):
     engine = "duckdb"
     engine_name = "DuckDB"
+    default_driver = "duckdb_engine"
 
     sqlalchemy_uri_placeholder = "duckdb:////path/to/duck.db"
 
@@ -107,89 +376,10 @@ class DuckDBEngineSpec(BaseEngineSpec):
         return extra
 
 
-# schema for adding a database by providing parameters instead of the
-# full SQLAlchemy URI
-class BasicParametersSchema(Schema):
-    database = fields.String(
-        required=True, metadata={"description": __("Database name")}
-    )
-    password = fields.String(allow_none=True, metadata={"description": __("MotherDuck token")})
-
-
-class MotherDuckParametersType(TypedDict, total=False):
-    database: str
-    password: str
-
-
-class MotherDuckPropertiesType(TypedDict):
-    parameters: MotherDuckParametersType
-
-
 class MotherDuckEngineSpec(DuckDBEngineSpec):
     engine = "duckdb"
     engine_name = "MotherDuck"
 
-    # recommended driver name for the DB engine spec
-    default_driver = "duckdb_engine"
-
     sqlalchemy_uri_placeholder = (
         "duckdb:///md:{database_name}?motherduck_token={SERVICE_TOKEN}"
     )
-
-    # schema describing the parameters used to configure the DB
-    parameters_schema = BasicParametersSchema()
-
-
-    @classmethod
-    def build_sqlalchemy_uri(  # pylint: disable=unused-argument
-        cls,
-        parameters: MotherDuckParametersType,
-        encrypted_extra: dict[str, str] | None = None,
-    ) -> str:
-        return f"{cls.engine}:///md:{parameters['database']}"\
-        f"?motherduck_token={parameters['password']}", 
-
-    @classmethod
-    def get_parameters_from_uri(  # pylint: disable=unused-argument
-        cls, uri: str, encrypted_extra: dict[str, Any] | None = None
-    ) -> MotherDuckParametersType:
-        # pattern = "md:(?P<database>\w+).*?motherduck_token=(?P<token>\w+)"
-        # m = re.search(pattern, uri)
-        # return {
-        #     "database": m.group('database'),
-        #     "motherduck_token": m.group('token')
-        # }
-        return {
-            "database": "foo",
-            "password": "bar"
-        }
-
-    @classmethod
-    def parameters_json_schema(cls) -> Any:
-        """
-        Return configuration parameters as OpenAPI.
-        """
-        if not cls.parameters_schema:
-            return None
-
-        spec = APISpec(
-            title="Database Parameters",
-            version="1.0.0",
-            openapi_version="3.0.2",
-            plugins=[MarshmallowPlugin()],
-        )
-        spec.components.schema(cls.__name__, schema=cls.parameters_schema)
-        return spec.to_dict()["components"]["schemas"][cls.__name__]
-    
-    @classmethod
-    def validate_parameters(
-        cls, properties: MotherDuckPropertiesType
-    ) -> list[SupersetError]:
-        """
-        Validates any number of parameters, for progressive validation.
-
-        If only the hostname is present it will check if the name is resolvable. As more
-        parameters are present in the request, more validation is done.
-        """
-        errors: list[SupersetError] = []
-        return errors

--- a/superset/db_engine_specs/duckdb.py
+++ b/superset/db_engine_specs/duckdb.py
@@ -109,6 +109,10 @@ class DuckDBParametersMixin:
         parameters: DuckDBParametersType,
         encrypted_extra: dict[str, str] | None = None,
     ) -> str:
+        """
+        Build SQLAlchemy URI for connecting to a DuckDB database.
+        If an access token is specified, return a URI to connect to a MotherDuck database.
+        """
         if parameters is None:
             parameters = {}
         query = parameters.get("query", {})
@@ -269,6 +273,9 @@ class MotherDuckEngineSpec(DuckDBEngineSpec):
         parameters: DuckDBParametersType,
         encrypted_extra: dict[str, str] | None = None,
     ) -> str:
+        """
+        Build SQLAlchemy URI for connecting to a MotherDuck database
+        """
         # make a copy so that we don't update the original
         query = parameters.get("query", {}).copy()
         database = parameters.get("database", "")

--- a/superset/db_engine_specs/duckdb.py
+++ b/superset/db_engine_specs/duckdb.py
@@ -270,7 +270,7 @@ class MotherDuckEngineSpec(DuckDBEngineSpec):
         # make a copy so that we don't update the original
         query = parameters.get("query", {}).copy()
         database = parameters.get("database", "")
-        token = parameters.get("access_token")
+        token = parameters.get("access_token", "")
 
         if not database.startswith("md:"):
             database = f"md:{database}"

--- a/superset/db_engine_specs/duckdb.py
+++ b/superset/db_engine_specs/duckdb.py
@@ -110,7 +110,7 @@ class DuckDBParametersMixin:
         encrypted_extra: dict[str, str] | None = None,
     ) -> str:
         query = parameters.get("query", {})
-        database = parameters.get("database", "")
+        database = parameters.get("database", ":memory:")
         token = parameters.get("access_token")
 
         if cls._is_motherduck(database) or (

--- a/superset/db_engine_specs/duckdb.py
+++ b/superset/db_engine_specs/duckdb.py
@@ -109,6 +109,8 @@ class DuckDBParametersMixin:
         parameters: DuckDBParametersType,
         encrypted_extra: dict[str, str] | None = None,
     ) -> str:
+        if parameters is None:
+            parameters = {}
         query = parameters.get("query", {})
         database = parameters.get("database", ":memory:")
         token = parameters.get("access_token")

--- a/superset/db_engine_specs/duckdb.py
+++ b/superset/db_engine_specs/duckdb.py
@@ -277,7 +277,9 @@ class MotherDuckEngineSpec(DuckDBEngineSpec):
         if token and token != DEFAULT_ACCESS_TOKEN_URL:
             query["motherduck_token"] = token
         else:
-            raise ValueError(f"Need MotherDuck token to connect to database '{database}'.")
+            raise ValueError(
+                f"Need MotherDuck token to connect to database '{database}'."
+            )
 
         return str(
             URL(drivername=DuckDBEngineSpec.engine, database=database, query=query)

--- a/superset/db_engine_specs/duckdb.py
+++ b/superset/db_engine_specs/duckdb.py
@@ -186,9 +186,10 @@ class MDURI(util.namedtuple(
 # schema for adding a database by providing parameters instead of the
 # full SQLAlchemy URI
 class DuckDBParametersSchema(Schema):
-    access_token = fields.String(allow_none=True, metadata={"description": __("MotherDuck token")})
+    access_token = fields.String(allow_none=True, metadata={"description": __("MotherDuck token")}
+    )
     database = fields.String(
-        required=True, metadata={"description": __("Database name")}
+        required=False, metadata={"description": __("Database name")}
     )
     query = fields.Dict(
         keys=fields.Str(),
@@ -244,7 +245,7 @@ class DuckDBParametersMixin:
         if database or token:
             database = "md:" + database
 
-        return MDURI(token, database, token, query)
+        return str(MDURI(token, database, token, query))
     
     @classmethod
     def get_parameters_from_uri(  # pylint: disable=unused-argument

--- a/superset/db_engine_specs/duckdb.py
+++ b/superset/db_engine_specs/duckdb.py
@@ -274,7 +274,10 @@ class MotherDuckEngineSpec(DuckDBEngineSpec):
 
         if not database.startswith("md:"):
             database = f"md:{database}"
-        query["motherduck_token"] = token
+        if token and token != DEFAULT_ACCESS_TOKEN_URL:
+            query["motherduck_token"] = token
+        else:
+            raise ValueError(f"Need MotherDuck token to connect to database '{database}'.")
 
         return str(
             URL(drivername=DuckDBEngineSpec.engine, database=database, query=query)

--- a/superset/db_engine_specs/duckdb.py
+++ b/superset/db_engine_specs/duckdb.py
@@ -203,9 +203,6 @@ class DuckDBParametersMixin:
     ) -> list[SupersetError]:
         """
         Validates any number of parameters, for progressive validation.
-
-        If only the hostname is present it will check if the name is resolvable. As more
-        parameters are present in the request, more validation is done.
         """
         errors: list[SupersetError] = []
 

--- a/superset/db_engine_specs/duckdb.py
+++ b/superset/db_engine_specs/duckdb.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import os
 import re
 from datetime import datetime
 from re import Pattern
@@ -26,17 +25,15 @@ from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
 from flask_babel import gettext as __, lazy_gettext as _
 from marshmallow import fields, Schema
-from marshmallow.validate import Range
-from sqlalchemy import types, util
+from sqlalchemy import types
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.engine.url import URL
 
 from superset.config import VERSION_STRING
-from superset.constants import PASSWORD_MASK, TimeGrain, USER_AGENT
+from superset.constants import TimeGrain, USER_AGENT
 from superset.databases.utils import make_url_safe
 from superset.db_engine_specs.base import BaseEngineSpec
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
-from superset.utils.network import is_hostname_valid, is_port_open
 
 if TYPE_CHECKING:
     # prevent circular imports
@@ -44,7 +41,9 @@ if TYPE_CHECKING:
 
 
 COLUMN_DOES_NOT_EXIST_REGEX = re.compile("no such column: (?P<column_name>.+)")
-DEFAULT_ACCESS_TOKEN_URL = "https://app.motherduck.com/token-request?appName=Superset&close=y"
+DEFAULT_ACCESS_TOKEN_URL = (
+    "https://app.motherduck.com/token-request?appName=Superset&close=y"
+)
 
 
 # schema for adding a database by providing parameters instead of the
@@ -88,6 +87,8 @@ class DuckDBParametersMixin:
 
     """
 
+    engine = "duckdb"
+
     # schema describing the parameters used to configure the DB
     parameters_schema = DuckDBParametersSchema()
 
@@ -112,7 +113,9 @@ class DuckDBParametersMixin:
         database = parameters.get("database", "")
         token = parameters.get("access_token")
 
-        if cls._is_motherduck(database) or (token and token != DEFAULT_ACCESS_TOKEN_URL):
+        if cls._is_motherduck(database) or (
+            token and token != DEFAULT_ACCESS_TOKEN_URL
+        ):
             return MotherDuckEngineSpec.build_sqlalchemy_uri(parameters)
 
         return str(URL(drivername=cls.engine, database=database, query=query))
@@ -259,7 +262,7 @@ class MotherDuckEngineSpec(DuckDBEngineSpec):
         return True
 
     @classmethod
-    def build_sqlalchemy_uri(  # pylint: disable=unused-argument
+    def build_sqlalchemy_uri(
         cls,
         parameters: DuckDBParametersType,
         encrypted_extra: dict[str, str] | None = None,
@@ -273,4 +276,6 @@ class MotherDuckEngineSpec(DuckDBEngineSpec):
             database = f"md:{database}"
         query["motherduck_token"] = token
 
-        return str(URL(drivername=DuckDBEngineSpec.engine, database=database, query=query))
+        return str(
+            URL(drivername=DuckDBEngineSpec.engine, database=database, query=query)
+        )

--- a/tests/unit_tests/db_engine_specs/test_duckdb.py
+++ b/tests/unit_tests/db_engine_specs/test_duckdb.py
@@ -72,3 +72,56 @@ def test_get_extra_params(mocker: MockerFixture) -> None:
             }
         }
     }
+
+
+def test_build_sqlalchemy_uri() -> None:
+    """Test DuckDBEngineSpec.build_sqlalchemy_uri"""
+    from superset.db_engine_specs.duckdb import DuckDBEngineSpec, DuckDBParametersType
+
+    # No database provided, default to :memory:
+    parameters = DuckDBParametersType()
+    uri = DuckDBEngineSpec.build_sqlalchemy_uri(parameters)
+    assert "duckdb:///:memory:" == uri
+
+    # Database provided
+    parameters = DuckDBParametersType(database="/path/to/duck.db")
+    uri = DuckDBEngineSpec.build_sqlalchemy_uri(parameters)
+    assert "duckdb:////path/to/duck.db" == uri
+
+
+def test_md_build_sqlalchemy_uri() -> None:
+    """Test MotherDuckEngineSpec.build_sqlalchemy_uri"""
+    from superset.db_engine_specs.duckdb import (
+        DuckDBParametersType,
+        MotherDuckEngineSpec,
+    )
+
+    # No access token provided, throw ValueError
+    parameters = DuckDBParametersType(database="my_db")
+    with pytest.raises(ValueError):
+        MotherDuckEngineSpec.build_sqlalchemy_uri(parameters)
+
+    # No database provided, default to "md:"
+    parameters = DuckDBParametersType(access_token="token")
+    uri = MotherDuckEngineSpec.build_sqlalchemy_uri(parameters)
+    assert "duckdb:///md:?motherduck_token=token"
+
+    # Database and access_token provided
+    parameters = DuckDBParametersType(database="my_db", access_token="token")
+    uri = MotherDuckEngineSpec.build_sqlalchemy_uri(parameters)
+    assert "duckdb:///md:my_db?motherduck_token=token" == uri
+
+
+def test_get_parameters_from_uri() -> None:
+    from superset.db_engine_specs.duckdb import DuckDBEngineSpec
+
+    uri = "duckdb:////path/to/duck.db"
+    parameters = DuckDBEngineSpec.get_parameters_from_uri(uri)
+
+    assert parameters["database"] == "/path/to/duck.db"
+
+    uri = "duckdb:///md:my_db?motherduck_token=token"
+    parameters = DuckDBEngineSpec.get_parameters_from_uri(uri)
+
+    assert parameters["database"] == "md:my_db"
+    assert parameters["access_token"] == "token"


### PR DESCRIPTION
### SUMMARY
- Add a `DuckDBParametersSchema` to break out the DuckDB connection URI into database, access token (for MotherDuck) and query
- Add a button to go to MotherDuck and copy an access token to paste directly into Superset.

The latter is implemented by adding support for the `metadata` `description` and `load_default` values from the parameters schema fields.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1459" alt="image" src="https://github.com/apache/superset/assets/4041805/dfb031ed-7608-4efc-a581-aef34a098646">

After:
![ebebe569-b32b-4c8b-9b0e-98bf7c1d9b6b](https://github.com/apache/superset/assets/4041805/c38a46d7-97b1-4317-a303-50b042d2f288)


### TESTING INSTRUCTIONS
See animated GIF.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
