### PR TITLE
fix: table with time comparison shows blank data when dimension is numeric

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -288,7 +288,11 @@ const processComparisonColumns = (
       const config = columnConfig[col.key] || {};
       const savedFormat = columnFormats?.[col.key];
       const numberFormat = config.d3NumberFormat || savedFormat;
-      if (col.isNumeric && !col.key.includes(COMPARISON_PREFIX)) {
+      if (
+        (col.isMetric || col.isPercentMetric) &&
+        !col.key.includes(COMPARISON_PREFIX) &&
+        col.isNumeric
+      ) {
         return [
           {
             ...col,


### PR DESCRIPTION


<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- table with time comparison shows blank data when dimension is numeric

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
before:
<img width="841" alt="Screen Shot 2024-04-04 at 5 13 00 PM" src="https://github.com/apache/superset/assets/5705598/dfe2b316-c78e-4768-9a00-46352706d563">
after:
<img width="1678" alt="Screen Shot 2024-04-04 at 5 11 12 PM" src="https://github.com/apache/superset/assets/5705598/fbd7634f-a173-426d-abcd-da554cc79f1a">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
