### PR TITLE
fix: data in table with time comparison without change should be grey 

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -394,7 +394,7 @@ const transformProps = (
         arrow: '',
         arrowColor: '',
         // eslint-disable-next-line theme-colors/no-literal-colors
-        backgroundColor: '#FFBFA133',
+        backgroundColor: 'rgba(0,0,0,0.2)',
       };
     }
     const isPositive = percentDifferenceNum > 0;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When color options are applied on tables and there has been no change (no increase or decrease), we should leave the table color as grey for that row/cell instead of using the orange.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
<img width="1221" alt="Screen Shot 2024-04-04 at 5 40 30 PM" src="https://github.com/apache/superset/assets/5705598/11865d40-2049-49a3-91d9-d5da63cd3273">
After:
<img width="1167" alt="Screen Shot 2024-04-04 at 5 35 21 PM" src="https://github.com/apache/superset/assets/5705598/af4db04a-e8cf-4297-8dd6-0c1b2357178d">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
