### PR TITLE
docs: add more warnings for default secrets and docker-compose

### DIFF
--- a/docker-compose-image-tag.yml
+++ b/docker-compose-image-tag.yml
@@ -14,6 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+# -----------------------------------------------------------------------
+# We don't support docker-compose for production environments.
+# If you choose to use this type of deployment make sure to
+# create you own docker environment file (docker/.env) with your own
+# unique random secure passwords and SECRET_KEY.
+# -----------------------------------------------------------------------
 x-superset-image: &superset-image apachesuperset.docker.scarf.sh/apache/superset:${TAG:-latest}
 x-superset-depends-on: &superset-depends-on
   - db

--- a/docker-compose-non-dev.yml
+++ b/docker-compose-non-dev.yml
@@ -14,6 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+# -----------------------------------------------------------------------
+# We don't support docker-compose for production environments.
+# If you choose to use this type of deployment make sure to
+# create you own docker environment file (docker/.env) with your own
+# unique random secure passwords and SECRET_KEY.
+# -----------------------------------------------------------------------
 x-superset-depends-on: &superset-depends-on
   - db
   - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+# -----------------------------------------------------------------------
+# We don't support docker-compose for production environments.
+# If you choose to use this type of deployment make sure to
+# create you own docker environment file (docker/.env) with your own
+# unique random secure passwords and SECRET_KEY.
+# -----------------------------------------------------------------------
 x-superset-user: &superset-user root
 x-superset-depends-on: &superset-depends-on
   - db

--- a/docker/.env
+++ b/docker/.env
@@ -14,17 +14,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+
 COMPOSE_PROJECT_NAME=superset
 
 # database configurations (do not modify)
 DATABASE_DB=superset
 DATABASE_HOST=db
+# Make sure you set this to a unique secure random value on production
 DATABASE_PASSWORD=superset
 DATABASE_USER=superset
 
 EXAMPLES_DB=examples
 EXAMPLES_HOST=db
 EXAMPLES_USER=examples
+# Make sure you set this to a unique secure random value on production
 EXAMPLES_PASSWORD=examples
 EXAMPLES_PORT=5432
 
@@ -34,6 +38,7 @@ DATABASE_PORT=5432
 DATABASE_DIALECT=postgresql
 POSTGRES_DB=superset
 POSTGRES_USER=superset
+# Make sure you set this to a unique secure random value on production
 POSTGRES_PASSWORD=superset
 #MYSQL_DATABASE=superset
 #MYSQL_USER=superset
@@ -52,4 +57,5 @@ CYPRESS_CONFIG=false
 SUPERSET_PORT=8088
 MAPBOX_API_KEY=''
 
+# Make sure you set this to a unique secure random value on production
 SUPERSET_SECRET_KEY=TEST_NON_DEV_SECRET

--- a/docs/docs/installation/configuring-superset.mdx
+++ b/docs/docs/installation/configuring-superset.mdx
@@ -99,6 +99,10 @@ SECRET_KEY = 'YOUR_OWN_RANDOM_GENERATED_SECRET_KEY'
 
 You can generate a strong secure key with `openssl rand -base64 42`.
 
+> Your secret key will be used for securely signing session cookies
+  and encrypting sensitive information on the database
+  Make sure you are changing this key for your deployment with a strong key.
+
 #### Rotating to a newer SECRET_KEY
 
 If you wish to change your existing SECRET_KEY, add the existing SECRET_KEY to your `superset_config.py` file as

--- a/docs/docs/installation/configuring-superset.mdx
+++ b/docs/docs/installation/configuring-superset.mdx
@@ -100,7 +100,7 @@ SECRET_KEY = 'YOUR_OWN_RANDOM_GENERATED_SECRET_KEY'
 You can generate a strong secure key with `openssl rand -base64 42`.
 
 :::caution Your secret key will be used for securely signing session cookies
-  and encrypting sensitive information on the database
+and encrypting sensitive information stored in Superset's application metadata database.
   Make sure you are changing this key for your deployment with a strong key.
 
 #### Rotating to a newer SECRET_KEY

--- a/docs/docs/installation/configuring-superset.mdx
+++ b/docs/docs/installation/configuring-superset.mdx
@@ -99,7 +99,7 @@ SECRET_KEY = 'YOUR_OWN_RANDOM_GENERATED_SECRET_KEY'
 
 You can generate a strong secure key with `openssl rand -base64 42`.
 
-> Your secret key will be used for securely signing session cookies
+:::caution Your secret key will be used for securely signing session cookies
   and encrypting sensitive information on the database
   Make sure you are changing this key for your deployment with a strong key.
 


### PR DESCRIPTION
### SUMMARY

Add more warnings on our default for docker-compose and stress out the importance of having a unique random `SECRET_KEY`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
