### PR TITLE
fix: docker-release GHA fails with pathspec error

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -61,6 +61,13 @@ jobs:
       - name: Setup supersetbot
         uses: ./.github/actions/setup-supersetbot/
 
+      - name: Try to login to DockerHub
+        continue-on-error: true
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Execute custom Node.js script
         env:
           DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -38,6 +38,9 @@ jobs:
   docker-release:
     needs: config
     if: needs.config.outputs.has-secrets
+    env:
+      DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     name: docker-release
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -69,9 +69,6 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Execute custom Node.js script
-        env:
-          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           RELEASE="${{ github.event.release.tag_name }}"
           FORCE_LATEST=""
@@ -92,3 +89,9 @@ jobs:
             --context-ref "$RELEASE" $FORCE_LATEST \
             --platform "linux/arm64" \
             --platform "linux/amd64"
+
+      # Going back on original branch to allow "post" GHA operations
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -55,6 +55,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+          depth: 0
 
       - name: Setup supersetbot
         uses: ./.github/actions/setup-supersetbot/
@@ -73,10 +74,7 @@ jobs:
             if [ "${{ github.event.inputs.force-latest }}" = "true" ]; then
               FORCE_LATEST="--force-latest"
             fi
-            # build_docker.py may not exist on that SHA, let's switcharoo to /tmp
-            cp ./scripts/build_docker.py /tmp
             git checkout "${{ github.event.inputs.git-ref }}"
-            cp /tmp/build_docker.py scripts/
             EVENT="release"
           fi
 

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           persist-credentials: false
           tags: true
-          depth: 0
+          fetch-depth: 0
 
       - name: Setup supersetbot
         uses: ./.github/actions/setup-supersetbot/

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -55,6 +55,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+          tags: true
           depth: 0
 
       - name: Setup supersetbot

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -38,9 +38,6 @@ jobs:
   docker-release:
     needs: config
     if: needs.config.outputs.has-secrets
-    env:
-      DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     name: docker-release
     runs-on: ubuntu-latest
     strategy:
@@ -72,6 +69,9 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Execute custom Node.js script
+        env:
+          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           RELEASE="${{ github.event.release.tag_name }}"
           FORCE_LATEST=""


### PR DESCRIPTION
### SUMMARY
Fixing error reported here https://github.com/apache/superset/issues/27378#issuecomment-2040246615 where the GHA for building docker release is unable to `git checkout` the git-ref provided. This PR changes the fetch-depth to 0, effectively doing a full clone of the repo as opposed to a shallow clone.

I'm unclear on why this stopped working as I used it many times successfully in the past.

The code here was tested with the following command:
```
gh workflow run docker-release.yml -r fix_release_docker --field release=3.1.2 --field git-ref=3.1.2 --field force-latest=true
```

Executing here:
https://github.com/apache/superset/actions/runs/8575368927

