### PR TITLE
docs: fix broken OS Dependencies link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -466,7 +466,7 @@ Commits to `master` trigger a rebuild and redeploy of the documentation site. Su
 
 #### OS Dependencies
 
-Make sure your machine meets the [OS dependencies](https://superset.apache.org/docs/installation/installing-superset-from-scratch#os-dependencies) before following these steps.
+Make sure your machine meets the [OS dependencies](https://superset.apache.org/docs/installation/installing-superset-from-pypi#os-dependencies) before following these steps.
 You also need to install MySQL or [MariaDB](https://mariadb.com/downloads).
 
 Ensure that you are using Python version 3.9, 3.10 or 3.11, then proceed with:


### PR DESCRIPTION
### SUMMARY
This fixes the link to [OS dependencies](https://superset.apache.org/docs/installation/installing-superset-from-pypi#os-dependencies) that was broken presumably when `installing-superset-from-scratch` was renamed to `installing-superset-from-pypi`.

### TESTING INSTRUCTIONS
Open [CONTRIBUTING.md#os-dependencies](https://github.com/bgreenlee/superset/blob/master/CONTRIBUTING.md#os-dependencies), click on the "OS dependencies" link. Verify that it goes to the correct document rather than 404-ing.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
