### PR TITLE
fix(drillby): Enable DrillBy in charts w/o filters (dimensions)

### DIFF
--- a/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.test.tsx
@@ -131,9 +131,9 @@ test('render disabled menu item for unsupported chart', async () => {
   );
 });
 
-test('render disabled menu item for supported chart, no filters', async () => {
+test('render enabled menu item for supported chart, no filters', async () => {
   renderMenu({ drillByConfig: { filters: [], groupbyFieldName: 'groupby' } });
-  await expectDrillByDisabled('Drill by is not available for this data point');
+  await expectDrillByEnabled();
 });
 
 test('render disabled menu item for supported chart, no columns', async () => {

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.tsx
@@ -107,9 +107,7 @@ export const DrillByMenuItems = ({
     setSearchInput('');
   }, [columns.length]);
 
-  const hasDrillBy =
-    ensureIsArray(drillByConfig?.filters).length &&
-    drillByConfig?.groupbyFieldName;
+  const hasDrillBy = drillByConfig?.groupbyFieldName;
 
   const handlesDimensionContextMenu = useMemo(
     () =>

--- a/superset-frontend/src/components/Chart/DrillBy/useDrillByBreadcrumbs.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/useDrillByBreadcrumbs.tsx
@@ -81,21 +81,23 @@ export const useDrillByBreadcrumbs = (
           margin: ${theme.gridUnit * 2}px 0 ${theme.gridUnit * 4}px;
         `}
       >
-        {breadcrumbsData.map((breadcrumb, index) => (
-          <BreadcrumbItem
-            key={index}
-            isClickable={isClickable(index)}
-            isHidden={isHidden(breadcrumb)}
-            onClick={
-              isClickable(index)
-                ? () => onBreadcrumbClick(breadcrumb, index)
-                : noOp
-            }
-            data-test="drill-by-breadcrumb-item"
-          >
-            {getBreadcrumbText(breadcrumb)}
-          </BreadcrumbItem>
-        ))}
+        {breadcrumbsData
+          .map((breadcrumb, index) => (
+            <BreadcrumbItem
+              key={index}
+              isClickable={isClickable(index)}
+              isHidden={isHidden(breadcrumb)}
+              onClick={
+                isClickable(index)
+                  ? () => onBreadcrumbClick(breadcrumb, index)
+                  : noOp
+              }
+              data-test="drill-by-breadcrumb-item"
+            >
+              {getBreadcrumbText(breadcrumb)}
+            </BreadcrumbItem>
+          ))
+          .filter(item => item.props.isHidden === false)}
       </AntdBreadcrumb>
     );
   }, [breadcrumbsData, onBreadcrumbClick]);

--- a/superset-frontend/src/components/Chart/DrillBy/useDrillByBreadcrumbs.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/useDrillByBreadcrumbs.tsx
@@ -74,20 +74,26 @@ export const useDrillByBreadcrumbs = (
           margin: ${theme.gridUnit * 2}px 0 ${theme.gridUnit * 4}px;
         `}
       >
-        {breadcrumbsData.map((breadcrumb, index) => (
-          <BreadcrumbItem
-            key={index}
-            isClickable={isClickable(index)}
-            onClick={
-              isClickable(index)
-                ? () => onBreadcrumbClick(breadcrumb, index)
-                : noOp
-            }
-            data-test="drill-by-breadcrumb-item"
-          >
-            {getBreadcrumbText(breadcrumb)}
-          </BreadcrumbItem>
-        ))}
+        {breadcrumbsData
+          .filter(
+            breadcrumb =>
+              ensureIsArray(breadcrumb.filters).length > 0 ||
+              ensureIsArray(breadcrumb.groupby).length > 0,
+          )
+          .map((breadcrumb, index) => (
+            <BreadcrumbItem
+              key={index}
+              isClickable={isClickable(index)}
+              onClick={
+                isClickable(index)
+                  ? () => onBreadcrumbClick(breadcrumb, index)
+                  : noOp
+              }
+              data-test="drill-by-breadcrumb-item"
+            >
+              {getBreadcrumbText(breadcrumb)}
+            </BreadcrumbItem>
+          ))}
       </AntdBreadcrumb>
     );
   }, [breadcrumbsData, onBreadcrumbClick]);

--- a/superset-frontend/src/components/Chart/DrillBy/useDrillByBreadcrumbs.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/useDrillByBreadcrumbs.tsx
@@ -34,8 +34,11 @@ export interface DrillByBreadcrumb {
   filters?: BinaryQueryObjectFilterClause[];
 }
 
-const BreadcrumbItem = styled(AntdBreadcrumb.Item)<{ isClickable: boolean }>`
-  ${({ theme, isClickable }) => css`
+const BreadcrumbItem = styled(AntdBreadcrumb.Item)<{
+  isClickable: boolean;
+  isHidden: boolean;
+}>`
+  ${({ theme, isClickable, isHidden }) => css`
     cursor: ${isClickable ? 'pointer' : 'auto'};
     color: ${theme.colors.grayscale.light1};
     transition: color ease-in ${theme.transitionTiming}s;
@@ -45,6 +48,7 @@ const BreadcrumbItem = styled(AntdBreadcrumb.Item)<{ isClickable: boolean }>`
     &:hover {
       color: ${isClickable ? theme.colors.grayscale.dark1 : 'inherit'};
     }
+    visibility: ${isHidden ? 'hidden' : 'visible'};
   `}
 `;
 
@@ -58,6 +62,9 @@ export const useDrillByBreadcrumbs = (
   useMemo(() => {
     // the last breadcrumb is not clickable
     const isClickable = (index: number) => index < breadcrumbsData.length - 1;
+    const isHidden = (breadcumb: DrillByBreadcrumb) =>
+      ensureIsArray(breadcumb.groupby).length === 0 &&
+      ensureIsArray(breadcumb.filters).length === 0;
     const getBreadcrumbText = (breadcrumb: DrillByBreadcrumb) =>
       `${ensureIsArray(breadcrumb.groupby)
         .map(column => column.verbose_name || column.column_name)
@@ -74,26 +81,21 @@ export const useDrillByBreadcrumbs = (
           margin: ${theme.gridUnit * 2}px 0 ${theme.gridUnit * 4}px;
         `}
       >
-        {breadcrumbsData
-          .filter(
-            breadcrumb =>
-              ensureIsArray(breadcrumb.filters).length > 0 ||
-              ensureIsArray(breadcrumb.groupby).length > 0,
-          )
-          .map((breadcrumb, index) => (
-            <BreadcrumbItem
-              key={index}
-              isClickable={isClickable(index)}
-              onClick={
-                isClickable(index)
-                  ? () => onBreadcrumbClick(breadcrumb, index)
-                  : noOp
-              }
-              data-test="drill-by-breadcrumb-item"
-            >
-              {getBreadcrumbText(breadcrumb)}
-            </BreadcrumbItem>
-          ))}
+        {breadcrumbsData.map((breadcrumb, index) => (
+          <BreadcrumbItem
+            key={index}
+            isClickable={isClickable(index)}
+            isHidden={isHidden(breadcrumb)}
+            onClick={
+              isClickable(index)
+                ? () => onBreadcrumbClick(breadcrumb, index)
+                : noOp
+            }
+            data-test="drill-by-breadcrumb-item"
+          >
+            {getBreadcrumbText(breadcrumb)}
+          </BreadcrumbItem>
+        ))}
       </AntdBreadcrumb>
     );
   }, [breadcrumbsData, onBreadcrumbClick]);


### PR DESCRIPTION
### SUMMARY
This fix resolves #27940 by enabling "Drll by" for Timeseries and Mixed Timeseries charts that do not have dimensions configured.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![Screenshot from 2024-04-08 15-30-47](https://github.com/apache/superset/assets/2765941/9bf0ed0b-1f98-4ab4-8ace-68c80330e932)


After

![image](https://github.com/apache/superset/assets/2765941/9a6617ea-12af-41d0-b0b3-743bea58d718)

![image](https://github.com/apache/superset/assets/2765941/18b06ac3-d2fb-4d8e-8a96-ac3f580ba4da)

### TESTING INSTRUCTIONS
Open any dashboard that includes either Timeseries or Mixed Timeseries charts without dimensions and right-click on any data point in those charts. The "Drill by" should be available and open the modal for the selected dimension.

### ADDITIONAL INFORMATION
- [X] Has associated issue:
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
