### PR TITLE
feat: improve event logging for queries + refactor

### DIFF
--- a/docs/docs/contributing/testing-locally.mdx
+++ b/docs/docs/contributing/testing-locally.mdx
@@ -83,9 +83,20 @@ To run a single test file:
 npm run test -- path/to/file.js
 ```
 
-### Integration Testing
+### e2e Integration Testing
 
-We use [Cypress](https://www.cypress.io/) for integration tests. Tests can be run by `tox -e cypress`. To open Cypress and explore tests first setup and run test server:
+We use [Cypress](https://www.cypress.io/) for end-to-end integration
+tests. One easy option to get started quickly is to leverage `tox` to
+run the whole suite in an isolated environment.
+
+```bash
+tox -e cypress
+```
+
+Alternatively, you can go lower level and set things up in your
+development environment by following these steps:
+
+First set up a python/flask backend:
 
 ```bash
 export SUPERSET_CONFIG=tests.integration_tests.superset_test_config
@@ -98,7 +109,7 @@ superset load-examples --load-test-data
 superset run --port 8081
 ```
 
-Run Cypress tests:
+In another terminal, prepare the frontend and run Cypress tests:
 
 ```bash
 cd superset-frontend

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,6 +267,7 @@ usedevelop = true
 allowlist_externals =
     npm
     pkill
+    {toxinidir}/superset-frontend/cypress_build.sh
 
 [testenv:cypress]
 setenv =

--- a/superset/config.py
+++ b/superset/config.py
@@ -74,6 +74,9 @@ if TYPE_CHECKING:
 
 # Realtime stats logger, a StatsD implementation exists
 STATS_LOGGER = DummyStatsLogger()
+
+# By default will log events to the metadata database with `DBEventLogger`
+# Note that you can use `StdOutEventLogger` for debugging
 EVENT_LOGGER = DBEventLogger()
 
 SUPERSET_LOG_VIEW = True

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1398,20 +1398,6 @@ class SqlaTable(
                 )
             ) from ex
 
-    def mutate_query_from_config(self, sql: str) -> str:
-        """Apply config's SQL_QUERY_MUTATOR
-
-        Typically adds comments to the query with context"""
-        sql_query_mutator = config["SQL_QUERY_MUTATOR"]
-        mutate_after_split = config["MUTATE_AFTER_SPLIT"]
-        if sql_query_mutator and not mutate_after_split:
-            sql = sql_query_mutator(
-                sql,
-                security_manager=security_manager,
-                database=self.database,
-            )
-        return sql
-
     def get_template_processor(self, **kwargs: Any) -> BaseTemplateProcessor:
         return get_template_processor(table=self, database=self.database, **kwargs)
 

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -58,7 +58,7 @@ from sqlalchemy.sql.expression import ColumnClause, Select, TextAsFrom, TextClau
 from sqlalchemy.types import TypeEngine
 from sqlparse.tokens import CTE
 
-from superset import security_manager, sql_parse
+from superset import sql_parse
 from superset.constants import TimeGrain as TimeGrainConstants
 from superset.databases.utils import make_url_safe
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1669,16 +1669,8 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         """
         parsed_query = ParsedQuery(statement, engine=cls.engine)
         sql = parsed_query.stripped()
-        sql_query_mutator = current_app.config["SQL_QUERY_MUTATOR"]
-        mutate_after_split = current_app.config["MUTATE_AFTER_SPLIT"]
-        if sql_query_mutator and not mutate_after_split:
-            sql = sql_query_mutator(
-                sql,
-                security_manager=security_manager,
-                database=database,
-            )
 
-        return sql
+        return database.mutate_sql_based_on_config(sql, is_splitted=True)
 
     @classmethod
     def estimate_query_cost(

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1670,7 +1670,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         parsed_query = ParsedQuery(statement, engine=cls.engine)
         sql = parsed_query.stripped()
 
-        return database.mutate_sql_based_on_config(sql, is_splitted=True)
+        return database.mutate_sql_based_on_config(sql, is_split=True)
 
     @classmethod
     def estimate_query_cost(

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -599,10 +599,7 @@ class Database(
           as to whether the SQL is split or already.
         """
         sql_mutator = config["SQL_QUERY_MUTATOR"]
-        if sql_mutator and (
-            (is_splitted and config["MUTATE_AFTER_SPLIT"])
-            or (not is_splitted and not config["MUTATE_AFTER_SPLIT"])
-        ):
+        if sql_mutator and (is_splitted == config["MUTATE_AFTER_SPLIT"]):
             return sql_mutator(
                 sql_,
                 security_manager=security_manager,

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -587,7 +587,7 @@ class Database(
     def get_reserved_words(self) -> set[str]:
         return self.get_dialect().preparer.reserved_words
 
-    def mutate_sql_based_on_config(self, sql_: str, is_splitted: bool = False) -> str:
+    def mutate_sql_based_on_config(self, sql_: str, is_split: bool = False) -> str:
         """
         Mutates the SQL query based on the app configuration.
 
@@ -599,7 +599,7 @@ class Database(
           as to whether the SQL is split or already.
         """
         sql_mutator = config["SQL_QUERY_MUTATOR"]
-        if sql_mutator and (is_splitted == config["MUTATE_AFTER_SPLIT"]):
+        if sql_mutator and (is_split == config["MUTATE_AFTER_SPLIT"]):
             return sql_mutator(
                 sql_,
                 security_manager=security_manager,
@@ -631,7 +631,7 @@ class Database(
             cursor = conn.cursor()
             df = None
             for i, sql_ in enumerate(sqls):
-                sql_ = self.mutate_sql_based_on_config(sql_, is_splitted=True)
+                sql_ = self.mutate_sql_based_on_config(sql_, is_split=True)
                 _log_query(sql_)
                 with event_logger.log_context(
                     action="execute_sql",

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -588,6 +588,16 @@ class Database(
         return self.get_dialect().preparer.reserved_words
 
     def mutate_sql_based_on_config(self, sql_: str, is_splitted: bool = False) -> str:
+        """
+        Mutates the SQL query based on the app configuration.
+
+        Two config params here affect the behavior of the SQL query mutator:
+        - `SQL_QUERY_MUTATOR`: A user-provided function that mutates the SQL query.
+        - `MUTATE_AFTER_SPLIT`: If True, the SQL query mutator is only called after the
+          sql is broken down into smaller queries. If False, the SQL query mutator applies
+          on the group of queries as a whole. Here the called passes the context
+          as to whether the SQL is split or already.
+        """
         sql_mutator = config["SQL_QUERY_MUTATOR"]
         if sql_mutator and (
             (is_splitted and config["MUTATE_AFTER_SPLIT"])

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -610,7 +610,7 @@ class Database(
             )
         return sql_
 
-    def get_df(  # pylint: disable=too-many-locals
+    def get_df(
         self,
         sql: str,
         schema: str | None = None,

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -73,7 +73,6 @@ SQLLAB_TIMEOUT = config["SQLLAB_ASYNC_TIME_LIMIT_SEC"]
 SQLLAB_HARD_TIMEOUT = SQLLAB_TIMEOUT + 60
 SQL_MAX_ROW = config["SQL_MAX_ROW"]
 SQLLAB_CTAS_NO_LIMIT = config["SQLLAB_CTAS_NO_LIMIT"]
-SQL_QUERY_MUTATOR = config["SQL_QUERY_MUTATOR"]
 log_query = config["QUERY_LOGGER"]
 logger = logging.getLogger(__name__)
 
@@ -264,11 +263,7 @@ def execute_sql_statement(  # pylint: disable=too-many-statements
         sql = apply_limit_if_exists(database, increased_limit, query, sql)
 
     # Hook to allow environment-specific mutation (usually comments) to the SQL
-    sql = SQL_QUERY_MUTATOR(
-        sql,
-        security_manager=security_manager,
-        database=database,
-    )
+    sql = database.mutate_sql_based_on_config(sql)
     try:
         query.executed_sql = sql
         if log_query:

--- a/superset/sql_validators/presto_db.py
+++ b/superset/sql_validators/presto_db.py
@@ -20,7 +20,7 @@ import time
 from contextlib import closing
 from typing import Any, Optional
 
-from superset import app, security_manager
+from superset import app
 from superset.models.core import Database
 from superset.sql_parse import ParsedQuery
 from superset.sql_validators.base import BaseSQLValidator, SQLValidationAnnotation

--- a/superset/sql_validators/presto_db.py
+++ b/superset/sql_validators/presto_db.py
@@ -54,12 +54,7 @@ class PrestoDBSQLValidator(BaseSQLValidator):
         sql = parsed_query.stripped()
 
         # Hook to allow environment-specific mutation (usually comments) to the SQL
-        if sql_query_mutator := config["SQL_QUERY_MUTATOR"]:
-            sql = sql_query_mutator(
-                sql,
-                security_manager=security_manager,
-                database=database,
-            )
+        sql = database.mutate_sql_based_on_config(sql)
 
         # Transform the final statement to an explain call before sending it on
         # to presto to validate

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1907,3 +1907,10 @@ def remove_extra_adhoc_filters(form_data: dict[str, Any]) -> None:
         form_data[key] = [
             filter_ for filter_ in value or [] if not filter_.get("isExtra")
         ]
+
+
+def to_int(v: Any, value_if_invalid: int = 0) -> int:
+    try:
+        return int(v)
+    except (ValueError, TypeError):
+        return value_if_invalid

--- a/superset/utils/log.py
+++ b/superset/utils/log.py
@@ -51,7 +51,7 @@ def collect_request_payload() -> dict[str, Any]:
     payload.update(**request.form.to_dict())
     payload.update(**request.args.to_dict())
     if request.is_json:
-        payload.update(request.json)
+        payload.update(request.get_json(cache=True))
 
     # save URL match pattern in addition to the request path
     url_rule = str(request.url_rule)

--- a/superset/utils/log.py
+++ b/superset/utils/log.py
@@ -32,7 +32,7 @@ from flask_appbuilder.const import API_URI_RIS_KEY
 from sqlalchemy.exc import SQLAlchemyError
 
 from superset.extensions import stats_logger_manager
-from superset.utils.core import get_user_id, LoggerLevel
+from superset.utils.core import get_user_id, LoggerLevel, to_int
 
 if TYPE_CHECKING:
     from superset.stats_logger import BaseStatsLogger
@@ -47,10 +47,11 @@ def collect_request_payload() -> dict[str, Any]:
 
     payload: dict[str, Any] = {
         "path": request.path,
-        **request.form.to_dict(),
-        # url search params can overwrite POST body
-        **request.args.to_dict(),
     }
+    payload.update(**request.form.to_dict())
+    payload.update(**request.args.to_dict())
+    if request.is_json:
+        payload.update(request.json)
 
     # save URL match pattern in addition to the request path
     url_rule = str(request.url_rule)
@@ -136,6 +137,7 @@ class AbstractEventLogger(ABC):
         duration: timedelta | None = None,
         object_ref: str | None = None,
         log_to_statsd: bool = True,
+        database: Any | None = None,
         **payload_override: dict[str, Any] | None,
     ) -> None:
         # pylint: disable=import-outside-toplevel
@@ -161,15 +163,19 @@ class AbstractEventLogger(ABC):
 
         payload = collect_request_payload()
         if object_ref:
-            payload["object_ref"] = object_ref
+            payload["object_ref"] = str(object_ref)
         if payload_override:
             payload.update(payload_override)
 
-        dashboard_id: int | None = None
-        try:
-            dashboard_id = int(payload.get("dashboard_id"))  # type: ignore
-        except (TypeError, ValueError):
-            dashboard_id = None
+        dashboard_id = to_int(payload.get("dashboard_id"))
+
+        database_params = {"database_id": payload.get("database_id")}
+        if database:
+            database_params = {
+                "database_id": database.id,
+                "engine": database.backend,
+                "database_driver": database.driver,
+            }
 
         if "form_data" in payload:
             form_data, _ = get_form_data()
@@ -178,10 +184,7 @@ class AbstractEventLogger(ABC):
         else:
             slice_id = payload.get("slice_id")
 
-        try:
-            slice_id = int(slice_id)  # type: ignore
-        except (TypeError, ValueError):
-            slice_id = 0
+        slice_id = to_int(slice_id)
 
         if log_to_statsd:
             stats_logger_manager.instance.incr(action)
@@ -196,11 +199,13 @@ class AbstractEventLogger(ABC):
         self.log(
             user_id,
             action,
-            records=records,
             dashboard_id=dashboard_id,
+            records=records,
+            object_ref=object_ref,
             slice_id=slice_id,
             duration_ms=duration_ms,
             referrer=referrer,
+            **database_params,
         )
 
     @contextmanager
@@ -209,6 +214,7 @@ class AbstractEventLogger(ABC):
         action: str,
         object_ref: str | None = None,
         log_to_statsd: bool = True,
+        **kwargs: Any,
     ) -> Iterator[Callable[..., None]]:
         """
         Log an event with additional information from the request context.
@@ -216,7 +222,7 @@ class AbstractEventLogger(ABC):
         :param object_ref: reference to the Python object that triggered this action
         :param log_to_statsd: whether to update statsd counter for the action
         """
-        payload_override = {}
+        payload_override = kwargs.copy()
         start = datetime.now()
         # yield a helper to add additional payload
         yield lambda **kwargs: payload_override.update(kwargs)
@@ -359,3 +365,30 @@ class DBEventLogger(AbstractEventLogger):
         except SQLAlchemyError as ex:
             logging.error("DBEventLogger failed to log event(s)")
             logging.exception(ex)
+
+
+class StdOutEventLogger(AbstractEventLogger):
+    """Event logger that prints to stdout for debugging purposes"""
+
+    def log(  # pylint: disable=too-many-arguments,too-many-locals
+        self,
+        user_id: int | None,
+        action: str,
+        dashboard_id: int | None,
+        duration_ms: int | None,
+        slice_id: int | None,
+        referrer: str | None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        print("-=" * 20)
+        d = dict(
+            user_id=user_id,
+            action=action,
+            dashboard_id=dashboard_id,
+            duration_ms=duration_ms,
+            slice_id=slice_id,
+            referrer=referrer,
+            **kwargs,
+        )
+        print("StdOutEventLogger: ", d)

--- a/superset/utils/log.py
+++ b/superset/utils/log.py
@@ -51,7 +51,7 @@ def collect_request_payload() -> dict[str, Any]:
     payload.update(**request.form.to_dict())
     payload.update(**request.args.to_dict())
     if request.is_json:
-        json_payload = request.get_json(cache=True, silent=True)
+        json_payload = request.get_json(cache=True, silent=True) or {}
         payload.update(json_payload)
 
     # save URL match pattern in addition to the request path

--- a/superset/utils/log.py
+++ b/superset/utils/log.py
@@ -47,9 +47,11 @@ def collect_request_payload() -> dict[str, Any]:
 
     payload: dict[str, Any] = {
         "path": request.path,
+        **request.form.to_dict(),
+        # url search params can overwrite POST body
+        **request.args.to_dict(),
     }
-    payload.update(**request.form.to_dict())
-    payload.update(**request.args.to_dict())
+
     if request.is_json:
         json_payload = request.get_json(cache=True, silent=True) or {}
         payload.update(json_payload)

--- a/superset/utils/log.py
+++ b/superset/utils/log.py
@@ -199,12 +199,12 @@ class AbstractEventLogger(ABC):
         self.log(
             user_id,
             action,
-            dashboard_id=dashboard_id,
             records=records,
-            object_ref=object_ref,
+            dashboard_id=dashboard_id,
             slice_id=slice_id,
             duration_ms=duration_ms,
             referrer=referrer,
+            object_ref=object_ref,
             **database_params,
         )
 

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -151,10 +151,12 @@ def get_form_data(
     form_data: dict[str, Any] = initial_form_data or {}
 
     if has_request_context():
+        json_data = request.get_json(cache=True) if request.is_json else {}
+
         # chart data API requests are JSON
-        request_json_data = (
-            request.json["queries"][0]
-            if request.is_json and "queries" in request.json
+        first_query = (
+            json_data["queries"][0]
+            if "queries" in json_data and json_data["queries"]
             else None
         )
 
@@ -162,8 +164,8 @@ def get_form_data(
 
         request_form_data = request.form.get("form_data")
         request_args_data = request.args.get("form_data")
-        if request_json_data:
-            form_data.update(request_json_data)
+        if first_query:
+            form_data.update(first_query)
         if request_form_data:
             parsed_form_data = loads_request_json(request_form_data)
             # some chart data api requests are form_data

--- a/tests/integration_tests/event_logger_tests.py
+++ b/tests/integration_tests/event_logger_tests.py
@@ -144,8 +144,9 @@ class TestEventLogger(unittest.TestCase):
         assert logger.records == [
             {
                 "records": [{"path": "/", "engine": "bar"}],
+                "database_id": None,
                 "user_id": 2,
-                "duration": 15000.0,
+                "duration": 15000,
             }
         ]
 
@@ -191,6 +192,7 @@ class TestEventLogger(unittest.TestCase):
                         "payload_override": {"engine": "sqlite"},
                     }
                 ],
+                "database_id": None,
                 "user_id": 2,
                 "duration": 5558756000,
             }

--- a/tests/unit_tests/sql_lab_test.py
+++ b/tests/unit_tests/sql_lab_test.py
@@ -38,6 +38,7 @@ def test_execute_sql_statement(mocker: MockerFixture, app: None) -> None:
     database = query.database
     database.allow_dml = False
     database.apply_limit_to_sql.return_value = "SELECT 42 AS answer LIMIT 2"
+    database.mutate_sql_based_on_config.return_value = "SELECT 42 AS answer LIMIT 2"
     db_engine_spec = database.db_engine_spec
     db_engine_spec.is_select_query.return_value = True
     db_engine_spec.fetch_data.return_value = [(42,)]
@@ -71,15 +72,16 @@ def test_execute_sql_statement_with_rls(
     from superset.sql_lab import execute_sql_statement
 
     sql_statement = "SELECT * FROM sales"
+    sql_statement_with_rls = f"{sql_statement} WHERE organization_id=42"
+    sql_statement_with_rls_and_limit = f"{sql_statement_with_rls} LIMIT 101"
 
     query = mocker.MagicMock()
     query.limit = 100
     query.select_as_cta_used = False
     database = query.database
     database.allow_dml = False
-    database.apply_limit_to_sql.return_value = (
-        "SELECT * FROM sales WHERE organization_id=42 LIMIT 101"
-    )
+    database.apply_limit_to_sql.return_value = sql_statement_with_rls_and_limit
+    database.mutate_sql_based_on_config.return_value = sql_statement_with_rls_and_limit
     db_engine_spec = database.db_engine_spec
     db_engine_spec.is_select_query.return_value = True
     db_engine_spec.fetch_data.return_value = [(42,)]


### PR DESCRIPTION
### SUMMARY

The main driver for this PR was to enrich event logging around database engine and database drivers for events that interact directly with analytics databases. While touching this up, I did some refactor along the way.

- Adding a new analytics event/action `execute_sql` that targets just that, that **isn't** called when hitting the cache for instance. Using the context manager insures capturing the duration of the call as well.
- refactored logic duplication around config items `SQL_QUERY_MUTATOR` and `MUTATE_AFTER_SPLIT`, where code had been copy/pasted and reimplemented in various places. Here I move it as a method of the Database model.
- side mission: I realized that `request.form` is empty when posting JSON payload, and `request.json` should be used instead. This should automatically capture more automated logging that parses context out of the request object proactively
- factored out `post_process_df` as it seemed logical to isolate this out of `get_df`
- fix cypress glitch + improved cypress docs
