### PR TITLE
docs: deploy docs when merging to master

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -72,6 +72,7 @@ jobs:
         env:
           DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           RELEASE="${{ github.event.release.tag_name }}"
           FORCE_LATEST=""

--- a/.github/workflows/superset-docs-deploy.yml
+++ b/.github/workflows/superset-docs-deploy.yml
@@ -6,7 +6,6 @@ on:
       - "docs/**"
     branches:
       - "master"
-      - "[0-9].[0-9]"
 
 jobs:
   config:

--- a/docs/docs/intro.mdx
+++ b/docs/docs/intro.mdx
@@ -13,7 +13,7 @@ geospatial charts.
 
 Here are a **few different ways you can get started with Superset**:
 
-- Try a [Quickstart deployment](/docs/quickstart), which runs with Docker Compose
+- Try a [Quickstart deployment](/docs/quickstart), powered by [Docker Compose](https://docs.docker.com/compose/)
 - Install Superset [from PyPI](/docs/installation/installing-superset-from-pypi/)
 - Deploy Superset [with Kubernetes](/docs/installation/running-on-kubernetes)
 - Download the [source code from Apache Foundation's website](https://dist.apache.org/repos/dist/release/superset/)


### PR DESCRIPTION
### SUMMARY

I believe the intention is to have the docs
aligned with what is on `master`, currently pushing on a release
branch will trigger a potential regression.

It could be reasonable for the docs to be aligned with the latest
release, but if that was the intention we should deploy the
docs as part of the release process, and avoid previous release branch
from deploying the docs.

I think this happened by mistake on
https://github.com/apache/superset/pull/27390/files#diff-1f3b6eaac4370772e5f0d6cebab7906e0a83ce78e07f6ae8a239c06b33a420d4R9
when the intention was to trigger CI on release branches, not to deploy
the docs.


