### PR TITLE
chore(ci): make pre-commit step faster by skipping superset install

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -24,6 +24,8 @@ jobs:
           submodules: recursive
       - name: Setup Python
         uses: ./.github/actions/setup-backend/
+        with:
+          install-superset: 'false'
       - name: Enable brew and helm-docs
         # Add brew to the path - see https://github.com/actions/runner-images/issues/6283
         run: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -37,6 +37,7 @@ jobs:
           brew install norwoodj/tap/helm-docs
       - name: pre-commit
         run: |
+          pip install pre-commit
           if ! pre-commit run --all-files; then
             git status
             git diff


### PR DESCRIPTION
### SUMMARY
Title - turns out there's no need to pip install superset and its deps when simply running pre-commit
