### PR TITLE
fix: Incorrect onChange value when an unloaded value is pasted into AsyncSelect

### DIFF
--- a/superset-frontend/src/components/Select/AsyncSelect.tsx
+++ b/superset-frontend/src/components/Select/AsyncSelect.tsx
@@ -538,8 +538,15 @@ const AsyncSelect = forwardRef(
     );
 
     const getPastedTextValue = useCallback(
-      (text: string) => {
-        const option = getOption(text, fullSelectOptions, true);
+      async (text: string) => {
+        let option = getOption(text, fullSelectOptions, true);
+        if (!option && !allValuesLoaded) {
+          const fetchOptions = options as SelectOptionsPagePromise;
+          option = await fetchOptions(text, 0, pageSize).then(
+            ({ data }: SelectOptionsTypePage) =>
+              data.find(item => item.label === text),
+          );
+        }
         const value: AntdLabeledValue = {
           label: text,
           value: text,
@@ -550,20 +557,22 @@ const AsyncSelect = forwardRef(
         }
         return value;
       },
-      [fullSelectOptions],
+      [allValuesLoaded, fullSelectOptions, options, pageSize],
     );
 
-    const onPaste = (e: ClipboardEvent<HTMLInputElement>) => {
+    const onPaste = async (e: ClipboardEvent<HTMLInputElement>) => {
       const pastedText = e.clipboardData.getData('text');
       if (isSingleMode) {
-        setSelectValue(getPastedTextValue(pastedText));
+        setSelectValue(await getPastedTextValue(pastedText));
       } else {
         const token = tokenSeparators.find(token => pastedText.includes(token));
         const array = token ? uniq(pastedText.split(token)) : [pastedText];
-        const values = array.map(item => getPastedTextValue(item));
+        const values = await Promise.all(
+          array.map(item => getPastedTextValue(item)),
+        );
         setSelectValue(previous => [
           ...((previous || []) as AntdLabeledValue[]),
-          ...values,
+          ...values.filter(value => !hasOption(value.value, previous)),
         ]);
       }
       fireOnChange();


### PR DESCRIPTION
### SUMMARY
Fixes a bug where the `onChange` event was being fired with an incorrect value when pasting a text that corresponds to an existing option in the database, which was not loaded previously due to pagination.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://github.com/apache/superset/assets/70410625/b6f340ec-0e4a-450b-be38-e4b1181c5dda

https://github.com/apache/superset/assets/70410625/305eb0f0-74ac-4053-a836-f877df2bc951

### TESTING INSTRUCTIONS
1 - Use an async select that has enough values to trigger pagination. You can also reduce the Select's default page size to test.
2 - Paste a value that is not loaded yet by the Select component
3 - Check that the `onChange` event is called with the correct value. It's easier to check this when the options have numeric values. In that case, `onChange` should receive the numeric value instead of the pasted text as the value property.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
