### PR TITLE
fix(ListView): avoid firing event on change of selection

### DIFF
--- a/superset-frontend/src/components/ListView/Filters/Select.tsx
+++ b/superset-frontend/src/components/ListView/Filters/Select.tsx
@@ -50,7 +50,7 @@ function SelectFilter(
 ) {
   const [selectedOption, setSelectedOption] = useState(initialValue);
 
-  const onChange = (selected: SelectOption) => {
+  const handleOnSelect = (selected: SelectOption) => {
     onSelect(
       selected ? { label: selected.label, value: selected.value } : undefined,
     );
@@ -93,7 +93,7 @@ function SelectFilter(
           ariaLabel={typeof Header === 'string' ? Header : name || t('Filter')}
           data-test="filters-select"
           header={<FormLabel>{Header}</FormLabel>}
-          onChange={onChange}
+          onSelect={handleOnSelect}
           onClear={onClear}
           options={fetchAndFormatSelects}
           placeholder={t('Select or type a value')}
@@ -107,7 +107,7 @@ function SelectFilter(
           data-test="filters-select"
           header={<FormLabel>{Header}</FormLabel>}
           labelInValue
-          onChange={onChange}
+          onSelect={handleOnSelect}
           onClear={onClear}
           options={selects}
           placeholder={t('Select or type a value')}

--- a/superset-frontend/src/components/ListView/ListView.test.jsx
+++ b/superset-frontend/src/components/ListView/ListView.test.jsx
@@ -387,7 +387,7 @@ describe('ListView', () => {
         .find('[data-test="filters-select"]')
         .first()
         .props()
-        .onChange({ label: 'bar', value: 'bar' });
+        .onSelect({ label: 'bar', value: 'bar' });
     });
 
     act(() => {
@@ -395,7 +395,7 @@ describe('ListView', () => {
         .find('[data-test="filters-search"]')
         .first()
         .props()
-        .onChange({
+        .onSelect({
           currentTarget: { label: 'something', value: 'something' },
         });
     });


### PR DESCRIPTION
### SUMMARY
When you paste a value in the list view filter, the input field automatically submits the input value right away.
This happens because the `onSelect` event is triggered when the `onChange` event occurs, instead of when the actual selection is made.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://github.com/apache/superset/assets/1392866/1b319b5a-e339-4ab4-988b-990576b0b8d8

After:

https://github.com/apache/superset/assets/1392866/ee9bde52-6e6e-4632-ba60-d2582f1fa323


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
