### PR TITLE
chore(docs): splitting out "stable" feature flags by intent (config vs feature dev)

### DIFF
--- a/RESOURCES/FEATURE_FLAGS.md
+++ b/RESOURCES/FEATURE_FLAGS.md
@@ -57,7 +57,7 @@ These features are **finished** but currently being tested. They are usable, but
 
 ## Stable
 
-These features flags are **safe for production**. They have been tested and will be supported for the foreseeable future.
+These features flags are **safe for production**. They have been tested and will be supported for the at least the current major version cycle.
 
 [//]: # "PLEASE KEEP THESE LISTS SORTED ALPHABETICALLY"
 

--- a/RESOURCES/FEATURE_FLAGS.md
+++ b/RESOURCES/FEATURE_FLAGS.md
@@ -59,15 +59,18 @@ These features are **finished** but currently being tested. They are usable, but
 
 These features flags are **safe for production**. They have been tested and will be supported for the foreseeable future.
 
-[//]: # "PLEASE KEEP THE LIST SORTED ALPHABETICALLY"
+[//]: # "PLEASE KEEP THESE LISTS SORTED ALPHABETICALLY"
 
+### Flags on the path to feature launch and flag deprecation/removal
+- DASHBOARD_VIRTUALIZATION
+- DRILL_BY
+- DISABLE_LEGACY_DATASOURCE_EDITOR
+
+### Flags retained for runtime configuration
 - ALERTS_ATTACH_REPORTS
 - ALLOW_ADHOC_SUBQUERY
 - DASHBOARD_RBAC [(docs)](https://superset.apache.org/docs/creating-charts-dashboards/first-dashboard#manage-access-to-dashboards)
-- DASHBOARD_VIRTUALIZATION
 - DATAPANEL_CLOSED_BY_DEFAULT
-- DISABLE_LEGACY_DATASOURCE_EDITOR
-- DRILL_BY
 - DRUID_JOINS
 - EMBEDDABLE_CHARTS
 - EMBEDDED_SUPERSET


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There was some discussion in Town Hall about whether or not we should use feature flags for runtime configuration or not. The jury is still out! No matter where they live, I figured that at least for now, we should split these up by intent. Then it's clearer to users whether these "stable" flags are ones that will remain (for now, anyway) as config, vs the ones that will march toward feature release and flag deprecation.

If this makes sense as a small intermediary step, let me know if I've miscategorized any of them :)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
