### PR TITLE
fix: Select is accepting unknown pasted values when `allowNewOptions` is false

### DIFF
--- a/superset-frontend/src/components/Select/AsyncSelect.test.tsx
+++ b/superset-frontend/src/components/Select/AsyncSelect.test.tsx
@@ -928,7 +928,14 @@ test('pasting an existing option does not duplicate it in multiple mode', async 
     ],
     totalCount: 3,
   }));
-  render(<AsyncSelect {...defaultProps} options={options} mode="multiple" />);
+  render(
+    <AsyncSelect
+      {...defaultProps}
+      options={options}
+      mode="multiple"
+      allowNewOptions
+    />,
+  );
   await open();
   const input = getElementByClassName('.ant-select-selection-search-input');
   const paste = createEvent.paste(input, {
@@ -941,6 +948,25 @@ test('pasting an existing option does not duplicate it in multiple mode', async 
     // Only Peter should be added
     expect(await findAllSelectOptions()).toHaveLength(4),
   );
+});
+
+test('pasting an non-existent option should not add it if allowNewOptions is false', async () => {
+  render(
+    <AsyncSelect
+      {...defaultProps}
+      allowNewOptions={false}
+      options={async () => ({ data: [], totalCount: 0 })}
+    />,
+  );
+  await open();
+  const input = getElementByClassName('.ant-select-selection-search-input');
+  const paste = createEvent.paste(input, {
+    clipboardData: {
+      getData: () => 'John',
+    },
+  });
+  await waitFor(() => fireEvent(input, paste));
+  expect(await findAllSelectOptions()).toHaveLength(0);
 });
 
 test('onChange is called with the value property when pasting an option that was not loaded yet', async () => {

--- a/superset-frontend/src/components/Select/AsyncSelect.tsx
+++ b/superset-frontend/src/components/Select/AsyncSelect.tsx
@@ -547,6 +547,9 @@ const AsyncSelect = forwardRef(
               data.find(item => item.label === text),
           );
         }
+        if (!option && !allowNewOptions) {
+          return undefined;
+        }
         const value: AntdLabeledValue = {
           label: text,
           value: text,
@@ -557,19 +560,22 @@ const AsyncSelect = forwardRef(
         }
         return value;
       },
-      [allValuesLoaded, fullSelectOptions, options, pageSize],
+      [allValuesLoaded, allowNewOptions, fullSelectOptions, options, pageSize],
     );
 
     const onPaste = async (e: ClipboardEvent<HTMLInputElement>) => {
       const pastedText = e.clipboardData.getData('text');
       if (isSingleMode) {
-        setSelectValue(await getPastedTextValue(pastedText));
+        const value = await getPastedTextValue(pastedText);
+        if (value) {
+          setSelectValue(value);
+        }
       } else {
         const token = tokenSeparators.find(token => pastedText.includes(token));
         const array = token ? uniq(pastedText.split(token)) : [pastedText];
-        const values = await Promise.all(
-          array.map(item => getPastedTextValue(item)),
-        );
+        const values = (
+          await Promise.all(array.map(item => getPastedTextValue(item)))
+        ).filter(item => item !== undefined) as AntdLabeledValue[];
         setSelectValue(previous => [
           ...((previous || []) as AntdLabeledValue[]),
           ...values.filter(value => !hasOption(value.value, previous)),

--- a/superset-frontend/src/components/Select/Select.test.tsx
+++ b/superset-frontend/src/components/Select/Select.test.tsx
@@ -1039,6 +1039,7 @@ test('pasting an existing option does not duplicate it in multiple mode', async 
       options={options}
       mode="multiple"
       allowSelectAll={false}
+      allowNewOptions
     />,
   );
   await open();
@@ -1051,6 +1052,19 @@ test('pasting an existing option does not duplicate it in multiple mode', async 
   fireEvent(input, paste);
   // Only Peter should be added
   expect(await findAllSelectOptions()).toHaveLength(4);
+});
+
+test('pasting an non-existent option should not add it if allowNewOptions is false', async () => {
+  render(<Select {...defaultProps} options={[]} allowNewOptions={false} />);
+  await open();
+  const input = getElementByClassName('.ant-select-selection-search-input');
+  const paste = createEvent.paste(input, {
+    clipboardData: {
+      getData: () => 'John',
+    },
+  });
+  fireEvent(input, paste);
+  expect(await findAllSelectOptions()).toHaveLength(0);
 });
 
 test('does not fire onChange if the same value is selected in single mode', async () => {

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -543,6 +543,9 @@ const Select = forwardRef(
     const getPastedTextValue = useCallback(
       (text: string) => {
         const option = getOption(text, fullSelectOptions, true);
+        if (!option && !allowNewOptions) {
+          return undefined;
+        }
         if (labelInValue) {
           const value: AntdLabeledValue = {
             label: text,
@@ -556,17 +559,22 @@ const Select = forwardRef(
         }
         return option ? (isObject(option) ? option.value! : option) : text;
       },
-      [fullSelectOptions, labelInValue],
+      [allowNewOptions, fullSelectOptions, labelInValue],
     );
 
     const onPaste = (e: ClipboardEvent<HTMLInputElement>) => {
       const pastedText = e.clipboardData.getData('text');
       if (isSingleMode) {
-        setSelectValue(getPastedTextValue(pastedText));
+        const value = getPastedTextValue(pastedText);
+        if (value) {
+          setSelectValue(value);
+        }
       } else {
         const token = tokenSeparators.find(token => pastedText.includes(token));
         const array = token ? uniq(pastedText.split(token)) : [pastedText];
-        const values = array.map(item => getPastedTextValue(item));
+        const values = array
+          .map(item => getPastedTextValue(item))
+          .filter(item => item !== undefined);
         if (labelInValue) {
           setSelectValue(previous => [
             ...((previous || []) as AntdLabeledValue[]),


### PR DESCRIPTION
### SUMMARY
Fix a bug where the `Select` component was accepting unknown pasted values when `allowNewOptions` is `false`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://github.com/apache/superset/assets/70410625/6bbcf70c-5cac-492b-b9c7-cef267acbbf7

https://github.com/apache/superset/assets/70410625/2b2cd334-d19b-47b0-bc05-246e2b6fa989

### TESTING INSTRUCTIONS
1 - Set `allowNewOptions` to `false`
2 - Paste an unknown value
3 - The component should not accept the value

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
