### PR TITLE
chore: stabilize MySQL tests by aligning isolation levels

### DIFF
--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -89,6 +89,7 @@ EOF
 setup-mysql() {
   say "::group::Initialize database"
   mysql -h 127.0.0.1 -P 13306 -u root --password=root <<-EOF
+    SET GLOBAL transaction_isolation='READ-COMMITTED';
     DROP DATABASE IF EXISTS superset;
     CREATE DATABASE superset DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci;
     DROP DATABASE IF EXISTS sqllab_test_db;

--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -90,6 +90,7 @@ setup-mysql() {
   say "::group::Initialize database"
   mysql -h 127.0.0.1 -P 13306 -u root --password=root <<-EOF
     SET GLOBAL transaction_isolation='READ-COMMITTED';
+    SET GLOBAL TRANSACTION ISOLATION LEVEL READ COMMITTED;
     DROP DATABASE IF EXISTS superset;
     CREATE DATABASE superset DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci;
     DROP DATABASE IF EXISTS sqllab_test_db;

--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -29,6 +29,13 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 13306:3306
+        # options bellow added to try and address flaky tests
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+          --transaction-isolation=READ-COMMITTED
       redis:
         image: redis:7-alpine
         options: --entrypoint redis-server

--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -40,10 +40,6 @@ jobs:
         ports:
           - 16379:6379
     steps:
-      - name: Set MySQL Isolation Level
-        run: |
-          echo "Setting MySQL isolation level..."
-          mysql -uroot -proot -h127.0.0.1 -P13306 -e "SET GLOBAL transaction_isolation='READ-COMMITTED';"
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -29,19 +29,21 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 13306:3306
-        # options bellow added to try and address flaky tests
         options: >-
           --health-cmd="mysqladmin ping --silent"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5
-          --transaction-isolation=READ-COMMITTED
       redis:
         image: redis:7-alpine
         options: --entrypoint redis-server
         ports:
           - 16379:6379
     steps:
+      - name: Set MySQL Isolation Level
+        run: |
+          echo "Setting MySQL isolation level..."
+          mysql -uroot -proot -h127.0.0.1 -P13306 -e "SET GLOBAL transaction_isolation='READ-COMMITTED';"
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4
         with:

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -724,6 +724,7 @@ class TestPostChartDataApi(BaseTestChartDataApi):
         app._got_first_request = False
         async_query_manager_factory.init_app(app)
         self.login(ADMIN_USERNAME)
+        # Introducing time.sleep to make test less flaky with MySQL
         time.sleep(1)
         rv = self.post_assert_metric(CHART_DATA_URI, self.query_context_payload, "data")
         time.sleep(1)

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -21,6 +21,7 @@ import unittest
 import copy
 from datetime import datetime
 from io import BytesIO
+import time
 from typing import Any, Optional
 from unittest import mock
 from zipfile import ZipFile
@@ -723,8 +724,11 @@ class TestPostChartDataApi(BaseTestChartDataApi):
         app._got_first_request = False
         async_query_manager_factory.init_app(app)
         self.login(ADMIN_USERNAME)
+        time.sleep(1)
         rv = self.post_assert_metric(CHART_DATA_URI, self.query_context_payload, "data")
+        time.sleep(1)
         self.assertEqual(rv.status_code, 202)
+        time.sleep(1)
         data = json.loads(rv.data.decode("utf-8"))
         keys = list(data.keys())
         self.assertCountEqual(

--- a/tests/integration_tests/query_context_tests.py
+++ b/tests/integration_tests/query_context_tests.py
@@ -151,8 +151,12 @@ class TestQueryContext(SupersetTestCase):
         description_original = datasource.description
         datasource.description = "temporary description"
         db.session.commit()
+        # wait a second since mysql records timestamps in second granularity
+        time.sleep(1)
         datasource.description = description_original
         db.session.commit()
+        # wait another second because why not
+        time.sleep(1)
 
         # create new QueryContext with unchanged attributes, extract new query_cache_key
         query_context = ChartDataQueryContextSchema().load(payload)


### PR DESCRIPTION
I've been keeping an eye on our CI and noticed that a couple of Python tests like `test_query_cache_key_changes_when_datasource_is_updated` and `test_chart_data_async` keep tripping up on MySQL. I think it might be the different isolation levels messing things up compared to PostgreSQL.

So, I've tweaked our MySQL setup in the GitHub Actions to use 'READ-COMMITTED', just like Postgres. Hopefully, this gets rid of those annoying inconsistencies and smooths things out for our test runs.

following https://dev.mysql.com/doc/refman/8.3/en/set-transaction.html#:~:text=To%20set%20the%20global%20isolation,REPEATABLE%2DREAD%20%2C%20or%20SERIALIZABLE%20.