### PR TITLE
fix: Dynamic filter does not show all values on blur/clear events

### DIFF
--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -189,7 +189,8 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
 
   const handleBlur = useCallback(() => {
     unsetFocusedFilter();
-  }, [unsetFocusedFilter]);
+    onSearch('');
+  }, [onSearch, unsetFocusedFilter]);
 
   const handleChange = useCallback(
     (value?: SelectValue | number | string) => {
@@ -293,7 +294,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
       >
         <Select
           allowClear
-          allowNewOptions
+          allowNewOptions={!searchAllOptions}
           allowSelectAll={!searchAllOptions}
           // @ts-ignore
           value={filterState.value || []}
@@ -307,6 +308,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
           showSearch={showSearch}
           mode={multiSelect ? 'multiple' : 'single'}
           placeholder={placeholderText}
+          onClear={() => onSearch('')}
           onSearch={onSearch}
           onBlur={handleBlur}
           onFocus={setFocusedFilter}


### PR DESCRIPTION
### SUMMARY
Fixes a bug where a filter was not showing all values on blur/clear events when the `Dynamically search all filter values` option is checked.

Fix https://github.com/apache/superset/issues/28004.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://github.com/apache/superset/assets/70410625/c31b38a9-563a-4b3a-baab-5d81d72fe95e

https://github.com/apache/superset/assets/70410625/4e7f2ea2-db71-4c07-bb5c-7d0c04daf286

### TESTING INSTRUCTIONS
Check the original issue and videos for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
