### PR TITLE
chore(asf): disable calendar display by default, click to show

### DIFF
--- a/docs/src/pages/community.tsx
+++ b/docs/src/pages/community.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
+import React, { useState } from 'react';
 import styled from '@emotion/styled';
 import { List } from 'antd';
 import Layout from '@theme/Layout';
@@ -179,7 +179,19 @@ const StyledLink = styled('a')`
   }
 `;
 
+const FinePrint = styled('div')`
+  font-size: 14px;
+  color: var(--ifm-secondary-text);
+`
+
 const Community = () => {
+
+  const [showCalendar, setShowCalendar] = useState(false); // State to control calendar visibility
+
+  const toggleCalendar = () => {
+    setShowCalendar(!showCalendar); // Toggle calendar visibility
+  };
+
   return (
     <Layout
       title="Community"
@@ -238,14 +250,22 @@ const Community = () => {
                   <img src="/img/calendar-icon.svg" alt="calendar-icon" />
                   Subscribe to the Superset Community Calendar
                 </StyledLink>
+                <br />
+                <StyledLink onClick={toggleCalendar}>
+                <img src="/img/calendar-icon.svg" alt="calendar-icon" />
+                  {showCalendar ? 'Hide Calendar' : 'Display Calendar*'}
+                </StyledLink>
+                {!showCalendar  && <FinePrint><sup>*</sup>Clicking on this link will load and send data from and to Google.</FinePrint>}
               </>
             }
           />
-          <StyledCalendarIframe
-            src="https://calendar.google.com/calendar/embed?src=superset.committers%40gmail.com&ctz=America%2FLos_Angeles"
-            frameBorder="0"
-            scrolling="no"
-          />
+          {showCalendar && (
+            <StyledCalendarIframe
+              src="https://calendar.google.com/calendar/embed?src=superset.committers%40gmail.com&ctz=America%2FLos_Angeles"
+              frameBorder="0"
+              scrolling="no"
+            />
+          )}
         </BlurredSection>
       </main>
     </Layout>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
ASF doesn't want people to get tracked by Google, so they suggest approximating [this approach](https://privacy.apache.org/examples/youtube-html/with-youtube-embeds.html) for our cal. Now, the Resources page does not hit google until you click that link to load the calendar/iframe. 

This kinda sucks, so hopefully there's a better way to subscribe/scrape the cal data and render it ourselves, in time.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
