### PR TITLE
fix(Dashboard): Support "Edit chart" click on a new window

### DIFF
--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -529,6 +529,7 @@ const SliceHeaderControls = (props: SliceHeaderControlsPropsWithRouter) => {
   const [openScopingModal, scopingModal] = useCrossFiltersScopingModal(
     props.slice.slice_id,
   );
+  const history = useHistory();
 
   const queryMenuRef: RefObject<any> = useRef(null);
   const menuRef: RefObject<any> = useRef(null);
@@ -677,7 +678,6 @@ const SliceHeaderControls = (props: SliceHeaderControlsPropsWithRouter) => {
     supersetCanShare = false,
     isCached = [],
   } = props;
-  const history = useHistory();
   const isTable = slice.viz_type === 'table';
   const cachedWhen = (cachedDttm || []).map(itemCachedDttm =>
     moment.utc(itemCachedDttm).fromNow(),

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -590,7 +590,12 @@ const SliceHeaderControls = (props: SliceHeaderControlsPropsWithRouter) => {
       case MenuKeys.ExploreChart:
         // eslint-disable-next-line no-unused-expressions
         props.logExploreChart?.(props.slice.slice_id);
-        window.open(props.exploreUrl);
+        if (domEvent.metaKey || domEvent.ctrlKey) {
+          domEvent.preventDefault();
+          window.open(props.exploreUrl, '_blank');
+        } else {
+          history.push(props.exploreUrl);
+        }
         break;
       case MenuKeys.ExportCsv:
         // eslint-disable-next-line no-unused-expressions
@@ -672,6 +677,7 @@ const SliceHeaderControls = (props: SliceHeaderControlsPropsWithRouter) => {
     supersetCanShare = false,
     isCached = [],
   } = props;
+  const history = useHistory();
   const isTable = slice.viz_type === 'table';
   const cachedWhen = (cachedDttm || []).map(itemCachedDttm =>
     moment.utc(itemCachedDttm).fromNow(),
@@ -907,16 +913,6 @@ const SliceHeaderControls = (props: SliceHeaderControlsPropsWithRouter) => {
         placement="bottomRight"
         visible={dropdownIsOpen}
         onVisibleChange={status => toggleDropdown({ close: !status })}
-        onBlur={e => {
-          // close unless the dropdown menu is clicked
-          const relatedTarget = e.relatedTarget as HTMLElement;
-          if (
-            dropdownIsOpen &&
-            menuRef?.current?.props.id !== relatedTarget?.id
-          ) {
-            toggleDropdown({ close: true });
-          }
-        }}
         onKeyDown={e =>
           handleDropdownNavigation(
             e,


### PR DESCRIPTION
### SUMMARY
This PR https://github.com/apache/superset/pull/26138 removed the link from the "Edit chart" menu item on dashboards to enhance accessibility but it caused the chart to open in a new window. The goal of this PR is to support opening the chart in the same window by default while still allowing for opening a chart in a separate window with `cmd + click`.

It also removes an `onBlur` handler that was causing the interruption of some menu item actions by closing the dropdown abruptly. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N.A.

### TESTING INSTRUCTIONS
1. Click on "Edit chart" in a Dashboard
2. The chart should open in the same window
3. cmd + click, the chart should open in a new window

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
