### PR TITLE
fix: switch off dependabot for pip/python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,14 +19,11 @@ updates:
     open-pull-requests-limit: 30
     versioning-strategy: increase
 
-  - package-ecosystem: "pip"
-    directory: "/requirements/"
-    schedule:
-      interval: "monthly"
-    labels:
-      - pip
-      - dependabot
-    open-pull-requests-limit: 30
+
+  # - package-ecosystem: "pip"
+  # NOTE: as dependabot isn't compatible with our python
+  # dependency setup (pip-compile-multi), we'll be using
+  # `supersetbot` instead
 
   - package-ecosystem: "npm"
     directory: ".github/actions"


### PR DESCRIPTION
This PR turns off `dependabot` for pip/python as it's not compatible
with our somewhat intricate setup that leverages pip-compile-multi

We'll be leveraging a custom bot `supersetbot` to do so that will
operate in specific pre-release time windows. The bot is ready
to go for the next window.

