### PR TITLE
chore(asf): setting website staging server to point at superset-site's lfs branch

### DIFF
--- a/docs/static/.asf.yaml
+++ b/docs/static/.asf.yaml
@@ -19,4 +19,4 @@ publish:
   whoami: asf-site
 
 staging:
-  whoami: asf-site
+  whoami: lfs


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Ok... so ASF doesn't like stuff served by Github, it appears. 

We want to keep large files (like our video) out of the repo. Currently this asset happens to be on the site's LFS branch:
https://github.com/apache/superset-site/tree/lfs

ASF gives us not only a prod site, but a staging site we've never taken advantage of. This PR points the ASF's staging server at the LFS branch. These files should get copied/hosted at our staging URL: https://superset.staged.apache.org/

Then we can link to that ASF hosted file rather than GitHub or Githubusercontent in a subsequent PR, and remove the CSP entries.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
