### PR TITLE
fix(sql_parse): Support Jinja format() filter when extracting latest[_sub]_partition

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -1559,7 +1559,7 @@ def extract_tables_from_jinja_sql(sql: str, database: Database) -> set[Table]:
                 Table(
                     *[
                         remove_quotes(part.strip())
-                        for part in node.args[0].value.split(".")[::-1]
+                        for part in node.args[0].as_const().split(".")[::-1]
                         if len(node.args) == 1
                     ]
                 )

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -1942,6 +1942,7 @@ def test_sqlstatement() -> None:
     [
         "latest_partition('foo.bar')",
         "latest_partition(' foo.bar ')",  # Non-atypical user error which works
+        "latest_partition('foo.%s'|format('bar'))",
         "latest_sub_partition('foo.bar', baz='qux')",
     ],
 )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

One can specify either a Jinja filter or Python `str` function to dynamically define the table referenced by the `latest[_sub]_partition` macros. Cases like `trino.latest_partition("foo.%s"|format("bar"))` and `trino.latest_partition("foo.{}".format("bar"))` resulted in errors of the form, 

```
AttributeError: 'Filter' object has no attribute 'value'
```

or 

```
AttributeError: 'Call' object has no attribute 'value'
```

respectively.

I went through numerous rabbit holes to try to have the Jinja environment render the AST subtree in a generic way, but alas I wasn't able find an elegant solution—especially when it comes to the `Call` node.

The fix—which only works for the `Filter` node—is to use the `as_const()` method as opposed to the `value` attribute to ensure the filter is rendered. Note that one can always rewrite the `str.format` using the Jinja `format()` filter.
 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
