### PR TITLE
feat(SIP-95): new endpoint for table metadata

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.js
@@ -508,10 +508,11 @@ describe('async actions', () => {
     fetchMock.delete(updateTableSchemaEndpoint, {});
     fetchMock.post(updateTableSchemaEndpoint, JSON.stringify({ id: 1 }));
 
-    const getTableMetadataEndpoint = 'glob:**/api/v1/database/*/table/*/*/';
+    const getTableMetadataEndpoint =
+      'glob:**/api/v1/database/*/table_metadata/*';
     fetchMock.get(getTableMetadataEndpoint, {});
     const getExtraTableMetadataEndpoint =
-      'glob:**/api/v1/database/*/table_metadata/extra/';
+      'glob:**/api/v1/database/*/table_metadata/extra/*';
     fetchMock.get(getExtraTableMetadataEndpoint, {});
 
     let isFeatureEnabledMock;

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/SqlEditorLeftBar.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/SqlEditorLeftBar.test.tsx
@@ -61,13 +61,13 @@ beforeEach(() => {
       },
     ],
   });
-  fetchMock.get('glob:*/api/v1/database/*/table/*/*', {
+  fetchMock.get('glob:*/api/v1/database/*/table_metadata/*', {
     status: 200,
     body: {
       columns: table.columns,
     },
   });
-  fetchMock.get('glob:*/api/v1/database/*/table_metadata/extra/', {
+  fetchMock.get('glob:*/api/v1/database/*/table_metadata/extra/*', {
     status: 200,
     body: {},
   });

--- a/superset-frontend/src/SqlLab/components/TableElement/TableElement.test.tsx
+++ b/superset-frontend/src/SqlLab/components/TableElement/TableElement.test.tsx
@@ -47,9 +47,10 @@ jest.mock(
       <div data-test="mock-column-element">{column.name}</div>
     ),
 );
-const getTableMetadataEndpoint = 'glob:**/api/v1/database/*/table_metadata/*';
+const getTableMetadataEndpoint =
+  /\/api\/v1\/database\/\d+\/table_metadata\/(?:\?.*)?$/;
 const getExtraTableMetadataEndpoint =
-  'glob:**/api/v1/database/*/table_metadata/extra/*';
+  /\/api\/v1\/database\/\d+\/table_metadata\/extra\/(?:\?.*)?$/;
 const updateTableSchemaEndpoint = 'glob:*/tableschemaview/*/expanded';
 
 beforeEach(() => {

--- a/superset-frontend/src/SqlLab/components/TableElement/TableElement.test.tsx
+++ b/superset-frontend/src/SqlLab/components/TableElement/TableElement.test.tsx
@@ -47,7 +47,7 @@ jest.mock(
       <div data-test="mock-column-element">{column.name}</div>
     ),
 );
-const getTableMetadataEndpoint = 'glob:**/api/v1/database/*/table/*/*/';
+const getTableMetadataEndpoint = 'glob:**/api/v1/database/*/table_metadata/*';
 const getExtraTableMetadataEndpoint =
   'glob:**/api/v1/database/*/table_metadata/extra/*';
 const updateTableSchemaEndpoint = 'glob:*/tableschemaview/*/expanded';

--- a/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/index.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/index.tsx
@@ -74,7 +74,9 @@ const DatasetPanelWrapper = ({
     const { dbId, tableName, schema } = props;
     setLoading(true);
     setHasColumns?.(false);
-    const path = `/api/v1/database/${dbId}/table/${tableName}/${schema}/`;
+    const path = schema
+      ? `/api/v1/database/${dbId}/table_metadata/?name=${tableName}&schema=${schema}/`
+      : `/api/v1/database/${dbId}/table_metadata/?name=${tableName}`;
     try {
       const response = await SupersetClient.get({
         endpoint: path,

--- a/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/index.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/index.tsx
@@ -75,7 +75,7 @@ const DatasetPanelWrapper = ({
     setLoading(true);
     setHasColumns?.(false);
     const path = schema
-      ? `/api/v1/database/${dbId}/table_metadata/?name=${tableName}&schema=${schema}/`
+      ? `/api/v1/database/${dbId}/table_metadata/?name=${tableName}&schema=${schema}`
       : `/api/v1/database/${dbId}/table_metadata/?name=${tableName}`;
     try {
       const response = await SupersetClient.get({

--- a/superset-frontend/src/hooks/apiResources/tables.ts
+++ b/superset-frontend/src/hooks/apiResources/tables.ts
@@ -114,9 +114,9 @@ const tableApi = api.injectEndpoints({
     }),
     tableMetadata: builder.query<TableMetaData, FetchTableMetadataQueryParams>({
       query: ({ dbId, schema, table }) => ({
-        endpoint: `/api/v1/database/${dbId}/table/${encodeURIComponent(
-          table,
-        )}/${encodeURIComponent(schema)}/`,
+        endpoint: schema
+          ? `/api/v1/database/${dbId}/table_metadata/?name=${table}&schema=${schema}`
+          : `/api/v1/database/${dbId}/table_metadata/?name=${table}`,
         transformResponse: ({ json }: TableMetadataReponse) => json,
       }),
     }),

--- a/superset/commands/database/tables.py
+++ b/superset/commands/database/tables.py
@@ -51,6 +51,7 @@ class TablesDatabaseCommand(BaseCommand):
                 datasource_names=sorted(
                     DatasourceName(*datasource_name)
                     for datasource_name in self._model.get_all_table_names_in_schema(
+                        catalog=None,
                         schema=self._schema_name,
                         force=self._force,
                         cache=self._model.table_cache_enabled,
@@ -65,6 +66,7 @@ class TablesDatabaseCommand(BaseCommand):
                 datasource_names=sorted(
                     DatasourceName(*datasource_name)
                     for datasource_name in self._model.get_all_view_names_in_schema(
+                        catalog=None,
                         schema=self._schema_name,
                         force=self._force,
                         cache=self._model.table_cache_enabled,

--- a/superset/commands/database/validate_sql.py
+++ b/superset/commands/database/validate_sql.py
@@ -61,11 +61,12 @@ class ValidateSQLCommand(BaseCommand):
             raise ValidatorSQLUnexpectedError()
         sql = self._properties["sql"]
         schema = self._properties.get("schema")
+        catalog = self._properties.get("catalog")
         try:
             timeout = current_app.config["SQLLAB_VALIDATION_TIMEOUT"]
             timeout_msg = f"The query exceeded the {timeout} seconds timeout."
             with utils.timeout(seconds=timeout, error_message=timeout_msg):
-                errors = self._validator.validate(sql, schema, self._model)
+                errors = self._validator.validate(sql, catalog, schema, self._model)
             return [err.to_dict() for err in errors]
         except Exception as ex:
             logger.exception(ex)

--- a/superset/commands/dataset/importers/v1/utils.py
+++ b/superset/commands/dataset/importers/v1/utils.py
@@ -32,6 +32,7 @@ from superset.commands.dataset.exceptions import DatasetForbiddenDataURI
 from superset.commands.exceptions import ImportFailedError
 from superset.connectors.sqla.models import SqlaTable
 from superset.models.core import Database
+from superset.sql_parse import Table
 from superset.utils.core import get_user
 
 logger = logging.getLogger(__name__)
@@ -164,7 +165,9 @@ def import_dataset(
         db.session.flush()
 
     try:
-        table_exists = dataset.database.has_table_by_name(dataset.table_name)
+        table_exists = dataset.database.has_table(
+            Table(dataset.table_name, dataset.schema),
+        )
     except Exception:  # pylint: disable=broad-except
         # MySQL doesn't play nice with GSheets table names
         logger.warning(
@@ -217,7 +220,10 @@ def load_data(data_uri: str, dataset: SqlaTable, database: Database) -> None:
         )
     else:
         logger.warning("Loading data outside the import transaction")
-        with database.get_sqla_engine() as engine:
+        with database.get_sqla_engine(
+            catalog=dataset.catalog,
+            schema=dataset.schema,
+        ) as engine:
             df.to_sql(
                 dataset.table_name,
                 con=engine,

--- a/superset/commands/dataset/update.py
+++ b/superset/commands/dataset/update.py
@@ -41,6 +41,7 @@ from superset.connectors.sqla.models import SqlaTable
 from superset.daos.dataset import DatasetDAO
 from superset.daos.exceptions import DAOUpdateFailedError
 from superset.exceptions import SupersetSecurityException
+from superset.sql_parse import Table
 
 logger = logging.getLogger(__name__)
 
@@ -90,9 +91,8 @@ class UpdateDatasetCommand(UpdateMixin, BaseCommand):
         # Validate uniqueness
         if not DatasetDAO.validate_update_uniqueness(
             self._model.database_id,
-            self._model.schema,
+            Table(table_name, self._model.schema, self._model.catalog),
             self._model_id,
-            table_name,
         ):
             exceptions.append(DatasetExistsValidationError(table_name))
         # Validate/Populate database not allowed to change

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -49,7 +49,7 @@ from sqlalchemy import (
     Integer,
     or_,
     String,
-    Table,
+    Table as DBTable,
     Text,
     update,
 )
@@ -108,7 +108,7 @@ from superset.models.helpers import (
     validate_adhoc_subquery,
 )
 from superset.models.slice import Slice
-from superset.sql_parse import ParsedQuery, sanitize_clause
+from superset.sql_parse import ParsedQuery, sanitize_clause, Table
 from superset.superset_typing import (
     AdhocColumn,
     AdhocMetric,
@@ -1065,7 +1065,7 @@ class SqlMetric(AuditMixinNullable, ImportExportMixin, CertificationMixin, Model
         return {s: getattr(self, s) for s in attrs}
 
 
-sqlatable_user = Table(
+sqlatable_user = DBTable(
     "sqlatable_user",
     metadata,
     Column("id", Integer, primary_key=True),
@@ -1143,6 +1143,7 @@ class SqlaTable(
         foreign_keys=[database_id],
     )
     schema = Column(String(255))
+    catalog = Column(String(256), nullable=True, default=None)
     sql = Column(MediumText())
     is_sqllab_view = Column(Boolean, default=False)
     template_params = Column(Text)
@@ -1319,8 +1320,7 @@ class SqlaTable(
             return get_virtual_table_metadata(dataset=self)
         return get_physical_table_metadata(
             database=self.database,
-            table_name=self.table_name,
-            schema_name=self.schema,
+            table=Table(self.table_name, self.schema, self.catalog),
             normalize_columns=self.normalize_columns,
         )
 
@@ -1336,7 +1336,9 @@ class SqlaTable(
         # show_cols and latest_partition set to false to avoid
         # the expensive cost of inspecting the DB
         return self.database.select_star(
-            self.table_name, schema=self.schema, show_cols=False, latest_partition=False
+            Table(self.table_name, self.schema, self.catalog),
+            show_cols=False,
+            latest_partition=False,
         )
 
     @property
@@ -1523,7 +1525,12 @@ class SqlaTable(
                     tbl, _ = self.get_from_clause(template_processor)
                     qry = sa.select([sqla_column]).limit(1).select_from(tbl)
                     sql = self.database.compile_sqla_query(qry)
-                    col_desc = get_columns_description(self.database, self.schema, sql)
+                    col_desc = get_columns_description(
+                        self.database,
+                        self.catalog,
+                        self.schema,
+                        sql,
+                    )
                     if not col_desc:
                         raise SupersetGenericDBErrorException("Column not found")
                     is_dttm = col_desc[0]["is_dttm"]  # type: ignore
@@ -1762,7 +1769,13 @@ class SqlaTable(
         )
 
     def get_sqla_table_object(self) -> Table:
-        return self.database.get_table(self.table_name, schema=self.schema)
+        return self.database.get_table(
+            Table(
+                self.table_name,
+                self.schema,
+                self.catalog,
+            )
+        )
 
     def fetch_metadata(self, commit: bool = True) -> MetadataResult:
         """
@@ -1774,7 +1787,13 @@ class SqlaTable(
         new_columns = self.external_metadata()
         metrics = [
             SqlMetric(**metric)
-            for metric in self.database.get_metrics(self.table_name, self.schema)
+            for metric in self.database.get_metrics(
+                Table(
+                    self.table_name,
+                    self.schema,
+                    self.catalog,
+                )
+            )
         ]
         any_date_col = None
         db_engine_spec = self.db_engine_spec
@@ -2021,7 +2040,7 @@ sa.event.listen(SqlaTable, "after_delete", SqlaTable.after_delete)
 sa.event.listen(SqlMetric, "after_update", SqlaTable.update_column)
 sa.event.listen(TableColumn, "after_update", SqlaTable.update_column)
 
-RLSFilterRoles = Table(
+RLSFilterRoles = DBTable(
     "rls_filter_roles",
     metadata,
     Column("id", Integer, primary_key=True),
@@ -2029,7 +2048,7 @@ RLSFilterRoles = Table(
     Column("rls_filter_id", Integer, ForeignKey("row_level_security_filters.id")),
 )
 
-RLSFilterTables = Table(
+RLSFilterTables = DBTable(
     "rls_filter_tables",
     metadata,
     Column("id", Integer, primary_key=True),

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -329,7 +329,7 @@ class BaseDatasource(AuditMixinNullable, ImportExportMixin):  # pylint: disable=
             "edit_url": self.url,
             "id": self.id,
             "uid": self.uid,
-            "schema": self.schema,
+            "schema": self.schema or None,
             "name": self.name,
             "type": self.type,
             "connection": self.connection,
@@ -383,7 +383,7 @@ class BaseDatasource(AuditMixinNullable, ImportExportMixin):  # pylint: disable=
             "datasource_name": self.datasource_name,
             "table_name": self.datasource_name,
             "type": self.type,
-            "schema": self.schema,
+            "schema": self.schema or None,
             "offset": self.offset,
             "cache_timeout": self.cache_timeout,
             "params": self.params,
@@ -1263,7 +1263,7 @@ class SqlaTable(
 
     def get_schema_perm(self) -> str | None:
         """Returns schema permission if present, database one otherwise."""
-        return security_manager.get_schema_perm(self.database, self.schema)
+        return security_manager.get_schema_perm(self.database, self.schema or None)
 
     def get_perm(self) -> str:
         """
@@ -1320,7 +1320,7 @@ class SqlaTable(
             return get_virtual_table_metadata(dataset=self)
         return get_physical_table_metadata(
             database=self.database,
-            table=Table(self.table_name, self.schema, self.catalog),
+            table=Table(self.table_name, self.schema or None, self.catalog),
             normalize_columns=self.normalize_columns,
         )
 
@@ -1336,7 +1336,7 @@ class SqlaTable(
         # show_cols and latest_partition set to false to avoid
         # the expensive cost of inspecting the DB
         return self.database.select_star(
-            Table(self.table_name, self.schema, self.catalog),
+            Table(self.table_name, self.schema or None, self.catalog),
             show_cols=False,
             latest_partition=False,
         )
@@ -1528,7 +1528,7 @@ class SqlaTable(
                     col_desc = get_columns_description(
                         self.database,
                         self.catalog,
-                        self.schema,
+                        self.schema or None,
                         sql,
                     )
                     if not col_desc:
@@ -1735,7 +1735,9 @@ class SqlaTable(
             return df
 
         try:
-            df = self.database.get_df(sql, self.schema, mutator=assign_column_label)
+            df = self.database.get_df(
+                sql, self.schema or None, mutator=assign_column_label
+            )
         except (SupersetErrorException, SupersetErrorsException) as ex:
             # SupersetError(s) exception should not be captured; instead, they should
             # bubble up to the Flask error handler so they are returned as proper SIP-40
@@ -1772,7 +1774,7 @@ class SqlaTable(
         return self.database.get_table(
             Table(
                 self.table_name,
-                self.schema,
+                self.schema or None,
                 self.catalog,
             )
         )
@@ -1790,7 +1792,7 @@ class SqlaTable(
             for metric in self.database.get_metrics(
                 Table(
                     self.table_name,
-                    self.schema,
+                    self.schema or None,
                     self.catalog,
                 )
             )

--- a/superset/connectors/sqla/utils.py
+++ b/superset/connectors/sqla/utils.py
@@ -38,7 +38,7 @@ from superset.exceptions import (
 )
 from superset.models.core import Database
 from superset.result_set import SupersetResultSet
-from superset.sql_parse import ParsedQuery
+from superset.sql_parse import ParsedQuery, Table
 from superset.superset_typing import ResultSetColumnType
 
 if TYPE_CHECKING:
@@ -47,24 +47,18 @@ if TYPE_CHECKING:
 
 def get_physical_table_metadata(
     database: Database,
-    table_name: str,
+    table: Table,
     normalize_columns: bool,
-    schema_name: str | None = None,
 ) -> list[ResultSetColumnType]:
     """Use SQLAlchemy inspector to get table metadata"""
     db_engine_spec = database.db_engine_spec
     db_dialect = database.get_dialect()
-    # ensure empty schema
-    _schema_name = schema_name if schema_name else None
+
     # Table does not exist or is not visible to a connection.
+    if not (database.has_table(table) or database.has_view(table)):
+        raise NoSuchTableError(table)
 
-    if not (
-        database.has_table_by_name(table_name=table_name, schema=_schema_name)
-        or database.has_view_by_name(view_name=table_name, schema=_schema_name)
-    ):
-        raise NoSuchTableError
-
-    cols = database.get_columns(table_name, schema=_schema_name)
+    cols = database.get_columns(table)
     for col in cols:
         try:
             if isinstance(col["type"], TypeEngine):
@@ -129,11 +123,17 @@ def get_virtual_table_metadata(dataset: SqlaTable) -> list[ResultSetColumnType]:
                 level=ErrorLevel.ERROR,
             )
         )
-    return get_columns_description(dataset.database, dataset.schema, statements[0])
+    return get_columns_description(
+        dataset.database,
+        dataset.catalog,
+        dataset.schema,
+        statements[0],
+    )
 
 
 def get_columns_description(
     database: Database,
+    catalog: str | None,
     schema: str | None,
     query: str,
 ) -> list[ResultSetColumnType]:
@@ -141,7 +141,7 @@ def get_columns_description(
     #  sql_lab.py:execute_sql_statements
     db_engine_spec = database.db_engine_spec
     try:
-        with database.get_raw_connection(schema=schema) as conn:
+        with database.get_raw_connection(catalog=catalog, schema=schema) as conn:
             cursor = conn.cursor()
             query = database.apply_limit_to_sql(query, limit=1)
             cursor.execute(query)

--- a/superset/constants.py
+++ b/superset/constants.py
@@ -134,6 +134,7 @@ MODEL_API_RW_METHOD_PERMISSION_MAP = {
     "schemas": "read",
     "select_star": "read",
     "table_metadata": "read",
+    "table_metadata_deprecated": "read",
     "table_extra_metadata": "read",
     "table_extra_metadata_deprecated": "read",
     "test_connection": "write",

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -136,6 +136,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         RouteMethod.RELATED,
         "tables",
         "table_metadata",
+        "table_metadata_deprecated",
         "table_extra_metadata",
         "table_extra_metadata_deprecated",
         "select_star",
@@ -722,10 +723,10 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        f".table_metadata",
+        f".table_metadata_deprecated",
         log_to_statsd=False,
     )
-    def table_metadata(
+    def table_metadata_deprecated(
         self, database: Database, table_name: str, schema_name: str
     ) -> FlaskResponse:
         """Get database table metadata.
@@ -766,16 +767,16 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
-        self.incr_stats("init", self.table_metadata.__name__)
+        self.incr_stats("init", self.table_metadata_deprecated.__name__)
         try:
-            table_info = get_table_metadata(database, table_name, schema_name)
+            table_info = get_table_metadata(database, Table(table_name, schema_name))
         except SQLAlchemyError as ex:
-            self.incr_stats("error", self.table_metadata.__name__)
+            self.incr_stats("error", self.table_metadata_deprecated.__name__)
             return self.response_422(error_msg_from_exception(ex))
         except SupersetException as ex:
             return self.response(ex.status, message=ex.message)
 
-        self.incr_stats("success", self.table_metadata.__name__)
+        self.incr_stats("success", self.table_metadata_deprecated.__name__)
         return self.response(200, **table_info)
 
     @expose("/<int:pk>/table_extra/<path:table_name>/<schema_name>/", methods=("GET",))
@@ -844,7 +845,86 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         payload = database.db_engine_spec.get_extra_table_metadata(database, table)
         return self.response(200, **payload)
 
-    @expose("/<int:pk>/table_metadata/extra/", methods=("GET",))
+    @expose("/<int:pk>/table_metadata/", methods=["GET"])
+    @protect()
+    @statsd_metrics
+    @event_logger.log_this_with_context(
+        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
+        f".table_metadata",
+        log_to_statsd=False,
+    )
+    def table_metadata(self, pk: int) -> FlaskResponse:
+        """
+        Get metadata for a given table.
+
+        Optionally, a schema and a catalog can be passed, if different from the default
+        ones.
+        ---
+        get:
+          summary: Get table metadata
+          description: >-
+            Metadata associated with the table (columns, indexes, etc.)
+          parameters:
+          - in: path
+            schema:
+              type: integer
+            name: pk
+            description: The database id
+          - in: query
+            schema:
+              type: string
+            name: table
+            required: true
+            description: Table name
+          - in: query
+            schema:
+              type: string
+            name: schema
+            description: >-
+              Optional table schema, if not passed default schema will be used
+          - in: query
+            schema:
+              type: string
+            name: catalog
+            description: >-
+              Optional table catalog, if not passed default catalog will be used
+          responses:
+            200:
+              description: Table metadata information
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/TableExtraMetadataResponseSchema"
+            401:
+              $ref: '#/components/responses/401'
+            404:
+              $ref: '#/components/responses/404'
+            500:
+              $ref: '#/components/responses/500'
+        """
+        self.incr_stats("init", self.table_metadata.__name__)
+
+        database = DatabaseDAO.find_by_id(pk)
+        if database is None:
+            raise DatabaseNotFoundException("No such database")
+
+        try:
+            parameters = QualifiedTableSchema().load(request.args)
+        except ValidationError as ex:
+            raise InvalidPayloadSchemaError(ex) from ex
+
+        table = Table(parameters["name"], parameters["schema"], parameters["catalog"])
+        try:
+            security_manager.raise_for_access(database=database, table=table)
+        except SupersetSecurityException as ex:
+            # instead of raising 403, raise 404 to hide table existence
+            raise TableNotFoundException("No such table") from ex
+
+        payload = database.db_engine_spec.get_table_metadata(database, table)
+
+        return self.response(200, **payload)
+
+    @expose("/<int:pk>/table_metadata/extra/", methods=["GET"])
     @protect()
     @statsd_metrics
     @event_logger.log_this_with_context(
@@ -978,7 +1058,8 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         self.incr_stats("init", self.select_star.__name__)
         try:
             result = database.select_star(
-                table_name, schema_name, latest_partition=True
+                Table(table_name, schema_name),
+                latest_partition=True,
             )
         except NoSuchTableError:
             self.incr_stats("error", self.select_star.__name__)

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -17,11 +17,13 @@
 
 # pylint: disable=unused-argument, too-many-lines
 
+from __future__ import annotations
+
 import inspect
 import json
 import os
 import re
-from typing import Any
+from typing import Any, TypedDict
 
 from flask import current_app
 from flask_babel import lazy_gettext as _
@@ -579,6 +581,49 @@ class DatabaseTestConnectionSchema(DatabaseParametersSchemaMixin, Schema):
     )
 
     ssh_tunnel = fields.Nested(DatabaseSSHTunnel, allow_none=True)
+
+
+class TableMetadataOptionsResponse(TypedDict):
+    deferrable: bool
+    initially: bool
+    match: bool
+    ondelete: bool
+    onupdate: bool
+
+
+class TableMetadataColumnsResponse(TypedDict, total=False):
+    keys: list[str]
+    longType: str
+    name: str
+    type: str
+    duplicates_constraint: str | None
+    comment: str | None
+
+
+class TableMetadataForeignKeysIndexesResponse(TypedDict):
+    column_names: list[str]
+    name: str
+    options: TableMetadataOptionsResponse
+    referred_columns: list[str]
+    referred_schema: str
+    referred_table: str
+    type: str
+
+
+class TableMetadataPrimaryKeyResponse(TypedDict):
+    column_names: list[str]
+    name: str
+    type: str
+
+
+class TableMetadataResponse(TypedDict):
+    name: str
+    columns: list[TableMetadataColumnsResponse]
+    foreignKeys: list[TableMetadataForeignKeysIndexesResponse]
+    indexes: list[TableMetadataForeignKeysIndexesResponse]
+    primaryKey: TableMetadataPrimaryKeyResponse
+    selectStar: str
+    comment: str | None
 
 
 class TableMetadataOptionsResponseSchema(Schema):

--- a/superset/databases/utils.py
+++ b/superset/databases/utils.py
@@ -14,19 +14,29 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Any, Optional, Union
+
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
 
 from sqlalchemy.engine.url import make_url, URL
 
 from superset.commands.database.exceptions import DatabaseInvalidError
+from superset.sql_parse import Table
+
+if TYPE_CHECKING:
+    from superset.databases.schemas import (
+        TableMetadataColumnsResponse,
+        TableMetadataForeignKeysIndexesResponse,
+        TableMetadataResponse,
+    )
 
 
 def get_foreign_keys_metadata(
     database: Any,
-    table_name: str,
-    schema_name: Optional[str],
-) -> list[dict[str, Any]]:
-    foreign_keys = database.get_foreign_keys(table_name, schema_name)
+    table: Table,
+) -> list[TableMetadataForeignKeysIndexesResponse]:
+    foreign_keys = database.get_foreign_keys(table)
     for fk in foreign_keys:
         fk["column_names"] = fk.pop("constrained_columns")
         fk["type"] = "fk"
@@ -34,9 +44,10 @@ def get_foreign_keys_metadata(
 
 
 def get_indexes_metadata(
-    database: Any, table_name: str, schema_name: Optional[str]
-) -> list[dict[str, Any]]:
-    indexes = database.get_indexes(table_name, schema_name)
+    database: Any,
+    table: Table,
+) -> list[TableMetadataForeignKeysIndexesResponse]:
+    indexes = database.get_indexes(table)
     for idx in indexes:
         idx["type"] = "index"
     return indexes
@@ -51,30 +62,27 @@ def get_col_type(col: dict[Any, Any]) -> str:
     return dtype
 
 
-def get_table_metadata(
-    database: Any, table_name: str, schema_name: Optional[str]
-) -> dict[str, Any]:
+def get_table_metadata(database: Any, table: Table) -> TableMetadataResponse:
     """
     Get table metadata information, including type, pk, fks.
     This function raises SQLAlchemyError when a schema is not found.
 
     :param database: The database model
-    :param table_name: Table name
-    :param schema_name: schema name
+    :param table: Table instance
     :return: Dict table metadata ready for API response
     """
     keys = []
-    columns = database.get_columns(table_name, schema_name)
-    primary_key = database.get_pk_constraint(table_name, schema_name)
+    columns = database.get_columns(table)
+    primary_key = database.get_pk_constraint(table)
     if primary_key and primary_key.get("constrained_columns"):
         primary_key["column_names"] = primary_key.pop("constrained_columns")
         primary_key["type"] = "pk"
         keys += [primary_key]
-    foreign_keys = get_foreign_keys_metadata(database, table_name, schema_name)
-    indexes = get_indexes_metadata(database, table_name, schema_name)
+    foreign_keys = get_foreign_keys_metadata(database, table)
+    indexes = get_indexes_metadata(database, table)
     keys += foreign_keys + indexes
-    payload_columns: list[dict[str, Any]] = []
-    table_comment = database.get_table_comment(table_name, schema_name)
+    payload_columns: list[TableMetadataColumnsResponse] = []
+    table_comment = database.get_table_comment(table)
     for col in columns:
         dtype = get_col_type(col)
         payload_columns.append(
@@ -87,11 +95,10 @@ def get_table_metadata(
             }
         )
     return {
-        "name": table_name,
+        "name": table.table,
         "columns": payload_columns,
         "selectStar": database.select_star(
-            table_name,
-            schema=schema_name,
+            table,
             indent=True,
             cols=columns,
             latest_partition=True,
@@ -103,7 +110,7 @@ def get_table_metadata(
     }
 
 
-def make_url_safe(raw_url: Union[str, URL]) -> URL:
+def make_url_safe(raw_url: str | URL) -> URL:
     """
     Wrapper for SQLAlchemy's make_url(), which tends to raise too detailed of
     errors, which inevitably find their way into server logs. ArgumentErrors

--- a/superset/db_engine_specs/README.md
+++ b/superset/db_engine_specs/README.md
@@ -660,7 +660,7 @@ This way, when a user selects a column that doesn't exist Superset can return a 
 
 ### Dynamic schema
 
-In SQL Lab it's possible to select a database, and then a schema in that database. Ideally, when running a query in SQL Lab, any unqualified table names (eg, `table`, instead of `schema.table`) should be in the selected schema. For example, if the user select `dev` as the schema and then runs the following query:
+In SQL Lab it's possible to select a database, and then a schema in that database. Ideally, when running a query in SQL Lab, any unqualified table names (eg, `table`, instead of `schema.table`) should be in the selected schema. For example, if the user selects `dev` as the schema and then runs the following query:
 
 ```sql
 SELECT * FROM my_table
@@ -674,7 +674,7 @@ Implementing this method is also important for usability. When the method is not
 
 ### Catalog
 
-In general, databases support a hierarchy of concepts of one-to-many concepts:
+In general, databases support a hierarchy of one-to-many concepts:
 
 1. Database
 2. Catalog
@@ -692,7 +692,7 @@ These concepts have different names depending on the database. For example, Post
 
 BigQuery, on the other hand:
 
-1. Bigquery (database)
+1. BigQuery (database)
 2. Project (catalog)
 3. Schema (namespace)
 4. Table

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1042,6 +1042,8 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         """
         Returns engine-specific table metadata
 
+        Deprecated, since it doesn't support catalogs.
+
         :param database: Database instance
         :param table: A Table instance
         :return: Engine-specific table metadata

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -61,7 +61,7 @@ from sqlparse.tokens import CTE
 
 from superset import sql_parse
 from superset.constants import TimeGrain as TimeGrainConstants
-from superset.databases.utils import make_url_safe
+from superset.databases.utils import get_table_metadata, make_url_safe
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.exceptions import OAuth2Error, OAuth2RedirectError
 from superset.sql_parse import ParsedQuery, SQLScript, Table
@@ -80,6 +80,7 @@ from superset.utils.oauth2 import encode_oauth2_state
 
 if TYPE_CHECKING:
     from superset.connectors.sqla.models import TableColumn
+    from superset.databases.schemas import TableMetadataResponse
     from superset.models.core import Database
     from superset.models.sql_lab import Query
 
@@ -642,7 +643,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         """
         Return the default schema in a given database.
         """
-        with database.get_inspector_with_context() as inspector:
+        with database.get_inspector() as inspector:
             return inspector.default_schema_name
 
     @classmethod
@@ -760,18 +761,19 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     def get_engine(
         cls,
         database: Database,
+        catalog: str | None = None,
         schema: str | None = None,
         source: utils.QuerySource | None = None,
     ) -> ContextManager[Engine]:
         """
         Return an engine context manager.
 
-            >>> with DBEngineSpec.get_engine(database, schema, source) as engine:
+            >>> with DBEngineSpec.get_engine(database, catalog, schema, source) as engine:
             ...     connection = engine.connect()
             ...     connection.execute(sql)
 
         """
-        return database.get_sqla_engine(schema=schema, source=source)
+        return database.get_sqla_engine(catalog=catalog, schema=schema, source=source)
 
     @classmethod
     def get_timestamp_expr(
@@ -1034,6 +1036,21 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         return indexes
 
     @classmethod
+    def get_table_metadata(
+        cls,
+        database: Database,
+        table: Table,
+    ) -> TableMetadataResponse:
+        """
+        Returns basic table metadata
+
+        :param database: Database instance
+        :param table: A Table instance
+        :return: Basic table metadata
+        """
+        return get_table_metadata(database, table)
+
+    @classmethod
     def get_extra_table_metadata(
         cls,
         database: Database,
@@ -1041,8 +1058,6 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     ) -> dict[str, Any]:
         """
         Returns engine-specific table metadata
-
-        Deprecated, since it doesn't support catalogs.
 
         :param database: Database instance
         :param table: A Table instance
@@ -1238,7 +1253,11 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
             # Only add schema when it is preset and non-empty.
             to_sql_kwargs["schema"] = table.schema
 
-        with cls.get_engine(database) as engine:
+        with cls.get_engine(
+            database,
+            catalog=table.catalog,
+            schema=table.schema,
+        ) as engine:
             if engine.dialect.supports_multivalues_insert:
                 to_sql_kwargs["method"] = "multi"
 
@@ -1473,36 +1492,34 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         cls,
         database: Database,  # pylint: disable=unused-argument
         inspector: Inspector,
-        table_name: str,
-        schema: str | None,
+        table: Table,
     ) -> list[dict[str, Any]]:
         """
         Get the indexes associated with the specified schema/table.
 
         :param database: The database to inspect
         :param inspector: The SQLAlchemy inspector
-        :param table_name: The table to inspect
-        :param schema: The schema to inspect
+        :param table: The table instance to inspect
         :returns: The indexes
         """
 
-        return inspector.get_indexes(table_name, schema)
+        return inspector.get_indexes(table.table, table.schema)
 
     @classmethod
     def get_table_comment(
-        cls, inspector: Inspector, table_name: str, schema: str | None
+        cls,
+        inspector: Inspector,
+        table: Table,
     ) -> str | None:
         """
         Get comment of table from a given schema and table
-
         :param inspector: SqlAlchemy Inspector instance
-        :param table_name: Table name
-        :param schema: Schema name. If omitted, uses default schema for database
+        :param table: Table instance
         :return: comment of table
         """
         comment = None
         try:
-            comment = inspector.get_table_comment(table_name, schema)
+            comment = inspector.get_table_comment(table.table, table.schema)
             comment = comment.get("text") if isinstance(comment, dict) else None
         except NotImplementedError:
             # It's expected that some dialects don't implement the comment method
@@ -1516,22 +1533,25 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     def get_columns(  # pylint: disable=unused-argument
         cls,
         inspector: Inspector,
-        table_name: str,
-        schema: str | None,
+        table: Table,
         options: dict[str, Any] | None = None,
     ) -> list[ResultSetColumnType]:
         """
-        Get all columns from a given schema and table
+        Get all columns from a given schema and table.
+
+        The inspector will be bound to a catalog, if one was specified.
 
         :param inspector: SqlAlchemy Inspector instance
-        :param table_name: Table name
-        :param schema: Schema name. If omitted, uses default schema for database
+        :param table: Table instance
         :param options: Extra options to customise the display of columns in
                         some databases
         :return: All columns in table
         """
         return convert_inspector_columns(
-            cast(list[SQLAColumnType], inspector.get_columns(table_name, schema))
+            cast(
+                list[SQLAColumnType],
+                inspector.get_columns(table.table, table.schema),
+            )
         )
 
     @classmethod
@@ -1539,8 +1559,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         cls,
         database: Database,
         inspector: Inspector,
-        table_name: str,
-        schema: str | None,
+        table: Table,
     ) -> list[MetricType]:
         """
         Get all metrics from a given schema and table.
@@ -1555,19 +1574,17 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         ]
 
     @classmethod
-    def where_latest_partition(  # pylint: disable=too-many-arguments,unused-argument
+    def where_latest_partition(  # pylint: disable=unused-argument
         cls,
-        table_name: str,
-        schema: str | None,
         database: Database,
+        table: Table,
         query: Select,
         columns: list[ResultSetColumnType] | None = None,
     ) -> Select | None:
         """
         Add a where clause to a query to reference only the most recent partition
 
-        :param table_name: Table name
-        :param schema: Schema name
+        :param table: Table instance
         :param database: Database instance
         :param query: SqlAlchemy query
         :param columns: List of TableColumns
@@ -1590,9 +1607,8 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     def select_star(  # pylint: disable=too-many-arguments,too-many-locals
         cls,
         database: Database,
-        table_name: str,
+        table: Table,
         engine: Engine,
-        schema: str | None = None,
         limit: int = 100,
         show_cols: bool = False,
         indent: bool = True,
@@ -1605,9 +1621,8 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         WARNING: expects only unquoted table and schema names.
 
         :param database: Database instance
-        :param table_name: Table name, unquoted
+        :param table: Table instance
         :param engine: SqlAlchemy Engine instance
-        :param schema: Schema, unquoted
         :param limit: limit to impose on query
         :param show_cols: Show columns in query; otherwise use "*"
         :param indent: Add indentation to query
@@ -1619,16 +1634,18 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         fields: str | list[Any] = "*"
         cols = cols or []
         if (show_cols or latest_partition) and not cols:
-            cols = database.get_columns(table_name, schema)
+            cols = database.get_columns(table)
 
         if show_cols:
             fields = cls._get_fields(cols)
+
         quote = engine.dialect.identifier_preparer.quote
         quote_schema = engine.dialect.identifier_preparer.quote_schema
-        if schema:
-            full_table_name = quote_schema(schema) + "." + quote(table_name)
-        else:
-            full_table_name = quote(table_name)
+        full_table_name = (
+            quote_schema(table.schema) + "." + quote(table.table)
+            if table.schema
+            else quote(table.table)
+        )
 
         qry = select(fields).select_from(text(full_table_name))
 
@@ -1636,7 +1653,10 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
             qry = qry.limit(limit)
         if latest_partition:
             partition_query = cls.where_latest_partition(
-                table_name, schema, database, qry, columns=cols
+                database,
+                table,
+                qry,
+                columns=cols,
             )
             if partition_query is not None:
                 qry = partition_query
@@ -1687,9 +1707,10 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         return database.mutate_sql_based_on_config(sql, is_split=True)
 
     @classmethod
-    def estimate_query_cost(
+    def estimate_query_cost(  # pylint: disable=too-many-arguments
         cls,
         database: Database,
+        catalog: str | None,
         schema: str,
         sql: str,
         source: utils.QuerySource | None = None,
@@ -1711,14 +1732,19 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         parsed_query = sql_parse.ParsedQuery(sql, engine=cls.engine)
         statements = parsed_query.get_statements()
 
-        costs = []
-        with database.get_raw_connection(schema=schema, source=source) as conn:
+        with database.get_raw_connection(
+            catalog=catalog,
+            schema=schema,
+            source=source,
+        ) as conn:
             cursor = conn.cursor()
-            for statement in statements:
-                processed_statement = cls.process_statement(statement, database)
-                costs.append(cls.estimate_statement_cost(processed_statement, cursor))
-
-        return costs
+            return [
+                cls.estimate_statement_cost(
+                    cls.process_statement(statement, database),
+                    cursor,
+                )
+                for statement in statements
+            ]
 
     @classmethod
     def get_url_for_impersonation(

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -639,11 +639,11 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         return driver in cls.drivers
 
     @classmethod
-    def get_default_schema(cls, database: Database) -> str | None:
+    def get_default_schema(cls, database: Database, catalog: str | None) -> str | None:
         """
         Return the default schema in a given database.
         """
-        with database.get_inspector() as inspector:
+        with database.get_inspector(catalog=catalog) as inspector:
             return inspector.default_schema_name
 
     @classmethod
@@ -698,7 +698,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
             return schema
 
         # return the default schema of the database
-        return cls.get_default_schema(database)
+        return cls.get_default_schema(database, query.catalog)
 
     @classmethod
     def get_dbapi_exception_mapping(cls) -> dict[type[Exception], type[Exception]]:

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -14,13 +14,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+from __future__ import annotations
+
 import contextlib
 import json
 import re
 import urllib
 from datetime import datetime
 from re import Pattern
-from typing import Any, Optional, TYPE_CHECKING, TypedDict
+from typing import Any, TYPE_CHECKING, TypedDict
 
 import pandas as pd
 from apispec import APISpec
@@ -220,8 +223,8 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
 
     @classmethod
     def convert_dttm(
-        cls, target_type: str, dttm: datetime, db_extra: Optional[dict[str, Any]] = None
-    ) -> Optional[str]:
+        cls, target_type: str, dttm: datetime, db_extra: dict[str, Any] | None = None
+    ) -> str | None:
         sqla_type = cls.get_sqla_column_type(target_type)
         if isinstance(sqla_type, types.Date):
             return f"CAST('{dttm.date().isoformat()}' AS DATE)"
@@ -234,9 +237,7 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
         return None
 
     @classmethod
-    def fetch_data(
-        cls, cursor: Any, limit: Optional[int] = None
-    ) -> list[tuple[Any, ...]]:
+    def fetch_data(cls, cursor: Any, limit: int | None = None) -> list[tuple[Any, ...]]:
         data = super().fetch_data(cursor, limit)
         # Support type BigQuery Row, introduced here PR #4071
         # google.cloud.bigquery.table.Row
@@ -302,30 +303,28 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
     @classmethod
     def get_indexes(
         cls,
-        database: "Database",
+        database: Database,
         inspector: Inspector,
-        table_name: str,
-        schema: Optional[str],
+        table: Table,
     ) -> list[dict[str, Any]]:
         """
         Get the indexes associated with the specified schema/table.
 
         :param database: The database to inspect
         :param inspector: The SQLAlchemy inspector
-        :param table_name: The table to inspect
-        :param schema: The schema to inspect
+        :param table: The table instance to inspect
         :returns: The indexes
         """
 
-        return cls.normalize_indexes(inspector.get_indexes(table_name, schema))
+        return cls.normalize_indexes(inspector.get_indexes(table.table, table.schema))
 
     @classmethod
     def get_extra_table_metadata(
         cls,
-        database: "Database",
+        database: Database,
         table: Table,
     ) -> dict[str, Any]:
-        indexes = database.get_indexes(table.table, table.schema)
+        indexes = database.get_indexes(table)
         if not indexes:
             return {}
         partitions_columns = [
@@ -354,7 +353,7 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
     @classmethod
     def df_to_sql(
         cls,
-        database: "Database",
+        database: Database,
         table: Table,
         df: pd.DataFrame,
         to_sql_kwargs: dict[str, Any],
@@ -380,7 +379,11 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
             raise SupersetException("The table schema must be defined")
 
         to_gbq_kwargs = {}
-        with cls.get_engine(database) as engine:
+        with cls.get_engine(
+            database,
+            catalog=table.catalog,
+            schema=table.schema,
+        ) as engine:
             to_gbq_kwargs = {
                 "destination_table": str(table),
                 "project_id": engine.url.host,
@@ -403,7 +406,7 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
         pandas_gbq.to_gbq(df, **to_gbq_kwargs)
 
     @classmethod
-    def _get_client(cls, engine: Engine) -> Any:
+    def _get_client(cls, engine: Engine) -> bigquery.Client:
         """
         Return the BigQuery client associated with an engine.
         """
@@ -418,17 +421,19 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
         return bigquery.Client(credentials=credentials)
 
     @classmethod
-    def estimate_query_cost(
+    def estimate_query_cost(  # pylint: disable=too-many-arguments
         cls,
-        database: "Database",
+        database: Database,
+        catalog: str | None,
         schema: str,
         sql: str,
-        source: Optional[utils.QuerySource] = None,
+        source: utils.QuerySource | None = None,
     ) -> list[dict[str, Any]]:
         """
         Estimate the cost of a multiple statement SQL query.
 
         :param database: Database instance
+        :param catalog: Database project
         :param schema: Database schema
         :param sql: SQL query with possibly multiple statements
         :param source: Source of the query (eg, "sql_lab")
@@ -439,17 +444,25 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
 
         parsed_query = sql_parse.ParsedQuery(sql, engine=cls.engine)
         statements = parsed_query.get_statements()
-        costs = []
-        for statement in statements:
-            processed_statement = cls.process_statement(statement, database)
 
-            costs.append(cls.estimate_statement_cost(processed_statement, database))
-        return costs
+        with cls.get_engine(
+            database,
+            catalog=catalog,
+            schema=schema,
+        ) as engine:
+            client = cls._get_client(engine)
+            return [
+                cls.custom_estimate_statement_cost(
+                    cls.process_statement(statement, database),
+                    client,
+                )
+                for statement in statements
+            ]
 
     @classmethod
     def get_catalog_names(
         cls,
-        database: "Database",
+        database: Database,
         inspector: Inspector,
     ) -> list[str]:
         """
@@ -469,14 +482,16 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
         return True
 
     @classmethod
-    def estimate_statement_cost(cls, statement: str, cursor: Any) -> dict[str, Any]:
-        with cls.get_engine(cursor) as engine:
-            client = cls._get_client(engine)
-            job_config = bigquery.QueryJobConfig(dry_run=True)
-            query_job = client.query(
-                statement,
-                job_config=job_config,
-            )  # Make an API request.
+    def custom_estimate_statement_cost(
+        cls,
+        statement: str,
+        client: bigquery.Client,
+    ) -> dict[str, Any]:
+        """
+        Custom version that receives a client instead of a cursor.
+        """
+        job_config = bigquery.QueryJobConfig(dry_run=True)
+        query_job = client.query(statement, job_config=job_config)
 
         # Format Bytes.
         # TODO: Humanize in case more db engine specs need to be added,
@@ -514,7 +529,7 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
     def build_sqlalchemy_uri(
         cls,
         parameters: BigQueryParametersType,
-        encrypted_extra: Optional[dict[str, Any]] = None,
+        encrypted_extra: dict[str, Any] | None = None,
     ) -> str:
         query = parameters.get("query", {})
         query_params = urllib.parse.urlencode(query)
@@ -536,7 +551,7 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
     def get_parameters_from_uri(
         cls,
         uri: str,
-        encrypted_extra: Optional[dict[str, Any]] = None,
+        encrypted_extra: dict[str, Any] | None = None,
     ) -> Any:
         value = make_url_safe(uri)
 
@@ -549,7 +564,7 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
         raise ValidationError("Invalid service credentials")
 
     @classmethod
-    def mask_encrypted_extra(cls, encrypted_extra: Optional[str]) -> Optional[str]:
+    def mask_encrypted_extra(cls, encrypted_extra: str | None) -> str | None:
         if encrypted_extra is None:
             return encrypted_extra
 
@@ -563,9 +578,7 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
         return json.dumps(config)
 
     @classmethod
-    def unmask_encrypted_extra(
-        cls, old: Optional[str], new: Optional[str]
-    ) -> Optional[str]:
+    def unmask_encrypted_extra(cls, old: str | None, new: str | None) -> str | None:
         """
         Reuse ``private_key`` if available and unchanged.
         """
@@ -628,15 +641,14 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
     @classmethod
     def select_star(  # pylint: disable=too-many-arguments
         cls,
-        database: "Database",
-        table_name: str,
+        database: Database,
+        table: Table,
         engine: Engine,
-        schema: Optional[str] = None,
         limit: int = 100,
         show_cols: bool = False,
         indent: bool = True,
         latest_partition: bool = True,
-        cols: Optional[list[ResultSetColumnType]] = None,
+        cols: list[ResultSetColumnType] | None = None,
     ) -> str:
         """
         Remove array structures from `SELECT *`.
@@ -690,9 +702,8 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
 
         return super().select_star(
             database,
-            table_name,
+            table,
             engine,
-            schema,
             limit,
             show_cols,
             indent,

--- a/superset/db_engine_specs/db2.py
+++ b/superset/db_engine_specs/db2.py
@@ -21,6 +21,7 @@ from sqlalchemy.engine.reflection import Inspector
 
 from superset.constants import TimeGrain
 from superset.db_engine_specs.base import BaseEngineSpec, LimitMethod
+from superset.sql_parse import Table
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +65,9 @@ class Db2EngineSpec(BaseEngineSpec):
 
     @classmethod
     def get_table_comment(
-        cls, inspector: Inspector, table_name: str, schema: Union[str, None]
+        cls,
+        inspector: Inspector,
+        table: Table,
     ) -> Optional[str]:
         """
         Get comment of table from a given schema
@@ -78,7 +81,7 @@ class Db2EngineSpec(BaseEngineSpec):
         """
         comment = None
         try:
-            table_comment = inspector.get_table_comment(table_name, schema)
+            table_comment = inspector.get_table_comment(table.table, table.schema)
             comment = table_comment.get("text")
             return comment[0]
         except IndexError:

--- a/superset/db_engine_specs/db2.py
+++ b/superset/db_engine_specs/db2.py
@@ -75,8 +75,7 @@ class Db2EngineSpec(BaseEngineSpec):
         Ibm Db2 return comments as tuples, so we need to get the first element
 
         :param inspector: SqlAlchemy Inspector instance
-        :param table_name: Table name
-        :param schema: Schema name. If omitted, uses default schema for database
+        :param table: Table instance
         :return: comment of table
         """
         comment = None

--- a/superset/db_engine_specs/gsheets.py
+++ b/superset/db_engine_specs/gsheets.py
@@ -142,7 +142,10 @@ class GSheetsEngineSpec(ShillelaghEngineSpec):
         database: Database,
         table: Table,
     ) -> dict[str, Any]:
-        with database.get_raw_connection(schema=table.schema) as conn:
+        with database.get_raw_connection(
+            catalog=table.catalog,
+            schema=table.schema,
+        ) as conn:
             cursor = conn.cursor()
             cursor.execute(f'SELECT GET_METADATA("{table.table}")')
             results = cursor.fetchone()[0]
@@ -395,7 +398,11 @@ class GSheetsEngineSpec(ShillelaghEngineSpec):
                 pass
 
         # get the Google session from the Shillelagh adapter
-        with cls.get_engine(database) as engine:
+        with cls.get_engine(
+            database,
+            catalog=table.catalog,
+            schema=table.schema,
+        ) as engine:
             with engine.connect() as conn:
                 # any GSheets URL will work to get a working session
                 adapter = get_adapter_for_table_name(

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -969,8 +969,7 @@ class PrestoEngineSpec(PrestoBaseEngineSpec):
         """
         Show presto column names
         :param inspector: object that performs database schema inspection
-        :param table_name: table name
-        :param schema: schema name
+        :param table: table instance
         :return: list of column objects
         """
         quote = inspector.engine.dialect.identifier_preparer.quote_identifier
@@ -990,8 +989,7 @@ class PrestoEngineSpec(PrestoBaseEngineSpec):
         Get columns from a Presto data source. This includes handling row and
         array data types
         :param inspector: object that performs database schema inspection
-        :param table_name: table name
-        :param schema: schema name
+        :param table: table instance
         :param options: Extra configuration options, not used by this backend
         :return: a list of results that contain column info
                 (i.e. column name and data type)

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -40,12 +40,12 @@ from superset.db_engine_specs.exceptions import (
 )
 from superset.db_engine_specs.presto import PrestoBaseEngineSpec
 from superset.models.sql_lab import Query
+from superset.sql_parse import Table
 from superset.superset_typing import ResultSetColumnType
 from superset.utils import core as utils
 
 if TYPE_CHECKING:
     from superset.models.core import Database
-    from superset.sql_parse import Table
 
     with contextlib.suppress(ImportError):  # trino may not be installed
         from trino.dbapi import Cursor
@@ -96,8 +96,11 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
                 ),
             }
 
-        if database.has_view_by_name(table.table, table.schema):
-            with database.get_inspector() as inspector:
+        if database.has_view(Table(table.table, table.schema)):
+            with database.get_inspector(
+                catalog=table.catalog,
+                schema=table.schema,
+            ) as inspector:
                 metadata["view"] = inspector.get_view_definition(
                     table.table,
                     table.schema,

--- a/superset/examples/bart_lines.py
+++ b/superset/examples/bart_lines.py
@@ -21,6 +21,7 @@ import polyline
 from sqlalchemy import inspect, String, Text
 
 from superset import db
+from superset.sql_parse import Table
 
 from ..utils.database import get_example_database
 from .helpers import get_example_url, get_table_connector_registry
@@ -31,7 +32,7 @@ def load_bart_lines(only_metadata: bool = False, force: bool = False) -> None:
     database = get_example_database()
     with database.get_sqla_engine() as engine:
         schema = inspect(engine).default_schema_name
-        table_exists = database.has_table_by_name(tbl_name)
+        table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
             url = get_example_url("bart-lines.json.gz")

--- a/superset/examples/birth_names.py
+++ b/superset/examples/birth_names.py
@@ -27,6 +27,7 @@ from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn
 from superset.models.core import Database
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
+from superset.sql_parse import Table
 from superset.utils.core import DatasourceType
 
 from ..utils.database import get_example_database
@@ -95,7 +96,7 @@ def load_birth_names(
         schema = inspect(engine).default_schema_name
 
     tbl_name = "birth_names"
-    table_exists = database.has_table_by_name(tbl_name, schema=schema)
+    table_exists = database.has_table(Table(tbl_name, schema))
 
     if not only_metadata and (not table_exists or force):
         load_data(tbl_name, database, sample=sample)

--- a/superset/examples/country_map.py
+++ b/superset/examples/country_map.py
@@ -24,6 +24,7 @@ import superset.utils.database as database_utils
 from superset import db
 from superset.connectors.sqla.models import SqlMetric
 from superset.models.slice import Slice
+from superset.sql_parse import Table
 from superset.utils.core import DatasourceType
 
 from .helpers import (
@@ -42,7 +43,7 @@ def load_country_map_data(only_metadata: bool = False, force: bool = False) -> N
 
     with database.get_sqla_engine() as engine:
         schema = inspect(engine).default_schema_name
-        table_exists = database.has_table_by_name(tbl_name)
+        table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
             url = get_example_url("birth_france_data_for_country_map.csv")

--- a/superset/examples/energy.py
+++ b/superset/examples/energy.py
@@ -26,6 +26,7 @@ import superset.utils.database as database_utils
 from superset import db
 from superset.connectors.sqla.models import SqlMetric
 from superset.models.slice import Slice
+from superset.sql_parse import Table
 from superset.utils.core import DatasourceType
 
 from .helpers import (
@@ -45,7 +46,7 @@ def load_energy(
 
     with database.get_sqla_engine() as engine:
         schema = inspect(engine).default_schema_name
-        table_exists = database.has_table_by_name(tbl_name)
+        table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
             url = get_example_url("energy.json.gz")

--- a/superset/examples/flights.py
+++ b/superset/examples/flights.py
@@ -19,6 +19,7 @@ from sqlalchemy import DateTime, inspect
 
 import superset.utils.database as database_utils
 from superset import db
+from superset.sql_parse import Table
 
 from .helpers import get_example_url, get_table_connector_registry
 
@@ -29,7 +30,7 @@ def load_flights(only_metadata: bool = False, force: bool = False) -> None:
     database = database_utils.get_example_database()
     with database.get_sqla_engine() as engine:
         schema = inspect(engine).default_schema_name
-        table_exists = database.has_table_by_name(tbl_name)
+        table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
             flight_data_url = get_example_url("flight_data.csv.gz")

--- a/superset/examples/long_lat.py
+++ b/superset/examples/long_lat.py
@@ -24,6 +24,7 @@ from sqlalchemy import DateTime, Float, inspect, String
 import superset.utils.database as database_utils
 from superset import db
 from superset.models.slice import Slice
+from superset.sql_parse import Table
 from superset.utils.core import DatasourceType
 
 from .helpers import (
@@ -41,7 +42,7 @@ def load_long_lat_data(only_metadata: bool = False, force: bool = False) -> None
     database = database_utils.get_example_database()
     with database.get_sqla_engine() as engine:
         schema = inspect(engine).default_schema_name
-        table_exists = database.has_table_by_name(tbl_name)
+        table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
             url = get_example_url("san_francisco.csv.gz")

--- a/superset/examples/multiformat_time_series.py
+++ b/superset/examples/multiformat_time_series.py
@@ -21,6 +21,7 @@ from sqlalchemy import BigInteger, Date, DateTime, inspect, String
 
 from superset import app, db
 from superset.models.slice import Slice
+from superset.sql_parse import Table
 from superset.utils.core import DatasourceType
 
 from ..utils.database import get_example_database
@@ -41,7 +42,7 @@ def load_multiformat_time_series(  # pylint: disable=too-many-locals
     database = get_example_database()
     with database.get_sqla_engine() as engine:
         schema = inspect(engine).default_schema_name
-        table_exists = database.has_table_by_name(tbl_name)
+        table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
             url = get_example_url("multiformat_time_series.json.gz")

--- a/superset/examples/paris.py
+++ b/superset/examples/paris.py
@@ -21,6 +21,7 @@ from sqlalchemy import inspect, String, Text
 
 import superset.utils.database as database_utils
 from superset import db
+from superset.sql_parse import Table
 
 from .helpers import get_example_url, get_table_connector_registry
 
@@ -30,7 +31,7 @@ def load_paris_iris_geojson(only_metadata: bool = False, force: bool = False) ->
     database = database_utils.get_example_database()
     with database.get_sqla_engine() as engine:
         schema = inspect(engine).default_schema_name
-        table_exists = database.has_table_by_name(tbl_name)
+        table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
             url = get_example_url("paris_iris.json.gz")

--- a/superset/examples/random_time_series.py
+++ b/superset/examples/random_time_series.py
@@ -21,6 +21,7 @@ from sqlalchemy import DateTime, inspect, String
 import superset.utils.database as database_utils
 from superset import app, db
 from superset.models.slice import Slice
+from superset.sql_parse import Table
 from superset.utils.core import DatasourceType
 
 from .helpers import (
@@ -39,7 +40,7 @@ def load_random_time_series_data(
     database = database_utils.get_example_database()
     with database.get_sqla_engine() as engine:
         schema = inspect(engine).default_schema_name
-        table_exists = database.has_table_by_name(tbl_name)
+        table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
             url = get_example_url("random_time_series.json.gz")

--- a/superset/examples/sf_population_polygons.py
+++ b/superset/examples/sf_population_polygons.py
@@ -21,6 +21,7 @@ from sqlalchemy import BigInteger, Float, inspect, Text
 
 import superset.utils.database as database_utils
 from superset import db
+from superset.sql_parse import Table
 
 from .helpers import get_example_url, get_table_connector_registry
 
@@ -32,7 +33,7 @@ def load_sf_population_polygons(
     database = database_utils.get_example_database()
     with database.get_sqla_engine() as engine:
         schema = inspect(engine).default_schema_name
-        table_exists = database.has_table_by_name(tbl_name)
+        table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
             url = get_example_url("sf_population.json.gz")

--- a/superset/examples/supported_charts_dashboard.py
+++ b/superset/examples/supported_charts_dashboard.py
@@ -26,6 +26,7 @@ from superset import db
 from superset.connectors.sqla.models import SqlaTable
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
+from superset.sql_parse import Table
 from superset.utils.core import DatasourceType
 
 from ..utils.database import get_example_database
@@ -443,7 +444,7 @@ def load_supported_charts_dashboard() -> None:
         schema = inspect(engine).default_schema_name
 
         tbl_name = "birth_names"
-        table_exists = database.has_table_by_name(tbl_name, schema=schema)
+        table_exists = database.has_table(Table(tbl_name, schema))
 
     if table_exists:
         table = get_table_connector_registry()

--- a/superset/examples/world_bank.py
+++ b/superset/examples/world_bank.py
@@ -37,6 +37,7 @@ from superset.examples.helpers import (
 )
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
+from superset.sql_parse import Table
 from superset.utils import core as utils
 from superset.utils.core import DatasourceType
 
@@ -51,7 +52,7 @@ def load_world_bank_health_n_pop(  # pylint: disable=too-many-locals, too-many-s
     database = superset.utils.database.get_example_database()
     with database.get_sqla_engine() as engine:
         schema = inspect(engine).default_schema_name
-        table_exists = database.has_table_by_name(tbl_name)
+        table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
             url = get_example_url("countries.json.gz")

--- a/superset/extensions/metadb.py
+++ b/superset/extensions/metadb.py
@@ -271,6 +271,8 @@ class SupersetShillelaghAdapter(Adapter):
         self.catalog = parts.pop(-1) if parts else None
 
         if self.catalog:
+            # TODO (betodealmeida): when SIP-95 is implemented we should check to see if
+            # the database has multi-catalog enabled, and if so, give access.
             raise NotImplementedError("Catalogs are not currently supported")
 
         # If the table has a single integer primary key we use that as the row ID in order
@@ -314,7 +316,8 @@ class SupersetShillelaghAdapter(Adapter):
         # store this callable for later whenever we need an engine
         self.engine_context = partial(
             database.get_sqla_engine,
-            self.schema,
+            catalog=self.catalog,
+            schema=self.schema,
         )
 
         # fetch column names and types

--- a/superset/migrations/versions/2024-04-11_15-41_5f57af97bc3f_add_catalog_column.py
+++ b/superset/migrations/versions/2024-04-11_15-41_5f57af97bc3f_add_catalog_column.py
@@ -17,7 +17,7 @@
 """Add catalog column
 
 Revision ID: 5f57af97bc3f
-Revises: 5ad7321c2169
+Revises: d60591c5515f
 Create Date: 2024-04-11 15:41:34.663989
 
 """
@@ -27,7 +27,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "5f57af97bc3f"
-down_revision = "5ad7321c2169"
+down_revision = "d60591c5515f"
 
 
 def upgrade():

--- a/superset/migrations/versions/2024-04-11_15-41_5f57af97bc3f_add_catalog_column.py
+++ b/superset/migrations/versions/2024-04-11_15-41_5f57af97bc3f_add_catalog_column.py
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Add catalog column
+
+Revision ID: 5f57af97bc3f
+Revises: 5ad7321c2169
+Create Date: 2024-04-11 15:41:34.663989
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "5f57af97bc3f"
+down_revision = "5ad7321c2169"
+
+
+def upgrade():
+    op.add_column("tables", sa.Column("catalog", sa.String(length=256), nullable=True))
+    op.add_column("query", sa.Column("catalog", sa.String(length=256), nullable=True))
+    op.add_column(
+        "saved_query",
+        sa.Column("catalog", sa.String(length=256), nullable=True),
+    )
+    op.add_column(
+        "tab_state",
+        sa.Column("catalog", sa.String(length=256), nullable=True),
+    )
+    op.add_column(
+        "table_schema",
+        sa.Column("catalog", sa.String(length=256), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("table_schema", "catalog")
+    op.drop_column("tab_state", "catalog")
+    op.drop_column("saved_query", "catalog")
+    op.drop_column("query", "catalog")
+    op.drop_column("tables", "catalog")

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# pylint: disable=line-too-long, too-many-lines, too-many-arguments
+# pylint: disable=too-many-lines, too-many-arguments
 
 """A collection of ORM sqlalchemy models for Superset"""
 
@@ -607,7 +607,7 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
             )
         return sql_
 
-    def get_df(
+    def get_df(  # pylint: disable=too-many-locals
         self,
         sql: str,
         catalog: str | None = None,

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -15,7 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# pylint: disable=too-many-lines
+# pylint: disable=line-too-long, too-many-lines, too-many-arguments
+
 """A collection of ORM sqlalchemy models for Superset"""
 
 from __future__ import annotations
@@ -46,7 +47,7 @@ from sqlalchemy import (
     Integer,
     MetaData,
     String,
-    Table,
+    Table as SqlaTable,
     Text,
 )
 from sqlalchemy.engine import Connection, Dialect, Engine
@@ -73,6 +74,7 @@ from superset.extensions import (
 )
 from superset.models.helpers import AuditMixinNullable, ImportExportMixin
 from superset.result_set import SupersetResultSet
+from superset.sql_parse import Table
 from superset.superset_typing import OAuth2ClientConfig, ResultSetColumnType
 from superset.utils import cache as cache_util, core as utils
 from superset.utils.backports import StrEnum
@@ -382,13 +384,22 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
         )
 
     @contextmanager
-    def get_sqla_engine(
+    def get_sqla_engine(  # pylint: disable=too-many-arguments
         self,
+        catalog: str | None = None,
         schema: str | None = None,
         nullpool: bool = True,
         source: utils.QuerySource | None = None,
         override_ssh_tunnel: SSHTunnel | None = None,
     ) -> Engine:
+        """
+        Context manager for a SQLAlchemy engine.
+
+        This method will return a context manager for a SQLAlchemy engine. Using the
+        context manager (as opposed to the engine directly) is important because we need
+        to potentially establish SSH tunnels before the connection is created, and clean
+        them up once the engine is no longer used.
+        """
         from superset.daos.database import (  # pylint: disable=import-outside-toplevel
             DatabaseDAO,
         )
@@ -403,7 +414,7 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
             # if ssh_tunnel is available build engine with information
             engine_context = ssh_manager_factory.instance.create_tunnel(
                 ssh_tunnel=ssh_tunnel,
-                sqlalchemy_database_uri=self.sqlalchemy_uri_decrypted,
+                sqlalchemy_database_uri=sqlalchemy_uri,
             )
 
         with engine_context as server_context:
@@ -415,22 +426,21 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
                     server_context.local_bind_address,
                 )
                 sqlalchemy_uri = ssh_manager_factory.instance.build_sqla_url(
-                    sqlalchemy_uri, server_context
+                    sqlalchemy_uri,
+                    server_context,
                 )
+
             yield self._get_sqla_engine(
+                catalog=catalog,
                 schema=schema,
                 nullpool=nullpool,
                 source=source,
                 sqlalchemy_uri=sqlalchemy_uri,
             )
 
-    # The `get_sqla_engine_with_context` was renamed to `get_sqla_engine`, but we kept a
-    # reference to the old method to prevent breaking third-party applications.
-    # TODO (betodealmeida): Remove in 5.0
-    get_sqla_engine_with_context = get_sqla_engine
-
     def _get_sqla_engine(
         self,
+        catalog: str | None = None,
         schema: str | None = None,
         nullpool: bool = True,
         source: utils.QuerySource | None = None,
@@ -447,26 +457,10 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
             params["poolclass"] = NullPool
         connect_args = params.get("connect_args", {})
 
-        # The ``adjust_database_uri`` method was renamed to ``adjust_engine_params`` and
-        # had its signature changed in order to support more DB engine specs. Since DB
-        # engine specs can be released as 3rd party modules we want to make sure the old
-        # method is still supported so we don't introduce a breaking change.
-        if hasattr(self.db_engine_spec, "adjust_database_uri"):
-            sqlalchemy_url = self.db_engine_spec.adjust_database_uri(
-                sqlalchemy_url,
-                schema,
-            )
-            logger.warning(
-                "DB engine spec %s implements the method `adjust_database_uri`, which is "
-                "deprecated and will be removed in version 3.0. Please update it to "
-                "implement `adjust_engine_params` instead.",
-                self.db_engine_spec,
-            )
-
         sqlalchemy_url, connect_args = self.db_engine_spec.adjust_engine_params(
             uri=sqlalchemy_url,
             connect_args=connect_args,
-            catalog=None,
+            catalog=catalog,
             schema=schema,
         )
 
@@ -532,17 +526,24 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
     @contextmanager
     def get_raw_connection(
         self,
+        catalog: str | None = None,
         schema: str | None = None,
         nullpool: bool = True,
         source: utils.QuerySource | None = None,
     ) -> Connection:
         with self.get_sqla_engine(
-            schema=schema, nullpool=nullpool, source=source
+            catalog=catalog,
+            schema=schema,
+            nullpool=nullpool,
+            source=source,
         ) as engine:
             with closing(engine.raw_connection()) as conn:
                 # pre-session queries are used to set the selected schema and, in the
                 # future, the selected catalog
-                for prequery in self.db_engine_spec.get_prequeries(schema=schema):
+                for prequery in self.db_engine_spec.get_prequeries(
+                    catalog=catalog,
+                    schema=schema,
+                ):
                     cursor = conn.cursor()
                     cursor.execute(prequery)
 
@@ -609,11 +610,12 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
     def get_df(
         self,
         sql: str,
+        catalog: str | None = None,
         schema: str | None = None,
         mutator: Callable[[pd.DataFrame], None] | None = None,
     ) -> pd.DataFrame:
         sqls = self.db_engine_spec.parse_sql(sql)
-        with self.get_sqla_engine(schema) as engine:
+        with self.get_sqla_engine(catalog=catalog, schema=schema) as engine:
             engine_url = engine.url
 
         def _log_query(sql: str) -> None:
@@ -626,7 +628,7 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
                     security_manager,
                 )
 
-        with self.get_raw_connection(schema=schema) as conn:
+        with self.get_raw_connection(catalog=catalog, schema=schema) as conn:
             cursor = conn.cursor()
             df = None
             for i, sql_ in enumerate(sqls):
@@ -653,8 +655,13 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
 
             return self.post_process_df(df)
 
-    def compile_sqla_query(self, qry: Select, schema: str | None = None) -> str:
-        with self.get_sqla_engine(schema) as engine:
+    def compile_sqla_query(
+        self,
+        qry: Select,
+        catalog: str | None = None,
+        schema: str | None = None,
+    ) -> str:
+        with self.get_sqla_engine(catalog=catalog, schema=schema) as engine:
             sql = str(qry.compile(engine, compile_kwargs={"literal_binds": True}))
 
             # pylint: disable=protected-access
@@ -665,8 +672,7 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
 
     def select_star(  # pylint: disable=too-many-arguments
         self,
-        table_name: str,
-        schema: str | None = None,
+        table: Table,
         limit: int = 100,
         show_cols: bool = False,
         indent: bool = True,
@@ -674,11 +680,10 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
         cols: list[ResultSetColumnType] | None = None,
     ) -> str:
         """Generates a ``select *`` statement in the proper dialect"""
-        with self.get_sqla_engine(schema) as engine:
+        with self.get_sqla_engine(catalog=table.catalog, schema=table.schema) as engine:
             return self.db_engine_spec.select_star(
                 self,
-                table_name,
-                schema=schema,
+                table,
                 engine=engine,
                 limit=limit,
                 show_cols=show_cols,
@@ -703,6 +708,7 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
     )
     def get_all_table_names_in_schema(  # pylint: disable=unused-argument
         self,
+        catalog: str | None,
         schema: str,
         cache: bool = False,
         cache_timeout: int | None = None,
@@ -720,7 +726,7 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
         :return: The table/schema pairs
         """
         try:
-            with self.get_inspector_with_context() as inspector:
+            with self.get_inspector(catalog=catalog, schema=schema) as inspector:
                 return {
                     (table, schema)
                     for table in self.db_engine_spec.get_table_names(
@@ -738,6 +744,7 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
     )
     def get_all_view_names_in_schema(  # pylint: disable=unused-argument
         self,
+        catalog: str | None,
         schema: str,
         cache: bool = False,
         cache_timeout: int | None = None,
@@ -755,7 +762,7 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
         :return: set of views
         """
         try:
-            with self.get_inspector_with_context() as inspector:
+            with self.get_inspector(catalog=catalog, schema=schema) as inspector:
                 return {
                     (view, schema)
                     for view in self.db_engine_spec.get_view_names(
@@ -768,10 +775,17 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
             raise self.db_engine_spec.get_dbapi_mapped_exception(ex)
 
     @contextmanager
-    def get_inspector_with_context(
-        self, ssh_tunnel: SSHTunnel | None = None
+    def get_inspector(
+        self,
+        catalog: str | None = None,
+        schema: str | None = None,
+        ssh_tunnel: SSHTunnel | None = None,
     ) -> Inspector:
-        with self.get_sqla_engine(override_ssh_tunnel=ssh_tunnel) as engine:
+        with self.get_sqla_engine(
+            catalog=catalog,
+            schema=schema,
+            override_ssh_tunnel=ssh_tunnel,
+        ) as engine:
             yield sqla.inspect(engine)
 
     @cache_util.memoized_func(
@@ -780,6 +794,7 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
     )
     def get_all_schema_names(  # pylint: disable=unused-argument
         self,
+        catalog: str | None = None,
         cache: bool = False,
         cache_timeout: int | None = None,
         force: bool = False,
@@ -796,7 +811,10 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
         :return: schema list
         """
         try:
-            with self.get_inspector_with_context(ssh_tunnel=ssh_tunnel) as inspector:
+            with self.get_inspector(
+                catalog=catalog,
+                ssh_tunnel=ssh_tunnel,
+            ) as inspector:
                 return self.db_engine_spec.get_schema_names(inspector)
         except Exception as ex:
             raise self.db_engine_spec.get_dbapi_mapped_exception(ex) from ex
@@ -848,51 +866,57 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
     def update_params_from_encrypted_extra(self, params: dict[str, Any]) -> None:
         self.db_engine_spec.update_params_from_encrypted_extra(self, params)
 
-    def get_table(self, table_name: str, schema: str | None = None) -> Table:
+    def get_table(self, table: Table) -> SqlaTable:
         extra = self.get_extra()
         meta = MetaData(**extra.get("metadata_params", {}))
-        with self.get_sqla_engine() as engine:
-            return Table(
-                table_name,
+        with self.get_sqla_engine(catalog=table.catalog, schema=table.schema) as engine:
+            return SqlaTable(
+                table.table,
                 meta,
-                schema=schema or None,
+                schema=table.schema or None,
                 autoload=True,
                 autoload_with=engine,
             )
 
-    def get_table_comment(
-        self, table_name: str, schema: str | None = None
-    ) -> str | None:
-        with self.get_inspector_with_context() as inspector:
-            return self.db_engine_spec.get_table_comment(inspector, table_name, schema)
+    def get_table_comment(self, table: Table) -> str | None:
+        with self.get_inspector(
+            catalog=table.catalog,
+            schema=table.schema,
+        ) as inspector:
+            return self.db_engine_spec.get_table_comment(inspector, table)
 
-    def get_columns(
-        self, table_name: str, schema: str | None = None
-    ) -> list[ResultSetColumnType]:
-        with self.get_inspector_with_context() as inspector:
+    def get_columns(self, table: Table) -> list[ResultSetColumnType]:
+        with self.get_inspector(
+            catalog=table.catalog,
+            schema=table.schema,
+        ) as inspector:
             return self.db_engine_spec.get_columns(
-                inspector, table_name, schema, self.schema_options
+                inspector, table, self.schema_options
             )
 
     def get_metrics(
         self,
-        table_name: str,
-        schema: str | None = None,
+        table: Table,
     ) -> list[MetricType]:
-        with self.get_inspector_with_context() as inspector:
-            return self.db_engine_spec.get_metrics(self, inspector, table_name, schema)
+        with self.get_inspector(
+            catalog=table.catalog,
+            schema=table.schema,
+        ) as inspector:
+            return self.db_engine_spec.get_metrics(self, inspector, table)
 
-    def get_indexes(
-        self, table_name: str, schema: str | None = None
-    ) -> list[dict[str, Any]]:
-        with self.get_inspector_with_context() as inspector:
-            return self.db_engine_spec.get_indexes(self, inspector, table_name, schema)
+    def get_indexes(self, table: Table) -> list[dict[str, Any]]:
+        with self.get_inspector(
+            catalog=table.catalog,
+            schema=table.schema,
+        ) as inspector:
+            return self.db_engine_spec.get_indexes(self, inspector, table)
 
-    def get_pk_constraint(
-        self, table_name: str, schema: str | None = None
-    ) -> dict[str, Any]:
-        with self.get_inspector_with_context() as inspector:
-            pk_constraint = inspector.get_pk_constraint(table_name, schema) or {}
+    def get_pk_constraint(self, table: Table) -> dict[str, Any]:
+        with self.get_inspector(
+            catalog=table.catalog,
+            schema=table.schema,
+        ) as inspector:
+            pk_constraint = inspector.get_pk_constraint(table.table, table.schema) or {}
 
             def _convert(value: Any) -> Any:
                 try:
@@ -902,11 +926,12 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
 
             return {key: _convert(value) for key, value in pk_constraint.items()}
 
-    def get_foreign_keys(
-        self, table_name: str, schema: str | None = None
-    ) -> list[dict[str, Any]]:
-        with self.get_inspector_with_context() as inspector:
-            return inspector.get_foreign_keys(table_name, schema)
+    def get_foreign_keys(self, table: Table) -> list[dict[str, Any]]:
+        with self.get_inspector(
+            catalog=table.catalog,
+            schema=table.schema,
+        ) as inspector:
+            return inspector.get_foreign_keys(table.table, table.schema)
 
     def get_schema_access_for_file_upload(  # pylint: disable=invalid-name
         self,
@@ -955,36 +980,23 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
         return self.perm  # type: ignore
 
     def has_table(self, table: Table) -> bool:
-        with self.get_sqla_engine() as engine:
-            return engine.has_table(table.table_name, table.schema or None)
+        with self.get_sqla_engine(catalog=table.catalog, schema=table.schema) as engine:
+            # do not pass "" as an empty schema; force null
+            return engine.has_table(table.table, table.schema or None)
 
-    def has_table_by_name(self, table_name: str, schema: str | None = None) -> bool:
-        with self.get_sqla_engine() as engine:
-            return engine.has_table(table_name, schema)
+    def has_view(self, table: Table) -> bool:
+        with self.get_sqla_engine(catalog=table.catalog, schema=table.schema) as engine:
+            connection = engine.connect()
+            try:
+                views = engine.dialect.get_view_names(
+                    connection=connection,
+                    schema=table.schema,
+                )
+            except Exception:  # pylint: disable=broad-except
+                logger.warning("Has view failed", exc_info=True)
+                views = []
 
-    @classmethod
-    def _has_view(
-        cls,
-        conn: Connection,
-        dialect: Dialect,
-        view_name: str,
-        schema: str | None = None,
-    ) -> bool:
-        view_names: list[str] = []
-        try:
-            view_names = dialect.get_view_names(connection=conn, schema=schema)
-        except Exception:  # pylint: disable=broad-except
-            logger.warning("Has view failed", exc_info=True)
-        return view_name in view_names
-
-    def has_view(self, view_name: str, schema: str | None = None) -> bool:
-        with self.get_sqla_engine(schema) as engine:
-            return engine.run_callable(
-                self._has_view, engine.dialect, view_name, schema
-            )
-
-    def has_view_by_name(self, view_name: str, schema: str | None = None) -> bool:
-        return self.has_view(view_name=view_name, schema=schema)
+        return table.table in views
 
     def get_dialect(self) -> Dialect:
         sqla_url = make_url_safe(self.sqlalchemy_uri_decrypted)

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -32,7 +32,6 @@ from sqlalchemy import (
     Column,
     ForeignKey,
     Integer,
-    MetaData,
     String,
     Table,
     Text,
@@ -213,13 +212,6 @@ class Dashboard(AuditMixinNullable, ImportExportMixin, Model):
     @property
     def charts(self) -> list[str]:
         return [slc.chart for slc in self.slices]
-
-    @property
-    def sqla_metadata(self) -> None:
-        # pylint: disable=no-member
-        with self.get_sqla_engine() as engine:
-            meta = MetaData(bind=engine)
-            meta.reflect()
 
     @property
     def status(self) -> utils.DashboardStatus:

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -109,6 +109,7 @@ class Query(
     tab_name = Column(String(256))
     sql_editor_id = Column(String(256))
     schema = Column(String(256))
+    catalog = Column(String(256), nullable=True, default=None)
     sql = Column(MediumText())
     # Query to retrieve the results,
     # used only in case of select_as_cta_used is true.
@@ -386,6 +387,7 @@ class SavedQuery(
     user_id = Column(Integer, ForeignKey("ab_user.id"), nullable=True)
     db_id = Column(Integer, ForeignKey("dbs.id"), nullable=True)
     schema = Column(String(128))
+    catalog = Column(String(256), nullable=True, default=None)
     label = Column(String(256))
     description = Column(Text)
     sql = Column(MediumText())
@@ -474,6 +476,7 @@ class TabState(AuditMixinNullable, ExtraJSONMixin, Model):
     database_id = Column(Integer, ForeignKey("dbs.id", ondelete="CASCADE"))
     database = relationship("Database", foreign_keys=[database_id])
     schema = Column(String(256))
+    catalog = Column(String(256), nullable=True, default=None)
 
     # tables that are open in the schema browser and their data previews
     table_schemas = relationship(
@@ -535,6 +538,7 @@ class TableSchema(AuditMixinNullable, ExtraJSONMixin, Model):
     )
     database = relationship("Database", foreign_keys=[database_id])
     schema = Column(String(256))
+    catalog = Column(String(256), nullable=True, default=None)
     table = Column(String(256))
 
     # JSON describing the schema, partitions, latest partition, etc.

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1922,6 +1922,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         table: Optional["Table"] = None,
         viz: Optional["BaseViz"] = None,
         sql: Optional[str] = None,
+        catalog: Optional[str] = None,  # pylint: disable=unused-argument
         schema: Optional[str] = None,
     ) -> None:
         """
@@ -1934,6 +1935,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         :param table: The Superset table (requires database)
         :param viz: The visualization
         :param sql: The SQL string (requires database)
+        :param catalog: Optional catalog name
         :param schema: Optional schema name
         :raises SupersetSecurityException: If the user cannot access the resource
         """

--- a/superset/sql_validators/base.py
+++ b/superset/sql_validators/base.py
@@ -14,7 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Any, Optional
+
+from __future__ import annotations
+
+from typing import Any
 
 from superset.models.core import Database
 
@@ -25,9 +28,9 @@ class SQLValidationAnnotation:  # pylint: disable=too-few-public-methods
     def __init__(
         self,
         message: str,
-        line_number: Optional[int],
-        start_column: Optional[int],
-        end_column: Optional[int],
+        line_number: int | None,
+        start_column: int | None,
+        end_column: int | None,
     ):
         self.message = message
         self.line_number = line_number
@@ -52,7 +55,11 @@ class BaseSQLValidator:  # pylint: disable=too-few-public-methods
 
     @classmethod
     def validate(
-        cls, sql: str, schema: Optional[str], database: Database
+        cls,
+        sql: str,
+        catalog: str | None,
+        schema: str | None,
+        database: Database,
     ) -> list[SQLValidationAnnotation]:
         """Check that the given SQL querystring is valid for the given engine"""
         raise NotImplementedError

--- a/superset/sql_validators/postgres.py
+++ b/superset/sql_validators/postgres.py
@@ -15,8 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from __future__ import annotations
+
 import re
-from typing import Optional
 
 from pgsanity.pgsanity import check_string
 
@@ -31,7 +32,11 @@ class PostgreSQLValidator(BaseSQLValidator):  # pylint: disable=too-few-public-m
 
     @classmethod
     def validate(
-        cls, sql: str, schema: Optional[str], database: Database
+        cls,
+        sql: str,
+        catalog: str | None,
+        schema: str | None,
+        database: Database,
     ) -> list[SQLValidationAnnotation]:
         annotations: list[SQLValidationAnnotation] = []
         valid, error = check_string(sql, add_semicolon=True)

--- a/superset/utils/mock_data.py
+++ b/superset/utils/mock_data.py
@@ -29,12 +29,13 @@ from uuid import uuid4
 import sqlalchemy.sql.sqltypes
 import sqlalchemy_utils
 from flask_appbuilder import Model
-from sqlalchemy import Column, inspect, MetaData, Table
+from sqlalchemy import Column, inspect, MetaData, Table as DBTable
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.sql import func
 from sqlalchemy.sql.visitors import VisitableType
 
 from superset import db
+from superset.sql_parse import Table
 
 logger = logging.getLogger(__name__)
 
@@ -182,7 +183,7 @@ def add_data(
     from superset.utils.database import get_example_database
 
     database = get_example_database()
-    table_exists = database.has_table_by_name(table_name)
+    table_exists = database.has_table(Table(table_name))
 
     with database.get_sqla_engine() as engine:
         if columns is None:
@@ -198,7 +199,7 @@ def add_data(
         # create table if needed
         column_objects = get_column_objects(columns)
         metadata = MetaData()
-        table = Table(table_name, metadata, *column_objects)
+        table = DBTable(table_name, metadata, *column_objects)
         metadata.create_all(engine)
 
         if not append:

--- a/superset/views/datasource/views.py
+++ b/superset/views/datasource/views.py
@@ -37,6 +37,7 @@ from superset.connectors.sqla.utils import get_physical_table_metadata
 from superset.daos.datasource import DatasourceDAO
 from superset.exceptions import SupersetException, SupersetSecurityException
 from superset.models.core import Database
+from superset.sql_parse import Table
 from superset.superset_typing import FlaskResponse
 from superset.utils.core import DatasourceType
 from superset.views.base import (
@@ -180,8 +181,7 @@ class Datasource(BaseSupersetView):
                 )
                 external_metadata = get_physical_table_metadata(
                     database=database,
-                    table_name=params["table_name"],
-                    schema_name=params["schema_name"],
+                    table=Table(params["table_name"], params["schema_name"]),
                     normalize_columns=params.get("normalize_columns") or False,
                 )
         except (NoResultFound, NoSuchTableError) as ex:

--- a/tests/integration_tests/celery_tests.py
+++ b/tests/integration_tests/celery_tests.py
@@ -121,7 +121,7 @@ def drop_table_if_exists(table_name: str, table_type: CtasMethod) -> None:
 def quote_f(value: Optional[str]):
     if not value:
         return value
-    with get_example_database().get_inspector_with_context() as inspector:
+    with get_example_database().get_inspector() as inspector:
         return inspector.engine.dialect.identifier_preparer.quote_identifier(value)
 
 

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -132,9 +132,7 @@ class BaseTestChartDataApi(SupersetTestCase):
 
     def quote_name(self, name: str):
         if get_main_database().backend in {"presto", "hive"}:
-            with (
-                get_example_database().get_inspector_with_context() as inspector
-            ):  # E: Ne
+            with get_example_database().get_inspector() as inspector:  # E: Ne
                 return inspector.engine.dialect.identifier_preparer.quote_identifier(
                     name
                 )

--- a/tests/integration_tests/core_tests.py
+++ b/tests/integration_tests/core_tests.py
@@ -50,6 +50,7 @@ from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.models.sql_lab import Query
 from superset.result_set import SupersetResultSet
+from superset.sql_parse import Table
 from superset.utils import core as utils
 from superset.utils.core import backend
 from superset.utils.database import get_example_database
@@ -1197,14 +1198,11 @@ class TestCore(SupersetTestCase):
         )
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
-    def test_has_table_by_name(self):
+    def test_has_table(self):
         if backend() in ("sqlite", "mysql"):
             return
         example_db = superset.utils.database.get_example_database()
-        assert (
-            example_db.has_table_by_name(table_name="birth_names", schema="public")
-            is True
-        )
+        assert example_db.has_table(Table("birth_names", "public")) is True
 
     @mock.patch("superset.views.core.request")
     @mock.patch(

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -2031,7 +2031,7 @@ class TestDatabaseApi(SupersetTestCase):
         if database.backend == "postgresql":
             response = json.loads(rv.data.decode("utf-8"))
             schemas = [
-                s[0] for s in database.get_all_table_names_in_schema(schema_name)
+                s[0] for s in database.get_all_table_names_in_schema(None, schema_name)
             ]
             self.assertEqual(response["count"], len(schemas))
             for option in response["result"]:

--- a/tests/integration_tests/databases/commands/upload_test.py
+++ b/tests/integration_tests/databases/commands/upload_test.py
@@ -73,7 +73,7 @@ def _setup_csv_upload(allowed_schemas: list[str] | None = None):
     yield
 
     upload_db = get_upload_db()
-    with upload_db.get_sqla_engine_with_context() as engine:
+    with upload_db.get_sqla_engine() as engine:
         engine.execute(f"DROP TABLE IF EXISTS {CSV_UPLOAD_TABLE}")
         engine.execute(f"DROP TABLE IF EXISTS {CSV_UPLOAD_TABLE_W_SCHEMA}")
     db.session.delete(upload_db)
@@ -107,7 +107,7 @@ def test_csv_upload_with_nulls():
             None,
             CSVReader({"null_values": ["N/A", "None"]}),
         ).run()
-    with upload_database.get_sqla_engine_with_context() as engine:
+    with upload_database.get_sqla_engine() as engine:
         data = engine.execute(f"SELECT * from {CSV_UPLOAD_TABLE}").fetchall()
         assert data == [
             ("name1", None, "city1", "1-1-1980"),

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -774,13 +774,13 @@ class TestDatasetApi(SupersetTestCase):
 
     @patch("superset.models.core.Database.get_columns")
     @patch("superset.models.core.Database.has_table")
-    @patch("superset.models.core.Database.has_view_by_name")
+    @patch("superset.models.core.Database.has_view")
     @patch("superset.models.core.Database.get_table")
     def test_create_dataset_validate_view_exists(
         self,
         mock_get_table,
         mock_has_table,
-        mock_has_view_by_name,
+        mock_has_view,
         mock_get_columns,
     ):
         """
@@ -797,7 +797,7 @@ class TestDatasetApi(SupersetTestCase):
         ]
 
         mock_has_table.return_value = False
-        mock_has_view_by_name.return_value = True
+        mock_has_view.return_value = True
         mock_get_table.return_value = None
 
         example_db = get_example_database()

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -773,13 +773,13 @@ class TestDatasetApi(SupersetTestCase):
         assert rv.status_code == 422
 
     @patch("superset.models.core.Database.get_columns")
-    @patch("superset.models.core.Database.has_table_by_name")
+    @patch("superset.models.core.Database.has_table")
     @patch("superset.models.core.Database.has_view_by_name")
     @patch("superset.models.core.Database.get_table")
     def test_create_dataset_validate_view_exists(
         self,
         mock_get_table,
-        mock_has_table_by_name,
+        mock_has_table,
         mock_has_view_by_name,
         mock_get_columns,
     ):
@@ -796,13 +796,12 @@ class TestDatasetApi(SupersetTestCase):
             }
         ]
 
-        mock_has_table_by_name.return_value = False
+        mock_has_table.return_value = False
         mock_has_view_by_name.return_value = True
         mock_get_table.return_value = None
 
         example_db = get_example_database()
         with example_db.get_sqla_engine() as engine:
-            engine = engine
             dialect = engine.dialect
 
             with patch.object(

--- a/tests/integration_tests/db_engine_specs/base_engine_spec_tests.py
+++ b/tests/integration_tests/db_engine_specs/base_engine_spec_tests.py
@@ -30,7 +30,7 @@ from superset.db_engine_specs.base import (
 from superset.db_engine_specs.mysql import MySQLEngineSpec
 from superset.db_engine_specs.sqlite import SqliteEngineSpec
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
-from superset.sql_parse import ParsedQuery
+from superset.sql_parse import ParsedQuery, Table
 from superset.utils.database import get_example_database
 from tests.integration_tests.db_engine_specs.base_tests import TestDbEngineSpec
 from tests.integration_tests.test_app import app
@@ -238,7 +238,7 @@ class TestDbEngineSpecs(TestDbEngineSpec):
     @pytest.mark.usefixtures("load_energy_table_with_slice")
     def test_column_datatype_to_string(self):
         example_db = get_example_database()
-        sqla_table = example_db.get_table("energy_usage")
+        sqla_table = example_db.get_table(Table("energy_usage"))
         dialect = example_db.get_dialect()
 
         # TODO: fix column type conversion for presto.
@@ -540,8 +540,7 @@ def test_get_indexes():
         BaseEngineSpec.get_indexes(
             database=mock.Mock(),
             inspector=inspector,
-            table_name="bar",
-            schema="foo",
+            table=Table("bar", "foo"),
         )
         == indexes
     )

--- a/tests/integration_tests/db_engine_specs/bigquery_tests.py
+++ b/tests/integration_tests/db_engine_specs/bigquery_tests.py
@@ -165,8 +165,7 @@ class TestBigQueryDbEngineSpec(TestDbEngineSpec):
             BigQueryEngineSpec.get_indexes(
                 database,
                 inspector,
-                table_name,
-                schema,
+                Table(table_name, schema),
             )
             == []
         )
@@ -184,8 +183,7 @@ class TestBigQueryDbEngineSpec(TestDbEngineSpec):
         assert BigQueryEngineSpec.get_indexes(
             database,
             inspector,
-            table_name,
-            schema,
+            Table(table_name, schema),
         ) == [
             {
                 "name": "partition",
@@ -207,8 +205,7 @@ class TestBigQueryDbEngineSpec(TestDbEngineSpec):
         assert BigQueryEngineSpec.get_indexes(
             database,
             inspector,
-            table_name,
-            schema,
+            Table(table_name, schema),
         ) == [
             {
                 "name": "partition",

--- a/tests/integration_tests/db_engine_specs/hive_tests.py
+++ b/tests/integration_tests/db_engine_specs/hive_tests.py
@@ -23,7 +23,7 @@ from sqlalchemy.sql import select
 
 from superset.db_engine_specs.hive import HiveEngineSpec, upload_to_s3
 from superset.exceptions import SupersetException
-from superset.sql_parse import Table, ParsedQuery
+from superset.sql_parse import ParsedQuery, Table
 from tests.integration_tests.test_app import app
 
 
@@ -328,7 +328,10 @@ def test_where_latest_partition(mock_method):
     columns = [{"name": "ds"}, {"name": "hour"}]
     with app.app_context():
         result = HiveEngineSpec.where_latest_partition(
-            "test_table", "test_schema", database, select(), columns
+            database,
+            Table("test_table", "test_schema"),
+            select(),
+            columns,
         )
     query_result = str(result.compile(compile_kwargs={"literal_binds": True}))
     assert "SELECT  \nWHERE ds = '01-01-19' AND hour = 1" == query_result
@@ -341,7 +344,10 @@ def test_where_latest_partition_super_method_exception(mock_method):
     columns = [{"name": "ds"}, {"name": "hour"}]
     with app.app_context():
         result = HiveEngineSpec.where_latest_partition(
-            "test_table", "test_schema", database, select(), columns
+            database,
+            Table("test_table", "test_schema"),
+            select(),
+            columns,
         )
     assert result is None
     mock_method.assert_called()
@@ -353,7 +359,9 @@ def test_where_latest_partition_no_columns_no_values(mock_method):
     db = mock.Mock()
     with app.app_context():
         result = HiveEngineSpec.where_latest_partition(
-            "test_table", "test_schema", db, select()
+            db,
+            Table("test_table", "test_schema"),
+            select(),
         )
     assert result is None
 

--- a/tests/integration_tests/db_engine_specs/postgres_tests.py
+++ b/tests/integration_tests/db_engine_specs/postgres_tests.py
@@ -530,7 +530,7 @@ def test_get_catalog_names(app_context: AppContext) -> None:
     if database.backend != "postgresql":
         return
 
-    with database.get_inspector_with_context() as inspector:
+    with database.get_inspector() as inspector:
         assert PostgresEngineSpec.get_catalog_names(database, inspector) == [
             "postgres",
             "superset",

--- a/tests/integration_tests/db_engine_specs/presto_tests.py
+++ b/tests/integration_tests/db_engine_specs/presto_tests.py
@@ -82,7 +82,7 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
         row = mock.Mock()
         row.Column, row.Type, row.Null = column
         inspector.bind.execute.return_value.fetchall = mock.Mock(return_value=[row])
-        results = PrestoEngineSpec.get_columns(inspector, "", "")
+        results = PrestoEngineSpec.get_columns(inspector, Table("", ""))
         self.assertEqual(len(expected_results), len(results))
         for expected_result, result in zip(expected_results, results):
             self.assertEqual(expected_result[0], result["column_name"])
@@ -573,7 +573,10 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
         db.get_df = mock.Mock(return_value=df)
         columns = [{"name": "ds"}, {"name": "hour"}]
         result = PrestoEngineSpec.where_latest_partition(
-            "test_table", "test_schema", db, select(), columns
+            db,
+            Table("test_table", "test_schema"),
+            select(),
+            columns,
         )
         query_result = str(result.compile(compile_kwargs={"literal_binds": True}))
         self.assertEqual("SELECT  \nWHERE ds = '01-01-19' AND hour = 1", query_result)
@@ -802,7 +805,7 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
             return_value=["a", "b"]
         )
         table_name = "table_name"
-        result = PrestoEngineSpec._show_columns(inspector, table_name, None)
+        result = PrestoEngineSpec._show_columns(inspector, Table(table_name))
         assert result == ["a", "b"]
         inspector.bind.execute.assert_called_once_with(
             f'SHOW COLUMNS FROM "{table_name}"'
@@ -818,7 +821,7 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
         )
         table_name = "table_name"
         schema = "schema"
-        result = PrestoEngineSpec._show_columns(inspector, table_name, schema)
+        result = PrestoEngineSpec._show_columns(inspector, Table(table_name, schema))
         assert result == ["a", "b"]
         inspector.bind.execute.assert_called_once_with(
             f'SHOW COLUMNS FROM "{schema}"."{table_name}"'
@@ -848,7 +851,14 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
         ]
         PrestoEngineSpec.select_star(database, Table(table_name), engine, cols=cols)
         mock_select_star.assert_called_once_with(
-            database, table_name, engine, None, 100, False, True, True, cols
+            database,
+            Table(table_name),
+            engine,
+            100,
+            False,
+            True,
+            True,
+            cols,
         )
 
     @mock.patch("superset.db_engine_specs.presto.is_feature_enabled")
@@ -877,9 +887,8 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
         )
         mock_select_star.assert_called_once_with(
             database,
-            table_name,
+            Table(table_name),
             engine,
-            None,
             100,
             True,
             True,

--- a/tests/integration_tests/db_engine_specs/presto_tests.py
+++ b/tests/integration_tests/db_engine_specs/presto_tests.py
@@ -846,7 +846,7 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
             {"col1": "val1"},
             {"col2": "val2"},
         ]
-        PrestoEngineSpec.select_star(database, table_name, engine, cols=cols)
+        PrestoEngineSpec.select_star(database, Table(table_name), engine, cols=cols)
         mock_select_star.assert_called_once_with(
             database, table_name, engine, None, 100, False, True, True, cols
         )
@@ -869,7 +869,11 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
             {"column_name": ".val2."},
         ]
         PrestoEngineSpec.select_star(
-            database, table_name, engine, show_cols=True, cols=cols
+            database,
+            Table(table_name),
+            engine,
+            show_cols=True,
+            cols=cols,
         )
         mock_select_star.assert_called_once_with(
             database,
@@ -1172,7 +1176,7 @@ def test_get_catalog_names(app_context: AppContext) -> None:
     if database.backend != "presto":
         return
 
-    with database.get_inspector_with_context() as inspector:
+    with database.get_inspector() as inspector:
         assert PrestoEngineSpec.get_catalog_names(database, inspector) == [
             "jmx",
             "memory",

--- a/tests/integration_tests/sql_validator_tests.py
+++ b/tests/integration_tests/sql_validator_tests.py
@@ -56,7 +56,7 @@ class TestPrestoValidator(SupersetTestCase):
         sql = "SELECT 1 FROM default.notarealtable"
         schema = "default"
 
-        errors = self.validator.validate(sql, schema, self.database)
+        errors = self.validator.validate(sql, None, schema, self.database)
 
         self.assertEqual([], errors)
 
@@ -70,7 +70,7 @@ class TestPrestoValidator(SupersetTestCase):
         fetch_fn.side_effect = DatabaseError("dummy db error")
 
         with self.assertRaises(PrestoSQLValidationError):
-            self.validator.validate(sql, schema, self.database)
+            self.validator.validate(sql, None, schema, self.database)
 
     @patch("superset.utils.core.g")
     def test_validator_unexpected_error(self, flask_g):
@@ -82,7 +82,7 @@ class TestPrestoValidator(SupersetTestCase):
         fetch_fn.side_effect = Exception("a mysterious failure")
 
         with self.assertRaises(Exception):
-            self.validator.validate(sql, schema, self.database)
+            self.validator.validate(sql, None, schema, self.database)
 
     @patch("superset.utils.core.g")
     def test_validator_query_error(self, flask_g):
@@ -93,7 +93,7 @@ class TestPrestoValidator(SupersetTestCase):
         fetch_fn = self.database.db_engine_spec.fetch_data
         fetch_fn.side_effect = DatabaseError(self.PRESTO_ERROR_TEMPLATE)
 
-        errors = self.validator.validate(sql, schema, self.database)
+        errors = self.validator.validate(sql, None, schema, self.database)
 
         self.assertEqual(1, len(errors))
 
@@ -105,7 +105,10 @@ class TestPostgreSQLValidator(SupersetTestCase):
 
         mock_database = MagicMock()
         annotations = PostgreSQLValidator.validate(
-            sql='SELECT 1, "col" FROM "table"', schema="", database=mock_database
+            sql='SELECT 1, "col" FROM "table"',
+            catalog=None,
+            schema="",
+            database=mock_database,
         )
         assert annotations == []
 
@@ -115,7 +118,10 @@ class TestPostgreSQLValidator(SupersetTestCase):
 
         mock_database = MagicMock()
         annotations = PostgreSQLValidator.validate(
-            sql='SELECT 1, "col"\nFROOM "table"', schema="", database=mock_database
+            sql='SELECT 1, "col"\nFROOM "table"',
+            catalog=None,
+            schema="",
+            database=mock_database,
         )
 
         assert len(annotations) == 1

--- a/tests/unit_tests/dao/dataset_test.py
+++ b/tests/unit_tests/dao/dataset_test.py
@@ -18,6 +18,7 @@
 from sqlalchemy.orm.session import Session
 
 from superset.daos.dataset import DatasetDAO
+from superset.sql_parse import Table
 
 
 def test_validate_update_uniqueness(session: Session) -> None:
@@ -54,9 +55,8 @@ def test_validate_update_uniqueness(session: Session) -> None:
     assert (
         DatasetDAO.validate_update_uniqueness(
             database_id=database.id,
-            schema=dataset1.schema,
+            table=Table(dataset1.table_name, dataset1.schema),
             dataset_id=dataset1.id,
-            name=dataset1.table_name,
         )
         is True
     )
@@ -65,9 +65,8 @@ def test_validate_update_uniqueness(session: Session) -> None:
     assert (
         DatasetDAO.validate_update_uniqueness(
             database_id=database.id,
-            schema=dataset2.schema,
+            table=Table(dataset1.table_name, dataset2.schema),
             dataset_id=dataset1.id,
-            name=dataset1.table_name,
         )
         is False
     )
@@ -76,9 +75,8 @@ def test_validate_update_uniqueness(session: Session) -> None:
     assert (
         DatasetDAO.validate_update_uniqueness(
             database_id=database.id,
-            schema=None,
+            table=Table(dataset1.table_name),
             dataset_id=dataset1.id,
-            name=dataset1.table_name,
         )
         is True
     )

--- a/tests/unit_tests/db_engine_specs/test_base.py
+++ b/tests/unit_tests/db_engine_specs/test_base.py
@@ -232,9 +232,8 @@ def test_select_star(mocker: MockFixture) -> None:
 
     sql = BaseEngineSpec.select_star(
         database=database,
-        table_name="my_table",
+        table=Table("my_table"),
         engine=engine,
-        schema=None,
         limit=100,
         show_cols=True,
         indent=True,
@@ -252,9 +251,8 @@ OFFSET ?"""
 
     sql = NoLimitDBEngineSpec.select_star(
         database=database,
-        table_name="my_table",
+        table=Table("my_table"),
         engine=engine,
-        schema=None,
         limit=100,
         show_cols=True,
         indent=True,

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -27,6 +27,7 @@ from sqlalchemy import select
 from sqlalchemy.sql import sqltypes
 from sqlalchemy_bigquery import BigQueryDialect
 
+from superset.sql_parse import Table
 from superset.superset_typing import ResultSetColumnType
 from tests.unit_tests.db_engine_specs.utils import assert_convert_dttm
 from tests.unit_tests.fixtures.common import dttm  # noqa: F401
@@ -156,9 +157,8 @@ def test_select_star(mocker: MockFixture) -> None:
 
     sql = BigQueryEngineSpec.select_star(
         database=database,
-        table_name="my_table",
+        table=Table("my_table"),
         engine=engine,
-        schema=None,
         limit=100,
         show_cols=True,
         indent=True,

--- a/tests/unit_tests/db_engine_specs/test_db2.py
+++ b/tests/unit_tests/db_engine_specs/test_db2.py
@@ -60,8 +60,9 @@ def test_get_table_comment_empty(mocker: MockerFixture):
     mock_inspector = mocker.MagicMock()
     mock_inspector.get_table_comment.return_value = {}
 
-    assert Db2EngineSpec.get_table_comment(
-        mock_inspector, Table("my_table", "my_schema")
+    assert (
+        Db2EngineSpec.get_table_comment(mock_inspector, Table("my_table", "my_schema"))
+        is None
     )
 
 

--- a/tests/unit_tests/db_engine_specs/test_db2.py
+++ b/tests/unit_tests/db_engine_specs/test_db2.py
@@ -18,6 +18,8 @@
 import pytest  # noqa: F401
 from pytest_mock import MockerFixture
 
+from superset.sql_parse import Table
+
 
 def test_epoch_to_dttm() -> None:
     """
@@ -43,7 +45,7 @@ def test_get_table_comment(mocker: MockerFixture):
     }
 
     assert (
-        Db2EngineSpec.get_table_comment(mock_inspector, "my_table", "my_schema")
+        Db2EngineSpec.get_table_comment(mock_inspector, Table("my_table", "my_schema"))
         == "This is a table comment"
     )
 
@@ -58,8 +60,8 @@ def test_get_table_comment_empty(mocker: MockerFixture):
     mock_inspector = mocker.MagicMock()
     mock_inspector.get_table_comment.return_value = {}
 
-    assert (
-        Db2EngineSpec.get_table_comment(mock_inspector, "my_table", "my_schema") is None  # noqa: E711
+    assert Db2EngineSpec.get_table_comment(
+        mock_inspector, Table("my_table", "my_schema")
     )
 
 

--- a/tests/unit_tests/db_engine_specs/test_presto.py
+++ b/tests/unit_tests/db_engine_specs/test_presto.py
@@ -24,6 +24,7 @@ from pyhive.sqlalchemy_presto import PrestoDialect
 from sqlalchemy import sql, text, types
 from sqlalchemy.engine.url import make_url
 
+from superset.sql_parse import Table
 from superset.superset_typing import ResultSetColumnType
 from superset.utils.core import GenericDataType
 from tests.unit_tests.db_engine_specs.utils import (
@@ -143,7 +144,10 @@ def test_where_latest_partition(
 
     expected = f"""SELECT * FROM table \nWHERE "partition_key" = {expected_value}"""
     result = spec.where_latest_partition(
-        "table", mock.MagicMock(), mock.MagicMock(), query, columns
+        mock.MagicMock(),
+        Table("table"),
+        query,
+        columns,
     )
     assert result is not None
     actual = result.compile(

--- a/tests/unit_tests/db_engine_specs/test_trino.py
+++ b/tests/unit_tests/db_engine_specs/test_trino.py
@@ -311,15 +311,15 @@ def test_convert_dttm(
     assert_convert_dttm(TrinoEngineSpec, target_type, expected_result, dttm)
 
 
-def test_get_extra_table_metadata() -> None:
+def test_get_extra_table_metadata(mocker: MockerFixture) -> None:
     from superset.db_engine_specs.trino import TrinoEngineSpec
 
-    db_mock = Mock()
+    db_mock = mocker.MagicMock()
     db_mock.get_indexes = Mock(
         return_value=[{"column_names": ["ds", "hour"], "name": "partition"}]
     )
     db_mock.get_extra = Mock(return_value={})
-    db_mock.has_view_by_name = Mock(return_value=None)
+    db_mock.has_view = Mock(return_value=None)
     db_mock.get_df = Mock(return_value=pd.DataFrame({"ds": ["01-01-19"], "hour": [1]}))
     result = TrinoEngineSpec.get_extra_table_metadata(
         db_mock,

--- a/tests/unit_tests/db_engine_specs/test_trino.py
+++ b/tests/unit_tests/db_engine_specs/test_trino.py
@@ -442,7 +442,7 @@ def test_get_columns(mocker: MockerFixture):
     mock_inspector = mocker.MagicMock()
     mock_inspector.get_columns.return_value = sqla_columns
 
-    actual = TrinoEngineSpec.get_columns(mock_inspector, "table", "schema")
+    actual = TrinoEngineSpec.get_columns(mock_inspector, Table("table", "schema"))
     expected = [
         ResultSetColumnType(
             name="field1", column_name="field1", type=field1_type, is_dttm=False
@@ -475,7 +475,9 @@ def test_get_columns_expand_rows(mocker: MockerFixture):
     mock_inspector.get_columns.return_value = sqla_columns
 
     actual = TrinoEngineSpec.get_columns(
-        mock_inspector, "table", "schema", {"expand_rows": True}
+        mock_inspector,
+        Table("table", "schema"),
+        {"expand_rows": True},
     )
     expected = [
         ResultSetColumnType(
@@ -538,7 +540,9 @@ def test_get_indexes_no_table():
         side_effect=NoSuchTableError("The specified table does not exist.")
     )
     result = TrinoEngineSpec.get_indexes(
-        db_mock, inspector_mock, "test_table", "test_schema"
+        db_mock,
+        inspector_mock,
+        Table("test_table", "test_schema"),
     )
     assert result == []
 

--- a/tests/unit_tests/models/core_test.py
+++ b/tests/unit_tests/models/core_test.py
@@ -18,7 +18,6 @@
 # pylint: disable=import-outside-toplevel
 import json
 from datetime import datetime
-from typing import Optional
 
 import pytest
 from pytest_mock import MockFixture
@@ -26,6 +25,7 @@ from sqlalchemy.engine.reflection import Inspector
 
 from superset.connectors.sqla.models import SqlaTable, TableColumn
 from superset.models.core import Database
+from superset.sql_parse import Table
 
 
 def test_get_metrics(mocker: MockFixture) -> None:
@@ -37,7 +37,7 @@ def test_get_metrics(mocker: MockFixture) -> None:
     from superset.models.core import Database
 
     database = Database(database_name="my_database", sqlalchemy_uri="sqlite://")
-    assert database.get_metrics("table") == [
+    assert database.get_metrics(Table("table")) == [
         {
             "expression": "COUNT(*)",
             "metric_name": "count",
@@ -52,8 +52,7 @@ def test_get_metrics(mocker: MockFixture) -> None:
             cls,
             database: Database,
             inspector: Inspector,
-            table_name: str,
-            schema: Optional[str],
+            table: Table,
         ) -> list[MetricType]:
             return [
                 {
@@ -65,7 +64,7 @@ def test_get_metrics(mocker: MockFixture) -> None:
             ]
 
     database.get_db_engine_spec = mocker.MagicMock(return_value=CustomSqliteEngineSpec)
-    assert database.get_metrics("table") == [
+    assert database.get_metrics(Table("table")) == [
         {
             "expression": "COUNT(DISTINCT user_id)",
             "metric_name": "count_distinct_user_id",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR adds a new endpoint to get metadata from a table, optionally passing a schema and a catalog.

In order to support the new endpoint, this PR has two refactors. Despite touching many files, they are simple:

1. All methods that take a `table_name` and a `schema` were updated to received a `Table` instance instead, since it carries the catalog:

https://github.com/apache/superset/blob/69a7bfc88d7aac3cb08cb45376be1699a67ebee0/superset/sql_parse.py#L242-L250

2. All other methods that take a `schema` now also take a `catalog`.

Note that currently the catalog being passed around is always `None`. It gets passed all the way to the `adjust_engine_params` method in the DB engine spec, and DB engine specs are responsible for modifying the SQLAlchemy URI to connect to the catalog.

In the next PR I'll start implementing support for catalogs in Postgres, and will modify the UI to allow choosing a catalog when running SQL or creating a dataset.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

I added unit tests for the new endpoint, and updated existing tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: https://github.com/apache/superset/issues/22862
- [ ] Required feature flags:
- [ ] Changes UI
- [X] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [X] Migration is atomic, supports rollback & is backwards-compatible
  - [X] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [X] Introduces new feature or API
- [ ] Removes existing feature or API
