### PR TITLE
docs: Updated quick start page. Docker compose command had a typo

### DIFF
--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -32,7 +32,7 @@ $ git clone https://github.com/apache/superset
 $ cd superset
 
 # Fire up Superset using Docker Compose
-$ docker compose -f docker compose-image-tag.yml up
+$ docker compose -f docker-compose-image-tag.yml up
 ```
 This may take a moment as Docker Compose will fetch the underlying
 container images and will load up some examples. Once all containers


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
The quick start guide appears to have a typo in the docker compose message.
Before
`docker compose -f docker compose-image-tag.yml up`
After
`docker compose -f docker-compose-image-tag.yml up`

Note the missing dash in the yml file.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
The compose command did not work before, but now it does.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
