### PR TITLE
fix: call render operator function

### DIFF
--- a/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from 'spec/helpers/testing-library';
+import { Comparator } from '@superset-ui/chart-controls';
+import { ColorSchemeEnum } from '@superset-ui/plugin-chart-table';
+import { FormattingPopoverContent } from './FormattingPopoverContent';
+
+const mockOnChange = jest.fn();
+
+const columns = [
+  { label: 'Column 1', value: 'column1' },
+  { label: 'Column 2', value: 'column2' },
+];
+
+const extraColorChoices = [
+  {
+    value: ColorSchemeEnum.Green,
+    label: 'Green for increase, red for decrease',
+  },
+  {
+    value: ColorSchemeEnum.Red,
+    label: 'Red for increase, green for decrease',
+  },
+];
+
+test('renders FormattingPopoverContent component', () => {
+  render(
+    <FormattingPopoverContent
+      onChange={mockOnChange}
+      columns={columns}
+      extraColorChoices={extraColorChoices}
+    />,
+  );
+
+  // Assert that the component renders correctly
+  expect(screen.getByLabelText('Column')).toBeInTheDocument();
+  expect(screen.getAllByLabelText('Color scheme')).toHaveLength(2);
+  expect(screen.getAllByLabelText('Operator')).toHaveLength(2);
+  expect(screen.queryByLabelText('Left value')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText('Right value')).not.toBeInTheDocument();
+  expect(screen.getByText('Apply')).toBeInTheDocument();
+});
+
+test('calls onChange when Apply button is clicked', async () => {
+  render(
+    <FormattingPopoverContent
+      onChange={mockOnChange}
+      columns={columns}
+      extraColorChoices={extraColorChoices}
+    />,
+  );
+
+  // Simulate user interaction by clicking the Apply button
+  fireEvent.click(screen.getByText('Apply'));
+
+  // Assert that the onChange function is called with the correct config
+  await waitFor(() => {
+    expect(mockOnChange).toHaveBeenCalled();
+  });
+});
+
+test('renders the correct input fields based on the selected operator', async () => {
+  render(
+    <FormattingPopoverContent
+      onChange={mockOnChange}
+      columns={columns}
+      extraColorChoices={extraColorChoices}
+    />,
+  );
+
+  // Select the 'Between' operator
+  fireEvent.change(screen.getAllByLabelText('Operator')[0], {
+    target: { value: Comparator.Between },
+  });
+  fireEvent.click(await screen.findByTitle('< x <'));
+
+  // Assert that the left and right value inputs are rendered
+  expect(await screen.findByLabelText('Left value')).toBeInTheDocument();
+  expect(await screen.findByLabelText('Right value')).toBeInTheDocument();
+});
+
+test('renders None for operator when Green for increase is selected', async () => {
+  render(
+    <FormattingPopoverContent
+      onChange={mockOnChange}
+      columns={columns}
+      extraColorChoices={extraColorChoices}
+    />,
+  );
+
+  // Select the 'Green for increase' color scheme
+  fireEvent.change(screen.getAllByLabelText(/color scheme/i)[0], {
+    target: { value: ColorSchemeEnum.Green },
+  });
+
+  fireEvent.click(await screen.findByTitle(/green for increase/i));
+
+  // Assert that the operator is set to 'None'
+  expect(screen.getByText(/none/i)).toBeInTheDocument();
+});

--- a/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
+++ b/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
@@ -124,7 +124,7 @@ const shouldFormItemUpdate = (
   isOperatorMultiValue(prevValues.operator) !==
     isOperatorMultiValue(currentValues.operator);
 
-const operatorField = (showOnlyNone?: boolean) => (
+const renderOperator = ({ showOnlyNone }: { showOnlyNone?: boolean } = {}) => (
   <FormItem
     name="operator"
     label={t('Operator')}
@@ -141,7 +141,7 @@ const operatorField = (showOnlyNone?: boolean) => (
 const renderOperatorFields = ({ getFieldValue }: GetFieldValue) =>
   isOperatorNone(getFieldValue('operator')) ? (
     <Row gutter={12}>
-      <Col span={6}>{operatorField()}</Col>
+      <Col span={6}>{renderOperator()}</Col>
     </Row>
   ) : isOperatorMultiValue(getFieldValue('operator')) ? (
     <Row gutter={12}>
@@ -157,7 +157,7 @@ const renderOperatorFields = ({ getFieldValue }: GetFieldValue) =>
           <FullWidthInputNumber />
         </FormItem>
       </Col>
-      <Col span={6}>{operatorField}</Col>
+      <Col span={6}>{renderOperator()}</Col>
       <Col span={9}>
         <FormItem
           name="targetValueRight"
@@ -173,7 +173,7 @@ const renderOperatorFields = ({ getFieldValue }: GetFieldValue) =>
     </Row>
   ) : (
     <Row gutter={12}>
-      <Col span={6}>{operatorField}</Col>
+      <Col span={6}>{renderOperator()}</Col>
       <Col span={18}>
         <FormItem
           name="targetValue"
@@ -248,7 +248,7 @@ export const FormattingPopoverContent = ({
           renderOperatorFields
         ) : (
           <Row gutter={12}>
-            <Col span={6}>{operatorField(true)}</Col>
+            <Col span={6}>{renderOperator({ showOnlyNone: true })}</Col>
           </Row>
         )}
       </FormItem>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Found a small bug where the render operator function was being passed in instead of executed and so the operator was undefined. I just renamed the variable so that it would sound more like a method to make it easier to catch in the future. Also added some tests. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: 
![image](https://github.com/apache/superset/assets/5186919/6814bb9d-e4ac-4abb-bf83-34934f70cad9)

After: 
<img width="737" alt="Screenshot 2024-04-18 at 2 30 39 PM" src="https://github.com/apache/superset/assets/5186919/a801da92-059b-4548-a7c0-bbf3682d1538">


### TESTING INSTRUCTIONS
Add a color condition to a column on the table viz

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
