### PR TITLE
fix(ComparisonRangeLabel): Add optional chaining to customTimeRangeComparisonFilters

### DIFF
--- a/superset-frontend/src/explore/components/controls/ComparisonRangeLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/ComparisonRangeLabel.tsx
@@ -63,7 +63,7 @@ export const ComparisonRangeLabel = () => {
 
   useEffect(() => {
     if (shift === ComparisonTimeRangeType.Custom) {
-      const promises = customTimeRangeComparisonFilters.map(filter =>
+      const promises = customTimeRangeComparisonFilters?.map(filter =>
         fetchTimeRange(filter.comparator, filter.subject),
       );
       Promise.all(promises).then(res => {
@@ -74,7 +74,7 @@ export const ComparisonRangeLabel = () => {
 
   useEffect(() => {
     if (shift !== ComparisonTimeRangeType.Custom) {
-      const promises = currentTimeRangeFilters.map(filter =>
+      const promises = currentTimeRangeFilters?.map(filter =>
         fetchTimeRange(
           filter.comparator,
           filter.subject,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is meant to the fix the error alert that is produced when a custom range is set. The value is now optional to wait for the promise. It is also added to currentTimeRangeFilters as a precaution.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
BEFORE:
![custom-bugg](https://github.com/apache/superset/assets/92495987/48abceb9-75e5-4bdf-905b-22d9f84e66ba)
AFTER:
![custom-fixed](https://github.com/apache/superset/assets/92495987/45ec7141-f261-4e63-baf2-2597b4d3550e)



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
