### PR TITLE
chore: clean up console upon firing up the CLI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,17 +95,3 @@ repos:
     hooks:
       - id: helm-docs
         files: helm
-  - repo: local
-    hooks:
-      - id: pylint
-        name: pylint
-        entry: pylint
-        language: system
-        types: [python]
-        args:
-          [
-            "-rn", # Only display messages
-            "-sn", # Don't display the score
-            "--rcfile=.pylintrc", # Link to your config file
-            "--load-plugins=pylint.extensions.docparams", # Load an extension
-          ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,3 +95,17 @@ repos:
     hooks:
       - id: helm-docs
         files: helm
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint
+        entry: pylint
+        language: system
+        types: [python]
+        args:
+          [
+            "-rn", # Only display messages
+            "-sn", # Don't display the score
+            "--rcfile=.pylintrc", # Link to your config file
+            "--load-plugins=pylint.extensions.docparams", # Load an extension
+          ]

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -41,6 +41,8 @@ assists people when migrating to a new version.
 - [27849](https://github.com/apache/superset/pull/27849/) More of an FYI, but we have a
   new config `SLACK_ENABLE_AVATARS` (False by default) that works in conjunction with
   set `SLACK_API_TOKEN` to fetch and serve Slack avatar links
+- [??](https://github.com/apache/superset/pull/???/) The default logging level was changed
+  from DEBUG to INFO - which is the normal/sane default logging level for most software.
 
 ## 4.0.0
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -41,7 +41,7 @@ assists people when migrating to a new version.
 - [27849](https://github.com/apache/superset/pull/27849/) More of an FYI, but we have a
   new config `SLACK_ENABLE_AVATARS` (False by default) that works in conjunction with
   set `SLACK_API_TOKEN` to fetch and serve Slack avatar links
-- [??](https://github.com/apache/superset/pull/???/) The default logging level was changed
+- [28134](https://github.com/apache/superset/pull/28134/) The default logging level was changed
   from DEBUG to INFO - which is the normal/sane default logging level for most software.
 
 ## 4.0.0

--- a/superset/cli/main.py
+++ b/superset/cli/main.py
@@ -38,6 +38,7 @@ logger = logging.getLogger(__name__)
 @with_appcontext
 def superset() -> None:
     """\033[1;37mThe Apache Superset CLI\033[0m"""
+    # NOTE: codes above are ANSI color codes for bold white in CLI header ^^^
 
     @app.shell_context_processor
     def make_shell_context() -> dict[str, Any]:

--- a/superset/cli/main.py
+++ b/superset/cli/main.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 )
 @with_appcontext
 def superset() -> None:
-    """This is a management script for the Superset application."""
+    """\033[1;37mThe Apache Superset CLI\033[0m"""
 
     @app.shell_context_processor
     def make_shell_context() -> dict[str, Any]:

--- a/superset/config.py
+++ b/superset/config.py
@@ -846,7 +846,7 @@ LOGGING_CONFIGURATOR = DefaultLoggingConfigurator()
 # Console Log Settings
 
 LOG_FORMAT = "%(asctime)s:%(levelname)s:%(name)s:%(message)s"
-LOG_LEVEL = "INFO"
+LOG_LEVEL = logging.INFO
 
 # ---------------------------------------------------
 # Enable Time Rotate Log Handler
@@ -854,7 +854,7 @@ LOG_LEVEL = "INFO"
 # LOG_LEVEL = DEBUG, INFO, WARNING, ERROR, CRITICAL
 
 ENABLE_TIME_ROTATE = False
-TIME_ROTATE_LOG_LEVEL = "DEBUG"
+TIME_ROTATE_LOG_LEVEL = logging.INFO
 FILENAME = os.path.join(DATA_DIR, "superset.log")
 ROLLOVER = "midnight"
 INTERVAL = 1

--- a/superset/config.py
+++ b/superset/config.py
@@ -20,6 +20,7 @@ All configuration in this file can be overridden by providing a superset_config
 in your PYTHONPATH as there is a ``from superset_config import *``
 at the end of this file.
 """
+
 # mypy: ignore-errors
 # pylint: disable=too-many-lines
 from __future__ import annotations
@@ -272,7 +273,7 @@ SCHEDULED_QUERIES: dict[str, Any] = {}
 # feature is on by default to make Superset secure by default, but you should
 # fine tune the limits to your needs. You can read more about the different
 # parameters here: https://flask-limiter.readthedocs.io/en/stable/configuration.html
-RATELIMIT_ENABLED = True if os.environ.get("SUPERSET_ENV") == "production" else False
+RATELIMIT_ENABLED = os.environ.get("SUPERSET_ENV") == "production"
 RATELIMIT_APPLICATION = "50 per second"
 AUTH_RATE_LIMITED = True
 AUTH_RATE_LIMIT = "5 per second"

--- a/superset/config.py
+++ b/superset/config.py
@@ -37,6 +37,7 @@ from email.mime.multipart import MIMEMultipart
 from importlib.resources import files
 from typing import Any, Callable, Literal, TYPE_CHECKING, TypedDict
 
+import click
 import pkg_resources
 from celery.schedules import crontab
 from flask import Blueprint
@@ -271,7 +272,7 @@ SCHEDULED_QUERIES: dict[str, Any] = {}
 # feature is on by default to make Superset secure by default, but you should
 # fine tune the limits to your needs. You can read more about the different
 # parameters here: https://flask-limiter.readthedocs.io/en/stable/configuration.html
-RATELIMIT_ENABLED = True
+RATELIMIT_ENABLED = True if os.environ.get("SUPERSET_ENV") == "production" else False
 RATELIMIT_APPLICATION = "50 per second"
 AUTH_RATE_LIMITED = True
 AUTH_RATE_LIMIT = "5 per second"
@@ -844,7 +845,7 @@ LOGGING_CONFIGURATOR = DefaultLoggingConfigurator()
 # Console Log Settings
 
 LOG_FORMAT = "%(asctime)s:%(levelname)s:%(name)s:%(message)s"
-LOG_LEVEL = "DEBUG"
+LOG_LEVEL = "INFO"
 
 # ---------------------------------------------------
 # Enable Time Rotate Log Handler
@@ -1743,7 +1744,7 @@ if CONFIG_PATH_ENV_VAR in os.environ:
             if key.isupper():
                 setattr(module, key, getattr(override_conf, key))
 
-        print(f"Loaded your LOCAL configuration at [{cfg_path}]")
+        click.secho(f"Loaded your LOCAL configuration at [{cfg_path}]", fg="cyan")
     except Exception:
         logger.exception(
             "Failed to import config for %s=%s", CONFIG_PATH_ENV_VAR, cfg_path
@@ -1755,7 +1756,10 @@ elif importlib.util.find_spec("superset_config") and not is_test():
         import superset_config
         from superset_config import *  # noqa: F403, F401
 
-        print(f"Loaded your LOCAL configuration at [{superset_config.__file__}]")
+        click.secho(
+            f"Loaded your LOCAL configuration at [{superset_config.__file__}]",
+            fg="cyan",
+        )
     except Exception:
         logger.exception("Found but failed to import local superset_config")
         raise

--- a/superset/utils/log.py
+++ b/superset/utils/log.py
@@ -313,7 +313,7 @@ def get_event_logger_from_cfg_value(cfg_value: Any) -> AbstractEventLogger:
             "of superset.utils.log.AbstractEventLogger."
         )
 
-    logging.info("Configured event logger of type %s", type(result))
+    logging.debug("Configured event logger of type %s", type(result))
     return cast(AbstractEventLogger, result)
 
 

--- a/superset/utils/logging_configurator.py
+++ b/superset/utils/logging_configurator.py
@@ -65,4 +65,4 @@ class DefaultLoggingConfigurator(  # pylint: disable=too-few-public-methods
             )
             logging.getLogger().addHandler(handler)
 
-        logger.info("logging was configured successfully")
+        logger.debug("logging was configured successfully")


### PR DESCRIPTION
### Summary

Currently there's some irrelevant DEBUG-level type logging happening when using the CLI, here I'm doing the following things:
- setting the default logging level to INFO, which is the normal/sane default usually used in software
- downgrading unimportant messages in the console from INFO to DEBUG
- adding a dash of color on the title (bolded-white) and config loading INFO (cyan)
- turning off load limiter `RATELIMIT_ENABLED` to `False` when not in a `production` environment (added a note to `UPDATING.md` for that)

### Screenshots
<img width="1173" alt="Screenshot 2024-04-18 at 3 34 24 PM" src="https://github.com/apache/superset/assets/487433/f432e8fd-f221-4c18-8171-68022c3c8a7b">
<img width="893" alt="Screenshot 2024-04-18 at 3 30 46 PM" src="https://github.com/apache/superset/assets/487433/2da57dd2-8876-477b-b7b7-f4766d8ccf5b">
