### PR TITLE
chore: get websocket service to start in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,6 +120,10 @@ services:
       - ./superset-websocket:/home/superset-websocket
       - /home/superset-websocket/node_modules
       - /home/superset-websocket/dist
+
+      # Mounting a config file that contains a dummy secret required to boot up.
+      # do no not use this docker-compose in production
+      - ./docker/superset-websocket/config.json:/home/superset-websocket/config.json
     environment:
       - PORT=8080
       - REDIS_HOST=redis

--- a/docker/superset-websocket/config.json
+++ b/docker/superset-websocket/config.json
@@ -1,0 +1,22 @@
+{
+  "port": 8080,
+  "logLevel": "info",
+  "logToFile": false,
+  "logFilename": "app.log",
+  "statsd": {
+    "host": "127.0.0.1",
+    "port": 8125,
+    "globalTags": []
+  },
+  "redis": {
+    "port": 6379,
+    "host": "127.0.0.1",
+    "password": "",
+    "db": 0,
+    "ssl": false
+  },
+  "redisStreamPrefix": "async-events-",
+  "jwtAlgorithms": ["HS256"],
+  "jwtSecret": "CHANGE-ME-IN-PRODUCTION-GOTTA-BE-LONG-AND-SECRET",
+  "jwtCookieName": "async-token"
+}

--- a/superset-websocket/src/index.ts
+++ b/superset-websocket/src/index.ts
@@ -100,7 +100,9 @@ if (startServer && opts.jwtSecret.length < 32) {
 }
 
 if (startServer && opts.jwtSecret.startsWith('CHANGE-ME')) {
-  console.warn('WARNING: it appears you secret in your config.json is insecure');
+  console.warn(
+    'WARNING: it appears you secret in your config.json is insecure',
+  );
   console.warn('DO NOT USE IN PRODUCTION');
 }
 

--- a/superset-websocket/src/index.ts
+++ b/superset-websocket/src/index.ts
@@ -94,8 +94,15 @@ export const statsd = new StatsD({
 });
 
 // enforce JWT secret length
-if (startServer && opts.jwtSecret.length < 32)
-  throw new Error('Please provide a JWT secret at least 32 bytes long');
+if (startServer && opts.jwtSecret.length < 32) {
+  console.error('ERROR: Please provide a JWT secret at least 32 bytes long');
+  process.exit(1);
+}
+
+if (startServer && opts.jwtSecret.startsWith('CHANGE-ME')) {
+  console.warn('WARNING: it appears you secret in your config.json is insecure');
+  console.warn('DO NOT USE IN PRODUCTION');
+}
 
 export const buildRedisOpts = (baseConfig: RedisConfig) => {
   const redisOpts: RedisOptions = {


### PR DESCRIPTION
When starting vanilla docker-compose, this shows up ->

<img width="1728" alt="Screenshot 2024-04-18 at 4 03 15 PM" src="https://github.com/apache/superset/assets/487433/f03db330-7e12-45f0-922b-c70ab841fa5a">


What's happening is upon start up, the superset-websocket service requires a config.json that contains a secret key (much like we set a SECRET_KEY up for flask on the python side). In normal operation, the administrator needs to provide such a file by copying and altering `superset-websocket/config.example.json`.

For `docker-compose`, now that we're 100% clear in our docs and files that our provided setup should not be used for production, we want to provide a dummy config file so that the service can start, as opposed to the confusion of starting a service that crashes upon start and spits a wall of confusing JSON.

Note that I've also:
- improved the error message for when the secret is too simple
- copied the example file into `docker/superset-websocket/config.json`
- altered the password with a dummy secret
