### PR TITLE
chore: add pylint to pre-commit hook

### DIFF
--- a/.github/workflows/superset-python-misc.yml
+++ b/.github/workflows/superset-python-misc.yml
@@ -31,10 +31,6 @@ jobs:
       - name: Setup Python
         uses: ./.github/actions/setup-backend/
         if: steps.check.outputs.python
-      - name: pylint
-        if: steps.check.outputs.python
-        # `-j 0` run Pylint in parallel
-        run: pylint -j 0 superset
 
   babel-extract:
     runs-on: ubuntu-20.04

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,6 +84,7 @@ repos:
         entry: pylint
         language: system
         types: [python]
+        exclude: ^(tests/|superset/migrations/)
         args:
           [
             "-rn", # Only display messages

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,5 +88,4 @@ repos:
           [
             "-rn", # Only display messages
             "-sn", # Don't display the score
-            "--rcfile=.pylintrc", # Link to your config file
           ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,6 +89,4 @@ repos:
             "-rn", # Only display messages
             "-sn", # Don't display the score
             "--rcfile=.pylintrc", # Link to your config file
-            "--load-plugins=pylint.extensions.docparams", # Load an extension
-            "--jobs 0"
           ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,3 +77,18 @@ repos:
       - id: ruff
         args: [ --fix ]
       - id: ruff-format
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint
+        entry: pylint
+        language: system
+        types: [python]
+        args:
+          [
+            "-rn", # Only display messages
+            "-sn", # Don't display the score
+            "--rcfile=.pylintrc", # Link to your config file
+            "--load-plugins=pylint.extensions.docparams", # Load an extension
+            "--jobs 0"
+          ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,7 +84,7 @@ repos:
         entry: pylint
         language: system
         types: [python]
-        exclude: ^(tests/|superset/migrations/)
+        exclude: ^(tests/|superset/migrations/|scripts/|RELEASING/|docker/)
         args:
           [
             "-rn", # Only display messages

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,4 +88,5 @@ repos:
           [
             "-rn", # Only display messages
             "-sn", # Don't display the score
+            "superset", # only the superset folder
           ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,5 +88,5 @@ repos:
           [
             "-rn", # Only display messages
             "-sn", # Don't display the score
-            "superset", # only the superset folder
+            "--rcfile=.pylintrc",
           ]

--- a/.pylintrc
+++ b/.pylintrc
@@ -29,7 +29,7 @@ ignore=CVS,migrations
 
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.
-ignore-patterns=ignore-patterns=tests.*,scripts.*
+ignore-patterns=ignore-patterns=.*tests.*,.*scripts.*,.*migrations.*
 
 # Pickle collected data for later comparisons.
 persistent=yes

--- a/.pylintrc
+++ b/.pylintrc
@@ -29,7 +29,7 @@ ignore=CVS,migrations
 
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.
-ignore-patterns=ignore-patterns=.*tests.*,.*scripts.*,.*migrations.*
+ignore-patterns=.*tests.*,.*scripts.*,.*migrations.*
 
 # Pickle collected data for later comparisons.
 persistent=yes

--- a/.pylintrc
+++ b/.pylintrc
@@ -29,7 +29,7 @@ ignore=CVS,migrations
 
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.
-ignore-patterns=
+ignore-patterns=ignore-patterns=tests.*,scripts.*
 
 # Pickle collected data for later comparisons.
 persistent=yes

--- a/.pylintrc
+++ b/.pylintrc
@@ -29,7 +29,7 @@ ignore=CVS,migrations
 
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.
-ignore-patterns=.*tests.*,.*scripts.*,.*migrations.*
+ignore-patterns=
 
 # Pickle collected data for later comparisons.
 persistent=yes

--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,9 @@ with open(PACKAGE_JSON) as package_file:
 
 def get_git_sha() -> str:
     try:
-        s = subprocess.check_output(["git", "rev-parse", "HEAD"])
-        return s.decode().strip()
-    except Exception:
+        output = subprocess.check_output(["git", "rev-parse", "HEAD"])
+        return output.decode().strip()
+    except Exception:  # pylint: disable=broad-except
         return ""
 
 


### PR DESCRIPTION
I got bit by the old pylint failing in CI again recently. pylint is too slow for IDEs
so I turn it off since it made vim too sluggish to my taste. Feels about
right as a pre-commit hook, I'd rather get that too take a moment than
waiting for a CI cycle.

Not sure why it wasn't there in the first place, too slow?

We should also consider moving to `ruff` and streamlining all this, but ruff
doesn't support all the pylint rules [yet].

