### PR TITLE
fix(TimeComparisonColumns): Remove currency formatter from percentage comparison column

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -311,6 +311,13 @@ const processComparisonColumns = (
           },
           {
             ...col,
+            config: {
+              ...col.config,
+              currencyFormat: {
+                symbol: ``,
+                symbolPosition: ``,
+              },
+            },
             formatter: getNumberFormatter(numberFormat || PERCENT_3_POINT),
             label: `%`,
             key: `% ${col.key}`,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This explicitly removes the currencyFormat entry in the `%` comparison column's config, prohibiting the currency symbol being applied to this column

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
AFTER:
![percent-fixed](https://github.com/apache/superset/assets/92495987/b371d5e1-1a1e-4d8e-9339-dac442c09450)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

- enable time comparison
- customize a column to add currency

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
