### PR TITLE
fix(sql_parse): Provide more lenient logic when extracting latest[_sub]_partition

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -1554,16 +1554,19 @@ def extract_tables_from_jinja_sql(sql: str, database: Database) -> set[Table]:
             "latest_partition",
             "latest_sub_partition",
         ):
-            # Extract the table referenced in the macro.
-            tables.add(
-                Table(
-                    *[
-                        remove_quotes(part.strip())
-                        for part in node.args[0].as_const().split(".")[::-1]
-                        if len(node.args) == 1
-                    ]
+            # Try to extract the table referenced in the macro.
+            try:
+                tables.add(
+                    Table(
+                        *[
+                            remove_quotes(part.strip())
+                            for part in node.args[0].as_const().split(".")[::-1]
+                            if len(node.args) == 1
+                        ]
+                    )
                 )
-            )
+            except nodes.Impossible:
+                pass
 
             # Replace the potentially problematic Jinja macro with some benign SQL.
             node.__class__ = nodes.TemplateData

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -1938,36 +1938,40 @@ def test_sqlstatement() -> None:
     ],
 )
 @pytest.mark.parametrize(
-    "macro",
-    [
-        "latest_partition('foo.bar')",
-        "latest_partition(' foo.bar ')",  # Non-atypical user error which works
-        "latest_partition('foo.%s'|format('bar'))",
-        "latest_sub_partition('foo.bar', baz='qux')",
-    ],
-)
-@pytest.mark.parametrize(
-    "sql,expected",
+    "macro,expected",
     [
         (
-            "SELECT '{{{{ {engine}.{macro} }}}}'",
+            "latest_partition('foo.bar')",
             {Table(table="bar", schema="foo")},
         ),
         (
-            "SELECT * FROM foo.baz WHERE quux = '{{{{ {engine}.{macro} }}}}'",
-            {Table(table="bar", schema="foo"), Table(table="baz", schema="foo")},
+            "latest_partition(' foo.bar ')",  # Non-atypical user error which works
+            {Table(table="bar", schema="foo")},
+        ),
+        (
+            "latest_partition('foo.%s'|format('bar'))",
+            {Table(table="bar", schema="foo")},
+        ),
+        (
+            "latest_sub_partition('foo.bar', baz='qux')",
+            {Table(table="bar", schema="foo")},
+        ),
+        (
+            "latest_partition('foo.%s'|format(str('bar')))",
+            set(),
+        ),
+        (
+            "latest_partition('foo.{}'.format('bar'))",
+            set(),
         ),
     ],
 )
 def test_extract_tables_from_jinja_sql(
-    engine: str,
-    macro: str,
-    sql: str,
-    expected: set[Table],
+    engine: str, macro: str, expected: set[Table]
 ) -> None:
     assert (
         extract_tables_from_jinja_sql(
-            sql=sql.format(engine=engine, macro=macro),
+            sql=f"'{{{{ {engine}.{macro} }}}}'",
             database=Mock(),
         )
         == expected


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->


### SUMMARY

This is a follow up to https://github.com/apache/superset/pull/28117, which sadly wasn't suffice when variables as opposed to constants were being used with the `format()` Jinja macro.

Sadly the `as_const()` method has only been implemented for a subset of node types and given that the plethora of logic which one could define is vast it's likely best to just acknowledge there are times when we wont be able to accurately extract the table referenced by the `latest[_sub]_partition` Jinja macro.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Added unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
