### PR TITLE
chore: Add custom keywords for SQL Lab autocomplete

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/ui-overrides/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/ui-overrides/types.ts
@@ -210,5 +210,5 @@ export type Extensions = Partial<{
   'dashboard.slice.header': React.ComponentType<SliceHeaderExtension>;
   'sqleditor.extension.customAutocomplete': (
     args: CustomAutoCompleteArgs,
-  ) => CustomAutocomplete[];
+  ) => CustomAutocomplete[] | undefined;
 }>;

--- a/superset-frontend/packages/superset-ui-core/src/ui-overrides/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/ui-overrides/types.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import React, { ReactNode, MouseEventHandler } from 'react';
+import type { Editor } from 'brace';
 
 /**
  * A function which returns text (or marked-up text)
@@ -164,6 +165,26 @@ export interface SubMenuProps {
   activeChild?: string;
 }
 
+export interface CustomAutoCompleteArgs {
+  queryEditorId: string;
+  dbId?: string | number;
+  schema?: string;
+}
+
+interface AutocompleteItem {
+  name: string;
+  value: string;
+  score: number;
+  meta: string;
+  label?: string;
+  docHTML?: string | undefined;
+  docText?: string | undefined;
+}
+
+export interface CustomAutocomplete extends AutocompleteItem {
+  insertMatch?: (editor: Editor, data: AutocompleteItem) => void;
+}
+
 export type Extensions = Partial<{
   'alertsreports.header.icon': React.ComponentType;
   'embedded.documentation.configuration_details': React.ComponentType<ConfigDetailsProps>;
@@ -187,4 +208,7 @@ export type Extensions = Partial<{
   'sqleditor.extension.form': React.ComponentType<SQLFormExtensionProps>;
   'sqleditor.extension.resultTable': React.ComponentType<SQLResultTableExtentionProps>;
   'dashboard.slice.header': React.ComponentType<SliceHeaderExtension>;
+  'sqleditor.extension.customAutocomplete': (args: CustomAutoCompleteArgs) => {
+    data?: CustomAutocomplete[];
+  };
 }>;

--- a/superset-frontend/packages/superset-ui-core/src/ui-overrides/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/ui-overrides/types.ts
@@ -177,8 +177,8 @@ interface AutocompleteItem {
   score: number;
   meta: string;
   label?: string;
-  docHTML?: string | undefined;
-  docText?: string | undefined;
+  docHTML?: string;
+  docText?: string;
 }
 
 export interface CustomAutocomplete extends AutocompleteItem {
@@ -208,7 +208,7 @@ export type Extensions = Partial<{
   'sqleditor.extension.form': React.ComponentType<SQLFormExtensionProps>;
   'sqleditor.extension.resultTable': React.ComponentType<SQLResultTableExtentionProps>;
   'dashboard.slice.header': React.ComponentType<SliceHeaderExtension>;
-  'sqleditor.extension.customAutocomplete': (args: CustomAutoCompleteArgs) => {
-    data?: CustomAutocomplete[];
-  };
+  'sqleditor.extension.customAutocomplete': (
+    args: CustomAutoCompleteArgs,
+  ) => CustomAutocomplete[];
 }>;

--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.test.ts
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.test.ts
@@ -18,6 +18,7 @@
  */
 import fetchMock from 'fetch-mock';
 import { act, renderHook } from '@testing-library/react-hooks';
+import { getExtensionsRegistry } from '@superset-ui/core';
 import {
   createWrapper,
   defaultStore as store,
@@ -312,4 +313,43 @@ test('returns long keywords with docText', async () => {
       }),
     ),
   );
+});
+
+test('Add extension to SliceHeader', () => {
+  const expected = [
+    {
+      name: 'Custom keyword 1',
+      label: 'Custom keyword 1',
+      meta: 'Custom',
+      value: 'custom1',
+      score: 100,
+    },
+    {
+      name: 'Custom keyword 2',
+      label: 'Custom keyword 2',
+      meta: 'Custom',
+      value: 'custom2',
+      score: 50,
+    },
+  ];
+  const extensionsRegistry = getExtensionsRegistry();
+  extensionsRegistry.set('sqleditor.extension.customAutocomplete', () => ({
+    data: expected,
+  }));
+  const { result } = renderHook(
+    () =>
+      useKeywords({
+        queryEditorId: 'testqueryid',
+        dbId: expectDbId,
+        schema: expectSchema,
+      }),
+    {
+      wrapper: createWrapper({
+        useRedux: true,
+        store,
+      }),
+    },
+  );
+  expect(result.current).toContainEqual(expect.objectContaining(expected[0]));
+  expect(result.current).toContainEqual(expect.objectContaining(expected[1]));
 });

--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.test.ts
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.test.ts
@@ -315,7 +315,7 @@ test('returns long keywords with docText', async () => {
   );
 });
 
-test('Add extension to SliceHeader', () => {
+test('Add custom keywords for autocomplete', () => {
   const expected = [
     {
       name: 'Custom keyword 1',

--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.test.ts
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.test.ts
@@ -333,9 +333,10 @@ test('Add custom keywords for autocomplete', () => {
     },
   ];
   const extensionsRegistry = getExtensionsRegistry();
-  extensionsRegistry.set('sqleditor.extension.customAutocomplete', () => ({
-    data: expected,
-  }));
+  extensionsRegistry.set(
+    'sqleditor.extension.customAutocomplete',
+    () => expected,
+  );
   const { result } = renderHook(
     () =>
       useKeywords({

--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.ts
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.ts
@@ -57,17 +57,15 @@ const getHelperText = (value: string) =>
 
 const extensionsRegistry = getExtensionsRegistry();
 
-const useDefaultCustomKeywords = () => ({ data: undefined });
-
 export function useKeywords(
   { queryEditorId, dbId, schema }: Params,
   skip = false,
 ) {
-  const useCustomKeywords =
-    extensionsRegistry.get('sqleditor.extension.customAutocomplete') ??
-    useDefaultCustomKeywords;
+  const useCustomKeywords = extensionsRegistry.get(
+    'sqleditor.extension.customAutocomplete',
+  );
 
-  const { data: customKeywords } = useCustomKeywords({
+  const customKeywords = useCustomKeywords?.({
     queryEditorId: String(queryEditorId),
     dbId,
     schema,

--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.ts
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.ts
@@ -18,7 +18,7 @@
  */
 import { useEffect, useMemo, useRef } from 'react';
 import { useSelector, useDispatch, shallowEqual, useStore } from 'react-redux';
-import { t } from '@superset-ui/core';
+import { getExtensionsRegistry, t } from '@superset-ui/core';
 
 import { Editor } from 'src/components/AsyncAceEditor';
 import sqlKeywords from 'src/SqlLab/utils/sqlKeywords';
@@ -55,10 +55,23 @@ const getHelperText = (value: string) =>
     docText: value,
   };
 
+const extensionsRegistry = getExtensionsRegistry();
+
+const useDefaultCustomKeywords = () => ({ data: undefined });
+
 export function useKeywords(
   { queryEditorId, dbId, schema }: Params,
   skip = false,
 ) {
+  const useCustomKeywords =
+    extensionsRegistry.get('sqleditor.extension.customAutocomplete') ??
+    useDefaultCustomKeywords;
+
+  const { data: customKeywords } = useCustomKeywords({
+    queryEditorId: String(queryEditorId),
+    dbId,
+    schema,
+  });
   const dispatch = useDispatch();
   const hasFetchedKeywords = useRef(false);
   // skipFetch is used to prevent re-evaluating memoized keywords
@@ -207,8 +220,15 @@ export function useKeywords(
         .concat(schemaKeywords)
         .concat(tableKeywords)
         .concat(functionKeywords)
-        .concat(sqlKeywords),
-    [schemaKeywords, tableKeywords, columnKeywords, functionKeywords],
+        .concat(sqlKeywords)
+        .concat(customKeywords ?? []),
+    [
+      schemaKeywords,
+      tableKeywords,
+      columnKeywords,
+      functionKeywords,
+      customKeywords,
+    ],
   );
 
   hasFetchedKeywords.current = !skip;


### PR DESCRIPTION
### SUMMARY
This commit includes the addition of `sqleditor.extension.customAutocomplete` to the extension registry, which allows for the utilization of custom keywords in SQL Lab autocomplete.

### TESTING INSTRUCTIONS
specs

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
