### PR TITLE
chore(TableTimeComparison): Add test for currency removal on percent columns

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -67,12 +67,13 @@ describe('plugin-chart-table', () => {
       expect(parsedDate.getTime()).toBe(1577882096000);
     });
 
-    it('does not include currencyFormat for percent columns', () => {
+    it('does not include currencyFormat in percent columns', () => {
       const transformedProps = transformProps(testData.advancedWithCurrency);
       const transformedColumns = transformedProps.columns;
       const percentColumns = transformedColumns.filter(
         col => col.isPercentMetric,
       );
+      expect(percentColumns.length).toBeGreaterThan(0);
       percentColumns.forEach(col => {
         expect(col?.config?.currencyFormat).toBeUndefined();
       });

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -66,6 +66,17 @@ describe('plugin-chart-table', () => {
       expect(String(parsedDate)).toBe('2020-01-01 12:34:56');
       expect(parsedDate.getTime()).toBe(1577882096000);
     });
+
+    it('does not include currencyFormat for percent columns', () => {
+      const transformedProps = transformProps(testData.advancedWithCurrency);
+      const transformedColumns = transformedProps.columns;
+      const percentColumns = transformedColumns.filter(
+        col => col.isPercentMetric,
+      );
+      percentColumns.forEach(col => {
+        expect(col?.config?.currencyFormat).toBeUndefined();
+      });
+    });
   });
 
   describe('TableChart', () => {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding a test to check the currency isn't applied to a percent column

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
