### PR TITLE
chore(applitools): making tests more static for consistent testing

### DIFF
--- a/superset-frontend/src/components/Table/Table.stories.tsx
+++ b/superset-frontend/src/components/Table/Table.stories.tsx
@@ -593,19 +593,19 @@ const shoppingData: ShoppingData[] = [
   {
     key: 1,
     item: 'Floppy Disk 10 pack',
-    orderDate: Date.now(),
+    orderDate: new Date('2015-07-02T16:16:00Z').getTime(),
     price: 9.99,
   },
   {
     key: 2,
     item: 'DVD 100 pack',
-    orderDate: Date.now(),
+    orderDate: new Date('2015-07-02T16:16:00Z').getTime(),
     price: 7.99,
   },
   {
     key: 3,
     item: '128 GB SSD',
-    orderDate: Date.now(),
+    orderDate: new Date('2015-07-02T16:16:00Z').getTime(),
     price: 3.99,
   },
 ];

--- a/superset-frontend/src/components/Table/cell-renderers/TimeCell/TimeCell.stories.tsx
+++ b/superset-frontend/src/components/Table/cell-renderers/TimeCell/TimeCell.stories.tsx
@@ -31,7 +31,7 @@ export const Basic: ComponentStory<typeof TimeCell> = args => (
 );
 
 Basic.args = {
-  value: Date.now(),
+  value: new Date('2015-07-02T16:16:00Z').getTime(),
 };
 
 Basic.argTypes = {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Applitools is throwing visual regression errors because of things like Date.now()... this branch will serve as a place to start locking these things down as static, so our tests will be more meaningful than ignoring these zones in countless places.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
