### PR TITLE
fix(contextmenu): uncaught TypeError 

### DIFF
--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -63,8 +63,13 @@ from superset.utils.core import (
     get_column_names_from_metrics,
     get_metric_names,
     get_xaxis_label,
+<<<<<<< HEAD
     is_adhoc_metric,
     is_adhoc_column,
+=======
+    is_adhoc_column,
+    is_adhoc_metric,
+>>>>>>> 831206fde (linting and unit test)
     normalize_dttm_col,
     TIME_COMPARISON,
 )

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -63,7 +63,7 @@ from superset.utils.core import (
     get_column_names_from_columns,
     get_column_names_from_metrics,
     get_metric_names,
-    get_xaxis_label,
+    get_x_axis_label,
     is_adhoc_column,
     is_adhoc_metric,
     normalize_dttm_col,

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -711,10 +711,13 @@ class QueryContextProcessor:
             if time_grain == TimeGrain.MONTH:
                 return value.strftime("%Y-%m")
 
-        if time_grain == TimeGrain.QUARTER:
-            return row[column_index].strftime("%Y-Q") + str(row[column_index].quarter)
+            if time_grain == TimeGrain.QUARTER:
+                return row[column_index].strftime("%Y-Q") + str(row[column_index].quarter)
 
-        return row[column_index].strftime("%Y")
+            if time_grain == TimeGrain.YEAR:
+                return row[column_index].strftime("%Y")
+
+        return str(value)
 
     def get_data(
         self, df: pd.DataFrame, coltypes: list[GenericDataType]

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -193,10 +193,13 @@ class QueryContextProcessor:
         })
         label_map.update({
             unescape_separator(metric_name): [
-                unescape_separator(metric)
+                unescape_separator(metric) 
                 for metric in re.split(r"(?<!\\),\s", query_obj.metrics[idx]
                 if not is_adhoc_metric(query_obj.metrics[idx])
-                else query_obj.metrics[idx]["sqlExpression"])
+                else
+                    query_obj.metrics[idx]["sqlExpression"]
+                    if query_obj.metrics[idx]["expressionType"] == "SQL"
+                    else metric_name)
             ]
             for idx, metric_name in enumerate(query_obj.metric_names) if query_obj
         })

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -712,10 +712,10 @@ class QueryContextProcessor:
                 return value.strftime("%Y-%m")
 
             if time_grain == TimeGrain.QUARTER:
-                return row[column_index].strftime("%Y-Q") + str(row[column_index].quarter)
+                return value.strftime("%Y-Q") + str(value.quarter)
 
             if time_grain == TimeGrain.YEAR:
-                return row[column_index].strftime("%Y")
+                return value.strftime("%Y")
 
         return str(value)
 

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -49,6 +49,7 @@ from superset.exceptions import (
 from superset.extensions import cache_manager, security_manager
 from superset.models.helpers import QueryResult
 from superset.models.sql_lab import Query
+from superset.superset_typing import AdhocColumn, AdhocMetric
 from superset.utils import csv, excel
 from superset.utils.cache import generate_cache_key, set_and_log_cache
 from superset.utils.core import (
@@ -184,33 +185,26 @@ class QueryContextProcessor:
         }
         label_map.update(
             {
-                unescape_separator(column_name): [
-                    unescape_separator(col)
-                    for col in re.split(
-                        r"(?<!\\),\s",
-                        query_obj.columns[idx]
-                        if not is_adhoc_column(query_obj.columns[idx])
-                        else query_obj.columns[idx]["sqlExpression"],
-                    )
+                column_name: [
+                    str(query_obj.columns[idx])
+                    if not is_adhoc_column(query_obj.columns[idx])
+                    else cast(AdhocColumn, query_obj.columns[idx])["sqlExpression"],
                 ]
                 for idx, column_name in enumerate(query_obj.column_names)
             }
         )
         label_map.update(
             {
-                unescape_separator(metric_name): [
-                    unescape_separator(metric)
-                    for metric in re.split(
-                        r"(?<!\\),\s",
-                        query_obj.metrics[idx]
-                        if not is_adhoc_metric(query_obj.metrics[idx])
-                        else query_obj.metrics[idx]["sqlExpression"]
-                        if query_obj.metrics[idx]["expressionType"] == "SQL"
-                        else metric_name,
-                    )
+                metric_name: [
+                    str(query_obj.metrics[idx])
+                    if not is_adhoc_metric(query_obj.metrics[idx])
+                    else str(cast(AdhocMetric, query_obj.metrics[idx])["sqlExpression"])
+                    if cast(AdhocMetric, query_obj.metrics[idx])["expressionType"]
+                    == "SQL"
+                    else metric_name,
                 ]
                 for idx, metric_name in enumerate(query_obj.metric_names)
-                if query_obj
+                if query_obj and query_obj.metrics
             }
         )
         cache.df.columns = [unescape_separator(col) for col in cache.df.columns.values]

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -63,13 +63,8 @@ from superset.utils.core import (
     get_column_names_from_metrics,
     get_metric_names,
     get_xaxis_label,
-<<<<<<< HEAD
-    is_adhoc_metric,
-    is_adhoc_column,
-=======
     is_adhoc_column,
     is_adhoc_metric,
->>>>>>> 831206fde (linting and unit test)
     normalize_dttm_col,
     TIME_COMPARISON,
 )

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -62,6 +62,8 @@ from superset.utils.core import (
     get_column_names_from_columns,
     get_column_names_from_metrics,
     get_metric_names,
+    is_adhoc_metric,
+    is_adhoc_column,
     get_x_axis_label,
     normalize_dttm_col,
     TIME_COMPARISON,
@@ -180,6 +182,24 @@ class QueryContextProcessor:
             ]
             for col in cache.df.columns.values
         }
+        label_map.update({
+            unescape_separator(column_name): [
+                unescape_separator(col)
+                for col in re.split(r"(?<!\\),\s", query_obj.columns[idx]
+                if not is_adhoc_column(query_obj.columns[idx])
+                else query_obj.columns[idx]["sqlExpression"])
+            ]
+            for idx, column_name in enumerate(query_obj.column_names)
+        })
+        label_map.update({
+            unescape_separator(metric_name): [
+                unescape_separator(metric)
+                for metric in re.split(r"(?<!\\),\s", query_obj.metrics[idx]
+                if not is_adhoc_metric(query_obj.metrics[idx])
+                else query_obj.metrics[idx]["sqlExpression"])
+            ]
+            for idx, metric_name in enumerate(query_obj.metric_names) if query_obj
+        })
         cache.df.columns = [unescape_separator(col) for col in cache.df.columns.values]
 
         return {

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -257,7 +257,7 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
     @property
     def metric_names(self) -> list[str]:
         """Return metrics names (labels), coerce adhoc metrics to strings."""
-        return get_metric_names(self.metrics or [])
+        return get_metric_names(self.metrics or [], self.datasource.verbose_map)
 
     @property
     def column_names(self) -> list[str]:

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -257,10 +257,12 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
     @property
     def metric_names(self) -> list[str]:
         """Return metrics names (labels), coerce adhoc metrics to strings."""
-        return get_metric_names(self.metrics or [], 
-                                self.datasource.verbose_map
-                                if self.datasource and self.datasource.verbose_map
-                                else None)
+        return get_metric_names(
+            self.metrics or [],
+            self.datasource.verbose_map
+            if self.datasource and self.datasource.verbose_map
+            else None,
+        )
 
     @property
     def column_names(self) -> list[str]:

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -260,7 +260,7 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
         return get_metric_names(
             self.metrics or [],
             self.datasource.verbose_map
-            if self.datasource and self.datasource.verbose_map
+            if self.datasource and hasattr(self.datasource, "verbose_map")
             else None,
         )
 

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -257,7 +257,10 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
     @property
     def metric_names(self) -> list[str]:
         """Return metrics names (labels), coerce adhoc metrics to strings."""
-        return get_metric_names(self.metrics or [], self.datasource.verbose_map)
+        return get_metric_names(self.metrics or [], 
+                                self.datasource.verbose_map
+                                if self.datasource and self.datasource.verbose_map
+                                else None)
 
     @property
     def column_names(self) -> list[str]:

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -421,7 +421,7 @@ class BaseDatasource(AuditMixinNullable, ImportExportMixin):  # pylint: disable=
             # pull out all required metrics from the form_data
             for metric_param in METRIC_FORM_DATA_PARAMS:
                 for metric in utils.as_list(form_data.get(metric_param) or []):
-                    metric_names.add(utils.get_metric_name(metric))
+                    metric_names.add(utils.get_metric_name(metric,self.verbose_map))
                     if utils.is_adhoc_metric(metric):
                         column_ = metric.get("column") or {}
                         if column_name := column_.get("column_name"):
@@ -1493,7 +1493,7 @@ class SqlaTable(
         :rtype: sqlalchemy.sql.column
         """
         expression_type = metric.get("expressionType")
-        label = utils.get_metric_name(metric)
+        label = utils.get_metric_name(metric,self.verbose_map)
 
         if expression_type == utils.AdhocMetricExpressionType.SIMPLE:
             metric_column = metric.get("column") or {}

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -421,7 +421,7 @@ class BaseDatasource(AuditMixinNullable, ImportExportMixin):  # pylint: disable=
             # pull out all required metrics from the form_data
             for metric_param in METRIC_FORM_DATA_PARAMS:
                 for metric in utils.as_list(form_data.get(metric_param) or []):
-                    metric_names.add(utils.get_metric_name(metric,self.verbose_map))
+                    metric_names.add(utils.get_metric_name(metric, self.verbose_map))
                     if utils.is_adhoc_metric(metric):
                         column_ = metric.get("column") or {}
                         if column_name := column_.get("column_name"):
@@ -473,7 +473,7 @@ class BaseDatasource(AuditMixinNullable, ImportExportMixin):  # pylint: disable=
             metric
             for metric in data["metrics"]
             if metric["metric_name"] in metric_names
-                or metric["verbose_name"] in metric_names
+            or metric["verbose_name"] in metric_names
         ]
 
         filtered_columns: list[Column] = []
@@ -1494,7 +1494,7 @@ class SqlaTable(
         :rtype: sqlalchemy.sql.column
         """
         expression_type = metric.get("expressionType")
-        label = utils.get_metric_name(metric,self.verbose_map)
+        label = utils.get_metric_name(metric, self.verbose_map)
 
         if expression_type == utils.AdhocMetricExpressionType.SIMPLE:
             metric_column = metric.get("column") or {}

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -473,6 +473,7 @@ class BaseDatasource(AuditMixinNullable, ImportExportMixin):  # pylint: disable=
             metric
             for metric in data["metrics"]
             if metric["metric_name"] in metric_names
+                or metric["verbose_name"] in metric_names
         ]
 
         filtered_columns: list[Column] = []

--- a/tests/common/query_context_generator.py
+++ b/tests/common/query_context_generator.py
@@ -24,7 +24,7 @@ from superset.utils.core import AnnotationType, DTTM_ALIAS
 query_birth_names = {
     "extras": {"where": "", "time_grain_sqla": "P1D"},
     "columns": ["name"],
-    "metrics": [{"label": "sum__num"}],
+    "metrics": [{"label": "sum__num"}, {"label": "num_girls"}, {"label": "num_boys"}],
     "orderby": [("sum__num", False)],
     "row_limit": 100,
     "granularity": "ds",

--- a/tests/common/query_context_generator.py
+++ b/tests/common/query_context_generator.py
@@ -24,7 +24,7 @@ from superset.utils.core import AnnotationType, DTTM_ALIAS
 query_birth_names = {
     "extras": {"where": "", "time_grain_sqla": "P1D"},
     "columns": ["name"],
-    "metrics": [{"label": "sum__num"}, {"label": "num_girls"}, {"label": "num_boys"}],
+    "metrics": [{"label": "sum__num"}],
     "orderby": [("sum__num", False)],
     "row_limit": 100,
     "granularity": "ds",

--- a/tests/integration_tests/query_context_tests.py
+++ b/tests/integration_tests/query_context_tests.py
@@ -786,6 +786,8 @@ def test_get_label_map(app_context, virtual_dataset_comma_in_column_value):
         "count, col2, row1": ["count", "col2, row1"],
         "count, col2, row2": ["count", "col2, row2"],
         "count, col2, row3": ["count", "col2, row3"],
+        "col2": ["col2"],
+        "count": ["count"],
     }
 
 

--- a/tests/unit_tests/common/test_query_object_factory.py
+++ b/tests/unit_tests/common/test_query_object_factory.py
@@ -129,6 +129,6 @@ class TestQueryObjectFactory:
         query_object = query_object_factory.create(
             raw_query_context["result_type"], 
             datasource=raw_query_context["datasource"], 
-            **raw_query_object
+            **raw_query_object,
         )
         assert query_object.metric_names == ["SUM", "num_girls", "num_boys"]

--- a/tests/unit_tests/common/test_query_object_factory.py
+++ b/tests/unit_tests/common/test_query_object_factory.py
@@ -66,6 +66,9 @@ def query_object_factory(
 def raw_query_context() -> dict[str, Any]:
     return QueryContextGenerator().generate("birth_names")
 
+@fixture
+def metric_label_raw_query_context() -> dict[str, Any]:
+    return QueryContextGenerator().generate("birth_names:metric_labels")
 
 class TestQueryObjectFactory:
     def test_query_context_limit_and_offset_defaults(
@@ -114,6 +117,7 @@ class TestQueryObjectFactory:
         query_object_factory: QueryObjectFactory,
         raw_query_context: dict[str, Any],
     ):
+        raw_query_context["queries"][0]["metrics"] = [{"label": "sum__num"}, {"label": "num_girls"}, {"label": "num_boys"}]
         raw_query_object = raw_query_context["queries"][0]
         query_object = query_object_factory.create(
             raw_query_context["result_type"], datasource=raw_query_context["datasource"], **raw_query_object

--- a/tests/unit_tests/common/test_query_object_factory.py
+++ b/tests/unit_tests/common/test_query_object_factory.py
@@ -44,6 +44,7 @@ def connector_registry() -> Mock:
     mock.get_datasource().verbose_map = {"sum__num": "SUM", "unused": "UNUSED"}
     return mock
 
+
 def apply_max_row_limit(limit: int, max_limit: Optional[int] = None) -> int:
     if max_limit is None:
         max_limit = create_app_config()["SQL_MAX_ROW"]
@@ -66,9 +67,11 @@ def query_object_factory(
 def raw_query_context() -> dict[str, Any]:
     return QueryContextGenerator().generate("birth_names")
 
+
 @fixture
 def metric_label_raw_query_context() -> dict[str, Any]:
     return QueryContextGenerator().generate("birth_names:metric_labels")
+
 
 class TestQueryObjectFactory:
     def test_query_context_limit_and_offset_defaults(
@@ -117,9 +120,15 @@ class TestQueryObjectFactory:
         query_object_factory: QueryObjectFactory,
         raw_query_context: dict[str, Any],
     ):
-        raw_query_context["queries"][0]["metrics"] = [{"label": "sum__num"}, {"label": "num_girls"}, {"label": "num_boys"}]
+        raw_query_context["queries"][0]["metrics"] = [
+            {"label": "sum__num"},
+            {"label": "num_girls"},
+            {"label": "num_boys"},
+        ]
         raw_query_object = raw_query_context["queries"][0]
         query_object = query_object_factory.create(
-            raw_query_context["result_type"], datasource=raw_query_context["datasource"], **raw_query_object
+            raw_query_context["result_type"], 
+            datasource=raw_query_context["datasource"], 
+            **raw_query_object
         )
         assert query_object.metric_names == ["SUM", "num_girls", "num_boys"]

--- a/tests/unit_tests/common/test_query_object_factory.py
+++ b/tests/unit_tests/common/test_query_object_factory.py
@@ -127,8 +127,8 @@ class TestQueryObjectFactory:
         ]
         raw_query_object = raw_query_context["queries"][0]
         query_object = query_object_factory.create(
-            raw_query_context["result_type"], 
-            datasource=raw_query_context["datasource"], 
+            raw_query_context["result_type"],
+            datasource=raw_query_context["datasource"],
             **raw_query_object,
         )
         assert query_object.metric_names == ["SUM", "num_girls", "num_boys"]

--- a/tests/unit_tests/common/test_query_object_factory.py
+++ b/tests/unit_tests/common/test_query_object_factory.py
@@ -40,8 +40,9 @@ def app_config() -> dict[str, Any]:
 
 @fixture
 def connector_registry() -> Mock:
-    return Mock(spec=["get_datasource"])
-
+    mock = Mock(spec=["get_datasource"])
+    mock.get_datasource().verbose_map = {"sum__num": "SUM", "unused": "UNUSED"}
+    return mock
 
 def apply_max_row_limit(limit: int, max_limit: Optional[int] = None) -> int:
     if max_limit is None:
@@ -107,3 +108,14 @@ class TestQueryObjectFactory:
             raw_query_context["result_type"], **raw_query_object
         )
         assert query_object.post_processing == []
+
+    def test_query_context_metric_names(
+        self,
+        query_object_factory: QueryObjectFactory,
+        raw_query_context: dict[str, Any],
+    ):
+        raw_query_object = raw_query_context["queries"][0]
+        query_object = query_object_factory.create(
+            raw_query_context["result_type"], datasource=raw_query_context["datasource"], **raw_query_object
+        )
+        assert query_object.metric_names == ["SUM", "num_girls", "num_boys"]


### PR DESCRIPTION
### SUMMARY
This PR resolves a uncaught TypeError in MixedTimeseries charts with saved metrics.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before
[Screencast from 04-24-2024 05:16:25 PM.webm](https://github.com/apache/superset/assets/2765941/23565cef-9104-4923-adef-b40d9ee806bd)

After
[Screencast from 04-24-2024 08:09:58 PM.webm](https://github.com/apache/superset/assets/2765941/6403a9d9-0917-41b3-b385-e92db5183fce)

fixes: #28199 
### TESTING INSTRUCTIONS
Create a MixedTimeseries chart with using saved metrics. Without the PR, the context menu (right click) will throw an uncaught TypeError exception. With the PR, the context menu works as expected.

### ADDITIONAL INFORMATION
- [X] Has associated issue: #28199
- [ ] Required feature flags: 
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
