### PR TITLE
fix: all_database_access should enable access to all datasets/charts/dashboards

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -43,6 +43,10 @@ assists people when migrating to a new version.
   set `SLACK_API_TOKEN` to fetch and serve Slack avatar links
 - [28134](https://github.com/apache/superset/pull/28134/) The default logging level was changed
   from DEBUG to INFO - which is the normal/sane default logging level for most software.
+- [28205](https://github.com/apache/superset/pull/28205) The permission `all_database_access` now
+  more clearly provides access to all databases, as specified in its name. Before it only allowed
+  listing all databases in CRUD-view and dropdown and didn't provide access to data as it
+  seemed the name would imply.
 
 ## 4.0.0
 

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -403,6 +403,14 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
 
         return self.can_access("all_query_access", "all_query_access")
 
+    def can_access_all_databases(self) -> bool:
+        """
+        Return True if the user can access all the databases, False otherwise.
+
+        :returns: Whether the user can access all the databases
+        """
+        return self.can_access("all_database_access", "all_database_access")
+
     def can_access_all_datasources(self) -> bool:
         """
         Return True if the user can access all the datasources, False otherwise.
@@ -410,16 +418,9 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         :returns: Whether the user can access all the datasources
         """
 
-        return self.can_access("all_datasource_access", "all_datasource_access")
-
-    def can_access_all_databases(self) -> bool:
-        """
-        Return True if the user can access all the databases, False otherwise.
-
-        :returns: Whether the user can access all the databases
-        """
-
-        return self.can_access("all_database_access", "all_database_access")
+        return self.can_access_all_databases() or self.can_access(
+            "all_datasource_access", "all_datasource_access"
+        )
 
     def can_access_database(self, database: "Database") -> bool:
         """
@@ -2433,7 +2434,6 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
 
         if self.is_admin():
             return
-
         orig_resource = db.session.query(resource.__class__).get(resource.id)
         owners = orig_resource.owners if hasattr(orig_resource, "owners") else []
 

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -403,14 +403,6 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
 
         return self.can_access("all_query_access", "all_query_access")
 
-    def can_access_all_databases(self) -> bool:
-        """
-        Return True if the user can access all the databases, False otherwise.
-
-        :returns: Whether the user can access all the databases
-        """
-        return self.can_access("all_database_access", "all_database_access")
-
     def can_access_all_datasources(self) -> bool:
         """
         Return True if the user can access all the datasources, False otherwise.
@@ -421,6 +413,14 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         return self.can_access_all_databases() or self.can_access(
             "all_datasource_access", "all_datasource_access"
         )
+
+    def can_access_all_databases(self) -> bool:
+        """
+        Return True if the user can access all the databases, False otherwise.
+
+        :returns: Whether the user can access all the databases
+        """
+        return self.can_access("all_database_access", "all_database_access")
 
     def can_access_database(self, database: "Database") -> bool:
         """

--- a/tests/integration_tests/base_tests.py
+++ b/tests/integration_tests/base_tests.py
@@ -249,8 +249,13 @@ class SupersetTestCase(TestCase):
         datasource.query = Mock(return_value=results)
         datasource.database = Mock()
         datasource.database.db_engine_spec = Mock()
+        datasource.database.perm = "mock_database_perm"
+        datasource.schema_perm = "mock_schema_perm"
+        datasource.perm = "mock_datasource_perm"
+        datasource.__class__ = SqlaTable
         datasource.database.db_engine_spec.mutate_expression_label = lambda x: x
         datasource.owners = MagicMock()
+        datasource.id = 99999
         return datasource
 
     def get_resp(

--- a/tests/integration_tests/base_tests.py
+++ b/tests/integration_tests/base_tests.py
@@ -176,7 +176,6 @@ class SupersetTestCase(TestCase):
             temp_user.password = clone_user.password
         else:
             temp_user.first_name = temp_user.last_name = username
-            password = DEFAULT_PASSWORD
 
         if clone_user:
             temp_user.roles = clone_user.roles

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -1302,7 +1302,6 @@ class TestChartApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
         def count_charts():
             uri = "api/v1/chart/"
             rv = self.client.get(uri, "get_list")
-            print(rv.data)
             self.assertEqual(rv.status_code, 200)
             data = rv.get_json()
             return data["count"]
@@ -1310,18 +1309,12 @@ class TestChartApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
         with self.temporary_user(gamma_user, login=True) as user:
             self.assertEqual(count_charts(), 0)
 
-        all_db_pvm = ("all_database_access", "all_database_access")
-        with self.temporary_user(
-            gamma_user, extra_pvms=[all_db_pvm], login=True
-        ) as user:
-            self.login(username=user.username)
+        perm = ("all_database_access", "all_database_access")
+        with self.temporary_user(gamma_user, extra_pvms=[perm], login=True) as user:
             assert count_charts() > 0
 
-        all_db_pvm = ("all_datasource_access", "all_datasource_access")
-        with self.temporary_user(
-            gamma_user, extra_pvms=[all_db_pvm], login=True
-        ) as user:
-            self.login(username=user.username)
+        perm = ("all_datasource_access", "all_datasource_access")
+        with self.temporary_user(gamma_user, extra_pvms=[perm], login=True) as user:
             assert count_charts() > 0
 
         # Back to normal

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -1306,19 +1306,19 @@ class TestChartApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
             data = rv.get_json()
             return data["count"]
 
-        with self.temporary_user(gamma_user, login=True) as user:
+        with self.temporary_user(gamma_user, login=True):
             self.assertEqual(count_charts(), 0)
 
         perm = ("all_database_access", "all_database_access")
-        with self.temporary_user(gamma_user, extra_pvms=[perm], login=True) as user:
+        with self.temporary_user(gamma_user, extra_pvms=[perm], login=True):
             assert count_charts() > 0
 
         perm = ("all_datasource_access", "all_datasource_access")
-        with self.temporary_user(gamma_user, extra_pvms=[perm], login=True) as user:
+        with self.temporary_user(gamma_user, extra_pvms=[perm], login=True):
             assert count_charts() > 0
 
         # Back to normal
-        with self.temporary_user(gamma_user, login=True) as user_gamma:
+        with self.temporary_user(gamma_user, login=True):
             self.assertEqual(count_charts(), 0)
 
     @pytest.mark.usefixtures("create_charts")

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -1294,6 +1294,40 @@ class TestChartApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
         data = json.loads(rv.data.decode("utf-8"))
         self.assertEqual(data["count"], 0)
 
+    @pytest.mark.usefixtures("load_energy_charts")
+    def test_user_gets_all_charts(self):
+        # test filtering on datasource_name
+        gamma_user = security_manager.find_user(username="gamma")
+
+        def count_charts():
+            uri = "api/v1/chart/"
+            rv = self.client.get(uri, "get_list")
+            print(rv.data)
+            self.assertEqual(rv.status_code, 200)
+            data = rv.get_json()
+            return data["count"]
+
+        with self.temporary_user(gamma_user, login=True) as user:
+            self.assertEqual(count_charts(), 0)
+
+        all_db_pvm = ("all_database_access", "all_database_access")
+        with self.temporary_user(
+            gamma_user, extra_pvms=[all_db_pvm], login=True
+        ) as user:
+            self.login(username=user.username)
+            assert count_charts() > 0
+
+        all_db_pvm = ("all_datasource_access", "all_datasource_access")
+        with self.temporary_user(
+            gamma_user, extra_pvms=[all_db_pvm], login=True
+        ) as user:
+            self.login(username=user.username)
+            assert count_charts() > 0
+
+        # Back to normal
+        with self.temporary_user(gamma_user, login=True) as user_gamma:
+            self.assertEqual(count_charts(), 0)
+
     @pytest.mark.usefixtures("create_charts")
     def test_get_charts_favorite_filter(self):
         """

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -217,7 +217,7 @@ class TestDatasetApi(SupersetTestCase):
             assert count_datasets() > 0
 
         # Back to normal
-        with self.temporary_user(gamma_user, login=True) as user_gamma:
+        with self.temporary_user(gamma_user, login=True):
             assert count_datasets() == 0
 
     def test_get_dataset_list(self):

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -186,6 +186,40 @@ class TestDatasetApi(SupersetTestCase):
         buf.seek(0)
         return buf
 
+    @pytest.mark.usefixtures("load_energy_table_with_slice")
+    def test_user_gets_all_datasets(self):
+        # test filtering on datasource_name
+        gamma_user = security_manager.find_user(username="gamma")
+
+        def count_datasets():
+            uri = "api/v1/chart/"
+            rv = self.client.get(uri, "get_list")
+            print(rv.data)
+            self.assertEqual(rv.status_code, 200)
+            data = rv.get_json()
+            return data["count"]
+
+        with self.temporary_user(gamma_user, login=True) as user:
+            assert count_datasets() == 0
+
+        all_db_pvm = ("all_database_access", "all_database_access")
+        with self.temporary_user(
+            gamma_user, extra_pvms=[all_db_pvm], login=True
+        ) as user:
+            self.login(username=user.username)
+            assert count_datasets() > 0
+
+        all_db_pvm = ("all_datasource_access", "all_datasource_access")
+        with self.temporary_user(
+            gamma_user, extra_pvms=[all_db_pvm], login=True
+        ) as user:
+            self.login(username=user.username)
+            assert count_datasets() > 0
+
+        # Back to normal
+        with self.temporary_user(gamma_user, login=True) as user_gamma:
+            assert count_datasets() == 0
+
     def test_get_dataset_list(self):
         """
         Dataset API: Test get dataset list

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -29,7 +29,7 @@ import prison
 import pytest
 
 from flask import current_app, g
-from flask_appbuilder.security.sqla.models import Role, User
+from flask_appbuilder.security.sqla.models import Role
 from superset.daos.datasource import DatasourceDAO  # noqa: F401
 from superset.models.dashboard import Dashboard
 from superset import app, appbuilder, db, security_manager, viz
@@ -1897,7 +1897,7 @@ class TestSecurityManager(SupersetTestCase):
 
         all_db_pvm = ("all_database_access", "all_database_access")
 
-        with self.temporary_user(gamma_user, extra_pvms=[all_db_pvm]) as tmp_user:
+        with self.temporary_user(gamma_user, extra_pvms=[all_db_pvm]):
             assert security_manager.can_access_all_databases()
             assert security_manager.can_access_datasource(self.get_datasource_mock())
 

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -28,8 +28,8 @@ import jwt
 import prison
 import pytest
 
-from flask import current_app
-from flask_appbuilder.security.sqla.models import Role
+from flask import current_app, g
+from flask_appbuilder.security.sqla.models import Role, User
 from superset.daos.datasource import DatasourceDAO  # noqa: F401
 from superset.models.dashboard import Dashboard
 from superset import app, appbuilder, db, security_manager, viz
@@ -74,6 +74,60 @@ NEW_SECURITY_CONVERGE_VIEWS = (
     "Query",
     "SavedQuery",
 )
+
+
+from contextlib import contextmanager
+from superset.utils.core import shortid
+
+
+@contextmanager
+def temporary_user(clone_user=None, extra_roles=None, extra_pvms=None):
+    temp_username = f"temp_user_{shortid()}"
+    print(temp_username)
+    temp_user = User(username=temp_username, email=f"{temp_username}@temp.com")
+    if clone_user:
+        temp_user.roles = clone_user.roles
+        temp_user.first_name = clone_user.first_name
+        temp_user.last_name = clone_user.last_name
+    else:
+        temp_user.first_name = "temp"
+        temp_user.last_name = "temp"
+
+    if clone_user:
+        temp_user.roles = clone_user.roles
+
+    if extra_roles:
+        temp_user.roles.extend(extra_roles)
+
+    pvms = []
+    temp_role = None
+    if extra_pvms:
+        temp_role = Role(name=f"tmp_role_{shortid()}")
+        for pvm in extra_pvms:
+            if isinstance(pvm, (tuple, list)):
+                pvms.append(security_manager.find_permission_view_menu(*pvm))
+            else:
+                pvms.append(pvm)
+        temp_role.permissions = pvms
+        temp_user.roles.append(temp_role)
+        db.session.add(temp_role)
+        db.session.commit()
+
+    # Add the temp user to the session and commit to apply changes for the test
+    db.session.add(temp_user)
+    db.session.commit()
+    previous_g_user = g.user
+    try:
+        # Yield control to the with block
+        g.user = temp_user
+        yield temp_user
+    finally:
+        # Revert changes after the test
+        if temp_role:
+            db.session.delete(temp_role)
+        db.session.delete(temp_user)
+        db.session.commit()
+        g.user = previous_g_user
 
 
 def get_perm_tuples(role_name):
@@ -1886,6 +1940,20 @@ class TestSecurityManager(SupersetTestCase):
         with override_user(security_manager.get_anonymous_user()):
             roles = security_manager.get_user_roles()
             self.assertEqual([security_manager.get_public_role()], roles)
+
+    def test_all_database_access(self):
+        gamma_user = security_manager.find_user(username="gamma")
+        g.user = gamma_user
+
+        # Double checking that gamma users can't access all databases
+        assert not security_manager.can_access_all_databases()
+        assert not security_manager.can_access_datasource(self.get_datasource_mock())
+
+        all_db_pvm = ("all_database_access", "all_database_access")
+
+        with temporary_user(gamma_user, extra_pvms=[all_db_pvm]) as tmp_user:
+            assert security_manager.can_access_all_databases()
+            assert security_manager.can_access_datasource(self.get_datasource_mock())
 
 
 class TestDatasources(SupersetTestCase):

--- a/tests/integration_tests/test_app.py
+++ b/tests/integration_tests/test_app.py
@@ -39,3 +39,4 @@ def login(
         data=dict(username=username, password=password),
     ).get_data(as_text=True)
     assert "User confirmation needed" not in resp
+    return resp


### PR DESCRIPTION
When granting `all_database_access`, one would expect to get access to all charts and datasets.

From my understanding `all_database_access` is practically identical to `all_datasource_access`, and perhaps the two perms should be collapsed into one. In the meantime, this addresses user confusion around this perm not working according to its name.

I'm guessing that the difference between the two could be that `all_database_access` would also allow you to CRUD database objects(?)

Side mission:

Introducing a nifty context manager for tests to create temp user:
```python 
with self.temporary_user(clone_user=gamma_user, extra_pvms=[('all_database_access', 'all_database_access')],login=True) as user:
    user.do_stuff()
```

The neat thing is it can clone a user, will delete it on exit, optionally can log user in/out. It's not mutating anything so it should work well for running tests in parallel and/or for tests that fail half way through.

I'm planning on a follow up refactoring PR to standardize on using `temporary_user` everywhere where the current create_user is used.