### PR TITLE
docs: depricated Marking on outdated docs - Local dev setup superset

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -424,7 +424,7 @@ Should you decide that reverting is desirable, it is the responsibility of the C
 - **Provide concise reproduction steps:** Ensure that the issue can be clearly understood and duplicated by the original author of the PR.
 - **Put the revert through code review:** The revert must be approved by another committer.
 
-## Setup Local Environment for Development
+## Setup Local Environment for Development (Depricated use docker compose https://superset.apache.org/docs/installation/docker-compose#option-1---for-an-interactive-development-environment)
 
 First, [fork the repository on GitHub](https://help.github.com/articles/about-forks/), then clone it. You can clone the main repository directly, but you won't be able to send pull requests.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -424,7 +424,9 @@ Should you decide that reverting is desirable, it is the responsibility of the C
 - **Provide concise reproduction steps:** Ensure that the issue can be clearly understood and duplicated by the original author of the PR.
 - **Put the revert through code review:** The revert must be approved by another committer.
 
-## Setup Local Environment for Development (Depricated use docker compose https://superset.apache.org/docs/installation/docker-compose#option-1---for-an-interactive-development-environment)
+## Setup Local Environment for Development 
+
+(Depricated use docker compose https://superset.apache.org/docs/installation/docker-compose#option-1---for-an-interactive-development-environment)
 
 First, [fork the repository on GitHub](https://help.github.com/articles/about-forks/), then clone it. You can clone the main repository directly, but you won't be able to send pull requests.
 

--- a/docs/docs/contributing/local-backend.mdx
+++ b/docs/docs/contributing/local-backend.mdx
@@ -7,6 +7,9 @@ version: 1
 
 ### Flask server
 
+(Depricated use docker compose https://superset.apache.org/docs/installation/docker-compose#option-1---for-an-interactive-development-environment)
+
+
 #### OS Dependencies
 
 Make sure your machine meets the [OS dependencies](/docs/installation/pypi#os-dependencies) before following these steps.

--- a/docs/docs/installation/pypi.mdx
+++ b/docs/docs/installation/pypi.mdx
@@ -7,6 +7,8 @@ version: 1
 
 ## Installing Superset from PyPI
 
+(Depricated)
+
 This page describes how to install Superset using the `apache-superset` package [published on PyPI](https://pypi.org/project/apache-superset/).
 
 ### OS Dependencies


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
I have spent multiple hours in figuring out setting up my local superset (development) setup.

I have followed both docs https://github.com/apache/superset/blob/master/CONTRIBUTING.md
and https://github.com/apache/superset/blob/master/docs/docs/contributing/local-backend.mdx

Ended up with a bunch of errors. (tried fixing, but chain it continuing) lot of breaking stuff.

I have even tried PyPI installation methods (even that method breaks) while delivering frontend content. Marked deprecated

Current way is https://superset.apache.org/docs/installation/docker-compose#option-1---for-an-interactive-development-environment

Updated same in other places. 

<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
