### PR TITLE
fix: Dremio alias

### DIFF
--- a/superset/db_engine_specs/__init__.py
+++ b/superset/db_engine_specs/__init__.py
@@ -154,7 +154,7 @@ def get_available_engine_specs() -> dict[type[BaseEngineSpec], set[str]]:
         try:
             dialect = ep.load()
         except Exception as ex:  # pylint: disable=broad-except
-            logger.warning("Unable to load SQLAlchemy dialect %s: %s", dialect, ex)
+            logger.warning("Unable to load SQLAlchemy dialect %s: %s", ep.name, ex)
         else:
             backend = dialect.name
             if isinstance(backend, bytes):

--- a/superset/db_engine_specs/dremio.py
+++ b/superset/db_engine_specs/dremio.py
@@ -37,6 +37,13 @@ FIXED_ALIAS_IN_SELECT_VERSION = Version("24.1.0")
 class DremioEngineSpec(BaseEngineSpec):
     engine = "dremio"
     engine_name = "Dremio"
+    engine_aliases = {"dremio+flight"}
+    sqlalchemy_uri_placeholder = (
+        "dremio+flight://data.dremio.cloud:443/?"
+        "Token=<TOKEN>&"
+        "UseEncryption=true&"
+        "disableCertificateVerification=true"
+    )
 
     _time_grain_expressions = {
         None: "{col}",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

For some reason the 3.x version of the Dremio driver shows the dialect as `dremio+flight`, instead of simply `dremio` with the driver `flight`.

This PR adds `dremio+flight` to the list of aliases in the Dremio DB engine spec, so that Dremio shows up in the database dropdown correctly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Tested locally, connected to Dremio:

1. Run Dremio locally: docker run -p 9047:9047 -p 31010:31010 -p 32010:32010 -p 45678:45678 dremio/dremio-oss
2. Visit http://localhost:9047/ and create an account.
3. Use dremio+flight://username:password@localhost:32010/?UseEncryption=false for the SQLAlchemy URI.
4. Run a query.


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
