### PR TITLE
fix(Dev-Server): Edit ChartPropsConfig reexport to be a type object

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/chart/index.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/index.ts
@@ -20,7 +20,11 @@
 export { default as ChartClient } from './clients/ChartClient';
 export { default as ChartMetadata } from './models/ChartMetadata';
 export { default as ChartPlugin } from './models/ChartPlugin';
-export { default as ChartProps, ChartPropsConfig } from './models/ChartProps';
+export { default as ChartProps } from './models/ChartProps';
+/* reexporting this interface as a type solves the dev-server
+ * warning the named export does not exist. See https://github.com/webpack/webpack/issues/7378#issuecomment-492641148
+ */
+export type { ChartPropsConfig } from './models/ChartProps';
 
 export { default as createLoadableRenderer } from './components/createLoadableRenderer';
 export { default as reactify } from './components/reactify';

--- a/superset-frontend/packages/superset-ui-core/src/chart/index.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/index.ts
@@ -17,14 +17,13 @@
  * under the License.
  */
 
+import ChartProps, { ChartPropsConfig } from './models/ChartProps';
+
 export { default as ChartClient } from './clients/ChartClient';
 export { default as ChartMetadata } from './models/ChartMetadata';
 export { default as ChartPlugin } from './models/ChartPlugin';
-export { default as ChartProps } from './models/ChartProps';
-/* reexporting this interface as a type solves the dev-server
- * warning the named export does not exist. See https://github.com/webpack/webpack/issues/7378#issuecomment-492641148
- */
-export type { ChartPropsConfig } from './models/ChartProps';
+export { ChartProps };
+export type { ChartPropsConfig };
 
 export { default as createLoadableRenderer } from './components/createLoadableRenderer';
 export { default as reactify } from './components/reactify';


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This should solve the warning that `ChartPropsConfig` does not exist in `superset-ui-core/src/chart/models/ChartProps`
See [here](https://github.com/rtexelm/superset-RTM/pull/new/fix/dev-server-warnings/chartpropsconfig/sc-80076) and [here](https://github.com/microsoft/TypeScript/issues/28481#issuecomment-479965467)

Example of warning fixed:

```zsh
WARNING in ./packages/superset-ui-core/src/chart/index.ts 24:0-28
export 'ChartPropsConfig' (reexported as 'ChartPropsConfig') was not found in './models/ChartProps' (possible exports: default)
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
