### PR TITLE
fix(Webpack dev-server build warning): Create false value alias for `moment-with-locales`

### DIFF
--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -288,6 +288,12 @@ const config = {
       // TODO: remove Handlebars alias once Handlebars NPM package has been updated to
       // correctly support webpack import (https://github.com/handlebars-lang/handlebars.js/issues/953)
       handlebars: 'handlebars/dist/handlebars.js',
+      /*
+      Temporary workaround to prevent Webpack from resolving moment locale
+      files, which are unnecessary for this project and causing build warnings.
+      This prevents "Module not found" errors for moment locale files.
+      */
+      'moment/min/moment-with-locales': false,
     },
     extensions: ['.ts', '.tsx', '.js', '.jsx', '.yml'],
     fallback: {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is a workaround to suppress the `./locale` build warning when using the webpack dev-server involving a [well documented](https://github.com/moment/moment/issues/4519) ([more reports](https://github.com/moment/moment/issues/4216)) bug in the now [defunct `moment` library](https://momentjs.com/docs/#/-project-status/). This is meant to remove the warning, anticipating a migration away from `moment` in the future. 

Example warning

```zsh
WARNING in ./node_modules/moment/min/moment-with-locales.js 2159:16-50
Module not found: Error: Can't resolve './locale' in 'superset-frontend/node_modules/moment/min'
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
