### PR TITLE
fix(Webpack dev-sever warnings): Add ignoreWarning to webpack config for @data-ui error

### DIFF
--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -215,10 +215,11 @@ const config = {
   output,
   stats: 'minimal',
   /*
-   * Suppressing warning about missing export in @data-ui's internal structure.
-   * It's from @data-ui due to an internal implementation detail. Since it's
-   * non-critical, we suppress it to avoid cluttering build output.
-   * See: https://github.com/williaster/data-ui/issues/208#issuecomment-946966712
+   Silence warning for missing export in @data-ui's internal structure. This
+   issue arises from an internal implementation detail of @data-ui. As it's
+   non-critical, we suppress it to prevent unnecessary clutter in the build
+   output. For more context, refer to:
+   https://github.com/williaster/data-ui/issues/208#issuecomment-946966712
    */
   ignoreWarnings: [
     {

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -216,10 +216,9 @@ const config = {
   stats: 'minimal',
   /*
    * Suppressing warning about missing export in @data-ui's internal structure.
-   * Originating from @data-ui, it's due to an internal implementation detail.
-   * It's non-critical, so we suppress it to avoid cluttering build output.
-   * See:
-   * https://github.com/williaster/data-ui/issues/208#issuecomment-946966712
+   * It's from @data-ui due to an internal implementation detail. Since it's
+   * non-critical, we suppress it to avoid cluttering build output.
+   * See: https://github.com/williaster/data-ui/issues/208#issuecomment-946966712
    */
   ignoreWarnings: [
     {

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -214,6 +214,19 @@ const config = {
   },
   output,
   stats: 'minimal',
+  /*
+   * Suppressing warning about missing export in @data-ui's internal structure.
+   * Originating from @data-ui, it's due to an internal implementation detail.
+   * It's non-critical, so we suppress it to avoid cluttering build output.
+   * See:
+   * https://github.com/williaster/data-ui/issues/208#issuecomment-946966712
+   */
+  ignoreWarnings: [
+    {
+      message:
+        /export 'withTooltipPropTypes' \(imported as 'vxTooltipPropTypes'\) was not found/,
+    },
+  ],
   performance: {
     assetFilter(assetFilename) {
       // don't throw size limit warning on geojson and font files


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Simply ignore the build warning related to [@data-ui](https://github.com/williaster/data-ui/issues/208#issuecomment-946966712).
Because this warning arises from within the external module itself, [which is no longer evolving](https://github.com/williaster/data-ui/issues/201), the idea is to ignore it until the module can be replaced by a living project to better fit the superset ecosystem.

Example warning:

```zsh
WARNING in ./node_modules/@data-ui/shared/esm/enhancer/WithTooltip.js 3:60-78
export 'withTooltipPropTypes' (imported as 'vxTooltipPropTypes') was not found in '@vx/tooltip/build/tooltips/TooltipWithBounds' (possible exports: __esModule, default)
```


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
