### PR TITLE
chore(docs): add closing ::: to caution tag

### DIFF
--- a/docs/docs/configuration/configuring-superset.mdx
+++ b/docs/docs/configuration/configuring-superset.mdx
@@ -101,7 +101,7 @@ You can generate a strong secure key with `openssl rand -base64 42`.
 
 :::caution Use a strong secret key
 This key will be used for securely signing session cookies and encrypting sensitive information stored in Superset's application metadata database.
-Make sure you are changing this key for your deployment with a strong key. :::
+Your deployment must use a complex, unique key. :::
 
 #### Rotating to a newer SECRET_KEY
 

--- a/docs/docs/configuration/configuring-superset.mdx
+++ b/docs/docs/configuration/configuring-superset.mdx
@@ -99,9 +99,9 @@ SECRET_KEY = 'YOUR_OWN_RANDOM_GENERATED_SECRET_KEY'
 
 You can generate a strong secure key with `openssl rand -base64 42`.
 
-:::caution Your secret key will be used for securely signing session cookies
-and encrypting sensitive information stored in Superset's application metadata database.
-  Make sure you are changing this key for your deployment with a strong key.
+:::caution Use a strong secret key
+This key will be used for securely signing session cookies and encrypting sensitive information stored in Superset's application metadata database.
+Make sure you are changing this key for your deployment with a strong key. :::
 
 #### Rotating to a newer SECRET_KEY
 


### PR DESCRIPTION
Right now there is no closing for the `::: caution` section so several screens of [this page ](https://superset.apache.org/docs/configuration/configuring-superset)are formatted as caution.