### PR TITLE
chore(docs): reorder pages in the Configuring Superset section

### DIFF
--- a/docs/docs/configuration/alerts-reports.mdx
+++ b/docs/docs/configuration/alerts-reports.mdx
@@ -1,7 +1,7 @@
 ---
 title: Alerts and Reports
 hide_title: true
-sidebar_position: 10
+sidebar_position: 2
 version: 2
 ---
 

--- a/docs/docs/configuration/async-queries-celery.mdx
+++ b/docs/docs/configuration/async-queries-celery.mdx
@@ -1,7 +1,7 @@
 ---
 title: Async Queries via Celery
 hide_title: true
-sidebar_position: 9
+sidebar_position: 3
 version: 1
 ---
 

--- a/docs/docs/configuration/async-queries-celery.mdx
+++ b/docs/docs/configuration/async-queries-celery.mdx
@@ -1,7 +1,7 @@
 ---
 title: Async Queries via Celery
 hide_title: true
-sidebar_position: 3
+sidebar_position: 4
 version: 1
 ---
 

--- a/docs/docs/configuration/cache.mdx
+++ b/docs/docs/configuration/cache.mdx
@@ -1,7 +1,7 @@
 ---
 title: Caching
 hide_title: true
-sidebar_position: 6
+sidebar_position: 3
 version: 1
 ---
 

--- a/docs/docs/configuration/configuring-superset.mdx
+++ b/docs/docs/configuration/configuring-superset.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuring Superset
 hide_title: true
-sidebar_position: 4
+sidebar_position: 1
 version: 1
 ---
 

--- a/docs/docs/configuration/country-map-tools.mdx
+++ b/docs/docs/configuration/country-map-tools.mdx
@@ -1,7 +1,7 @@
 ---
 title: Country Map Tools
 hide_title: true
-sidebar_position: 1
+sidebar_position: 10
 version: 1
 ---
 

--- a/docs/docs/configuration/event-logging.mdx
+++ b/docs/docs/configuration/event-logging.mdx
@@ -1,7 +1,7 @@
 ---
 title: Event Logging
 hide_title: true
-sidebar_position: 7
+sidebar_position: 9
 version: 1
 ---
 

--- a/docs/docs/configuration/importing-exporting-datasources.mdx
+++ b/docs/docs/configuration/importing-exporting-datasources.mdx
@@ -1,7 +1,7 @@
 ---
 title: Importing and Exporting Datasources
 hide_title: true
-sidebar_position: 2
+sidebar_position: 11
 version: 1
 ---
 

--- a/docs/docs/configuration/networking-settings.mdx
+++ b/docs/docs/configuration/networking-settings.mdx
@@ -1,7 +1,7 @@
 ---
 title: Additional Networking Settings
 hide_title: true
-sidebar_position: 5
+sidebar_position: 7
 version: 1
 ---
 

--- a/docs/docs/configuration/setup-ssh-tunneling.mdx
+++ b/docs/docs/configuration/setup-ssh-tunneling.mdx
@@ -1,7 +1,7 @@
 ---
 title: Setup SSH Tunneling
 hide_title: true
-sidebar_position: 12
+sidebar_position: 8
 version: 1
 ---
 

--- a/docs/docs/configuration/sql-templating.mdx
+++ b/docs/docs/configuration/sql-templating.mdx
@@ -1,7 +1,7 @@
 ---
 title: SQL Templating
 hide_title: true
-sidebar_position: 11
+sidebar_position: 5
 version: 1
 ---
 

--- a/docs/docs/configuration/timezones.mdx
+++ b/docs/docs/configuration/timezones.mdx
@@ -1,7 +1,7 @@
 ---
 title: Timezones
 hide_title: true
-sidebar_position: 1
+sidebar_position: 6
 version: 1
 ---
 

--- a/docs/docs/using-superset/issue-codes.mdx
+++ b/docs/docs/using-superset/issue-codes.mdx
@@ -1,6 +1,6 @@
 ---
 title: Issue Codes
-sidebar_position: 3
+sidebar_position: 5
 version: 1
 ---
 


### PR DESCRIPTION
### SUMMARY
These pages seem randomly ordered.  Certainly the main page, "Configuring Superset", should be in position 1 and it's currently position 5.  And why would "Country Map Tools" and "Timezones" be first?

I attempted to order the pages by what was most relevant when setting up Superset and what topics I see asked about the most in Slack and Discussions.  And I moved "Issue Codes" into the "Using Superset" section -- there's not a great fit for it anywhere, but this is definitely an improvement over keeping it in "Configuration".