### PR TITLE
fix(explore): temporal column mixin

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/mixins.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/mixins.tsx
@@ -23,7 +23,12 @@ import {
   t,
   validateNonEmpty,
 } from '@superset-ui/core';
-import { BaseControlConfig, ControlPanelState, ControlState } from '../types';
+import {
+  BaseControlConfig,
+  ControlPanelState,
+  ControlState,
+  ExtraControlProps,
+} from '../types';
 import { getTemporalColumns } from '../utils';
 
 const getAxisLabel = (
@@ -52,14 +57,15 @@ export const xAxisMixin = {
   default: undefined,
 };
 
-export const temporalColumnMixin: Pick<BaseControlConfig, 'mapStateToProps'> = {
+export const temporalColumnMixin: Pick<BaseControlConfig, 'mapStateToProps'> &
+  Partial<ExtraControlProps> = {
+  isTemporal: true,
   mapStateToProps: ({ datasource }) => {
     const payload = getTemporalColumns(datasource);
 
     return {
       options: payload.temporalColumns,
       default: payload.defaultTemporalColumn,
-      isTemporal: true,
     };
   },
 };


### PR DESCRIPTION
### SUMMARY
In order to address the issue of the `isTemporal` property not being calculated from the mapping state in temporalColumnMixin, this commit migrates the property to the override object property.
This change ensures that the 3rd party controlOverrides can be properly overridden.

### TESTING INSTRUCTIONS
Big number with Trendline works as before

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
