### PR TITLE
fix(dashboard): unable to drop tabs in columns

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Column.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Column.jsx
@@ -243,18 +243,15 @@ class Column extends React.PureComponent {
                 {editMode && (
                   <Droppable
                     component={columnComponent}
-                    parentComponent={parentComponent}
+                    parentComponent={columnComponent}
                     {...(columnItems.length === 0
                       ? {
-                          component: columnComponent,
-                          parentComponent,
                           dropToChild: true,
                         }
                       : {
-                          component: columnItems,
-                          parentComponent: columnComponent,
+                          component: columnItems[0],
                         })}
-                    depth={depth + 1}
+                    depth={depth}
                     index={0}
                     orientation="column"
                     onDrop={handleComponentDrop}
@@ -291,7 +288,7 @@ class Column extends React.PureComponent {
                         <Droppable
                           component={columnItems}
                           parentComponent={columnComponent}
-                          depth={depth + 1}
+                          depth={depth}
                           index={itemIndex + 1}
                           orientation="column"
                           onDrop={handleComponentDrop}

--- a/superset-frontend/src/dashboard/components/gridComponents/Column.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Column.test.jsx
@@ -31,8 +31,10 @@ jest.mock('src/dashboard/components/dnd/DragDroppable', () => ({
   Draggable: ({ children }) => (
     <div data-test="mock-draggable">{children({})}</div>
   ),
-  Droppable: ({ children }) => (
-    <div data-test="mock-droppable">{children({})}</div>
+  Droppable: ({ children, depth }) => (
+    <div data-test="mock-droppable" depth={depth}>
+      {children({})}
+    </div>
   ),
 }));
 jest.mock(
@@ -130,7 +132,7 @@ test('should render a ResizableContainer', () => {
 
 test('should render a HoverMenu in editMode', () => {
   // we cannot set props on the Row because of the WithDragDropContext wrapper
-  const { container, getAllByTestId } = setup({
+  const { container, getAllByTestId, getByTestId } = setup({
     component: columnWithoutChildren,
     editMode: true,
   });
@@ -138,6 +140,12 @@ test('should render a HoverMenu in editMode', () => {
 
   // Droppable area enabled in editMode
   expect(getAllByTestId('mock-droppable').length).toBe(1);
+
+  // pass the same depth of its droppable area
+  expect(getByTestId('mock-droppable')).toHaveAttribute(
+    'depth',
+    `${props.depth}`,
+  );
 });
 
 test('should render a DeleteComponentButton in editMode', () => {

--- a/superset-frontend/src/dashboard/components/gridComponents/Row.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Row.jsx
@@ -323,14 +323,14 @@ class Row extends React.PureComponent {
                   {...(rowItems.length === 0
                     ? {
                         component: rowComponent,
-                        parentComponent,
+                        parentComponent: rowComponent,
                         dropToChild: true,
                       }
                     : {
-                        component: rowItems,
+                        component: rowItems[0],
                         parentComponent: rowComponent,
                       })}
-                  depth={depth + 1}
+                  depth={depth}
                   index={0}
                   orientation="row"
                   onDrop={handleComponentDrop}
@@ -375,7 +375,7 @@ class Row extends React.PureComponent {
                       <Droppable
                         component={rowItems}
                         parentComponent={rowComponent}
-                        depth={depth + 1}
+                        depth={depth}
                         index={itemIndex + 1}
                         orientation="row"
                         onDrop={handleComponentDrop}

--- a/superset-frontend/src/dashboard/components/gridComponents/Row.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Row.test.jsx
@@ -32,8 +32,10 @@ jest.mock('src/dashboard/components/dnd/DragDroppable', () => ({
   Draggable: ({ children }) => (
     <div data-test="mock-draggable">{children({})}</div>
   ),
-  Droppable: ({ children }) => (
-    <div data-test="mock-droppable">{children({})}</div>
+  Droppable: ({ children, depth }) => (
+    <div data-test="mock-droppable" depth={depth}>
+      {children({})}
+    </div>
   ),
 }));
 jest.mock(
@@ -125,7 +127,7 @@ test('should render a WithPopoverMenu', () => {
 });
 
 test('should render a HoverMenu in editMode', () => {
-  const { container, getAllByTestId } = setup({
+  const { container, getAllByTestId, getByTestId } = setup({
     component: rowWithoutChildren,
     editMode: true,
   });
@@ -133,6 +135,12 @@ test('should render a HoverMenu in editMode', () => {
 
   // Droppable area enabled in editMode
   expect(getAllByTestId('mock-droppable').length).toBe(1);
+
+  // pass the same depth of its droppable area
+  expect(getByTestId('mock-droppable')).toHaveAttribute(
+    'depth',
+    `${props.depth}`,
+  );
 });
 
 test('should render a DeleteComponentButton in editMode', () => {


### PR DESCRIPTION
### SUMMARY
It fixes the addressed issue #28025.
The tabs cannot be placed in columns due to the invalid depth level assigned to the siblings of the columns.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://github.com/apache/superset/assets/1392866/648e170c-c2bb-4f18-baa6-3f6448c7bcb0

After:

https://github.com/apache/superset/assets/1392866/1ff64308-b245-49e1-ad85-9a158e855e86


### TESTING INSTRUCTIONS
Create a new dashboard and then drop a column
Drop tabs to the column

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
