### PR TITLE
chore(docs): Move ::: onto its own line to fix caution formatting

### DIFF
--- a/docs/docs/configuration/configuring-superset.mdx
+++ b/docs/docs/configuration/configuring-superset.mdx
@@ -101,7 +101,8 @@ You can generate a strong secure key with `openssl rand -base64 42`.
 
 :::caution Use a strong secret key
 This key will be used for securely signing session cookies and encrypting sensitive information stored in Superset's application metadata database.
-Your deployment must use a complex, unique key. :::
+Your deployment must use a complex, unique key.
+:::
 
 #### Rotating to a newer SECRET_KEY
 


### PR DESCRIPTION
### SUMMARY
Tried to fix this in #28236, it didn't work, trying again.  I'm modeling the fix on the caution block on the page https://raw.githubusercontent.com/apache/superset/master/docs/docs/quickstart.mdx which renders correctly.