### PR TITLE
docs: set up redirects

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -160,7 +160,7 @@ const config = {
             from: '/docs/contributing/creating-viz-plugins/',
           },
           {
-            to: '/docs/installation/kubernetes/',
+            to: '/docs/installation/kubernetes',
             from: '/docs/installation/',
           },
         ],

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -135,6 +135,34 @@ const config = {
             to: '/docs/faq',
             from: '/docs/frequently-asked-questions',
           },
+          {
+            to: '/docs/installation/kubernetes',
+            from: '/docs/installation/running-on-kubernetes/',
+          },
+          {
+            to: '/docs/contributing/howtos',
+            from: '/docs/contributing/testing-locally/',
+          },
+          {
+            to: '/docs/using-superset/creating-your-first-dashboard',
+            from: '/docs/creating-charts-dashboards/creating-your-first-dashboard/',
+          },
+          {
+            to: '/docs/using-superset/creating-your-first-dashboard',
+            from: '/docs/creating-charts-dashboards/exploring-data/',
+          },
+          {
+            to: '/docs/quickstart',
+            from: '/docs/installation/installing-superset-using-docker-compose/',
+          },
+          {
+            to: '/docs/contributing/howtos',
+            from: '/docs/contributing/creating-viz-plugins/',
+          },
+          {
+            to: '/docs/installation/kubernetes/',
+            from: '/docs/installation/',
+          },
         ],
       },
     ],

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -152,7 +152,7 @@ const config = {
             from: '/docs/creating-charts-dashboards/exploring-data/',
           },
           {
-            to: '/docs/quickstart',
+            to: '/docs/installation/docker-compose',
             from: '/docs/installation/installing-superset-using-docker-compose/',
           },
           {

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -163,6 +163,26 @@ const config = {
             to: '/docs/installation/kubernetes',
             from: '/docs/installation/',
           },
+          {
+            to: '/docs/installation/pypi',
+            from: '/docs/installation/installing-superset-from-pypi/',
+          },
+          {
+            to: '/docs/configuration/configuring-superset',
+            from: '/docs/installation/configuring-superset/',
+          },
+          {
+            to: '/docs/configuration/cache',
+            from: '/docs/installation/cache/',
+          },
+          {
+            to: '/docs/configuration/async-queries-celery',
+            from: '/docs/installation/async-queries-celery/',
+          },
+          {
+            to: '/docs/configuration/event-logging',
+            from: '/docs/installation/event-logging/',
+          },
         ],
       },
     ],


### PR DESCRIPTION
### SUMMARY
Someone filled an issue about search index referring to dead links in our
documentation. Turns out many of the top links when googling `apache
superset documentation` point to 404s now.

In this PR I'm trying to set up client-side redirects to the related pages.

Note that the docs for this plugin state that server-side redirects are
better, and that the redirects don't work in dev, only prod, which
makes it hard to test

In the future, we'll need more rigor around catching dead links,
either during code review for the docs, or through some docusaurus
automation magic forcing us to come up with redirects whenever we kill
routes.

 [Docusaurus redirect plugin documentation](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-client-redirects) for reference

### Testing
I took the freedom to run `gh workflow run superset-docs-deploy.yml -r docs_redirect`, [logs here](https://github.com/apache/superset/actions/runs/8863837953/job/24338367534) since there's no way to test in dev and wanted this fix asap.

closes https://github.com/apache/superset/issues/28245