### PR TITLE
feat(deckgl): Plugin enhancement: Ability to add dashboard filter on click of deckGL polygon

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/common.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/common.tsx
@@ -57,7 +57,7 @@ export function commonLayerProps(
     };
   } else if (fd.table_filter && onSelect !== undefined) {
     onClick = (o: any) => {
-      onSelect(o.object[fd.line_column]);
+      onSelect(o.object[fd.line_column.replace('_geojson', '')]);
       return true;
     };
   }

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/transformProps.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/transformProps.ts
@@ -24,13 +24,18 @@ const NOOP = () => {};
 export default function transformProps(chartProps: ChartProps) {
   const { datasource, height, hooks, queriesData, rawFormData, width } =
     chartProps;
-  const { onAddFilter = NOOP, setControlValue = NOOP } = hooks;
+  const {
+    onAddFilter = NOOP,
+    setControlValue = NOOP,
+    setDataMask = NOOP,
+  } = hooks;
 
   return {
     datasource,
     formData: rawFormData,
     height,
     onAddFilter,
+    setDataMask,
     payload: queriesData[0],
     setControlValue,
     viewport: {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
DeckGl polygon has an onclick function that emits a filter event. This doesn't seem to work as expected on the latest master and we were getting some errors. With these changes I have added the ability to setData mask (a filter at dashboard level). 
I have made the changes based on what I understood of the plugin directory structure. I would be really helpful if you can verify these changes or guide me on how to add dashboard level filters with DeckGL polygon.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
