### PR TITLE
fix: use pessimistic json encoder in SQL Lab

### DIFF
--- a/superset/sqllab/api.py
+++ b/superset/sqllab/api.py
@@ -340,13 +340,15 @@ class SqlLabRestApi(BaseSupersetApi):
         key = params.get("key")
         rows = params.get("rows")
         result = SqlExecutionResultsCommand(key=key, rows=rows).run()
+
+        payload = json.dumps(
+            result,
+            default=utils.pessimistic_json_iso_dttm_ser,
+            ignore_nan=True,
+        )
         # return the result without special encoding
         return json_success(
-            json.dumps(
-                result,
-                default=utils.json_iso_dttm_ser,
-                ignore_nan=True,
-            ),
+            payload,
             200,
         )
 

--- a/superset/sqllab/api.py
+++ b/superset/sqllab/api.py
@@ -341,16 +341,14 @@ class SqlLabRestApi(BaseSupersetApi):
         rows = params.get("rows")
         result = SqlExecutionResultsCommand(key=key, rows=rows).run()
 
+        # Using pessimistic json serialization since some database drivers can return
+        # unserializeable types at times
         payload = json.dumps(
             result,
             default=utils.pessimistic_json_iso_dttm_ser,
             ignore_nan=True,
         )
-        # return the result without special encoding
-        return json_success(
-            payload,
-            200,
-        )
+        return json_success(payload, 200)
 
     @expose("/execute/", methods=("POST",))
     @protect()

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -507,8 +507,8 @@ def json_iso_dttm_ser(obj: Any, pessimistic: bool = False) -> Any:
         return base_json_conv(obj)
     except TypeError as ex:
         if pessimistic:
+            logger.error("Failed to serialize %s", obj)
             return f"Unserializable [{type(obj)}]"
-
         raise ex
 
 

--- a/tests/unit_tests/utils/test_core.py
+++ b/tests/unit_tests/utils/test_core.py
@@ -14,12 +14,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import datetime
+import json
 import os
 from dataclasses import dataclass
 from typing import Any, Optional
 from unittest.mock import MagicMock, patch
-import datetime
-import json
 
 import pandas as pd
 import pytest
@@ -33,12 +33,12 @@ from superset.utils.core import (
     generic_find_fk_constraint_name,
     get_datasource_full_name,
     is_test,
+    json_iso_dttm_ser,
     normalize_dttm_col,
     parse_boolean_string,
+    pessimistic_json_iso_dttm_ser,
     QueryObjectFilterClause,
     remove_extra_adhoc_filters,
-    pessimistic_json_iso_dttm_ser,
-    json_iso_dttm_ser,
 )
 
 ADHOC_FILTER: QueryObjectFilterClause = {


### PR DESCRIPTION
### SUMMARY
An issue reported in https://github.com/apache/superset/issues/28001 shows SQL Lab failing hard when a database driver returns a type that can't be decoded for serialization. Switching to this pessimistic helper function for json serialization will prevent a hard failure, but will obfuscate the data for the specific cells where things can't be serialized.

Not being in a situation where I can reproduce the issue, I'm operating with the stacktrace, meaning I can't really handle the specific cell, but can prevent SQL Lab from failing hard on a single cell issue.

Few related notes:
- maybe there's something around the driver being in utf8 mode of some kind. In theory we could say that driver / superset should agree on utf8 for things to work
- driver should probably giving us a `bytes` type from a `VARBINARY` and from the stacktrace it appears to be something else, presumably `str`, though that's unclear
- could be good to refactor out everything json-related out of superset/utils/core.py and into a new superset/utils/json.py, and make sure we always use thesame utility functions throughout the codebase as opposed to raw `import json` across the codebase. From my understanding there's some magic around simplejson injecting itself everywhere that happens too.


closes https://github.com/apache/superset/issues/28001