### PR TITLE
chore: enable ruff's isort equivalent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -424,6 +424,7 @@ exclude = [
     "venv",
 ]
 
+
 # Same as Black.
 line-length = 88
 indent-width = 4
@@ -438,12 +439,30 @@ target-version = "py310"
 select = ["E4", "E7", "E9", "F"]
 ignore = []
 
+extend-select = ["I"]
+
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]
 unfixable = []
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.lint.isort]
+case-sensitive = false
+combine-as-imports = true
+force-sort-within-sections = false
+known-first-party = []
+known-third-party = []
+lines-after-imports = -1
+order-by-type = false
+section-order = [
+    "future",
+    "standard-library",
+    "third-party",
+    "first-party",
+    "local-folder"
+]
 
 [tool.ruff.format]
 # Like Black, use double quotes for strings.

--- a/superset/async_events/async_query_manager.py
+++ b/superset/async_events/async_query_manager.py
@@ -21,7 +21,7 @@ from typing import Any, Literal, Optional
 
 import jwt
 import redis
-from flask import Flask, request, Request, Response, session
+from flask import Flask, Request, request, Response, session
 
 from superset.utils.core import get_user_id
 

--- a/superset/migrations/versions/2018-06-13_10-20_4451805bbaa1_remove_double_percents.py
+++ b/superset/migrations/versions/2018-06-13_10-20_4451805bbaa1_remove_double_percents.py
@@ -30,7 +30,14 @@ down_revision = "bddc498dd179"
 import json  # noqa: E402
 
 from alembic import op  # noqa: E402
-from sqlalchemy import Column, create_engine, ForeignKey, Integer, String, Text  # noqa: E402
+from sqlalchemy import (  # noqa: E402
+    Column,
+    create_engine,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+)
 from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402

--- a/superset/migrations/versions/2020-12-23_11-34_c878781977c6_alert_reports_shared_uniqueness.py
+++ b/superset/migrations/versions/2020-12-23_11-34_c878781977c6_alert_reports_shared_uniqueness.py
@@ -32,7 +32,6 @@ from sqlalchemy.dialects.mysql.base import MySQLDialect  # noqa: E402
 from sqlalchemy.dialects.postgresql.base import PGDialect  # noqa: E402
 from sqlalchemy.dialects.sqlite.base import SQLiteDialect  # noqa: E402
 
-
 report_schedule = sa.Table(
     "report_schedule",
     sa.MetaData(),

--- a/superset/migrations/versions/2022-04-01_14-38_a9422eeaae74_new_dataset_models_take_2.py
+++ b/superset/migrations/versions/2022-04-01_14-38_a9422eeaae74_new_dataset_models_take_2.py
@@ -43,7 +43,10 @@ from sqlalchemy.sql.expression import and_, or_  # noqa: E402
 from sqlalchemy_utils import UUIDType  # noqa: E402
 
 from superset.connectors.sqla.models import ADDITIVE_METRIC_TYPES_LOWER  # noqa: E402
-from superset.connectors.sqla.utils import get_dialect_name, get_identifier_quoter  # noqa: E402
+from superset.connectors.sqla.utils import (  # noqa: E402
+    get_dialect_name,
+    get_identifier_quoter,
+)
 from superset.extensions import encrypted_field_factory  # noqa: E402
 from superset.migrations.shared.utils import assign_uuids  # noqa: E402
 from superset.sql_parse import extract_table_references, Table  # noqa: E402

--- a/superset/migrations/versions/2023-06-08_11-34_ae58e1e58e5c_migrate_dual_line_to_mixed_chart.py
+++ b/superset/migrations/versions/2023-06-08_11-34_ae58e1e58e5c_migrate_dual_line_to_mixed_chart.py
@@ -25,12 +25,13 @@ Create Date: 2023-06-08 11:34:36.241939
 from alembic import op
 
 from superset import db
+from superset.migrations.shared.migrate_viz.processors import (
+    MigrateDualLine,  # noqa: E402
+)
 
 # revision identifiers, used by Alembic.
 revision = "ae58e1e58e5c"
 down_revision = "4c5da39be729"
-
-from superset.migrations.shared.migrate_viz.processors import MigrateDualLine  # noqa: E402
 
 
 def upgrade():

--- a/superset/migrations/versions/2023-09-06_13-18_317970b4400c_added_time_secondary_column_to_.py
+++ b/superset/migrations/versions/2023-09-06_13-18_317970b4400c_added_time_secondary_column_to_.py
@@ -31,7 +31,10 @@ from alembic import op  # noqa: E402
 from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
 
 from superset import db  # noqa: E402
-from superset.migrations.shared.utils import paginated_update, table_has_column  # noqa: E402
+from superset.migrations.shared.utils import (  # noqa: E402
+    paginated_update,
+    table_has_column,
+)
 
 Base = declarative_base()
 

--- a/superset/migrations/versions/2023-12-01_12-03_b7851ee5522f_replay_317970b4400c.py
+++ b/superset/migrations/versions/2023-12-01_12-03_b7851ee5522f_replay_317970b4400c.py
@@ -28,7 +28,6 @@ down_revision = "4b85906e5b91"
 
 from importlib import import_module  # noqa: E402
 
-
 module = import_module(
     "superset.migrations.versions.2023-09-06_13-18_317970b4400c_added_time_secondary_column_to_"
 )

--- a/superset/migrations/versions/2024-01-16_13-14_59a1450b3c10_drop_filter_sets_table.py
+++ b/superset/migrations/versions/2024-01-16_13-14_59a1450b3c10_drop_filter_sets_table.py
@@ -28,7 +28,6 @@ down_revision = "65a167d4c62e"
 
 from importlib import import_module  # noqa: E402
 
-
 module = import_module(
     "superset.migrations.versions.2021-03-29_11-15_3ebe0993c770_filterset_table"
 )

--- a/tests/common/logger_utils.py
+++ b/tests/common/logger_utils.py
@@ -25,8 +25,8 @@ from inspect import (
     isclass,
     isfunction,
     ismethod,
-    signature,
     Signature,
+    signature,
 )
 from logging import Logger
 from typing import Any, Callable, cast, Union

--- a/tests/integration_tests/dashboards/filter_state/api_tests.py
+++ b/tests/integration_tests/dashboards/filter_state/api_tests.py
@@ -23,7 +23,9 @@ from flask_appbuilder.security.sqla.models import User
 from sqlalchemy.orm import Session  # noqa: F401
 
 from superset import db
-from superset.commands.dashboard.exceptions import DashboardAccessDeniedError  # noqa: F401
+from superset.commands.dashboard.exceptions import (
+    DashboardAccessDeniedError,  # noqa: F401
+)
 from superset.commands.temporary_cache.entry import Entry
 from superset.extensions import cache_manager
 from superset.models.dashboard import Dashboard

--- a/tests/integration_tests/dashboards/permalink/api_tests.py
+++ b/tests/integration_tests/dashboards/permalink/api_tests.py
@@ -23,7 +23,9 @@ from flask_appbuilder.security.sqla.models import User  # noqa: F401
 from sqlalchemy.orm import Session  # noqa: F401
 
 from superset import db
-from superset.commands.dashboard.exceptions import DashboardAccessDeniedError  # noqa: F401
+from superset.commands.dashboard.exceptions import (
+    DashboardAccessDeniedError,  # noqa: F401
+)
 from superset.key_value.models import KeyValueEntry
 from superset.key_value.types import KeyValueResource
 from superset.key_value.utils import decode_permalink_id

--- a/tests/integration_tests/dashboards/security/security_rbac_tests.py
+++ b/tests/integration_tests/dashboards/security/security_rbac_tests.py
@@ -45,7 +45,9 @@ from tests.integration_tests.fixtures.birth_names_dashboard import (
     load_birth_names_dashboard_with_slices,  # noqa: F401
     load_birth_names_data,  # noqa: F401
 )
-from tests.integration_tests.fixtures.public_role import public_role_like_gamma  # noqa: F401
+from tests.integration_tests.fixtures.public_role import (
+    public_role_like_gamma,  # noqa: F401
+)
 from tests.integration_tests.fixtures.query_context import get_query_context
 from tests.integration_tests.fixtures.world_bank_dashboard import (
     load_world_bank_dashboard_with_slices,  # noqa: F401

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -46,7 +46,10 @@ from superset.utils.core import backend, get_example_default_schema
 from superset.utils.database import get_example_database, get_main_database
 from superset.utils.dict_import_export import export_to_dict
 from tests.integration_tests.base_tests import SupersetTestCase
-from tests.integration_tests.conftest import CTAS_SCHEMA_NAME, with_feature_flags  # noqa: F401
+from tests.integration_tests.conftest import (  # noqa: F401
+    CTAS_SCHEMA_NAME,
+    with_feature_flags,
+)
 from tests.integration_tests.constants import (
     ADMIN_USERNAME,
     ALPHA_USERNAME,

--- a/tests/integration_tests/datasource_tests.py
+++ b/tests/integration_tests/datasource_tests.py
@@ -27,13 +27,20 @@ import pytest
 from superset import app, db
 from superset.commands.dataset.exceptions import DatasetNotFoundError
 from superset.common.utils.query_cache_manager import QueryCacheManager
-from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn  # noqa: F401
+from superset.connectors.sqla.models import (  # noqa: F401
+    SqlaTable,
+    SqlMetric,
+    TableColumn,
+)
 from superset.constants import CacheRegion
 from superset.daos.exceptions import DatasourceNotFound, DatasourceTypeNotSupportedError
 from superset.exceptions import SupersetGenericDBErrorException
 from superset.models.core import Database
 from superset.utils.core import backend, get_example_default_schema  # noqa: F401
-from superset.utils.database import get_example_database, get_main_database  # noqa: F401
+from superset.utils.database import (  # noqa: F401
+    get_example_database,
+    get_main_database,
+)
 from tests.integration_tests.base_tests import db_insert_temp_object, SupersetTestCase
 from tests.integration_tests.constants import ADMIN_USERNAME
 from tests.integration_tests.fixtures.birth_names_dashboard import (

--- a/tests/integration_tests/fixtures/__init__.py
+++ b/tests/integration_tests/fixtures/__init__.py
@@ -19,8 +19,14 @@ from .birth_names_dashboard import (
     load_birth_names_dashboard_with_slices,  # noqa: F401
     load_birth_names_dashboard_with_slices_module_scope,  # noqa: F401
 )
-from .energy_dashboard import load_energy_table_data, load_energy_table_with_slice  # noqa: F401
-from .public_role import public_role_like_gamma, public_role_like_test_role  # noqa: F401
+from .energy_dashboard import (  # noqa: F401
+    load_energy_table_data,
+    load_energy_table_with_slice,
+)
+from .public_role import (  # noqa: F401
+    public_role_like_gamma,
+    public_role_like_test_role,
+)
 from .unicode_dashboard import (
     load_unicode_dashboard_with_position,  # noqa: F401
     load_unicode_dashboard_with_slice,  # noqa: F401

--- a/tests/integration_tests/reports/commands/create_dashboard_report_tests.py
+++ b/tests/integration_tests/reports/commands/create_dashboard_report_tests.py
@@ -26,7 +26,9 @@ from superset.reports.models import (
     ReportRecipientType,
     ReportScheduleType,
 )
-from tests.integration_tests.fixtures.tabbed_dashboard import tabbed_dashboard  # noqa: F401
+from tests.integration_tests.fixtures.tabbed_dashboard import (
+    tabbed_dashboard,  # noqa: F401
+)
 
 DASHBOARD_REPORT_SCHEDULE_DEFAULTS = {
     "type": ReportScheduleType.REPORT,

--- a/tests/integration_tests/reports/commands/execute_dashboard_report_tests.py
+++ b/tests/integration_tests/reports/commands/execute_dashboard_report_tests.py
@@ -24,7 +24,9 @@ from superset.commands.dashboard.permalink.create import CreateDashboardPermalin
 from superset.commands.report.execute import AsyncExecuteReportScheduleCommand
 from superset.models.dashboard import Dashboard
 from superset.reports.models import ReportSourceFormat
-from tests.integration_tests.fixtures.tabbed_dashboard import tabbed_dashboard  # noqa: F401
+from tests.integration_tests.fixtures.tabbed_dashboard import (
+    tabbed_dashboard,  # noqa: F401
+)
 from tests.integration_tests.reports.utils import create_dashboard_report
 
 

--- a/tests/integration_tests/tagging_tests.py
+++ b/tests/integration_tests/tagging_tests.py
@@ -29,7 +29,9 @@ from superset.utils.core import DatasourceType
 from superset.utils.database import get_main_database
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.conftest import with_feature_flags
-from tests.integration_tests.fixtures.tags import with_tagging_system_feature  # noqa: F401
+from tests.integration_tests.fixtures.tags import (
+    with_tagging_system_feature,  # noqa: F401
+)
 
 
 class TestTagging(SupersetTestCase):

--- a/tests/integration_tests/tags/commands_tests.py
+++ b/tests/integration_tests/tags/commands_tests.py
@@ -48,7 +48,9 @@ from tests.integration_tests.fixtures.importexport import (
     dataset_config,  # noqa: F401
     dataset_metadata_config,  # noqa: F401
 )
-from tests.integration_tests.fixtures.tags import with_tagging_system_feature  # noqa: F401
+from tests.integration_tests.fixtures.tags import (
+    with_tagging_system_feature,  # noqa: F401
+)
 from tests.integration_tests.fixtures.world_bank_dashboard import (
     load_world_bank_dashboard_with_slices,  # noqa: F401
     load_world_bank_data,  # noqa: F401

--- a/tests/integration_tests/tasks/async_queries_tests.py
+++ b/tests/integration_tests/tasks/async_queries_tests.py
@@ -32,7 +32,9 @@ from tests.integration_tests.fixtures.birth_names_dashboard import (
     load_birth_names_data,  # noqa: F401
 )
 from tests.integration_tests.fixtures.query_context import get_query_context
-from tests.integration_tests.fixtures.tags import with_tagging_system_feature  # noqa: F401
+from tests.integration_tests.fixtures.tags import (
+    with_tagging_system_feature,  # noqa: F401
+)
 from tests.integration_tests.test_app import app
 
 

--- a/tests/unit_tests/commands/test_utils.py
+++ b/tests/unit_tests/commands/test_utils.py
@@ -17,7 +17,6 @@
 
 from unittest.mock import MagicMock, patch
 
-
 from superset.commands.utils import compute_owner_list, populate_owner_list, User
 
 


### PR DESCRIPTION
### SUMMARY
Recently when I set up `ruff` (new linter/formatter that replaces black, isort, pyupgrade, ...) I didn't check that isort rules were enabled properly, this PR:

- enables the isort-like features
- configures them in ways that match the settings we had originally, minimize changes
- runs `ruff check --fix` with these new settings - everything here except a single change was auto-fixed in milliseconds

For the record, my configuration is based on the one suggested here ->  https://github.com/astral-sh/ruff/issues/4670#issuecomment-1920024170

For convenience, the list of all possible isort-related configs: https://docs.astral.sh/ruff/settings/#lint_isort_lines-after-imports.

Note that now that this is so fast and `--fix` works very well, it'd be easy to reconsider some configs if we wanted, for example setting `lines-after-imports = 2` instead of `-1` could be nice.