### PR TITLE
fix: druid double percent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ databricks = [
 db2 = ["ibm-db-sa>0.3.8, <=0.4.0"]
 dremio = ["sqlalchemy-dremio>=1.1.5, <1.3"]
 drill = ["sqlalchemy-drill>=1.1.4, <2"]
-druid = ["pydruid>=0.6.5,<0.7"]
+druid = ["pydruid>=0.6.7,<0.7"]
 duckdb = ["duckdb-engine>=0.9.5, <0.10"]
 dynamodb = ["pydynamodb>=0.4.2"]
 solr = ["sqlalchemy-solr >= 0.2.0"]

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -206,7 +206,7 @@ pure-sasl==0.6.2
     #   thrift-sasl
 pydata-google-auth==1.7.0
     # via pandas-gbq
-pydruid==0.6.6
+pydruid==0.6.7
     # via apache-superset
 pyee==11.0.1
     # via playwright

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -664,10 +664,6 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
         with self.get_sqla_engine(catalog=catalog, schema=schema) as engine:
             sql = str(qry.compile(engine, compile_kwargs={"literal_binds": True}))
 
-            # pylint: disable=protected-access
-            if engine.dialect.identifier_preparer._double_percents:  # noqa
-                sql = sql.replace("%%", "%")
-
         return sql
 
     def select_star(  # pylint: disable=too-many-arguments


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Some DB API 2.0 drivers use `pyformat` for `paramstyle`. This means that queries should be parameterized with `%s` for the placeholders, like this:

```python
cursor.execute("SELECT * FROM t WHERE role = '%s'", ("engineer",))
```

The driver then performs "old-school" string interpolation:

```python
sql = "SELECT * FROM t WHERE role = '%s'"
parameters = ("engineer",)
escaped_parameters = escape_parameters(parameters)  # important to prevent SQL injection
final_query = sql % escaped_parameters
```

Because of the percent interpolation, when SQL compiles a query for [a database that uses `pyformat` or `format`](https://github.com/sqlalchemy/sqlalchemy/blob/6888cf79db79d5e5660300ccf2a2a91f1eecf75f/lib/sqlalchemy/sql/compiler.py#L7361-L7364), any percent symbols in the query are escaped by being replaced with `%%`:

https://github.com/sqlalchemy/sqlalchemy/blob/6888cf79db79d5e5660300ccf2a2a91f1eecf75f/lib/sqlalchemy/sql/compiler.py#L2652-L2653

For some reason we undo that process (introduced in https://github.com/apache/superset/pull/5178):

https://github.com/apache/superset/blob/76d897eaa2f9e137102bc194c2e3109c29d0348f/superset/models/core.py#L668-L669

The code above doesn't make sense. If SQLAlchemy is replacing `%` with `%%` for databases where `dialect.identifier_preparer._double_percents` is true, why would we reverse it when we compile the query for the same databases?

One clue can be found in another codepath were we compile the query, but that replacement is missing. In `values_for_column`:

https://github.com/apache/superset/blob/44690fb299ab3b7adc24e84eeec73bccdde14420/superset/models/helpers.py#L1380-L1384

@Vitor-Avila noticed that here, when the column is a calculated column containing a percent symbol, like:

```sql
case when column like '%a%' then 1 else 0 end
```

Then the generated SQL being sent to the database is:

```sql
case when column like '%%a%%' then 1 else 0 end
``` 

Note that the query above is completely valid and syntactically equivalent to the original one, so everything works as expected when we run it... except that in Druid, the query performs extremely poorly, compared to the one with a single percent. This suggests that the fix is to add `sql = sql.replace("%%", "%")` to the `values_for_column` method as well.

But again... why are we undoing what SQLAlchemy is doing?

Looking deeper into the problem, I found a bug in pydruid:

https://github.com/druid-io/pydruid/blob/1d72d26c3e14bc9a7c6725dfa877c98a7afbe6f3/pydruid/db/api.py#L430-L435

Note that in the code above, when no parameters are passed to `execute` — which is the case when Superset calls the method — the string interpolation never happens, because the SQL is returned early! This means that any escaped percent symbols (`%%`) **will not** be unescaped to `%`.

I've fixed pydruid in https://github.com/druid-io/pydruid/pull/317, and made a new release. This PR bumps the version to the fixed one, and removes the `sql = sql.replace("%%", "%")` logic completely. This way, when double percents are passed to pydruid, they will be unescaped **by the driver**, as expected.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

I tested with Postgres, since psycopg2 uses `pyformat`. Queries run as expected:

![Screenshot 2024-04-29 at 16-42-51 Superset](https://github.com/apache/superset/assets/1534870/c92f030b-0369-4b43-8cb0-22b68880d8b8)


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
