### PR TITLE
docs(upgrading): clarify upgrade process

### DIFF
--- a/docs/docs/installation/upgrading-superset.mdx
+++ b/docs/docs/installation/upgrading-superset.mdx
@@ -33,6 +33,13 @@ To upgrade superset in a native installation, run the following commands:
 
 ```bash
 pip install apache-superset --upgrade
+```
+
+## Upgrading Metadata Database
+
+Migrate the metadata database by running:
+
+```bash
 superset db upgrade
 superset init
 ```


### PR DESCRIPTION
Differentiate between upgrading superset docker/native itself and the metadata database to indicate that upgrading the database is necessary in either case.

### SUMMARY
Indicate that `superset db upgrade` and `superset init` are necessary after upgrading superset, independent of the deployment method.

Personally it was obvious that `superset db upgrade` was needed, but at that point I already felt the documentation could be clearer. I didn't execute `superset init` though, as it was not obvious from the `Docker Compose` section of the upgrade guide. I thought some weird HTTP 403 errors in the SQLLAB were a regression in 4.0.0 until I stumbled upon this line by accident, which, after execution, fixed everything.