### PR TITLE
chore: use depth=1 for cloning

### DIFF
--- a/docs/docs/installation/docker-compose.mdx
+++ b/docs/docs/installation/docker-compose.mdx
@@ -50,7 +50,7 @@ Note that this documentation assumes that you have [Docker](https://www.docker.c
 following command:
 
 ```bash
-git clone https://github.com/apache/superset.git
+git clone --depth=1  https://github.com/apache/superset.git
 ```
 
 Once that command completes successfully, you should see a new `superset` folder in your


### PR DESCRIPTION
It's not needed to clone full history of the repository just to get and spin up docker compose.