### PR TITLE
feat: accelerate webpack builds with filesystem cache

### DIFF
--- a/superset-frontend/.gitignore
+++ b/superset-frontend/.gitignore
@@ -2,3 +2,4 @@ coverage/*
 cypress/screenshots
 cypress/videos
 src/temp
+.temp_cache/

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -212,6 +212,13 @@ const config = {
     spa: addPreamble('/src/views/index.tsx'),
     embedded: addPreamble('/src/embedded/index.tsx'),
   },
+  cache: {
+    type: 'filesystem', // Enable filesystem caching
+    cacheDirectory: path.resolve(__dirname, '.temp_cache'),
+    buildDependencies: {
+      config: [__filename],
+    },
+  },
   output,
   stats: 'minimal',
   /*


### PR DESCRIPTION
# NOW 5 TIMES FASTER 🔥 🍌🔥 🍌🔥 🍌🔥 🍌 

the only concern is there won't be enough time to fix a coffee ☕  when firing up webpack

![speedy-gonzales-running-t0uvc86wu0vlqdwv](https://github.com/apache/superset/assets/487433/6d9361f4-520d-48b1-b233-686d47720e25)


```
real    0m50.233s
user    1m56.371s
sys     0m10.192s
```

```
real    0m9.892s
user    0m11.070s
sys     0m2.034s
```

Works in docker-compose too
![unusual-whale-typing-x2q3860nvo2i3hgz](https://github.com/apache/superset/assets/487433/b86ed2d9-617a-4433-8a13-150bab3423fe)
