### PR TITLE
chore(docs): video now hosted by ASF instead of GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Superset provides:
 
 **Video Overview**
 <!-- File hosted here https://github.com/apache/superset-site/raw/lfs/superset-video-4k.mp4 -->
-https://user-images.githubusercontent.com/64562059/234390129-321d4f35-cb4b-45e8-89d9-20ae292f34fc.mp4
+https://superset.staged.apache.org/superset-video-4k.mp4
 
 <br/>
 

--- a/docs/docs/intro.mdx
+++ b/docs/docs/intro.mdx
@@ -20,8 +20,8 @@ Here are a **few different ways you can get started with Superset**:
 
 #### Video Overview
 
-<video src="https://user-images.githubusercontent.com/64562059/234390129-321d4f35-cb4b-45e8-89d9-20ae292f34fc.mp4" width="100%" height="auto" controls="">
-    https://user-images.githubusercontent.com/64562059/234390129-321d4f35-cb4b-45e8-89d9-20ae292f34fc.mp4
+<video src="https://superset.staged.apache.org/superset-video-4k.mp4" width="100%" height="auto" controls="">
+    https://superset.staged.apache.org/superset-video-4k.mp4
 </video>
 
 #### Features

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -644,7 +644,7 @@ export default function Home(): JSX.Element {
               </div>
             </Carousel>
             <video autoPlay muted controls loop>
-              <source src="https://user-images.githubusercontent.com/64562059/234390129-321d4f35-cb4b-45e8-89d9-20ae292f34fc.mp4" type="video/mp4" />
+              <source src="https://superset.staged.apache.org/superset-video-4k.mp4" type="video/mp4" />
             </video>
           </StyledSliderSection>
           <StyledKeyFeatures>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Got the "staging" site to pull from the "lfs" branch, so now our video is hosted there. See links in code for details

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
