### PR TITLE
chore(dev): remove obsolete image reference to `superset-websocket` + fix minor typo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,7 +98,6 @@ services:
   superset-websocket:
     container_name: superset_websocket
     build: ./superset-websocket
-    image: superset-websocket
     ports:
       - 8080:8080
     extra_hosts:
@@ -121,7 +120,7 @@ services:
       - /home/superset-websocket/dist
 
       # Mounting a config file that contains a dummy secret required to boot up.
-      # do no not use this docker-compose in production
+      # do not use this docker-compose in production
       - ./docker/superset-websocket/config.json:/home/superset-websocket/config.json
     environment:
       - PORT=8080


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
chore(dev): remove obsolete image reference to `superset-websocket` + fix minor typo

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove obsolete image reference to `superset-websocket` in `docker-compose.yml`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before
<img width="1201" alt="image" src="https://github.com/apache/superset/assets/41283691/dfab1241-a3d5-4339-a1cb-d894c30ef488">

After
<img width="1201" alt="image" src="https://github.com/apache/superset/assets/41283691/d8e98d34-a0d0-47be-ade9-00eddceee598">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
