### PR TITLE
fix(sql_parse): Add Apache Spark to SQLGlot dialect mapping

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -137,6 +137,7 @@ SQLGLOT_DIALECTS = {
     "shillelagh": Dialects.SQLITE,
     "snowflake": Dialects.SNOWFLAKE,
     # "solr": ???
+    "spark": Dialects.SPARK,
     "sqlite": Dialects.SQLITE,
     "starrocks": Dialects.STARROCKS,
     "superset": Dialects.SQLITE,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Though we support [Apache Spark](https://github.com/apache/superset/blob/master/superset/db_engine_specs/spark.py) there's no associated entry in the engine to SQLGlot dialect mapping, meaning that certain Spark SQL statements are non parsable when [no dialect is specified](https://github.com/apache/superset/blob/e94360486e3db9488119f805f4c118ba5021754a/superset/sql_parse.py#L464-L467):


```python
>>> from sqlglot import parse_one
>>>
>>> parse_one("SELECT * FROM `foo`.`bar`", dialect=None)
Traceback (most recent call last):
  ...
sqlglot.errors.ParseError: Invalid expression / Unexpected token. Line 1, Col: 19.
  SELECT * FROM `foo`.`bar`
```

compared to 

```python
>>> from sqlglot import parse_one
>>>
>>> parse_one("SELECT * FROM `foo`.`bar`", dialect="spark")
Select(
  expressions=[
    Star()],
  from=From(
    this=Table(
      this=Identifier(this=bar, quoted=True),
      db=Identifier(this=foo, quoted=True))))
``` 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
