### PR TITLE
fix(ci): correct input type for `allow-dependencies-licenses` in Dependency Review GH action

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -23,22 +23,13 @@ jobs:
           # compatible/incompatible licenses addressed here: https://www.apache.org/legal/resolved.html
           # find SPDX identifiers here: https://spdx.org/licenses/
           deny-licenses: MS-LPL, BUSL-1.1, QPL-1.0, Sleepycat, SSPL-1.0, CPOL-1.02, AGPL-3.0, GPL-1.0+, BSD-4-Clause-UC, NPL-1.0, NPL-1.1, JSON
-          allow-dependencies-licenses:
-            # adding an exception for an ambigious license on store2, which has been resolved in
-            # the latest version. It's MIT: https://github.com/nbubna/store/blob/master/LICENSE-MIT
-            - 'pkg:npm/store2@2.14.2'
-            # adding exception for all applitools modules (eyes-cypress and its dependencies),
-            # which has an explicit OSS license approved by ASF
-            # license: https://applitools.com/legal/open-source-terms-of-use/
-            - 'pkg:npm/applitools/core'
-            - 'pkg:npm/applitools/core-base'
-            - 'pkg:npm/applitools/css-tree'
-            - 'pkg:npm/applitools/ec-client'
-            - 'pkg:npm/applitools/eg-socks5-proxy-server'
-            - 'pkg:npm/applitools/eyes'
-            - 'pkg:npm/applitools/eyes-cypress'
-            - 'pkg:npm/applitools/nml-client'
-            - 'pkg:npm/applitools/tunnel-client'
-            - 'pkg:npm/applitools/utils'
-            # Selecting BSD-3-Clause licensing terms for node-forge to ensure compatibility with Apache
-            - 'pkg:npm/node-forge@1.3.1'
+          # pkg:npm/store2@2.14.2
+          #   adding an exception for an ambigious license on store2, which has been resolved in
+          #   the latest version. It's MIT: https://github.com/nbubna/store/blob/master/LICENSE-MIT
+          # pkg:npm/applitools/*
+          #   adding exception for all applitools modules (eyes-cypress and its dependencies),
+          #   which has an explicit OSS license approved by ASF
+          #   license: https://applitools.com/legal/open-source-terms-of-use/
+          # pkg:npm/node-forge@1.3.1
+          #   selecting BSD-3-Clause licensing terms for node-forge to ensure compatibility with Apache
+          allow-dependencies-licenses: pkg:npm/store2@2.14.2, pkg:npm/applitools/core, pkg:npm/applitools/core-base, pkg:npm/applitools/css-tree, pkg:npm/applitools/ec-client, pkg:npm/applitools/eg-socks5-proxy-server, pkg:npm/applitools/eyes, pkg:npm/applitools/eyes-cypress, pkg:npm/applitools/nml-client, pkg:npm/applitools/tunnel-client, pkg:npm/applitools/utils, pkg:npm/node-forge@1.3.1


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
fix(ci): correct input type for `allow-dependencies-licenses` for Dependency Review GH action


### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Some of my PRs got failed in the GH action due to incorrect input type for said GH action. This change is to restore the CI job's functionality.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before
<img width="1133" alt="image" src="https://github.com/apache/superset/assets/41283691/97beca33-87f6-4ef4-a764-f57de15220b6">


After
<img width="1157" alt="image" src="https://github.com/apache/superset/assets/41283691/bd5288b6-b60e-458a-8344-264729c85f2e">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
