### PR TITLE
fix: Add back description column to saved queries #12431

### DIFF
--- a/superset-frontend/src/components/InfoTooltip/index.tsx
+++ b/superset-frontend/src/components/InfoTooltip/index.tsx
@@ -83,7 +83,11 @@ export default function InfoTooltip({
       overlayStyle={overlayStyle}
       color={bgColor}
     >
-      <Icons.InfoSolidSmall className="info-solid-small" viewBox={viewBox} />
+      <Icons.InfoSolidSmall
+        className="info-solid-small"
+        viewBox={viewBox}
+        iconSize="m"
+      />
     </StyledTooltip>
   );
 }

--- a/superset-frontend/src/components/InfoTooltip/index.tsx
+++ b/superset-frontend/src/components/InfoTooltip/index.tsx
@@ -83,11 +83,7 @@ export default function InfoTooltip({
       overlayStyle={overlayStyle}
       color={bgColor}
     >
-      <Icons.InfoSolidSmall
-        className="info-solid-small"
-        viewBox={viewBox}
-        iconSize="m"
-      />
+      <Icons.InfoSolidSmall className="info-solid-small" viewBox={viewBox} />
     </StyledTooltip>
   );
 }

--- a/superset-frontend/src/components/ListView/Filters/Search.tsx
+++ b/superset-frontend/src/components/ListView/Filters/Search.tsx
@@ -29,7 +29,7 @@ interface SearchHeaderProps extends BaseFilter {
   Header: string;
   onSubmit: (val: string) => void;
   name: string;
-  toolTipDescription: string;
+  toolTipDescription: string | undefined;
 }
 
 const Container = styled.div`
@@ -77,7 +77,9 @@ function SearchFilter(
   return (
     <Container>
       <FormLabel>{Header}</FormLabel>
-      {toolTipDescription && <InfoTooltip tooltip={toolTipDescription} />}
+      {toolTipDescription && (
+        <InfoTooltip tooltip={toolTipDescription} viewBox="0 -7 28 28" />
+      )}
       <StyledInput
         allowClear
         data-test="filters-search"

--- a/superset-frontend/src/components/ListView/Filters/Search.tsx
+++ b/superset-frontend/src/components/ListView/Filters/Search.tsx
@@ -22,12 +22,14 @@ import Icons from 'src/components/Icons';
 import { AntdInput } from 'src/components';
 import { SELECT_WIDTH } from 'src/components/ListView/utils';
 import { FormLabel } from 'src/components/Form';
+import InfoTooltip from 'src/components/InfoTooltip';
 import { BaseFilter, FilterHandler } from './Base';
 
 interface SearchHeaderProps extends BaseFilter {
   Header: string;
   onSubmit: (val: string) => void;
   name: string;
+  toolTipDescription: string;
 }
 
 const Container = styled.div`
@@ -43,7 +45,13 @@ const StyledInput = styled(AntdInput)`
 `;
 
 function SearchFilter(
-  { Header, name, initialValue, onSubmit }: SearchHeaderProps,
+  {
+    Header,
+    name,
+    initialValue,
+    toolTipDescription,
+    onSubmit,
+  }: SearchHeaderProps,
   ref: React.RefObject<FilterHandler>,
 ) {
   const [value, setValue] = useState(initialValue || '');
@@ -69,6 +77,7 @@ function SearchFilter(
   return (
     <Container>
       <FormLabel>{Header}</FormLabel>
+      {toolTipDescription && <InfoTooltip tooltip={toolTipDescription} />}
       <StyledInput
         allowClear
         data-test="filters-search"

--- a/superset-frontend/src/components/ListView/Filters/index.tsx
+++ b/superset-frontend/src/components/ListView/Filters/index.tsx
@@ -71,6 +71,7 @@ function UIFilters(
             input,
             paginate,
             selects,
+            toolTipDescription,
             onFilterUpdate,
           },
           index,
@@ -111,6 +112,7 @@ function UIFilters(
                 initialValue={initialValue}
                 key={key}
                 name={id}
+                toolTipDescription={toolTipDescription}
                 onSubmit={(value: string) => {
                   if (onFilterUpdate) {
                     onFilterUpdate(value);

--- a/superset-frontend/src/components/ListView/types.ts
+++ b/superset-frontend/src/components/ListView/types.ts
@@ -39,6 +39,7 @@ export interface Filter {
   Header: ReactNode;
   key: string;
   id: string;
+  toolTipDescription?: string;
   urlDisplay?: string;
   operator?: FilterOperator;
   input?:

--- a/superset-frontend/src/pages/SavedQueryList/index.tsx
+++ b/superset-frontend/src/pages/SavedQueryList/index.tsx
@@ -298,6 +298,10 @@ function SavedQueryList({
         Header: t('Name'),
       },
       {
+        accessor: 'description',
+        Header: t('Description'),
+      },
+      {
         accessor: 'database.database_name',
         Header: t('Database'),
         size: 'xl',
@@ -447,6 +451,12 @@ function SavedQueryList({
         id: 'label',
         key: 'search',
         input: 'search',
+        operator: FilterOperator.AllText,
+      },
+      {
+        Header: t('Description'),
+        id: 'description',
+        key: 'description',
         operator: FilterOperator.AllText,
       },
       {

--- a/superset-frontend/src/pages/SavedQueryList/index.tsx
+++ b/superset-frontend/src/pages/SavedQueryList/index.tsx
@@ -447,7 +447,7 @@ function SavedQueryList({
   const filters: Filters = useMemo(
     () => [
       {
-        Header: t('search'),
+        Header: t('Search'),
         id: 'label',
         key: 'search',
         input: 'search',

--- a/superset-frontend/src/pages/SavedQueryList/index.tsx
+++ b/superset-frontend/src/pages/SavedQueryList/index.tsx
@@ -447,16 +447,10 @@ function SavedQueryList({
   const filters: Filters = useMemo(
     () => [
       {
-        Header: t('Name'),
+        Header: t('search'),
         id: 'label',
         key: 'search',
         input: 'search',
-        operator: FilterOperator.AllText,
-      },
-      {
-        Header: t('Description'),
-        id: 'description',
-        key: 'description',
         operator: FilterOperator.AllText,
       },
       {

--- a/superset-frontend/src/pages/SavedQueryList/index.tsx
+++ b/superset-frontend/src/pages/SavedQueryList/index.tsx
@@ -452,6 +452,8 @@ function SavedQueryList({
         key: 'search',
         input: 'search',
         operator: FilterOperator.AllText,
+        toolTipDescription:
+          'Searches all text fields: Name, Description, Database & Schema',
       },
       {
         Header: t('Database'),


### PR DESCRIPTION
Fixes https://github.com/apache/superset/issues/12431

**Add back Description column**
<img width="1728" alt="Screenshot 2024-05-05 at 6 08 34 PM" src="https://github.com/apache/superset/assets/5911558/1db98d7f-2e10-4736-9bf0-c5580d3349a9">


**Add tooltip for search box**
<img width="1724" alt="Screenshot 2024-05-06 at 4 25 32 PM" src="https://github.com/apache/superset/assets/5911558/ef25f34b-6cbe-42a4-a20a-30bcdb320678">

