### PR TITLE
fix(sqllab): sqllab/execute returns 500 when user only has schema access

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -1622,7 +1622,7 @@ def extract_tables_from_jinja_sql(sql: str, database: Database) -> set[Table]:
     return (
         tables
         | ParsedQuery(
-            sql_statement=processor.process_template(template),
+            sql_statement=processor.process_template(sql),
             engine=database.db_engine_spec.engine,
         ).tables
     )


### PR DESCRIPTION
### SUMMARY

When a user has no admin access and is trying to run a query in SQL Lab, Superset needs to check:

- Database access
- Schema access
- Data source access

To be able to check schema access, Superset needs to know which table the user is trying to execute on and use `extract_tables_from_jinja_sql()` to get it. The function extract tables in both ways:

- Extract any tables referenced within the confines of specific Jinja macros.
- Parse SQL and get tables.

In the line I changed, there is simply a bug that uses `template` which has type Template. The correct one should be `sql`, which is a string sent by the user.

### TESTING INSTRUCTIONS

Reproduce steps:

1. Create a new user
2. Create a role with permission: "schema access on [examples].[main]"
3. Assign the user to the role and "sql_lab" role
4. Log in with the new user and go to SQL Lab.
5. Write a simple query and execute it. You will see that the `/api/v1/sqllab/execute/` endpoint returns 500

### Impact

- Fixes: https://github.com/apache/superset/issues/28145

