### PR TITLE
chore: add a github "action-validator" in CI

### DIFF
--- a/.github/workflows/github-action-validator.sh
+++ b/.github/workflows/github-action-validator.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Inspired from https://github.com/mpalmer/action-validator?tab=readme-ov-file#pre-commit-hook-example
+echo "Running pre-commit hook for GitHub Actions: https://github.com/mpalmer/action-validator"
+	for action in $(git ls-files .github/ | grep -E '^\.github/(workflows|actions)/.*\.ya?ml$'); do
+  if action-validator "$action"; then
+	echo "✅ $action"
+  else
+	echo "❌ $action"
+	exit 1
+  fi
+done

--- a/.github/workflows/github-action-validator.yml
+++ b/.github/workflows/github-action-validator.yml
@@ -12,7 +12,6 @@ jobs:
 
   validate-all-ghas:
     runs-on: ubuntu-latest
-    name: Generate Reports
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/github-action-validator.yml
+++ b/.github/workflows/github-action-validator.yml
@@ -1,4 +1,4 @@
-name: Upload Technical Debt Metrics to Google Sheets
+name: Validate All GitHub Actions
 
 on:
   push:

--- a/.github/workflows/github-action-validator.yml
+++ b/.github/workflows/github-action-validator.yml
@@ -1,0 +1,27 @@
+name: Upload Technical Debt Metrics to Google Sheets
+
+on:
+  push:
+    branches:
+      - master
+      - "[0-9].[0-9]"
+
+jobs:
+
+  validate-all-ghas:
+    runs-on: ubuntu-latest
+    name: Generate Reports
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install Dependencies
+        run: npm install -g @action-validator/core @action-validator/cli --save-dev
+
+      - name: Run Script
+        run: bash .github/workflows/github-action-validator.sh

--- a/.github/workflows/github-action-validator.yml
+++ b/.github/workflows/github-action-validator.yml
@@ -3,8 +3,10 @@ name: Validate All GitHub Actions
 on:
   push:
     branches:
-      - master
+      - "master"
       - "[0-9].[0-9]"
+  pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
 
 jobs:
 

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -19,8 +19,8 @@ on:
         default: 'false'
         description: Whether to force a latest tag on the release
         options:
-          - true
-          - false
+          - 'true'
+          - 'false'
 jobs:
   config:
     runs-on: "ubuntu-latest"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,3 +91,7 @@ repos:
             "-sn", # Don't display the score
             "--rcfile=.pylintrc",
           ]
+  - repo: https://github.com/mpalmer/action-validator
+    rev: v0.5.1
+    hooks:
+      - id: action-validator

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,7 +91,3 @@ repos:
             "-sn", # Don't display the score
             "--rcfile=.pylintrc",
           ]
-  - repo: https://github.com/mpalmer/action-validator
-    rev: v0.5.1
-    hooks:
-      - id: action-validator


### PR DESCRIPTION
### SUMMARY

https://github.com/apache/superset/pull/28343 fixes an issue where I had broken a specific github action workflow in a previous PR without realizing I did. If/when altering the yaml, if the yaml itsefl is valid (we have a check for that) yet the schema is not - either through passing the right data structure or required types, the action just won't run and the PR is still mergeable. 

NOTE: it's really easy to break a github action (yaml is brittle, and schema enforcement for actions is loose), and it's also really easy to miss the error message about it. The failure gets somewhat buried on the Actions tab (at the bottom of https://github.com/apache/superset/actions), which is super easy to miss.

Originally I tried the pre-commit hook, but bailed on that approach as it requires installing `action-validator` in PATH, which is not super convenient as it's a Rust package. There's a node wrapper we leverage in this action, but didn't want to extend the dev deps beyond python/pip.

Find out more about the hook here: https://github.com/mpalmer/action-validator

### TESTING

For testing, I reverted the change from #28343, and tested the bash script fails. It did and provided a nice json blob with everything wrong with the schema provided.

### SCREENSHOT
<img width="802" alt="Screenshot 2024-05-06 at 11 02 18 AM" src="https://github.com/apache/superset/assets/487433/818c9ce2-fabc-4334-a7f0-0b34ea9448d1">

