### PR TITLE
fix: Enable explore button on SQL Lab view when connected to Apache Pinot as a database

### DIFF
--- a/docs/docs/configuration/databases.mdx
+++ b/docs/docs/configuration/databases.mdx
@@ -1035,6 +1035,11 @@ The expected connection string using username and password is formatted as follo
 pinot://<username>:<password>@<pinot-broker-host>:<pinot-broker-port>/query/sql?controller=http://<pinot-controller-host>:<pinot-controller-port>/verify_ssl=true``
 ```
 
+If you want to use explore view or joins, window functions, etc. then enable [multi-stage query engine](https://docs.pinot.apache.org/reference/multi-stage-engine).
+Add below argument while creating database connection in Advanced -> Other -> ENGINE PARAMETERS
+```
+{"connect_args":{"use_multistage_engine":"true"}}
+```
 
 #### Postgres
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,7 @@ ocient = [
     "geojson",
 ]
 oracle = ["cx-Oracle>8.0.0, <8.1"]
-pinot = ["pinotdb>=0.3.3, <0.4"]
+pinot = ["pinotdb>=5.0.0, <6.0.0"]
 playwright = ["playwright>=1.37.0, <2"]
 postgres = ["psycopg2-binary==2.9.6"]
 presto = ["pyhive[presto]>=0.6.5"]

--- a/superset/db_engine_specs/pinot.py
+++ b/superset/db_engine_specs/pinot.py
@@ -25,10 +25,10 @@ from superset.db_engine_specs.base import BaseEngineSpec
 class PinotEngineSpec(BaseEngineSpec):
     engine = "pinot"
     engine_name = "Apache Pinot"
-    allows_subqueries = False
-    allows_joins = False
-    allows_alias_in_select = False
-    allows_alias_in_orderby = False
+    allows_subqueries = True
+    allows_joins = True
+    allows_alias_in_select = True
+    allows_alias_in_orderby = True
 
     # https://docs.pinot.apache.org/users/user-guide-query/supported-transformations#datetime-functions
     _time_grain_expressions = {

--- a/superset/db_engine_specs/pinot.py
+++ b/superset/db_engine_specs/pinot.py
@@ -25,10 +25,6 @@ from superset.db_engine_specs.base import BaseEngineSpec
 class PinotEngineSpec(BaseEngineSpec):
     engine = "pinot"
     engine_name = "Apache Pinot"
-    allows_subqueries = True
-    allows_joins = True
-    allows_alias_in_select = True
-    allows_alias_in_orderby = True
 
     # https://docs.pinot.apache.org/users/user-guide-query/supported-transformations#datetime-functions
     _time_grain_expressions = {


### PR DESCRIPTION
Older versions of Pinot did not support subquery, hence the explore view on SQL Lab was disabled. [Apache Pinot 1.0](https://docs.pinot.apache.org/reference/multi-stage-engine) added support for subquery, join, etc. in multi-stage query engine, so this PR enables the explore button.

### Create chart button is disabled before the fix
<img width="900" alt="create-chart-disabled" src="https://github.com/apache/superset/assets/127247229/3205c19a-8f4b-41f2-a96c-400f4cb5fda8">

### Create chart button is enabled after the fix
<img width="947" alt="Screenshot 2024-05-06 at 6 32 59 PM" src="https://github.com/apache/superset/assets/127247229/1b0b0393-970e-4d03-a5c9-d9e89be52671">

### Query in explore view
<img width="1454" alt="explore-view" src="https://github.com/apache/superset/assets/127247229/8ca58b69-314f-4082-978c-8a620592604c">

### Query with alias in SQL Lab
<img width="1039" alt="alias-in-query" src="https://github.com/apache/superset/assets/127247229/66314342-c290-4634-be53-3843daef3ee0">

### Query with alias in explore
<img width="806" alt="explore-query-with-alias" src="https://github.com/apache/superset/assets/127247229/5a6c6c40-8419-46d7-90fd-f80eb23056fd">

### ADDITIONAL INFORMATION
Fixes #13623 issue
- [x] Changes UI