### PR TITLE
chore(build): fix issue that prevent `eslint` displaying type-check report during build

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -311,7 +311,7 @@
     "eslint-plugin-translation-vars": "file:tools/eslint-plugin-translation-vars",
     "exports-loader": "^0.7.0",
     "fetch-mock": "^7.7.3",
-    "fork-ts-checker-webpack-plugin": "^6.3.3",
+    "fork-ts-checker-webpack-plugin": "^6.5.3",
     "history": "^4.10.1",
     "ignore-styles": "^5.0.1",
     "imports-loader": "^3.1.1",


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
chore(build): fix issue that prevent `eslint` displaying type-check report during build

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix issue reported in this [thread](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/issues/664) by updating related package to fixed version

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before
<img width="1071" alt="image" src="https://github.com/apache/superset/assets/41283691/60530cba-4c5a-4a27-ad4f-e87030045c2e">

After
<img width="1071" alt="image" src="https://github.com/apache/superset/assets/41283691/c405ca2e-243d-4f59-bc26-ddb7d9e59dcb">

After build, the typecheck report is properly displayed.
<img width="1071" alt="image" src="https://github.com/apache/superset/assets/41283691/a13c325e-aa83-40e7-8584-678963699f22">

<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
