### PR TITLE
fix: Scroll to top when selecting a global dashboard tab

### DIFF
--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -603,11 +603,6 @@ export function setActiveTab(tabId, prevTabId) {
   return { type: SET_ACTIVE_TAB, tabId, prevTabId };
 }
 
-export const SET_ACTIVE_TABS = 'SET_ACTIVE_TABS';
-export function setActiveTabs(activeTabs) {
-  return { type: SET_ACTIVE_TABS, activeTabs };
-}
-
 export const SET_FOCUSED_FILTER_FIELD = 'SET_FOCUSED_FILTER_FIELD';
 export function setFocusedFilterField(chartId, column) {
   return { type: SET_FOCUSED_FILTER_FIELD, chartId, column };

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -412,6 +412,7 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
   const handleChangeTab = useCallback(
     ({ pathToTabIndex }: { pathToTabIndex: string[] }) => {
       dispatch(setDirectPathToChild(pathToTabIndex));
+      window.scrollTo(0, 0);
     },
     [dispatch],
   );

--- a/superset-frontend/src/dashboard/reducers/dashboardState.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.js
@@ -38,7 +38,6 @@ import {
   SET_FOCUSED_FILTER_FIELD,
   UNSET_FOCUSED_FILTER_FIELD,
   SET_ACTIVE_TAB,
-  SET_ACTIVE_TABS,
   SET_FULL_SIZE_CHART_ID,
   ON_FILTERS_REFRESH,
   ON_FILTERS_REFRESH_SUCCESS,
@@ -187,12 +186,6 @@ export default function dashboardStateReducer(state = {}, action) {
       return {
         ...state,
         activeTabs: Array.from(newActiveTabs),
-      };
-    },
-    [SET_ACTIVE_TABS]() {
-      return {
-        ...state,
-        activeTabs: action.activeTabs,
       };
     },
     [SET_OVERRIDE_CONFIRM]() {

--- a/superset-frontend/src/dashboard/reducers/dashboardState.test.ts
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.test.ts
@@ -18,7 +18,7 @@
  */
 
 import dashboardStateReducer from './dashboardState';
-import { setActiveTab, setActiveTabs } from '../actions/dashboardState';
+import { setActiveTab } from '../actions/dashboardState';
 
 describe('DashboardState reducer', () => {
   it('SET_ACTIVE_TAB', () => {
@@ -34,17 +34,5 @@ describe('DashboardState reducer', () => {
         setActiveTab('tab2', 'tab1'),
       ),
     ).toEqual({ activeTabs: ['tab2'] });
-  });
-
-  it('SET_ACTIVE_TABS', () => {
-    expect(
-      dashboardStateReducer({ activeTabs: [] }, setActiveTabs(['tab1'])),
-    ).toEqual({ activeTabs: ['tab1'] });
-    expect(
-      dashboardStateReducer(
-        { activeTabs: ['tab1', 'tab2'] },
-        setActiveTabs(['tab3', 'tab4']),
-      ),
-    ).toEqual({ activeTabs: ['tab3', 'tab4'] });
   });
 });


### PR DESCRIPTION
### SUMMARY
This PR changes the dashboard component to scroll to top when a global tab is selected. This is to avoid the situation where a blank dashboard is shown to the user because of the previous tab scroll position. This change does not affect internal tab selections.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://github.com/apache/superset/assets/70410625/9936bba7-7259-4b49-b3fd-b87fe5396b7e

https://github.com/apache/superset/assets/70410625/e63cf3db-d5c6-4610-bd64-7249dbb21b15

### TESTING INSTRUCTIONS
Check the videos for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
