### PR TITLE
fix: update links to reference docs listing Superset issue codes

### DIFF
--- a/superset-frontend/src/components/ErrorMessage/IssueCode.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/IssueCode.test.tsx
@@ -41,6 +41,6 @@ test('should render the link', () => {
   const link = screen.getByRole('link');
   expect(link).toHaveAttribute(
     'href',
-    `https://superset.apache.org/docs/miscellaneous/issue-codes#issue-${mockedProps.code}`,
+    `https://superset.apache.org/docs/using-superset/issue-codes#issue-${mockedProps.code}`,
   );
 });

--- a/superset-frontend/src/components/ErrorMessage/IssueCode.tsx
+++ b/superset-frontend/src/components/ErrorMessage/IssueCode.tsx
@@ -28,7 +28,7 @@ export default function IssueCode({ code, message }: IssueCodeProps) {
     <>
       {message}{' '}
       <a
-        href={`https://superset.apache.org/docs/miscellaneous/issue-codes#issue-${code}`}
+        href={`https://superset.apache.org/docs/using-superset/issue-codes#issue-${code}`}
         rel="noopener noreferrer"
         target="_blank"
       >


### PR DESCRIPTION
### SUMMARY
Replaces broken links for all referenced issue codes

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://github.com/apache/superset/assets/9538230/ac8eda1a-c21d-4061-9d42-b7182c98bc51)
After:
![image](https://github.com/apache/superset/assets/9538230/dc5f372d-846d-42f2-b9d6-c217190f4c85)

### TESTING INSTRUCTIONS

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes apache/superset/issues/28388
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
