### PR TITLE
feat: catalog support for Databricks native

### DIFF
--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -143,7 +143,7 @@ export default function DatabaseSelector({
   const showCatalogSelector = !!db?.allow_multi_catalog;
   const [currentDb, setCurrentDb] = useState<DatabaseValue | undefined>();
   const [currentCatalog, setCurrentCatalog] = useState<
-    CatalogOption | undefined
+    CatalogOption | null | undefined
   >(catalog ? { label: catalog, value: catalog, title: catalog } : undefined);
   const catalogRef = useRef(catalog);
   catalogRef.current = catalog;
@@ -265,7 +265,7 @@ export default function DatabaseSelector({
 
   const schemaOptions = schemaData || EMPTY_SCHEMA_OPTIONS;
 
-  function changeCatalog(catalog: CatalogOption | undefined) {
+  function changeCatalog(catalog: CatalogOption | null | undefined) {
     setCurrentCatalog(catalog);
     setCurrentSchema(undefined);
     if (onCatalogChange && catalog?.value !== catalogRef.current) {
@@ -280,7 +280,9 @@ export default function DatabaseSelector({
   } = useCatalogs({
     dbId: currentDb?.value,
     onSuccess: (catalogs, isFetched) => {
-      if (catalogs.length === 1) {
+      if (!showCatalogSelector) {
+        changeCatalog(null);
+      } else if (catalogs.length === 1) {
         changeCatalog(catalogs[0]);
       } else if (
         !catalogs.find(
@@ -290,11 +292,15 @@ export default function DatabaseSelector({
         changeCatalog(undefined);
       }
 
-      if (isFetched) {
+      if (showCatalogSelector && isFetched) {
         addSuccessToast('List refreshed');
       }
     },
-    onError: () => handleError(t('There was an error loading the catalogs')),
+    onError: () => {
+      if (showCatalogSelector) {
+        handleError(t('There was an error loading the catalogs'));
+      }
+    },
   });
 
   const catalogOptions = catalogData || EMPTY_CATALOG_OPTIONS;
@@ -365,7 +371,7 @@ export default function DatabaseSelector({
         onChange={item => changeCatalog(item as CatalogOption)}
         options={catalogOptions}
         showSearch
-        value={currentCatalog}
+        value={currentCatalog || undefined}
       />,
       refreshIcon,
     );

--- a/superset/migrations/versions/2024-05-08_19-33_4081be5b6b74_enable_catalog_in_databricks.py
+++ b/superset/migrations/versions/2024-05-08_19-33_4081be5b6b74_enable_catalog_in_databricks.py
@@ -14,16 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Add catalog_perm to tables
+"""Enable catalog in Databricks
 
-Revision ID: 58d051681a3b
-Revises: 4a33124c18ad
-Create Date: 2024-05-01 10:52:31.458433
+Revision ID: 4081be5b6b74
+Revises: 645bb206f96c
+Create Date: 2024-05-08 19:33:18.311411
 
 """
-
-import sqlalchemy as sa
-from alembic import op
 
 from superset.migrations.shared.catalogs import (
     downgrade_catalog_perms,
@@ -31,23 +28,13 @@ from superset.migrations.shared.catalogs import (
 )
 
 # revision identifiers, used by Alembic.
-revision = "58d051681a3b"
-down_revision = "4a33124c18ad"
+revision = "4081be5b6b74"
+down_revision = "645bb206f96c"
 
 
 def upgrade():
-    op.add_column(
-        "tables",
-        sa.Column("catalog_perm", sa.String(length=1000), nullable=True),
-    )
-    op.add_column(
-        "slices",
-        sa.Column("catalog_perm", sa.String(length=1000), nullable=True),
-    )
-    upgrade_catalog_perms(engine="postgresql")
+    upgrade_catalog_perms(engine="databricks")
 
 
 def downgrade():
-    op.drop_column("slices", "catalog_perm")
-    op.drop_column("tables", "catalog_perm")
-    downgrade_catalog_perms(engine="postgresql")
+    downgrade_catalog_perms(engine="databricks")

--- a/superset/utils/pandas_postprocessing/contribution.py
+++ b/superset/utils/pandas_postprocessing/contribution.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 from __future__ import annotations
 
 from decimal import Decimal

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -368,8 +368,8 @@ class TestDatasetApi(SupersetTestCase):
         expected_result = {
             "cache_timeout": None,
             "database": {
-                "backend": main_db.backend,
                 "allow_multi_catalog": False,
+                "backend": main_db.backend,
                 "database_name": "examples",
                 "id": 1,
             },

--- a/tests/unit_tests/db_engine_specs/test_databricks.py
+++ b/tests/unit_tests/db_engine_specs/test_databricks.py
@@ -245,3 +245,22 @@ def test_convert_dttm(
     from superset.db_engine_specs.databricks import DatabricksNativeEngineSpec as spec
 
     assert_convert_dttm(spec, target_type, expected_result, dttm)
+
+
+def test_get_prequeries() -> None:
+    """
+    Test the ``get_prequeries`` method.
+    """
+    from superset.db_engine_specs.databricks import DatabricksNativeEngineSpec
+
+    assert DatabricksNativeEngineSpec.get_prequeries() == []
+    assert DatabricksNativeEngineSpec.get_prequeries(schema="test") == [
+        "USE SCHEMA test",
+    ]
+    assert DatabricksNativeEngineSpec.get_prequeries(catalog="test") == [
+        "USE CATALOG test",
+    ]
+    assert DatabricksNativeEngineSpec.get_prequeries(catalog="foo", schema="bar") == [
+        "USE CATALOG foo",
+        "USE SCHEMA bar",
+    ]

--- a/tests/unit_tests/migrations/shared/__init__.py
+++ b/tests/unit_tests/migrations/shared/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/unit_tests/migrations/shared/catalogs_test.py
+++ b/tests/unit_tests/migrations/shared/catalogs_test.py
@@ -1,0 +1,145 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from pytest_mock import MockerFixture
+from sqlalchemy.orm.session import Session
+
+from superset.migrations.shared.catalogs import (
+    downgrade_catalog_perms,
+    upgrade_catalog_perms,
+)
+from superset.migrations.shared.security_converge import ViewMenu
+
+
+def test_upgrade_catalog_perms(mocker: MockerFixture, session: Session) -> None:
+    """
+    Test the `upgrade_catalog_perms` function.
+
+    The function is called when catalogs are introduced into a new DB engine spec. When
+    that happens, we need to update the `catalog` attribute so it points to the default
+    catalog, instead of being `NULL`. We also need to update `schema_perms` to include
+    the default catalog.
+    """
+    from superset.connectors.sqla.models import SqlaTable
+    from superset.models.core import Database
+    from superset.models.slice import Slice
+    from superset.models.sql_lab import Query, SavedQuery, TableSchema, TabState
+
+    engine = session.get_bind()
+    Database.metadata.create_all(engine)
+
+    mocker.patch("superset.migrations.shared.catalogs.op")
+    db = mocker.patch("superset.migrations.shared.catalogs.db")
+    db.Session.return_value = session
+
+    mocker.patch.object(
+        Database,
+        "get_all_schema_names",
+        return_value=["public", "information_schema"],
+    )
+
+    database = Database(
+        database_name="my_db",
+        sqlalchemy_uri="postgresql://localhost/db",
+    )
+    dataset = SqlaTable(
+        table_name="my_table",
+        database=database,
+        catalog=None,
+        schema="public",
+        schema_perm="[my_db].[public]",
+    )
+    session.add(dataset)
+    session.commit()
+
+    chart = Slice(
+        slice_name="my_chart",
+        datasource_type="table",
+        datasource_id=dataset.id,
+    )
+    query = Query(
+        client_id="foo",
+        database=database,
+        catalog=None,
+        schema="public",
+    )
+    saved_query = SavedQuery(
+        database=database,
+        sql="SELECT * FROM public.t",
+        catalog=None,
+        schema="public",
+    )
+    tab_state = TabState(
+        database=database,
+        catalog=None,
+        schema="public",
+    )
+    table_schema = TableSchema(
+        database=database,
+        catalog=None,
+        schema="public",
+    )
+    session.add_all([chart, query, saved_query, tab_state, table_schema])
+    session.commit()
+
+    # before migration
+    assert dataset.catalog is None
+    assert query.catalog is None
+    assert saved_query.catalog is None
+    assert tab_state.catalog is None
+    assert table_schema.catalog is None
+    assert dataset.schema_perm == "[my_db].[public]"
+    assert chart.schema_perm == "[my_db].[public]"
+    assert session.query(ViewMenu.name).all() == [
+        ("[my_db].(id:1)",),
+        ("[my_db].[my_table](id:1)",),
+        ("[my_db].[public]",),
+    ]
+
+    upgrade_catalog_perms()
+
+    # after migration
+    assert dataset.catalog == "db"
+    assert query.catalog == "db"
+    assert saved_query.catalog == "db"
+    assert tab_state.catalog == "db"
+    assert table_schema.catalog == "db"
+    assert dataset.schema_perm == "[my_db].[db].[public]"
+    assert chart.schema_perm == "[my_db].[db].[public]"
+    assert session.query(ViewMenu.name).all() == [
+        ("[my_db].(id:1)",),
+        ("[my_db].[my_table](id:1)",),
+        ("[my_db].[db].[public]",),
+        ("[my_db].[db]",),
+    ]
+
+    downgrade_catalog_perms()
+
+    # revert
+    assert dataset.catalog is None
+    assert query.catalog is None
+    assert saved_query.catalog is None
+    assert tab_state.catalog is None
+    assert table_schema.catalog is None
+    assert dataset.schema_perm == "[my_db].[public]"
+    assert chart.schema_perm == "[my_db].[public]"
+    assert session.query(ViewMenu.name).all() == [
+        ("[my_db].(id:1)",),
+        ("[my_db].[my_table](id:1)",),
+        ("[my_db].[public]",),
+        ("[my_db].[db]",),
+    ]


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add support for catalogs in Databricks, and improve the migration that updates permissions and models with the catalog.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

<img width="932" alt="Screen Shot 2024-05-09 at 9 51 57 AM" src="https://github.com/apache/superset/assets/1534870/3b28238a-71b7-4109-8098-bd2995e73e05">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Before running the upgrade, add a Databricks database, create a dataset, make a chart, run and save a query. They all should have no catalog information:

```sql
databricks_catalogs=# SELECT catalog FROM saved_query UNION ALL SELECT catalog FROM query UNION ALL SELECT catalog FROM tab_state UNION ALL SELECT catalog FROM table_schema UNION ALL SELECT catalog FROM tables;
 catalog
---------





(5 rows)

databricks_catalogs=# SELECT schema_perm FROM slices UNION ALL SELECT schema_perm FROM tables;      schema_perm
------------------------
 [Databricks].[default]
 [Databricks].[default]
(2 rows)

databricks_catalogs=# SELECT * FROM ab_view_menu JOIN ab_permission_view ON ab_view_menu.id = view_menu_id JOIN ab_permission ON ab_permission.id = permission_id WHERE ab_permission.name IN ('schema_access', 'catalog_access');
 id  |             name              | id  | permission_id | view_menu_id | id |      name
-----+-------------------------------+-----+---------------+--------------+----+----------------
  76 | [Databricks].[default]        | 167 |            74 |           76 | 74 | schema_access
(1 row)
```

Run the upgrade, and check that the catalog is present:

```sql
databricks_catalogs=# SELECT catalog FROM saved_query UNION ALL SELECT catalog FROM query UNION ALL SELECT catalog FROM tab_state UNION ALL SELECT catalog FROM table_schema UNION ALL SELECT catalog FROM tables;
    catalog
----------------
 hive_metastore
 hive_metastore
 hive_metastore
 hive_metastore
 hive_metastore
(5 rows)

databricks_catalogs=# SELECT schema_perm FROM slices UNION ALL SELECT schema_perm FROM tables;
               schema_perm
-----------------------------------------
 [Databricks].[hive_metastore].[default]
 [Databricks].[hive_metastore].[default]
(2 rows)

databricks_catalogs=# SELECT * FROM ab_view_menu JOIN ab_permission_view ON ab_view_menu.id = view_menu_id JOIN ab_permission ON ab_permission.id = permission_id WHERE ab_permission.name IN ('schema_access', 'catalog_access');
 id  |                  name                   | id  | permission_id | view_menu_id | id |      name
-----+-----------------------------------------+-----+---------------+--------------+----+----------------
  76 | [Databricks].[hive_metastore].[default] | 167 |            74 |           76 | 74 | schema_access
 110 | [Databricks].[hive_metastore]           | 192 |            76 |          110 | 76 | catalog_access
(3 rows)
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
