### PR TITLE
fix(dashboard): Change class name on last Droppable in a column

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Column.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Column.jsx
@@ -271,58 +271,41 @@ class Column extends React.PureComponent {
                 ) : (
                   columnItems.map((componentId, itemIndex) => (
                     <React.Fragment key={componentId}>
-                      <ResizableContainer
-                        id={columnComponent.id}
-                        adjustableWidth
-                        adjustableHeight={false}
-                        widthStep={columnWidth}
-                        widthMultiple={columnComponent.meta.width}
-                        minWidthMultiple={minColumnWidth}
-                        maxWidthMultiple={
-                          availableColumnCount +
-                          (columnComponent.meta.width || 0)
-                        }
+                      <DashboardComponent
+                        id={componentId}
+                        parentId={columnComponent.id}
+                        depth={depth + 1}
+                        index={itemIndex}
+                        availableColumnCount={columnComponent.meta.width}
+                        columnWidth={columnWidth}
                         onResizeStart={onResizeStart}
                         onResize={onResize}
                         onResizeStop={onResizeStop}
-                        editMode={editMode}
-                      >
-                        <DashboardComponent
-                          id={componentId}
-                          parentId={columnComponent.id}
-                          depth={depth + 1}
-                          index={itemIndex}
-                          availableColumnCount={columnComponent.meta.width}
-                          columnWidth={columnWidth}
-                          onResizeStart={onResizeStart}
-                          onResize={onResize}
-                          onResizeStop={onResizeStop}
-                          isComponentVisible={isComponentVisible}
-                          onChangeTab={onChangeTab}
-                        />
-                        {editMode && (
-                          <Droppable
-                            component={columnItems}
-                            parentComponent={columnComponent}
-                            depth={depth}
-                            index={itemIndex + 1}
-                            orientation="column"
-                            onDrop={handleComponentDrop}
-                            className={cx(
-                              'empty-droptarget',
-                              itemIndex === columnItems.length - 1 &&
-                                'droptarget-edge',
-                            )}
-                            editMode
-                          >
-                            {({ dropIndicatorProps }) =>
-                              dropIndicatorProps && (
-                                <div {...dropIndicatorProps} />
-                              )
-                            }
-                          </Droppable>
-                        )}
-                      </ResizableContainer>
+                        isComponentVisible={isComponentVisible}
+                        onChangeTab={onChangeTab}
+                      />
+                      {editMode && (
+                        <Droppable
+                          component={columnItems}
+                          parentComponent={columnComponent}
+                          depth={depth}
+                          index={itemIndex + 1}
+                          orientation="column"
+                          onDrop={handleComponentDrop}
+                          className={cx(
+                            'empty-droptarget',
+                            itemIndex === columnItems.length - 1 &&
+                              'droptarget-edge-last',
+                          )}
+                          editMode
+                        >
+                          {({ dropIndicatorProps }) =>
+                            dropIndicatorProps && (
+                              <div {...dropIndicatorProps} />
+                            )
+                          }
+                        </Droppable>
+                      )}
                     </React.Fragment>
                   ))
                 )}

--- a/superset-frontend/src/dashboard/components/gridComponents/Column.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Column.jsx
@@ -271,41 +271,58 @@ class Column extends React.PureComponent {
                 ) : (
                   columnItems.map((componentId, itemIndex) => (
                     <React.Fragment key={componentId}>
-                      <DashboardComponent
-                        id={componentId}
-                        parentId={columnComponent.id}
-                        depth={depth + 1}
-                        index={itemIndex}
-                        availableColumnCount={columnComponent.meta.width}
-                        columnWidth={columnWidth}
+                      <ResizableContainer
+                        id={columnComponent.id}
+                        adjustableWidth
+                        adjustableHeight={false}
+                        widthStep={columnWidth}
+                        widthMultiple={columnComponent.meta.width}
+                        minWidthMultiple={minColumnWidth}
+                        maxWidthMultiple={
+                          availableColumnCount +
+                          (columnComponent.meta.width || 0)
+                        }
                         onResizeStart={onResizeStart}
                         onResize={onResize}
                         onResizeStop={onResizeStop}
-                        isComponentVisible={isComponentVisible}
-                        onChangeTab={onChangeTab}
-                      />
-                      {editMode && (
-                        <Droppable
-                          component={columnItems}
-                          parentComponent={columnComponent}
-                          depth={depth}
-                          index={itemIndex + 1}
-                          orientation="column"
-                          onDrop={handleComponentDrop}
-                          className={cx(
-                            'empty-droptarget',
-                            itemIndex === columnItems.length - 1 &&
-                              'droptarget-edge',
-                          )}
-                          editMode
-                        >
-                          {({ dropIndicatorProps }) =>
-                            dropIndicatorProps && (
-                              <div {...dropIndicatorProps} />
-                            )
-                          }
-                        </Droppable>
-                      )}
+                        editMode={editMode}
+                      >
+                        <DashboardComponent
+                          id={componentId}
+                          parentId={columnComponent.id}
+                          depth={depth + 1}
+                          index={itemIndex}
+                          availableColumnCount={columnComponent.meta.width}
+                          columnWidth={columnWidth}
+                          onResizeStart={onResizeStart}
+                          onResize={onResize}
+                          onResizeStop={onResizeStop}
+                          isComponentVisible={isComponentVisible}
+                          onChangeTab={onChangeTab}
+                        />
+                        {editMode && (
+                          <Droppable
+                            component={columnItems}
+                            parentComponent={columnComponent}
+                            depth={depth}
+                            index={itemIndex + 1}
+                            orientation="column"
+                            onDrop={handleComponentDrop}
+                            className={cx(
+                              'empty-droptarget',
+                              itemIndex === columnItems.length - 1 &&
+                                'droptarget-edge',
+                            )}
+                            editMode
+                          >
+                            {({ dropIndicatorProps }) =>
+                              dropIndicatorProps && (
+                                <div {...dropIndicatorProps} />
+                              )
+                            }
+                          </Droppable>
+                        )}
+                      </ResizableContainer>
                     </React.Fragment>
                   ))
                 )}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is meant to allow resizing of each item in a column. No longer will the last child be bereft of resizing capabilities.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
B:
![no-resize-column-ezgif com-optimize](https://github.com/apache/superset/assets/92495987/0872018c-676b-4a83-85d0-ccc834165cec)
A:
![ezgif com-optimize](https://github.com/apache/superset/assets/92495987/99f82048-792e-4617-b221-489dfd62b76b)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #28209
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
