### PR TITLE
chore: deprecate old Dashboard endpoints

### DIFF
--- a/superset/views/css_templates.py
+++ b/superset/views/css_templates.py
@@ -59,4 +59,4 @@ class CssTemplateAsyncModelView(  # pylint: disable=too-many-ancestors
     @permission_name("list")
     @deprecated(eol_version="5.0.0")
     def api_read(self) -> FlaskResponse:
-        return self.api_read()
+        return super().api_read()

--- a/superset/views/dashboard/views.py
+++ b/superset/views/dashboard/views.py
@@ -16,18 +16,22 @@
 # under the License.
 import builtins
 import json
-import re
 from typing import Callable, Union
 
 from flask import g, redirect, request, Response
 from flask_appbuilder import expose
 from flask_appbuilder.actions import action
+from flask_appbuilder.baseviews import expose_api
 from flask_appbuilder.models.sqla.interface import SQLAInterface
-from flask_appbuilder.security.decorators import has_access
+from flask_appbuilder.security.decorators import (
+    has_access,
+    has_access_api,
+    permission_name,
+)
 from flask_babel import gettext as __, lazy_gettext as _
 from flask_login import AnonymousUserMixin, login_user
 
-from superset import db, event_logger, is_feature_enabled, security_manager
+from superset import db, event_logger, is_feature_enabled
 from superset.constants import MODEL_VIEW_RW_METHOD_PERMISSION_MAP, RouteMethod
 from superset.models.dashboard import Dashboard as DashboardModel
 from superset.superset_typing import FlaskResponse
@@ -36,6 +40,7 @@ from superset.views.base import (
     BaseSupersetView,
     common_bootstrap_payload,
     DeleteMixin,
+    deprecated,
     generate_download_headers,
     SupersetModelView,
 )
@@ -50,11 +55,26 @@ class DashboardModelView(DashboardMixin, SupersetModelView, DeleteMixin):  # pyl
     class_permission_name = "Dashboard"
     method_permission_name = MODEL_VIEW_RW_METHOD_PERMISSION_MAP
 
-    include_route_methods = RouteMethod.CRUD_SET | {
+    include_route_methods = {
+        RouteMethod.LIST,
         RouteMethod.API_READ,
         RouteMethod.API_DELETE,
         "download_dashboards",
     }
+
+    @expose_api(name="read", url="/api/read", methods=["GET"])
+    @has_access_api
+    @permission_name("list")
+    @deprecated(eol_version="5.0.0")
+    def api_read(self) -> FlaskResponse:
+        return super().api_read()
+
+    @expose_api(name="delete", url="/api/delete/<pk>", methods=["DELETE"])
+    @has_access_api
+    @permission_name("delete")
+    @deprecated(eol_version="5.0.0")
+    def api_delete(self, pk: int) -> FlaskResponse:
+        return super().delete(pk)
 
     @has_access
     @expose("/list/")
@@ -74,6 +94,7 @@ class DashboardModelView(DashboardMixin, SupersetModelView, DeleteMixin):  # pyl
     @event_logger.log_this
     @has_access
     @expose("/export_dashboards_form")
+    @deprecated(eol_version="5.0.0")
     def download_dashboards(self) -> FlaskResponse:
         if request.args.get("action") == "go":
             ids = set(request.args.getlist("id"))
@@ -85,23 +106,6 @@ class DashboardModelView(DashboardMixin, SupersetModelView, DeleteMixin):  # pyl
         return self.render_template(
             "superset/export_dashboards.html", dashboards_url="/dashboard/list"
         )
-
-    def pre_add(self, item: "DashboardModelView") -> None:
-        item.slug = item.slug or None
-        if item.slug:
-            item.slug = item.slug.strip()
-            item.slug = item.slug.replace(" ", "-")
-            item.slug = re.sub(r"[^\w\-]+", "", item.slug)
-        if g.user not in item.owners:
-            item.owners.append(g.user)
-        utils.validate_json(item.json_metadata)
-        utils.validate_json(item.position_json)
-        for slc in item.slices:
-            slc.owners = list(set(item.owners) | set(slc.owners))
-
-    def pre_update(self, item: "DashboardModelView") -> None:
-        security_manager.raise_for_ownership(item)
-        self.pre_add(item)
 
 
 class Dashboard(BaseSupersetView):
@@ -185,3 +189,10 @@ class DashboardModelViewAsync(DashboardModelView):  # pylint: disable=too-many-a
         "creator": _("Creator"),
         "modified": _("Modified"),
     }
+
+    @expose_api(name="read", url="/api/read", methods=["GET"])
+    @has_access_api
+    @permission_name("list")
+    @deprecated(eol_version="5.0.0")
+    def api_read(self) -> FlaskResponse:
+        return super().api_read()


### PR DESCRIPTION
### SUMMARY
Removing server side rendered pages endpoints from Dashboard view.
Also deprecating:
- `dashboard/api/read`
- `dashboard/api/delete`
- `dashboard/export_dashboards_form`
- `dashboardasync/api/read`


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
