### PR TITLE
fix: table autocomplete should pass catalog

### DIFF
--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.test.ts
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.test.ts
@@ -61,6 +61,7 @@ const fakeFunctionNamesApiResult = {
 };
 
 const expectDbId = 1;
+const expectCatalog = null;
 const expectSchema = 'schema1';
 
 beforeEach(() => {
@@ -228,7 +229,12 @@ test('returns column keywords among selected tables', async () => {
       ),
     );
     storeWithSqlLab.dispatch(
-      addTable({ id: expectQueryEditorId }, expectTable, expectSchema),
+      addTable(
+        { id: expectQueryEditorId },
+        expectTable,
+        expectCatalog,
+        expectSchema,
+      ),
     );
   });
 
@@ -267,7 +273,12 @@ test('returns column keywords among selected tables', async () => {
 
   act(() => {
     storeWithSqlLab.dispatch(
-      addTable({ id: expectQueryEditorId }, unexpectedTable, expectSchema),
+      addTable(
+        { id: expectQueryEditorId },
+        unexpectedTable,
+        expectCatalog,
+        expectSchema,
+      ),
     );
   });
 

--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.ts
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.ts
@@ -146,7 +146,9 @@ export function useKeywords(
 
   const insertMatch = useEffectEvent((editor: Editor, data: any) => {
     if (data.meta === 'table') {
-      dispatch(addTable({ id: queryEditorId, dbId }, data.value, schema));
+      dispatch(
+        addTable({ id: queryEditorId, dbId }, data.value, catalog, schema),
+      );
     }
 
     let { caption } = data;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When autocompleting a table name in SQL Lab we should include the catalog in the metadata.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
