### PR TITLE
fix(SIP-95): missing catalog cache key

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/SqlEditorLeftBar.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/SqlEditorLeftBar.test.tsx
@@ -18,7 +18,7 @@
  */
 import React from 'react';
 import fetchMock from 'fetch-mock';
-import { render, screen, waitFor } from 'spec/helpers/testing-library';
+import { render, screen, waitFor, within } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
 import SqlEditorLeftBar, {
   SqlEditorLeftBarProps,
@@ -107,14 +107,11 @@ test('renders a TableElement', async () => {
 });
 
 test('table should be visible when expanded is true', async () => {
-  const { container, getByText, getByRole } = await renderAndWait(
-    mockedProps,
-    undefined,
-    {
+  const { container, getByText, getByRole, getAllByLabelText } =
+    await renderAndWait(mockedProps, undefined, {
       ...initialState,
       sqlLab: { ...initialState.sqlLab, tables: [table] },
-    },
-  );
+    });
 
   const dbSelect = getByRole('combobox', {
     name: 'Select database or type to search databases',
@@ -122,14 +119,16 @@ test('table should be visible when expanded is true', async () => {
   const schemaSelect = getByRole('combobox', {
     name: 'Select schema or type to search schemas',
   });
-  const dropdown = getByText(/Select table/i);
-  const abUser = getByText(/ab_user/i);
+  const tableSelect = getAllByLabelText(
+    /Select table or type to search tables/i,
+  )[0];
+  const tableOption = within(tableSelect).getByText(/ab_user/i);
 
   expect(getByText(/Database/i)).toBeInTheDocument();
   expect(dbSelect).toBeInTheDocument();
   expect(schemaSelect).toBeInTheDocument();
-  expect(dropdown).toBeInTheDocument();
-  expect(abUser).toBeInTheDocument();
+  expect(tableSelect).toBeInTheDocument();
+  expect(tableOption).toBeInTheDocument();
   expect(
     container.querySelector('.ant-collapse-content-active'),
   ).toBeInTheDocument();

--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -278,7 +278,7 @@ export default function DatabaseSelector({
     isFetching: loadingCatalogs,
     refetch: refetchCatalogs,
   } = useCatalogs({
-    dbId: currentDb?.value,
+    dbId: showCatalogSelector ? currentDb?.value : undefined,
     onSuccess: (catalogs, isFetched) => {
       if (catalogs.length === 1) {
         changeCatalog(catalogs[0]);

--- a/superset-frontend/src/hooks/apiResources/schemas.ts
+++ b/superset-frontend/src/hooks/apiResources/schemas.ts
@@ -54,8 +54,9 @@ const schemaApi = api.injectEndpoints({
             title: value,
           })),
       }),
-      serializeQueryArgs: ({ queryArgs: { dbId } }) => ({
+      serializeQueryArgs: ({ queryArgs: { dbId, catalog } }) => ({
         dbId,
+        catalog,
       }),
     }),
   }),


### PR DESCRIPTION
### SUMMARY
This commit aims to resolve the bugs that were introduced by SIP-95 (#28376).

- Avoid fetching catalog API when multi-catalog is not allowed.
- Fix cache key collision on schema caused by missing composite catalog key. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

|Before|After|
|--|--|
|![Screenshot 2024-05-09 at 11 02 06 AM](https://github.com/apache/superset/assets/1392866/c5e60e32-e6f2-4e05-a0bd-4797f19a1e43)|![Screenshot 2024-05-09 at 11 05 11 AM](https://github.com/apache/superset/assets/1392866/d5fc671d-73fe-486e-8d06-057e8ae3feb8)|
|![Screenshot 2024-05-09 at 11 08 30 AM](https://github.com/apache/superset/assets/1392866/05664469-c69a-4ba4-ac9c-9019b2dcc4fb)|![Screenshot 2024-05-09 at 11 08 08 AM](https://github.com/apache/superset/assets/1392866/693c8bb2-6da2-4b3a-b339-c7a48c1b256f)|

### TESTING INSTRUCTIONS
Go to SQL Lab and check the network tab checking `api/v1/catalog`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
