### PR TITLE
feat: add support for catalogs

### DIFF
--- a/superset/db_engine_specs/README.md
+++ b/superset/db_engine_specs/README.md
@@ -706,29 +706,11 @@ Hive and Trino:
 4. Table
 5. Column
 
-If the database supports catalogs, then the DB engine spec should have the `supports_catalog` class attribute set to true.
+If the database supports catalogs, then the DB engine spec should have the `supports_catalog` class attribute set to true. It should also implement the `get_default_catalog` method, so that the proper permissions can be created when datasets are added.
 
 ### Dynamic catalog
 
-Superset has no support for multiple catalogs. A given SQLAlchemy URI connects to a single catalog, and it's impossible to browse other catalogs, or change the catalog. This means that datasets can only be added for the main catalog of the database. For example, with this Postgres SQLAlchemy URI:
-
-```
-postgresql://admin:password123@db.example.org:5432/db
-```
-
-Here, datasets can only be added to the `db` catalog (which Postgres calls a "database").
-
-One confusing problem is that many databases allow querying across catalogs in SQL Lab. For example, with BigQuery one can write:
-
-```sql
-SELECT * FROM project.schema.table
-```
-
-This means that **even though the database is configured for a given catalog (project), users can query other projects**. This is a common workaround for creating datasets in catalogs other than the catalog configured in the database: just create a virtual dataset.
-
-Ideally we would want users to be able to choose the catalog when using SQL Lab and when creating datasets. In order to do that, DB engine specs need to implement a method that rewrites the SQLAlchemy URI depending on the desired catalog. This method already exists, and is the same method used for dynamic schemas, `adjust_engine_params`, but currently there are no UI affordances for choosing a catalog.
-
-Before the UI is implemented Superset still needs to implement support for catalogs in its security manager. But in the meantime, it's possible for DB engine spec developers to support dynamic catalogs, by setting `supports_dynamic_catalog` to true and implementing `adjust_engine_params` to handle a catalog.
+Superset support for multiple catalogs. Since, in general, a given SQLAlchemy URI connects only to a single catalog, it requires DB engine specs to implement the `adjust_engine_params` method to rewrite the URL to connect to a different catalog, similar to how dynamic schemas work. Additionally, DB engine specs should also implement the `get_catalog_names` method, so that users can browse the available catalogs.
 
 ### SSH tunneling
 

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -14,7 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 # pylint: disable=too-many-lines
+
 from __future__ import annotations
 
 import contextlib
@@ -165,6 +167,7 @@ class PrestoBaseEngineSpec(BaseEngineSpec, metaclass=ABCMeta):
     """
 
     supports_dynamic_schema = True
+    supports_catalog = supports_dynamic_catalog = True
 
     column_type_mappings = (
         (
@@ -296,6 +299,24 @@ class PrestoBaseEngineSpec(BaseEngineSpec, metaclass=ABCMeta):
         return "from_unixtime({col})"
 
     @classmethod
+    def get_default_catalog(cls, database: "Database") -> str | None:
+        """
+        Return the default catalog.
+        """
+        return database.url_object.database.split("/")[0]
+
+    @classmethod
+    def get_catalog_names(
+        cls,
+        database: Database,
+        inspector: Inspector,
+    ) -> set[str]:
+        """
+        Get all catalogs.
+        """
+        return {catalog for (catalog,) in inspector.bind.execute("SHOW CATALOGS")}
+
+    @classmethod
     def adjust_engine_params(
         cls,
         uri: URL,
@@ -303,14 +324,22 @@ class PrestoBaseEngineSpec(BaseEngineSpec, metaclass=ABCMeta):
         catalog: str | None = None,
         schema: str | None = None,
     ) -> tuple[URL, dict[str, Any]]:
-        database = uri.database
-        if schema and database:
+        if uri.database and "/" in uri.database:
+            current_catalog, current_schema = uri.database.split("/", 1)
+        else:
+            current_catalog, current_schema = uri.database, None
+
+        if schema:
             schema = parse.quote(schema, safe="")
-            if "/" in database:
-                database = database.split("/")[0] + "/" + schema
-            else:
-                database += "/" + schema
-            uri = uri.set(database=database)
+
+        adjusted_database = "/".join(
+            [
+                catalog or current_catalog or "",
+                schema or current_schema or "",
+            ]
+        ).rstrip("/")
+
+        uri = uri.set(database=adjusted_database)
 
         return uri, connect_args
 
@@ -648,8 +677,6 @@ class PrestoEngineSpec(PrestoBaseEngineSpec):
     engine_name = "Presto"
     allows_alias_to_source_column = False
 
-    supports_catalog = False
-
     custom_errors: dict[Pattern[str], tuple[str, SupersetErrorType, dict[str, Any]]] = {
         COLUMN_DOES_NOT_EXIST_REGEX: (
             __(
@@ -811,17 +838,6 @@ class PrestoEngineSpec(PrestoBaseEngineSpec):
             cursor.execute(sql, params)
             results = cursor.fetchall()
             return {row[0] for row in results}
-
-    @classmethod
-    def get_catalog_names(
-        cls,
-        database: Database,
-        inspector: Inspector,
-    ) -> set[str]:
-        """
-        Get all catalogs.
-        """
-        return {catalog for (catalog,) in inspector.bind.execute("SHOW CATALOGS")}
 
     @classmethod
     def _create_column_info(
@@ -1248,7 +1264,6 @@ class PrestoEngineSpec(PrestoBaseEngineSpec):
                 ),
             }
 
-        # flake8 is not matching `Optional[str]` to `Any` for some reason...
         metadata["view"] = cast(
             Any,
             cls.get_create_view(database, table.schema, table.table),

--- a/superset/migrations/shared/catalogs.py
+++ b/superset/migrations/shared/catalogs.py
@@ -86,7 +86,7 @@ class Slice(Base):
     schema_perm = sa.Column(sa.String(1000))
 
 
-def upgrade_catalog_perms(engine: str | None = None) -> None:
+def upgrade_catalog_perms(engines: set[str] | None = None) -> None:
     """
     Update models when catalogs are introduced in a DB engine spec.
 
@@ -102,7 +102,7 @@ def upgrade_catalog_perms(engine: str | None = None) -> None:
     for database in session.query(Database).all():
         db_engine_spec = database.db_engine_spec
         if (
-            engine and db_engine_spec.engine != engine
+            engines and db_engine_spec.engine not in engines
         ) or not db_engine_spec.supports_catalog:
             continue
 
@@ -166,7 +166,7 @@ def upgrade_catalog_perms(engine: str | None = None) -> None:
     session.commit()
 
 
-def downgrade_catalog_perms(engine: str | None = None) -> None:
+def downgrade_catalog_perms(engines: set[str] | None = None) -> None:
     """
     Reverse the process of `upgrade_catalog_perms`.
     """
@@ -175,7 +175,7 @@ def downgrade_catalog_perms(engine: str | None = None) -> None:
     for database in session.query(Database).all():
         db_engine_spec = database.db_engine_spec
         if (
-            engine and db_engine_spec.engine != engine
+            engines and db_engine_spec.engine not in engines
         ) or not db_engine_spec.supports_catalog:
             continue
 

--- a/superset/migrations/versions/2024-05-01_10-52_58d051681a3b_add_catalog_perm_to_tables.py
+++ b/superset/migrations/versions/2024-05-01_10-52_58d051681a3b_add_catalog_perm_to_tables.py
@@ -44,10 +44,10 @@ def upgrade():
         "slices",
         sa.Column("catalog_perm", sa.String(length=1000), nullable=True),
     )
-    upgrade_catalog_perms(engine="postgresql")
+    upgrade_catalog_perms(engines={"postgresql"})
 
 
 def downgrade():
     op.drop_column("slices", "catalog_perm")
     op.drop_column("tables", "catalog_perm")
-    downgrade_catalog_perms(engine="postgresql")
+    downgrade_catalog_perms(engines={"postgresql"})

--- a/superset/migrations/versions/2024-05-09_18-44_87ffc36f9842_enable_catalog_in_bigquery_presto_trino_.py
+++ b/superset/migrations/versions/2024-05-09_18-44_87ffc36f9842_enable_catalog_in_bigquery_presto_trino_.py
@@ -14,11 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Enable catalog in Databricks
+"""Enable catalog in BigQuery/Presto/Trino/Snowflake
 
-Revision ID: 4081be5b6b74
-Revises: 645bb206f96c
-Create Date: 2024-05-08 19:33:18.311411
+Revision ID: 87ffc36f9842
+Revises: 4081be5b6b74
+Create Date: 2024-05-09 18:44:43.289445
 
 """
 
@@ -28,13 +28,13 @@ from superset.migrations.shared.catalogs import (
 )
 
 # revision identifiers, used by Alembic.
-revision = "4081be5b6b74"
-down_revision = "645bb206f96c"
+revision = "87ffc36f9842"
+down_revision = "4081be5b6b74"
 
 
 def upgrade():
-    upgrade_catalog_perms(engines={"databricks"})
+    upgrade_catalog_perms(engines={"trino", "presto", "bigquery", "snowflake"})
 
 
 def downgrade():
-    downgrade_catalog_perms(engines={"databricks"})
+    downgrade_catalog_perms(engines={"trino", "presto", "bigquery", "snowflake"})

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -3281,7 +3281,7 @@ class TestDatabaseApi(SupersetTestCase):
                     "sqlalchemy_uri_placeholder": "bigquery://{project_id}",
                     "engine_information": {
                         "supports_file_upload": True,
-                        "supports_dynamic_catalog": False,
+                        "supports_dynamic_catalog": True,
                         "disable_ssh_tunneling": True,
                     },
                 },

--- a/tests/integration_tests/model_tests.py
+++ b/tests/integration_tests/model_tests.py
@@ -167,7 +167,7 @@ class TestDatabaseModel(SupersetTestCase):
             model._get_sqla_engine()
             call_args = mocked_create_engine.call_args
 
-            assert str(call_args[0][0]) == "presto://gamma@localhost"
+            assert str(call_args[0][0]) == "presto://gamma@localhost/"
 
             assert call_args[1]["connect_args"] == {
                 "protocol": "https",
@@ -180,7 +180,7 @@ class TestDatabaseModel(SupersetTestCase):
             model._get_sqla_engine()
             call_args = mocked_create_engine.call_args
 
-            assert str(call_args[0][0]) == "presto://localhost"
+            assert str(call_args[0][0]) == "presto://localhost/"
 
             assert call_args[1]["connect_args"] == {
                 "protocol": "https",
@@ -225,7 +225,7 @@ class TestDatabaseModel(SupersetTestCase):
             model._get_sqla_engine()
             call_args = mocked_create_engine.call_args
 
-            assert str(call_args[0][0]) == "trino://localhost"
+            assert str(call_args[0][0]) == "trino://localhost/"
             assert call_args[1]["connect_args"]["user"] == "gamma"
 
             model = Database(
@@ -239,7 +239,7 @@ class TestDatabaseModel(SupersetTestCase):
 
             assert (
                 str(call_args[0][0])
-                == "trino://original_user:original_user_password@localhost"
+                == "trino://original_user:original_user_password@localhost/"
             )
             assert call_args[1]["connect_args"]["user"] == "gamma"
 

--- a/tests/unit_tests/db_engine_specs/test_presto.py
+++ b/tests/unit_tests/db_engine_specs/test_presto.py
@@ -155,3 +155,91 @@ def test_where_latest_partition(
     )
 
     assert str(actual) == expected
+
+
+def test_adjust_engine_params_fully_qualified() -> None:
+    """
+    Test the ``adjust_engine_params`` method when the URL has catalog and schema.
+    """
+    from superset.db_engine_specs.presto import PrestoEngineSpec
+
+    url = make_url("presto://localhost:8080/hive/default")
+
+    uri = PrestoEngineSpec.adjust_engine_params(url, {})[0]
+    assert str(uri) == "presto://localhost:8080/hive/default"
+
+    uri = PrestoEngineSpec.adjust_engine_params(
+        url,
+        {},
+        schema="new_schema",
+    )[0]
+    assert str(uri) == "presto://localhost:8080/hive/new_schema"
+
+    uri = PrestoEngineSpec.adjust_engine_params(
+        url,
+        {},
+        catalog="new_catalog",
+    )[0]
+    assert str(uri) == "presto://localhost:8080/new_catalog/default"
+
+    uri = PrestoEngineSpec.adjust_engine_params(
+        url,
+        {},
+        catalog="new_catalog",
+        schema="new_schema",
+    )[0]
+    assert str(uri) == "presto://localhost:8080/new_catalog/new_schema"
+
+
+def test_adjust_engine_params_catalog_only() -> None:
+    """
+    Test the ``adjust_engine_params`` method when the URL has only the catalog.
+    """
+    from superset.db_engine_specs.presto import PrestoEngineSpec
+
+    url = make_url("presto://localhost:8080/hive")
+
+    uri = PrestoEngineSpec.adjust_engine_params(url, {})[0]
+    assert str(uri) == "presto://localhost:8080/hive"
+
+    uri = PrestoEngineSpec.adjust_engine_params(
+        url,
+        {},
+        schema="new_schema",
+    )[0]
+    assert str(uri) == "presto://localhost:8080/hive/new_schema"
+
+    uri = PrestoEngineSpec.adjust_engine_params(
+        url,
+        {},
+        catalog="new_catalog",
+    )[0]
+    assert str(uri) == "presto://localhost:8080/new_catalog"
+
+    uri = PrestoEngineSpec.adjust_engine_params(
+        url,
+        {},
+        catalog="new_catalog",
+        schema="new_schema",
+    )[0]
+    assert str(uri) == "presto://localhost:8080/new_catalog/new_schema"
+
+
+def test_get_default_catalog() -> None:
+    """
+    Test the ``get_default_catalog`` method.
+    """
+    from superset.db_engine_specs.presto import PrestoEngineSpec
+    from superset.models.core import Database
+
+    database = Database(
+        database_name="my_db",
+        sqlalchemy_uri="presto://localhost:8080/hive",
+    )
+    assert PrestoEngineSpec.get_default_catalog(database) == "hive"
+
+    database = Database(
+        database_name="my_db",
+        sqlalchemy_uri="presto://localhost:8080/hive/default",
+    )
+    assert PrestoEngineSpec.get_default_catalog(database) == "hive"

--- a/tests/unit_tests/db_engine_specs/test_snowflake.py
+++ b/tests/unit_tests/db_engine_specs/test_snowflake.py
@@ -203,3 +203,91 @@ def test_get_schema_from_engine_params() -> None:
         )
         is None
     )
+
+
+def test_adjust_engine_params_fully_qualified() -> None:
+    """
+    Test the ``adjust_engine_params`` method when the URL has catalog and schema.
+    """
+    from superset.db_engine_specs.snowflake import SnowflakeEngineSpec
+
+    url = make_url("snowflake://user:pass@account/database_name/default")
+
+    uri = SnowflakeEngineSpec.adjust_engine_params(url, {})[0]
+    assert str(uri) == "snowflake://user:pass@account/database_name/default"
+
+    uri = SnowflakeEngineSpec.adjust_engine_params(
+        url,
+        {},
+        schema="new_schema",
+    )[0]
+    assert str(uri) == "snowflake://user:pass@account/database_name/new_schema"
+
+    uri = SnowflakeEngineSpec.adjust_engine_params(
+        url,
+        {},
+        catalog="new_catalog",
+    )[0]
+    assert str(uri) == "snowflake://user:pass@account/new_catalog/default"
+
+    uri = SnowflakeEngineSpec.adjust_engine_params(
+        url,
+        {},
+        catalog="new_catalog",
+        schema="new_schema",
+    )[0]
+    assert str(uri) == "snowflake://user:pass@account/new_catalog/new_schema"
+
+
+def test_adjust_engine_params_catalog_only() -> None:
+    """
+    Test the ``adjust_engine_params`` method when the URL has only the catalog.
+    """
+    from superset.db_engine_specs.snowflake import SnowflakeEngineSpec
+
+    url = make_url("snowflake://user:pass@account/database_name")
+
+    uri = SnowflakeEngineSpec.adjust_engine_params(url, {})[0]
+    assert str(uri) == "snowflake://user:pass@account/database_name"
+
+    uri = SnowflakeEngineSpec.adjust_engine_params(
+        url,
+        {},
+        schema="new_schema",
+    )[0]
+    assert str(uri) == "snowflake://user:pass@account/database_name/new_schema"
+
+    uri = SnowflakeEngineSpec.adjust_engine_params(
+        url,
+        {},
+        catalog="new_catalog",
+    )[0]
+    assert str(uri) == "snowflake://user:pass@account/new_catalog"
+
+    uri = SnowflakeEngineSpec.adjust_engine_params(
+        url,
+        {},
+        catalog="new_catalog",
+        schema="new_schema",
+    )[0]
+    assert str(uri) == "snowflake://user:pass@account/new_catalog/new_schema"
+
+
+def test_get_default_catalog() -> None:
+    """
+    Test the ``get_default_catalog`` method.
+    """
+    from superset.db_engine_specs.snowflake import SnowflakeEngineSpec
+    from superset.models.core import Database
+
+    database = Database(
+        database_name="my_db",
+        sqlalchemy_uri="snowflake://user:pass@account/database_name",
+    )
+    assert SnowflakeEngineSpec.get_default_catalog(database) == "database_name"
+
+    database = Database(
+        database_name="my_db",
+        sqlalchemy_uri="snowflake://user:pass@account/database_name/default",
+    )
+    assert SnowflakeEngineSpec.get_default_catalog(database) == "database_name"


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add support for catalogs to:

- Presto
- Trino
- Snowflake
- BigQuery

We already have support for Postgres and Databricks.

@john-bodley I'm worried about the DB migration here and how it will affect AirBnB. Can you take a look? The migration needs to:

- Read the default catalog for each of these 4 DBs and update the `catalog` column in a few models (`SqlaTable`, `Query`, `SavedQuery`, `TabState`, and `TableSchema`).
- Update the `schema_perm` column for any `SqlaTable` and `Slice` models in these databases.
- Rename existing permissions of type `schema_perm`.

I'm happy to hold back on this PR until we know it's safe to merge to `master`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: https://github.com/apache/superset/issues/22862
- [ ] Required feature flags:
- [ ] Changes UI
- [X] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [X] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
