### PR TITLE
fix: set supersetbot orglabel to always succeed

### DIFF
--- a/.github/workflows/issue_creation.yml
+++ b/.github/workflows/issue_creation.yml
@@ -31,4 +31,4 @@ jobs:
           # Label the issue with the appropriate org using supersetbot
           # - this requires for the author to be publicly associated with their org
           # - and for the org to be listed in `supersetbot/src/metadata.js`
-          supersetbot orglabel --issue ${{ github.event.number }} --repo ${{ github.repository }}
+          supersetbot orglabel --issue ${{ github.event.number }} --repo ${{ github.repository }} || true


### PR DESCRIPTION
For reasons I can't seem to understand or conditions I cannot reproduce,
the GHA that auto-add org labels based on user association fails for
dpgaspar.

For now I just want to set this to never fail as this is not critical in
any ways, maybe I can troubleshoot later.

