### PR TITLE
fix: run some CI tests against previous python version

### DIFF
--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -29,6 +29,8 @@ runs:
           echo "PYTHON_VERSION=3.10" >> $GITHUB_ENV
         elif [ "${{ inputs.python-version }}" = "next" ]; then
           echo "PYTHON_VERSION=3.11" >> $GITHUB_ENV
+        elif [ "${{ inputs.python-version }}" = "previous" ]; then
+          echo "PYTHON_VERSION=3.9" >> $GITHUB_ENV
         else
           echo "PYTHON_VERSION=${{ inputs.python-version }}" >> $GITHUB_ENV
         fi

--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["current", "next"]
+        python-version: ["current", "next", "previous"]
     env:
       PYTHONPATH: ${{ github.workspace }}
       SUPERSET_CONFIG: tests.integration_tests.superset_test_config


### PR DESCRIPTION
As currently python3.10 is our main version, we do run a bit of CI (not
the full matrix) against 3.11.

This is introducing doing the same for 3.9 as we do for 3.11. Check
isn't required, but should show as failed and inform something broke 3.9
support

Now that refactor/cleaned up some of the CI / GHAs, it's pretty easy to get this going.
