### PR TITLE
chore(🦾): bump python werkzeug 3.0.1 -> 3.0.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -162,7 +162,11 @@ idna==3.2
     #   email-validator
     #   requests
 importlib-metadata==6.6.0
-    # via apache-superset
+    # via
+    #   apache-superset
+    #   flask
+    #   markdown
+    #   shillelagh
 importlib-resources==5.12.0
     # via limits
 isodate==0.6.1
@@ -193,7 +197,7 @@ markdown==3.6
     # via apache-superset
 markdown-it-py==2.2.0
     # via rich
-markupsafe==2.1.1
+markupsafe==2.1.5
     # via
     #   jinja2
     #   mako
@@ -361,6 +365,7 @@ typing-extensions==4.10.0
     #   apache-superset
     #   cattrs
     #   flask-limiter
+    #   kombu
     #   limits
     #   shillelagh
 tzdata==2023.3
@@ -382,7 +387,7 @@ vine==5.1.0
     #   kombu
 wcwidth==0.2.5
     # via prompt-toolkit
-werkzeug==3.0.1
+werkzeug==3.0.3
     # via
     #   -r requirements/base.in
     #   flask
@@ -402,7 +407,9 @@ wtforms-json==0.3.5
 xlsxwriter==3.0.9
     # via apache-superset
 zipp==3.15.0
-    # via importlib-metadata
+    # via
+    #   importlib-metadata
+    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
Updates the python "werkzeug" library version from 3.0.1 to 3.0.3. 

Generated by @supersetbot 🦾