### PR TITLE
fix: Update migration logic in #27119

### DIFF
--- a/superset/migrations/shared/utils.py
+++ b/superset/migrations/shared/utils.py
@@ -34,21 +34,40 @@ logger = logging.getLogger(__name__)
 DEFAULT_BATCH_SIZE = int(os.environ.get("BATCH_SIZE", 1000))
 
 
-def table_has_column(table: str, column: str) -> bool:
+def get_table_column(
+    table_name: str,
+    column_name: str,
+) -> Optional[list[dict[str, Any]]]:
     """
-    Checks if a column exists in a given table.
+    Get the specified column.
 
-    :param table: A table name
-    :param column: A column name
-    :returns: True iff the column exists in the table
+    :param table_name: The Table name
+    :param column_name: The column name
+    :returns: The column
     """
 
     insp = inspect(op.get_context().bind)
 
     try:
-        return any(col["name"] == column for col in insp.get_columns(table))
+        for column in insp.get_columns(table_name):
+            if column["name"] == column_name:
+                return column
     except NoSuchTableError:
-        return False
+        pass
+
+    return None
+
+
+def table_has_column(table_name: str, column_name: str) -> bool:
+    """
+    Checks if a column exists in a given table.
+
+    :param table_name: A table name
+    :param column_name: A column name
+    :returns: True iff the column exists in the table
+    """
+
+    return bool(get_table_column(table_name, column_name))
 
 
 def table_has_index(table: str, index: str) -> bool:

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -59,7 +59,13 @@ from superset.models.helpers import (
 )
 from superset.sql_parse import CtasMethod, extract_tables_from_jinja_sql, Table
 from superset.sqllab.limiting_factor import LimitingFactor
-from superset.utils.core import get_column_name, MediumText, QueryStatus, user_label
+from superset.utils.core import (
+    get_column_name,
+    LongText,
+    MediumText,
+    QueryStatus,
+    user_label,
+)
 
 if TYPE_CHECKING:
     from superset.connectors.sqla.models import TableColumn
@@ -110,11 +116,11 @@ class Query(
     sql_editor_id = Column(String(256), index=True)
     schema = Column(String(256))
     catalog = Column(String(256), nullable=True, default=None)
-    sql = Column(MediumText())
+    sql = Column(LongText())
     # Query to retrieve the results,
     # used only in case of select_as_cta_used is true.
-    select_sql = Column(MediumText())
-    executed_sql = Column(MediumText())
+    select_sql = Column(LongText())
+    executed_sql = Column(LongText())
     # Could be configured in the superset config.
     limit = Column(Integer)
     limiting_factor = Column(

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -70,7 +70,7 @@ from markupsafe import Markup
 from pandas.api.types import infer_dtype
 from pandas.core.dtypes.common import is_numeric_dtype
 from sqlalchemy import event, exc, inspect, select, Text
-from sqlalchemy.dialects.mysql import MEDIUMTEXT
+from sqlalchemy.dialects.mysql import LONGTEXT, MEDIUMTEXT
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.sql.type_api import Variant
@@ -1495,6 +1495,10 @@ def time_function(
 
 def MediumText() -> Variant:  # pylint:disable=invalid-name
     return Text().with_variant(MEDIUMTEXT(), "mysql")
+
+
+def LongText() -> Variant:  # pylint:disable=invalid-name
+    return Text().with_variant(LONGTEXT(), "mysql")
 
 
 def shortid() -> str:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

I realize it's generally perceived as poor form to change an existing migration, however per [here](https://github.com/apache/superset/blob/f29e1e4c29a46f7d607cfa59adb8bb21d107091c/superset/migrations/versions/2019-05-06_14-30_afc69274c25a_alter_sql_column_data_type_in_query_mysql_table.py#L36-L46) the `query. executed_sql` and `query. select_sql` were previously defined as type `LONGTEXT` rather than `TEXT`, thus  https://github.com/apache/superset/pull/27119 resulted in:

1. Downsizing these columns to `MEDIUMTEXT` could result in data loss.
2. Altering the `query` table unnecessarily can be rather expensive given the size of the table. 

This PR remove mutating these columns unnecessarily.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Tested the migration using a MySQL metadata database.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
