### PR TITLE
fix: move to slack-sdk files_upload_v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ dependencies = [
     "shortid",
     "sshtunnel>=0.4.0, <0.5",
     "simplejson>=3.15.0",
-    "slack_sdk>=3.19.0",
+    "slack_sdk>=3.19.0, <4",
     "sqlalchemy>=1.4, <2",
     "sqlalchemy-utils>=0.38.3, <0.39",
     "sqlglot>=23.0.2,<24",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ dependencies = [
     "shortid",
     "sshtunnel>=0.4.0, <0.5",
     "simplejson>=3.15.0",
-    "slack_sdk>=3.19.0, <4",
+    "slack_sdk>=3.19.0",
     "sqlalchemy>=1.4, <2",
     "sqlalchemy-utils>=0.38.3, <0.39",
     "sqlglot>=23.0.2,<24",

--- a/superset/tasks/slack_util.py
+++ b/superset/tasks/slack_util.py
@@ -48,7 +48,7 @@ def deliver_slack_msg(
     if file:
         response = cast(
             SlackResponse,
-            client.files_upload(
+            client.files_upload_v2(
                 channels=slack_channel, file=file, initial_comment=body, title=subject
             ),
         )


### PR DESCRIPTION
Randomly caught https://github.com/apache/superset/issues/28353 and decided to propose a fix. This seemed straightforward when I looked at the docs here https://github.com/slackapi/python-slack-sdk/releases/tag/v3.19.0

Confirmed we're on the latest client and that stuff is pretty well covered by unit tests