### PR TITLE
feat: clarify that 'Text' supports markdown

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/new/NewMarkdown.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/new/NewMarkdown.jsx
@@ -28,7 +28,7 @@ export default function DraggableNewDivider() {
     <DraggableNewComponent
       id={NEW_MARKDOWN_ID}
       type={MARKDOWN_TYPE}
-      label={t('Text')}
+      label={t('Text / Markdown')}
       className="fa fa-font"
     />
   );


### PR DESCRIPTION
Making it more clear that the "Text" layout element in dashboards supports Markdown by relabeling to "Text / Markdown"


<img width="481" alt="Screenshot 2024-05-09 at 9 54 20 PM" src="https://github.com/apache/superset/assets/487433/0fe68deb-4bd4-489d-9cd7-32480e92e916">

