### PR TITLE
chore(docs): fix two broken Docusaurus redirect links

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -113,8 +113,11 @@ const config = {
           },
           {
             to: '/docs/configuration/alerts-reports',
-            from: '/docs/installation/email-reports',
+            from: '/docs/installation/alerts-reports',
           },
+          {
+            to: 'docs/contributing/development',
+            from: 'docs/contributing/hooks-and-linting'
           {
             to: '/docs/intro',
             from: '/docs/roadmap',

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -116,8 +116,8 @@ const config = {
             from: '/docs/installation/alerts-reports',
           },
           {
-            to: 'docs/contributing/development',
-            from: 'docs/contributing/hooks-and-linting',
+            to: '/docs/contributing/development',
+            from: '/docs/contributing/hooks-and-linting',
           },
           {
             to: '/docs/intro',

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -118,6 +118,7 @@ const config = {
           {
             to: 'docs/contributing/development',
             from: 'docs/contributing/hooks-and-linting',
+          },
           {
             to: '/docs/intro',
             from: '/docs/roadmap',

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -117,7 +117,7 @@ const config = {
           },
           {
             to: 'docs/contributing/development',
-            from: 'docs/contributing/hooks-and-linting'
+            from: 'docs/contributing/hooks-and-linting',
           {
             to: '/docs/intro',
             from: '/docs/roadmap',


### PR DESCRIPTION
One per Evan in Slack, one I believe was a typo in the previous fix (was email-reports instead of alerts-reports, so the redirect from alerts-reports doesn't happen).